### PR TITLE
feat(ts): init + label + review CLI commands (parity batch 7)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.23.0` | `goldenmatch` | 90 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.24.0` | `goldenmatch` | 90 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 83 | 7 | 0 |
-| `goldenmatch` | cli_commands | 28 | 9 | 0 |
+| `goldenmatch` | cli_commands | 31 | 6 | 0 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -64,7 +64,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `ingest-docs`, `init`, `label`, `review`, `schedule`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `ingest-docs`, `schedule`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — Python-only: `date_diff`, `geo_haversine`, `numeric_diff`.

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [1.24.0] - 2026-07-24
+
+### Added
+- **`init`, `label`, and `review` CLI commands** (parity batch 7) -- the interactive tier. goldenmatch `cli_commands.python_only` **9 -> 6**.
+  - `init [-o out.yaml]` -- config wizard. `src/node/config-wizard.ts` ports `config/wizard.py`, including the `suggestTransforms` / `suggestScorer` heuristic tables byte-faithfully, so both wizards propose the same config for the same column names.
+  - `label <files...> -c <config> [-o gt.csv] [-n 50] [--strategy borderline|random|hardest] [-a]` -- build ground truth by labeling pairs (y/n/s/q), writing a CSV for `evaluate`.
+  - `review <files...> -c <config> [--merge-threshold] [--reject-below] [-n 50]` -- steward the borderline band via the existing `gatePairs`, recording approve/reject decisions to Learning Memory.
+
+### Design note
+- **The loops take an injectable `Ask` rather than reading stdin directly** (`src/node/interactive.ts`), so the decision logic is unit-testable by scripting a session. Python's equivalents call Rich prompts inline and therefore have no loop tests; this port deliberately does not reproduce that. 28 tests cover strategy ordering, y/n/s/q handling, mid-session quit preserving work, either-orientation `--append` dedup, 4dp score rounding, and two scripted end-to-end wizard sessions.
+- `review` persists **after** the loop, so a mid-session `q` still records what was already decided.
+- `toYaml` is hand-rolled rather than pulling the optional `yaml` peer dep, so `init` cannot fail on a missing optional dependency. It quotes values YAML would otherwise reinterpret (a column named `no` stays a string).
+
 ## [1.23.0] - 2026-07-24
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from "commander";
-import { extname, basename } from "node:path";
+import { extname, basename, dirname } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   readFile,
@@ -25,7 +25,7 @@ import {
 import { analyzeBlocking } from "./core/block-analyzer.js";
 import { autoConfigure } from "./core/autoconfig.js";
 import { loadConfigFile } from "./node/config-file.js";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import {
   compareClusters,
   ccmsSummary,
@@ -1507,6 +1507,203 @@ configCmd
       process.exit(1);
     }
   });
