### PR TITLE
feat: domain rulebooks on TS + close the interactive/tui naming gap (parity batch 3)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -581,38 +581,38 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 | Command | Option | Type | Default | Notes |
 |---|---|---|---|---|
-| `agent-serve` | `--port` | integer | `8200` | Port for the A2A server |
-| `agent-serve` | `--host` | text | `'0.0.0.0'` | Host to bind to |
-| `analyze-blocking` | `files` | text | **required** | File(s) to analyze |
-| `analyze-blocking` | `--config` | text | **required** | Config file with matchkeys |
-| `anomalies` | `files` | text | **required** | Input files (path or path:source_name) |
-| `anomalies` | `--sensitivity` | text | `'medium'` | low, medium, or high |
-| `anomalies` | `--output` | text | `None` | Write anomalies to a CSV instead of printing |
-| `anomalies` | `--limit` | integer | `50` | Max rows to print |
-| `autoconfig` | `files` | text | **required** | Input files as path or path:source_name |
-| `autoconfig` | `--out` | text | `None` | Write committed config to this path instead of stdout. |
-| `autoconfig` | `--domain` | text | `None` | Pin a domain rulebook (electronics, software, …) instead of auto-detecting. |
+| `agent-serve` | `--port` | int | `8200` | Port for the A2A server |
+| `agent-serve` | `--host` | str | `'0.0.0.0'` | Host to bind to |
+| `analyze-blocking` | `files` | str | **required** | File(s) to analyze |
+| `analyze-blocking` | `--config` | str | **required** | Config file with matchkeys |
+| `anomalies` | `files` | str | **required** | Input files (path or path:source_name) |
+| `anomalies` | `--sensitivity` | str | `'medium'` | low, medium, or high |
+| `anomalies` | `--output` | str | `None` | Write anomalies to a CSV instead of printing |
+| `anomalies` | `--limit` | int | `50` | Max rows to print |
+| `autoconfig` | `files` | str | **required** | Input files as path or path:source_name |
+| `autoconfig` | `--out` | str | `None` | Write committed config to this path instead of stdout. |
+| `autoconfig` | `--domain` | str | `None` | Pin a domain rulebook (electronics, software, …) instead of auto-detecting. |
 | `autoconfig` | `--show-controller` | boolean | `True` | Render the controller telemetry panel on stderr. |
 | `autoconfig` | `--verbose` | boolean | `False` | Include indicator priors + decision trace in the panel. |
 | `autoconfig` | `--quiet` | boolean | `False` | Suppress all stderr output (panel + status messages). |
-| `compare-clusters` | `file_a` | text | **required** | First cluster JSON file (baseline / ER1) |
-| `compare-clusters` | `file_b` | text | **required** | Second cluster JSON file (comparison / ER2) |
+| `compare-clusters` | `file_a` | str | **required** | First cluster JSON file (baseline / ER1) |
+| `compare-clusters` | `file_b` | str | **required** | Second cluster JSON file (comparison / ER2) |
 | `compare-clusters` | `--details` | boolean | `False` | Show per-cluster transformation details |
-| `compare-clusters` | `--case-type` | text | `None` | Filter details by case: unchanged, merged, partitioned, overlapping |
+| `compare-clusters` | `--case-type` | str | `None` | Filter details by case: unchanged, merged, partitioned, overlapping |
 | `compare-clusters` | `--output` | path | `None` | Save results to JSON |
-| `config delete` | `name` | text | **required** | Preset name to delete |
-| `config load` | `name` | text | **required** | Preset name to load |
-| `config load` | `--dest` | text | `'goldenmatch.yaml'` | Destination path |
-| `config save` | `name` | text | **required** | Preset name |
-| `config save` | `config_path` | text | **required** | Path to config YAML file |
-| `config show` | `name` | text | **required** | Preset name to display |
-| `dedupe` | `files` | text | **required** | Input files as path or path:source_name |
-| `dedupe` | `--config` | text | `None` | Path to YAML config file (optional - auto-detects if omitted) |
+| `config delete` | `name` | str | **required** | Preset name to delete |
+| `config load` | `name` | str | **required** | Preset name to load |
+| `config load` | `--dest` | str | `'goldenmatch.yaml'` | Destination path |
+| `config save` | `name` | str | **required** | Preset name |
+| `config save` | `config_path` | str | **required** | Path to config YAML file |
+| `config show` | `name` | str | **required** | Preset name to display |
+| `dedupe` | `files` | str | **required** | Input files as path or path:source_name |
+| `dedupe` | `--config` | str | `None` | Path to YAML config file (optional - auto-detects if omitted) |
 | `dedupe` | `--tui` | boolean | `False` | Open the interactive review TUI instead of running directly (auto-config path only). |
 | `dedupe` | `--no-tui` | boolean | `False` | Deprecated: non-interactive is now the default. Accepted for back-compat (no-op). |
-| `dedupe` | `--model` | text | `None` | Override embedding model selection |
+| `dedupe` | `--model` | str | `None` | Override embedding model selection |
 | `dedupe` | `--preview` | boolean | `False` | Preview results without writing files |
-| `dedupe` | `--preview-size` | integer | `10000` | Number of records for preview sample |
+| `dedupe` | `--preview-size` | int | `10000` | Number of records for preview sample |
 | `dedupe` | `--preview-random` | boolean | `False` | Random sample instead of first N |
 | `dedupe` | `--output-golden` | boolean | `False` | Output golden records |
 | `dedupe` | `--output-clusters` | boolean | `False` | Output cluster info |
@@ -623,24 +623,24 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `dedupe` | `--html-report` | boolean | `False` | Generate standalone HTML report |
 | `dedupe` | `--dashboard` | boolean | `False` | Generate before/after data quality dashboard |
 | `dedupe` | `--across-files-only` | boolean | `False` | Only match across different sources |
-| `dedupe` | `--output-dir` | text | `None` | Output directory |
-| `dedupe` | `--format` | text | `None` | Output format (csv, parquet) |
-| `dedupe` | `--run-name` | text | `None` | Run name for output files |
+| `dedupe` | `--output-dir` | str | `None` | Output directory |
+| `dedupe` | `--format` | str | `None` | Output format (csv, parquet) |
+| `dedupe` | `--run-name` | str | `None` | Run name for output files |
 | `dedupe` | `--auto-fix` | boolean | `False` | Run auto-fix before matching |
 | `dedupe` | `--auto-block` | boolean | `False` | Auto-suggest blocking keys |
 | `dedupe` | `--chunked` | boolean | `False` | Large dataset mode - process in chunks for files >1M records |
-| `dedupe` | `--chunk-size` | integer | `100000` | Records per chunk in chunked mode |
+| `dedupe` | `--chunk-size` | int | `100000` | Records per chunk in chunked mode |
 | `dedupe` | `--diff` | boolean | `False` | Generate before/after CSV diff |
 | `dedupe` | `--diff-html` | boolean | `False` | Generate before/after HTML diff with highlighting |
 | `dedupe` | `--merge-preview` | boolean | `False` | Show merge preview (what will change) without writing |
 | `dedupe` | `--anomalies` | boolean | `False` | Detect suspicious/fake records |
-| `dedupe` | `--anomaly-sensitivity` | text | `'medium'` | low, medium, or high |
+| `dedupe` | `--anomaly-sensitivity` | str | `'medium'` | low, medium, or high |
 | `dedupe` | `--llm-boost` | boolean | `False` | Boost accuracy with LLM-labeled training data |
 | `dedupe` | `--llm-retrain` | boolean | `False` | Force re-labeling (ignore saved model) |
-| `dedupe` | `--llm-provider` | text | `None` | LLM provider: auto, anthropic, or openai |
-| `dedupe` | `--llm-max-labels` | integer | `500` | Max pairs to label with LLM |
-| `dedupe` | `--backend` | text | `None` | Processing backend: default, bucket, chunked, ray, duckdb |
-| `dedupe` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present. |
+| `dedupe` | `--llm-provider` | str | `None` | LLM provider: auto, anthropic, or openai |
+| `dedupe` | `--llm-max-labels` | int | `500` | Max pairs to label with LLM |
+| `dedupe` | `--backend` | str | `None` | Processing backend: default, bucket, chunked, ray, duckdb |
+| `dedupe` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present. |
 | `dedupe` | `--show-controller` | boolean | `True` | Render AutoConfigController telemetry (stop_reason, decisions, Path Y) when auto-config ran. No-op for runs with an explicit --config. |
 | `dedupe` | `--suggest` | boolean | `False` | Show verified config-improvement suggestions for this run. |
 | `dedupe` | `--heal` | boolean | `False` | Apply the suggestion heal loop and print the applied trail. |
@@ -651,11 +651,11 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `demo` | `--dashboard` | boolean | `False` | Generate before/after dashboard |
 | `demo` | `--graph` | boolean | `False` | Generate cluster graph |
 | `demo` | `--quiet` | boolean | `False` | Suppress animated output |
-| `evaluate` | `files` | text | **required** | Input files (path or path:source_name) |
+| `evaluate` | `files` | str | **required** | Input files (path or path:source_name) |
 | `evaluate` | `--config` | path | **required** | Config YAML path |
 | `evaluate` | `--ground-truth` | path | `None` | Ground truth CSV path (required unless --certify) |
-| `evaluate` | `--col-a` | text | `'id_a'` | Ground truth column A |
-| `evaluate` | `--col-b` | text | `'id_b'` | Ground truth column B |
+| `evaluate` | `--col-a` | str | `'id_a'` | Ground truth column A |
+| `evaluate` | `--col-b` | str | `'id_b'` | Ground truth column B |
 | `evaluate` | `--threshold` | float | `None` | Override match threshold |
 | `evaluate` | `--output` | path | `None` | Save results to JSON |
 | `evaluate` | `--min-f1` | float | `None` | Minimum F1 score (exit code 1 if below). For CI/CD quality gates. |
