### PR TITLE
fix(exp): llm-labeler row-ids + refuse to report a dead API as data

### DIFF
--- a/scripts/llm_labeler_accuracy.py
+++ b/scripts/llm_labeler_accuracy.py
@@ -18,7 +18,10 @@ vs a different John Smith b.1850), the labels RATIFY the bias instead of correct
 it, and calibration confidently finds the wrong cut. A labeler that is 85% accurate
 with uncorrelated errors is more useful than one that is 90% accurate and correlated.
 
-Diagnostic only: never fails the job, prints a verdict table to the step summary.
+Diagnostic: a dataset that is absent or errors is reported and skipped rather than
+failing the run -- but a run where NO dataset produced results exits non-zero, so a
+broken harness cannot report green with an empty table (which is exactly how the
+missing-``__row_id__`` bug shipped a SUCCESS carrying no data).
 """
 from __future__ import annotations
 
@@ -101,6 +104,24 @@ def _sample(pairs, gt, n_band: int, n_ctrl: int, rng):
     return band, hi[:n_ctrl], lo[:n_ctrl], base_rate
 
 
+def _with_row_ids(df):
+    """Attach ``__row_id__`` for the LLM scorer's record lookup.
+
+    ``llm_score_pairs`` resolves each pair id through ``select_dicts(["__row_id__",
+    ...])``, but the raw dataset frame has no such column -- the pipeline adds it
+    internally, so a frame handed straight from a loader raises ColumnNotFoundError.
+    Pair ids are ROW INDICES (dedupe assigns them positionally), so a plain arange is
+    the correct mapping. Kept separate from the frame used for auto-config/scoring:
+    profiling a synthetic id column would hand auto-config a cardinality-1.0
+    "identifier" that it would then reason about.
+    """
+    import polars as pl
+
+    if "__row_id__" in df.columns:
+        return df
+    return df.with_columns(pl.arange(0, df.height).alias("__row_id__"))
+
+
 def _llm_verdicts(sampled, df, budget_usd: float):
     """Send every sampled pair to the LLM; return {(a,b): is_match}.
 
@@ -119,6 +140,17 @@ def _llm_verdicts(sampled, df, budget_usd: float):
     out, summary = llm_score_pairs(
         sampled, df, config=cfg, return_budget=True,
     )
+    # CRITICAL: llm_score_pairs SWALLOWS API errors -- on a 401 it logs and returns
+    # every pair unchanged, which reads as a unanimous "reject" and would produce a
+    # confident table of pure noise. Verified: a bad key yields total_calls=0,
+    # cost=$0.00, and a full set of False verdicts. Refuse to treat that as data.
+    calls = (summary or {}).get("total_calls", 0)
+    if sampled and not calls:
+        raise RuntimeError(
+            f"LLM returned no successful calls for {len(sampled)} pairs "
+            f"(total_calls=0, cost=$0.00) -- the API rejected the request; "
+            f"verdicts would be meaningless"
+        )
     verdicts = {(a, b): (s == 1.0) for a, b, s in out}
     return verdicts, summary
 
@@ -233,7 +265,7 @@ def main() -> int:
             continue
         sampled = band + hi + lo
         try:
-            verdicts, summary = _llm_verdicts(sampled, df, args.budget_usd)
+            verdicts, summary = _llm_verdicts(sampled, _with_row_ids(df), args.budget_usd)
         except Exception as e:
             lines.append(f"| {name} | - | - | - | - | - | _LLM failed: {type(e).__name__}: {str(e)[:60]}_ |")
             continue
@@ -256,6 +288,12 @@ def main() -> int:
     lines.append("")
     if not totals:
         lines.append("_No dataset produced a labeled band; nothing to conclude._")
+        _emit("\n".join(lines) + "\n")
+        # Do NOT let a totally failed run report green. "Never fail the job" is
+        # right for a dataset being absent; it is wrong when every dataset errored,
+        # which is exactly how the __row_id__ bug shipped a SUCCESS with no data.
+        print("::error::llm-labeler-accuracy produced no results for any dataset")
+        return 1
     for name, r in totals:
         c = r["corr"]
         if r["acc"] >= 0.90 and (c is None or c <= 0.40):


### PR DESCRIPTION
Run `30110619272` reported **SUCCESS with an empty table**. Two distinct faults, the second worse than the first.

## 1. `ColumnNotFoundError: __row_id__`

`llm_score_pairs` resolves each pair id via `select_dicts(["__row_id__", ...])`. The pipeline adds that column internally, so a frame handed straight from a dataset loader doesn't have it. Pair ids are row **indices**, so an `arange` is the correct mapping.

Attached on a *separate* frame from the one auto-config profiles — a synthetic cardinality-1.0 id column is exactly the sort of thing the identifier heuristics would then reason about.

## 2. The one that actually matters

Found while verifying (1): **`llm_score_pairs` swallows API errors.** With a bad key it logs `LLM API error: HTTP Error 401` and returns every pair *unchanged* — which, under this script's encoding (approved ⇒ score 1.0), reads as a unanimous **"reject"**.

Verified against a dummy key:

```
verdicts: {(3061,5583): False, (2681,6125): False, (2782,7072): False, (2016,5286): False}
budget:   {'total_cost_usd': 0.0, 'total_calls': 0, ...}
```

So a dead API, an expired key, or a rate-limit would have produced a **confident-looking accuracy and error-correlation table made entirely of noise** — and I'd have reported it as the experiment's result. Now refuses to treat zero successful calls as data.

## Also: a fully-failed run must be red

`return 1` when no dataset produced results. "Never fail the job" is right for an *absent* dataset; it's wrong when everything errored — which is precisely how fault (1) shipped a green run carrying nothing.

Verified locally: guard fires, `::error::` emitted, real exit code `1`.

Generated with [Claude Code](https://claude.com/claude-code)