### PR TITLE
feat(ts): schedule CLI command (parity batch 8)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.24.0` | `goldenmatch` | 90 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.25.0` | `goldenmatch` | 90 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 83 | 7 | 0 |
-| `goldenmatch` | cli_commands | 31 | 6 | 0 |
+| `goldenmatch` | cli_commands | 32 | 5 | 0 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -64,7 +64,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `ingest-docs`, `schedule`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `ingest-docs`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — Python-only: `date_diff`, `geo_haversine`, `numeric_diff`.

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [1.25.0] - 2026-07-24
+
+### Added
+- **`schedule` CLI command** (parity batch 8). goldenmatch `cli_commands.python_only` **6 -> 5**.
+  `schedule <files...> [-c cfg] (--every 1h | --cron '0 6 * * *') [--output-dir .] [--max-runs N]`
+  runs dedupe on a repeating interval, writing `<jobId>_run<N>_golden.csv` per run.
+  `src/node/scheduler.ts` ports `core/scheduler.py` (`parseInterval` / `parseCron` / `ScheduledJob`).
+
+### Known shared limitation (deliberately NOT fixed one-sided)
+- **`--cron` is interval-only, not wall-clock.** `parseCron` validates the 5-field shape and then collapses to a coarse interval (daily / hourly) -- it does not compute the next matching time. This is a faithful port of Python's behavior, whose own docstring says "For full cron support, use system cron." Implementing real cron on TypeScript alone would make `--cron "0 6 * * *"` mean *daily at 06:00* on TS and *every 86400s from now* on Python: a silent operational divergence in a scheduling tool, which is worse than a shared limitation. The TS CLI prints a note when `--cron` is used, and the limitation is pinned by tests. Fixing it properly means changing both surfaces together.
+
+### Fixed (bug found while porting)
+- **`--max-runs` now bounds ATTEMPTS, not successes.** Counting only successful runs meant a permanently-failing job ignored the cap and looped forever, because a failed attempt never advances `runCount`. Guarded by a test that would hang under the old semantics. A failing run is still reported and the schedule continues -- a scheduled job that dies on one bad input is worse than one that logs and retries.
+- `parseInterval` rejects a non-integer numeric part (`1.5h`). Python's `int(spec[:-1])` raises on it, so silently reading it as `1h` would have diverged the two CLIs on the same flag.
+
 ## [1.24.0] - 2026-07-24
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -9,6 +9,7 @@
 import { Command } from "commander";
 import { extname, basename, dirname } from "node:path";
 import { pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
 import {
   readFile,
   writeCsv,
@@ -1507,6 +1508,61 @@ configCmd
       process.exit(1);
     }
   });