@@ -664,206 +664,207 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `evaluate` | `--certify` | boolean | `False` | Estimate recall WITHOUT ground truth (unsupervised, via capture-recapture over the config's matchkeys/passes; needs >=3). |
 | `evaluate` | `--audit-out` | path | `None` | With --certify: emit a stratified audit sample CSV to label for a SAFE recall lower bound. |
 | `evaluate` | `--audit-in` | path | `None` | With --certify: read a labelled audit sample and print the audit-calibrated SAFE lower bound. |
-| `evaluate` | `--audit-n` | integer | `50` | Audit samples per stratum (default 50). |
+| `evaluate` | `--audit-n` | int | `50` | Audit samples per stratum (default 50). |
 | `evaluate` | `--threshold-sweep` | boolean | `False` | Sweep the link threshold over scored pairs: P/R/F1 table + recommended cut (+ Fellegi-Sunter m/u model report when a probabilistic matchkey ran). |
-| `explain` | `files` | text | **required** | Input files (path or path:source_name) |
+| `explain` | `files` | str | **required** | Input files (path or path:source_name) |
 | `explain` | `--config` | path | **required** | Config YAML path |
-| `explain` | `--pair` | text | `None` | Explain a pair: 'id_a,id_b' |
-| `explain` | `--cluster` | integer | `None` | Explain a cluster by id |
-| `identity conflicts` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity conflicts` | `--dataset` | text | `None` | Filter to identities in this dataset. |
+| `explain` | `--pair` | str | `None` | Explain a pair: 'id_a,id_b' |
+| `explain` | `--cluster` | int | `None` | Explain a cluster by id |
+| `identity conflicts` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity conflicts` | `--dataset` | str | `None` | Filter to identities in this dataset. |
 | `identity conflicts` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity history` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
-| `identity history` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity history` | `--limit` | integer | `50` | Maximum number of events to return. |
+| `identity history` | `entity_id` | str | **required** | The entity_id of the identity to operate on. |
+| `identity history` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity history` | `--limit` | int | `50` | Maximum number of events to return. |
 | `identity history` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity list` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity list` | `--dataset` | text | `None` | Filter to identities in this dataset. |
-| `identity list` | `--status` | text | `None` | Filter to identities with this status. |
-| `identity list` | `--limit` | integer | `50` | Maximum number of identities to return. |
-| `identity list` | `--offset` | integer | `0` | Number of identities to skip for pagination. |
+| `identity list` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity list` | `--dataset` | str | `None` | Filter to identities in this dataset. |
+| `identity list` | `--status` | str | `None` | Filter to identities with this status. |
+| `identity list` | `--limit` | int | `50` | Maximum number of identities to return. |
+| `identity list` | `--offset` | int | `0` | Number of identities to skip for pagination. |
 | `identity list` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity merge` | `keep` | text | **required** | entity_id to keep |
-| `identity merge` | `absorb` | text | **required** | entity_id to absorb |
-| `identity merge` | `--reason` | text | `None` | Optional reason recorded in the event log. |
-| `identity merge` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity migrate` | `--dsn` | text | **required** | Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN. |
+| `identity merge` | `keep` | str | **required** | entity_id to keep |
+| `identity merge` | `absorb` | str | **required** | entity_id to absorb |
+| `identity merge` | `--reason` | str | `None` | Optional reason recorded in the event log. |
+| `identity merge` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity migrate` | `--dsn` | str | **required** | Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN. |
 | `identity migrate` | `--stamp-existing` | boolean | `False` | Stamp an existing v1 schema at revision 0001 without re-creating tables. |
-| `identity migrate` | `--revision` | text | `'head'` | Target revision (default: head). |
-| `identity migrate-ids` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity migrate-ids` | `--dsn` | text | `None` | Database connection string for the identity store. |
+| `identity migrate` | `--revision` | str | `'head'` | Target revision (default: head). |
+| `identity migrate-ids` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity migrate-ids` | `--dsn` | str | `None` | Database connection string for the identity store. |
 | `identity migrate-ids` | `--dry-run` | boolean | `False` | Report what would change; mutate nothing. |
-| `identity resolve` | `record_id` | text | **required** | `&#123;source&#125;:&#123;pk&#125;` to look up |
-| `identity resolve` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity resolve` | `record_id` | str | **required** | `&#123;source&#125;:&#123;pk&#125;` to look up |
+| `identity resolve` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
 | `identity resolve` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity show` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
-| `identity show` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity show` | `entity_id` | str | **required** | The entity_id of the identity to operate on. |
+| `identity show` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
 | `identity show` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity split` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
-| `identity split` | `record_ids` | text | **required** | record_ids to move to a new identity |
-| `identity split` | `--reason` | text | `None` | Optional reason recorded in the event log. |
-| `identity split` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `import-splink` | `input_path` | text | **required** | Splink settings or trained-model JSON file |
-| `import-splink` | `--output` | text | `'goldenmatch.yaml'` | Output YAML config path |
-| `import-splink` | `--model-out` | text | `None` | Persist imported trained m/u as an FS model JSON; sets model_path in the config |
+| `identity split` | `entity_id` | str | **required** | The entity_id of the identity to operate on. |
+| `identity split` | `record_ids` | str | **required** | record_ids to move to a new identity |
+| `identity split` | `--reason` | str | `None` | Optional reason recorded in the event log. |
+| `identity split` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `import-splink` | `input_path` | str | **required** | Splink settings or trained-model JSON file |
+| `import-splink` | `--output` | str | `'goldenmatch.yaml'` | Output YAML config path |
+| `import-splink` | `--model-out` | str | `None` | Persist imported trained m/u as an FS model JSON; sets model_path in the config |
 | `import-splink` | `--strict` | boolean | `False` | Fail on any lossy mapping (warnings), not just errors |
-| `import-splink` | `--upgrade` | text | `None` | Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json. |
-| `import-splink` | `--splink-clusters` | text | `None` | Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id. |
-| `import-splink` | `--labels` | text | `None` | Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id. |
-| `import-splink` | `--sample-cap` | integer | `100000` | Row cap for --upgrade lever computation and measurement (seeded subsample above it) |
+| `import-splink` | `--upgrade` | str | `None` | Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json. |
+| `import-splink` | `--splink-clusters` | str | `None` | Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id. |
+| `import-splink` | `--labels` | str | `None` | Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id. |
+| `import-splink` | `--sample-cap` | int | `100000` | Row cap for --upgrade lever computation and measurement (seeded subsample above it) |
 | `import-splink` | `--no-measure` | boolean | `False` | Skip the baseline-vs-upgraded measurement pass |
-| `import-splink` | `--id-column` | text | `None` | Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id) |
-| `incremental` | `base_file` | text | **required** | Base dataset file path |
+| `import-splink` | `--id-column` | str | `None` | Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id) |
+| `incremental` | `base_file` | str | **required** | Base dataset file path |
 | `incremental` | `--new-records` | path | **required** | New records CSV to match |
 | `incremental` | `--config` | path | **required** | Config YAML path |
 | `incremental` | `--output` | path | `None` | Output CSV path |
 | `incremental` | `--threshold` | float | `None` | Override threshold |
-| `incremental` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
-| `ingest-docs run` | `docs` | text | **required** | Document paths (PDF/image). |
-| `ingest-docs run` | `--schema` | text | **required** | Target schema JSON file. |
-| `ingest-docs run` | `--out` | text | **required** | Write records here (.csv or .parquet). |
-| `ingest-docs run` | `--backend` | text | `'vlm'` | Extraction backend. |
-| `ingest-docs run` | `--model` | text | `'gpt-4o'` | Vision model. |
-| `ingest-docs suggest-schema` | `sample` | text | **required** | A representative document (PDF/image). |
-| `ingest-docs suggest-schema` | `--out` | text | **required** | Write the proposed schema JSON here. |
-| `ingest-docs suggest-schema` | `--backend` | text | `'vlm'` | Extraction backend. |
-| `ingest-docs suggest-schema` | `--model` | text | `'gpt-4o'` | Vision model. |
-| `init` | `--output` | text | `None` | Output path for generated config |
-| `interactive` | `files` | text | **required** | File(s) to load |
-| `label` | `files` | text | **required** | Input files (path or path:source_name) |
+| `incremental` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
+| `ingest-docs run` | `docs` | str | **required** | Document paths (PDF/image). |
+| `ingest-docs run` | `--schema` | str | **required** | Target schema JSON file. |
+| `ingest-docs run` | `--out` | str | **required** | Write records here (.csv or .parquet). |
+| `ingest-docs run` | `--backend` | str | `'vlm'` | Extraction backend. |
+| `ingest-docs run` | `--model` | str | `'gpt-4o'` | Vision model. |
+| `ingest-docs suggest-schema` | `sample` | str | **required** | A representative document (PDF/image). |
+| `ingest-docs suggest-schema` | `--out` | str | **required** | Write the proposed schema JSON here. |
+| `ingest-docs suggest-schema` | `--backend` | str | `'vlm'` | Extraction backend. |
+| `ingest-docs suggest-schema` | `--model` | str | `'gpt-4o'` | Vision model. |
+| `init` | `--output` | str | `None` | Output path for generated config |
+| `interactive` | `files` | str | **required** | File(s) to load |
+| `label` | `files` | str | **required** | Input files (path or path:source_name) |
 | `label` | `--config` | path | **required** | Config YAML path |
 | `label` | `--output` | path | `'ground_truth.csv'` | Output ground truth CSV |
-| `label` | `--n` | integer | `50` | Number of pairs to label |
-| `label` | `--strategy` | text | `'borderline'` | Pair selection: borderline, random, or hardest |
+| `label` | `--n` | int | `50` | Number of pairs to label |
+| `label` | `--strategy` | str | `'borderline'` | Pair selection: borderline, random, or hardest |
 | `label` | `--append` | boolean | `False` | Append to existing ground truth file |
-| `lineage` | `files` | text | **required** | Input files (path or path:source_name) |
+| `lineage` | `files` | str | **required** | Input files (path or path:source_name) |
 | `lineage` | `--config` | path | **required** | Config YAML path |
-| `lineage` | `--output-dir` | text | `None` | Write lineage.json here (default: print a summary) |
-| `lineage` | `--run-name` | text | `'lineage'` | Run name for the lineage file |
-| `lineage` | `--max-pairs` | integer | `10000` | Cap on lineage records (0 = no cap) |
+| `lineage` | `--output-dir` | str | `None` | Write lineage.json here (default: print a summary) |
+| `lineage` | `--run-name` | str | `'lineage'` | Run name for the lineage file |
+| `lineage` | `--max-pairs` | int | `10000` | Cap on lineage records (0 = no cap) |
 | `lineage` | `--nl` | boolean | `False` | Include natural-language explanations |
-| `match` | `target` | text | **required** | Target file as path or path:source_name |
-| `match` | `--against` | text | **required** | Reference files as path or path:source_name |
-| `match` | `--config` | text | `None` | Path to YAML config file (optional - auto-detects if omitted) |
+| `match` | `target` | str | **required** | Target file as path or path:source_name |
+| `match` | `--against` | str | **required** | Reference files as path or path:source_name |
+| `match` | `--config` | str | `None` | Path to YAML config file (optional - auto-detects if omitted) |
 | `match` | `--preview` | boolean | `False` | Preview results without writing files |
-| `match` | `--preview-size` | integer | `10000` | Number of records for preview sample |
+| `match` | `--preview-size` | int | `10000` | Number of records for preview sample |
 | `match` | `--preview-random` | boolean | `False` | Random sample instead of first N |
 | `match` | `--output-matched` | boolean | `False` | Output matched records |
 | `match` | `--output-unmatched` | boolean | `False` | Output unmatched records |
 | `match` | `--output-scores` | boolean | `False` | Output score details |
 | `match` | `--output-all` | boolean | `False` | Output all result types |
 | `match` | `--output-report` | boolean | `False` | Generate summary report |
-| `match` | `--match-mode` | text | `'best'` | Match mode: best or all |
-| `match` | `--output-dir` | text | `None` | Output directory |
-| `match` | `--format` | text | `None` | Output format (csv, parquet) |
-| `match` | `--run-name` | text | `None` | Run name for output files |
+| `match` | `--match-mode` | str | `'best'` | Match mode: best or all |
+| `match` | `--output-dir` | str | `None` | Output directory |
+| `match` | `--format` | str | `None` | Output format (csv, parquet) |
+| `match` | `--run-name` | str | `None` | Run name for output files |
 | `match` | `--auto-fix` | boolean | `False` | Run auto-fix before matching |
 | `match` | `--auto-block` | boolean | `False` | Auto-suggest blocking keys |
-| `match` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
+| `match` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
 | `match` | `--verbose` | boolean | `False` | Verbose output |
 | `match` | `--quiet` | boolean | `False` | Suppress output |
-| `mcp-serve` | `files` | text | `None` | Data files to load |
-| `mcp-serve` | `--config` | text | `None` | Config YAML file |
-| `mcp-serve` | `--transport` | text | `'stdio'` | Transport: stdio or http |
-| `mcp-serve` | `--host` | text | `'0.0.0.0'` | HTTP host (only for http transport) |
-| `mcp-serve` | `--port` | integer | `8200` | HTTP port (only for http transport) |
-| `memory add` | `--decision` | text | **required** | approve \| reject \| field_correct |
-| `memory add` | `--dataset` | text | **required** | Dataset key (required) |
-| `memory add` | `--id-a` | integer | `None` | Pair-level: first row id |
-| `memory add` | `--id-b` | integer | `None` | Pair-level: second row id |
-| `memory add` | `--cluster-id` | integer | `None` | Field-level: cluster id the correction targets |
-| `memory add` | `--field-name` | text | `None` | Field-level: column being corrected |
-| `memory add` | `--original-value` | text | `None` | Field-level: original chosen value |
-| `memory add` | `--corrected-value` | text | `None` | Field-level: the value the reviewer changed it to |
-| `memory add` | `--reason` | text | `None` | Optional reason |
-| `memory add` | `--matchkey-name` | text | `None` | Optional matchkey scope |
-| `memory add` | `--source` | text | `'steward'` | Source: steward (1.0 trust) \| agent (0.5) \| boost \| unmerge |
-| `memory add` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory export` | `out` | text | **required** | Output CSV path |
-| `memory export` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory import` | `src` | text | **required** | Source CSV path |
-| `memory import` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory learn` | `--matchkey-name` | text | `None` | Limit learning to this matchkey |
-| `memory learn` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory show` | `id_a` | integer | **required** | First record ID |
-| `memory show` | `id_b` | integer | **required** | Second record ID |
-| `memory show` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory stats` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
+| `mcp-serve` | `files` | str | `None` | Data files to load |
+| `mcp-serve` | `--config` | str | `None` | Config YAML file |
+| `mcp-serve` | `--transport` | str | `'stdio'` | Transport: stdio or http |
+| `mcp-serve` | `--host` | str | `'0.0.0.0'` | HTTP host (only for http transport) |
+| `mcp-serve` | `--port` | int | `8200` | HTTP port (only for http transport) |
+| `memory add` | `--decision` | str | **required** | approve \| reject \| field_correct |
+| `memory add` | `--dataset` | str | **required** | Dataset key (required) |
+| `memory add` | `--id-a` | int | `None` | Pair-level: first row id |
+| `memory add` | `--id-b` | int | `None` | Pair-level: second row id |
+| `memory add` | `--cluster-id` | int | `None` | Field-level: cluster id the correction targets |
+| `memory add` | `--field-name` | str | `None` | Field-level: column being corrected |
+| `memory add` | `--original-value` | str | `None` | Field-level: original chosen value |
+| `memory add` | `--corrected-value` | str | `None` | Field-level: the value the reviewer changed it to |
+| `memory add` | `--reason` | str | `None` | Optional reason |
+| `memory add` | `--matchkey-name` | str | `None` | Optional matchkey scope |
+| `memory add` | `--source` | str | `'steward'` | Source: steward (1.0 trust) \| agent (0.5) \| boost \| unmerge |
+| `memory add` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory export` | `out` | str | **required** | Output CSV path |
+| `memory export` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory import` | `src` | str | **required** | Source CSV path |
+| `memory import` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory learn` | `--matchkey-name` | str | `None` | Limit learning to this matchkey |
+| `memory learn` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory show` | `id_a` | int | **required** | First record ID |
+| `memory show` | `id_b` | int | **required** | Second record ID |
+| `memory show` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory stats` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
 | `pprl auto-config` | `file` | path | **required** | Data file to analyze (CSV) |
-| `pprl auto-config` | `--security` | text | `'high'` | Security level: standard, high, paranoid |
+| `pprl auto-config` | `--security` | str | `'high'` | Security level: standard, high, paranoid |
 | `pprl auto-config` | `--llm` | boolean | `False` | Use LLM for enhanced recommendations |
 | `pprl link` | `--file-a` | path | **required** | Party A data file (CSV) |
 | `pprl link` | `--file-b` | path | **required** | Party B data file (CSV) |
-| `pprl link` | `--fields` | text | **required** | Comma-separated field names to match on |
+| `pprl link` | `--fields` | str | **required** | Comma-separated field names to match on |
 | `pprl link` | `--threshold` | float | `0.85` | Match threshold |
-| `pprl link` | `--security` | text | `'high'` | Security level: standard, high, paranoid |
-| `pprl link` | `--protocol` | text | `'trusted_third_party'` | Protocol: trusted_third_party or smc |
-| `pprl link` | `--scorer` | text | `'dice'` | Similarity scorer: dice or jaccard |
+| `pprl link` | `--security` | str | `'high'` | Security level: standard, high, paranoid |
+| `pprl link` | `--protocol` | str | `'trusted_third_party'` | Protocol: trusted_third_party or smc |
+| `pprl link` | `--scorer` | str | `'dice'` | Similarity scorer: dice or jaccard |
 | `pprl link` | `--output` | path | `None` | Output CSV path for cluster assignments |
-| `pprl link` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them. |
-| `profile` | `files` | text | **required** | File(s) to profile |
+| `pprl link` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them. |
+| `profile` | `files` | str | **required** | File(s) to profile |
 | `profile` | `--verbose` | boolean | `False` | Show detailed per-column info |
 | `profile` | `--suggest-fixes` | boolean | `False` | Show what auto-fix would do (dry run) |
 | `profile` | `--exclusions` | boolean | `False` | Show GoldenCheck auto-config column exclusions (#404). Lists columns auto-config will skip (audit timestamps, foreign IDs, sentinel values, etc) and why. |
-| `review` | `files` | text | `None` | Input files (path or path:source_name). Omit to review only the pending queue. |
+| `review` | `files` | str | `None` | Input files (path or path:source_name). Omit to review only the pending queue. |
 | `review` | `--config` | path | **required** | Config YAML path |
-| `review` | `--job` | text | `'review'` | Review-queue job name for freshly-gated pairs |
-| `review` | `--queue-path` | text | `None` | SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db) |
-| `review` | `--memory-path` | text | `'.goldenmatch/memory.db'` | Learning Memory SQLite path |
+| `review` | `--job` | str | `'review'` | Review-queue job name for freshly-gated pairs |
+| `review` | `--queue-path` | str | `None` | SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db) |
+| `review` | `--memory-path` | str | `'.goldenmatch/memory.db'` | Learning Memory SQLite path |
 | `review` | `--merge-threshold` | float | `0.95` | Scores above this auto-merge (skip review) |
 | `review` | `--review-threshold` | float | `0.75` | Scores >= this go to review |
-| `review` | `--decided-by` | text | `'cli'` | Steward identifier recorded on each decision |
-| `review` | `--limit` | integer | `50` | Max pairs to review this session |
-| `rollback` | `run_id` | text | **required** | Run ID to rollback |
-| `rollback` | `--output-dir` | text | `'.'` | Directory containing run log |
-| `runs` | `--output-dir` | text | `'.'` | Directory containing run log |
-| `schedule` | `files` | text | **required** | Data files to process |
-| `schedule` | `--config` | text | `None` | Config YAML file |
-| `schedule` | `--every` | text | `None` | Run interval (e.g. 1h, 30m, 6h, 1d) |
-| `schedule` | `--cron` | text | `None` | Cron schedule (e.g. '0 6 * * *') |
-| `schedule` | `--output-dir` | text | `'.'` | Output directory |
-| `score` | `a` | text | **required** | First string. |
-| `score` | `b` | text | **required** | Second string. |
-| `score` | `--scorer` | text | `'jaro_winkler'` | Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble. |
-| `sensitivity` | `files` | text | **required** | Input files (path or path:source_name) |
+| `review` | `--decided-by` | str | `'cli'` | Steward identifier recorded on each decision |
+| `review` | `--limit` | int | `50` | Max pairs to review this session |
+| `rollback` | `run_id` | str | **required** | Run ID to rollback |
+| `rollback` | `--output-dir` | str | `'.'` | Directory containing run log |
+| `runs` | `--output-dir` | str | `'.'` | Directory containing run log |
+| `schedule` | `files` | str | **required** | Data files to process |
+| `schedule` | `--config` | str | `None` | Config YAML file |
+| `schedule` | `--every` | str | `None` | Run interval (e.g. 1h, 30m, 6h, 1d) |
+| `schedule` | `--cron` | str | `None` | Cron schedule (e.g. '0 6 * * *') |
+| `schedule` | `--output-dir` | str | `'.'` | Output directory |
+| `score` | `a` | str | **required** | First string. |
+| `score` | `b` | str | **required** | Second string. |
+| `score` | `--scorer` | str | `'jaro_winkler'` | Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble. |
+| `sensitivity` | `files` | str | **required** | Input files (path or path:source_name) |
 | `sensitivity` | `--config` | path | **required** | Config YAML path |
-| `sensitivity` | `--sweep` | text | **required** | Sweep spec: field:start:stop:step (repeatable) |
-| `sensitivity` | `--sample` | integer | `None` | Random sample size for speed |
+| `sensitivity` | `--sweep` | str | **required** | Sweep spec: field:start:stop:step (repeatable) |
+| `sensitivity` | `--sample` | int | `None` | Random sample size for speed |
 | `sensitivity` | `--output` | path | `None` | Save results to JSON |
-| `serve` | `files` | text | **required** | Data files to load |
-| `serve` | `--config` | text | `None` | Config YAML file |
-| `serve` | `--host` | text | `'127.0.0.1'` | Server host |
-| `serve` | `--port` | integer | `8080` | Server port |
+| `serve` | `files` | str | **required** | Data files to load |
+| `serve` | `--config` | str | `None` | Config YAML file |
+| `serve` | `--host` | str | `'127.0.0.1'` | Server host |
+| `serve` | `--port` | int | `8080` | Server port |
 | `serve-ui` | `path` | path | `None` | Optional run dir or project dir. |
-| `serve-ui` | `--host` | text | `'127.0.0.1'` | Host to bind. |
-| `serve-ui` | `--port` | integer | `5050` | Port (0 = pick free, default 5050 matches Vite proxy). |
+| `serve-ui` | `--host` | str | `'127.0.0.1'` | Host to bind. |
+| `serve-ui` | `--port` | int | `5050` | Port (0 = pick free, default 5050 matches Vite proxy). |
 | `serve-ui` | `--dev` | boolean | `False` | Skip static; expect Vite at :5173. |
 | `serve-ui` | `--open` | boolean | `True` | Open the UI in a browser once the server starts. |
-| `sync` | `--source-type` | text | `'postgres'` | Database type |
-| `sync` | `--connection-string` | text | `None` | Database URL |
-| `sync` | `--table` | text | **required** | Source table name |
-| `sync` | `--config` | text | `None` | Config YAML file |
-| `sync` | `--output-mode` | text | `'separate'` | separate or in_place |
+| `sync` | `--source-type` | str | `'postgres'` | Database type |
+| `sync` | `--connection-string` | str | `None` | Database URL |
+| `sync` | `--table` | str | **required** | Source table name |
+| `sync` | `--config` | str | `None` | Config YAML file |
+| `sync` | `--output-mode` | str | `'separate'` | separate or in_place |
 | `sync` | `--full-rescan` | boolean | `False` | Force full rescan |
 | `sync` | `--dry-run` | boolean | `False` | Match without writing results |
-| `sync` | `--incremental-column` | text | `None` | Column for incremental detection |
-| `sync` | `--chunk-size` | integer | `10000` | Records per chunk |
-| `sync` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set. |
+| `sync` | `--incremental-column` | str | `None` | Column for incremental detection |
+| `sync` | `--chunk-size` | int | `10000` | Records per chunk |
+| `sync` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set. |
 | `sync` | `--verbose` | boolean | `False` | Enable debug-level logging output. |
 | `sync` | `--quiet` | boolean | `False` | Suppress informational output. |
-| `unmerge` | `record_id` | integer | **required** | Record row ID to unmerge from its cluster |
-| `unmerge` | `--clusters` | text | `None` | Path to clusters CSV from a previous run |
-| `unmerge` | `--pairs` | text | `None` | Path to scored pairs CSV (id_a,id_b,score) |
+| `tui` | `files` | str | **required** | File(s) to load |
+| `unmerge` | `record_id` | int | **required** | Record row ID to unmerge from its cluster |
+| `unmerge` | `--clusters` | str | `None` | Path to clusters CSV from a previous run |
+| `unmerge` | `--pairs` | str | `None` | Path to scored pairs CSV (id_a,id_b,score) |
 | `unmerge` | `--shatter` | boolean | `False` | Shatter the entire cluster into singletons |
 | `unmerge` | `--threshold` | float | `0.0` | Min score threshold for re-clustering |
-| `unmerge` | `--output` | text | `None` | Where to write the re-clustered CSV (default: &lt;clusters>.unmerged.csv) |
-| `watch` | `--source-type` | text | `'postgres'` | Database type |
-| `watch` | `--connection-string` | text | `None` | Database URL |
-| `watch` | `--table` | text | **required** | Table to watch |
-| `watch` | `--config` | text | `None` | Config YAML file |
-| `watch` | `--interval` | integer | `30` | Seconds between polls |
-| `watch` | `--output-mode` | text | `'separate'` | separate or in_place |
-| `watch` | `--incremental-column` | text | `None` | Column for change detection |
+| `unmerge` | `--output` | str | `None` | Where to write the re-clustered CSV (default: &lt;clusters>.unmerged.csv) |
+| `watch` | `--source-type` | str | `'postgres'` | Database type |
+| `watch` | `--connection-string` | str | `None` | Database URL |
+| `watch` | `--table` | str | **required** | Table to watch |
+| `watch` | `--config` | str | `None` | Config YAML file |
+| `watch` | `--interval` | int | `30` | Seconds between polls |
+| `watch` | `--output-mode` | str | `'separate'` | separate or in_place |
+| `watch` | `--incremental-column` | str | `None` | Column for change detection |
 
 ## MCP tools
 

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -581,38 +581,38 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 | Command | Option | Type | Default | Notes |
 |---|---|---|---|---|
-| `agent-serve` | `--port` | int | `8200` | Port for the A2A server |
-| `agent-serve` | `--host` | str | `'0.0.0.0'` | Host to bind to |
-| `analyze-blocking` | `files` | str | **required** | File(s) to analyze |
-| `analyze-blocking` | `--config` | str | **required** | Config file with matchkeys |
-| `anomalies` | `files` | str | **required** | Input files (path or path:source_name) |
-| `anomalies` | `--sensitivity` | str | `'medium'` | low, medium, or high |
-| `anomalies` | `--output` | str | `None` | Write anomalies to a CSV instead of printing |
-| `anomalies` | `--limit` | int | `50` | Max rows to print |
-| `autoconfig` | `files` | str | **required** | Input files as path or path:source_name |
-| `autoconfig` | `--out` | str | `None` | Write committed config to this path instead of stdout. |
-| `autoconfig` | `--domain` | str | `None` | Pin a domain rulebook (electronics, software, …) instead of auto-detecting. |
+| `agent-serve` | `--port` | integer | `8200` | Port for the A2A server |
+| `agent-serve` | `--host` | text | `'0.0.0.0'` | Host to bind to |
+| `analyze-blocking` | `files` | text | **required** | File(s) to analyze |
+| `analyze-blocking` | `--config` | text | **required** | Config file with matchkeys |
+| `anomalies` | `files` | text | **required** | Input files (path or path:source_name) |
+| `anomalies` | `--sensitivity` | text | `'medium'` | low, medium, or high |
+| `anomalies` | `--output` | text | `None` | Write anomalies to a CSV instead of printing |
+| `anomalies` | `--limit` | integer | `50` | Max rows to print |
+| `autoconfig` | `files` | text | **required** | Input files as path or path:source_name |
+| `autoconfig` | `--out` | text | `None` | Write committed config to this path instead of stdout. |
+| `autoconfig` | `--domain` | text | `None` | Pin a domain rulebook (electronics, software, …) instead of auto-detecting. |
 | `autoconfig` | `--show-controller` | boolean | `True` | Render the controller telemetry panel on stderr. |
 | `autoconfig` | `--verbose` | boolean | `False` | Include indicator priors + decision trace in the panel. |
 | `autoconfig` | `--quiet` | boolean | `False` | Suppress all stderr output (panel + status messages). |
-| `compare-clusters` | `file_a` | str | **required** | First cluster JSON file (baseline / ER1) |
-| `compare-clusters` | `file_b` | str | **required** | Second cluster JSON file (comparison / ER2) |
+| `compare-clusters` | `file_a` | text | **required** | First cluster JSON file (baseline / ER1) |
+| `compare-clusters` | `file_b` | text | **required** | Second cluster JSON file (comparison / ER2) |
 | `compare-clusters` | `--details` | boolean | `False` | Show per-cluster transformation details |
-| `compare-clusters` | `--case-type` | str | `None` | Filter details by case: unchanged, merged, partitioned, overlapping |
+| `compare-clusters` | `--case-type` | text | `None` | Filter details by case: unchanged, merged, partitioned, overlapping |
 | `compare-clusters` | `--output` | path | `None` | Save results to JSON |
-| `config delete` | `name` | str | **required** | Preset name to delete |
-| `config load` | `name` | str | **required** | Preset name to load |
-| `config load` | `--dest` | str | `'goldenmatch.yaml'` | Destination path |
-| `config save` | `name` | str | **required** | Preset name |
-| `config save` | `config_path` | str | **required** | Path to config YAML file |
-| `config show` | `name` | str | **required** | Preset name to display |
-| `dedupe` | `files` | str | **required** | Input files as path or path:source_name |
-| `dedupe` | `--config` | str | `None` | Path to YAML config file (optional - auto-detects if omitted) |
+| `config delete` | `name` | text | **required** | Preset name to delete |
+| `config load` | `name` | text | **required** | Preset name to load |
+| `config load` | `--dest` | text | `'goldenmatch.yaml'` | Destination path |
+| `config save` | `name` | text | **required** | Preset name |
+| `config save` | `config_path` | text | **required** | Path to config YAML file |
+| `config show` | `name` | text | **required** | Preset name to display |
+| `dedupe` | `files` | text | **required** | Input files as path or path:source_name |
+| `dedupe` | `--config` | text | `None` | Path to YAML config file (optional - auto-detects if omitted) |
 | `dedupe` | `--tui` | boolean | `False` | Open the interactive review TUI instead of running directly (auto-config path only). |
 | `dedupe` | `--no-tui` | boolean | `False` | Deprecated: non-interactive is now the default. Accepted for back-compat (no-op). |
-| `dedupe` | `--model` | str | `None` | Override embedding model selection |
+| `dedupe` | `--model` | text | `None` | Override embedding model selection |
 | `dedupe` | `--preview` | boolean | `False` | Preview results without writing files |
-| `dedupe` | `--preview-size` | int | `10000` | Number of records for preview sample |
+| `dedupe` | `--preview-size` | integer | `10000` | Number of records for preview sample |
 | `dedupe` | `--preview-random` | boolean | `False` | Random sample instead of first N |
 | `dedupe` | `--output-golden` | boolean | `False` | Output golden records |
 | `dedupe` | `--output-clusters` | boolean | `False` | Output cluster info |
@@ -623,24 +623,24 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `dedupe` | `--html-report` | boolean | `False` | Generate standalone HTML report |
 | `dedupe` | `--dashboard` | boolean | `False` | Generate before/after data quality dashboard |
 | `dedupe` | `--across-files-only` | boolean | `False` | Only match across different sources |
-| `dedupe` | `--output-dir` | str | `None` | Output directory |
-| `dedupe` | `--format` | str | `None` | Output format (csv, parquet) |
-| `dedupe` | `--run-name` | str | `None` | Run name for output files |
+| `dedupe` | `--output-dir` | text | `None` | Output directory |
+| `dedupe` | `--format` | text | `None` | Output format (csv, parquet) |
+| `dedupe` | `--run-name` | text | `None` | Run name for output files |
 | `dedupe` | `--auto-fix` | boolean | `False` | Run auto-fix before matching |
 | `dedupe` | `--auto-block` | boolean | `False` | Auto-suggest blocking keys |
 | `dedupe` | `--chunked` | boolean | `False` | Large dataset mode - process in chunks for files >1M records |
-| `dedupe` | `--chunk-size` | int | `100000` | Records per chunk in chunked mode |
+| `dedupe` | `--chunk-size` | integer | `100000` | Records per chunk in chunked mode |
 | `dedupe` | `--diff` | boolean | `False` | Generate before/after CSV diff |
 | `dedupe` | `--diff-html` | boolean | `False` | Generate before/after HTML diff with highlighting |
 | `dedupe` | `--merge-preview` | boolean | `False` | Show merge preview (what will change) without writing |
 | `dedupe` | `--anomalies` | boolean | `False` | Detect suspicious/fake records |
-| `dedupe` | `--anomaly-sensitivity` | str | `'medium'` | low, medium, or high |
+| `dedupe` | `--anomaly-sensitivity` | text | `'medium'` | low, medium, or high |
 | `dedupe` | `--llm-boost` | boolean | `False` | Boost accuracy with LLM-labeled training data |
 | `dedupe` | `--llm-retrain` | boolean | `False` | Force re-labeling (ignore saved model) |
-| `dedupe` | `--llm-provider` | str | `None` | LLM provider: auto, anthropic, or openai |
-| `dedupe` | `--llm-max-labels` | int | `500` | Max pairs to label with LLM |
-| `dedupe` | `--backend` | str | `None` | Processing backend: default, bucket, chunked, ray, duckdb |
-| `dedupe` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present. |
+| `dedupe` | `--llm-provider` | text | `None` | LLM provider: auto, anthropic, or openai |
+| `dedupe` | `--llm-max-labels` | integer | `500` | Max pairs to label with LLM |
+| `dedupe` | `--backend` | text | `None` | Processing backend: default, bucket, chunked, ray, duckdb |
+| `dedupe` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present. |
 | `dedupe` | `--show-controller` | boolean | `True` | Render AutoConfigController telemetry (stop_reason, decisions, Path Y) when auto-config ran. No-op for runs with an explicit --config. |
 | `dedupe` | `--suggest` | boolean | `False` | Show verified config-improvement suggestions for this run. |
 | `dedupe` | `--heal` | boolean | `False` | Apply the suggestion heal loop and print the applied trail. |
@@ -651,11 +651,11 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `demo` | `--dashboard` | boolean | `False` | Generate before/after dashboard |
 | `demo` | `--graph` | boolean | `False` | Generate cluster graph |
 | `demo` | `--quiet` | boolean | `False` | Suppress animated output |
-| `evaluate` | `files` | str | **required** | Input files (path or path:source_name) |
+| `evaluate` | `files` | text | **required** | Input files (path or path:source_name) |
 | `evaluate` | `--config` | path | **required** | Config YAML path |
 | `evaluate` | `--ground-truth` | path | `None` | Ground truth CSV path (required unless --certify) |
-| `evaluate` | `--col-a` | str | `'id_a'` | Ground truth column A |
-| `evaluate` | `--col-b` | str | `'id_b'` | Ground truth column B |
+| `evaluate` | `--col-a` | text | `'id_a'` | Ground truth column A |
+| `evaluate` | `--col-b` | text | `'id_b'` | Ground truth column B |
 | `evaluate` | `--threshold` | float | `None` | Override match threshold |
 | `evaluate` | `--output` | path | `None` | Save results to JSON |
 | `evaluate` | `--min-f1` | float | `None` | Minimum F1 score (exit code 1 if below). For CI/CD quality gates. |
@@ -664,207 +664,207 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `evaluate` | `--certify` | boolean | `False` | Estimate recall WITHOUT ground truth (unsupervised, via capture-recapture over the config's matchkeys/passes; needs >=3). |
 | `evaluate` | `--audit-out` | path | `None` | With --certify: emit a stratified audit sample CSV to label for a SAFE recall lower bound. |
 | `evaluate` | `--audit-in` | path | `None` | With --certify: read a labelled audit sample and print the audit-calibrated SAFE lower bound. |
-| `evaluate` | `--audit-n` | int | `50` | Audit samples per stratum (default 50). |
+| `evaluate` | `--audit-n` | integer | `50` | Audit samples per stratum (default 50). |
 | `evaluate` | `--threshold-sweep` | boolean | `False` | Sweep the link threshold over scored pairs: P/R/F1 table + recommended cut (+ Fellegi-Sunter m/u model report when a probabilistic matchkey ran). |
-| `explain` | `files` | str | **required** | Input files (path or path:source_name) |
+| `explain` | `files` | text | **required** | Input files (path or path:source_name) |
 | `explain` | `--config` | path | **required** | Config YAML path |
-| `explain` | `--pair` | str | `None` | Explain a pair: 'id_a,id_b' |
-| `explain` | `--cluster` | int | `None` | Explain a cluster by id |
-| `identity conflicts` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity conflicts` | `--dataset` | str | `None` | Filter to identities in this dataset. |
+| `explain` | `--pair` | text | `None` | Explain a pair: 'id_a,id_b' |
+| `explain` | `--cluster` | integer | `None` | Explain a cluster by id |
+| `identity conflicts` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity conflicts` | `--dataset` | text | `None` | Filter to identities in this dataset. |
 | `identity conflicts` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity history` | `entity_id` | str | **required** | The entity_id of the identity to operate on. |
-| `identity history` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity history` | `--limit` | int | `50` | Maximum number of events to return. |
+| `identity history` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
+| `identity history` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity history` | `--limit` | integer | `50` | Maximum number of events to return. |
 | `identity history` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity list` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity list` | `--dataset` | str | `None` | Filter to identities in this dataset. |
-| `identity list` | `--status` | str | `None` | Filter to identities with this status. |
-| `identity list` | `--limit` | int | `50` | Maximum number of identities to return. |
-| `identity list` | `--offset` | int | `0` | Number of identities to skip for pagination. |
+| `identity list` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity list` | `--dataset` | text | `None` | Filter to identities in this dataset. |
+| `identity list` | `--status` | text | `None` | Filter to identities with this status. |
+| `identity list` | `--limit` | integer | `50` | Maximum number of identities to return. |
+| `identity list` | `--offset` | integer | `0` | Number of identities to skip for pagination. |
 | `identity list` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity merge` | `keep` | str | **required** | entity_id to keep |
-| `identity merge` | `absorb` | str | **required** | entity_id to absorb |
-| `identity merge` | `--reason` | str | `None` | Optional reason recorded in the event log. |
-| `identity merge` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity migrate` | `--dsn` | str | **required** | Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN. |
+| `identity merge` | `keep` | text | **required** | entity_id to keep |
+| `identity merge` | `absorb` | text | **required** | entity_id to absorb |
+| `identity merge` | `--reason` | text | `None` | Optional reason recorded in the event log. |
+| `identity merge` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity migrate` | `--dsn` | text | **required** | Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN. |
 | `identity migrate` | `--stamp-existing` | boolean | `False` | Stamp an existing v1 schema at revision 0001 without re-creating tables. |
-| `identity migrate` | `--revision` | str | `'head'` | Target revision (default: head). |
-| `identity migrate-ids` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `identity migrate-ids` | `--dsn` | str | `None` | Database connection string for the identity store. |
+| `identity migrate` | `--revision` | text | `'head'` | Target revision (default: head). |
+| `identity migrate-ids` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity migrate-ids` | `--dsn` | text | `None` | Database connection string for the identity store. |
 | `identity migrate-ids` | `--dry-run` | boolean | `False` | Report what would change; mutate nothing. |
-| `identity resolve` | `record_id` | str | **required** | `&#123;source&#125;:&#123;pk&#125;` to look up |
-| `identity resolve` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity resolve` | `record_id` | text | **required** | `&#123;source&#125;:&#123;pk&#125;` to look up |
+| `identity resolve` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
 | `identity resolve` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity show` | `entity_id` | str | **required** | The entity_id of the identity to operate on. |
-| `identity show` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity show` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
+| `identity show` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
 | `identity show` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
-| `identity split` | `entity_id` | str | **required** | The entity_id of the identity to operate on. |
-| `identity split` | `record_ids` | str | **required** | record_ids to move to a new identity |
-| `identity split` | `--reason` | str | `None` | Optional reason recorded in the event log. |
-| `identity split` | `--path` | str | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
-| `import-splink` | `input_path` | str | **required** | Splink settings or trained-model JSON file |
-| `import-splink` | `--output` | str | `'goldenmatch.yaml'` | Output YAML config path |
-| `import-splink` | `--model-out` | str | `None` | Persist imported trained m/u as an FS model JSON; sets model_path in the config |
+| `identity split` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
+| `identity split` | `record_ids` | text | **required** | record_ids to move to a new identity |
+| `identity split` | `--reason` | text | `None` | Optional reason recorded in the event log. |
+| `identity split` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `import-splink` | `input_path` | text | **required** | Splink settings or trained-model JSON file |
+| `import-splink` | `--output` | text | `'goldenmatch.yaml'` | Output YAML config path |
+| `import-splink` | `--model-out` | text | `None` | Persist imported trained m/u as an FS model JSON; sets model_path in the config |
 | `import-splink` | `--strict` | boolean | `False` | Fail on any lossy mapping (warnings), not just errors |
-| `import-splink` | `--upgrade` | str | `None` | Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json. |
-| `import-splink` | `--splink-clusters` | str | `None` | Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id. |
-| `import-splink` | `--labels` | str | `None` | Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id. |
-| `import-splink` | `--sample-cap` | int | `100000` | Row cap for --upgrade lever computation and measurement (seeded subsample above it) |
+| `import-splink` | `--upgrade` | text | `None` | Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json. |
+| `import-splink` | `--splink-clusters` | text | `None` | Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id. |
+| `import-splink` | `--labels` | text | `None` | Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id. |
+| `import-splink` | `--sample-cap` | integer | `100000` | Row cap for --upgrade lever computation and measurement (seeded subsample above it) |
 | `import-splink` | `--no-measure` | boolean | `False` | Skip the baseline-vs-upgraded measurement pass |
-| `import-splink` | `--id-column` | str | `None` | Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id) |
-| `incremental` | `base_file` | str | **required** | Base dataset file path |
+| `import-splink` | `--id-column` | text | `None` | Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id) |
+| `incremental` | `base_file` | text | **required** | Base dataset file path |
 | `incremental` | `--new-records` | path | **required** | New records CSV to match |
 | `incremental` | `--config` | path | **required** | Config YAML path |
 | `incremental` | `--output` | path | `None` | Output CSV path |
 | `incremental` | `--threshold` | float | `None` | Override threshold |