+
+// ---------- init (interactive config wizard) ----------
+program
+  .command("init")
+  .description("Launch the interactive config wizard")
+  .option("-o, --output <path>", "output path for the generated config")
+  .action(async (opts: { output?: string }) => {
+    const { runWizard, toYaml } = await import("./node/config-wizard.js");
+    const { createStdinAsk, askYesNo, askWithDefault } = await import("./node/interactive.js");
+    const { ask, close } = createStdinAsk();
+    try {
+      const config = await runWizard(ask, (s) => process.stdout.write(s + "\n"));
+      let target = opts.output;
+      if (!target) {
+        // Python asks before saving when no --output was given; same here.
+        target = (await askYesNo(ask, "\nSave config to file?", true))
+          ? await askWithDefault(ask, "Output path", "goldenmatch.yaml")
+          : undefined;
+      }
+      if (target) {
+        mkdirSync(dirname(target), { recursive: true });
+        writeFileSync(target, toYaml(config), "utf-8");
+        process.stdout.write(`\nConfig saved to ${target}\n`);
+      } else {
+        process.stdout.write("\n" + toYaml(config));
+      }
+    } finally {
+      close();
+    }
+  });
+
+// ---------- label (build ground truth interactively) ----------
+program
+  .command("label")
+  .description("Build ground truth by labeling record pairs interactively")
+  .argument("<files...>", "input file paths")
+  .requiredOption("-c, --config <path>", "config YAML path")
+  .option("-o, --output <path>", "output ground-truth CSV", "ground_truth.csv")
+  .option("-n, --n <count>", "number of pairs to label", (v) => parseInt(v, 10), 50)
+  .option("--strategy <name>", "pair selection: borderline, random, or hardest", "borderline")
+  .option("-a, --append", "append to an existing ground-truth file")
+  .action(
+    async (
+      files: string[],
+      opts: { config: string; output: string; n: number; strategy: string; append?: boolean },
+    ) => {
+      const { selectPairs, runLabelSession } = await import("./node/label-session.js");
+      const { createStdinAsk } = await import("./node/interactive.js");
+      const strategy = opts.strategy as "borderline" | "random" | "hardest";
+      if (!["borderline", "random", "hardest"].includes(strategy)) {
+        process.stderr.write("Error: --strategy must be borderline, random, or hardest\n");
+        process.exit(2);
+      }
+
+      const rows = loadFilesWithSource(files);
+      process.stdout.write("Running pipeline to generate candidate pairs...\n");
+      const result = await dedupe(rows, { config: loadConfigFile(opts.config) });
+      if (result.scoredPairs.length === 0) {
+        process.stderr.write("No pairs found. Check your config.\n");
+        process.exit(1);
+      }
+
+      const rowsById = new Map<number, Row>(rows.map((r, i) => [i, r]));
+      const displayColumns = Object.keys(rows[0] ?? {})
+        .filter((c) => !c.startsWith("__"))
+        .slice(0, 6);
+
+      // --append: skip pairs already present in the existing file (either orientation).
+      const existing = new Set<string>();
+      if (opts.append && existsSync(opts.output)) {
+        for (const r of readFile(opts.output)) {
+          existing.add(`${Number(r["id_a"])}:${Number(r["id_b"])}`);
+        }
+        process.stdout.write(`Loaded ${existing.size} existing labels from ${opts.output}\n`);
+      }
+
+      const { ask, close } = createStdinAsk();
+      let session;
+      try {
+        process.stdout.write(`\nLabel ${opts.n} pairs. Type: y=match, n=no match, s=skip, q=quit\n\n`);
+        session = await runLabelSession({
+          pairs: selectPairs(result.scoredPairs, strategy),
+          rowsById,
+          displayColumns,
+          target: opts.n,
+          ask,
+          existing,
+          out: (s) => process.stdout.write(s + "\n"),
+        });
+      } finally {
+        close();
+      }
+
+      if (session.labels.length === 0) {
+        process.stdout.write("\nNo labels saved.\n");
+        return;
+      }
+      const prior = opts.append && existsSync(opts.output) ? readFile(opts.output) : [];
+      writeOutputRows(opts.output, [...prior, ...session.labels] as unknown as Row[], "csv");
+      const matches = session.labels.filter((l) => l.label === 1).length;
+      process.stdout.write(`\nSaved ${session.labels.length} labels to ${opts.output}\n`);
+      process.stdout.write(
+        `  Matches: ${matches}, Non-matches: ${session.labels.length - matches}, Skipped: ${session.skipped}\n`,
+      );
+    },
+  );
+
+// ---------- review (steward the borderline band) ----------
+program
+  .command("review")
+  .description("Review borderline pairs and record approve/reject decisions")
+  .argument("<files...>", "input file paths")
+  .requiredOption("-c, --config <path>", "config YAML path")
+  .option("--memory-path <path>", "Learning Memory SQLite path", ".goldenmatch/memory.db")
+  .option("--merge-threshold <value>", "scores above this auto-merge (skip review)", parseFloat, 0.95)
+  .option("--reject-below <value>", "scores below this are rejected outright", parseFloat, 0.75)
+  .option("--decided-by <who>", "steward identifier recorded on each decision", "cli")
+  .option("-n, --limit <count>", "max pairs to review this session", (v) => parseInt(v, 10), 50)
+  .action(
+    async (
+      files: string[],
+      opts: {
+        config: string;
+        memoryPath: string;
+        mergeThreshold: number;
+        rejectBelow: number;
+        decidedBy: string;
+        limit: number;
+      },
+    ) => {
+      const { gatePairs } = await import("./core/review-queue.js");
+      const { runReviewSession } = await import("./node/label-session.js");
+      const { createStdinAsk } = await import("./node/interactive.js");
+      const { addCorrection } = await import("./node/memory/api.js");
+
+      const rows = loadFilesWithSource(files);
+      process.stdout.write("Running pipeline to generate candidate pairs...\n");
+      const result = await dedupe(rows, { config: loadConfigFile(opts.config) });
+
+      const gated = gatePairs(result.scoredPairs, {
+        approveAbove: opts.mergeThreshold,
+        rejectBelow: opts.rejectBelow,
+      });
+      if (gated.needsReview.length === 0) {
+        process.stdout.write(
+          `\nNothing to review: ${gated.autoApproved.length} auto-approved, ${gated.rejected.length} rejected.\n`,
+        );
+        return;
+      }
+
+      const rowsById = new Map<number, Row>(rows.map((r, i) => [i, r]));
+      const displayColumns = Object.keys(rows[0] ?? {})
+        .filter((c) => !c.startsWith("__"))
+        .slice(0, 6);
+
+      const { ask, close } = createStdinAsk();
+      let session;
+      try {
+        process.stdout.write(
+          `\n${gated.needsReview.length} pair(s) in the review band. ` +
+            `Type: y=match, n=no match, s=skip, q=quit\n\n`,
+        );
+        session = await runReviewSession({
+          items: gated.needsReview.map((i) => ({ idA: i.idA, idB: i.idB, score: i.score })),
+          rowsById,
+          displayColumns,
+          ask,
+          limit: opts.limit,
+          out: (s) => process.stdout.write(s + "\n"),
+        });
+      } finally {
+        close();
+      }
+
+      // Persist AFTER the loop so a mid-session quit still records what was decided.
+      let written = 0;
+      for (const d of session.decisions) {
+        try {
+          await addCorrection({
+            idA: d.idA,
+            idB: d.idB,
+            decision: d.decision,
+            source: "steward",
+            path: opts.memoryPath,
+          });
+          written++;
+        } catch (err) {
+          process.stderr.write(`Failed to record ${d.idA}/${d.idB}: ${(err as Error).message}\n`);
+        }
+      }
+      const approved = session.decisions.filter((d) => d.decision === "approve").length;
+      process.stdout.write(
+        `\nDone. Approved ${approved}, rejected ${session.decisions.length - approved}, skipped ${session.skipped}.\n`,
+      );
+      process.stdout.write(`${written} decision(s) recorded to Learning Memory (${opts.memoryPath}).\n`);
+    },
+  );
 
 // ---------- anomalies ----------
 program

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.23.0",
+  version: "1.24.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/config-wizard.ts
+++ b/packages/typescript/goldenmatch/src/node/config-wizard.ts
@@ -1,0 +1,222 @@
+/**
+ * config-wizard.ts -- the `init` interactive config wizard.
+ *
+ * Ports `goldenmatch/config/wizard.py`. The heuristic suggestion tables
+ * (`suggestTransforms` / `suggestScorer`) are byte-faithful to the Python ones so
+ * the two wizards propose the same config for the same column names -- that's the
+ * part worth parity, and it's what the tests pin.
+ *
+ * The flow takes an injectable `Ask`, so the whole wizard is testable by scripting
+ * a session (Python's is untestable because it calls Rich prompts inline).
+ */
+import type { Ask } from "./interactive.js";
+import { askWithDefault, askYesNo, askChoice } from "./interactive.js";
+
+const NAME_KEYWORDS = ["name", "first", "last", "fname", "lname", "given", "surname", "full_name"];
+const EMAIL_KEYWORDS = ["email", "mail", "e_mail"];
+const PHONE_KEYWORDS = ["phone", "tel", "mobile", "fax", "cell"];
+const ZIP_KEYWORDS = ["zip", "postal", "postcode", "zip_code"];
+const ADDRESS_KEYWORDS = ["address", "addr", "street", "city", "state", "country"];
+
+function matchesAny(col: string, keywords: readonly string[]): boolean {
+  return keywords.some((k) => col.includes(k));
+}
+
+/** Python `suggest_transforms` -- same order, same outputs. */
+export function suggestTransforms(columnName: string): string[] {
+  const col = columnName.toLowerCase();
+  if (matchesAny(col, NAME_KEYWORDS)) return ["lowercase", "strip", "normalize_whitespace"];
+  if (matchesAny(col, EMAIL_KEYWORDS)) return ["lowercase", "strip"];
+  if (matchesAny(col, PHONE_KEYWORDS)) return ["digits_only"];
+  if (matchesAny(col, ZIP_KEYWORDS)) return ["strip", "substring:0:5"];
+  if (matchesAny(col, ADDRESS_KEYWORDS)) return ["lowercase", "strip", "normalize_whitespace"];
+  return ["strip"];
+}
+
+/** Python `suggest_scorer` -- same order, same outputs. */
+export function suggestScorer(columnName: string): string {
+  const col = columnName.toLowerCase();
+  if (matchesAny(col, NAME_KEYWORDS)) return "jaro_winkler";
+  if (matchesAny(col, EMAIL_KEYWORDS)) return "levenshtein";
+  if (matchesAny(col, PHONE_KEYWORDS)) return "exact";
+  if (matchesAny(col, ZIP_KEYWORDS)) return "exact";
+  if (matchesAny(col, ADDRESS_KEYWORDS)) return "token_sort";
+  return "jaro_winkler";
+}
+
+const SCORERS = ["exact", "jaro_winkler", "levenshtein", "token_sort", "soundex_match"];
+
+export interface WizardConfig {
+  matchkeys: Array<Record<string, unknown>>;
+  blocking?: Record<string, unknown>;
+  output: Record<string, string>;
+}
+
+/** Basename without extension -- the default source label, as Python's `Path.stem`. */
+function stem(p: string): string {
+  const base = p.split(/[/\\]/).pop() ?? p;
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(0, dot) : base;
+}
+
+/**
+ * Run the wizard. Returns the config object; the caller serializes + writes it,
+ * so this function does no I/O and can be tested end-to-end on a scripted session.
+ */
+export async function runWizard(
+  ask: Ask,
+  out: (s: string) => void = () => {},
+): Promise<WizardConfig> {
+  out("GoldenMatch Config Wizard\n");
+
+  const mode = await askChoice(ask, "What would you like to do? [dedupe/match]: ", ["dedupe", "match"], "dedupe");
+
+  // File selection is collected for the operator's benefit (Python prompts for it
+  // too) but, exactly as in Python, does NOT land in the emitted config -- files
+  // are CLI arguments, not config keys.
+  if (mode === "dedupe") {
+    for (;;) {
+      const path = await ask("Enter input file path: ");
+      await askWithDefault(ask, "Source label", stem(path.trim()));
+      if (!(await askYesNo(ask, "Add another file?", false))) break;
+    }
+  } else {
+    const target = await ask("Enter target file path: ");
+    await askWithDefault(ask, "Target source label", stem(target.trim()));
+    for (;;) {
+      const ref = await ask("Enter reference file path: ");
+      await askWithDefault(ask, "Reference source label", stem(ref.trim()));
+      if (!(await askYesNo(ask, "Add another reference file?", false))) break;
+    }
+  }
+
+  // ---- matchkeys ----
+  out("\nMatchkey Configuration");
+  const matchkeys: Array<Record<string, unknown>> = [];
+  for (;;) {
+    const mkName = await askWithDefault(ask, "Matchkey name", `mk_${matchkeys.length + 1}`);
+    const mkType = await askChoice(ask, "Matchkey type [exact/weighted]: ", ["exact", "weighted"], "exact");
+
+    const fields: Array<Record<string, unknown>> = [];
+    for (;;) {
+      const fieldName = (await ask("  Field/column name: ")).trim();
+      const suggested = suggestTransforms(fieldName);
+      out(`  Suggested transforms: ${JSON.stringify(suggested)}`);
+      const useSuggested = await askYesNo(ask, "  Use suggested transforms?", true);
+      const field: Record<string, unknown> = {
+        field: fieldName,
+        transforms: useSuggested ? suggested : [],
+      };
+
+      if (mkType === "weighted") {
+        let scorer = suggestScorer(fieldName);
+        out(`  Suggested scorer: ${scorer}`);
+        if (!(await askYesNo(ask, "  Use suggested scorer?", true))) {
+          scorer = await askChoice(ask, `  Scorer [${SCORERS.join("/")}]: `, SCORERS, scorer);
+        }
+        const weightRaw = await askWithDefault(ask, "  Weight", "1.0");
+        const weight = Number.parseFloat(weightRaw);
+        field["scorer"] = scorer;
+        field["weight"] = Number.isFinite(weight) ? weight : 1.0;
+      }
+      fields.push(field);
+      if (!(await askYesNo(ask, "  Add another field to this matchkey?", false))) break;
+    }
+
+    const mk: Record<string, unknown> = { name: mkName, type: mkType, fields };
+    if (mkType === "weighted") {
+      const thrRaw = await askWithDefault(ask, "  Match threshold (0.0-1.0)", "0.8");
+      const thr = Number.parseFloat(thrRaw);
+      mk["threshold"] = Number.isFinite(thr) ? thr : 0.8;
+    }
+    matchkeys.push(mk);
+    if (!(await askYesNo(ask, "Add another matchkey?", false))) break;
+  }
+
+  // ---- blocking ----
+  // Python's condition: prompt only when there is no weighted matchkey; a weighted
+  // matchkey forces blocking configuration without asking.
+  const hasWeighted = matchkeys.some((mk) => mk["type"] === "weighted");
+  let blocking: Record<string, unknown> | undefined;
+  if (hasWeighted || (await askYesNo(ask, "\nConfigure blocking?", hasWeighted))) {
+    out("\nBlocking Configuration");
+    const keys: Array<Record<string, unknown>> = [];
+    for (;;) {
+      const raw = await ask("  Blocking fields (comma-separated): ");
+      const blockFields = raw.split(",").map((s) => s.trim()).filter((s) => s !== "");
+      if (blockFields.length > 0) {
+        keys.push({
+          fields: blockFields,
+          transforms: suggestTransforms(blockFields[0]!),
+        });
+      }
+      if (!(await askYesNo(ask, "  Add another blocking key?", false))) break;
+    }
+    if (keys.length > 0) blocking = { strategy: "static", keys };
+  }
+
+  // ---- output ----
+  out("\nOutput Configuration");
+  const format = await askChoice(ask, "Output format [csv/parquet]: ", ["csv", "parquet"], "csv");
+  const directory = await askWithDefault(ask, "Output directory", "./output");
+  const runName = (await askWithDefault(ask, "Run name (optional)", "")).trim();
+
+  const output: Record<string, string> = { format, directory };
+  if (runName !== "") output["run_name"] = runName;
+
+  return { matchkeys, ...(blocking ? { blocking } : {}), output };
+}
+
+/**
+ * Serialize the wizard config to YAML.
+ *
+ * Deliberately hand-rolled rather than pulling the optional `yaml` peer dep: the
+ * shape here is a closed set (strings, finite numbers, string arrays, nested
+ * objects/arrays), so a targeted emitter is safer than making `init` fail on a
+ * missing optional dependency. Key ORDER is preserved to match Python's
+ * `sort_keys=False`.
+ */
+export function toYaml(value: unknown, indent = 0): string {
+  const pad = "  ".repeat(indent);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${pad}[]\n`;
+    return value
+      .map((item) => {
+        if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+          const body = toYaml(item, indent + 1);
+          // Hoist the first key onto the dash line.
+          const lines = body.split("\n").filter((l) => l !== "");
+          const first = lines[0]!.slice((indent + 1) * 2);
+          const rest = lines.slice(1).join("\n");
+          return `${pad}- ${first}${rest ? "\n" + rest : ""}`;
+        }
+        return `${pad}- ${scalar(item)}`;
+      })
+      .join("\n") + "\n";
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return `${pad}{}\n`;
+    return entries
+      .map(([k, v]) => {
+        if (v !== null && typeof v === "object") {
+          const body = toYaml(v, indent + 1);
+          return `${pad}${k}:\n${body.replace(/\n$/, "")}`;
+        }
+        return `${pad}${k}: ${scalar(v)}`;
+      })
+      .join("\n") + "\n";
+  }
+  return `${pad}${scalar(value)}\n`;
+}
+
+function scalar(v: unknown): string {
+  if (v === null || v === undefined) return "null";
+  if (typeof v === "boolean" || typeof v === "number") return String(v);
+  const s = String(v);
+  // Quote when YAML would otherwise reinterpret the value.
+  if (s === "" || /^[\s]|[\s]$|[:#\-{}[\],&*?|>%@`"']/.test(s) || /^(true|false|null|yes|no|on|off|~)$/i.test(s) || /^-?\d/.test(s)) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return s;
+}

