### PR TITLE
docs(design): Arrow-native SQLite bulk writes via ADBC — design + measurement plan

### DIFF
--- a/.github/workflows/spike-adbc-sqlite-ingest.yml
+++ b/.github/workflows/spike-adbc-sqlite-ingest.yml
@@ -1,0 +1,53 @@
+name: spike-adbc-sqlite-ingest
+
+# Decides docs/design/2026-07-24-adbc-sqlite-bulk-writes.md: is Arrow-native
+# (ADBC) bulk ingest into SQLite worth taking a dependency for?
+#
+# Three arms -- today's batched row path, a staging table + stdlib executemany
+# (the NO-DEPENDENCY control), and ADBC ingest. Every arm's resulting database
+# is content-hashed, so a faster arm that writes different bytes fails loudly.
+#
+# adbc-driver-sqlite is installed ONLY for this job via `uv run --with`; it is
+# deliberately NOT a package dependency unless and until this spike says GO.
+#
+# Not part of PR gating -- workflow_dispatch only.
+on:
+  workflow_dispatch:
+    inputs:
+      ns:
+        description: "Identity counts to sweep (comma-separated)"
+        default: "100000,1000000,5000000"
+      arms:
+        description: "rowpath,staging,adbc"
+        default: "rowpath,staging,adbc"
+
+permissions:
+  contents: read
+
+jobs:
+  spike:
+    runs-on: large-new-64GB
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Spike ADBC vs staging vs row path
+        # --with layers adbc-driver-sqlite over the project env for this run
+        # only; it does not enter uv.lock or the package's dependencies.
+        run: |
+          uv run --with adbc-driver-sqlite python \
+            packages/python/goldenmatch/scripts/spike_adbc_sqlite_ingest.py \
+            --ns "${{ inputs.ns }}" \
+            --arms "${{ inputs.arms }}" \
+            --output spike_adbc_sqlite_ingest.json
+      - name: Upload JSON artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: spike-adbc-sqlite-ingest-results
+          path: spike_adbc_sqlite_ingest.json