-| `incremental` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
-| `ingest-docs run` | `docs` | str | **required** | Document paths (PDF/image). |
-| `ingest-docs run` | `--schema` | str | **required** | Target schema JSON file. |
-| `ingest-docs run` | `--out` | str | **required** | Write records here (.csv or .parquet). |
-| `ingest-docs run` | `--backend` | str | `'vlm'` | Extraction backend. |
-| `ingest-docs run` | `--model` | str | `'gpt-4o'` | Vision model. |
-| `ingest-docs suggest-schema` | `sample` | str | **required** | A representative document (PDF/image). |
-| `ingest-docs suggest-schema` | `--out` | str | **required** | Write the proposed schema JSON here. |
-| `ingest-docs suggest-schema` | `--backend` | str | `'vlm'` | Extraction backend. |
-| `ingest-docs suggest-schema` | `--model` | str | `'gpt-4o'` | Vision model. |
-| `init` | `--output` | str | `None` | Output path for generated config |
-| `interactive` | `files` | str | **required** | File(s) to load |
-| `label` | `files` | str | **required** | Input files (path or path:source_name) |
+| `incremental` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
+| `ingest-docs run` | `docs` | text | **required** | Document paths (PDF/image). |
+| `ingest-docs run` | `--schema` | text | **required** | Target schema JSON file. |
+| `ingest-docs run` | `--out` | text | **required** | Write records here (.csv or .parquet). |
+| `ingest-docs run` | `--backend` | text | `'vlm'` | Extraction backend. |
+| `ingest-docs run` | `--model` | text | `'gpt-4o'` | Vision model. |
+| `ingest-docs suggest-schema` | `sample` | text | **required** | A representative document (PDF/image). |
+| `ingest-docs suggest-schema` | `--out` | text | **required** | Write the proposed schema JSON here. |
+| `ingest-docs suggest-schema` | `--backend` | text | `'vlm'` | Extraction backend. |
+| `ingest-docs suggest-schema` | `--model` | text | `'gpt-4o'` | Vision model. |
+| `init` | `--output` | text | `None` | Output path for generated config |
+| `interactive` | `files` | text | **required** | File(s) to load |
+| `label` | `files` | text | **required** | Input files (path or path:source_name) |
 | `label` | `--config` | path | **required** | Config YAML path |
 | `label` | `--output` | path | `'ground_truth.csv'` | Output ground truth CSV |
-| `label` | `--n` | int | `50` | Number of pairs to label |
-| `label` | `--strategy` | str | `'borderline'` | Pair selection: borderline, random, or hardest |
+| `label` | `--n` | integer | `50` | Number of pairs to label |
+| `label` | `--strategy` | text | `'borderline'` | Pair selection: borderline, random, or hardest |
 | `label` | `--append` | boolean | `False` | Append to existing ground truth file |
-| `lineage` | `files` | str | **required** | Input files (path or path:source_name) |
+| `lineage` | `files` | text | **required** | Input files (path or path:source_name) |
 | `lineage` | `--config` | path | **required** | Config YAML path |
-| `lineage` | `--output-dir` | str | `None` | Write lineage.json here (default: print a summary) |
-| `lineage` | `--run-name` | str | `'lineage'` | Run name for the lineage file |
-| `lineage` | `--max-pairs` | int | `10000` | Cap on lineage records (0 = no cap) |
+| `lineage` | `--output-dir` | text | `None` | Write lineage.json here (default: print a summary) |
+| `lineage` | `--run-name` | text | `'lineage'` | Run name for the lineage file |
+| `lineage` | `--max-pairs` | integer | `10000` | Cap on lineage records (0 = no cap) |
 | `lineage` | `--nl` | boolean | `False` | Include natural-language explanations |
-| `match` | `target` | str | **required** | Target file as path or path:source_name |
-| `match` | `--against` | str | **required** | Reference files as path or path:source_name |
-| `match` | `--config` | str | `None` | Path to YAML config file (optional - auto-detects if omitted) |
+| `match` | `target` | text | **required** | Target file as path or path:source_name |
+| `match` | `--against` | text | **required** | Reference files as path or path:source_name |
+| `match` | `--config` | text | `None` | Path to YAML config file (optional - auto-detects if omitted) |
 | `match` | `--preview` | boolean | `False` | Preview results without writing files |
-| `match` | `--preview-size` | int | `10000` | Number of records for preview sample |
+| `match` | `--preview-size` | integer | `10000` | Number of records for preview sample |
 | `match` | `--preview-random` | boolean | `False` | Random sample instead of first N |
 | `match` | `--output-matched` | boolean | `False` | Output matched records |
 | `match` | `--output-unmatched` | boolean | `False` | Output unmatched records |
 | `match` | `--output-scores` | boolean | `False` | Output score details |
 | `match` | `--output-all` | boolean | `False` | Output all result types |
 | `match` | `--output-report` | boolean | `False` | Generate summary report |
-| `match` | `--match-mode` | str | `'best'` | Match mode: best or all |
-| `match` | `--output-dir` | str | `None` | Output directory |
-| `match` | `--format` | str | `None` | Output format (csv, parquet) |
-| `match` | `--run-name` | str | `None` | Run name for output files |
+| `match` | `--match-mode` | text | `'best'` | Match mode: best or all |
+| `match` | `--output-dir` | text | `None` | Output directory |
+| `match` | `--format` | text | `None` | Output format (csv, parquet) |
+| `match` | `--run-name` | text | `None` | Run name for output files |
 | `match` | `--auto-fix` | boolean | `False` | Run auto-fix before matching |
 | `match` | `--auto-block` | boolean | `False` | Auto-suggest blocking keys |
-| `match` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
+| `match` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. |
 | `match` | `--verbose` | boolean | `False` | Verbose output |
 | `match` | `--quiet` | boolean | `False` | Suppress output |
-| `mcp-serve` | `files` | str | `None` | Data files to load |
-| `mcp-serve` | `--config` | str | `None` | Config YAML file |
-| `mcp-serve` | `--transport` | str | `'stdio'` | Transport: stdio or http |
-| `mcp-serve` | `--host` | str | `'0.0.0.0'` | HTTP host (only for http transport) |
-| `mcp-serve` | `--port` | int | `8200` | HTTP port (only for http transport) |
-| `memory add` | `--decision` | str | **required** | approve \| reject \| field_correct |
-| `memory add` | `--dataset` | str | **required** | Dataset key (required) |
-| `memory add` | `--id-a` | int | `None` | Pair-level: first row id |
-| `memory add` | `--id-b` | int | `None` | Pair-level: second row id |
-| `memory add` | `--cluster-id` | int | `None` | Field-level: cluster id the correction targets |
-| `memory add` | `--field-name` | str | `None` | Field-level: column being corrected |
-| `memory add` | `--original-value` | str | `None` | Field-level: original chosen value |
-| `memory add` | `--corrected-value` | str | `None` | Field-level: the value the reviewer changed it to |
-| `memory add` | `--reason` | str | `None` | Optional reason |
-| `memory add` | `--matchkey-name` | str | `None` | Optional matchkey scope |
-| `memory add` | `--source` | str | `'steward'` | Source: steward (1.0 trust) \| agent (0.5) \| boost \| unmerge |
-| `memory add` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory export` | `out` | str | **required** | Output CSV path |
-| `memory export` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory import` | `src` | str | **required** | Source CSV path |
-| `memory import` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory learn` | `--matchkey-name` | str | `None` | Limit learning to this matchkey |
-| `memory learn` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory show` | `id_a` | int | **required** | First record ID |
-| `memory show` | `id_b` | int | **required** | Second record ID |
-| `memory show` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
-| `memory stats` | `--path` | str | `'.goldenmatch/memory.db'` | Memory DB path |
+| `mcp-serve` | `files` | text | `None` | Data files to load |
+| `mcp-serve` | `--config` | text | `None` | Config YAML file |
+| `mcp-serve` | `--transport` | text | `'stdio'` | Transport: stdio or http |
+| `mcp-serve` | `--host` | text | `'0.0.0.0'` | HTTP host (only for http transport) |
+| `mcp-serve` | `--port` | integer | `8200` | HTTP port (only for http transport) |
+| `memory add` | `--decision` | text | **required** | approve \| reject \| field_correct |
+| `memory add` | `--dataset` | text | **required** | Dataset key (required) |
+| `memory add` | `--id-a` | integer | `None` | Pair-level: first row id |
+| `memory add` | `--id-b` | integer | `None` | Pair-level: second row id |
+| `memory add` | `--cluster-id` | integer | `None` | Field-level: cluster id the correction targets |
+| `memory add` | `--field-name` | text | `None` | Field-level: column being corrected |
+| `memory add` | `--original-value` | text | `None` | Field-level: original chosen value |
+| `memory add` | `--corrected-value` | text | `None` | Field-level: the value the reviewer changed it to |
+| `memory add` | `--reason` | text | `None` | Optional reason |
+| `memory add` | `--matchkey-name` | text | `None` | Optional matchkey scope |
+| `memory add` | `--source` | text | `'steward'` | Source: steward (1.0 trust) \| agent (0.5) \| boost \| unmerge |
+| `memory add` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory export` | `out` | text | **required** | Output CSV path |
+| `memory export` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory import` | `src` | text | **required** | Source CSV path |
+| `memory import` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory learn` | `--matchkey-name` | text | `None` | Limit learning to this matchkey |
+| `memory learn` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory show` | `id_a` | integer | **required** | First record ID |
+| `memory show` | `id_b` | integer | **required** | Second record ID |
+| `memory show` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
+| `memory stats` | `--path` | text | `'.goldenmatch/memory.db'` | Memory DB path |
 | `pprl auto-config` | `file` | path | **required** | Data file to analyze (CSV) |
-| `pprl auto-config` | `--security` | str | `'high'` | Security level: standard, high, paranoid |
+| `pprl auto-config` | `--security` | text | `'high'` | Security level: standard, high, paranoid |
 | `pprl auto-config` | `--llm` | boolean | `False` | Use LLM for enhanced recommendations |
 | `pprl link` | `--file-a` | path | **required** | Party A data file (CSV) |
 | `pprl link` | `--file-b` | path | **required** | Party B data file (CSV) |
-| `pprl link` | `--fields` | str | **required** | Comma-separated field names to match on |
+| `pprl link` | `--fields` | text | **required** | Comma-separated field names to match on |
 | `pprl link` | `--threshold` | float | `0.85` | Match threshold |
-| `pprl link` | `--security` | str | `'high'` | Security level: standard, high, paranoid |
-| `pprl link` | `--protocol` | str | `'trusted_third_party'` | Protocol: trusted_third_party or smc |
-| `pprl link` | `--scorer` | str | `'dice'` | Similarity scorer: dice or jaccard |
+| `pprl link` | `--security` | text | `'high'` | Security level: standard, high, paranoid |
+| `pprl link` | `--protocol` | text | `'trusted_third_party'` | Protocol: trusted_third_party or smc |
+| `pprl link` | `--scorer` | text | `'dice'` | Similarity scorer: dice or jaccard |
 | `pprl link` | `--output` | path | `None` | Output CSV path for cluster assignments |
-| `pprl link` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them. |
-| `profile` | `files` | str | **required** | File(s) to profile |
+| `pprl link` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them. |
+| `profile` | `files` | text | **required** | File(s) to profile |
 | `profile` | `--verbose` | boolean | `False` | Show detailed per-column info |
 | `profile` | `--suggest-fixes` | boolean | `False` | Show what auto-fix would do (dry run) |
 | `profile` | `--exclusions` | boolean | `False` | Show GoldenCheck auto-config column exclusions (#404). Lists columns auto-config will skip (audit timestamps, foreign IDs, sentinel values, etc) and why. |
-| `review` | `files` | str | `None` | Input files (path or path:source_name). Omit to review only the pending queue. |
+| `review` | `files` | text | `None` | Input files (path or path:source_name). Omit to review only the pending queue. |
 | `review` | `--config` | path | **required** | Config YAML path |
-| `review` | `--job` | str | `'review'` | Review-queue job name for freshly-gated pairs |
-| `review` | `--queue-path` | str | `None` | SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db) |
-| `review` | `--memory-path` | str | `'.goldenmatch/memory.db'` | Learning Memory SQLite path |
+| `review` | `--job` | text | `'review'` | Review-queue job name for freshly-gated pairs |
+| `review` | `--queue-path` | text | `None` | SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db) |
+| `review` | `--memory-path` | text | `'.goldenmatch/memory.db'` | Learning Memory SQLite path |
 | `review` | `--merge-threshold` | float | `0.95` | Scores above this auto-merge (skip review) |
 | `review` | `--review-threshold` | float | `0.75` | Scores >= this go to review |
-| `review` | `--decided-by` | str | `'cli'` | Steward identifier recorded on each decision |
-| `review` | `--limit` | int | `50` | Max pairs to review this session |
-| `rollback` | `run_id` | str | **required** | Run ID to rollback |
-| `rollback` | `--output-dir` | str | `'.'` | Directory containing run log |
-| `runs` | `--output-dir` | str | `'.'` | Directory containing run log |
-| `schedule` | `files` | str | **required** | Data files to process |
-| `schedule` | `--config` | str | `None` | Config YAML file |
-| `schedule` | `--every` | str | `None` | Run interval (e.g. 1h, 30m, 6h, 1d) |
-| `schedule` | `--cron` | str | `None` | Cron schedule (e.g. '0 6 * * *') |
-| `schedule` | `--output-dir` | str | `'.'` | Output directory |
-| `score` | `a` | str | **required** | First string. |
-| `score` | `b` | str | **required** | Second string. |
-| `score` | `--scorer` | str | `'jaro_winkler'` | Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble. |
-| `sensitivity` | `files` | str | **required** | Input files (path or path:source_name) |
+| `review` | `--decided-by` | text | `'cli'` | Steward identifier recorded on each decision |
+| `review` | `--limit` | integer | `50` | Max pairs to review this session |
+| `rollback` | `run_id` | text | **required** | Run ID to rollback |
+| `rollback` | `--output-dir` | text | `'.'` | Directory containing run log |
+| `runs` | `--output-dir` | text | `'.'` | Directory containing run log |
+| `schedule` | `files` | text | **required** | Data files to process |
+| `schedule` | `--config` | text | `None` | Config YAML file |
+| `schedule` | `--every` | text | `None` | Run interval (e.g. 1h, 30m, 6h, 1d) |
+| `schedule` | `--cron` | text | `None` | Cron schedule (e.g. '0 6 * * *') |
+| `schedule` | `--output-dir` | text | `'.'` | Output directory |
+| `score` | `a` | text | **required** | First string. |
+| `score` | `b` | text | **required** | Second string. |
+| `score` | `--scorer` | text | `'jaro_winkler'` | Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble. |
+| `sensitivity` | `files` | text | **required** | Input files (path or path:source_name) |
 | `sensitivity` | `--config` | path | **required** | Config YAML path |
-| `sensitivity` | `--sweep` | str | **required** | Sweep spec: field:start:stop:step (repeatable) |
-| `sensitivity` | `--sample` | int | `None` | Random sample size for speed |
+| `sensitivity` | `--sweep` | text | **required** | Sweep spec: field:start:stop:step (repeatable) |
+| `sensitivity` | `--sample` | integer | `None` | Random sample size for speed |
 | `sensitivity` | `--output` | path | `None` | Save results to JSON |
-| `serve` | `files` | str | **required** | Data files to load |
-| `serve` | `--config` | str | `None` | Config YAML file |
-| `serve` | `--host` | str | `'127.0.0.1'` | Server host |
-| `serve` | `--port` | int | `8080` | Server port |
+| `serve` | `files` | text | **required** | Data files to load |
+| `serve` | `--config` | text | `None` | Config YAML file |
+| `serve` | `--host` | text | `'127.0.0.1'` | Server host |
+| `serve` | `--port` | integer | `8080` | Server port |
 | `serve-ui` | `path` | path | `None` | Optional run dir or project dir. |
-| `serve-ui` | `--host` | str | `'127.0.0.1'` | Host to bind. |
-| `serve-ui` | `--port` | int | `5050` | Port (0 = pick free, default 5050 matches Vite proxy). |
+| `serve-ui` | `--host` | text | `'127.0.0.1'` | Host to bind. |
+| `serve-ui` | `--port` | integer | `5050` | Port (0 = pick free, default 5050 matches Vite proxy). |
 | `serve-ui` | `--dev` | boolean | `False` | Skip static; expect Vite at :5173. |
 | `serve-ui` | `--open` | boolean | `True` | Open the UI in a browser once the server starts. |
