### PR TITLE
docs: plug CLI/MCP/API reference gaps + generated native.mdx pages

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -805,6 +805,12 @@ docs:
   - 'scripts/check_docs_consistency.py'
   - 'scripts/check_docs_links.py'
   - 'scripts/check_docs_sections.py'
+  # native.mdx pages are generated from these loaders (gen_native_docs.py --check,
+  # run by check_docs_consistency); a loader edit must re-run the docs gate.
+  - 'scripts/gen_native_docs.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/_native_loader.py'
+  - 'packages/python/goldenflow/goldenflow/core/_native_loader.py'
+  - 'packages/python/infermap/infermap/_native_loader.py'
   - 'scripts/test_docs_sections.py'
   - 'scripts/check_benchmark_claims.py'
   - 'docs/benchmark-claims.json'

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -66,6 +66,7 @@
                   "goldenmatch/data-quality",
                   "goldenmatch/pipeline",
                   "goldenmatch/backends-and-scale",
+                  "goldenmatch/native",
                   "goldenmatch/pprl",
                   "goldenmatch/llm",
                   "goldenmatch/learning-memory",
@@ -120,6 +121,7 @@
               "goldenflow/config-matrix",
               "goldenflow/recipes",
               "goldenflow/cli",
+              "goldenflow/native",
               "goldenflow/performance"
             ]
           },
@@ -152,7 +154,8 @@
               "infermap/mapping",
               "infermap/config-matrix",
               "infermap/recipes",
-              "infermap/cli"
+              "infermap/cli",
+              "infermap/native"
             ]
           },
           {

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -129,7 +129,8 @@
               "goldenpipe/overview",
               "goldenpipe/stages",
               "goldenpipe/config-matrix",
-              "goldenpipe/recipes"
+              "goldenpipe/recipes",
+              "goldenpipe/cli"
             ]
           },
           {
@@ -140,6 +141,7 @@
               "goldenanalysis/cross-run",
               "goldenanalysis/config-matrix",
               "goldenanalysis/recipes",
+              "goldenanalysis/cli",
               "goldenanalysis/native"
             ]
           },
@@ -149,7 +151,8 @@
               "infermap/overview",
               "infermap/mapping",
               "infermap/config-matrix",