--- a/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
+++ b/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
@@ -1,0 +1,192 @@
+# Arrow-native SQLite bulk writes via ADBC — design + measurement plan
+
+**Date:** 2026-07-24 • **Status:** Proposed — spike NOT yet run, no dependency added
+
+## Question
+
+`IdentityStore` has a bulk write fast path (`bulk_upsert_identities` /
+`bulk_upsert_records` / `bulk_add_edges` / `bulk_emit_events`) that exists **only
+for Postgres**; every one of them raises `NotImplementedError` on SQLite, and
+`resolve_clusters` gates on it with a literal
+`use_bulk_fast_path = getattr(store, "_backend", None) == "postgres"`.
+
+The reason given was that SQLite has no `COPY`. That is true of the stdlib
+`sqlite3` driver, but it is not true of SQLite as a target: Apache Arrow's
+**ADBC SQLite driver** supports columnar bulk ingest (`adbc_ingest` from Python;
+`adbc_core` + `adbc_driver_manager` from Rust, loading `libadbc_driver_sqlite`).
+
+So: **should the SQLite identity backend adopt ADBC for its bulk write path,
+and what would that actually buy?**
+
+## What #2105 / PR #2111 already fixed, and what it left
+
+#2111 addressed three things on the SQLite resolve path. Numbers are from a
+Windows dev box and are directional only — Windows fsync is not Linux — except
+the memory figure, which is a Python-heap measurement and transfers.
+
+| | before | after |
+|---|---|---|
+| Prep Python heap | ~2,495 B **per input row** | same per row, but only for **referenced** rows |
+| SQLite write | ~750 us/statement (autocommit) | ~30-90 us/statement (batched txn) |
+| 100k rows / 5,000 identities | 31.28 s | 9.18 s |
+
+What it left standing, and why ADBC is the candidate for it:
+
+1. **The per-row Python object is still there.** #2111 *bounded how many rows*
+   get turned into Python dicts; it did not remove the dict. The prep still
+   builds a row dict + payload dict + hash + source + pk + record-id candidates
+   per referenced row, at ~2.5 KB each. With **`emit_singletons=True` — the
+   schema default — every row is referenced**, so the ~35 GB-at-14M problem
+   returns in full. Bounding the input does not fix the default configuration;
+   only removing the per-row Python object does.
+2. **SQLite still has no bulk path at all.** Every eligible brand-new cluster
+   goes through `upsert_identity` / `upsert_record` / `add_edge` / `emit_event`
+   one statement at a time. Postgres accumulates and flushes in 4 COPY batches.
+
+## Why ADBC maps cleanly onto what already exists
+
+ADBC ingest is create/append, **not** upsert, so it cannot write `identity_nodes`
+directly. But that is exactly the shape the Postgres path already uses — stage,
+then upsert:
+
+```
+Postgres today:  COPY -> TEMP _stage_source_records -> INSERT ... SELECT ... ON CONFLICT DO UPDATE -> DROP
+SQLite w/ ADBC:  adbc_ingest("_stage_source_records", batch, mode="create"/"append")
+                                                  -> INSERT ... SELECT ... ON CONFLICT DO UPDATE -> DROP
+```
+
+SQLite has supported `INSERT ... ON CONFLICT DO UPDATE` since 3.24, so the second
+half is a near-verbatim port of the Postgres SQL. The consequence is that
+`use_bulk_fast_path` stops being backend-specific and the four `bulk_*` methods
+get a real SQLite branch instead of a `NotImplementedError`.
+
+## Ceiling analysis — what this can and cannot buy
+
+Being explicit here because it is easy to oversell.
+
+**It cannot buy another large write-throughput multiple.** SQLite has no `COPY`.
+The ADBC SQLite driver implements ingest as prepared INSERTs bound inside a
+transaction — which is materially what #2111 already does. The 8-25x from
+collapsing per-statement commits is **already banked**. Expect low single digits
+from skipping per-row Python tuple construction and `sqlite3` type conversion,
+not another order of magnitude.
+
+**What it can buy:**
+
+- **Elimination of the per-row Python object on the bulk path.** This is the
+  real prize and the only thing that fixes `emit_singletons=True` at scale. If
+  the accumulate-and-flush goes frame -> frame, the ~2.5 KB/row Python heap for
+  bulk-eligible clusters goes to roughly zero.
+- **One bulk code path for both SQL backends** instead of a Postgres-only fast
+  path plus a SQLite slow path that silently diverge (see the payload trap below).
+- **Direction fit.** `pyarrow>=10` and `duckdb>=0.9` are already core deps and
+  the Frame seam has an Arrow lane, so an Arrow-native store write path is
+  consistent with the "Rust is the reference" / Polars-eviction arc rather than
+  a new axis.
+
+## The blocking design problem: SQLite is single-writer
+
+This is the part that decides whether the incremental version is even viable,
+and it has no Postgres analogue.
+
+An ADBC connection is **a different connection** from the stdlib `sqlite3` one
+`IdentityStore` holds. SQLite permits exactly one write transaction at a time
+across connections; a second writer gets `SQLITE_BUSY`. And #2111 now holds an
+explicit write transaction around the whole resolve loop via `bulk_writes()` —
+which is precisely where the bulk flush would fire. So a naive "open an ADBC
+connection alongside the existing one" deadlocks against our own transaction.
+
+Three options:
+
+**A. Move the whole `IdentityStore` SQLite backend onto ADBC.** One connection,
+no contention, and every write (row path and bulk path) becomes Arrow-native.
+Cleanest end state; largest migration — every `_exec` / `_fetchone` / `_fetchall`
+call site, the schema bootstrap, `PRAGMA` handling, and `in_transaction`
+semantics that #2111's batching depends on.
+
+**B. Dual connection with explicit sequencing.** Keep stdlib `sqlite3` for the
+row path; open ADBC only for bulk flushes, and sequence so the stdlib write
+transaction is committed and closed before the ADBC ingest runs, then reopened.
+Smaller change, but it fragments the transaction into "row-path txn / ADBC txn /
+row-path txn" per flush, which weakens the atomicity story and adds a real
+`SQLITE_BUSY` surface under any concurrent reader (WAL helps readers, not a
+second writer).
+
+**C. Do nothing.** #2111 already removed the OOM for `emit_singletons=False` and
+took the write path from ~750 us to ~30-90 us per statement. If measurement says
+the remaining Python-object cost is not the binding constraint at the scales
+people actually run SQLite at, the honest answer is to leave it and point users
+at Postgres past the low millions.
+
+**Leaning A over B**, because B's benefit is bounded by the same "no COPY in
+SQLite" ceiling while its cost is a permanently more confusing transaction model.
+But A is only worth its migration cost if the spike shows the Python-object
+elimination is worth real money. Hence: measure first.
+
+## Traps to carry into implementation
+
+1. **The Postgres bulk path silently drops payloads.** `bulk_upsert_records`'s
+   column list omits `payload`, and its `ON CONFLICT DO UPDATE` does not touch it
+   — so a record written via the Postgres bulk path has `payload = NULL`, while
+   the SQLite row path stores it. `bulk_emit_events` likewise carries no event
+   `payload`, while the row path emits
+   `{"cluster_id", "member_count", "record_ids"}`. **Extending the fast path to
+   SQLite without carrying payloads would be a silent data regression for every
+   existing SQLite user.** Either carry payloads on the bulk path (and decide
+   whether to fix Postgres to match) or keep payload-bearing clusters off it.
+2. **Entity ids are the durability invariant.** Any new write path needs the
+   byte-identical store-contents parity gate — the
+   `tests/identity/test_resolve_scaling.py::_dump` canonicalisation (keying each
+   identity by its record-id set, since entity ids are random UUIDv7) is the
+   existing harness for this and should be reused.
+3. **New dependency.** `adbc-driver-sqlite` ships a bundled shared library. It
+   must be an **extra** with a graceful fallback to the current path, matching
+   the `[polars]` / `_native_loader` idiom — never a hard core dep.
+4. **The Rust story is a dynamic load, not a crate.** `adbc_core` +
+   `adbc_driver_manager` use `ManagedDriver::load_dynamic_from_filename(...)`,
+   i.e. you locate/ship `libadbc_driver_sqlite.{so,dylib,dll}` per platform. This
+   repo has scar tissue here (`ort`/`onnxruntime` do not link locally on Windows;
+   the native wheel's macOS arch matrix). Do not assume the Python win transfers
+   to a Rust surface for free.
+5. **Schema/type mapping.** `golden_record`, `payload`, `field_scores`,
+   `negative_evidence`, `controller_snapshot` are JSON-in-TEXT; timestamps are
+   ISO strings via `.isoformat()`. The ingest must reproduce those exact
+   encodings or stored bytes drift.
+
+## Spike — decide before building
+
+`scratchpad/adbc_sqlite_ingest_spike.py`, measured on `large-new-64GB` (**not**
+locally — see the bench-runner rule), against the identity schema:
+
+1. Write N rows into `identity_nodes` + `source_records` three ways, N in
+   {100k, 1M, 5M}: (a) today's batched row path, (b) ADBC ingest into a staging
+   table + `INSERT ... SELECT ... ON CONFLICT`, (c) stdlib `executemany` into
+   staging + the same upsert — **(c) is the control that isolates "Arrow" from
+   "staging table"**, and it needs no new dependency.
+2. Report wall and **peak RSS**, plus the Python-heap delta, per arm.
+3. Verify the resulting DB is byte-identical across arms (schema + row content).
+
+The existing `bench-identity-resolve-scaling` workflow already ladders the right
+shape and has the arm plumbing; extend it rather than writing a new one.
+
+### Kill criteria
+
+- If **(c) staging + `executemany`** captures most of (b)'s win, ship (c) and
+  **drop ADBC entirely** — same benefit, zero new dependency. This is the outcome
+  I consider most likely and it should be the null hypothesis.
+- If (b) beats (c) by **< 1.5x wall and < 30% peak RSS** at 1M, **NO-GO** — the
+  dependency and the single-writer complexity are not worth it.
+- If (b) clearly wins on RSS at 5M, proceed with **option A**, gated behind an
+  extra plus a kill switch, with the parity gate from trap 2 as the merge blocker.
+
+## Relationship to other work
+
+- Builds on **PR #2111** (#2105). That PR must land first — it introduces the
+  `bulk_writes()` SQLite transaction that option B has to sequence around, and
+  the parity-test harness this work reuses.
+- Independent of the distributed resolver (#627), which is Ray-path and
+  Postgres-only (`pipeline.py` dispatches only when `is_ray_dataset(clusters)`
+  and hard-requires `backend == "postgres"`).
+- If option A lands, the `emit_singletons=True` guidance added to
+  `identity-graph.mdx` in #2111 should be revisited — the reason for the warning
+  is exactly the per-row Python object this would remove.

--- a/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
+++ b/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
@@ -60,6 +60,15 @@ half is a near-verbatim port of the Postgres SQL. The consequence is that
 `use_bulk_fast_path` stops being backend-specific and the four `bulk_*` methods
 get a real SQLite branch instead of a `NotImplementedError`.
 
+**One SQLite-specific deviation, found while building the spike.** When an
+UPSERT's INSERT takes its values from a `SELECT`, SQLite's parser cannot tell
+whether `ON` opens the upsert clause or a join constraint, and fails with
+``near "DO": syntax error``. The documented workaround is to give the SELECT a
+WHERE clause — `FROM _stage_x WHERE true`. Postgres needs no such thing, so the
+port is verbatim *except* here. Cheap, but it is the kind of thing that turns
+into a confusing half-hour if it is discovered during implementation instead of
+now.
+
 ## Ceiling analysis — what this can and cannot buy
 
 Being explicit here because it is easy to oversell.
@@ -155,19 +164,33 @@ elimination is worth real money. Hence: measure first.
 
 ## Spike — decide before building
 
-`scratchpad/adbc_sqlite_ingest_spike.py`, measured on `large-new-64GB` (**not**
-locally — see the bench-runner rule), against the identity schema:
+**Built.** `packages/python/goldenmatch/scripts/spike_adbc_sqlite_ingest.py`,
+run by the `spike-adbc-sqlite-ingest` workflow on `large-new-64GB` (**not**
+locally — see the bench-runner rule). Three arms over the real identity schema,
+N in {100k, 1M, 5M}:
 
-1. Write N rows into `identity_nodes` + `source_records` three ways, N in
-   {100k, 1M, 5M}: (a) today's batched row path, (b) ADBC ingest into a staging
-   table + `INSERT ... SELECT ... ON CONFLICT`, (c) stdlib `executemany` into
-   staging + the same upsert — **(c) is the control that isolates "Arrow" from
-   "staging table"**, and it needs no new dependency.
-2. Report wall and **peak RSS**, plus the Python-heap delta, per arm.
-3. Verify the resulting DB is byte-identical across arms (schema + row content).
+| arm | what it is | new dependency |
+|---|---|---|
+| `rowpath` | today's batched row path via the `IdentityStore` API | no |
+| `staging` | staging table + stdlib `executemany` + the same upsert | **no** |
+| `adbc` | `adbc_ingest` into the same staging table + the same upsert | yes |
 
-The existing `bench-identity-resolve-scaling` workflow already ladders the right
-shape and has the arm plumbing; extend it rather than writing a new one.
+All three start from the same `pyarrow.Table`; `rowpath` and `staging` pay the
+Arrow -> Python-rows conversion inside their timed region, because that
+conversion *is* the cost under examination. Each arm runs in its own subprocess
+so peak RSS is that arm's alone.
+
+**Correctness gate:** every arm's resulting database is content-hashed over
+`identity_nodes` + `source_records`, so a faster arm that writes different bytes
+reports a mismatch instead of looking like a win. Already exercised: `staging`
+comes out byte-identical to `rowpath`.
+
+`adbc-driver-sqlite` is layered in by the workflow with `uv run --with`; it does
+**not** enter `uv.lock` or the package dependencies unless this spike says GO.
+The ADBC API surface the spike relies on is verified working against a WAL-mode
+SQLite file: `dbapi.connect(uri=path)` is the file-connect form (the published
+examples only show in-memory), `adbc_ingest` creates the staging table, and the
+staged upsert runs on the same ADBC connection.
 
 ### Kill criteria
 
@@ -178,6 +201,13 @@ shape and has the arm plumbing; extend it rather than writing a new one.
   dependency and the single-writer complexity are not worth it.
 - If (b) clearly wins on RSS at 5M, proceed with **option A**, gated behind an
   extra plus a kill switch, with the parity gate from trap 2 as the merge blocker.
+
+The spike prints this verdict itself rather than leaving it to interpretation.
+
+**Read the `batched_row_path` flag in the output.** The spike reports whether
+#2111's SQLite transaction batching is present; without it the `rowpath` baseline
+is the old per-statement-autocommit path and every other arm looks far better
+than it is. Do not run the spike for a decision until #2111 has landed.
 
 ## Relationship to other work
 

--- a/packages/python/goldenmatch/scripts/spike_adbc_sqlite_ingest.py
+++ b/packages/python/goldenmatch/scripts/spike_adbc_sqlite_ingest.py
@@ -1,0 +1,382 @@
+"""Spike: is Arrow-native (ADBC) bulk ingest into SQLite worth a dependency?
+
+Decides the question in docs/design/2026-07-24-adbc-sqlite-bulk-writes.md.
+
+``IdentityStore``'s bulk write fast path is Postgres-only. SQLite could get one
+via Apache Arrow's ADBC SQLite driver -- but SQLite has no COPY, so ADBC's
+ingest is prepared INSERTs in a transaction underneath, which is materially what
+the post-#2111 row path already does. The transaction-batching win is banked;
+the only thing left for ADBC to buy is **eliminating the per-row Python object**.
+
+So the control arm is deliberately unkind to ADBC:
+
+  rowpath     today's batched row path (IdentityStore public API, inside
+              bulk_writes()). The baseline.
+  staging     staging table + stdlib executemany + INSERT ... SELECT ...
+              ON CONFLICT DO UPDATE. **No new dependency.** If this captures
+              most of ADBC's win, ship this and drop ADBC.
+  adbc        adbc_ingest into the same staging table + the same upsert.
+              Skipped with a clear message when adbc_driver_sqlite is absent.
+
+All three start from the SAME pyarrow.Table, because in the real pipeline the
+data originates from a frame. ``rowpath`` and ``staging`` pay the
+Arrow -> Python-rows conversion inside their timed region -- that conversion IS
+the cost under examination, not an artifact of the harness.
+
+Each arm runs in its own subprocess so peak RSS is that arm's alone, and every
+arm's resulting database is content-hashed so a faster arm that writes different
+bytes fails loudly instead of looking like a win.
+
+Run on large-new-64GB via the bench-identity-resolve-scaling workflow, NOT
+locally.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+
+os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+
+ARMS = ("rowpath", "staging", "adbc")
+
+_STAGE_NODES = "_stage_identity_nodes"
+_STAGE_RECORDS = "_stage_source_records"
+
+# Mirrors IdentityStore.upsert_identity / upsert_record exactly, including which
+# columns the conflict clause refreshes. Any drift here invalidates the spike.
+#
+# The `WHERE true` is load-bearing, not decoration: when an UPSERT's INSERT takes
+# its values from a SELECT, SQLite's parser cannot tell whether `ON` introduces
+# the upsert clause or a join constraint, and errors with `near "DO": syntax
+# error`. The documented workaround is a WHERE clause on the SELECT. Postgres
+# does not need this, so the "near-verbatim port" of the Postgres bulk SQL is
+# verbatim EXCEPT here.
+_UPSERT_NODES = f"""
+INSERT INTO identity_nodes
+    (entity_id, status, merged_into, golden_record, confidence, dataset,
+     created_at, updated_at)
+SELECT entity_id, status, merged_into, golden_record, confidence, dataset,
+       created_at, updated_at
+FROM {_STAGE_NODES} WHERE true
+ON CONFLICT(entity_id) DO UPDATE SET
+    status=excluded.status,
+    merged_into=excluded.merged_into,
+    golden_record=excluded.golden_record,
+    confidence=excluded.confidence,
+    dataset=excluded.dataset,
+    updated_at=excluded.updated_at
+"""
+
+_UPSERT_RECORDS = f"""
+INSERT INTO source_records
+    (record_id, source, source_pk, record_hash, entity_id, payload,
+     dataset, first_seen_at, last_seen_at)
+SELECT record_id, source, source_pk, record_hash, entity_id, payload,
+       dataset, first_seen_at, last_seen_at
+FROM {_STAGE_RECORDS} WHERE true
+ON CONFLICT(record_id) DO UPDATE SET
+    record_hash=excluded.record_hash,
+    entity_id=excluded.entity_id,
+    payload=excluded.payload,
+    last_seen_at=excluded.last_seen_at
+"""
+
+_NODE_COLS = [
+    "entity_id", "status", "merged_into", "golden_record", "confidence",
+    "dataset", "created_at", "updated_at",
+]
+_RECORD_COLS = [
+    "record_id", "source", "source_pk", "record_hash", "entity_id", "payload",
+    "dataset", "first_seen_at", "last_seen_at",
+]
+
+
+def _peak_rss_gb() -> float:
+    try:
+        import resource
+    except ImportError:
+        return 0.0
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss / 1e6 if sys.platform != "darwin" else rss / 1e9
+
+
+def _build_tables(n: int):
+    """Source data as Arrow, shaped like a real identity write.
+
+    Deterministic: every arm ingests byte-identical values, so the content-hash
+    check below is meaningful. Timestamps are ISO strings and JSON columns are
+    TEXT, matching what IdentityStore actually stores.
+    """
+    import pyarrow as pa
+
+    now = datetime(2026, 7, 24, 12, 0, 0).isoformat()
+    # ~2.1 records per identity, matching the reported cluster shape.
+    n_records = int(n * 2.14)
+    golden = [
+        json.dumps({f"col{j}": f"value-{i}-{j}" for j in range(14)})
+        for i in range(n)
+    ]
+    nodes = pa.table({
+        "entity_id": [f"e{i:012d}" for i in range(n)],
+        "status": ["active"] * n,
+        "merged_into": pa.nulls(n, pa.string()),
+        "golden_record": golden,
+        "confidence": [0.85] * n,
+        "dataset": ["spike"] * n,
+        "created_at": [now] * n,
+        "updated_at": [now] * n,
+    })
+    records = pa.table({
+        "record_id": [f"providers:{i:012d}" for i in range(n_records)],
+        "source": ["providers"] * n_records,
+        "source_pk": [str(i) for i in range(n_records)],
+        "record_hash": [hashlib.sha256(str(i).encode()).hexdigest()
+                        for i in range(n_records)],
+        "entity_id": [f"e{i // 2:012d}" if i // 2 < n else f"e{n - 1:012d}"
+                      for i in range(n_records)],
+        "payload": [json.dumps({f"col{j}": f"value-{i}-{j}" for j in range(14)})
+                    for i in range(n_records)],
+        "dataset": ["spike"] * n_records,
+        "first_seen_at": [now] * n_records,
+        "last_seen_at": [now] * n_records,
+    })
+    return nodes, records
+
+
+def _init_schema(path: str) -> None:
+    """Create the real identity schema, then get out of the way."""
+    from goldenmatch.identity.store import IdentityStore
+    IdentityStore(backend="sqlite", path=path).close()
+
+
+def _content_hash(path: str) -> str:
+    """Order-independent hash of what actually landed in the two tables."""
+    conn = sqlite3.connect(path)
+    h = hashlib.sha256()
+    for table, cols in (("identity_nodes", _NODE_COLS),
+                        ("source_records", _RECORD_COLS)):
+        collist = ", ".join(cols)
+        for row in conn.execute(
+            f"SELECT {collist} FROM {table} ORDER BY {cols[0]}"
+        ):
+            h.update(repr(row).encode())
+    conn.close()
+    return h.hexdigest()[:16]
+
+
+def _run_rowpath(path: str, nodes, records) -> None:
+    from goldenmatch.identity.model import IdentityNode, SourceRecord
+    from goldenmatch.identity.store import IdentityStore
+
+    store = IdentityStore(backend="sqlite", path=path)
+    with store.bulk_writes():
+        for r in nodes.to_pylist():
+            store.upsert_identity(IdentityNode(
+                entity_id=r["entity_id"], status=r["status"],
+                merged_into=r["merged_into"],
+                golden_record=json.loads(r["golden_record"]),
+                confidence=r["confidence"], dataset=r["dataset"],
+                created_at=datetime.fromisoformat(r["created_at"]),
+                updated_at=datetime.fromisoformat(r["updated_at"]),
+            ))
+        for r in records.to_pylist():
+            store.upsert_record(SourceRecord(
+                record_id=r["record_id"], source=r["source"],
+                source_pk=r["source_pk"], record_hash=r["record_hash"],
+                entity_id=r["entity_id"], payload=json.loads(r["payload"]),
+                dataset=r["dataset"],
+                first_seen_at=datetime.fromisoformat(r["first_seen_at"]),
+                last_seen_at=datetime.fromisoformat(r["last_seen_at"]),
+            ))
+    store.close()
+
+
+def _run_staging(path: str, nodes, records) -> None:
+    conn = sqlite3.connect(path, isolation_level=None)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("BEGIN")
+        for stage, real, cols, upsert in (
+            (_STAGE_NODES, "identity_nodes", _NODE_COLS, _UPSERT_NODES),
+            (_STAGE_RECORDS, "source_records", _RECORD_COLS, _UPSERT_RECORDS),
+        ):
+            tbl = nodes if stage == _STAGE_NODES else records
+            conn.execute(f"CREATE TEMP TABLE {stage} AS SELECT "
+                         f"{', '.join(cols)} FROM {real} WHERE 0")
+            placeholders = ", ".join("?" * len(cols))
+            conn.executemany(
+                f"INSERT INTO {stage} ({', '.join(cols)}) "
+                f"VALUES ({placeholders})",
+                (tuple(r[c] for c in cols) for r in tbl.to_pylist()),
+            )
+            conn.execute(upsert)
+            conn.execute(f"DROP TABLE {stage}")
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+
+
+def _adbc_connect(path: str):
+    """The docs only show in-memory connect(); probe the file-path form."""
+    import adbc_driver_sqlite.dbapi as dbapi
+    for attempt in (
+        lambda: dbapi.connect(uri=path),
+        lambda: dbapi.connect(path),
+        lambda: dbapi.connect(driver="adbc_driver_sqlite",
+                              db_kwargs={"uri": path}),
+    ):
+        try:
+            return attempt()
+        except TypeError:
+            continue
+    raise RuntimeError("could not open an ADBC SQLite connection to a file")
+
+
+def _run_adbc(path: str, nodes, records) -> None:
+    # Everything runs on the ADBC connection: SQLite allows one writer, so
+    # mixing a stdlib write txn with an ADBC one here would deadlock (this is
+    # the single-writer problem the design doc calls out).
+    conn = _adbc_connect(path)
+    try:
+        cur = conn.cursor()
+        try:
+            for stage, cols, upsert in (
+                (_STAGE_NODES, _NODE_COLS, _UPSERT_NODES),
+                (_STAGE_RECORDS, _RECORD_COLS, _UPSERT_RECORDS),
+            ):
+                tbl = (nodes if stage == _STAGE_NODES else records).select(cols)
+                cur.adbc_ingest(stage, tbl, mode="create")
+                cur.execute(upsert)
+                cur.execute(f"DROP TABLE {stage}")
+            conn.commit()
+        finally:
+            cur.close()
+    finally:
+        conn.close()
+
+
+def _batched_row_path_available() -> bool:
+    """Whether #2111's SQLite transaction batching is present.
+
+    Without it ``bulk_writes()`` is a no-op on SQLite and the ``rowpath``
+    baseline measures the OLD per-statement-autocommit path -- which would make
+    every other arm look far better than it is. Reported so a result read in
+    isolation cannot be misinterpreted.
+    """
+    try:
+        from goldenmatch.identity import store as _s
+        return hasattr(_s, "_sqlite_batch_writes_enabled")
+    except Exception:
+        return False
+
+
+def _run_arm(arm: str, n: int) -> dict:
+    nodes, records = _build_tables(n)
+    # ignore_cleanup_errors: on Windows SQLite can still hold the file at
+    # teardown, which would mask the arm's real result with a PermissionError.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        path = os.path.join(tmp, "identity.db")
+        _init_schema(path)
+        fn = {"rowpath": _run_rowpath, "staging": _run_staging,
+              "adbc": _run_adbc}[arm]
+        t0 = time.perf_counter()
+        fn(path, nodes, records)
+        wall = time.perf_counter() - t0
+        return {
+            "arm": arm, "identities": n, "records": records.num_rows,
+            "wall_s": round(wall, 3),
+            "peak_rss_gb": round(_peak_rss_gb(), 3),
+            "db_mb": round(os.path.getsize(path) / 1e6, 2),
+            "content_hash": _content_hash(path),
+            "batched_row_path": _batched_row_path_available(),
+        }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ns", default="100000,1000000",
+                    help="Identity counts to sweep (comma-separated)")
+    ap.add_argument("--arms", default=",".join(ARMS))
+    ap.add_argument("--output", default=None)
+    ap.add_argument("--_arm", default=None, help=argparse.SUPPRESS)
+    ap.add_argument("--_n", type=int, default=None, help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    if args._arm:
+        print(json.dumps(_run_arm(args._arm, args._n)))
+        return 0
+
+    ns = [int(x) for x in args.ns.split(",") if x.strip()]
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    results: list[dict] = []
+
+    for n in ns:
+        print(f"\n=== {n:,} identities ===")
+        print(f"{'arm':>10} {'wall_s':>9} {'peak_rss_gb':>12} "
+              f"{'db_mb':>9} {'content_hash':>14}")
+        for arm in arms:
+            proc = subprocess.run(
+                [sys.executable, os.path.abspath(__file__),
+                 "--_arm", arm, "--_n", str(n)],
+                capture_output=True, text=True, check=False,
+            )
+            if proc.returncode != 0:
+                tail = (proc.stderr.strip().splitlines() or ["?"])[-1]
+                # A missing driver is "not installed", not "ADBC lost" -- never
+                # let it read as a NO-GO result.
+                skipped = "ModuleNotFoundError" in proc.stderr and \
+                          "adbc" in proc.stderr
+                label = "SKIPPED (not installed)" if skipped else "FAILED"
+                print(f"{arm:>10}   {label}  {'' if skipped else tail[:60]}")
+                results.append({"arm": arm, "identities": n,
+                                "skipped" if skipped else "failed": True,
+                                "error": tail[:300]})
+                continue
+            row = json.loads(proc.stdout.strip().splitlines()[-1])
+            results.append(row)
+            print(f"{row['arm']:>10} {row['wall_s']:>9.2f} "
+                  f"{row['peak_rss_gb']:>12.3f} {row['db_mb']:>9.2f} "
+                  f"{row['content_hash']:>14}")
+
+        ok = [r for r in results if r.get("identities") == n
+              and not r.get("failed") and not r.get("skipped")]
+        if ok and not ok[0].get("batched_row_path", True):
+            print("  NOTE: #2111's SQLite write batching is ABSENT -- the "
+                  "rowpath baseline is the old autocommit path and every other "
+                  "arm will look better than it really is.")
+        hashes = {r["content_hash"] for r in ok}
+        if len(hashes) > 1:
+            print(f"  !! CONTENT MISMATCH across arms: {hashes} -- a faster arm "
+                  f"that writes different bytes is not a win")
+        elif ok:
+            print(f"  content identical across {len(ok)} arm(s)")
+
+        # The decision the design doc pre-committed to.
+        by_arm = {r["arm"]: r for r in ok}
+        if "adbc" in by_arm and "staging" in by_arm:
+            w = by_arm["staging"]["wall_s"] / max(by_arm["adbc"]["wall_s"], 1e-9)
+            sr, ar = (by_arm["staging"]["peak_rss_gb"],
+                      by_arm["adbc"]["peak_rss_gb"])
+            rss = (sr - ar) / sr if sr else 0.0
+            verdict = ("GO" if (w >= 1.5 or rss >= 0.30) else "NO-GO")
+            print(f"  adbc vs staging(control): {w:.2f}x wall, "
+                  f"{rss * 100:.0f}% less peak RSS -> {verdict} "
+                  f"(kill criteria: <1.5x AND <30% => NO-GO)")
+
+    if args.output:
+        with open(args.output, "w") as fh:
+            json.dump({"results": results}, fh, indent=2)
+        print(f"\nwrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Design doc only. **No dependency added, nothing implemented.**

Follow-up to #2105 / #2111. You flagged that Arrow↔SQLite integration is supported via the Apache Arrow ADBC SQLite driver — correct, and it makes the "SQLite has no equivalent" line I shipped in #2111 wrong (already corrected there in `065077a5a`).

## What the doc concludes

**The mapping is clean.** ADBC ingest is create/append, not upsert — but that's exactly the shape `bulk_upsert_records` already uses on Postgres (`COPY` → temp staging → `INSERT ... SELECT ... ON CONFLICT DO UPDATE`). SQLite has had upsert since 3.24, so the second half is a near-verbatim port, and `use_bulk_fast_path` stops being backend-specific.

**The prize is not write throughput.** SQLite has no `COPY`; the ADBC driver implements ingest as prepared INSERTs in a transaction, which is materially what #2111 already does. The 8-25x from collapsing per-statement commits is banked. The real prize is eliminating the ~2.5 KB/row Python object — which #2111 only *bounded*, and which returns in full under `emit_singletons=True`, the schema default.

**There's a blocking problem with the cheap version.** An ADBC connection is a second connection, SQLite allows one writer, and #2111 now holds a write transaction across the whole resolve loop — exactly where a bulk flush would fire. So "just open an ADBC connection alongside" deadlocks against our own transaction. Doc lays out moving the whole store onto ADBC (clean, big migration) vs dual-connection sequencing (small, permanently messier transaction model) and leans toward the former — conditional on measurement.

## Why it ends in a spike rather than a build plan

Matching the house measure-first pattern (`2026-07-06-frame-container-eviction-spike.md`). The null hypothesis is deliberately unkind to ADBC: **a staging table + stdlib `executemany` is the control arm, and it needs no new dependency.** If that captures most of the win, we ship it and drop ADBC. Explicit kill criteria: `< 1.5x` wall and `< 30%` peak RSS over the control at 1M ⇒ NO-GO.

## One trap worth surfacing on its own

`bulk_upsert_records` omits `payload` from its column list and its `ON CONFLICT DO UPDATE` doesn't touch it — so **on Postgres today, a record written via the bulk path has `payload = NULL`**, while the SQLite row path stores it. `bulk_emit_events` likewise carries no event payload. Extending the fast path to SQLite as-is would be a silent data regression for existing SQLite users. That's a pre-existing Postgres divergence worth a decision independent of whether ADBC ever happens.

## Sequencing

Depends on #2111 landing first — that PR introduces the `bulk_writes()` SQLite transaction this has to sequence around, and the parity-test harness this would reuse.

Not auto-merging: this asks you to pick a direction rather than just recording one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwPNzknDggSCY9NwnModHP