-| `sync` | `--source-type` | str | `'postgres'` | Database type |
-| `sync` | `--connection-string` | str | `None` | Database URL |
-| `sync` | `--table` | str | **required** | Source table name |
-| `sync` | `--config` | str | `None` | Config YAML file |
-| `sync` | `--output-mode` | str | `'separate'` | separate or in_place |
+| `sync` | `--source-type` | text | `'postgres'` | Database type |
+| `sync` | `--connection-string` | text | `None` | Database URL |
+| `sync` | `--table` | text | **required** | Source table name |
+| `sync` | `--config` | text | `None` | Config YAML file |
+| `sync` | `--output-mode` | text | `'separate'` | separate or in_place |
 | `sync` | `--full-rescan` | boolean | `False` | Force full rescan |
 | `sync` | `--dry-run` | boolean | `False` | Match without writing results |
-| `sync` | `--incremental-column` | str | `None` | Column for incremental detection |
-| `sync` | `--chunk-size` | int | `10000` | Records per chunk |
-| `sync` | `--exclude-columns` | str | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set. |
+| `sync` | `--incremental-column` | text | `None` | Column for incremental detection |
+| `sync` | `--chunk-size` | integer | `10000` | Records per chunk |
+| `sync` | `--exclude-columns` | text | `None` | Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set. |
 | `sync` | `--verbose` | boolean | `False` | Enable debug-level logging output. |
 | `sync` | `--quiet` | boolean | `False` | Suppress informational output. |
-| `tui` | `files` | str | **required** | File(s) to load |
-| `unmerge` | `record_id` | int | **required** | Record row ID to unmerge from its cluster |
-| `unmerge` | `--clusters` | str | `None` | Path to clusters CSV from a previous run |
-| `unmerge` | `--pairs` | str | `None` | Path to scored pairs CSV (id_a,id_b,score) |
+| `tui` | `files` | text | **required** | File(s) to load |
+| `unmerge` | `record_id` | integer | **required** | Record row ID to unmerge from its cluster |
+| `unmerge` | `--clusters` | text | `None` | Path to clusters CSV from a previous run |
+| `unmerge` | `--pairs` | text | `None` | Path to scored pairs CSV (id_a,id_b,score) |
 | `unmerge` | `--shatter` | boolean | `False` | Shatter the entire cluster into singletons |
 | `unmerge` | `--threshold` | float | `0.0` | Min score threshold for re-clustering |