--- a/packages/typescript/goldenmatch/src/node/interactive.ts
+++ b/packages/typescript/goldenmatch/src/node/interactive.ts
@@ -1,0 +1,95 @@
+/**
+ * interactive.ts -- shared prompt plumbing for the interactive CLI commands
+ * (`label`, `review`, `init`).
+ *
+ * Node-only (uses `node:readline`), so it lives under `src/node/`.
+ *
+ * THE POINT OF THIS MODULE: every loop below takes an injectable `Ask` instead of
+ * reading stdin directly, so the decision logic is unit-testable without a TTY.
+ * Python's equivalents call `console.input(...)` inline, which is why they have no
+ * loop tests -- that is the wart this port deliberately does not reproduce.
+ */
+import { createInterface } from "node:readline";
+
+/** Prompts for one line of input. Injectable so tests can script a session. */
+export type Ask = (prompt: string) => Promise<string>;
+
+/** Real stdin-backed prompt. One readline interface for the whole session. */
+export function createStdinAsk(): { ask: Ask; close: () => void } {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return {
+    ask: (prompt: string) => new Promise<string>((resolve) => rl.question(prompt, resolve)),
+    close: () => rl.close(),
+  };
+}
+
+/** Scripted prompt for tests: replays `answers`, then repeats the last one. */
+export function scriptedAsk(answers: readonly string[]): Ask {
+  let i = 0;
+  return async () => answers[Math.min(i++, answers.length - 1)] ?? "q";
+}
+
+/**
+ * Ask until the answer is one of `allowed` (case-insensitive, trimmed).
+ *
+ * Mirrors Python's `while True: ... if response in (...)` loop. Returns the
+ * fallback if the stream ends (EOF -> empty answers forever), so a piped or
+ * closed stdin terminates instead of spinning.
+ */
+export async function askChoice(
+  ask: Ask,
+  prompt: string,
+  allowed: readonly string[],
+  fallback: string,
+  onInvalid?: (raw: string) => void,
+): Promise<string> {
+  for (let attempts = 0; attempts < 100; attempts++) {
+    const raw = (await ask(prompt)).trim().toLowerCase();
+    if (allowed.includes(raw)) return raw;
+    if (raw === "") return fallback;
+    onInvalid?.(raw);
+  }
+  return fallback;
+}
+
+/** Ask with a default shown in the prompt; empty input takes the default. */
+export async function askWithDefault(
+  ask: Ask,
+  question: string,
+  fallback: string,
+): Promise<string> {
+  const answer = (await ask(`${question} [${fallback}]: `)).trim();
+  return answer === "" ? fallback : answer;
+}
+
+/** Yes/no with a default. */
+export async function askYesNo(
+  ask: Ask,
+  question: string,
+  fallback: boolean,
+): Promise<boolean> {
+  const hint = fallback ? "Y/n" : "y/N";
+  const answer = (await ask(`${question} [${hint}]: `)).trim().toLowerCase();
+  if (answer === "") return fallback;
+  return answer.startsWith("y");
+}
+
+/** Render a side-by-side field comparison. Shared by `label` and `review`. */
+export function renderPair(
+  rowA: Readonly<Record<string, unknown>>,
+  rowB: Readonly<Record<string, unknown>>,
+  columns: readonly string[],
+  title: string,
+): string {
+  const cell = (v: unknown) => String(v ?? "").slice(0, 60);
+  const width = Math.max(5, ...columns.map((c) => c.length));
+  const lines = [title, "-".repeat(Math.max(title.length, 40))];
+  for (const col of columns) {
+    const a = cell(rowA[col]);
+    const b = cell(rowB[col]);
+    // Mark agreeing non-empty fields, the signal Python bolds.
+    const same = a !== "" && a.toLowerCase() === b.toLowerCase();
+    lines.push(`${col.padEnd(width)} | ${a.padEnd(60)} | ${b}${same ? "   =" : ""}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/typescript/goldenmatch/src/node/label-session.ts
+++ b/packages/typescript/goldenmatch/src/node/label-session.ts
@@ -1,0 +1,173 @@
+/**
+ * label-session.ts -- the `label` and `review` interactive loops, as pure-ish
+ * functions over an injectable `Ask` so they can be tested without a TTY.
+ *
+ * Ports `goldenmatch/cli/label.py` and `goldenmatch/cli/review.py`.
+ */
+import type { Ask } from "./interactive.js";
+import { askChoice, renderPair } from "./interactive.js";
+import type { Row, ScoredPair } from "../core/types.js";
+
+export type PairStrategy = "borderline" | "random" | "hardest";
+
+/** Python's borderline anchor: the most ambiguous score. */
+export const BORDERLINE_ANCHOR = 0.85;
+
+export interface LabelRow {
+  readonly id_a: number;
+  readonly id_b: number;
+  readonly label: 0 | 1;
+  readonly score: number;
+}
+
+export interface LabelSessionResult {
+  readonly labels: LabelRow[];
+  readonly skipped: number;
+  readonly quit: boolean;
+}
+
+/** Python's `round(x, 4)`. */
+function round4(x: number): number {
+  return Math.round(x * 10000) / 10000;
+}
+
+/**
+ * Order candidate pairs. Mirrors Python exactly:
+ *   borderline -> by |score - 0.85| ascending (most ambiguous first)
+ *   hardest    -> by score ascending
+ *   random     -> shuffled
+ *
+ * `rng` is injectable so the random strategy is deterministic under test.
+ */
+export function selectPairs(
+  pairs: readonly ScoredPair[],
+  strategy: PairStrategy,
+  rng: () => number = Math.random,
+): ScoredPair[] {
+  const out = [...pairs];
+  if (strategy === "borderline") {
+    out.sort((a, b) => Math.abs(a.score - BORDERLINE_ANCHOR) - Math.abs(b.score - BORDERLINE_ANCHOR));
+  } else if (strategy === "hardest") {
+    out.sort((a, b) => a.score - b.score);
+  } else {
+    // Fisher-Yates with the injected rng.
+    for (let i = out.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [out[i], out[j]] = [out[j]!, out[i]!];
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk pairs one at a time collecting y/n/s/q decisions.
+ *
+ * Faithful to Python: `s` skips (counted, not labeled), `q` stops immediately,
+ * already-labeled pairs are passed over in EITHER orientation, and the loop ends
+ * once `n` labels are collected.
+ */
+export async function runLabelSession(opts: {
+  pairs: readonly ScoredPair[];
+  rowsById: ReadonlyMap<number, Row>;
+  displayColumns: readonly string[];
+  target: number;
+  ask: Ask;
+  existing?: ReadonlySet<string>;
+  out?: (s: string) => void;
+}): Promise<LabelSessionResult> {
+  const { pairs, rowsById, displayColumns, target, ask } = opts;
+  const existing = opts.existing ?? new Set<string>();
+  const out = opts.out ?? (() => {});
+  const labels: LabelRow[] = [];
+  let skipped = 0;
+
+  for (const p of pairs) {
+    if (labels.length >= target) break;
+    // Either orientation counts as already-labeled (Python checks both).
+    if (existing.has(`${p.idA}:${p.idB}`) || existing.has(`${p.idB}:${p.idA}`)) continue;
+
+    out(
+      renderPair(
+        rowsById.get(p.idA) ?? {},
+        rowsById.get(p.idB) ?? {},
+        displayColumns,
+        `Pair ${labels.length + 1}/${target} (score: ${p.score.toFixed(3)})`,
+      ),
+    );
+
+    const answer = await askChoice(ask, "[y/n/s/q] > ", ["y", "n", "s", "q"], "q", () =>
+      out("Type y, n, s, or q"),
+    );
+    if (answer === "q") return { labels, skipped, quit: true };
+    if (answer === "s") {
+      skipped++;
+      continue;
+    }
+    labels.push({
+      id_a: p.idA,
+      id_b: p.idB,
+      label: answer === "y" ? 1 : 0,
+      score: round4(p.score),
+    });
+  }
+  return { labels, skipped, quit: false };
+}
+
+export interface ReviewDecision {
+  readonly idA: number;
+  readonly idB: number;
+  readonly decision: "approve" | "reject";
+}
+
+export interface ReviewSessionResult {
+  readonly decisions: ReviewDecision[];
+  readonly skipped: number;
+  readonly quit: boolean;
+}
+
+/**
+ * The `review` loop. Same keys as `label`, but each y/n becomes an approve/reject
+ * decision destined for Learning Memory rather than a ground-truth row.
+ *
+ * Returns the decisions instead of writing them, so the persistence step (and its
+ * failure modes) stays outside the interactive loop and both are testable alone.
+ */
+export async function runReviewSession(opts: {
+  items: readonly { idA: number; idB: number; score: number }[];
+  rowsById: ReadonlyMap<number, Row>;
+  displayColumns: readonly string[];
+  ask: Ask;
+  limit?: number;
+  out?: (s: string) => void;
+}): Promise<ReviewSessionResult> {
+  const { items, rowsById, displayColumns, ask } = opts;
+  const out = opts.out ?? (() => {});
+  const limit = opts.limit ?? items.length;
+  const decisions: ReviewDecision[] = [];
+  let skipped = 0;
+
+  for (const item of items.slice(0, limit)) {
+    out(
+      renderPair(
+        rowsById.get(item.idA) ?? {},
+        rowsById.get(item.idB) ?? {},
+        displayColumns,
+        `Record ${item.idA} vs ${item.idB} (score: ${item.score.toFixed(3)})`,
+      ),
+    );
+    const answer = await askChoice(ask, "[y/n/s/q] > ", ["y", "n", "s", "q"], "q", () =>
+      out("Type y, n, s, or q"),
+    );
+    if (answer === "q") return { decisions, skipped, quit: true };
+    if (answer === "s") {
+      skipped++;
+      continue;
+    }
+    decisions.push({
+      idA: item.idA,
+      idB: item.idB,
+      decision: answer === "y" ? "approve" : "reject",
+    });
+  }
+  return { decisions, skipped, quit: false };
+}

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1172,7 +1172,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.23.0",
+          version: "1.24.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1599,7 +1599,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.23.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.24.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenmatch/tests/unit/cli-interactive.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/cli-interactive.test.ts
@@ -1,0 +1,286 @@
+/**
+ * cli-interactive.test.ts -- `init` / `label` / `review` (parity batch 7).
+ *
+ * These commands are interactive, which is exactly why the loops take an
+ * injectable `Ask`: a scripted session tests the real decision logic with no TTY.
+ * The Python originals call Rich prompts inline and have no loop tests -- that is
+ * the wart this port deliberately does not reproduce.
+ */
+import { describe, it, expect } from "vitest";
+import { scriptedAsk, askChoice, askYesNo, askWithDefault, renderPair } from "../../src/node/interactive.js";
+import {
+  selectPairs,
+  runLabelSession,
+  runReviewSession,
+  BORDERLINE_ANCHOR,
+} from "../../src/node/label-session.js";
+import { runWizard, suggestTransforms, suggestScorer, toYaml } from "../../src/node/config-wizard.js";
+import type { Row, ScoredPair } from "../../src/core/types.js";
+
+const ROWS = new Map<number, Row>([
+  [0, { name: "Alice Nguyen", email: "a@x.com" }],
+  [1, { name: "Alice Nguyen", email: "a@x.com" }],
+  [2, { name: "Bob Okafor", email: "b@y.com" }],
+  [3, { name: "Carol Petrov", email: "c@z.com" }],
+]);
+const COLS = ["name", "email"];
+
+describe("prompt helpers", () => {
+  it("askChoice re-asks until the answer is allowed", async () => {
+    const invalid: string[] = [];
+    const got = await askChoice(scriptedAsk(["maybe", "wat", "y"]), "> ", ["y", "n"], "n", (r) =>
+      invalid.push(r),
+    );
+    expect(got).toBe("y");
+    expect(invalid).toEqual(["maybe", "wat"]);
+  });
+
+  it("askChoice takes the fallback on empty input (EOF / piped stdin)", async () => {
+    // Without this, a closed stdin would spin forever re-prompting.
+    expect(await askChoice(scriptedAsk([""]), "> ", ["y", "n"], "q")).toBe("q");
+  });
+
+  it("askYesNo and askWithDefault honor their defaults on empty input", async () => {
+    expect(await askYesNo(scriptedAsk([""]), "ok?", true)).toBe(true);
+    expect(await askYesNo(scriptedAsk([""]), "ok?", false)).toBe(false);
+    expect(await askYesNo(scriptedAsk(["yes"]), "ok?", false)).toBe(true);
+    expect(await askWithDefault(scriptedAsk([""]), "name", "mk_1")).toBe("mk_1");
+    expect(await askWithDefault(scriptedAsk(["custom"]), "name", "mk_1")).toBe("custom");
+  });
+
+  it("renderPair marks agreeing non-empty fields", () => {
+    const out = renderPair(ROWS.get(0)!, ROWS.get(1)!, COLS, "t");
+    expect(out).toContain("=");
+    const differing = renderPair(ROWS.get(0)!, ROWS.get(2)!, COLS, "t");
+    expect(differing.split("\n").filter((l) => l.endsWith("="))).toHaveLength(0);
+  });
+});
+
+describe("selectPairs (Python strategy parity)", () => {
+  const pairs: ScoredPair[] = [
+    { idA: 0, idB: 1, score: 0.99 },
+    { idA: 0, idB: 2, score: 0.86 },
+    { idA: 1, idB: 3, score: 0.4 },
+  ];
+
+  it("borderline orders by distance from 0.85", () => {
+    expect(BORDERLINE_ANCHOR).toBe(0.85);
+    expect(selectPairs(pairs, "borderline").map((p) => p.score)).toEqual([0.86, 0.99, 0.4]);
+  });
+
+  it("hardest orders by ascending score", () => {
+    expect(selectPairs(pairs, "hardest").map((p) => p.score)).toEqual([0.4, 0.86, 0.99]);
+  });
+
+  it("random permutes without losing or duplicating pairs", () => {
+    const out = selectPairs(pairs, "random", () => 0.5);
+    expect(out).toHaveLength(3);
+    expect(new Set(out.map((p) => `${p.idA}:${p.idB}`)).size).toBe(3);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const original = [...pairs];
+    selectPairs(pairs, "hardest");
+    expect(pairs).toEqual(original);
+  });
+});
+
+describe("label session", () => {
+  const pairs: ScoredPair[] = [
+    { idA: 0, idB: 1, score: 0.95 },
+    { idA: 0, idB: 2, score: 0.7 },
+    { idA: 1, idB: 3, score: 0.6 },
+  ];
+  const base = { pairs, rowsById: ROWS, displayColumns: COLS };
+
+  it("records y/n and counts skips", async () => {
+    const r = await runLabelSession({ ...base, target: 3, ask: scriptedAsk(["y", "s", "n"]) });
+    expect(r.labels).toEqual([
+      { id_a: 0, id_b: 1, label: 1, score: 0.95 },
+      { id_a: 1, id_b: 3, label: 0, score: 0.6 },
+    ]);
+    expect(r.skipped).toBe(1);
+    expect(r.quit).toBe(false);
+  });
+
+  it("q stops immediately but KEEPS what was already labeled", async () => {
+    const r = await runLabelSession({ ...base, target: 3, ask: scriptedAsk(["y", "q"]) });
+    expect(r.quit).toBe(true);
+    expect(r.labels).toHaveLength(1);
+  });
+
+  it("stops at the target count without consuming more pairs", async () => {
+    const r = await runLabelSession({ ...base, target: 1, ask: scriptedAsk(["y", "y", "y"]) });
+    expect(r.labels).toHaveLength(1);
+  });
+
+  it("skips already-labeled pairs in EITHER orientation (--append)", async () => {
+    // Python checks (a,b) and (b,a); a one-way check would re-serve the pair.
+    const r = await runLabelSession({
+      ...base,
+      target: 3,
+      ask: scriptedAsk(["y", "y"]),
+      existing: new Set(["1:0"]), // reversed form of the first pair
+    });
+    expect(r.labels.map((l) => [l.id_a, l.id_b])).toEqual([
+      [0, 2],
+      [1, 3],
+    ]);
+  });
+
+  it("rounds the recorded score to 4dp like Python", async () => {
+    const r = await runLabelSession({
+      pairs: [{ idA: 0, idB: 1, score: 0.123456789 }],
+      rowsById: ROWS,
+      displayColumns: COLS,
+      target: 1,
+      ask: scriptedAsk(["y"]),
+    });
+    expect(r.labels[0]!.score).toBe(0.1235);
+  });
+});
+
+describe("review session", () => {
+  const items = [
+    { idA: 0, idB: 1, score: 0.9 },
+    { idA: 0, idB: 2, score: 0.8 },
+  ];
+  const base = { items, rowsById: ROWS, displayColumns: COLS };
+
+  it("maps y/n to approve/reject", async () => {
+    const r = await runReviewSession({ ...base, ask: scriptedAsk(["y", "n"]) });
+    expect(r.decisions).toEqual([
+      { idA: 0, idB: 1, decision: "approve" },
+      { idA: 0, idB: 2, decision: "reject" },
+    ]);
+  });
+
+  it("a mid-session quit still returns the decisions already made", async () => {
+    // The CLI persists AFTER the loop, so losing these would discard real work.
+    const r = await runReviewSession({ ...base, ask: scriptedAsk(["y", "q"]) });
+    expect(r.quit).toBe(true);
+    expect(r.decisions).toHaveLength(1);
+  });
+
+  it("honors --limit", async () => {
+    const r = await runReviewSession({ ...base, ask: scriptedAsk(["y", "y"]), limit: 1 });
+    expect(r.decisions).toHaveLength(1);
+  });
+});
+
+describe("config wizard: heuristic parity with Python", () => {
+  it.each([
+    ["first_name", ["lowercase", "strip", "normalize_whitespace"], "jaro_winkler"],
+    ["email", ["lowercase", "strip"], "levenshtein"],
+    ["phone", ["digits_only"], "exact"],
+    ["zip_code", ["strip", "substring:0:5"], "exact"],
+    ["street_address", ["lowercase", "strip", "normalize_whitespace"], "token_sort"],
+    ["widget_id", ["strip"], "jaro_winkler"],
+  ])("%s -> transforms + scorer", (col, transforms, scorer) => {
+    expect(suggestTransforms(col)).toEqual(transforms);
+    expect(suggestScorer(col)).toBe(scorer);
+  });
+
+  it("keyword matching is substring-based and case-insensitive, as in Python", () => {
+    expect(suggestScorer("CustomerEMAIL")).toBe("levenshtein");
+    expect(suggestTransforms("Mobile_Number")).toEqual(["digits_only"]);
+  });
+});
+
+describe("config wizard: scripted end-to-end", () => {
+  it("builds an exact-matchkey config", async () => {
+    const cfg = await runWizard(
+      scriptedAsk([
+        "dedupe",        // mode
+        "people.csv",    // input path
+        "",              // source label -> default
+        "",              // add another file? -> no
+        "",              // matchkey name -> mk_1
+        "exact",         // type
+        "email",         // field
+        "",              // use suggested transforms -> yes
+        "",              // add another field -> no
+        "",              // add another matchkey -> no
+        "",              // configure blocking? -> default (no weighted -> false)
+        "",              // output format -> csv
+        "",              // output dir -> ./output
+        "",              // run name -> empty
+      ]),
+    );
+    expect(cfg.matchkeys).toEqual([
+      { name: "mk_1", type: "exact", fields: [{ field: "email", transforms: ["lowercase", "strip"] }] },
+    ]);
+    expect(cfg.blocking).toBeUndefined();
+    expect(cfg.output).toEqual({ format: "csv", directory: "./output" });
+  });
+
+  it("a weighted matchkey forces blocking configuration without asking", async () => {
+    const cfg = await runWizard(
+      scriptedAsk([
+        "dedupe", "people.csv", "", "",   // mode + file
+        "", "weighted",                    // mk_1, weighted
+        "last_name", "", "",               // field, suggested transforms, suggested scorer
+        "1.0",                             // weight
+        "",                                // another field? no
+        "0.9",                             // threshold
+        "",                                // another matchkey? no
+        "zip",                             // blocking fields (NOT asked whether to configure)
+        "",                                // another blocking key? no
+        "", "", "",                        // format, dir, run name
+      ]),
+    );
+    const mk = cfg.matchkeys[0]!;
+    expect(mk["type"]).toBe("weighted");
+    expect(mk["threshold"]).toBe(0.9);
+    expect((mk["fields"] as Array<Record<string, unknown>>)[0]).toEqual({
+      field: "last_name",
+      transforms: ["lowercase", "strip", "normalize_whitespace"],
+      scorer: "jaro_winkler",
+      weight: 1.0,
+    });
+    expect(cfg.blocking).toEqual({
+      strategy: "static",
+      keys: [{ fields: ["zip"], transforms: ["strip", "substring:0:5"] }],
+    });
+  });
+
+  it("declining the suggested scorer prompts for an explicit one", async () => {
+    const cfg = await runWizard(
+      scriptedAsk([
+        "dedupe", "p.csv", "", "",
+        "", "weighted",
+        "nickname", "",          // field, suggested transforms yes
+        "n", "token_sort",       // decline suggested scorer -> pick explicitly
+        "2.5", "", "0.8", "",
+        "zip", "",
+        "", "", "",
+      ]),
+    );
+    const field = (cfg.matchkeys[0]!["fields"] as Array<Record<string, unknown>>)[0]!;
+    expect(field["scorer"]).toBe("token_sort");
+    expect(field["weight"]).toBe(2.5);
+  });
+});
+
+describe("toYaml", () => {
+  it("round-trips the wizard shape with key order preserved", () => {
+    const yaml = toYaml({
+      matchkeys: [{ name: "mk_1", type: "exact", fields: [{ field: "email", transforms: ["lowercase"] }] }],
+      output: { format: "csv", directory: "./output" },
+    });
+    expect(yaml).toContain("matchkeys:");
+    expect(yaml).toContain("- name: mk_1");
+    expect(yaml.indexOf("matchkeys:")).toBeLessThan(yaml.indexOf("output:"));
+    expect(yaml).toContain("- lowercase");
+  });
+
+  it("quotes values YAML would otherwise reinterpret", () => {
+    // `no`/`yes`/`true` are YAML booleans; a bare digit-leading string becomes a
+    // number. A column literally named "no" must survive the round trip as a string.
+    expect(toYaml({ a: "no" })).toBe('a: "no"\n');
+    expect(toYaml({ a: "true" })).toBe('a: "true"\n');
+    expect(toYaml({ a: "0.85" })).toBe('a: "0.85"\n');
+    expect(toYaml({ a: 0.85 })).toBe("a: 0.85\n");
+    expect(toYaml({ a: "plain" })).toBe("a: plain\n");
+  });
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -155,13 +155,16 @@ cli_commands:
   - import-splink
   - incremental
   - info
+  - init
   - interactive
+  - label
   - lineage
   - match
   - mcp-serve
   - memory
   - pprl
   - profile
+  - review
   - rollback
   - runs
   - score
@@ -171,9 +174,6 @@ cli_commands:
   - unmerge
   python_only:
   - ingest-docs
-  - init
-  - label
-  - review
   - schedule
   - serve-ui
   - setup


### PR DESCRIPTION
> **Stacked on #2109**; targets `main`, so no auto-close. Review the top commit.

The interactive tier. goldenmatch `cli_commands.python_only` **9 → 6**.

| Command | Does |
|---|---|
| `init [-o out.yaml]` | config wizard → YAML |
| `label <files...> -c <cfg> [-n 50] [--strategy borderline\|random\|hardest] [-a]` | label pairs (y/n/s/q) → ground-truth CSV for `evaluate` |
| `review <files...> -c <cfg> [--merge-threshold] [--reject-below]` | steward the borderline band → approve/reject to Learning Memory |

## I was wrong about these

I said these "shouldn't be ported." My objection was *"interactive TTY loop"* — which is a **cost** statement, not an architectural one, and it doesn't even hold: this package already ships an **ink TUI with a working label flow**, and **`src/core/review-queue.ts` already existed** with no CLI over it.

The project's North Star lists *every-capability-on-every-surface* as a decision-test commitment, so the burden was on **not** porting. I had it backwards, and I'd let effort masquerade as architecture.

## Design: injectable prompts

The loops take an injectable `Ask` (`src/node/interactive.ts`) instead of reading stdin, so the decision logic is **unit-testable by scripting a session**. Python's equivalents call Rich prompts inline and consequently have **no loop tests at all** — that's the wart this port deliberately doesn't reproduce.

Details worth flagging:
- **`review` persists after the loop**, so a mid-session `q` still records what was already decided rather than discarding real steward work.
- **`--append` skips already-labeled pairs in either orientation** (Python checks both); a one-way check silently re-serves the same pair.
- `askChoice` returns the fallback on empty input, so a **piped or closed stdin terminates** instead of spinning on re-prompts.
- `toYaml` is hand-rolled rather than pulling the optional `yaml` peer dep, so `init` can't fail on a missing optional dependency. It quotes values YAML would reinterpret — a column literally named `no` stays a string, not `false`.
- `suggestTransforms` / `suggestScorer` are ported byte-faithfully, so both wizards propose the same config for the same column names. That's the part worth parity, and it's pinned by a table test.

## Scope correction

I'd listed **`setup`** in this tier. It's *"Interactive setup wizard for GPU, API keys, and database"* — GPU/torch are Python-runtime concerns, so a TS `setup` would be a **different wizard, not a port**. Left out deliberately rather than shipping a same-named command that does other work.

## Verification

- **28 tests**: strategy ordering, y/n/s/q, mid-session quit preserving work, either-orientation append dedup, 4dp rounding, the heuristic parity table, YAML quoting, and two scripted end-to-end wizard sessions (including the weighted-matchkey path that forces blocking without asking).
- `check_api_parity.py` OK; TS emitter on a built dist shows cli **31** with all three present; `tsc --noEmit` clean; `1.23.0 → 1.24.0` with lockstep green; all 10 doc gates pass.

**Remaining python-only (6):** `serve-ui` (React SPA, declared), `setup` (Python-runtime subject matter), and `sync`/`watch`/`schedule`/`ingest-docs` — which want a Postgres-connector subsystem and a VLM pipeline TS doesn't have yet. Those are real work, not "shouldn't."

🤖 Generated with [Claude Code](https://claude.com/claude-code)