-              "infermap/recipes"
+              "infermap/recipes",
+              "infermap/cli"
             ]
           },
           {

--- a/docs-site/goldenanalysis/cli.mdx
+++ b/docs-site/goldenanalysis/cli.mdx
@@ -1,0 +1,16 @@
+---
+title: "GoldenAnalysis CLI"
+description: "Every GoldenAnalysis command for reporting, trending, and regression detection."
+keywords: ["goldenanalysis", "cli", "commands", "report", "regressions"]
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `goldenanalysis report <file>` | Analyze a frame (or re-render a saved report) and print a report. |
+| `goldenanalysis trend <metric>` | Trend a metric over a run history. |
+| `goldenanalysis regressions` | Detect metric regressions vs a baseline. |
+| `goldenanalysis mcp-serve` | Start the GoldenAnalysis MCP server (requires the `[mcp]` extra). |
+
+See [Analyzers](/goldenanalysis/analyzers) for the analyzer catalog and [Cross-run](/goldenanalysis/cross-run) for trend/regression details.

--- a/docs-site/goldenflow/native.mdx
+++ b/docs-site/goldenflow/native.mdx
@@ -1,0 +1,64 @@
+---
+title: "Native acceleration"
+description: "GoldenFlow's optional compiled Rust/Arrow runtime — which components run native, the `GOLDENFLOW_NATIVE` gate, and how parity is enforced. Generated from the native loader; do not edit by hand."
+keywords: ["goldenflow", "native", "rust", "arrow", "pyo3", "performance", "reference-mode"]
+---
+
+{/* GENERATED FILE — do not edit. Source of truth: goldenflow/goldenflow/core/_native_loader.py. Regenerate: python scripts/gen_native_docs.py --write */}
+
+GoldenFlow is pure-Python by default. An optional compiled kernel (Rust + PyO3/Arrow, crate `packages/rust/extensions/native-flow`) accelerates the CPU-heavy components below. Under reference-mode the compiled path is the reference implementation and pure-Python is the byte-identical fallback — output is the same either way; native only changes wall-clock.
+
+```bash
+pip install goldenflow[native]
+```
+
+## The gate
+
+One env var, `GOLDENFLOW_NATIVE`, read in `goldenflow/goldenflow/core/_native_loader.py`:
+
+- `GOLDENFLOW_NATIVE=auto` (default, or unset) — run native for any component whose kernel symbol is present on the loaded wheel, except the known-divergent components below.
+- `GOLDENFLOW_NATIVE=0` — force the pure-Python fallback everywhere.
+- `GOLDENFLOW_NATIVE=1` — require native; raise if the kernel isn't importable (the CI parity lane).
+
+The kernel is discovered two ways, in order: the in-tree build `goldenflow._native` (local dev / parity lane), then the distributed `goldenflow_native._native` wheel (`pip install goldenflow[native]`). When neither is importable, every path runs pure-Python unchanged.
+
+## Components
+
+Each component maps to the native kernel symbol(s) its `auto` call site invokes (the *floor* symbol first — a component is native-capable when **any** listed symbol is present, so an older wheel stays wheel-skew safe). A ✓ in **Parity-signed** marks a component that cleared the byte-exact sign-off recorded in `_GATED_ON`.
+
+| Component | Kernel symbol(s) | Parity-signed |
+|---|---|---|
+| `phone` | `phone_e164_arrow`, `phone_national_arrow`, `phone_country_code_arrow` | ✓ |
+| `phone_digits` | `phone_digits_arrow` |  |
+| `us_id` | `ssn_format_arrow`, `ssn_mask_arrow`, `ein_format_arrow` |  |
+| `cc` | `cc_validate_arrow` |  |
+| `iban` | `iban_validate_arrow` |  |
+| `isbn` | `isbn_validate_arrow` |  |
+| `ean` | `ean_validate_arrow` |  |
+| `swift` | `swift_validate_arrow` |  |
+| `vat` | `vat_validate_arrow` |  |
+| `aba` | `aba_validate_arrow` |  |
+| `imei` | `imei_validate_arrow` |  |
+| `isin` | `isin_validate_arrow` |  |
+| `cusip` | `cusip_validate_arrow` |  |
+| `npi` | `npi_validate_arrow` |  |
+| `luhn` | `luhn_validate_arrow` |  |
+| `name_transliterate` | `name_transliterate_arrow` |  |
+| `name_script` | `name_script_arrow` |  |
+| `email` | `email_validate_arrow` |  |
+| `url` | `url_normalize_arrow` |  |
+| `company` | `company_normalize_arrow` |  |
+| `numeric` | `currency_strip_arrow` |  |
+| `categorical` | `boolean_normalize_arrow` |  |
+| `names_ext` | `strip_titles_arrow` |  |
+| `address` | `address_standardize_arrow` |  |
+| `autocorrect` | `build_canonical_map_arrow` |  |
+| `text` | `strip_arrow` |  |
+| `phonetic` | `soundex_arrow` |  |
+| `profile` | `infer_type_list_arrow` |  |
+
+**Kept pure-Python under `auto` (GOLDENFLOW_NATIVE reference-mode):** `phone_validate`. These carry (or could bind) a native symbol that is known to diverge from the pure-Python reference, so they stay on the fallback path until their parity battery is green — reachable only via `GOLDENFLOW_NATIVE=1`.
+
+## How parity stays honest
+
+A component joins the native path only after a parity test proves its kernel is byte-identical (or integer-exact) to the pure-Python reference. CI runs a `GOLDENFLOW_NATIVE=1` lane that builds the wheel and asserts native == pure-Python, and `scripts/check_native_symbols.py` reconciles the host's kernel references against the crate's `wrap_pyfunction!` exports so a referenced-but-unregistered symbol fails loudly. Because output is identical with or without the wheel, toggling the gate never changes a result — only speed.

--- a/docs-site/goldenmatch/cli.mdx
+++ b/docs-site/goldenmatch/cli.mdx
@@ -28,8 +28,19 @@ keywords: ["cli", "commands", "dedupe", "flags"]
 | `goldenmatch rollback RUN_ID` | Undo a previous merge run. |
 | `goldenmatch unmerge RECORD_ID --clusters FILE` | Remove a record from its cluster and re-cluster the rest; writes the updated clusters CSV. Use `--shatter` to break the whole cluster apart. |
 | `goldenmatch runs` | List previous runs for rollback. |
+| `goldenmatch schedule FILE [...]` | Run deduplication on a recurring schedule. |
+| `goldenmatch autoconfig FILE [...]` | Run the AutoConfig controller and print the committed config + telemetry **without** running the pipeline. |
+| `goldenmatch score A B [--scorer NAME]` | Score string similarity between two values (default `jaro_winkler`). |
+| `goldenmatch explain --config CONFIG ...` | Explain why a pair matched, or summarize a cluster, in plain language. |
+| `goldenmatch lineage FILE --config CONFIG` | Build and persist the per-pair match lineage for a run. |
+| `goldenmatch anomalies FILE` | Detect suspicious / fake records as a standalone pass. |
+| `goldenmatch agent-serve FILE [...]` | Start the A2A agent server for AI-to-AI discovery. |
+| `goldenmatch info` | Show package version and available scorers / strategies / blocking / transforms. |
+| `goldenmatch tui FILE [...]` | Launch the interactive TUI (alias of `interactive`). |
 | `goldenmatch memory stats\|learn\|export\|import\|show` | Manage the Learning Memory store. |
-| `goldenmatch config save\|load\|list\|show` | Manage config presets. |
+| `goldenmatch config save\|load\|list\|delete\|show` | Manage config presets. |
+| `goldenmatch identity resolve\|history\|list\|show\|conflicts\|merge\|split\|migrate-ids\|migrate` | Inspect and maintain the persistent identity graph (`entity_id` stability, manual merges/splits, conflict review, id-scheme migration). See [Identity graph](/goldenmatch/identity-graph). |
+| `goldenmatch ingest-docs suggest-schema\|run` | Extract structured records from unstructured documents (schema suggestion + extraction). See [Documents](/goldenmatch/documents). |
 | `goldenmatch import-splink SETTINGS.json -o CONFIG.yaml [--model-out MODEL.json] [--upgrade DATA]` | Convert a Splink settings or trained-model JSON to a GoldenMatch config; `--model-out` persists trained m/u probabilities for reuse. `--upgrade DATA.parquet` additionally runs the data-aware upgrade pass (TF tables, measured distance thresholds, fan-out defenses: NE suggestion + cluster-guard tuning, threshold calibration) and writes the faithful baseline alongside as `*.baseline.*`. |
 | `goldenmatch compare-clusters A B` | Cluster comparison (unchanged / merged / partitioned / overlapping). |
 | `goldenmatch sensitivity FILE` | Parameter sweep over threshold, blocking, and matchkey. |

--- a/docs-site/goldenmatch/configuration.mdx
+++ b/docs-site/goldenmatch/configuration.mdx
@@ -204,7 +204,7 @@ memory:
   dataset: customers            # tag corrections so one DB can hold memory for many tables
   learning:
     threshold_min_corrections: 10   # learner runs once per matchkey at this floor
-    weights_min_corrections: 50     # field-weight learner floor (stub in v1.6, returns null)
+    weights_min_corrections: 50     # field-weight learner floor (not yet implemented; the learner returns null)
 
 output:
   directory: ./output
@@ -587,7 +587,7 @@ The optional `memory:` section enables persistent corrections. Once a steward, a
 | `reanchor` | `true` | Re-anchor by `record_hash` when row IDs miss; ambiguous re-anchors report `stale_ambiguous`. |
 | `dataset` | `null` | Tag corrections; isolates per-table memory in shared DBs. |
 | `learning.threshold_min_corrections` | `10` | Trust-weighted grid search runs once a matchkey crosses this floor. |
-| `learning.weights_min_corrections` | `50` | Field-weight learning is stubbed in v1.6.0 and returns `null`. |
+| `learning.weights_min_corrections` | `50` | Field-weight learning is not yet implemented — the learner returns `null` until per-field scores are persisted with corrections. Threshold tuning (above) is the active learning mechanism. |
 
 Full guide: [Learning Memory](/goldenmatch/learning-memory).
 

--- a/docs-site/goldenmatch/identity-graph.mdx
+++ b/docs-site/goldenmatch/identity-graph.mdx
@@ -255,7 +255,7 @@ Both paths produce identical schemas. The migration script also creates three an
 
 ## Migration / backfill
 
-Existing projects without an identity graph don't get retroactive `entity_id` stability. New runs will assign fresh UUIDs from the moment you enable identity. A best-effort backfill command that walks lineage JSONL + cluster snapshots is on the v2.1 roadmap.
+Existing projects without an identity graph don't get retroactive `entity_id` stability. New runs will assign fresh UUIDs from the moment you enable identity. A best-effort backfill command that walks lineage JSONL + cluster snapshots is a planned follow-up and is not yet available; today you enable identity and let stability accrue from the first resolved run forward.
 
 ## Migrating legacy record ids
 

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -1,10 +1,10 @@
 ---
 title: "MCP server"
-description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 82 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
+description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 85 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
 keywords: ["mcp", "claude desktop", "model context protocol", "entity resolution", "learning memory"]
 ---
 
-GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 82 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, and Identity Graph tools.
+GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 85 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, Identity Graph tools, and document-extraction tools.
 
 <Tip>
   Looking for AI-to-AI autonomy? See the [ER Agent (A2A)](/goldenmatch/agent) page for agent framework integration (LangChain, CrewAI, AutoGen).
@@ -323,7 +323,43 @@ Undo a previous run by deleting its output files (looked up by run_id). Destruct
 "Roll back run 2026-06-05-abc123"
 ```
 
-In addition, 18 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, controller_telemetry, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms, sensitivity, incremental, certify_recall, retrieve_similar). See [ER Agent](/goldenmatch/agent) for details.
+### More base tools (introspection, scoring, I/O)
+
+Beyond the sections above, the base surface exposes these tools. They round out the 39 base tools and are mostly leaf primitives an agent composes.
+
+| Tool | Behavior |
+|---|---|
+| `list_clusters` | List duplicate clusters: cluster IDs, sizes, and member counts. |
+| `get_golden_record` | Get the merged golden (canonical) record for a cluster. |
+| `shatter_cluster` | Break an entire cluster into individual records. |
+| `profile_data` | Data-quality profile: column types, null rates, unique counts, sample values. (Also the target of the `profile` alias.) |
+| `review_config` | Run the config healer over the loaded dataset and report recommended fixes. |
+| `config_weaknesses` | Diagnose weaknesses in the loaded run's config. |
+| `convert_splink_config` | Convert a Splink settings JSON (bare or trained) into a GoldenMatch config. |
+| `export_results` | Export matching results to a file (CSV or JSON). |
+| `write_csv` | Write a list of record objects to a CSV file. |
+| `read_file` | Read a CSV/JSON file and return the first N records. |
+| `score_strings` | Score similarity between two strings with the requested scorer. |
+| `score_pair` | Score two record objects across weighted fields; returns a combined score. |
+| `find_exact_matches` | Find exact matches on a field in a file; returns pairs. |
+| `find_fuzzy_matches` | Find fuzzy matches in a block of rows; returns scored pairs. |
+| `build_clusters` | Group records into clusters given a file and matchkey definition. |
+| `list_scorers` | List all available similarity scorers. |
+| `list_transforms` | List all available field transforms. |
+| `list_strategies` | List all golden-record survivorship strategies. |
+| `list_blocking_strategies` | List all blocking strategy names. |
+| `server_info` | Return metadata about this GoldenMatch MCP server. |
+
+### Document extraction tools
+
+Two tools extract structured records from unstructured documents (PDF / image). See [Documents](/goldenmatch/documents).
+
+| Tool | Behavior |
+|---|---|
+| `documents_suggest_schema` | Propose a target extraction schema (JSON) from a sample document image/PDF. |
+| `documents_ingest` | Extract records from documents (PDF/image) against a target schema. |
+
+In addition, 19 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, controller_telemetry, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms, sensitivity, incremental, certify_recall, retrieve_similar, upload_dataset). See [ER Agent](/goldenmatch/agent) for details.
 
 ### AutoConfigController telemetry (v1.7-v1.12)
 
@@ -404,9 +440,9 @@ Three tools plan and validate distributed execution routing for a run.
 
 ### Tool count breakdown
 
-The 69 distinct tools reconcile as: 18 agent-level + 7 Learning Memory + 15 Identity Graph + 3 routing + 26 base data/inspection tools.
+The 85 distinct tools reconcile as: 19 agent-level + 7 Learning Memory + 15 Identity Graph + 3 routing + 39 base data/inspection + 2 document-extraction tools.
 
-The server additionally advertises 5 cross-language naming aliases — `dedupe`, `match`, `explain_pair`, `profile`, and `explain_cluster` — alternate names that match the TypeScript server's tool names, so an agent trained against either server can call the other. They forward to the canonical handlers above (`find_duplicates`, `match_record`, `explain_match`, `profile_data`, `agent_explain_cluster`), bringing the advertised total to 74. The TypeScript server mirrors this: it also answers to the Python names (`find_duplicates`, `match_record`, `explain_match`, `profile_data`).
+The server additionally advertises 5 cross-language naming aliases — `dedupe`, `match`, `explain_pair`, `profile`, and `explain_cluster` — alternate names that match the TypeScript server's tool names, so an agent trained against either server can call the other. They forward to the canonical handlers above (`find_duplicates`, `match_record`, `explain_match`, `profile_data`, `agent_explain_cluster`), bringing the advertised total to 90. The TypeScript server mirrors this: it also answers to the Python names (`find_duplicates`, `match_record`, `explain_match`, `profile_data`).
 
 ## How it works
 

--- a/docs-site/goldenmatch/native.mdx
+++ b/docs-site/goldenmatch/native.mdx
@@ -1,0 +1,50 @@
+---
+title: "Native acceleration"
+description: "GoldenMatch's optional compiled Rust/Arrow runtime — which components run native, the `GOLDENMATCH_NATIVE` gate, and how parity is enforced. Generated from the native loader; do not edit by hand."
+keywords: ["goldenmatch", "native", "rust", "arrow", "pyo3", "performance", "reference-mode"]
+---
+
+{/* GENERATED FILE — do not edit. Source of truth: goldenmatch/goldenmatch/core/_native_loader.py. Regenerate: python scripts/gen_native_docs.py --write */}
+
+GoldenMatch is pure-Python by default. An optional compiled kernel (Rust + PyO3/Arrow, crate `packages/rust/extensions/native`) accelerates the CPU-heavy components below. Under reference-mode the compiled path is the reference implementation and pure-Python is the byte-identical fallback — output is the same either way; native only changes wall-clock.
+
+```bash
+pip install goldenmatch[native]
+```
+
+## The gate
+
+One env var, `GOLDENMATCH_NATIVE`, read in `goldenmatch/goldenmatch/core/_native_loader.py`:
+
+- `GOLDENMATCH_NATIVE=auto` (default, or unset) — run native for any component whose kernel symbol is present on the loaded wheel, except the known-divergent components below.
+- `GOLDENMATCH_NATIVE=0` — force the pure-Python fallback everywhere.
+- `GOLDENMATCH_NATIVE=1` — require native; raise if the kernel isn't importable (the CI parity lane).
+
+The kernel is discovered two ways, in order: the in-tree build `goldenmatch._native` (local dev / parity lane), then the distributed `goldenmatch_native._native` wheel (`pip install goldenmatch[native]`). When neither is importable, every path runs pure-Python unchanged.
+
+The Fellegi-Sunter block-scoring path has its own gate, `GOLDENMATCH_FS_NATIVE` (default-on; the Rust rapidfuzz path is the reference, `=0` forces the pure-Python fallback).
+
+## Components
+
+Each component maps to the native kernel symbol(s) its `auto` call site invokes (the *floor* symbol first — a component is native-capable when **any** listed symbol is present, so an older wheel stays wheel-skew safe). A ✓ in **Parity-signed** marks a component that cleared the byte-exact sign-off recorded in `_GATED_ON`.
+
+| Component | Kernel symbol(s) | Parity-signed |
+|---|---|---|
+| `clustering` | `connected_components`, `mst_split_components` | ✓ |
+| `block_scoring` | `score_block_pairs_arrow` | ✓ |
+| `pairs` | `canonicalize_pairs`, `dedup_pairs_max_score` | ✓ |
+| `featurize` | `char_ngram_features` | ✓ |
+| `hashing` | `record_fingerprint`, `record_fingerprints_batch` | ✓ |
+| `field_scoring` | `score_field_matrix` | ✓ |
+| `autoconfig` | `autoconfig_decide_plan` | ✓ |
+| `sketch` | `sketch_simhash_band_hashes_batch` | ✓ |
+| `simhash` | `sketch_simhash_band_hashes_batch` |  |
+| `pprl_bloom` | `bloom_clk_batch` |  |
+| `perceptual` | `perceptual_phash_image` |  |
+| `documents` | `documents_parse_message_text`, `documents_schema_validate`, `documents_extract_instruction`, `documents_normalize_record`, `documents_template`, `documents_template_list`, `documents_classify_prompt`, `documents_parse_classify`, `documents_parse_structured` |  |
+
+**Kept pure-Python under `auto` (GOLDENMATCH_NATIVE reference-mode):** `sail_scoring`. These carry (or could bind) a native symbol that is known to diverge from the pure-Python reference, so they stay on the fallback path until their parity battery is green — reachable only via `GOLDENMATCH_NATIVE=1`.
+
+## How parity stays honest
+
+A component joins the native path only after a parity test proves its kernel is byte-identical (or integer-exact) to the pure-Python reference. CI runs a `GOLDENMATCH_NATIVE=1` lane that builds the wheel and asserts native == pure-Python, and `scripts/check_native_symbols.py` reconciles the host's kernel references against the crate's `wrap_pyfunction!` exports so a referenced-but-unregistered symbol fails loudly. Because output is identical with or without the wheel, toggling the gate never changes a result — only speed.

--- a/docs-site/goldenmatch/python-api.mdx
+++ b/docs-site/goldenmatch/python-api.mdx
@@ -930,6 +930,150 @@ print(result.memory_stats)
 
 Full guide: [Learning Memory](/goldenmatch/learning-memory).
 
+## More public exports
+
+These symbols are exported from the top-level `goldenmatch` package but are lower-traffic than the surfaces above. One-line summaries follow; authoritative signatures live in the cited source modules.
+
+### Config optimization and edits
+
+Search the config space, or apply a single typed lever to an existing config.
+
+| Symbol | Purpose |
+|---|---|
+| `optimize_config` | Search the candidate-config space and return the best config + trials. |
+| `OptimizeResult` | Outcome of an `optimize_config` search. |
+| `OptimizerTrial` | One scored candidate config from the search. |
+| `GridProposer` | Deterministic threshold sweep (single round is byte-identical to the legacy grid). |
+| `CoordinateDescentProposer` | Deterministic multi-lever search; each round optimizes one lever family. |
+| `LLMProposer` | AI-driven iteration: an LLM agent proposes the next lever moves. |
+| `ThresholdShift` | Shift every perturbable matchkey threshold by a delta (clamped). |
+| `WeightShift` | Reweight one field of a weighted matchkey (floor 0.0). |
+| `ScorerSwap` | Swap one matchkey field's scorer. |
+| `MatchkeyTypeSwap` | Swap a matchkey between `weighted` and `probabilistic`. |
+| `BlockingStrategyEdit` | Change the blocking strategy (keys preserved). |
+| `BlockingKeyEdit` | Add or remove a blocking key, identified by its field set + transforms. |
+
+Source: `goldenmatch/core/config_optimizer.py`, `goldenmatch/core/config_edits.py`.
+
+### Screening and review gating
+
+| Symbol | Purpose |
+|---|---|
+| `gate_pairs` | Split scored pairs into auto-merged, review, and auto-rejected buckets. |
+| `ReviewQueue` | Confidence-gated review queue with pluggable backends. |
+| `screen_record` | Screen one record against a watchlist; return scored, explained hits. |
+| `screen_records` | Batch screening: `screen_record` for each row. |
+| `ScreeningResult` | The ranked hits for one screened record. |
+| `ScreeningHit` | A single watchlist entry the query record resembles. |
+| `FieldReason` | Why one field contributed to a hit: the two values and their similarity. |
+
+Source: `goldenmatch/core/review_queue.py`, `goldenmatch/core/screening.py`.
+
+### Retrieval and entity-aware RAG
+
+| Symbol | Purpose |
+|---|---|
+| `retrieve_similar_records` | Retrieve the top-`k` records in `df` most similar to a query. |
+| `RetrievedRecord` | One record returned by `retrieve_similar_records`. |
+| `entity_aware_retrieve` | Retrieve, resolve, and canonicalize — the entity-aware RAG surface. |
+| `Entity` | One resolved entity: a canonical record + the retrieved records it absorbed. |
+| `EntityRetrievalResult` | The entity-aware retrieval result: distinct entities + dedup headline. |
+
+Source: `goldenmatch/core/retrieval.py`, `goldenmatch/core/rag_surface.py`.
+
+### Vector stores
+
+Persistent embedding indexes behind a unified surface.
+
+| Symbol | Purpose |
+|---|---|
+| `VectorStore` | The unified surface every vector backend implements. |
+| `open_vector_index` | Open (load-or-create) a vector index on the chosen backend. |
+| `DuckDBVectorIndex` | Vector index backed by a DuckDB database file. |
+| `PgVectorIndex` | Vector index backed by Postgres + pgvector. |
+
+Source: `goldenmatch/core/vector_store.py`.
+
+### Embedding operations
+
+| Symbol | Purpose |
+|---|---|
+| `embedding_drift` | Measure embedding-space drift between a reference set and a current set. |
+| `EmbeddingDriftReport` | The measured drift between a reference embedding set and a current one. |
+| `select_field_model` | Choose an embedding model for one field. |
+| `select_field_models` | Choose a per-field embedding model for each text column of `df`. |
+| `FieldModelChoice` | The embedding model chosen for one field + why. |
+| `evaluate_canonicalization` | Measure the quality of a batch of `CanonicalRecord` outputs. |
+| `CanonicalizationEval` | Measured quality of a batch of `canonicalize_cluster` outputs. |
+
+Source: `goldenmatch/core/embedding_ops.py`.
+
+### Recall certification
+
+| Symbol | Purpose |
+|---|---|
+| `estimate_recall` | Estimate recall for a blocking candidate using pair sampling. |
+| `certify_recall_df` | Unsupervised recall estimate for a DataFrame (no ground truth). |
+| `RecallEstimate` | Result of an unsupervised recall estimate (`recall` is `None` when unmeasurable). |
+| `RecallCertificate` | Audit-calibrated recall certificate; `recall_lower` is a safe lower bound. |
+| `audit_calibrated_bound` | Compute a safe recall lower bound from stratified audit counts. |
+
+Source: `goldenmatch/core/recall_certificate.py`, `goldenmatch/core/block_analyzer.py`.
+
+### Canonicalization
+
+| Symbol | Purpose |
+|---|---|
+| `canonicalize_cluster` | Produce a canonical record for one cluster's source records. |
+| `CanonicalRecord` | The canonical record for a cluster, with per-cell provenance. |
+| `explain_cluster_nl` | Generate a template-based natural-language cluster summary. |
+
+Source: `goldenmatch/core/llm_canonicalize.py`, `goldenmatch/core/explain.py`.
+
+### Splink migration result types
+
+Returned by the Splink conversion / upgrade functions (see [Migrating from Splink](/goldenmatch/configuration)).
+
+| Symbol | Purpose |
+|---|---|
+| `SplinkConversion` | Result of `from_splink` (the converted config + mapping report). |
+| `SplinkConversionError` | Raised in strict mode on any lossy mapping, or always on an error-severity issue. |
+| `MigrationResult` | Result of the data-aware `upgrade_splink_conversion` pass. |
+| `SplinkUpgradeError` | Raised on unusable input to `upgrade_splink_conversion`. |
+
+Source: `goldenmatch/config/from_splink.py`, `goldenmatch/config/splink_upgrade.py`.
+
+### Identity graph types and queries
+
+Low-level building blocks behind the [Identity graph](/goldenmatch/identity-graph); most users go through `resolve_clusters` / the CLI instead.
+
+| Symbol | Purpose |
+|---|---|
+| `new_entity_id` | Generate a stable, time-ordered (UUIDv7-shaped) entity id. |
+| `list_identities` | List identities in the store, optionally filtered by dataset/status. |
+| `find_conflicts` | Return evidence edges flagged `conflicts_with` for steward review. |
+| `manual_split` | Detach `record_ids` from an `entity_id` into a brand-new identity. |
+| `ResolveSummary` | Summary of a resolve pass (counts of new/updated/merged identities). |
+| `IdentityNode` | A durable identity node (its members, aliases, and status). |
+| `SourceRecord` | A single record observation; `record_id` is `{source}:{source_pk}`. |
+| `EvidenceEdge` | An edge between records/identities carrying match evidence. |
+| `IdentityEvent` | One entry in an identity's temporal event log. |
+| `IdentityAlias` | An alternate key an identity is known by. |
+| `IdentityStatus` | Enum of identity lifecycle states. |
+| `EdgeKind` | Enum of evidence-edge kinds. |
+| `EventKind` | Enum of identity-event kinds. |
+
+Source: `goldenmatch/identity/`.
+
+### Other exports
+
+| Symbol | Purpose |
+|---|---|
+| `record_fingerprint` | Deterministic, cross-surface-stable SHA-256 fingerprint of a record. |
+| `CorrectionStats` | Statistics from applying Learning Memory corrections. |
+| `CorrectionSource` | Canonical correction-source identifiers (`steward`, `agent`, `llm`, `unmerge`). |
+| `BUILTIN_PLUGINS` | The list of built-in Learning Memory plugins registered by default. |
+
 ## REST API client
 
 ```python

--- a/docs-site/goldenpipe/cli.mdx
+++ b/docs-site/goldenpipe/cli.mdx
@@ -1,0 +1,20 @@
+---
+title: "GoldenPipe CLI"
+description: "Every GoldenPipe command for running and inspecting pipelines."
+keywords: ["goldenpipe", "cli", "commands", "pipeline", "stages"]
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `goldenpipe run <file>` | Run a pipeline on a data file. |
+| `goldenpipe stages` | List all discovered stages. |
+| `goldenpipe validate` | Dry-run wiring validation without executing. |
+| `goldenpipe init` | Generate a starter `goldenpipe.yml` from installed tools. |
+| `goldenpipe interactive` | Launch the TUI. |
+| `goldenpipe serve` | Start the REST API server. |
+| `goldenpipe mcp-serve` | Start the MCP server. |
+| `goldenpipe agent-serve` | Start the A2A agent server for AI-to-AI discovery. |
+
+See [Stages](/goldenpipe/stages) for the stage catalog and [Config matrix](/goldenpipe/config-matrix) for the `goldenpipe.yml` reference.

--- a/docs-site/infermap/cli.mdx
+++ b/docs-site/infermap/cli.mdx
@@ -1,0 +1,17 @@
+---
+title: "InferMap CLI"
+description: "Every InferMap command for schema mapping and inspection."
+keywords: ["infermap", "cli", "commands", "schema", "mapping"]
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `infermap map SOURCE TARGET` | Map fields from `SOURCE` to a `TARGET` schema. |
+| `infermap apply CONFIG SOURCE OUTPUT` | Apply a saved mapping config to a source CSV, writing renamed columns to `OUTPUT`. |
+| `infermap inspect SOURCE` | Inspect a data source: show fields, types, samples, and stats. |
+| `infermap validate CONFIG SOURCE` | Validate that source columns exist for a saved mapping config. |
+| `infermap mcp-serve` | Start the MCP server for Claude Desktop (stdio) or remote deployment (http). |
+
+See [Mapping](/infermap/mapping) for how mappings are inferred and [Config matrix](/infermap/config-matrix) for the config reference.

--- a/docs-site/infermap/native.mdx
+++ b/docs-site/infermap/native.mdx
@@ -1,0 +1,40 @@
+---
+title: "Native acceleration"
+description: "InferMap's optional compiled Rust/Arrow runtime — which components run native, the `INFERMAP_NATIVE` gate, and how parity is enforced. Generated from the native loader; do not edit by hand."
+keywords: ["infermap", "native", "rust", "arrow", "pyo3", "performance", "reference-mode"]
+---
+
+{/* GENERATED FILE — do not edit. Source of truth: infermap/infermap/_native_loader.py. Regenerate: python scripts/gen_native_docs.py --write */}
+
+InferMap is pure-Python by default. An optional compiled kernel (Rust + PyO3/Arrow, crate `packages/rust/extensions/infermap-native`) accelerates the CPU-heavy components below. Under reference-mode the compiled path is the reference implementation and pure-Python is the byte-identical fallback — output is the same either way; native only changes wall-clock.
+
+```bash
+pip install infermap[native]
+```
+
+## The gate
+
+One env var, `INFERMAP_NATIVE`, read in `infermap/infermap/_native_loader.py`:
+
+- `INFERMAP_NATIVE=auto` (default, or unset) — run native for any component whose kernel symbol is present on the loaded wheel, except the known-divergent components below.
+- `INFERMAP_NATIVE=0` — force the pure-Python fallback everywhere.
+- `INFERMAP_NATIVE=1` — require native; raise if the kernel isn't importable (the CI parity lane).
+
+The kernel is discovered two ways, in order: the in-tree build `infermap._native` (local dev / parity lane), then the distributed `infermap_native._native` wheel (`pip install infermap[native]`). When neither is importable, every path runs pure-Python unchanged.
+
+## Components
+
+Each component maps to the native kernel symbol(s) its `auto` call site invokes (the *floor* symbol first — a component is native-capable when **any** listed symbol is present, so an older wheel stays wheel-skew safe). A ✓ in **Parity-signed** marks a component that cleared the byte-exact sign-off recorded in `_GATED_ON`.
+
+| Component | Kernel symbol(s) | Parity-signed |
+|---|---|---|
+| `detect_domain` | `detect_domain` | ✓ |
+| `exact_score` | `exact_score` | ✓ |
+| `fuzzy_name_score` | `fuzzy_name_score` | ✓ |
+| `initialism_score` | `initialism_score` | ✓ |
+| `profile_score` | `profile_score` | ✓ |
+| `pattern_match_types` | `pattern_match_types` | ✓ |
+
+## How parity stays honest
+
+A component joins the native path only after a parity test proves its kernel is byte-identical (or integer-exact) to the pure-Python reference. CI runs a `INFERMAP_NATIVE=1` lane that builds the wheel and asserts native == pure-Python, and `scripts/check_native_symbols.py` reconciles the host's kernel references against the crate's `wrap_pyfunction!` exports so a referenced-but-unregistered symbol fails loudly. Because output is identical with or without the wheel, toggling the gate never changes a result — only speed.

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -555,6 +555,8 @@ def main(argv: list[str] | None = None) -> int:
                 [str(SCRIPTS / "check_version_consistency.py")])
     run_subgate(res, "readme_callouts --check (subprocess)",
                 [str(SCRIPTS / "sync_readme_callouts.py"), "--check"])