-| `unmerge` | `--output` | str | `None` | Where to write the re-clustered CSV (default: &lt;clusters>.unmerged.csv) |
-| `watch` | `--source-type` | str | `'postgres'` | Database type |
-| `watch` | `--connection-string` | str | `None` | Database URL |
-| `watch` | `--table` | str | **required** | Table to watch |
-| `watch` | `--config` | str | `None` | Config YAML file |
-| `watch` | `--interval` | int | `30` | Seconds between polls |
-| `watch` | `--output-mode` | str | `'separate'` | separate or in_place |
-| `watch` | `--incremental-column` | str | `None` | Column for change detection |
+| `unmerge` | `--output` | text | `None` | Where to write the re-clustered CSV (default: &lt;clusters>.unmerged.csv) |
+| `watch` | `--source-type` | text | `'postgres'` | Database type |
+| `watch` | `--connection-string` | text | `None` | Database URL |
+| `watch` | `--table` | text | **required** | Table to watch |
+| `watch` | `--config` | text | `None` | Config YAML file |
+| `watch` | `--interval` | integer | `30` | Seconds between polls |
+| `watch` | `--output-mode` | text | `'separate'` | separate or in_place |
+| `watch` | `--incremental-column` | text | `None` | Column for change detection |
 
 ## MCP tools
 

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.19.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.20.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 82 | 201 | 47 | 36 | Yes | Yes |
+| `goldenmatch` | 82 | 201 | 47 | 37 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
@@ -41,8 +41,8 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 72 | 10 | 8 |
-| `goldenmatch` | cli_commands | 19 | 17 | 1 |
+| `goldenmatch` | mcp_tools | 75 | 7 | 8 |
+| `goldenmatch` | cli_commands | 21 | 16 | 0 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -63,10 +63,9 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `create_domain`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_domains`, `list_plugins`, `plan_routing`, `pprl_auto_config`, `test_domain`.
+- `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
 - `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
-- `goldenmatch` **cli_commands** — Python-only: `anomalies`, `config`, `ingest-docs`, `init`, `interactive`, `label`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
-- `goldenmatch` **cli_commands** — TS-only: `tui`.
+- `goldenmatch` **cli_commands** — Python-only: `anomalies`, `config`, `ingest-docs`, `init`, `label`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — Python-only: `date_diff`, `geo_haversine`, `numeric_diff`.

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2172,14 +2172,14 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8200",
               "help": "Port for the A2A server"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to"
@@ -2191,13 +2191,13 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "File(s) to analyze"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Config file with matchkeys"
             }
@@ -2208,27 +2208,27 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
             {
               "name": "--sensitivity",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Write anomalies to a CSV instead of printing"
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Max rows to print"
@@ -2240,20 +2240,20 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--out",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Write committed config to this path instead of stdout."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Pin a domain rulebook (electronics, software, …) instead of auto-detecting."
@@ -2286,13 +2286,13 @@
           "options": [
             {
               "name": "file_a",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "First cluster JSON file (baseline / ER1)"
             },
             {
               "name": "file_b",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Second cluster JSON file (comparison / ER2)"
             },
@@ -2305,7 +2305,7 @@
             },
             {
               "name": "--case-type",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter details by case: unchanged, merged, partitioned, overlapping"
@@ -2324,7 +2324,7 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name to delete"
             }
@@ -2339,13 +2339,13 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name to load"
             },
             {
               "name": "--dest",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Destination path"
@@ -2357,13 +2357,13 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name"
             },
             {
               "name": "config_path",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Path to config YAML file"
             }
@@ -2374,7 +2374,7 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name to display"
             }
@@ -2385,13 +2385,13 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -2412,7 +2412,7 @@
             },
             {
               "name": "--model",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Override embedding model selection"
@@ -2426,7 +2426,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -2503,21 +2503,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -2545,7 +2545,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Records per chunk in chunked mode"
@@ -2580,7 +2580,7 @@
             },
             {
               "name": "--anomaly-sensitivity",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
@@ -2601,28 +2601,28 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "LLM provider: auto, anthropic, or openai"
             },
             {
               "name": "--llm-max-labels",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "500",
               "help": "Max pairs to label with LLM"
             },
             {
               "name": "--backend",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Processing backend: default, bucket, chunked, ray, duckdb"
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present."
@@ -2709,7 +2709,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2728,14 +2728,14 @@
             },
             {
               "name": "--col-a",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'id_a'",
               "help": "Ground truth column A"
             },
             {
               "name": "--col-b",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'id_b'",
               "help": "Ground truth column B"
@@ -2798,7 +2798,7 @@
             },
             {
               "name": "--audit-n",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Audit samples per stratum (default 50)."
@@ -2817,7 +2817,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2829,14 +2829,14 @@
             },
             {
               "name": "--pair",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Explain a pair: 'id_a,id_b'"
             },
             {
               "name": "--cluster",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Explain a cluster by id"
@@ -2848,14 +2848,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
@@ -2874,20 +2874,20 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Maximum number of events to return."
@@ -2906,35 +2906,35 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
             },
             {
               "name": "--status",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter to identities with this status."
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Maximum number of identities to return."
             },
             {
               "name": "--offset",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "0",
               "help": "Number of identities to skip for pagination."
@@ -2953,26 +2953,26 @@
           "options": [
             {
               "name": "keep",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "entity_id to keep"
             },
             {
               "name": "absorb",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "entity_id to absorb"
             },
             {
               "name": "--reason",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -2984,7 +2984,7 @@
           "options": [
             {
               "name": "--dsn",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN."
             },
@@ -2997,7 +2997,7 @@
             },
             {
               "name": "--revision",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'head'",
               "help": "Target revision (default: head)."
@@ -3009,14 +3009,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dsn",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Database connection string for the identity store."
@@ -3035,13 +3035,13 @@
           "options": [
             {
               "name": "record_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "`{source}:{pk}` to look up"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3060,13 +3060,13 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3085,26 +3085,26 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "record_ids",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "record_ids to move to a new identity"
             },
             {
               "name": "--reason",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3116,20 +3116,20 @@
           "options": [
             {
               "name": "input_path",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Splink settings or trained-model JSON file"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Output YAML config path"
             },
             {
               "name": "--model-out",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Persist imported trained m/u as an FS model JSON; sets model_path in the config"
@@ -3143,28 +3143,28 @@
             },
             {
               "name": "--upgrade",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json."
             },
             {
               "name": "--splink-clusters",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--labels",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--sample-cap",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Row cap for --upgrade lever computation and measurement (seeded subsample above it)"
@@ -3178,7 +3178,7 @@
             },
             {
               "name": "--id-column",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
@@ -3190,7 +3190,7 @@
           "options": [
             {
               "name": "base_file",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Base dataset file path"
             },
@@ -3222,7 +3222,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3238,32 +3238,32 @@
           "options": [
             {
               "name": "docs",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Document paths (PDF/image)."
             },
             {
               "name": "--schema",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Target schema JSON file."
             },
             {
               "name": "--out",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Write records here (.csv or .parquet)."
             },
             {
               "name": "--backend",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3275,26 +3275,26 @@
           "options": [
             {
               "name": "sample",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "A representative document (PDF/image)."
             },
             {
               "name": "--out",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Write the proposed schema JSON here."
             },
             {
               "name": "--backend",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3306,7 +3306,7 @@
           "options": [
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output path for generated config"
@@ -3318,7 +3318,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "File(s) to load"
             }
@@ -3329,7 +3329,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3348,14 +3348,14 @@
             },
             {
               "name": "--n",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Number of pairs to label"
             },
             {
               "name": "--strategy",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'borderline'",
               "help": "Pair selection: borderline, random, or hardest"
@@ -3374,7 +3374,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3386,21 +3386,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Write lineage.json here (default: print a summary)"
             },
             {
               "name": "--run-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'lineage'",
               "help": "Run name for the lineage file"
             },
             {
               "name": "--max-pairs",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Cap on lineage records (0 = no cap)"
@@ -3419,19 +3419,19 @@
           "options": [
             {
               "name": "target",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Target file as path or path:source_name"
             },
             {
               "name": "--against",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Reference files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -3445,7 +3445,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -3494,28 +3494,28 @@
             },
             {
               "name": "--match-mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'best'",
               "help": "Match mode: best or all"
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -3536,7 +3536,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3562,35 +3562,35 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "HTTP host (only for http transport)"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8200",
               "help": "HTTP port (only for http transport)"
@@ -3602,82 +3602,82 @@
           "options": [
             {
               "name": "--decision",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "approve | reject | field_correct"
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Dataset key (required)"
             },
             {
               "name": "--id-a",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Pair-level: first row id"
             },
             {
               "name": "--id-b",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Pair-level: second row id"
             },
             {
               "name": "--cluster-id",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Field-level: cluster id the correction targets"
             },
             {
               "name": "--field-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Field-level: column being corrected"
             },
             {
               "name": "--original-value",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Field-level: original chosen value"
             },
             {
               "name": "--corrected-value",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Field-level: the value the reviewer changed it to"
             },
             {
               "name": "--reason",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reason"
             },
             {
               "name": "--matchkey-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional matchkey scope"
             },
             {
               "name": "--source",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'steward'",
               "help": "Source: steward (1.0 trust) | agent (0.5) | boost | unmerge"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3689,13 +3689,13 @@
           "options": [
             {
               "name": "out",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Output CSV path"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3707,13 +3707,13 @@
           "options": [
             {
               "name": "src",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source CSV path"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3725,14 +3725,14 @@
           "options": [
             {
               "name": "--matchkey-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Limit learning to this matchkey"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3744,19 +3744,19 @@
           "options": [
             {
               "name": "id_a",
-              "type": "integer",
+              "type": "int",
               "required": true,
               "help": "First record ID"
             },
             {
               "name": "id_b",
-              "type": "integer",
+              "type": "int",
               "required": true,
               "help": "Second record ID"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3768,7 +3768,7 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3786,7 +3786,7 @@
             },
             {
               "name": "--security",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
@@ -3817,7 +3817,7 @@
             },
             {
               "name": "--fields",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Comma-separated field names to match on"
             },
@@ -3830,21 +3830,21 @@
             },
             {
               "name": "--security",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
             },
             {
               "name": "--protocol",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'trusted_third_party'",
               "help": "Protocol: trusted_third_party or smc"
             },
             {
               "name": "--scorer",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'dice'",
               "help": "Similarity scorer: dice or jaccard"
@@ -3858,7 +3858,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them."
@@ -3870,7 +3870,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "File(s) to profile"
             },
@@ -3902,7 +3902,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Input files (path or path:source_name). Omit to review only the pending queue."
@@ -3915,21 +3915,21 @@
             },
             {
               "name": "--job",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'review'",
               "help": "Review-queue job name for freshly-gated pairs"
             },
             {
               "name": "--queue-path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db)"
             },
             {
               "name": "--memory-path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Learning Memory SQLite path"
@@ -3950,14 +3950,14 @@
             },
             {
               "name": "--decided-by",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'cli'",
               "help": "Steward identifier recorded on each decision"
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Max pairs to review this session"
@@ -3969,13 +3969,13 @@
           "options": [
             {
               "name": "run_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Run ID to rollback"
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3987,7 +3987,7 @@
           "options": [
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3999,34 +3999,34 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Data files to process"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--every",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run interval (e.g. 1h, 30m, 6h, 1d)"
             },
             {
               "name": "--cron",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Cron schedule (e.g. '0 6 * * *')"
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Output directory"
@@ -4038,19 +4038,19 @@
           "options": [
             {
               "name": "a",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "First string."
             },
             {
               "name": "b",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Second string."
             },
             {
               "name": "--scorer",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'jaro_winkler'",
               "help": "Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble."
@@ -4062,7 +4062,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -4074,13 +4074,13 @@
             },
             {
               "name": "--sweep",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Sweep spec: field:start:stop:step (repeatable)"
             },
             {
               "name": "--sample",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Random sample size for speed"
@@ -4099,27 +4099,27 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Server host"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8080",
               "help": "Server port"
@@ -4138,14 +4138,14 @@
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Host to bind."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "5050",
               "help": "Port (0 = pick free, default 5050 matches Vite proxy)."
@@ -4175,34 +4175,34 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source table name"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--output-mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
@@ -4223,21 +4223,21 @@
             },
             {
               "name": "--incremental-column",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column for incremental detection"
             },
             {
               "name": "--chunk-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Records per chunk"
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set."
@@ -4259,24 +4259,35 @@
           ]
         },
         {
+          "command": "tui",
+          "options": [
+            {
+              "name": "files",
+              "type": "str",
+              "required": true,
+              "help": "File(s) to load"
+            }
+          ]
+        },
+        {
           "command": "unmerge",
           "options": [
             {
               "name": "record_id",
-              "type": "integer",
+              "type": "int",
               "required": true,
               "help": "Record row ID to unmerge from its cluster"
             },
             {
               "name": "--clusters",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to clusters CSV from a previous run"
             },
             {
               "name": "--pairs",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to scored pairs CSV (id_a,id_b,score)"
@@ -4297,7 +4308,7 @@
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Where to write the re-clustered CSV (default: <clusters>.unmerged.csv)"
@@ -4309,48 +4320,48 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Table to watch"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--interval",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "30",
               "help": "Seconds between polls"
             },
             {
               "name": "--output-mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
             },
             {
               "name": "--incremental-column",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column for change detection"
@@ -5666,7 +5677,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8100",
               "help": "Port for the A2A server"
@@ -5691,7 +5702,7 @@
             },
             {
               "name": "--skip",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "[]",
               "help": "Techniques to skip"
@@ -5717,7 +5728,7 @@
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack to apply."
@@ -5742,14 +5753,14 @@
             },
             {
               "name": "--sample-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Bound the cross-tuple (pairwise) pass."
             },
             {
               "name": "--max-constraints",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Cap the ranked number of DCs reported."
@@ -5774,7 +5785,7 @@
             },
             {
               "name": "--ref",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Git ref to compare against (default: HEAD)."
@@ -5830,7 +5841,7 @@
             },
             {
               "name": "--mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'safe'",
               "help": "Fix mode: safe, moderate, or aggressive."
@@ -5881,7 +5892,7 @@
             },
             {
               "name": "--last",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Show last N scans."
@@ -5931,7 +5942,7 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
@@ -5947,21 +5958,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -5979,7 +5990,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Rows to sample."
@@ -6003,7 +6014,7 @@
             },
             {
               "name": "--on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "FK mapping 'child_col=parent_col' (repeatable). Omit to auto-detect same-named parent-key columns."
@@ -6017,7 +6028,7 @@
             },
             {
               "name": "--fail-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'error'",
               "help": "CI exit threshold: error/warning/info."
@@ -6063,14 +6074,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6109,14 +6120,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6144,14 +6155,14 @@
             },
             {
               "name": "--webhook",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "URL to POST findings to."
             },
             {
               "name": "--notify-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6198,27 +6209,27 @@
           "options": [
             {
               "name": "connection",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Database connection string (postgres://, snowflake://, etc.)"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Table name to scan."
             },
             {
               "name": "--query",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Custom SQL query."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack."
@@ -6239,7 +6250,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Max rows to fetch."
@@ -6257,28 +6268,28 @@
             },
             {
               "name": "--interval",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'daily'",
               "help": "Interval: hourly, daily, weekly, 5min, 15min, 30min, or seconds."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack."
             },
             {
               "name": "--webhook",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Webhook URL for notifications."
             },
             {
               "name": "--notify-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6297,14 +6308,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8000",
               "help": "Port to listen on."
@@ -6354,21 +6365,21 @@
             },
             {
               "name": "--interval",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "60",
               "help": "Poll interval in seconds."
             },
             {
               "name": "--pattern",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Glob pattern (e.g., '*.csv')."
             },
             {
               "name": "--exit-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Exit on severity: error or warning."
@@ -6914,7 +6925,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8150",
               "help": "Port the A2A agent server listens on."
@@ -6955,7 +6966,7 @@
           "options": [
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "20",
               "help": "Number of recent runs to show"
@@ -7047,21 +7058,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8150",
               "help": "Port for HTTP transport"
@@ -7090,7 +7101,7 @@
             },
             {
               "name": "--every",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'1h'",
               "help": "Interval (e.g., 5m, 1h, 30s)"
@@ -7116,14 +7127,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Network interface the REST API server binds to."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8000",
               "help": "Port the REST API server listens on."
@@ -7141,7 +7152,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Rows per batch"
@@ -7187,7 +7198,7 @@
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack to use"
@@ -8009,7 +8020,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8250",
               "help": "Port for A2A server"
@@ -8021,7 +8032,7 @@
           "options": [
             {
               "name": "--dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Directory to create config in"
@@ -8033,14 +8044,14 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional data file to load (press 'r' to run)."
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional pipeline YAML config."
@@ -8052,21 +8063,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport type: stdio or http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8250",
               "help": "Port for HTTP transport"
@@ -8078,20 +8089,20 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input file path"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Pipeline YAML config"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output file path"
@@ -8105,21 +8116,21 @@
             },
             {
               "name": "--identity-path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Enable Identity Graph; persist to this SQLite path"
             },
             {
               "name": "--identity-dataset",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Identity Graph dataset namespace"
             },
             {
               "name": "--identity-source-pk",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column to derive `{source}:{source_pk}` record_id from"
@@ -8138,7 +8149,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8000",
               "help": "Port for REST API"
@@ -8154,7 +8165,7 @@
           "options": [
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Pipeline YAML config"
             }
@@ -8449,19 +8460,19 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source CSV file to apply mapping to"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Output CSV path (required)"
             },
@@ -8479,13 +8490,13 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source data to inspect (CSV path, schema YAML, etc.)"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Table name for DB sources"
@@ -8504,47 +8515,47 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source data (CSV path, DataFrame, DB URI, schema YAML)"
             },
             {
               "name": "target",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Target data (same variety of inputs)"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional table name for DB sources"
             },
             {
               "name": "--required",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated required target field names"
             },
             {
               "name": "--schema-file",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to schema YAML file"
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'table'",
               "help": "Output format: table, json, or yaml"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Save mapping config to this YAML file"
@@ -8577,21 +8588,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -8603,19 +8614,19 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source data to validate (CSV path, etc.)"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--required",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated required field names"
@@ -8818,21 +8829,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "stdio | http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host interface to bind when transport is http."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8300",
               "help": "HTTP port (A2A convention: Analysis = 8300)."
@@ -8844,7 +8855,7 @@
           "options": [
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Dataset name whose run history to check."
             },
@@ -8856,21 +8867,21 @@
             },
             {
               "name": "--baseline",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'rolling_median'",
               "help": "Baseline strategy to compare against, e.g. rolling_median."
             },
             {
               "name": "--window",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "7",
               "help": "Number of prior runs the baseline is computed over."
             },
             {
               "name": "--policy",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Per-metric gates: JSON or \"key=pct,key=pct\"."
@@ -8895,14 +8906,14 @@
             },
             {
               "name": "--analyzers",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'all'",
               "help": "Comma-separated analyzer names, or 'all'."
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'markdown'",
               "help": "markdown | json"
@@ -8921,13 +8932,13 @@
           "options": [
             {
               "name": "--metric",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Metric key to trend, e.g. cluster.singleton_ratio."
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Dataset name whose run history to read."
             },
@@ -8939,7 +8950,7 @@
             },
             {
               "name": "--last",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "30",
               "help": "Number of most recent runs to include in the trend."

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2172,14 +2172,14 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8200",
               "help": "Port for the A2A server"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to"
@@ -2191,13 +2191,13 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to analyze"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Config file with matchkeys"
             }
@@ -2208,27 +2208,27 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
             {
               "name": "--sensitivity",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Write anomalies to a CSV instead of printing"
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Max rows to print"
@@ -2240,20 +2240,20 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--out",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Write committed config to this path instead of stdout."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Pin a domain rulebook (electronics, software, …) instead of auto-detecting."
@@ -2286,13 +2286,13 @@
           "options": [
             {
               "name": "file_a",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "First cluster JSON file (baseline / ER1)"
             },
             {
               "name": "file_b",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Second cluster JSON file (comparison / ER2)"
             },
@@ -2305,7 +2305,7 @@
             },
             {
               "name": "--case-type",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter details by case: unchanged, merged, partitioned, overlapping"
@@ -2324,7 +2324,7 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name to delete"
             }
@@ -2339,13 +2339,13 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name to load"
             },
             {
               "name": "--dest",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Destination path"
@@ -2357,13 +2357,13 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name"
             },
             {
               "name": "config_path",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Path to config YAML file"
             }
@@ -2374,7 +2374,7 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name to display"
             }
@@ -2385,13 +2385,13 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -2412,7 +2412,7 @@
             },
             {
               "name": "--model",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Override embedding model selection"
@@ -2426,7 +2426,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -2503,21 +2503,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -2545,7 +2545,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Records per chunk in chunked mode"
@@ -2580,7 +2580,7 @@
             },
             {
               "name": "--anomaly-sensitivity",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
@@ -2601,28 +2601,28 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "LLM provider: auto, anthropic, or openai"
             },
             {
               "name": "--llm-max-labels",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "500",
               "help": "Max pairs to label with LLM"
             },
             {
               "name": "--backend",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Processing backend: default, bucket, chunked, ray, duckdb"
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present."
@@ -2709,7 +2709,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2728,14 +2728,14 @@
             },
             {
               "name": "--col-a",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'id_a'",
               "help": "Ground truth column A"
             },
             {
               "name": "--col-b",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'id_b'",
               "help": "Ground truth column B"
@@ -2798,7 +2798,7 @@
             },
             {
               "name": "--audit-n",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Audit samples per stratum (default 50)."
@@ -2817,7 +2817,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2829,14 +2829,14 @@
             },
             {
               "name": "--pair",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Explain a pair: 'id_a,id_b'"
             },
             {
               "name": "--cluster",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Explain a cluster by id"
@@ -2848,14 +2848,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
@@ -2874,20 +2874,20 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Maximum number of events to return."
@@ -2906,35 +2906,35 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
             },
             {
               "name": "--status",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter to identities with this status."
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Maximum number of identities to return."
             },
             {
               "name": "--offset",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "0",
               "help": "Number of identities to skip for pagination."
@@ -2953,26 +2953,26 @@
           "options": [
             {
               "name": "keep",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "entity_id to keep"
             },
             {
               "name": "absorb",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "entity_id to absorb"
             },
             {
               "name": "--reason",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -2984,7 +2984,7 @@
           "options": [
             {
               "name": "--dsn",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN."
             },
@@ -2997,7 +2997,7 @@
             },
             {
               "name": "--revision",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'head'",
               "help": "Target revision (default: head)."
@@ -3009,14 +3009,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dsn",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Database connection string for the identity store."
@@ -3035,13 +3035,13 @@
           "options": [
             {
               "name": "record_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "`{source}:{pk}` to look up"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3060,13 +3060,13 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3085,26 +3085,26 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "record_ids",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "record_ids to move to a new identity"
             },
             {
               "name": "--reason",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3116,20 +3116,20 @@
           "options": [
             {
               "name": "input_path",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Splink settings or trained-model JSON file"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Output YAML config path"
             },
             {
               "name": "--model-out",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Persist imported trained m/u as an FS model JSON; sets model_path in the config"
@@ -3143,28 +3143,28 @@
             },
             {
               "name": "--upgrade",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json."
             },
             {
               "name": "--splink-clusters",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--labels",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--sample-cap",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Row cap for --upgrade lever computation and measurement (seeded subsample above it)"
@@ -3178,7 +3178,7 @@
             },
             {
               "name": "--id-column",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
@@ -3190,7 +3190,7 @@
           "options": [
             {
               "name": "base_file",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Base dataset file path"
             },
@@ -3222,7 +3222,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3238,32 +3238,32 @@
           "options": [
             {
               "name": "docs",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Document paths (PDF/image)."
             },
             {
               "name": "--schema",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Target schema JSON file."
             },
             {
               "name": "--out",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Write records here (.csv or .parquet)."
             },
             {
               "name": "--backend",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3275,26 +3275,26 @@
           "options": [
             {
               "name": "sample",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "A representative document (PDF/image)."
             },
             {
               "name": "--out",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Write the proposed schema JSON here."
             },
             {
               "name": "--backend",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3306,7 +3306,7 @@
           "options": [
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output path for generated config"
@@ -3318,7 +3318,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to load"
             }
@@ -3329,7 +3329,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3348,14 +3348,14 @@
             },
             {
               "name": "--n",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Number of pairs to label"
             },
             {
               "name": "--strategy",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'borderline'",
               "help": "Pair selection: borderline, random, or hardest"
@@ -3374,7 +3374,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3386,21 +3386,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Write lineage.json here (default: print a summary)"
             },
             {
               "name": "--run-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'lineage'",
               "help": "Run name for the lineage file"
             },
             {
               "name": "--max-pairs",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Cap on lineage records (0 = no cap)"
@@ -3419,19 +3419,19 @@
           "options": [
             {
               "name": "target",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Target file as path or path:source_name"
             },
             {
               "name": "--against",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Reference files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -3445,7 +3445,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -3494,28 +3494,28 @@
             },
             {
               "name": "--match-mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'best'",
               "help": "Match mode: best or all"
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -3536,7 +3536,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3562,35 +3562,35 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "HTTP host (only for http transport)"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8200",
               "help": "HTTP port (only for http transport)"
@@ -3602,82 +3602,82 @@
           "options": [
             {
               "name": "--decision",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "approve | reject | field_correct"
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Dataset key (required)"
             },
             {
               "name": "--id-a",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Pair-level: first row id"
             },
             {
               "name": "--id-b",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Pair-level: second row id"
             },
             {
               "name": "--cluster-id",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Field-level: cluster id the correction targets"
             },
             {
               "name": "--field-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Field-level: column being corrected"
             },
             {
               "name": "--original-value",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Field-level: original chosen value"
             },
             {
               "name": "--corrected-value",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Field-level: the value the reviewer changed it to"
             },
             {
               "name": "--reason",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reason"
             },
             {
               "name": "--matchkey-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional matchkey scope"
             },
             {
               "name": "--source",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'steward'",
               "help": "Source: steward (1.0 trust) | agent (0.5) | boost | unmerge"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3689,13 +3689,13 @@
           "options": [
             {
               "name": "out",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Output CSV path"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3707,13 +3707,13 @@
           "options": [
             {
               "name": "src",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source CSV path"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3725,14 +3725,14 @@
           "options": [
             {
               "name": "--matchkey-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Limit learning to this matchkey"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3744,19 +3744,19 @@
           "options": [
             {
               "name": "id_a",
-              "type": "int",
+              "type": "integer",
               "required": true,
               "help": "First record ID"
             },
             {
               "name": "id_b",
-              "type": "int",
+              "type": "integer",
               "required": true,
               "help": "Second record ID"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3768,7 +3768,7 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3786,7 +3786,7 @@
             },
             {
               "name": "--security",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
@@ -3817,7 +3817,7 @@
             },
             {
               "name": "--fields",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Comma-separated field names to match on"
             },
@@ -3830,21 +3830,21 @@
             },
             {
               "name": "--security",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
             },
             {
               "name": "--protocol",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'trusted_third_party'",
               "help": "Protocol: trusted_third_party or smc"
             },
             {
               "name": "--scorer",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'dice'",
               "help": "Similarity scorer: dice or jaccard"
@@ -3858,7 +3858,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them."
@@ -3870,7 +3870,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to profile"
             },
@@ -3902,7 +3902,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Input files (path or path:source_name). Omit to review only the pending queue."
@@ -3915,21 +3915,21 @@
             },
             {
               "name": "--job",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'review'",
               "help": "Review-queue job name for freshly-gated pairs"
             },
             {
               "name": "--queue-path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db)"
             },
             {
               "name": "--memory-path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Learning Memory SQLite path"
@@ -3950,14 +3950,14 @@
             },
             {
               "name": "--decided-by",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'cli'",
               "help": "Steward identifier recorded on each decision"
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Max pairs to review this session"
@@ -3969,13 +3969,13 @@
           "options": [
             {
               "name": "run_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Run ID to rollback"
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3987,7 +3987,7 @@
           "options": [
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3999,34 +3999,34 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Data files to process"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--every",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run interval (e.g. 1h, 30m, 6h, 1d)"
             },
             {
               "name": "--cron",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Cron schedule (e.g. '0 6 * * *')"
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Output directory"
@@ -4038,19 +4038,19 @@
           "options": [
             {
               "name": "a",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "First string."
             },
             {
               "name": "b",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Second string."
             },
             {
               "name": "--scorer",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'jaro_winkler'",
               "help": "Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble."
@@ -4062,7 +4062,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -4074,13 +4074,13 @@
             },
             {
               "name": "--sweep",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Sweep spec: field:start:stop:step (repeatable)"
             },
             {
               "name": "--sample",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Random sample size for speed"
@@ -4099,27 +4099,27 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Server host"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8080",
               "help": "Server port"
@@ -4138,14 +4138,14 @@
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Host to bind."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "5050",
               "help": "Port (0 = pick free, default 5050 matches Vite proxy)."
@@ -4175,34 +4175,34 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source table name"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--output-mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
@@ -4223,21 +4223,21 @@
             },
             {
               "name": "--incremental-column",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column for incremental detection"
             },
             {
               "name": "--chunk-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Records per chunk"
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set."
@@ -4263,7 +4263,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to load"
             }
@@ -4274,20 +4274,20 @@
           "options": [
             {
               "name": "record_id",
-              "type": "int",
+              "type": "integer",
               "required": true,
               "help": "Record row ID to unmerge from its cluster"
             },
             {
               "name": "--clusters",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to clusters CSV from a previous run"
             },
             {
               "name": "--pairs",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to scored pairs CSV (id_a,id_b,score)"
@@ -4308,7 +4308,7 @@
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Where to write the re-clustered CSV (default: <clusters>.unmerged.csv)"
@@ -4320,48 +4320,48 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Table to watch"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--interval",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "30",
               "help": "Seconds between polls"
             },
             {
               "name": "--output-mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
             },
             {
               "name": "--incremental-column",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column for change detection"
@@ -5677,7 +5677,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8100",
               "help": "Port for the A2A server"
@@ -5702,7 +5702,7 @@
             },
             {
               "name": "--skip",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "[]",
               "help": "Techniques to skip"
@@ -5728,7 +5728,7 @@
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack to apply."
@@ -5753,14 +5753,14 @@
             },
             {
               "name": "--sample-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Bound the cross-tuple (pairwise) pass."
             },
             {
               "name": "--max-constraints",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Cap the ranked number of DCs reported."
@@ -5785,7 +5785,7 @@
             },
             {
               "name": "--ref",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Git ref to compare against (default: HEAD)."
@@ -5841,7 +5841,7 @@
             },
             {
               "name": "--mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'safe'",
               "help": "Fix mode: safe, moderate, or aggressive."
@@ -5892,7 +5892,7 @@
             },
             {
               "name": "--last",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Show last N scans."
@@ -5942,7 +5942,7 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
@@ -5958,21 +5958,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -5990,7 +5990,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Rows to sample."
@@ -6014,7 +6014,7 @@
             },
             {
               "name": "--on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "FK mapping 'child_col=parent_col' (repeatable). Omit to auto-detect same-named parent-key columns."
@@ -6028,7 +6028,7 @@
             },
             {
               "name": "--fail-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'error'",
               "help": "CI exit threshold: error/warning/info."
@@ -6074,14 +6074,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6120,14 +6120,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6155,14 +6155,14 @@
             },
             {
               "name": "--webhook",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "URL to POST findings to."
             },
             {
               "name": "--notify-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6209,27 +6209,27 @@
           "options": [
             {
               "name": "connection",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Database connection string (postgres://, snowflake://, etc.)"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Table name to scan."
             },
             {
               "name": "--query",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Custom SQL query."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack."
@@ -6250,7 +6250,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Max rows to fetch."
@@ -6268,28 +6268,28 @@
             },
             {
               "name": "--interval",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'daily'",
               "help": "Interval: hourly, daily, weekly, 5min, 15min, 30min, or seconds."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack."
             },
             {
               "name": "--webhook",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Webhook URL for notifications."
             },
             {
               "name": "--notify-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6308,14 +6308,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8000",
               "help": "Port to listen on."
@@ -6365,21 +6365,21 @@
             },
             {
               "name": "--interval",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "60",
               "help": "Poll interval in seconds."
             },
             {
               "name": "--pattern",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Glob pattern (e.g., '*.csv')."
             },
             {
               "name": "--exit-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Exit on severity: error or warning."
@@ -6925,7 +6925,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8150",
               "help": "Port the A2A agent server listens on."
@@ -6966,7 +6966,7 @@
           "options": [
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "20",
               "help": "Number of recent runs to show"
@@ -7058,21 +7058,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8150",
               "help": "Port for HTTP transport"
@@ -7101,7 +7101,7 @@
             },
             {
               "name": "--every",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'1h'",
               "help": "Interval (e.g., 5m, 1h, 30s)"
@@ -7127,14 +7127,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Network interface the REST API server binds to."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8000",
               "help": "Port the REST API server listens on."
@@ -7152,7 +7152,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Rows per batch"
@@ -7198,7 +7198,7 @@
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack to use"
@@ -8020,7 +8020,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8250",
               "help": "Port for A2A server"
@@ -8032,7 +8032,7 @@
           "options": [
             {
               "name": "--dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Directory to create config in"
@@ -8044,14 +8044,14 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional data file to load (press 'r' to run)."
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional pipeline YAML config."
@@ -8063,21 +8063,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport type: stdio or http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8250",
               "help": "Port for HTTP transport"
@@ -8089,20 +8089,20 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input file path"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Pipeline YAML config"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output file path"
@@ -8116,21 +8116,21 @@
             },
             {
               "name": "--identity-path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Enable Identity Graph; persist to this SQLite path"
             },
             {
               "name": "--identity-dataset",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Identity Graph dataset namespace"
             },
             {
               "name": "--identity-source-pk",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column to derive `{source}:{source_pk}` record_id from"
@@ -8149,7 +8149,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8000",
               "help": "Port for REST API"
@@ -8165,7 +8165,7 @@
           "options": [
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Pipeline YAML config"
             }
@@ -8460,19 +8460,19 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source CSV file to apply mapping to"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Output CSV path (required)"
             },
@@ -8490,13 +8490,13 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source data to inspect (CSV path, schema YAML, etc.)"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Table name for DB sources"
@@ -8515,47 +8515,47 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source data (CSV path, DataFrame, DB URI, schema YAML)"
             },
             {
               "name": "target",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Target data (same variety of inputs)"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional table name for DB sources"
             },
             {
               "name": "--required",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated required target field names"
             },
             {
               "name": "--schema-file",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to schema YAML file"
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'table'",
               "help": "Output format: table, json, or yaml"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Save mapping config to this YAML file"
@@ -8588,21 +8588,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -8614,19 +8614,19 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source data to validate (CSV path, etc.)"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--required",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated required field names"
@@ -8829,21 +8829,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "stdio | http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host interface to bind when transport is http."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8300",
               "help": "HTTP port (A2A convention: Analysis = 8300)."
@@ -8855,7 +8855,7 @@
           "options": [
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Dataset name whose run history to check."
             },
@@ -8867,21 +8867,21 @@
             },
             {
               "name": "--baseline",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'rolling_median'",
               "help": "Baseline strategy to compare against, e.g. rolling_median."
             },
             {
               "name": "--window",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "7",
               "help": "Number of prior runs the baseline is computed over."
             },
             {
               "name": "--policy",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Per-metric gates: JSON or \"key=pct,key=pct\"."
@@ -8906,14 +8906,14 @@
             },
             {
               "name": "--analyzers",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'all'",
               "help": "Comma-separated analyzer names, or 'all'."
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'markdown'",
               "help": "markdown | json"
@@ -8932,13 +8932,13 @@
           "options": [
             {
               "name": "--metric",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Metric key to trend, e.g. cluster.singleton_ratio."
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Dataset name whose run history to read."
             },
@@ -8950,7 +8950,7 @@
             },
             {
               "name": "--last",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "30",
               "help": "Number of most recent runs to include in the trend."

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -332,6 +332,16 @@ def interactive_cmd(
     tui_app.run()
 
 
+# Same command under the TypeScript CLI's name. `interactive` (Python) and `tui`
+# (TS) were always the SAME operation, so the parity manifest counted one
+# capability as both a python_only and a ts_only gap; both CLIs now answer to
+# both names. Registering the function twice (rather than aliasing) is what the
+# surface emitters actually see.
+app.command("tui", help="Launch the interactive TUI (alias of `interactive`).")(
+    interactive_cmd
+)
+
+
 @app.command("score")
 def score_cmd(
     a: str = typer.Argument(..., help="First string."),

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2172,14 +2172,14 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8200",
               "help": "Port for the A2A server"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to"
@@ -2191,13 +2191,13 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "File(s) to analyze"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Config file with matchkeys"
             }
@@ -2208,27 +2208,27 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
             {
               "name": "--sensitivity",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Write anomalies to a CSV instead of printing"
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Max rows to print"
@@ -2240,20 +2240,20 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--out",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Write committed config to this path instead of stdout."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Pin a domain rulebook (electronics, software, …) instead of auto-detecting."
@@ -2286,13 +2286,13 @@
           "options": [
             {
               "name": "file_a",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "First cluster JSON file (baseline / ER1)"
             },
             {
               "name": "file_b",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Second cluster JSON file (comparison / ER2)"
             },
@@ -2305,7 +2305,7 @@
             },
             {
               "name": "--case-type",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter details by case: unchanged, merged, partitioned, overlapping"
@@ -2324,7 +2324,7 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name to delete"
             }
@@ -2339,13 +2339,13 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name to load"
             },
             {
               "name": "--dest",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Destination path"
@@ -2357,13 +2357,13 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name"
             },
             {
               "name": "config_path",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Path to config YAML file"
             }
@@ -2374,7 +2374,7 @@
           "options": [
             {
               "name": "name",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Preset name to display"
             }
@@ -2385,13 +2385,13 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -2412,7 +2412,7 @@
             },
             {
               "name": "--model",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Override embedding model selection"
@@ -2426,7 +2426,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -2503,21 +2503,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -2545,7 +2545,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Records per chunk in chunked mode"
@@ -2580,7 +2580,7 @@
             },
             {
               "name": "--anomaly-sensitivity",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
@@ -2601,28 +2601,28 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "LLM provider: auto, anthropic, or openai"
             },
             {
               "name": "--llm-max-labels",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "500",
               "help": "Max pairs to label with LLM"
             },
             {
               "name": "--backend",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Processing backend: default, bucket, chunked, ray, duckdb"
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present."
@@ -2709,7 +2709,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2728,14 +2728,14 @@
             },
             {
               "name": "--col-a",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'id_a'",
               "help": "Ground truth column A"
             },
             {
               "name": "--col-b",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'id_b'",
               "help": "Ground truth column B"
@@ -2798,7 +2798,7 @@
             },
             {
               "name": "--audit-n",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Audit samples per stratum (default 50)."
@@ -2817,7 +2817,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2829,14 +2829,14 @@
             },
             {
               "name": "--pair",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Explain a pair: 'id_a,id_b'"
             },
             {
               "name": "--cluster",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Explain a cluster by id"
@@ -2848,14 +2848,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
@@ -2874,20 +2874,20 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Maximum number of events to return."
@@ -2906,35 +2906,35 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
             },
             {
               "name": "--status",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Filter to identities with this status."
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Maximum number of identities to return."
             },
             {
               "name": "--offset",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "0",
               "help": "Number of identities to skip for pagination."
@@ -2953,26 +2953,26 @@
           "options": [
             {
               "name": "keep",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "entity_id to keep"
             },
             {
               "name": "absorb",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "entity_id to absorb"
             },
             {
               "name": "--reason",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -2984,7 +2984,7 @@
           "options": [
             {
               "name": "--dsn",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN."
             },
@@ -2997,7 +2997,7 @@
             },
             {
               "name": "--revision",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'head'",
               "help": "Target revision (default: head)."
@@ -3009,14 +3009,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dsn",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Database connection string for the identity store."
@@ -3035,13 +3035,13 @@
           "options": [
             {
               "name": "record_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "`{source}:{pk}` to look up"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3060,13 +3060,13 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3085,26 +3085,26 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "record_ids",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "record_ids to move to a new identity"
             },
             {
               "name": "--reason",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3116,20 +3116,20 @@
           "options": [
             {
               "name": "input_path",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Splink settings or trained-model JSON file"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Output YAML config path"
             },
             {
               "name": "--model-out",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Persist imported trained m/u as an FS model JSON; sets model_path in the config"
@@ -3143,28 +3143,28 @@
             },
             {
               "name": "--upgrade",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json."
             },
             {
               "name": "--splink-clusters",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--labels",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--sample-cap",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Row cap for --upgrade lever computation and measurement (seeded subsample above it)"
@@ -3178,7 +3178,7 @@
             },
             {
               "name": "--id-column",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
@@ -3190,7 +3190,7 @@
           "options": [
             {
               "name": "base_file",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Base dataset file path"
             },
@@ -3222,7 +3222,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3238,32 +3238,32 @@
           "options": [
             {
               "name": "docs",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Document paths (PDF/image)."
             },
             {
               "name": "--schema",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Target schema JSON file."
             },
             {
               "name": "--out",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Write records here (.csv or .parquet)."
             },
             {
               "name": "--backend",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3275,26 +3275,26 @@
           "options": [
             {
               "name": "sample",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "A representative document (PDF/image)."
             },
             {
               "name": "--out",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Write the proposed schema JSON here."
             },
             {
               "name": "--backend",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3306,7 +3306,7 @@
           "options": [
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output path for generated config"
@@ -3318,7 +3318,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "File(s) to load"
             }
@@ -3329,7 +3329,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3348,14 +3348,14 @@
             },
             {
               "name": "--n",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Number of pairs to label"
             },
             {
               "name": "--strategy",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'borderline'",
               "help": "Pair selection: borderline, random, or hardest"
@@ -3374,7 +3374,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3386,21 +3386,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Write lineage.json here (default: print a summary)"
             },
             {
               "name": "--run-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'lineage'",
               "help": "Run name for the lineage file"
             },
             {
               "name": "--max-pairs",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Cap on lineage records (0 = no cap)"
@@ -3419,19 +3419,19 @@
           "options": [
             {
               "name": "target",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Target file as path or path:source_name"
             },
             {
               "name": "--against",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Reference files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -3445,7 +3445,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -3494,28 +3494,28 @@
             },
             {
               "name": "--match-mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'best'",
               "help": "Match mode: best or all"
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -3536,7 +3536,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3562,35 +3562,35 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "HTTP host (only for http transport)"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8200",
               "help": "HTTP port (only for http transport)"
@@ -3602,82 +3602,82 @@
           "options": [
             {
               "name": "--decision",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "approve | reject | field_correct"
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Dataset key (required)"
             },
             {
               "name": "--id-a",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Pair-level: first row id"
             },
             {
               "name": "--id-b",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Pair-level: second row id"
             },
             {
               "name": "--cluster-id",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Field-level: cluster id the correction targets"
             },
             {
               "name": "--field-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Field-level: column being corrected"
             },
             {
               "name": "--original-value",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Field-level: original chosen value"
             },
             {
               "name": "--corrected-value",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Field-level: the value the reviewer changed it to"
             },
             {
               "name": "--reason",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional reason"
             },
             {
               "name": "--matchkey-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional matchkey scope"
             },
             {
               "name": "--source",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'steward'",
               "help": "Source: steward (1.0 trust) | agent (0.5) | boost | unmerge"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3689,13 +3689,13 @@
           "options": [
             {
               "name": "out",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Output CSV path"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3707,13 +3707,13 @@
           "options": [
             {
               "name": "src",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source CSV path"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3725,14 +3725,14 @@
           "options": [
             {
               "name": "--matchkey-name",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Limit learning to this matchkey"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3744,19 +3744,19 @@
           "options": [
             {
               "name": "id_a",
-              "type": "integer",
+              "type": "int",
               "required": true,
               "help": "First record ID"
             },
             {
               "name": "id_b",
-              "type": "integer",
+              "type": "int",
               "required": true,
               "help": "Second record ID"
             },
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3768,7 +3768,7 @@
           "options": [
             {
               "name": "--path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3786,7 +3786,7 @@
             },
             {
               "name": "--security",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
@@ -3817,7 +3817,7 @@
             },
             {
               "name": "--fields",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Comma-separated field names to match on"
             },
@@ -3830,21 +3830,21 @@
             },
             {
               "name": "--security",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
             },
             {
               "name": "--protocol",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'trusted_third_party'",
               "help": "Protocol: trusted_third_party or smc"
             },
             {
               "name": "--scorer",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'dice'",
               "help": "Similarity scorer: dice or jaccard"
@@ -3858,7 +3858,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them."
@@ -3870,7 +3870,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "File(s) to profile"
             },
@@ -3902,7 +3902,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Input files (path or path:source_name). Omit to review only the pending queue."
@@ -3915,21 +3915,21 @@
             },
             {
               "name": "--job",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'review'",
               "help": "Review-queue job name for freshly-gated pairs"
             },
             {
               "name": "--queue-path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db)"
             },
             {
               "name": "--memory-path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Learning Memory SQLite path"
@@ -3950,14 +3950,14 @@
             },
             {
               "name": "--decided-by",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'cli'",
               "help": "Steward identifier recorded on each decision"
             },
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "50",
               "help": "Max pairs to review this session"
@@ -3969,13 +3969,13 @@
           "options": [
             {
               "name": "run_id",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Run ID to rollback"
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3987,7 +3987,7 @@
           "options": [
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3999,34 +3999,34 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Data files to process"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--every",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Run interval (e.g. 1h, 30m, 6h, 1d)"
             },
             {
               "name": "--cron",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Cron schedule (e.g. '0 6 * * *')"
             },
             {
               "name": "--output-dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Output directory"
@@ -4038,19 +4038,19 @@
           "options": [
             {
               "name": "a",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "First string."
             },
             {
               "name": "b",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Second string."
             },
             {
               "name": "--scorer",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'jaro_winkler'",
               "help": "Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble."
@@ -4062,7 +4062,7 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -4074,13 +4074,13 @@
             },
             {
               "name": "--sweep",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Sweep spec: field:start:stop:step (repeatable)"
             },
             {
               "name": "--sample",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Random sample size for speed"
@@ -4099,27 +4099,27 @@
           "options": [
             {
               "name": "files",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Server host"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8080",
               "help": "Server port"
@@ -4138,14 +4138,14 @@
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Host to bind."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "5050",
               "help": "Port (0 = pick free, default 5050 matches Vite proxy)."
@@ -4175,34 +4175,34 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source table name"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--output-mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
@@ -4223,21 +4223,21 @@
             },
             {
               "name": "--incremental-column",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column for incremental detection"
             },
             {
               "name": "--chunk-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Records per chunk"
             },
             {
               "name": "--exclude-columns",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set."
@@ -4259,24 +4259,35 @@
           ]
         },
         {
+          "command": "tui",
+          "options": [
+            {
+              "name": "files",
+              "type": "str",
+              "required": true,
+              "help": "File(s) to load"
+            }
+          ]
+        },
+        {
           "command": "unmerge",
           "options": [
             {
               "name": "record_id",
-              "type": "integer",
+              "type": "int",
               "required": true,
               "help": "Record row ID to unmerge from its cluster"
             },
             {
               "name": "--clusters",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to clusters CSV from a previous run"
             },
             {
               "name": "--pairs",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to scored pairs CSV (id_a,id_b,score)"
@@ -4297,7 +4308,7 @@
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Where to write the re-clustered CSV (default: <clusters>.unmerged.csv)"
@@ -4309,48 +4320,48 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Table to watch"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--interval",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "30",
               "help": "Seconds between polls"
             },
             {
               "name": "--output-mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
             },
             {
               "name": "--incremental-column",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column for change detection"
@@ -5666,7 +5677,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8100",
               "help": "Port for the A2A server"
@@ -5691,7 +5702,7 @@
             },
             {
               "name": "--skip",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "[]",
               "help": "Techniques to skip"
@@ -5717,7 +5728,7 @@
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack to apply."
@@ -5742,14 +5753,14 @@
             },
             {
               "name": "--sample-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Bound the cross-tuple (pairwise) pass."
             },
             {
               "name": "--max-constraints",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Cap the ranked number of DCs reported."
@@ -5774,7 +5785,7 @@
             },
             {
               "name": "--ref",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Git ref to compare against (default: HEAD)."
@@ -5830,7 +5841,7 @@
             },
             {
               "name": "--mode",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'safe'",
               "help": "Fix mode: safe, moderate, or aggressive."
@@ -5881,7 +5892,7 @@
             },
             {
               "name": "--last",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "None",
               "help": "Show last N scans."
@@ -5931,7 +5942,7 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
@@ -5947,21 +5958,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -5979,7 +5990,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Rows to sample."
@@ -6003,7 +6014,7 @@
             },
             {
               "name": "--on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "FK mapping 'child_col=parent_col' (repeatable). Omit to auto-detect same-named parent-key columns."
@@ -6017,7 +6028,7 @@
             },
             {
               "name": "--fail-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'error'",
               "help": "CI exit threshold: error/warning/info."
@@ -6063,14 +6074,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6109,14 +6120,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6144,14 +6155,14 @@
             },
             {
               "name": "--webhook",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "URL to POST findings to."
             },
             {
               "name": "--notify-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6198,27 +6209,27 @@
           "options": [
             {
               "name": "connection",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Database connection string (postgres://, snowflake://, etc.)"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Table name to scan."
             },
             {
               "name": "--query",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Custom SQL query."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack."
@@ -6239,7 +6250,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "100000",
               "help": "Max rows to fetch."
@@ -6257,28 +6268,28 @@
             },
             {
               "name": "--interval",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'daily'",
               "help": "Interval: hourly, daily, weekly, 5min, 15min, 30min, or seconds."
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack."
             },
             {
               "name": "--webhook",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Webhook URL for notifications."
             },
             {
               "name": "--notify-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6297,14 +6308,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8000",
               "help": "Port to listen on."
@@ -6354,21 +6365,21 @@
             },
             {
               "name": "--interval",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "60",
               "help": "Poll interval in seconds."
             },
             {
               "name": "--pattern",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Glob pattern (e.g., '*.csv')."
             },
             {
               "name": "--exit-on",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Exit on severity: error or warning."
@@ -6914,7 +6925,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8150",
               "help": "Port the A2A agent server listens on."
@@ -6955,7 +6966,7 @@
           "options": [
             {
               "name": "--limit",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "20",
               "help": "Number of recent runs to show"
@@ -7047,21 +7058,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8150",
               "help": "Port for HTTP transport"
@@ -7090,7 +7101,7 @@
             },
             {
               "name": "--every",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'1h'",
               "help": "Interval (e.g., 5m, 1h, 30s)"
@@ -7116,14 +7127,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Network interface the REST API server binds to."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8000",
               "help": "Port the REST API server listens on."
@@ -7141,7 +7152,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "10000",
               "help": "Rows per batch"
@@ -7187,7 +7198,7 @@
             },
             {
               "name": "--domain",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Domain pack to use"
@@ -8009,7 +8020,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8250",
               "help": "Port for A2A server"
@@ -8021,7 +8032,7 @@
           "options": [
             {
               "name": "--dir",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'.'",
               "help": "Directory to create config in"
@@ -8033,14 +8044,14 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional data file to load (press 'r' to run)."
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional pipeline YAML config."
@@ -8052,21 +8063,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport type: stdio or http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8250",
               "help": "Port for HTTP transport"
@@ -8078,20 +8089,20 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Input file path"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Pipeline YAML config"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Output file path"
@@ -8105,21 +8116,21 @@
             },
             {
               "name": "--identity-path",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Enable Identity Graph; persist to this SQLite path"
             },
             {
               "name": "--identity-dataset",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Identity Graph dataset namespace"
             },
             {
               "name": "--identity-source-pk",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Column to derive `{source}:{source_pk}` record_id from"
@@ -8138,7 +8149,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8000",
               "help": "Port for REST API"
@@ -8154,7 +8165,7 @@
           "options": [
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Pipeline YAML config"
             }
@@ -8449,19 +8460,19 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source CSV file to apply mapping to"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Output CSV path (required)"
             },
@@ -8479,13 +8490,13 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source data to inspect (CSV path, schema YAML, etc.)"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Table name for DB sources"
@@ -8504,47 +8515,47 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source data (CSV path, DataFrame, DB URI, schema YAML)"
             },
             {
               "name": "target",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Target data (same variety of inputs)"
             },
             {
               "name": "--table",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Optional table name for DB sources"
             },
             {
               "name": "--required",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated required target field names"
             },
             {
               "name": "--schema-file",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Path to schema YAML file"
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'table'",
               "help": "Output format: table, json, or yaml"
             },
             {
               "name": "--output",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Save mapping config to this YAML file"
@@ -8577,21 +8588,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -8603,19 +8614,19 @@
           "options": [
             {
               "name": "source",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Source data to validate (CSV path, etc.)"
             },
             {
               "name": "--config",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--required",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Comma-separated required field names"
@@ -8818,21 +8829,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'stdio'",
               "help": "stdio | http"
             },
             {
               "name": "--host",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host interface to bind when transport is http."
             },
             {
               "name": "--port",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "8300",
               "help": "HTTP port (A2A convention: Analysis = 8300)."
@@ -8844,7 +8855,7 @@
           "options": [
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Dataset name whose run history to check."
             },
@@ -8856,21 +8867,21 @@
             },
             {
               "name": "--baseline",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'rolling_median'",
               "help": "Baseline strategy to compare against, e.g. rolling_median."
             },
             {
               "name": "--window",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "7",
               "help": "Number of prior runs the baseline is computed over."
             },
             {
               "name": "--policy",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "None",
               "help": "Per-metric gates: JSON or \"key=pct,key=pct\"."
@@ -8895,14 +8906,14 @@
             },
             {
               "name": "--analyzers",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'all'",
               "help": "Comma-separated analyzer names, or 'all'."
             },
             {
               "name": "--format",
-              "type": "text",
+              "type": "str",
               "required": false,
               "default": "'markdown'",
               "help": "markdown | json"
@@ -8921,13 +8932,13 @@
           "options": [
             {
               "name": "--metric",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Metric key to trend, e.g. cluster.singleton_ratio."
             },
             {
               "name": "--dataset",
-              "type": "text",
+              "type": "str",
               "required": true,
               "help": "Dataset name whose run history to read."
             },
@@ -8939,7 +8950,7 @@
             },
             {
               "name": "--last",
-              "type": "integer",
+              "type": "int",
               "required": false,
               "default": "30",
               "help": "Number of most recent runs to include in the trend."

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2172,14 +2172,14 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8200",
               "help": "Port for the A2A server"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to"
@@ -2191,13 +2191,13 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to analyze"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Config file with matchkeys"
             }
@@ -2208,27 +2208,27 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
             {
               "name": "--sensitivity",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Write anomalies to a CSV instead of printing"
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Max rows to print"
@@ -2240,20 +2240,20 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--out",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Write committed config to this path instead of stdout."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Pin a domain rulebook (electronics, software, …) instead of auto-detecting."
@@ -2286,13 +2286,13 @@
           "options": [
             {
               "name": "file_a",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "First cluster JSON file (baseline / ER1)"
             },
             {
               "name": "file_b",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Second cluster JSON file (comparison / ER2)"
             },
@@ -2305,7 +2305,7 @@
             },
             {
               "name": "--case-type",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter details by case: unchanged, merged, partitioned, overlapping"
@@ -2324,7 +2324,7 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name to delete"
             }
@@ -2339,13 +2339,13 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name to load"
             },
             {
               "name": "--dest",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Destination path"
@@ -2357,13 +2357,13 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name"
             },
             {
               "name": "config_path",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Path to config YAML file"
             }
@@ -2374,7 +2374,7 @@
           "options": [
             {
               "name": "name",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Preset name to display"
             }
@@ -2385,13 +2385,13 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -2412,7 +2412,7 @@
             },
             {
               "name": "--model",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Override embedding model selection"
@@ -2426,7 +2426,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -2503,21 +2503,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -2545,7 +2545,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Records per chunk in chunked mode"
@@ -2580,7 +2580,7 @@
             },
             {
               "name": "--anomaly-sensitivity",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'medium'",
               "help": "low, medium, or high"
@@ -2601,28 +2601,28 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "LLM provider: auto, anthropic, or openai"
             },
             {
               "name": "--llm-max-labels",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "500",
               "help": "Max pairs to label with LLM"
             },
             {
               "name": "--backend",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Processing backend: default, bucket, chunked, ray, duckdb"
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present."
@@ -2709,7 +2709,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2728,14 +2728,14 @@
             },
             {
               "name": "--col-a",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'id_a'",
               "help": "Ground truth column A"
             },
             {
               "name": "--col-b",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'id_b'",
               "help": "Ground truth column B"
@@ -2798,7 +2798,7 @@
             },
             {
               "name": "--audit-n",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Audit samples per stratum (default 50)."
@@ -2817,7 +2817,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -2829,14 +2829,14 @@
             },
             {
               "name": "--pair",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Explain a pair: 'id_a,id_b'"
             },
             {
               "name": "--cluster",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Explain a cluster by id"
@@ -2848,14 +2848,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
@@ -2874,20 +2874,20 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Maximum number of events to return."
@@ -2906,35 +2906,35 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter to identities in this dataset."
             },
             {
               "name": "--status",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Filter to identities with this status."
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Maximum number of identities to return."
             },
             {
               "name": "--offset",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "0",
               "help": "Number of identities to skip for pagination."
@@ -2953,26 +2953,26 @@
           "options": [
             {
               "name": "keep",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "entity_id to keep"
             },
             {
               "name": "absorb",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "entity_id to absorb"
             },
             {
               "name": "--reason",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -2984,7 +2984,7 @@
           "options": [
             {
               "name": "--dsn",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN."
             },
@@ -2997,7 +2997,7 @@
             },
             {
               "name": "--revision",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'head'",
               "help": "Target revision (default: head)."
@@ -3009,14 +3009,14 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
             },
             {
               "name": "--dsn",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Database connection string for the identity store."
@@ -3035,13 +3035,13 @@
           "options": [
             {
               "name": "record_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "`{source}:{pk}` to look up"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3060,13 +3060,13 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3085,26 +3085,26 @@
           "options": [
             {
               "name": "entity_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "The entity_id of the identity to operate on."
             },
             {
               "name": "record_ids",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "record_ids to move to a new identity"
             },
             {
               "name": "--reason",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reason recorded in the event log."
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/identity.db'",
               "help": "Path to the identity graph database."
@@ -3116,20 +3116,20 @@
           "options": [
             {
               "name": "input_path",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Splink settings or trained-model JSON file"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'goldenmatch.yaml'",
               "help": "Output YAML config path"
             },
             {
               "name": "--model-out",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Persist imported trained m/u as an FS model JSON; sets model_path in the config"
@@ -3143,28 +3143,28 @@
             },
             {
               "name": "--upgrade",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json."
             },
             {
               "name": "--splink-clusters",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--labels",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id."
             },
             {
               "name": "--sample-cap",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Row cap for --upgrade lever computation and measurement (seeded subsample above it)"
@@ -3178,7 +3178,7 @@
             },
             {
               "name": "--id-column",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
@@ -3190,7 +3190,7 @@
           "options": [
             {
               "name": "base_file",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Base dataset file path"
             },
@@ -3222,7 +3222,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3238,32 +3238,32 @@
           "options": [
             {
               "name": "docs",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Document paths (PDF/image)."
             },
             {
               "name": "--schema",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Target schema JSON file."
             },
             {
               "name": "--out",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Write records here (.csv or .parquet)."
             },
             {
               "name": "--backend",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3275,26 +3275,26 @@
           "options": [
             {
               "name": "sample",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "A representative document (PDF/image)."
             },
             {
               "name": "--out",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Write the proposed schema JSON here."
             },
             {
               "name": "--backend",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'vlm'",
               "help": "Extraction backend."
             },
             {
               "name": "--model",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'gpt-4o'",
               "help": "Vision model."
@@ -3306,7 +3306,7 @@
           "options": [
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output path for generated config"
@@ -3318,7 +3318,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to load"
             }
@@ -3329,7 +3329,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3348,14 +3348,14 @@
             },
             {
               "name": "--n",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Number of pairs to label"
             },
             {
               "name": "--strategy",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'borderline'",
               "help": "Pair selection: borderline, random, or hardest"
@@ -3374,7 +3374,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -3386,21 +3386,21 @@
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Write lineage.json here (default: print a summary)"
             },
             {
               "name": "--run-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'lineage'",
               "help": "Run name for the lineage file"
             },
             {
               "name": "--max-pairs",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Cap on lineage records (0 = no cap)"
@@ -3419,19 +3419,19 @@
           "options": [
             {
               "name": "target",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Target file as path or path:source_name"
             },
             {
               "name": "--against",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Reference files as path or path:source_name"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to YAML config file (optional - auto-detects if omitted)"
@@ -3445,7 +3445,7 @@
             },
             {
               "name": "--preview-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Number of records for preview sample"
@@ -3494,28 +3494,28 @@
             },
             {
               "name": "--match-mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'best'",
               "help": "Match mode: best or all"
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output directory"
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output format (csv, parquet)"
             },
             {
               "name": "--run-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run name for output files"
@@ -3536,7 +3536,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
@@ -3562,35 +3562,35 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "HTTP host (only for http transport)"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8200",
               "help": "HTTP port (only for http transport)"
@@ -3602,82 +3602,82 @@
           "options": [
             {
               "name": "--decision",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "approve | reject | field_correct"
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Dataset key (required)"
             },
             {
               "name": "--id-a",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Pair-level: first row id"
             },
             {
               "name": "--id-b",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Pair-level: second row id"
             },
             {
               "name": "--cluster-id",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Field-level: cluster id the correction targets"
             },
             {
               "name": "--field-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Field-level: column being corrected"
             },
             {
               "name": "--original-value",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Field-level: original chosen value"
             },
             {
               "name": "--corrected-value",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Field-level: the value the reviewer changed it to"
             },
             {
               "name": "--reason",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional reason"
             },
             {
               "name": "--matchkey-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional matchkey scope"
             },
             {
               "name": "--source",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'steward'",
               "help": "Source: steward (1.0 trust) | agent (0.5) | boost | unmerge"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3689,13 +3689,13 @@
           "options": [
             {
               "name": "out",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Output CSV path"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3707,13 +3707,13 @@
           "options": [
             {
               "name": "src",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source CSV path"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3725,14 +3725,14 @@
           "options": [
             {
               "name": "--matchkey-name",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Limit learning to this matchkey"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3744,19 +3744,19 @@
           "options": [
             {
               "name": "id_a",
-              "type": "int",
+              "type": "integer",
               "required": true,
               "help": "First record ID"
             },
             {
               "name": "id_b",
-              "type": "int",
+              "type": "integer",
               "required": true,
               "help": "Second record ID"
             },
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3768,7 +3768,7 @@
           "options": [
             {
               "name": "--path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Memory DB path"
@@ -3786,7 +3786,7 @@
             },
             {
               "name": "--security",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
@@ -3817,7 +3817,7 @@
             },
             {
               "name": "--fields",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Comma-separated field names to match on"
             },
@@ -3830,21 +3830,21 @@
             },
             {
               "name": "--security",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'high'",
               "help": "Security level: standard, high, paranoid"
             },
             {
               "name": "--protocol",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'trusted_third_party'",
               "help": "Protocol: trusted_third_party or smc"
             },
             {
               "name": "--scorer",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'dice'",
               "help": "Similarity scorer: dice or jaccard"
@@ -3858,7 +3858,7 @@
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them."
@@ -3870,7 +3870,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to profile"
             },
@@ -3902,7 +3902,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Input files (path or path:source_name). Omit to review only the pending queue."
@@ -3915,21 +3915,21 @@
             },
             {
               "name": "--job",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'review'",
               "help": "Review-queue job name for freshly-gated pairs"
             },
             {
               "name": "--queue-path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db)"
             },
             {
               "name": "--memory-path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.goldenmatch/memory.db'",
               "help": "Learning Memory SQLite path"
@@ -3950,14 +3950,14 @@
             },
             {
               "name": "--decided-by",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'cli'",
               "help": "Steward identifier recorded on each decision"
             },
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "50",
               "help": "Max pairs to review this session"
@@ -3969,13 +3969,13 @@
           "options": [
             {
               "name": "run_id",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Run ID to rollback"
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3987,7 +3987,7 @@
           "options": [
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Directory containing run log"
@@ -3999,34 +3999,34 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Data files to process"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--every",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Run interval (e.g. 1h, 30m, 6h, 1d)"
             },
             {
               "name": "--cron",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Cron schedule (e.g. '0 6 * * *')"
             },
             {
               "name": "--output-dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Output directory"
@@ -4038,19 +4038,19 @@
           "options": [
             {
               "name": "a",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "First string."
             },
             {
               "name": "b",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Second string."
             },
             {
               "name": "--scorer",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'jaro_winkler'",
               "help": "Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble."
@@ -4062,7 +4062,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input files (path or path:source_name)"
             },
@@ -4074,13 +4074,13 @@
             },
             {
               "name": "--sweep",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Sweep spec: field:start:stop:step (repeatable)"
             },
             {
               "name": "--sample",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Random sample size for speed"
@@ -4099,27 +4099,27 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Data files to load"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Server host"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8080",
               "help": "Server port"
@@ -4138,14 +4138,14 @@
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'127.0.0.1'",
               "help": "Host to bind."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "5050",
               "help": "Port (0 = pick free, default 5050 matches Vite proxy)."
@@ -4175,34 +4175,34 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source table name"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--output-mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
@@ -4223,21 +4223,21 @@
             },
             {
               "name": "--incremental-column",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column for incremental detection"
             },
             {
               "name": "--chunk-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Records per chunk"
             },
             {
               "name": "--exclude-columns",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set."
@@ -4263,7 +4263,7 @@
           "options": [
             {
               "name": "files",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "File(s) to load"
             }
@@ -4274,20 +4274,20 @@
           "options": [
             {
               "name": "record_id",
-              "type": "int",
+              "type": "integer",
               "required": true,
               "help": "Record row ID to unmerge from its cluster"
             },
             {
               "name": "--clusters",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to clusters CSV from a previous run"
             },
             {
               "name": "--pairs",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to scored pairs CSV (id_a,id_b,score)"
@@ -4308,7 +4308,7 @@
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Where to write the re-clustered CSV (default: <clusters>.unmerged.csv)"
@@ -4320,48 +4320,48 @@
           "options": [
             {
               "name": "--source-type",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'postgres'",
               "help": "Database type"
             },
             {
               "name": "--connection-string",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Database URL"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Table to watch"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Config YAML file"
             },
             {
               "name": "--interval",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "30",
               "help": "Seconds between polls"
             },
             {
               "name": "--output-mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'separate'",
               "help": "separate or in_place"
             },
             {
               "name": "--incremental-column",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column for change detection"
@@ -5677,7 +5677,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8100",
               "help": "Port for the A2A server"
@@ -5702,7 +5702,7 @@
             },
             {
               "name": "--skip",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "[]",
               "help": "Techniques to skip"
@@ -5728,7 +5728,7 @@
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack to apply."
@@ -5753,14 +5753,14 @@
             },
             {
               "name": "--sample-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Bound the cross-tuple (pairwise) pass."
             },
             {
               "name": "--max-constraints",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Cap the ranked number of DCs reported."
@@ -5785,7 +5785,7 @@
             },
             {
               "name": "--ref",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Git ref to compare against (default: HEAD)."
@@ -5841,7 +5841,7 @@
             },
             {
               "name": "--mode",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'safe'",
               "help": "Fix mode: safe, moderate, or aggressive."
@@ -5892,7 +5892,7 @@
             },
             {
               "name": "--last",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "None",
               "help": "Show last N scans."
@@ -5942,7 +5942,7 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
@@ -5958,21 +5958,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -5990,7 +5990,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Rows to sample."
@@ -6014,7 +6014,7 @@
             },
             {
               "name": "--on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "FK mapping 'child_col=parent_col' (repeatable). Omit to auto-detect same-named parent-key columns."
@@ -6028,7 +6028,7 @@
             },
             {
               "name": "--fail-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'error'",
               "help": "CI exit threshold: error/warning/info."
@@ -6074,14 +6074,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6120,14 +6120,14 @@
             },
             {
               "name": "--llm-provider",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'anthropic'",
               "help": "LLM provider: anthropic or openai."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack: healthcare, finance, ecommerce."
@@ -6155,14 +6155,14 @@
             },
             {
               "name": "--webhook",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "URL to POST findings to."
             },
             {
               "name": "--notify-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6209,27 +6209,27 @@
           "options": [
             {
               "name": "connection",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Database connection string (postgres://, snowflake://, etc.)"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Table name to scan."
             },
             {
               "name": "--query",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Custom SQL query."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack."
@@ -6250,7 +6250,7 @@
             },
             {
               "name": "--sample-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "100000",
               "help": "Max rows to fetch."
@@ -6268,28 +6268,28 @@
             },
             {
               "name": "--interval",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'daily'",
               "help": "Interval: hourly, daily, weekly, 5min, 15min, 30min, or seconds."
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack."
             },
             {
               "name": "--webhook",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Webhook URL for notifications."
             },
             {
               "name": "--notify-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'grade-drop'",
               "help": "Trigger: grade-drop, any-error, any-warning."
@@ -6308,14 +6308,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host to bind to."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8000",
               "help": "Port to listen on."
@@ -6365,21 +6365,21 @@
             },
             {
               "name": "--interval",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "60",
               "help": "Poll interval in seconds."
             },
             {
               "name": "--pattern",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Glob pattern (e.g., '*.csv')."
             },
             {
               "name": "--exit-on",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Exit on severity: error or warning."
@@ -6925,7 +6925,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8150",
               "help": "Port the A2A agent server listens on."
@@ -6966,7 +6966,7 @@
           "options": [
             {
               "name": "--limit",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "20",
               "help": "Number of recent runs to show"
@@ -7058,21 +7058,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: stdio or http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8150",
               "help": "Port for HTTP transport"
@@ -7101,7 +7101,7 @@
             },
             {
               "name": "--every",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'1h'",
               "help": "Interval (e.g., 5m, 1h, 30s)"
@@ -7127,14 +7127,14 @@
           "options": [
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Network interface the REST API server binds to."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8000",
               "help": "Port the REST API server listens on."
@@ -7152,7 +7152,7 @@
             },
             {
               "name": "--chunk-size",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "10000",
               "help": "Rows per batch"
@@ -7198,7 +7198,7 @@
             },
             {
               "name": "--domain",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Domain pack to use"
@@ -8020,7 +8020,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8250",
               "help": "Port for A2A server"
@@ -8032,7 +8032,7 @@
           "options": [
             {
               "name": "--dir",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'.'",
               "help": "Directory to create config in"
@@ -8044,14 +8044,14 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional data file to load (press 'r' to run)."
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional pipeline YAML config."
@@ -8063,21 +8063,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport type: stdio or http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8250",
               "help": "Port for HTTP transport"
@@ -8089,20 +8089,20 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Input file path"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Pipeline YAML config"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Output file path"
@@ -8116,21 +8116,21 @@
             },
             {
               "name": "--identity-path",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Enable Identity Graph; persist to this SQLite path"
             },
             {
               "name": "--identity-dataset",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Identity Graph dataset namespace"
             },
             {
               "name": "--identity-source-pk",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Column to derive `{source}:{source_pk}` record_id from"
@@ -8149,7 +8149,7 @@
           "options": [
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8000",
               "help": "Port for REST API"
@@ -8165,7 +8165,7 @@
           "options": [
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Pipeline YAML config"
             }
@@ -8460,19 +8460,19 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source CSV file to apply mapping to"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Output CSV path (required)"
             },
@@ -8490,13 +8490,13 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source data to inspect (CSV path, schema YAML, etc.)"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Table name for DB sources"
@@ -8515,47 +8515,47 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source data (CSV path, DataFrame, DB URI, schema YAML)"
             },
             {
               "name": "target",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Target data (same variety of inputs)"
             },
             {
               "name": "--table",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Optional table name for DB sources"
             },
             {
               "name": "--required",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated required target field names"
             },
             {
               "name": "--schema-file",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Path to schema YAML file"
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'table'",
               "help": "Output format: table, json, or yaml"
             },
             {
               "name": "--output",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Save mapping config to this YAML file"
@@ -8588,21 +8588,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "Transport: 'stdio' or 'http'"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host for HTTP transport"
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8100",
               "help": "Port for HTTP transport"
@@ -8614,19 +8614,19 @@
           "options": [
             {
               "name": "source",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Source data to validate (CSV path, etc.)"
             },
             {
               "name": "--config",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Path to mapping config YAML (required)"
             },
             {
               "name": "--required",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Comma-separated required field names"
@@ -8829,21 +8829,21 @@
           "options": [
             {
               "name": "--transport",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'stdio'",
               "help": "stdio | http"
             },
             {
               "name": "--host",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'0.0.0.0'",
               "help": "Host interface to bind when transport is http."
             },
             {
               "name": "--port",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "8300",
               "help": "HTTP port (A2A convention: Analysis = 8300)."
@@ -8855,7 +8855,7 @@
           "options": [
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Dataset name whose run history to check."
             },
@@ -8867,21 +8867,21 @@
             },
             {
               "name": "--baseline",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'rolling_median'",
               "help": "Baseline strategy to compare against, e.g. rolling_median."
             },
             {
               "name": "--window",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "7",
               "help": "Number of prior runs the baseline is computed over."
             },
             {
               "name": "--policy",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "None",
               "help": "Per-metric gates: JSON or \"key=pct,key=pct\"."
@@ -8906,14 +8906,14 @@
             },
             {
               "name": "--analyzers",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'all'",
               "help": "Comma-separated analyzer names, or 'all'."
             },
             {
               "name": "--format",
-              "type": "str",
+              "type": "text",
               "required": false,
               "default": "'markdown'",
               "help": "markdown | json"
@@ -8932,13 +8932,13 @@
           "options": [
             {
               "name": "--metric",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Metric key to trend, e.g. cluster.singleton_ratio."
             },
             {
               "name": "--dataset",
-              "type": "str",
+              "type": "text",
               "required": true,
               "help": "Dataset name whose run history to read."
             },
@@ -8950,7 +8950,7 @@
             },
             {
               "name": "--last",
-              "type": "int",
+              "type": "integer",
               "required": false,
               "default": "30",
               "help": "Number of most recent runs to include in the trend."

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [1.20.0] - 2026-07-24
+
+### Added
+- **Domain rulebooks + the `list_domains` / `create_domain` / `test_domain` MCP tools** (parity batch 3; MCP **80 → 83**). Port of Python `core/domain_registry.py` — user-authored YAML extraction rules for a data domain (medical devices, automotive parts, …), the counterpart to the compiled-in `core/domain.ts` extractors.
+  - `src/core/domain-rulebook.ts` (**edge-safe**): rulebook shape, `compileRulebook`, `extractWithRulebook` (brand / identifiers / attributes / normalized name + Python's exact confidence scoring), `matchDomain`. An invalid user regex is skipped and reported, never thrown — one bad pattern can't take down a rulebook.
+  - `src/node/domain-registry.ts` (**node**): YAML `loadRulebook` / `saveRulebook` / `discoverRulebooks` over `.goldenmatch/domains` + `~/.goldenmatch/domains`, in Python's snake_case key order so a rulebook authored by either toolkit loads in the other. `yaml` is an optional peer dep with an actionable error when absent.
+  - `test_domain` reads the current run's rows from `RUN_STORE` (the TS analogue of Python's server-held `_rows`).
+- **`interactive` CLI command** — see below.
+
+### Fixed
+- **`interactive` / `tui` were the same command counted as two gaps.** Python's CLI called it `interactive`, the TS CLI called it `tui`; both launch the TUI over optional input files, so the parity manifest listed one capability as *both* a `python_only` and a `ts_only` gap. Both CLIs now register both names (TS `cli_commands.ts_only` is now **empty**). It had to be a real second `.command()`, not `.alias()` — the surface emitter reads `program.commands.map(c => c.name())` and does not see commander aliases, so an alias would have left the manifest lying.
+
+### Known difference (documented, not a gap)
+- TS `list_domains` returns only user-authored rulebooks. Python additionally ships 7 built-in YAML packs inside its wheel (`goldenmatch/domains/`); the TS package's built-in domain knowledge is the compiled-in `core/domain.ts` extractors instead, so there is no third search path and a fresh TS install lists zero domains where Python lists 7.
+- Regex parity is the common Python/JS subset. Python-only constructs (named groups `(?P<x>…)`, atomic/possessive groups, conditionals) are reported invalid rather than silently mis-matching. `\w`-style word splitting is normalized to `\p{L}\p{N}_` so it stays Unicode-aware like Python's.
+
 ## [1.19.0] - 2026-07-24
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -1059,38 +1059,53 @@ program
     startA2aServer({ port: parseInt(opts.port, 10), host: opts.host });
   });
 
-// ---------- tui ----------
-program
-  .command("tui")
-  .description("Launch interactive TUI (requires optional peer deps: ink + react)")
-  .argument("[files...]", "input files to load on startup")
-  .option("-c, --config <path>", "path to YAML config file")
-  .option("--memory-path <path>", "Learning Memory SQLite path for Boost-tab labels")
-  .option("-o, --output-dir <dir>", "directory the Export tab writes into")
-  .action(
-    async (
-      files: string[],
-      opts: { config?: string; memoryPath?: string; outputDir?: string },
-    ) => {
-    try {
-      const { startTui } = await import("./node/tui/app.js");
-      const tuiOpts: {
-        files?: string[];
-        config?: ReturnType<typeof loadConfigFile>;
-        memoryPath?: string;
-        outputDir?: string;
-      } = {};
-      if (files && files.length > 0) tuiOpts.files = files;
-      if (opts.config) tuiOpts.config = loadConfigFile(opts.config);
-      if (opts.memoryPath) tuiOpts.memoryPath = opts.memoryPath;
-      if (opts.outputDir) tuiOpts.outputDir = opts.outputDir;
-      await startTui(tuiOpts);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`TUI error: ${message}\n`);
-      process.exit(1);
-    }
-  });
+// ---------- tui / interactive (one command, two names) ----------
+//
+// Python's CLI calls this `interactive`; the TS CLI has always called it `tui`.
+// They are the SAME operation (launch the TUI over optional input files), so the
+// parity manifest was counting ONE capability as BOTH a python_only gap and a
+// ts_only gap. Registering both names on both sides closes both halves.
+//
+// It must be a real second `.command()`, NOT `.alias("interactive")`: the API
+// surface emitter reads `program.commands.map(c => c.name())`, which does not
+// see commander aliases -- an alias would leave the manifest lying.
+interface TuiCmdOpts {
+  config?: string;
+  memoryPath?: string;
+  outputDir?: string;
+}
+
+async function runTuiCommand(files: string[], opts: TuiCmdOpts): Promise<void> {
+  try {
+    const { startTui } = await import("./node/tui/app.js");
+    const tuiOpts: {
+      files?: string[];
+      config?: ReturnType<typeof loadConfigFile>;
+      memoryPath?: string;
+      outputDir?: string;
+    } = {};
+    if (files && files.length > 0) tuiOpts.files = files;
+    if (opts.config) tuiOpts.config = loadConfigFile(opts.config);
+    if (opts.memoryPath) tuiOpts.memoryPath = opts.memoryPath;
+    if (opts.outputDir) tuiOpts.outputDir = opts.outputDir;
+    await startTui(tuiOpts);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`TUI error: ${message}\n`);
+    process.exit(1);
+  }
+}
+
+for (const cmdName of ["tui", "interactive"] as const) {
+  program
+    .command(cmdName)
+    .description("Launch the interactive TUI (requires optional peer deps: ink + react)")
+    .argument("[files...]", "input files to load on startup")
+    .option("-c, --config <path>", "path to YAML config file")
+    .option("--memory-path <path>", "Learning Memory SQLite path for Boost-tab labels")
+    .option("-o, --output-dir <dir>", "directory the Export tab writes into")
+    .action(runTuiCommand);
+}
 
 // ---------- analyze-blocking ----------
 program

--- a/packages/typescript/goldenmatch/src/core/domain-rulebook.ts
+++ b/packages/typescript/goldenmatch/src/core/domain-rulebook.ts
@@ -1,0 +1,198 @@
+/**
+ * domain-rulebook.ts -- user-defined domain extraction rulebooks (edge-safe half).
+ *
+ * Port of the pure logic in Python `core/domain_registry.py`: the rulebook
+ * shape, regex compilation, `extract`, and `match_domain`. Everything here is
+ * dependency-free and `node:*`-free so it runs on the edge; the filesystem half
+ * (load / save / discover YAML) lives in `src/node/domain-registry.ts`.
+ *
+ * A rulebook is the user-authored counterpart to the built-in `core/domain.ts`
+ * extractors: instead of hard-coded electronics/software heuristics, the user
+ * declares signals + regex patterns for their own domain (medical devices,
+ * automotive parts, ...).
+ *
+ * REGEX PARITY CAVEAT: Python `re` and JS `RegExp` are not the same engine.
+ * Patterns using only the common subset (literals, classes, groups, `\b`,
+ * `\d`, `\s`, quantifiers) behave identically; Python-specific constructs
+ * (named groups `(?P<x>...)`, possessive/atomic groups, conditionals) do NOT
+ * translate and are reported as invalid rather than silently mis-matching.
+ * `\w` is normalized below so word-splitting stays Unicode-aware like Python's.
+ */
+
+export interface DomainRulebook {
+  readonly name: string;
+  readonly signals: readonly string[];
+  /** name -> regex source, e.g. `{ ndc: "\\b(\\d{5}-\\d{4}-\\d{2})\\b" }` */
+  readonly identifierPatterns: Readonly<Record<string, string>>;
+  /** literal brand strings (escaped + alternated at compile time) */
+  readonly brandPatterns: readonly string[];
+  readonly attributePatterns: Readonly<Record<string, string>>;
+  readonly stopWords: readonly string[];
+  readonly normalization: Readonly<Record<string, string>>;
+}
+
+export interface CompiledRulebook {
+  readonly rulebook: DomainRulebook;
+  readonly identifiers: ReadonlyMap<string, RegExp>;
+  readonly attributes: ReadonlyMap<string, RegExp>;
+  readonly brands: RegExp | null;
+  /** Patterns that failed to compile (Python logs a warning and skips them). */
+  readonly invalid: readonly string[];
+}
+
+export interface RulebookExtraction {
+  readonly brand: string | null;
+  readonly identifiers: Record<string, string>;
+  readonly attributes: Record<string, string>;
+  readonly nameNormalized: string | null;
+  readonly confidence: number;
+}
+
+/** Empty-but-valid rulebook, so callers can build one field-by-field. */
+export function makeRulebook(name: string, partial: Partial<DomainRulebook> = {}): DomainRulebook {
+  return {
+    name,
+    signals: partial.signals ?? [],
+    identifierPatterns: partial.identifierPatterns ?? {},
+    brandPatterns: partial.brandPatterns ?? [],
+    attributePatterns: partial.attributePatterns ?? {},
+    stopWords: partial.stopWords ?? [],
+    normalization: partial.normalization ?? {},
+  };
+}
+
+/** Escape a literal for use inside a RegExp (the `re.escape` analogue). */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Compile a rulebook's patterns. Mirrors Python's `DomainRulebook.compile`:
+ * every pattern is case-insensitive, and an invalid pattern is SKIPPED (Python
+ * logs a warning) rather than throwing -- one bad user regex must not take down
+ * the whole rulebook.
+ */
+export function compileRulebook(rb: DomainRulebook): CompiledRulebook {
+  const invalid: string[] = [];
+  const identifiers = new Map<string, RegExp>();
+  for (const [name, pattern] of Object.entries(rb.identifierPatterns)) {
+    try {
+      identifiers.set(name, new RegExp(pattern, "i"));
+    } catch {
+      invalid.push(`identifier:${name}`);
+    }
+  }
+  const attributes = new Map<string, RegExp>();
+  for (const [name, pattern] of Object.entries(rb.attributePatterns)) {
+    try {
+      attributes.set(name, new RegExp(pattern, "i"));
+    } catch {
+      invalid.push(`attribute:${name}`);
+    }
+  }
+  let brands: RegExp | null = null;
+  if (rb.brandPatterns.length > 0) {
+    const alternation = rb.brandPatterns.map(escapeRegExp).join("|");
+    try {
+      brands = new RegExp(`\\b(${alternation})\\b`, "i");
+    } catch {
+      invalid.push("brands");
+    }
+  }
+  return { rulebook: rb, identifiers, attributes, brands, invalid };
+}
+
+/**
+ * Extract brand / identifiers / attributes / a normalized name from `text`.
+ *
+ * Faithful to Python's scoring: brand and each matched identifier add 1 signal,
+ * each matched attribute adds 0.5, a non-empty normalized name adds 1, and
+ * `confidence = min(1, signals / max(identifierPatterns + 1, 2))`.
+ */
+export function extractWithRulebook(
+  compiled: CompiledRulebook,
+  text: string,
+): RulebookExtraction {
+  const rb = compiled.rulebook;
+  let signals = 0;
+
+  let brand: string | null = null;
+  if (compiled.brands) {
+    const m = compiled.brands.exec(text);
+    if (m) {
+      brand = (m[1] ?? m[0]).trim();
+      signals += 1;
+    }
+  }
+
+  const identifiers: Record<string, string> = {};
+  for (const [name, re] of compiled.identifiers) {
+    const m = re.exec(text);
+    if (m) {
+      // Python: `m.group(1) if m.lastindex else m.group(0)`.
+      identifiers[name] = (m[1] ?? m[0]).trim();
+      signals += 1;
+    }
+  }
+
+  const attributes: Record<string, string> = {};
+  for (const [name, re] of compiled.attributes) {
+    const m = re.exec(text);
+    if (m) {
+      attributes[name] = m[0].trim(); // Python uses group(0) for attributes
+      signals += 0.5;
+    }
+  }
+
+  // Name normalization: lowercase, strip the parts already extracted, drop
+  // punctuation, then drop stop words and 1-char tokens.
+  let name = text.toLowerCase();
+  for (const re of compiled.identifiers.values()) name = name.replace(stripAll(re), " ");
+  for (const re of compiled.attributes.values()) name = name.replace(stripAll(re), " ");
+  const stop = new Set(rb.stopWords);
+  // `\p{L}\p{N}_` keeps this Unicode-aware like Python's `\w` (JS `\w` is ASCII).
+  const words = name
+    .replace(/[^\p{L}\p{N}_\s]/gu, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 1 && !stop.has(w));
+  const nameNormalized = words.length > 0 ? words.join(" ").trim() : null;
+  if (nameNormalized) signals += 1;
+
+  const denom = Math.max(Object.keys(rb.identifierPatterns).length + 1, 2);
+  return {
+    brand,
+    identifiers,
+    attributes,
+    nameNormalized,
+    confidence: Math.min(1, signals / denom),
+  };
+}
+
+/** A global-flag twin of `re`, so `.replace` strips EVERY occurrence (Python's `pattern.sub`). */
+function stripAll(re: RegExp): RegExp {
+  return re.global ? re : new RegExp(re.source, `${re.flags}g`);
+}
+
+/**
+ * Best-matching rulebook for a set of column names, scored by how many of a
+ * rulebook's `signals` appear in the joined lowercased column names. Returns
+ * `null` when nothing scores above zero (Python's `match_domain`).
+ */
+export function matchDomain(
+  columns: readonly string[],
+  rulebooks: readonly DomainRulebook[],
+): DomainRulebook | null {
+  if (rulebooks.length === 0) return null;
+  const colStr = columns.map((c) => c.toLowerCase()).join(" ");
+  let best: DomainRulebook | null = null;
+  let bestScore = 0;
+  for (const rb of rulebooks) {
+    let score = 0;
+    for (const s of rb.signals) if (colStr.includes(s.toLowerCase())) score += 1;
+    if (score > bestScore) {
+      bestScore = score;
+      best = rb;
+    }
+  }
+  return bestScore > 0 ? best : null;
+}

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.19.0",
+  version: "1.20.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/domain-registry.ts
+++ b/packages/typescript/goldenmatch/src/node/domain-registry.ts
@@ -1,0 +1,139 @@
+/**
+ * domain-registry.ts -- discover / load / save domain rulebooks (node half).
+ *
+ * Port of the filesystem side of Python `core/domain_registry.py`. The pure
+ * logic (shape, compile, extract, match) is edge-safe in
+ * `src/core/domain-rulebook.ts`; this module owns YAML + `node:fs` so the core
+ * stays `node:*`-free.
+ *
+ * Search order mirrors Python -- later paths do NOT override earlier ones by
+ * position; the LAST loaded name wins, exactly as Python's dict assignment does:
+ *   1. `.goldenmatch/domains/`            (project-local)
+ *   2. `~/.goldenmatch/domains/`          (user global)
+ *
+ * DELIBERATE DIFFERENCE: Python has a third, built-in `goldenmatch/domains/`
+ * directory shipped inside the wheel (7 packs: electronics, software, ...).
+ * The TS package ships no YAML packs -- its built-in domain knowledge is the
+ * compiled-in `core/domain.ts` extractors -- so there is no third search path.
+ * `list_domains` on TS therefore returns only user-authored rulebooks, and is
+ * empty on a fresh install where Python's would list the 7 built-ins.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from "node:fs";
+import { join, resolve, extname, basename } from "node:path";
+import { homedir } from "node:os";
+import { createRequire } from "node:module";
+import type { DomainRulebook } from "../core/domain-rulebook.js";
+import { makeRulebook } from "../core/domain-rulebook.js";
+
+/** Rulebook search directories, highest precedence LAST (last loaded wins). */
+export function searchPaths(): string[] {
+  return [
+    resolve(".goldenmatch", "domains"),
+    join(homedir(), ".goldenmatch", "domains"),
+  ];
+}
+
+interface YamlModule {
+  parse(src: string): unknown;
+  stringify(value: unknown, opts?: Record<string, unknown>): string;
+}
+
+/**
+ * `yaml` is an OPTIONAL peer dep (same posture as better-sqlite3). Resolve it
+ * lazily and fail with an actionable message instead of a bare MODULE_NOT_FOUND.
+ */
+function loadYaml(): YamlModule {
+  try {
+    const req = createRequire(import.meta.url);
+    return req("yaml") as YamlModule;
+  } catch {
+    throw new Error(
+      "Domain rulebooks are YAML; install the optional peer dependency: npm install yaml",
+    );
+  }
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+function asStringRecord(v: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (v && typeof v === "object" && !Array.isArray(v)) {
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      if (typeof val === "string") out[k] = val;
+    }
+  }
+  return out;
+}
+
+/** Load one rulebook from a YAML file. Throws if the file is missing. */
+export function loadRulebook(path: string): DomainRulebook {
+  if (!existsSync(path)) throw new Error(`Domain rulebook not found: ${path}`);
+  const data = loadYaml().parse(readFileSync(path, "utf-8"));
+  const obj = (data && typeof data === "object" ? data : {}) as Record<string, unknown>;
+  const fallbackName = basename(path, extname(path));
+  return makeRulebook(
+    typeof obj["name"] === "string" ? obj["name"] : fallbackName,
+    {
+      signals: asStringArray(obj["signals"]),
+      identifierPatterns: asStringRecord(obj["identifier_patterns"]),
+      brandPatterns: asStringArray(obj["brand_patterns"]),
+      attributePatterns: asStringRecord(obj["attribute_patterns"]),
+      stopWords: asStringArray(obj["stop_words"]),
+      normalization: asStringRecord(obj["normalization"]),
+    },
+  );
+}
+
+/**
+ * Write a rulebook to YAML, creating parent dirs. Keys are emitted in Python's
+ * order (`sort_keys=False`) and in Python's snake_case so a rulebook authored by
+ * either toolkit loads in the other.
+ */
+export function saveRulebook(rb: DomainRulebook, path: string): string {
+  const yaml = loadYaml();
+  const dir = resolve(path, "..");
+  mkdirSync(dir, { recursive: true });
+  const data = {
+    name: rb.name,
+    signals: [...rb.signals],
+    identifier_patterns: { ...rb.identifierPatterns },
+    brand_patterns: [...rb.brandPatterns],
+    attribute_patterns: { ...rb.attributePatterns },
+    stop_words: [...rb.stopWords],
+    normalization: { ...rb.normalization },
+  };
+  writeFileSync(path, yaml.stringify(data), "utf-8");
+  return resolve(path);
+}
+
+/**
+ * Discover every rulebook across the search paths, keyed by rulebook name.
+ * A file that fails to parse is SKIPPED (Python logs a warning) so one broken
+ * YAML can't hide every other domain.
+ */
+export function discoverRulebooks(): Map<string, DomainRulebook> {
+  const found = new Map<string, DomainRulebook>();
+  for (const dir of searchPaths()) {
+    if (!existsSync(dir)) continue;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries.sort()) {
+      const ext = extname(entry).toLowerCase();
+      if (ext !== ".yaml" && ext !== ".yml") continue;
+      try {
+        const rb = loadRulebook(join(dir, entry));
+        found.set(rb.name, rb);
+      } catch {
+        // skip unreadable / invalid rulebook, like Python's warn-and-continue
+      }
+    }
+  }
+  return found;
+}

--- a/packages/typescript/goldenmatch/src/node/mcp/domain-tools.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/domain-tools.ts
@@ -1,0 +1,206 @@
+/**
+ * domain-tools.ts -- MCP tools for user-defined domain rulebooks.
+ *
+ * Ports the three Python domain tools (`_tool_list_domains`,
+ * `_tool_create_domain`, `_tool_test_domain` in `goldenmatch/mcp/server.py`)
+ * onto the TS registry: pure logic in `core/domain-rulebook.ts`, YAML +
+ * filesystem in `node/domain-registry.ts`.
+ *
+ * `test_domain` reads the CURRENT RUN's rows from `RUN_STORE` -- the TS analogue
+ * of Python's server-held `_rows` (populated there by `--file` at startup, here
+ * by a `dedupe` call in the session).
+ */
+
+import type { Tool } from "./run-tools.js";
+import { compileRulebook, extractWithRulebook } from "../../core/domain-rulebook.js";
+import { makeRulebook } from "../../core/domain-rulebook.js";
+import { discoverRulebooks, saveRulebook } from "../domain-registry.js";
+import { RUN_STORE } from "./run-store.js";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export const DOMAIN_TOOLS: readonly Tool[] = [
+  {
+    name: "list_domains",
+    description:
+      "List available domain extraction rulebooks (user-defined YAML in " +
+      ".goldenmatch/domains or ~/.goldenmatch/domains).",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "create_domain",
+    description:
+      "Create a custom domain extraction rulebook. Define patterns for a " +
+      "specific data domain (medical devices, automotive parts, real estate, etc.).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Domain name" },
+        scope: {
+          type: "string",
+          enum: ["local", "global"],
+          description: "local = .goldenmatch/domains, global = ~/.goldenmatch/domains",
+        },
+        signals: {
+          type: "array",
+          items: { type: "string" },
+          description: "Column-name substrings that trigger this domain",
+        },
+        identifier_patterns: {
+          type: "object",
+          description: "name -> regex for identifier/model/SKU extraction",
+        },
+        brand_patterns: {
+          type: "array",
+          items: { type: "string" },
+          description: "Literal brand names",
+        },
+        attribute_patterns: {
+          type: "object",
+          description: "name -> regex for domain-specific attributes",
+        },
+        stop_words: {
+          type: "array",
+          items: { type: "string" },
+          description: "Words stripped during name normalization",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "test_domain",
+    description:
+      "Test a domain extraction rulebook against the loaded data. Shows what " +
+      "features would be extracted from sample records.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        domain_name: { type: "string", description: "Rulebook name to test" },
+        sample_size: { type: "number", description: "Rows to sample (default 10)" },
+      },
+      required: ["domain_name"],
+    },
+  },
+];
+
+export const DOMAIN_TOOL_NAMES: ReadonlySet<string> = new Set(
+  DOMAIN_TOOLS.map((t) => t.name),
+);
+
+function strArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+function strRecord(v: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (v && typeof v === "object" && !Array.isArray(v)) {
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      if (typeof val === "string") out[k] = val;
+    }
+  }
+  return out;
+}
+
+function toolListDomains(): unknown {
+  const rulebooks = discoverRulebooks();
+  const domains = [...rulebooks.values()].map((rb) => ({
+    name: rb.name,
+    signals: [...rb.signals],
+    identifier_patterns: Object.keys(rb.identifierPatterns),
+    brand_count: rb.brandPatterns.length,
+    attribute_patterns: Object.keys(rb.attributePatterns),
+  }));
+  return { domains, count: domains.length };
+}
+
+function toolCreateDomain(args: Record<string, unknown>): unknown {
+  const name = typeof args["name"] === "string" ? args["name"] : "";
+  if (!name) return { error: "create_domain requires a 'name'." };
+  const scope = args["scope"] === "global" ? "global" : "local";
+  const dir =
+    scope === "global"
+      ? join(homedir(), ".goldenmatch", "domains")
+      : resolve(".goldenmatch", "domains");
+
+  const rb = makeRulebook(name, {
+    signals: strArray(args["signals"]),
+    identifierPatterns: strRecord(args["identifier_patterns"]),
+    brandPatterns: strArray(args["brand_patterns"]),
+    attributePatterns: strRecord(args["attribute_patterns"]),
+    stopWords: strArray(args["stop_words"]),
+  });
+
+  const path = saveRulebook(rb, join(dir, `${name}.yaml`));
+  return {
+    status: "created",
+    name,
+    path,
+    scope,
+    signals: [...rb.signals],
+    identifier_patterns: Object.keys(rb.identifierPatterns),
+  };
+}
+
+function toolTestDomain(args: Record<string, unknown>): unknown {
+  const domainName = typeof args["domain_name"] === "string" ? args["domain_name"] : "";
+  const sampleSize =
+    typeof args["sample_size"] === "number" && Number.isFinite(args["sample_size"])
+      ? Math.floor(args["sample_size"])
+      : 10;
+
+  const run = RUN_STORE.getCurrent();
+  if (!run) {
+    return { error: "No data loaded. Run dedupe (or find_duplicates) in this session first." };
+  }
+  const rows = [...run.rowsById.values()];
+  if (rows.length === 0) return { error: "No data loaded." };
+
+  const rulebooks = discoverRulebooks();
+  const rb = rulebooks.get(domainName);
+  if (!rb) {
+    return {
+      error: `Domain '${domainName}' not found. Available: ${[...rulebooks.keys()].join(", ")}`,
+    };
+  }
+
+  // First non-internal string column, mirroring Python's sample_cols pick.
+  const first = rows[0]!;
+  const textCol = Object.keys(first).find(
+    (c) => !c.startsWith("__") && typeof first[c] === "string",
+  );
+  if (!textCol) return { error: "No text columns found in data." };
+
+  const compiled = compileRulebook(rb);
+  const extractions = rows.slice(0, sampleSize).map((row) => {
+    const text = String(row[textCol] ?? "");
+    const ex = extractWithRulebook(compiled, text);
+    return {
+      original: text.slice(0, 100),
+      brand: ex.brand,
+      identifiers: ex.identifiers,
+      name_normalized: ex.nameNormalized,
+      confidence: Math.round(ex.confidence * 100) / 100,
+    };
+  });
+
+  return {
+    domain: domainName,
+    text_column: textCol,
+    sample_size: extractions.length,
+    extractions,
+  };
+}
+
+export function handleDomainTool(name: string, args: Record<string, unknown>): unknown {
+  switch (name) {
+    case "list_domains":
+      return toolListDomains();
+    case "create_domain":
+      return toolCreateDomain(args);
+    case "test_domain":
+      return toolTestDomain(args);
+    default:
+      return { error: `Unknown domain tool: ${name}` };
+  }
+}

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -4,7 +4,7 @@
  *
  * Node-only: uses node:fs, node:path, node:readline. NOT edge-safe.
  *
- * Exposes 80 tools covering dedupe, match, scoring, explanation,
+ * Exposes 83 tools covering dedupe, match, scoring, explanation,
  * profiling, auto-config (shorthand), evaluation, listings, the Splink ->
  * GoldenMatch config converter (convert_splink_config), CCMS cluster
  * comparison (compare_clusters), Learning Memory (6 memory tools via
@@ -15,9 +15,11 @@
  * get_stats/list_clusters/get_cluster/get_golden_record/export_results/
  * upload_dataset/lineage, backed by the server-held RUN_STORE), the rollback
  * subsystem tools (list_runs/rollback via ROLLBACK_TOOLS, backed by the
- * on-disk .goldenmatch_runs.json run log), and the cluster-surgery tools
+ * on-disk .goldenmatch_runs.json run log), the cluster-surgery tools
  * (unmerge_record/shatter_cluster via SURGERY_TOOLS, which mutate the current
- * RUN_STORE run in place).
+ * RUN_STORE run in place), and the user-defined domain rulebooks
+ * (list_domains/create_domain/test_domain via DOMAIN_TOOLS, over YAML in
+ * .goldenmatch/domains).
  *
  * Every tool dispatch is wrapped in try/catch so a single failure never
  * crashes the JSON-RPC loop; errors come back as `{ error: "<msg>" }`.
@@ -73,6 +75,7 @@ import { getMatchkeys } from "../../core/types.js";
 import { sanitizePath } from "./paths.js";
 import { RUN_STORE } from "./run-store.js";
 import { RUN_TOOLS, RUN_TOOL_NAMES, handleRunTool } from "./run-tools.js";
+import { DOMAIN_TOOLS, DOMAIN_TOOL_NAMES, handleDomainTool } from "./domain-tools.js";
 import {
   ROLLBACK_TOOLS,
   ROLLBACK_TOOL_NAMES,
@@ -679,6 +682,7 @@ export const TOOLS: readonly Tool[] = [
   ...RUN_TOOLS,
   ...ROLLBACK_TOOLS,
   ...SURGERY_TOOLS,
+  ...DOMAIN_TOOLS,
 ];
 
 // ---------------------------------------------------------------------------
@@ -814,6 +818,10 @@ export async function handleTool(
     // Cluster-surgery tools mutate the current run in RUN_STORE in place.
     if (SURGERY_TOOL_NAMES.has(name)) {
       return await handleSurgeryTool(name, args);
+    }
+    // Domain-rulebook tools read/write user YAML under .goldenmatch/domains.
+    if (DOMAIN_TOOL_NAMES.has(name)) {
+      return handleDomainTool(name, args);
     }
     switch (name) {
       case "find_duplicates":   // alias
@@ -1164,7 +1172,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.19.0",
+          version: "1.20.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1591,7 +1599,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.19.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.20.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenmatch/tests/unit/domain-rulebook.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/domain-rulebook.test.ts
@@ -1,0 +1,137 @@
+/**
+ * domain-rulebook.test.ts -- the user-defined domain rulebook port (parity batch 3).
+ *
+ * Covers the edge-safe core (compile / extract / matchDomain) and the node
+ * registry round-trip (save -> discover -> load), which together back the
+ * `list_domains` / `create_domain` / `test_domain` MCP tools.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  makeRulebook,
+  compileRulebook,
+  extractWithRulebook,
+  matchDomain,
+} from "../../src/core/domain-rulebook.js";
+import { loadRulebook, saveRulebook } from "../../src/node/domain-registry.js";
+
+const MEDICAL = makeRulebook("medical_devices", {
+  signals: ["device", "ndc", "implant", "catheter"],
+  identifierPatterns: { ndc: "\\b(\\d{5}-\\d{4}-\\d{2})\\b" },
+  brandPatterns: ["Medtronic", "Abbott"],
+  attributePatterns: { size: "\\b(\\d+\\.?\\d*)\\s*(mm|cm|fr)\\b" },
+  stopWords: ["sterile", "single", "use", "disposable"],
+});
+
+const tmpDirs: string[] = [];
+function newTmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "gm-domains-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("rulebook extraction", () => {
+  it("pulls brand, identifier, attribute and a normalized name out of one string", () => {
+    const c = compileRulebook(MEDICAL);
+    const ex = extractWithRulebook(
+      c,
+      "Medtronic sterile catheter 12345-6789-01 6.5 fr single use",
+    );
+    expect(ex.brand).toBe("Medtronic");
+    expect(ex.identifiers["ndc"]).toBe("12345-6789-01");
+    expect(ex.attributes["size"]).toBe("6.5 fr");
+    // stop words + the extracted spans are stripped; 1-char tokens dropped
+    expect(ex.nameNormalized).toContain("catheter");
+    expect(ex.nameNormalized).not.toContain("sterile");
+    expect(ex.nameNormalized).not.toContain("12345");
+    expect(ex.confidence).toBeGreaterThan(0);
+    expect(ex.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it("returns nulls (not throws) when nothing matches", () => {
+    const ex = extractWithRulebook(compileRulebook(MEDICAL), "unrelated text");
+    expect(ex.brand).toBeNull();
+    expect(ex.identifiers).toEqual({});
+    expect(ex.attributes).toEqual({});
+  });
+
+  it("skips an invalid regex instead of failing the whole rulebook", () => {
+    const bad = makeRulebook("bad", {
+      identifierPatterns: { good: "(\\d+)", broken: "([unclosed" },
+    });
+    const c = compileRulebook(bad);
+    expect(c.invalid).toContain("identifier:broken");
+    expect(c.identifiers.has("good")).toBe(true);
+    // the surviving pattern still works
+    expect(extractWithRulebook(c, "order 42").identifiers["good"]).toBe("42");
+  });
+
+  it("escapes brand literals so regex metacharacters are matched literally", () => {
+    const rb = makeRulebook("b", { brandPatterns: ["Johnson & Johnson"] });
+    const ex = extractWithRulebook(compileRulebook(rb), "a Johnson & Johnson stent");
+    expect(ex.brand).toBe("Johnson & Johnson");
+  });
+});
+
+describe("matchDomain", () => {
+  it("picks the rulebook whose signals appear in the column names", () => {
+    const other = makeRulebook("automotive", { signals: ["vin", "trim"] });
+    const best = matchDomain(["device_name", "ndc_code"], [other, MEDICAL]);
+    expect(best?.name).toBe("medical_devices");
+  });
+
+  it("returns null when nothing scores", () => {
+    expect(matchDomain(["a", "b"], [MEDICAL])).toBeNull();
+  });
+});
+
+describe("registry round-trip", () => {
+  it("saves to YAML and loads back an equivalent rulebook", () => {
+    const dir = newTmpDir();
+    const path = saveRulebook(MEDICAL, join(dir, "medical_devices.yaml"));
+    const back = loadRulebook(path);
+    expect(back.name).toBe(MEDICAL.name);
+    expect([...back.signals]).toEqual([...MEDICAL.signals]);
+    expect(back.identifierPatterns).toEqual(MEDICAL.identifierPatterns);
+    expect([...back.brandPatterns]).toEqual([...MEDICAL.brandPatterns]);
+    expect([...back.stopWords]).toEqual([...MEDICAL.stopWords]);
+  });
+
+  it("reads Python's snake_case YAML keys", () => {
+    const dir = newTmpDir();
+    const p = join(dir, "auto.yaml");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      p,
+      [
+        "name: automotive",
+        "signals:",
+        "  - vin",
+        "identifier_patterns:",
+        '  vin: "\\\\b([A-HJ-NPR-Z0-9]{17})\\\\b"',
+        "brand_patterns:",
+        "  - Toyota",
+        "stop_words:",
+        "  - used",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const rb = loadRulebook(p);
+    expect(rb.name).toBe("automotive");
+    expect(Object.keys(rb.identifierPatterns)).toEqual(["vin"]);
+    expect([...rb.brandPatterns]).toEqual(["Toyota"]);
+  });
+
+  it("falls back to the filename when the YAML omits `name`", () => {
+    const dir = newTmpDir();
+    const p = join(dir, "fallback_name.yaml");
+    writeFileSync(p, "signals:\n  - x\n", "utf-8");
+    expect(loadRulebook(p).name).toBe("fallback_name");
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
@@ -184,7 +184,7 @@ describe("MCP server — handleTool dispatcher", () => {
 
 describe("MCP server — agent tools wiring", () => {
   it("TOOLS exposes 80 tools (46 + 4 cross-language naming aliases, #1451; +convert_splink_config +compare_clusters +7 run tools (incl. lineage) +2 rollback tools +2 surgery tools +2 identity-conflict tools +memory_import +schema_match +config_weaknesses +analyze_blocking +certify_recall +incremental +sensitivity +retrieve_similar)", () => {
-    expect(TOOLS.length).toBe(80);
+    expect(TOOLS.length).toBe(83);
   });
 
   it("TOOLS includes the agent skill names", () => {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -63,6 +63,7 @@ mcp_tools:
   - config_weaknesses
   - controller_telemetry
   - convert_splink_config
+  - create_domain
   - dedupe
   - evaluate
   - explain_cluster
@@ -95,6 +96,7 @@ mcp_tools:
   - list_blocking_strategies
   - list_clusters
   - list_corrections
+  - list_domains
   - list_runs
   - list_scorers
   - list_strategies
@@ -117,19 +119,17 @@ mcp_tools:
   - shatter_cluster
   - suggest_config
   - suggest_pprl
+  - test_domain
   - unmerge_record
   - upload_dataset
   python_only:
-  - create_domain
   - documents_ingest
   - documents_suggest_schema
   - explain_routing
   - lint_routing
-  - list_domains
   - list_plugins
   - plan_routing
   - pprl_auto_config
-  - test_domain
   ts_only:
   - build_clusters
   - find_exact_matches
@@ -153,6 +153,7 @@ cli_commands:
   - import-splink
   - incremental
   - info
+  - interactive
   - lineage
   - match
   - mcp-serve
@@ -160,12 +161,12 @@ cli_commands:
   - profile
   - score
   - serve
+  - tui
   python_only:
   - anomalies
   - config
   - ingest-docs
   - init
-  - interactive
   - label
   - pprl
   - review
@@ -178,8 +179,7 @@ cli_commands:
   - sync
   - unmerge
   - watch
-  ts_only:
-  - tui
+  ts_only: []
 a2a_skills:
   shared:
   - add_correction


### PR DESCRIPTION
> **Stacked on #2096** (batch 1). It targets `main`, so the squash-merge auto-close gotcha does not apply, but the diff shows batch 1's commits until #2096 lands. Review the top two commits.

Two items; **four** `python_only` entries closed, plus the last `ts_only` CLI entry.

## 1. Domain rulebooks — a real port, not wiring

`list_domains` / `create_domain` / `test_domain` move `python_only → shared` (TS MCP **80 → 83**).

I'd originally billed this as a cheap win. It wasn't: TS had domain **extraction** (`core/domain.ts`) but **no rulebook registry** — no `DomainRulebook`, `discover_rulebooks`, `load/save_rulebook`. So this ports Python's `core/domain_registry.py`:

- **`src/core/domain-rulebook.ts`** (edge-safe) — shape, `compileRulebook`, `extractWithRulebook`, `matchDomain`, with Python's exact confidence scoring (brand + each identifier = 1 signal, each attribute = 0.5, normalized name = 1, `min(1, signals / max(identifiers+1, 2))`).
- **`src/node/domain-registry.ts`** (node) — YAML load/save/discover over `.goldenmatch/domains` + `~/.goldenmatch/domains`, emitted in Python's snake_case key order **so a rulebook authored by either toolkit loads in the other**. `yaml` stays an optional peer dep with an actionable error.
- **`src/node/mcp/domain-tools.ts`** — the three tools. `test_domain` reads the current run's rows from `RUN_STORE` (the analogue of Python's server-held `_rows`).

An invalid user regex is **skipped and reported, never thrown** — one bad pattern must not take down a whole rulebook.

## 2. `interactive` / `tui` — one capability counted as two gaps

Python's CLI called it `interactive`; TS called it `tui`. Both launch the TUI over optional input files, so the manifest listed the same capability as **both** a `python_only` and a `ts_only` gap. Both CLIs now register both names, and TS `cli_commands.ts_only` is now **empty**.

It had to be a real second `.command()`, **not** `.alias()`: the surface emitter reads `program.commands.map(c => c.name())` and doesn't see commander aliases — an alias would have left the manifest lying while looking fixed.

## Documented differences (not gaps)

- TS `list_domains` returns only user-authored rulebooks. Python also ships **7 built-in YAML packs** inside its wheel; TS's built-in domain knowledge is the compiled-in `core/domain.ts` extractors, so there's no third search path and a fresh TS install lists zero where Python lists seven.
- Regex support is the common Python/JS subset. Python-only constructs (named groups, atomic/possessive, conditionals) are reported invalid rather than silently mis-matching; `\w`-style splitting is normalized to `\p{L}\p{N}_` to stay Unicode-aware like Python's.

## Verification

Ran the **actual gate** locally against both real surfaces, not just a proxy:

```
check_api_parity.py goldenmatch
  -> parity OK: manifest exactly partitions the real MCP + CLI surface
TS emitter (built dist): cli 21, mcp 83, all 3 domain tools present
Python emitter:          cli 37 (tui AND interactive present), mcp 82
```

9 new tests pass; `tsc --noEmit` clean; `ruff` clean; `1.19.0 → 1.20.0` with `check_version_consistency` green; `suite-matrix.mdx` + `api-surface.mdx` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)