+
+// ---------- schedule ----------
+program
+  .command("schedule")
+  .description("Run deduplication on a schedule")
+  .argument("<files...>", "data files to process")
+  .option("-c, --config <path>", "config YAML path")
+  .option("--every <spec>", "run interval (e.g. 1h, 30m, 6h, 1d)")
+  .option("--cron <spec>", "cron schedule (e.g. '0 6 * * *')")
+  .option("--output-dir <dir>", "output directory", ".")
+  .option("--max-runs <n>", "stop after N runs (default: run until interrupted)", (v) =>
+    parseInt(v, 10),
+  )
+  .action(
+    async (
+      files: string[],
+      opts: { config?: string; every?: string; cron?: string; outputDir: string; maxRuns?: number },
+    ) => {
+      const { ScheduledJob, parseInterval, parseCron } = await import("./node/scheduler.js");
+      if (!opts.every && !opts.cron) {
+        process.stderr.write("Error: specify --every or --cron\n");
+        process.exit(1);
+      }
+      let interval: number;
+      try {
+        interval = opts.every ? parseInterval(opts.every) : parseCron(opts.cron!);
+      } catch (err) {
+        process.stderr.write(`Error: ${(err as Error).message}\n`);
+        process.exit(1);
+      }
+      if (opts.cron) {
+        // Be explicit rather than let an operator assume real cron semantics.
+        process.stderr.write(
+          "Note: --cron is simplified (interval only, not wall-clock scheduling), " +
+            "matching the Python CLI. Use system cron for exact times.\n",
+        );
+      }
+
+      const job = new ScheduledJob({
+        jobId: `gm-${randomUUID().replace(/-/g, "").slice(0, 8)}`,
+        filePaths: files,
+        ...(opts.config ? { config: loadConfigFile(opts.config) } : {}),
+        intervalSeconds: interval,
+        outputDir: opts.outputDir,
+        loadRows: (paths) => loadFilesWithSource(paths),
+        out: (s) => process.stdout.write(s + "\n"),
+      });
+      // Ctrl+C finishes the current run's bookkeeping instead of hard-killing.
+      process.on("SIGINT", () => {
+        process.stdout.write("\nStopping after the current run...\n");
+        job.stop();
+      });
+      await job.run(opts.maxRuns !== undefined ? { maxRuns: opts.maxRuns } : {});
+    },
+  );
 
 // ---------- init (interactive config wizard) ----------
 program

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.24.0",
+  version: "1.25.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1172,7 +1172,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.24.0",
+          version: "1.25.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1599,7 +1599,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.24.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.25.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenmatch/src/node/scheduler.ts
+++ b/packages/typescript/goldenmatch/src/node/scheduler.ts
@@ -1,0 +1,173 @@
+/**
+ * scheduler.ts -- scheduled dedupe runs. Ports `goldenmatch/core/scheduler.py`.
+ *
+ * Node-only: it writes output files and sleeps between runs.
+ *
+ * PARITY WARNING (deliberate, do not "fix" one-sided): `parseCron` is a FAITHFUL
+ * port of Python's deliberately-simplified cron handling. It validates the 5-field
+ * shape and then collapses to a coarse interval (daily / hourly) -- it does NOT
+ * compute the next matching wall-clock time. Python's own docstring says "For full
+ * cron support, use system cron."
+ *
+ * Implementing real cron here would make `--cron "0 6 * * *"` mean *daily at 06:00*
+ * on TS and *every 86400s starting now* on Python -- a silent operational
+ * divergence in a scheduling tool, which is worse than a shared limitation. If this
+ * should become real cron, it needs to change on BOTH surfaces in one go.
+ */
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { dedupe } from "../core/api.js";
+import { writeCsv } from "./connectors/file.js";
+import type { GoldenMatchConfig, Row } from "../core/types.js";
+
+/** Python `parse_interval`: '30s' | '30m' | '1h' | '1d' | bare seconds. */
+export function parseInterval(spec: string): number {
+  const s = spec.trim().toLowerCase();
+  const suffixes: Array<[string, number]> = [
+    ["s", 1],
+    ["m", 60],
+    ["h", 3600],
+    ["d", 86400],
+  ];
+  // The numeric part must be a whole number. Python does `int(spec[:-1])`, which
+  // RAISES on "1.5h" -- so accepting it here (parseInt would silently yield 1)
+  // would mean a scheduler that runs hourly on TS and errors on Python for the
+  // same flag. Reject it on both.
+  for (const [suffix, mult] of suffixes) {
+    if (s.endsWith(suffix)) {
+      const body = s.slice(0, -1);
+      if (!/^-?\d+$/.test(body)) {
+        throw new Error(`Invalid interval: ${spec}. Use format: 30m, 1h, 6h, 1d`);
+      }
+      return Number.parseInt(body, 10) * mult;
+    }
+  }
+  if (!/^-?\d+$/.test(s)) {
+    throw new Error(`Invalid interval: ${spec}. Use format: 30m, 1h, 6h, 1d`);
+  }
+  return Number.parseInt(s, 10);
+}
+
+/**
+ * Python `parse_cron`: validate 5 fields, then return a COARSE interval.
+ * See the module-level parity warning -- this is intentionally not real cron.
+ */
+export function parseCron(cronSpec: string): number {
+  const parts = cronSpec.trim().split(/\s+/).filter((p) => p !== "");
+  if (parts.length !== 5) {
+    throw new Error("Cron spec must have 5 fields: minute hour day month weekday");
+  }
+  const [minute, hour] = parts as [string, string, string, string, string];
+  if (hour !== "*" && minute !== "*") return 86400; // daily
+  if (minute !== "*") return 3600; // hourly
+  return 3600; // default hourly
+}
+
+export interface ScheduledRunResult {
+  readonly runNumber: number;
+  readonly totalRecords: number;
+  readonly totalClusters: number;
+  readonly matchRate: number;
+  readonly outputPath: string;
+}
+
+export interface ScheduledJobOptions {
+  readonly jobId: string;
+  readonly filePaths: readonly string[];
+  readonly config?: GoldenMatchConfig;
+  readonly intervalSeconds?: number;
+  readonly outputDir?: string;
+  readonly loadRows: (paths: readonly string[]) => Row[];
+  readonly onComplete?: (r: ScheduledRunResult) => void;
+  readonly out?: (s: string) => void;
+}
+
+/**
+ * A repeating dedupe job. `runOnce` is separated from `run` so a single execution
+ * is testable without any timers -- Python's loop and its body are entangled.
+ */
+export class ScheduledJob {
+  readonly jobId: string;
+  readonly intervalSeconds: number;
+  runCount = 0;
+  lastRun: Date | null = null;
+  lastResult: ScheduledRunResult | null = null;
+
+  private readonly opts: ScheduledJobOptions;
+  private stopped = false;
+
+  constructor(opts: ScheduledJobOptions) {
+    this.opts = opts;
+    this.jobId = opts.jobId;
+    this.intervalSeconds = opts.intervalSeconds ?? 3600;
+  }
+
+  async runOnce(): Promise<ScheduledRunResult> {
+    const rows = this.opts.loadRows(this.opts.filePaths);
+    const result = await dedupe(rows, this.opts.config ? { config: this.opts.config } : {});
+    this.runCount++;
+    this.lastRun = new Date();
+
+    const dir = this.opts.outputDir ?? ".";
+    mkdirSync(dir, { recursive: true });
+    // Run number in the filename so successive runs don't clobber each other.
+    const outputPath = join(dir, `${this.jobId}_run${this.runCount}_golden.csv`);
+    writeCsv(outputPath, result.goldenRecords as readonly Row[]);
+
+    const summary: ScheduledRunResult = {
+      runNumber: this.runCount,
+      totalRecords: result.stats.totalRecords,
+      totalClusters: result.stats.totalClusters,
+      matchRate: result.stats.matchRate,
+      outputPath,
+    };
+    this.lastResult = summary;
+    this.opts.onComplete?.(summary);
+    return summary;
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  /**
+   * Run forever (until `stop()`), sleeping `intervalSeconds` between runs.
+   *
+   * `sleep` and `maxRuns` are injectable so the loop itself is testable -- a real
+   * timer-driven loop is otherwise untestable, which is why Python's has no test.
+   * An error in one run is reported and the schedule CONTINUES; a scheduled job
+   * that dies on one bad input is worse than one that logs and retries.
+   */
+  async run(
+    opts: { maxRuns?: number; sleep?: (ms: number) => Promise<void> } = {},
+  ): Promise<void> {
+    const out = this.opts.out ?? (() => {});
+    const sleep =
+      opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+    const maxRuns = opts.maxRuns ?? Infinity;
+
+    out(`Scheduled job ${this.jobId}: every ${this.intervalSeconds}s`);
+    // maxRuns bounds ATTEMPTS, not successes. Counting only successful runs means
+    // a permanently-failing job ignores `--max-runs` and loops forever, since a
+    // failed attempt never advances runCount.
+    let attempts = 0;
+    while (!this.stopped && attempts < maxRuns) {
+      attempts++;
+      const started = Date.now();
+      try {
+        const r = await this.runOnce();
+        out(
+          `  run ${r.runNumber}: ${r.totalRecords} records -> ${r.totalClusters} clusters ` +
+            `(${(r.matchRate * 100).toFixed(1)}%) in ${((Date.now() - started) / 1000).toFixed(1)}s`,
+        );
+      } catch (err) {
+        out(`  run failed: ${(err as Error).message}`);
+      }
+      if (this.stopped || attempts >= maxRuns) break;
+      await sleep(this.intervalSeconds * 1000);
+    }
+    out(
+      `Job ${this.jobId} stopped after ${attempts} attempt(s), ${this.runCount} successful run(s).`,
+    );
+  }
+}

--- a/packages/typescript/goldenmatch/tests/unit/scheduler.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scheduler.test.ts
@@ -1,0 +1,184 @@
+/**
+ * scheduler.test.ts -- `schedule` command (parity batch 8).
+ *
+ * `sleep` and `maxRuns` are injectable, so the run LOOP is tested without timers.
+ * Python's loop is entangled with `time.sleep` and has no test.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseInterval, parseCron, ScheduledJob } from "../../src/node/scheduler.js";
+import type { Row } from "../../src/core/types.js";
+
+describe("parseInterval (Python parity)", () => {
+  it.each([
+    ["30s", 30],
+    ["30m", 1800],
+    ["1h", 3600],
+    ["6h", 21600],
+    ["1d", 86400],
+    ["45", 45], // bare seconds
+    [" 2H ", 7200], // trimmed + case-insensitive
+  ])("%s -> %i seconds", (spec, expected) => {
+    expect(parseInterval(spec)).toBe(expected);
+  });
+
+  it.each(["abc", "", "h", "1x", "1.5h"])("rejects %o", (spec) => {
+    expect(() => parseInterval(spec)).toThrow(/Invalid interval/);
+  });
+});
+
+describe("parseCron -- faithful to Python's SIMPLIFIED handling", () => {
+  it("requires exactly 5 fields", () => {
+    expect(() => parseCron("0 6 * *")).toThrow(/5 fields/);
+    expect(() => parseCron("0 6 * * * *")).toThrow(/5 fields/);
+  });
+
+  it.each([
+    ["0 6 * * *", 86400], // minute AND hour pinned -> daily
+    ["30 * * * *", 3600], // minute only -> hourly
+    ["* * * * *", 3600], // nothing pinned -> hourly default
+  ])("%s -> %i seconds", (spec, expected) => {
+    expect(parseCron(spec)).toBe(expected);
+  });
+
+  it("is INTERVAL-only, not wall-clock -- the documented shared limitation", () => {
+    // "0 6 * * *" means "every 86400s from now", NOT "daily at 06:00". This is
+    // Python's behavior; implementing real cron on TS alone would silently diverge
+    // a scheduling tool across surfaces. Pinned so the limitation stays visible.
+    expect(parseCron("0 6 * * *")).toBe(86400);
+    expect(parseCron("0 23 * * *")).toBe(86400); // hour is ignored entirely
+    expect(parseCron("0 6 * * 1")).toBe(86400); // weekday ignored too
+  });
+});
+
+const ROWS: Row[] = [
+  { name: "Alice Nguyen", email: "a@x.com" },
+  { name: "Alice Nguyen", email: "a@x.com" },
+  { name: "Bob Okafor", email: "b@y.com" },
+  { name: "Carol Petrov", email: "c@z.com" },
+];
+
+// Explicit config: zero-config finds no matches on a 4-row fixture, so the golden
+// output would be empty and the "wrote real content" assertion would be vacuous.
+const CONFIG = {
+  matchkeys: [
+    {
+      name: "exact_email",
+      type: "exact" as const,
+      fields: [{ field: "email", transforms: ["lowercase", "strip"], scorer: "exact", weight: 1 }],
+    },
+  ],
+};
+
+function makeJob(dir: string, extra: Record<string, unknown> = {}) {
+  return new ScheduledJob({
+    jobId: "gm-test123",
+    filePaths: ["ignored.csv"],
+    outputDir: dir,
+    config: CONFIG as never,
+    loadRows: () => ROWS,
+    ...extra,
+  });
+}
+
+describe("ScheduledJob.runOnce", () => {
+  it("writes a golden CSV and reports stats", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-sched-"));
+    const job = makeJob(dir);
+    const r = await job.runOnce();
+    expect(r.runNumber).toBe(1);
+    expect(r.totalRecords).toBeGreaterThan(0);
+    expect(existsSync(r.outputPath)).toBe(true);
+    expect(readFileSync(r.outputPath, "utf-8").length).toBeGreaterThan(0);
+    expect(job.lastRun).toBeInstanceOf(Date);
+    expect(job.lastResult).toEqual(r);
+  }, 20000);
+
+  it("run number is in the filename so successive runs do not clobber", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-sched-"));
+    const job = makeJob(dir);
+    const a = await job.runOnce();
+    const b = await job.runOnce();
+    expect(a.outputPath).not.toBe(b.outputPath);
+    expect(existsSync(a.outputPath)).toBe(true);
+    expect(existsSync(b.outputPath)).toBe(true);
+    expect(job.runCount).toBe(2);
+  }, 25000);
+
+  it("fires onComplete with the summary", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-sched-"));
+    const seen: number[] = [];
+    const job = makeJob(dir, { onComplete: (r: { runNumber: number }) => seen.push(r.runNumber) });
+    await job.runOnce();
+    await job.runOnce();
+    expect(seen).toEqual([1, 2]);
+  }, 25000);
+});
+
+describe("ScheduledJob.run loop", () => {
+  it("runs maxRuns times and sleeps BETWEEN runs, not after the last", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-sched-"));
+    const sleeps: number[] = [];
+    const job = makeJob(dir, { intervalSeconds: 7 });
+    await job.run({ maxRuns: 3, sleep: async (ms) => void sleeps.push(ms) });
+    expect(job.runCount).toBe(3);
+    expect(sleeps).toEqual([7000, 7000]); // 2 sleeps for 3 runs
+  }, 40000);
+
+  it("stop() ends the loop", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-sched-"));
+    const job = makeJob(dir);
+    await job.run({
+      maxRuns: 10,
+      sleep: async () => {
+        job.stop();
+      },
+    });
+    expect(job.runCount).toBe(1);
+  }, 20000);
+
+  it("a failing run is reported and the schedule CONTINUES", async () => {
+    // A scheduled job that dies on one bad input is worse than one that logs on.
+    const dir = mkdtempSync(join(tmpdir(), "gm-sched-"));
+    let calls = 0;
+    const lines: string[] = [];
+    const job = new ScheduledJob({
+      jobId: "gm-flaky",
+      filePaths: ["x.csv"],
+      outputDir: dir,
+      intervalSeconds: 1,
+      loadRows: () => {
+        if (++calls === 1) throw new Error("transient read failure");
+        return ROWS;
+      },
+      out: (s) => lines.push(s),
+    });
+    await job.run({ maxRuns: 2, sleep: async () => {} });
+    expect(lines.some((l) => l.includes("run failed: transient read failure"))).toBe(true);
+    // maxRuns bounds ATTEMPTS: 2 attempts = 1 failure + 1 success. Bounding
+    // SUCCESSES instead would let a permanently-failing job loop forever.
+    expect(calls).toBe(2);
+    expect(job.runCount).toBe(1);
+    expect(lines.at(-1)).toContain("2 attempt(s), 1 successful");
+  }, 30000);
+});
+
+describe("maxRuns bounds attempts, not successes", () => {
+  it("a permanently-failing job still terminates", async () => {
+    // The bug this guards: if maxRuns counted only successful runs, this loop
+    // would never exit because runCount never advances.
+    const job = new ScheduledJob({
+      jobId: "gm-broken",
+      filePaths: ["x.csv"],
+      outputDir: mkdtempSync(join(tmpdir(), "gm-sched-")),
+      intervalSeconds: 1,
+      loadRows: () => {
+        throw new Error("always fails");
+      },
+    });
+    await job.run({ maxRuns: 3, sleep: async () => {} });
+    expect(job.runCount).toBe(0); // nothing ever succeeded
+  }, 20000);
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -167,6 +167,7 @@ cli_commands:
   - review
   - rollback
   - runs
+  - schedule
   - score
   - sensitivity
   - serve
@@ -174,7 +175,6 @@ cli_commands:
   - unmerge
   python_only:
   - ingest-docs
-  - schedule
   - serve-ui
   - setup
   - sync


### PR DESCRIPTION
> **Stacked on #2110**; targets `main`, so no auto-close. Review the top commit.

goldenmatch `cli_commands.python_only` **6 → 5**.

`schedule <files...> [-c cfg] (--every 1h | --cron '0 6 * * *') [--output-dir .] [--max-runs N]` — repeating dedupe, writing `<jobId>_run<N>_golden.csv` per run.

## Scope correction (my second on this tier)

I said `sync`/`watch`/`schedule` were "one dependency, one wave" because all three were Postgres-backed. **Wrong** — `schedule` has **no database dependency at all**. It's `core/scheduler.py` + dedupe-over-files, so it ports independently and cheaply.

`sync`/`watch` are the *actual* Postgres wave: `db/sync.py` alone is 1052 lines, and its tests need a live Postgres that CI doesn't run. Worth knowing before that one gets picked up — see the note at the end.

## Known shared limitation, deliberately not fixed one-sided

`parseCron` validates the 5-field shape and then collapses to a coarse interval (daily/hourly). It does **not** compute the next matching wall-clock time. That's faithful to Python, whose docstring says *"For full cron support, use system cron."*

Implementing real cron on TS alone would make `--cron "0 6 * * *"` mean **daily at 06:00** on TS and **every 86400s from now** on Python — a silent operational divergence in a *scheduling* tool, which is worse than a shared limitation. The CLI prints a note when `--cron` is used, tests pin the behavior, and fixing it properly means changing both surfaces together. Happy to do that as its own change if you want real cron.

## Two bugs the tests found

1. **`--max-runs` bounded successes, so a permanently-failing job looped forever** — a failed attempt never advances `runCount`, so the cap was unreachable. Now bounds *attempts*, guarded by a test that would hang under the old semantics.
2. **`parseInterval("1.5h")` silently returned 3600** (parseInt truncation). Python's `int(spec[:-1])` raises, so the same flag behaved differently on each CLI. Now rejected on both.

A failing run is still reported and the schedule **continues** — a scheduled job that dies on one bad input is worse than one that logs and retries.

`sleep` and `maxRuns` are injectable, so the run **loop** is tested without timers (Python's is entangled with `time.sleep` and has no test). Third fix: my `runOnce` test originally asserted non-empty CSV content while zero-config found no matches on a 4-row fixture — it was asserting on an empty file. Now passes an explicit exact-email config so a golden record genuinely exists.

## Verification

24 tests; `check_api_parity.py` OK; TS emitter on a **rebuilt** dist shows cli **32** with `schedule` present; `tsc` clean; `1.24.0 → 1.25.0` lockstep green; all 10 doc gates pass.

**Remaining python-only (5):** `serve-ui` (React SPA, declared), `setup` (GPU/torch subject matter), `ingest-docs` (VLM pipeline), and `sync`/`watch`. Flagging honestly on that last pair: it's ~1300 lines of Postgres-dependent code, and I can't verify it against a real database locally — the Python DB tests are `--ignore`d in CI for the same reason. I'd want to agree on how it gets validated before writing it, rather than ship a large untested DB subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)