+    run_subgate(res, "native_docs --check (subprocess)",
+                [str(SCRIPTS / "gen_native_docs.py"), "--check"])
     check_roster_matrix(res)
     check_docs_nav_integrity(res)
     check_changelog_versions(res)

--- a/scripts/gen_native_docs.py
+++ b/scripts/gen_native_docs.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Generate (or check) the per-package native-acceleration docs from the loaders.
+
+  python scripts/gen_native_docs.py --write            # regenerate all pages
+  python scripts/gen_native_docs.py --check            # exit 1 if any page is stale
+  python scripts/gen_native_docs.py --write -p infermap  # one package
+
+Each ``docs-site/<pkg>/native.mdx`` is rendered from that package's
+``_native_loader.py`` — the ``_COMPONENT_SYMBOLS`` map (component -> kernel
+symbol(s)), the ``_GATED_ON`` byte-exact sign-off set, and the ``_FALLBACK_ONLY``
+known-divergent set — so the reference-mode gate and the page cannot drift. The
+loader is the single source of truth; CI runs ``--check`` (wired into
+``check_docs_consistency.py`` and the ``docs`` path filter), mirroring the
+``gen_lint_docs.py`` / config-linter pattern.
+
+Parsing is static (``ast`` only, stdlib) so the generator runs in the docs job
+without importing the packages or building any wheel.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs-site"
+
+# --- per-package metadata (source of truth: the loaders + pyproject extras) ---
+PACKAGES: dict[str, dict[str, str]] = {
+    "goldenmatch": {
+        "product": "GoldenMatch",
+        "loader": "packages/python/goldenmatch/goldenmatch/core/_native_loader.py",
+        "env": "GOLDENMATCH_NATIVE",
+        "pip_extra": "goldenmatch[native]",
+        "wheel": "goldenmatch-native",
+        "in_tree_mod": "goldenmatch._native",
+        "wheel_mod": "goldenmatch_native._native",
+        "crate": "packages/rust/extensions/native",
+        "extra_note": (
+            "The Fellegi-Sunter block-scoring path has its own gate, "
+            "`GOLDENMATCH_FS_NATIVE` (default-on; the Rust rapidfuzz path is the "
+            "reference, `=0` forces the pure-Python fallback)."
+        ),
+    },
+    "goldenflow": {
+        "product": "GoldenFlow",
+        "loader": "packages/python/goldenflow/goldenflow/core/_native_loader.py",
+        "env": "GOLDENFLOW_NATIVE",
+        "pip_extra": "goldenflow[native]",
+        "wheel": "goldenflow-native",
+        "in_tree_mod": "goldenflow._native",
+        "wheel_mod": "goldenflow_native._native",
+        "crate": "packages/rust/extensions/native-flow",
+        "extra_note": "",
+    },
+    "infermap": {
+        "product": "InferMap",
+        "loader": "packages/python/infermap/infermap/_native_loader.py",
+        "env": "INFERMAP_NATIVE",
+        "pip_extra": "infermap[native]",
+        "wheel": "infermap-native",
+        "in_tree_mod": "infermap._native",
+        "wheel_mod": "infermap_native._native",
+        "crate": "packages/rust/extensions/infermap-native",
+        "extra_note": "",
+    },
+}
+
+
+# --- static extraction ------------------------------------------------------
+def _lit(node: ast.AST):
+    """Evaluate a literal-ish node, including ``frozenset({...})`` / ``set({...})``
+    wrappers the loaders use (which ``ast.literal_eval`` rejects)."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Set):
+        return {_lit(e) for e in node.elts}
+    if isinstance(node, ast.Tuple):
+        return tuple(_lit(e) for e in node.elts)
+    if isinstance(node, ast.List):
+        return [_lit(e) for e in node.elts]
+    if isinstance(node, ast.Dict):
+        return {_lit(k): _lit(v) for k, v in zip(node.keys, node.values)}
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in ("frozenset", "set"):
+        return set(_lit(node.args[0])) if node.args else set()
+    raise ValueError(f"unsupported node {ast.dump(node)}")
+
+
+def _extract(loader_path: Path, required: set[str], optional: set[str]) -> dict:
+    names = required | optional
+    tree = ast.parse(loader_path.read_text(encoding="utf-8"))
+    out: dict = {}
+    for node in tree.body:  # module-level assignments only
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id in names:
+                    out[tgt.id] = _lit(node.value)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id in names and node.value is not None:
+                out[node.target.id] = _lit(node.value)
+    missing = required - out.keys()
+    if missing:
+        raise SystemExit(f"::error::{loader_path}: could not extract {sorted(missing)}")
+    return out
+
+
+def _symbols_str(sym) -> str:
+    """Render a component's symbol(s) as inline code (str or tuple/list)."""
+    if isinstance(sym, (tuple, list)):
+        return ", ".join(f"`{s}`" for s in sym)
+    return f"`{sym}`"
+
+
+# --- rendering --------------------------------------------------------------
+def render(pkg: str) -> str:
+    meta = PACKAGES[pkg]
+    data = _extract(
+        ROOT / meta["loader"],
+        required={"_COMPONENT_SYMBOLS", "_GATED_ON"},
+        optional={"_FALLBACK_ONLY"},
+    )
+    components: dict = data["_COMPONENT_SYMBOLS"]
+    gated: set = data["_GATED_ON"]
+    fallback: set = data.get("_FALLBACK_ONLY", set())
+    env = meta["env"]
+    loader_rel = meta["loader"].split("packages/python/")[-1]
+
+    kw = f'["{pkg}", "native", "rust", "arrow", "pyo3", "performance", "reference-mode"]'
+    header = (
+        "---\n"
+        'title: "Native acceleration"\n'
+        f'description: "{meta["product"]}\'s optional compiled Rust/Arrow runtime — '
+        f"which components run native, the `{env}` gate, and how parity is enforced. "
+        'Generated from the native loader; do not edit by hand."\n'
+        f"keywords: {kw}\n"
+        "---\n\n"
+        "{/* GENERATED FILE — do not edit. Source of truth: "
+        f"{loader_rel}. Regenerate: python scripts/gen_native_docs.py --write */}}\n\n"
+    )
+
+    body: list[str] = [
+        f"{meta['product']} is pure-Python by default. An optional compiled kernel "
+        f"(Rust + PyO3/Arrow, crate `{meta['crate']}`) accelerates the CPU-heavy "
+        "components below. Under reference-mode the compiled path is the reference "
+        "implementation and pure-Python is the byte-identical fallback — output is "
+        "the same either way; native only changes wall-clock.\n",
+        f"```bash\npip install {meta['pip_extra']}\n```\n",
+        "## The gate\n",
+        f"One env var, `{env}`, read in `{loader_rel}`:\n\n"
+        f"- `{env}=auto` (default, or unset) — run native for any component whose "
+        "kernel symbol is present on the loaded wheel, except the known-divergent "
+        "components below.\n"
+        f"- `{env}=0` — force the pure-Python fallback everywhere.\n"
+        f"- `{env}=1` — require native; raise if the kernel isn't importable (the "
+        "CI parity lane).\n",
+        "The kernel is discovered two ways, in order: the in-tree build "
+        f"`{meta['in_tree_mod']}` (local dev / parity lane), then the distributed "
+        f"`{meta['wheel_mod']}` wheel (`pip install {meta['pip_extra']}`). When "
+        "neither is importable, every path runs pure-Python unchanged.\n",
+    ]
+    if meta["extra_note"]:
+        body.append(f"{meta['extra_note']}\n")
+
+    body.append("## Components\n")
+    body.append(
+        "Each component maps to the native kernel symbol(s) its `auto` call site "
+        "invokes (the *floor* symbol first — a component is native-capable when "
+        "**any** listed symbol is present, so an older wheel stays wheel-skew "
+        "safe). A ✓ in **Parity-signed** marks a component that cleared the "
+        "byte-exact sign-off recorded in `_GATED_ON`.\n"
+    )
+    body.append("| Component | Kernel symbol(s) | Parity-signed |")
+    body.append("|---|---|---|")
+    for comp, sym in components.items():
+        mark = "✓" if comp in gated else ""
+        body.append(f"| `{comp}` | {_symbols_str(sym)} | {mark} |")
+    body.append("")
+
+    if fallback:
+        listed = ", ".join(f"`{c}`" for c in sorted(fallback))
+        body.append(
+            f"**Kept pure-Python under `auto` ({env} reference-mode):** {listed}. "
+            "These carry (or could bind) a native symbol that is known to diverge "
+            "from the pure-Python reference, so they stay on the fallback path "
+            f"until their parity battery is green — reachable only via `{env}=1`.\n"
+        )
+
+    body.append("## How parity stays honest\n")
+    body.append(
+        "A component joins the native path only after a parity test proves its "
+        "kernel is byte-identical (or integer-exact) to the pure-Python reference. "
+        f"CI runs a `{env}=1` lane that builds the wheel and asserts native == "
+        "pure-Python, and `scripts/check_native_symbols.py` reconciles the host's "
+        "kernel references against the crate's `wrap_pyfunction!` exports so a "
+        "referenced-but-unregistered symbol fails loudly. Because output is "
+        "identical with or without the wheel, toggling the gate never changes a "
+        "result — only speed.\n"
+    )
+
+    return header + "\n".join(body).rstrip() + "\n"
+
+
+def _page_path(pkg: str) -> Path:
+    return DOCS / pkg / "native.mdx"
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--write", action="store_true", help="regenerate the page(s)")
+    ap.add_argument("--check", action="store_true", help="exit 1 if any page is stale")
+    ap.add_argument("-p", "--package", choices=[*PACKAGES, "all"], default="all")
+    args = ap.parse_args(argv)
+
+    pkgs = list(PACKAGES) if args.package == "all" else [args.package]
+
+    if args.write:
+        for pkg in pkgs:
+            p = _page_path(pkg)
+            p.write_text(render(pkg), encoding="utf-8")
+            print(f"wrote {p.relative_to(ROOT)}")
+        return 0
+
+    if args.check:
+        stale = []
+        for pkg in pkgs:
+            p = _page_path(pkg)
+            if not p.exists() or p.read_text(encoding="utf-8") != render(pkg):
+                stale.append(str(p.relative_to(ROOT)))
+        if stale:
+            print(
+                "::error::native docs stale vs the loaders: "
+                + ", ".join(stale)
+                + ". Run: python scripts/gen_native_docs.py --write",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"native docs are current: {', '.join(pkgs)}")
+        return 0
+
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What and why

