### PR TITLE
fix(ci): llm-labeler-accuracy install via uv sync (polars-based dataset harness)

### DIFF
--- a/.github/workflows/llm-labeler-accuracy.yml
+++ b/.github/workflows/llm-labeler-accuracy.yml
@@ -46,10 +46,20 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install goldenmatch (+ openai client)
-        run: |
-          pip install -e packages/python/goldenmatch
-          pip install openai
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      # Mirrors the ci.yml auto-config-quality-gate job, which runs this same
+      # dataset harness. `uv sync --all-packages` is what makes polars available:
+      # goldenmatch 3.x is arrow-native and does NOT pull polars, but
+      # scripts/autoconfig_quality/datasets.py is polars-based. Do NOT "fix" that
+      # by re-adding polars to the package. Native builds are skipped (we run with
+      # GOLDENMATCH_NATIVE=0), so the rust toolchain steps are not needed here.
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      # pyarrow backs pl.from_pandas in the ncvr loader; openai is the labeler client.
+      - run: uv pip install pyarrow openai
 
       # Fail fast and loudly: a missing secret would otherwise look like a clean
       # "skipped" run and be mistaken for a result.
@@ -67,7 +77,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          python scripts/llm_labeler_accuracy.py \
+          uv run python scripts/llm_labeler_accuracy.py \
             --datasets "${{ inputs.datasets }}" \
             --row-cap "${{ inputs.row_cap }}" \
             --n-band "${{ inputs.n_band }}" \


### PR DESCRIPTION
First dispatch of `llm-labeler-accuracy` (run 30107018348) failed:

```
File "scripts/autoconfig_quality/datasets.py", line 20, in <module>
    import polars as pl
ModuleNotFoundError: No module named 'polars'
```

goldenmatch 3.x is arrow-native and deliberately does **not** pull polars, but the quality-gate dataset harness (`scripts/autoconfig_quality/datasets.py`) is polars-based. The fix is **not** to re-add polars to the package.

Instead, mirror the `ci.yml` auto-config-quality-gate job, which already runs this exact harness in CI:
- `uv sync --all-packages` (with the native packages excluded)
- `uv pip install pyarrow openai` — pyarrow backs `pl.from_pandas` in the ncvr loader; openai is the labeler client

The rust-toolchain / `build_native.py` steps that job carries are unnecessary here: this workflow runs with `GOLDENMATCH_NATIVE=0`.

The key check passed on the failed run, so the `OPENAI_API_KEY` secret is confirmed present and wired correctly.

Generated with [Claude Code](https://claude.com/claude-code)