### PR TITLE
feat(ts): sensitivity + pprl CLI commands (parity batch 5)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.21.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.22.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 75 | 7 | 8 |
-| `goldenmatch` | cli_commands | 25 | 12 | 0 |
+| `goldenmatch` | cli_commands | 27 | 10 | 0 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -65,7 +65,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
 - `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
-- `goldenmatch` **cli_commands** — Python-only: `anomalies`, `ingest-docs`, `init`, `label`, `pprl`, `review`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `anomalies`, `ingest-docs`, `init`, `label`, `review`, `schedule`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — Python-only: `date_diff`, `geo_haversine`, `numeric_diff`.

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [1.22.0] - 2026-07-24
+
+### Added
+- **`sensitivity` + `pprl` CLI commands** (parity batch 5). goldenmatch `cli_commands.python_only` **12 → 10**. Both wrap cores TypeScript already had.
+  - `sensitivity <files...> -c <config> -s field:start:stop:step [--sample n] [-o out.json]` — parameter-sensitivity sweep compared against one baseline clustering via CCMS (`runSensitivitySweep` + `sweepStabilityReport`). `--sweep` is repeatable; the `field:start:stop:step` grammar matches Python's and rejects wrong arity / non-numeric ranges with exit 2 rather than a confusing downstream error.
+  - `pprl link -a <fileA> -b <fileB> -f <fields> [-t thr] [-s level] [-p protocol] [--scorer] [--salt] [-o out.csv]` — privacy-preserving record linkage over bloom-filter CLKs (`runPPRL`), writing one CSV row per cluster member (`cluster_id`, `party`, `record_id`).
+
+### Known difference (documented, exits non-zero)
+- **`pprl auto-config` is not ported.** Python's `pprl` is a Typer sub-app with `link` **and** `auto-config`; the TS package has the linkage protocol but not the PPRL parameter profiler, which stays tracked as the `pprl_auto_config` **python_only MCP tool**. The TS subcommand exists so the gap is visible, and it exits 2 with a pointer to the Python command rather than silently doing something different.
+
 ## [1.21.0] - 2026-07-24
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -1508,6 +1508,167 @@ configCmd
     }
   });
 
+// ---------- sensitivity ----------
+program
+  .command("sensitivity")
+  .description("Analyze parameter sensitivity using CCMS cluster comparison")
+  .argument("<files...>", "input file paths (.csv, .tsv, .json, .jsonl)")
+  .requiredOption("-c, --config <path>", "config YAML path")
+  .requiredOption(
+    "-s, --sweep <spec>",
+    "sweep spec 'field:start:stop:step' (repeatable)",
+    (v: string, prev: string[]) => [...prev, v],
+    [] as string[],
+  )
+  .option("--sample <n>", "random sample size for speed", (v) => parseInt(v, 10))
+  .option("-o, --output <path>", "save results to JSON")
+  .action(
+    async (
+      files: string[],
+      opts: { config: string; sweep: string[]; sample?: number; output?: string },
+    ) => {
+      const { runSensitivitySweep, sweepStabilityReport } = await import(
+        "./core/sensitivity.js"
+      );
+      // Python's spec grammar: field:start:stop:step (all numeric after the field).
+      const specs = opts.sweep.map((raw) => {
+        const parts = raw.split(":");
+        if (parts.length !== 4) {
+          process.stderr.write(
+            `Error: bad --sweep '${raw}'; expected field:start:stop:step\n`,
+          );
+          process.exit(2);
+        }
+        const [field, start, stop, step] = parts as [string, string, string, string];
+        const nums = [start, stop, step].map(parseFloat);
+        if (nums.some((n) => !Number.isFinite(n))) {
+          process.stderr.write(`Error: non-numeric range in --sweep '${raw}'\n`);
+          process.exit(2);
+        }
+        return { field, start: nums[0]!, stop: nums[1]!, step: nums[2]! };
+      });
+
+      const rows = loadFilesWithSource(files);
+      const config = loadConfigFile(opts.config);
+      const results = await runSensitivitySweep(
+        rows,
+        config,
+        specs,
+        opts.sample,
+      );
+
+      const report = { results: results.map((r) => sweepStabilityReport(r)) };
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i]!;
+        const s = report.results[i]!;
+        process.stdout.write(
+          `${r.param.field}: baseline=${r.baselineValue} ` +
+            `best=${s.best_value} (${s.best_unchanged_pct.toFixed(1)}% unchanged)\n`,
+        );
+        for (const p of s.points) {
+          process.stdout.write(
+            `    ${p.value}: unchanged=${p.unchanged} merged=${p.merged} ` +
+              `partitioned=${p.partitioned} overlapping=${p.overlapping} twi=${p.twi.toFixed(4)}\n`,
+          );
+        }
+      }
+      if (opts.output) {
+        writeFileSync(opts.output, JSON.stringify(report, null, 2) + "\n", "utf-8");
+        process.stdout.write(`Results saved to ${opts.output}\n`);
+      }
+    },
+  );
+
+// ---------- pprl (privacy-preserving record linkage) ----------
+//
+// Python's `pprl` is a Typer sub-app with `link` + `auto-config`. Only `link`
+// is ported: the TS package has the linkage protocol (`runPPRL`) but NOT the
+// PPRL auto-config profiler, which remains tracked as the `pprl_auto_config`
+// python_only MCP tool. `pprl auto-config` therefore errors with a pointer
+// rather than silently doing something different.
+const pprlCmd = program
+  .command("pprl")
+  .description("Privacy-preserving record linkage (bloom-filter CLKs)");
+
+pprlCmd
+  .command("link")
+  .description("Link two parties' records without sharing raw values")
+  .requiredOption("-a, --file-a <path>", "party A data file")
+  .requiredOption("-b, --file-b <path>", "party B data file")
+  .requiredOption("-f, --fields <fields>", "comma-separated fields to match on")
+  .option("-t, --threshold <value>", "match threshold", parseFloat, 0.85)
+  .option("-s, --security <level>", "standard | high | paranoid", "high")
+  .option("-p, --protocol <name>", "trusted_third_party | smc", "trusted_third_party")
+  .option("--scorer <name>", "dice | jaccard", "dice")
+  .option("--salt <key>", "shared HMAC key (both parties must use the same)")
+  .option("-o, --output <path>", "output CSV of cluster assignments")
+  .action(
+    async (opts: {
+      fileA: string;
+      fileB: string;
+      fields: string;
+      threshold: number;
+      security: string;
+      protocol: string;
+      scorer: string;
+      salt?: string;
+      output?: string;
+    }) => {
+      const { runPPRL } = await import("./core/pprl/protocol.js");
+      const security = opts.security as "standard" | "high" | "paranoid";
+      const protocol = opts.protocol as "trusted_third_party" | "smc";
+      const scorer = opts.scorer as "dice" | "jaccard";
+      if (!["standard", "high", "paranoid"].includes(security)) {
+        process.stderr.write(`Error: --security must be standard|high|paranoid\n`);
+        process.exit(2);
+      }
+      if (!["trusted_third_party", "smc"].includes(protocol)) {
+        process.stderr.write(`Error: --protocol must be trusted_third_party|smc\n`);
+        process.exit(2);
+      }
+
+      const rowsA = readFile(opts.fileA);
+      const rowsB = readFile(opts.fileB);
+      const result = runPPRL(rowsA, rowsB, {
+        fields: parseCsvList(opts.fields),
+        securityLevel: security,
+        protocol,
+        threshold: opts.threshold,
+        scorer,
+        ...(opts.salt ? { salt: opts.salt } : {}),
+      });
+
+      process.stdout.write(
+        `PPRL (${protocol}, ${security}): ${result.matchCount} match(es) ` +
+          `over ${result.totalComparisons} comparison(s), ${result.clusters.length} cluster(s)\n`,
+      );
+      if (opts.output) {
+        // One row per cluster member: cluster_id + which party + that party's row id.
+        const rows: Row[] = [];
+        result.clusters.forEach((members, cid) => {
+          for (const m of members) {
+            rows.push({ cluster_id: cid, party: m.party, record_id: m.id });
+          }
+        });
+        writeOutputRows(opts.output, rows, "csv");
+        process.stdout.write(`Cluster assignments written to ${opts.output}\n`);
+      }
+    },
+  );
+
+pprlCmd
+  .command("auto-config")
+  .description("(not ported) profile a file and suggest PPRL parameters")
+  .argument("[file]", "data file to analyze")
+  .action(() => {
+    process.stderr.write(
+      "pprl auto-config is not available in the TypeScript package.\n" +
+        "The PPRL auto-config profiler is Python-only (`pprl_auto_config`).\n" +
+        "Use: goldenmatch pprl auto-config <file>   (Python)\n",
+    );
+    process.exit(2);
+  });
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.21.0",
+  version: "1.22.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1172,7 +1172,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.21.0",
+          version: "1.22.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1599,7 +1599,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.21.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.22.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenmatch/tests/unit/cli-parity-batch5.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/cli-parity-batch5.test.ts
@@ -1,0 +1,133 @@
+/**
+ * cli-parity-batch5.test.ts -- `sensitivity` + `pprl` CLI commands (parity batch 5).
+ *
+ * Per repo convention we test the logic each subcommand wraps, plus the parsing
+ * the command itself owns (the `field:start:stop:step` sweep grammar and the
+ * PPRL cluster -> CSV row shaping).
+ */
+import { describe, it, expect } from "vitest";
+import { runSensitivitySweep, sweepStabilityReport } from "../../src/core/sensitivity.js";
+import type { SweepSpec } from "../../src/core/sensitivity.js";
+import { runPPRL } from "../../src/core/pprl/protocol.js";
+import { autoConfigure } from "../../src/core/autoconfig.js";
+import type { Row } from "../../src/core/types.js";
+
+/** Mirrors the `--sweep` parser in the CLI command. */
+function parseSweep(raw: string): SweepSpec | null {
+  const parts = raw.split(":");
+  if (parts.length !== 4) return null;
+  const [field, a, b, c] = parts as [string, string, string, string];
+  const nums = [a, b, c].map(parseFloat);
+  if (nums.some((n) => !Number.isFinite(n))) return null;
+  return { field, start: nums[0]!, stop: nums[1]!, step: nums[2]! };
+}
+
+// Surnames spread across distinct soundex codes (a same-code fixture makes
+// blocking degenerate and the sweep meaninglessly slow).
+const ROWS: Row[] = [
+  { id: "1", name: "Alice Nguyen", email: "a@x.com" },
+  { id: "2", name: "Alice Nguyen", email: "a@x.com" },
+  { id: "3", name: "Bob Okafor", email: "b@y.com" },
+  { id: "4", name: "Carol Petrov", email: "c@z.com" },
+  { id: "5", name: "Dave Quinn", email: "d@w.com" },
+];
+
+describe("sensitivity command: --sweep parsing", () => {
+  it("parses field:start:stop:step", () => {
+    expect(parseSweep("threshold:0.7:0.9:0.1")).toEqual({
+      field: "threshold",
+      start: 0.7,
+      stop: 0.9,
+      step: 0.1,
+    });
+  });
+
+  it("rejects the wrong arity and non-numeric ranges", () => {
+    expect(parseSweep("threshold:0.7:0.9")).toBeNull(); // too few
+    expect(parseSweep("threshold:0.7:0.9:0.1:2")).toBeNull(); // too many
+    expect(parseSweep("threshold:low:high:step")).toBeNull(); // non-numeric
+  });
+});
+
+describe("sensitivity command logic", () => {
+  it("sweeps a threshold and reports stability against the baseline", async () => {
+    const config = autoConfigure(ROWS);
+    const results = await runSensitivitySweep(
+      ROWS,
+      config,
+      [{ field: "threshold", start: 0.7, stop: 0.9, step: 0.1 }],
+    );
+    expect(results.length).toBe(1);
+    const r = results[0]!;
+    expect(r.param.field).toBe("threshold");
+    expect(r.points.length).toBeGreaterThan(0);
+
+    const report = sweepStabilityReport(r);
+    expect(typeof report.best_value).toBe("number");
+    expect(report.best_unchanged_pct).toBeGreaterThanOrEqual(0);
+    expect(report.best_unchanged_pct).toBeLessThanOrEqual(100);
+    for (const p of report.points) {
+      expect(typeof p.twi).toBe("number");
+      expect(p.unchanged).toBeGreaterThanOrEqual(0);
+    }
+  }, 20000);
+});
+
+describe("pprl link command logic", () => {
+  const A: Row[] = [
+    { name: "alice nguyen", city: "boston" },
+    { name: "bob okafor", city: "denver" },
+  ];
+  const B: Row[] = [
+    { name: "alice nguyen", city: "boston" },
+    { name: "carol petrov", city: "austin" },
+  ];
+
+  it("links the shared record across parties without sharing raw values", () => {
+    const res = runPPRL(A, B, {
+      fields: ["name", "city"],
+      securityLevel: "high",
+      protocol: "trusted_third_party",
+      threshold: 0.85,
+      scorer: "dice",
+    });
+    expect(res.matchCount).toBeGreaterThan(0);
+    expect(res.totalComparisons).toBe(A.length * B.length);
+    // the identical alice record should land in a cross-party cluster
+    expect(res.clusters.length).toBeGreaterThan(0);
+    const parties = new Set(res.clusters[0]!.map((m) => m.party));
+    expect(parties.size).toBe(2);
+  });
+
+  it("shapes clusters into the CSV rows the command writes", () => {
+    const res = runPPRL(A, B, {
+      fields: ["name", "city"],
+      securityLevel: "high",
+      protocol: "trusted_third_party",
+      threshold: 0.85,
+      scorer: "dice",
+    });
+    const rows: Row[] = [];
+    res.clusters.forEach((members, cid) => {
+      for (const m of members) rows.push({ cluster_id: cid, party: m.party, record_id: m.id });
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(typeof r["cluster_id"]).toBe("number");
+      expect(typeof r["party"]).toBe("string");
+      expect(typeof r["record_id"]).toBe("number");
+    }
+  });
+
+  it("smc reveals only match bits (score == threshold), per the protocol contract", () => {
+    const res = runPPRL(A, B, {
+      fields: ["name", "city"],
+      securityLevel: "high",
+      protocol: "smc",
+      threshold: 0.85,
+      scorer: "dice",
+      salt: "shared-key",
+    });
+    for (const m of res.matches) expect(m.score).toBeCloseTo(0.85, 10);
+  });
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -159,10 +159,12 @@ cli_commands:
   - match
   - mcp-serve
   - memory
+  - pprl
   - profile
   - rollback
   - runs
   - score
+  - sensitivity
   - serve
   - tui
   - unmerge
@@ -171,10 +173,8 @@ cli_commands:
   - ingest-docs
   - init
   - label
-  - pprl
   - review
   - schedule
-  - sensitivity
   - serve-ui
   - setup
   - sync


### PR DESCRIPTION
> **Stacked on #2101** (batch 4); targets `main`, so no auto-close. Review the top commit.

goldenmatch `cli_commands.python_only` **12 → 10**. Both wrap cores TypeScript already had.

| Command | Wraps |
|---|---|
| `sensitivity <files...> -c <config> -s field:start:stop:step [--sample n] [-o out.json]` | `runSensitivitySweep` + `sweepStabilityReport` |
| `pprl link -a <A> -b <B> -f <fields> [-t] [-s] [-p] [--scorer] [--salt] [-o out.csv]` | `runPPRL` |

`--sweep` is repeatable and the `field:start:stop:step` grammar matches Python's — wrong arity or a non-numeric range exits 2 rather than failing confusingly downstream. `pprl link` writes one CSV row per cluster member (`cluster_id`, `party`, `record_id`).

## Honest gap: `pprl auto-config` is NOT ported

Python's `pprl` is a Typer sub-app with **`link` and `auto-config`**. TS has the linkage protocol but not the PPRL parameter profiler, which stays tracked as the `pprl_auto_config` **python_only MCP tool**.

I registered the subcommand anyway so the gap is **visible in `--help`**, and it exits 2 pointing at the Python command instead of silently doing something different.

Worth noting: the `api_parity` gate matches **top-level** command names, so bare `pprl` would have satisfied it. This is deliberately more honest than the gate requires — the same class of "green but hollow" I found in batch 2, where goldencheck's `mcp-serve` was marked `shared` while its handler just exited 1.

## Verification

- `check_api_parity.py goldenmatch` → *"manifest exactly partitions the real MCP + CLI surface"*.
- TS emitter against a **built dist**: cli 27, both commands present.
- 6 new tests; `tsc --noEmit` clean; `1.21.0 → 1.22.0` with `check_version_consistency` green.
- Only `suite-matrix` + `api-surface` needed regeneration — a TS-only change leaves the three Python-derived artifacts untouched, which is now a checked expectation rather than a guess. All **10** generated-doc gates pass.

Remaining python-only CLI: `anomalies`, `ingest-docs`, `init`, `label`, `review`, `schedule`, `serve-ui`, `setup`, `sync`, `watch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)