Audited the Mintlify docs (`docs-site/`) against the current code surface (parallel explorers: nav/structure, content freshness, code-vs-docs) and closed the concrete gaps found. Every command / tool / symbol list was enumerated from source, not guessed.

## Changes

**Correctness (stale version-pinned claims):**
- `identity-graph.mdx` — backfill note said "on the v2.1 roadmap"; product is at 3.10.0 and no such command exists. Reworded to "planned, not yet available."
- `configuration.mdx` (x2) — field-weight learner "stubbed in v1.6". Verified `MemoryLearner._compute_weights` still returns `null`, so de-pinned the wording to "not yet implemented" (behavior claim kept, stale version dropped).

**Surface coverage (goldenmatch):**
- `cli.mdx` — added `schedule` (was undocumented everywhere), `autoconfig`, `score`, `info`, `explain`, `lineage`, `anomalies`, `agent-serve`, `tui`, the `identity` / `ingest-docs` groups, and the `config delete` subcommand.
- `mcp.mdx` — corrected the tool counts (**85 canonical + 5 aliases = 90**; header said 82, breakdown reconciled to 69/74) and documented the 20 base introspection/scoring/IO tools + 2 document-extraction tools that had no entry.
- `python-api.mdx` — added a "More public exports" section for the ~60 top-level exports with no reference entry (config optimizer/edits, screening, RAG/retrieval, vector stores, embedding ops, recall certification, canonicalization, Splink result types, identity types).

**New pages — sibling-consistency:**
- Added the missing `cli.mdx` for **goldenpipe**, **infermap**, **goldenanalysis**.
- Added the missing `native.mdx` for **goldenmatch**, **goldenflow**, **infermap** — **programmatically generated and CI-gated**, not hand-authored:
  - `scripts/gen_native_docs.py` renders each page from that package's `_native_loader.py` (`_COMPONENT_SYMBOLS` / `_GATED_ON` / `_FALLBACK_ONLY`) via static `ast` parsing (stdlib-only; no package import, no wheel build). `--write` / `--check` / `-p <pkg>`, mirroring `gen_lint_docs.py`.
  - The required `docs_consistency` job now runs `gen_native_docs.py --check` as a subgate, and the three loaders + the generator are added to the `docs` path filter so a loader edit re-runs the gate and fails on un-regenerated drift.
  - Pages carry the `GENERATED` marker and are wired into `docs.json` in canonical section order.

## Testing

- `python scripts/check_docs_links.py` → OK (85 pages, frontmatter + internal links).
- `python scripts/check_docs_consistency.py` → all PASS (incl. the new `native_docs --check` subgate).
- `python scripts/check_docs_sections.py` → OK (6 sections, 85 pages, canonical shape).
- `gen_native_docs.py --write/--check` idempotent; drift caught (mutating a page → exit 1).

## Checklist

- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Tests added/updated — n/a (docs + generator; drift is gated by `--check` in `docs_consistency`)
- [ ] `CHANGELOG.md` updated — n/a (no behavior change)

## Follow-up (out of scope)

- `docs.json` still carries the placeholder PostHog key `phc_REPLACE_WITH_POSTHOG_PROJECT_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)