### PR TITLE
Splink domain-comparator conversion P2: date_diff recognizer + domain-family-wins

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -951,7 +951,8 @@
           "imports": [
             "goldenmatch.config.schemas",
             "goldenmatch.core._paths",
-            "goldenmatch.core.probabilistic"
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.scorer"
           ]
         },
         {

--- a/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
+++ b/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
@@ -207,9 +207,39 @@ End with the Claude Code attribution footer.)
 
 ---
 
-## 7. Open decisions for Ben
-1. **Array count→ratio fidelity** (§3 Array): approximate-ratio+warn (recommended) vs a new
-   `array_intersect:count:<n>` scorer mode.
-2. **Numeric scope** (§3 Numeric): drop numeric from P2 (rare, no standard Splink shape) and make
-   it opportunistic, vs holding P2 for a CustomComparison numeric recognizer.
+## 7. Decisions (RESOLVED 2026-07-25)
+1. **Array count→ratio fidelity** → **(a) approximate-overlap-ratio + warn** (`approx=True`).
+   Consistent with the existing levenshtein distance→sim snap; a `array_intersect:count:<n>`
+   scorer mode is a disproportionate new public surface for a rare comparison and its output
+   isn't a normalized similarity. P3 implementation note: snap `>= n` using **overlap-coefficient**
+   semantics, bias the threshold LOW to preserve recall, warn naming the approximation. Revisit
+   (b) only if a measured recall gap appears.
+2. **Numeric scope** → **dropped from P2, opportunistic.** Splink has no standard generic
+   numeric-difference comparison (magnitude only via `CustomComparison`/`DistanceFunction` with
+   arbitrary SQL), so a recognizer with no ground truth is speculative. **P2 = date recognizer
+   only.** Add a best-effort `ABS("c_l" - "c_r") <= eps` → `numeric_diff` recognizer only when a
+   real `CustomComparison` sample appears.
 3. Everything else in the spec is already approved.
+
+Revised roadmap: **P2 = date recognizer (DONE — this branch)**, **P3 = geo + array
+(approx-overlap-ratio)**, numeric opportunistic, P4-P6 as scoped.
+
+## 8. P2 delivered (2026-07-25)
+`date_diff` recognizer in `from_splink.py`, built against the REAL Splink 4 SQL (both dialects):
+- `recognize_level`: new `date_diff` kind. `_DATE_DIFF_MARKER`/`_DATE_DIFF_TAIL`/`_DATE_DIFF_COL`
+  match `ABS(EPOCH(try_strptime(...)) - ...) <= <secs>` (DuckDB) and the Spark
+  `UNIX_TIMESTAMP([date(]try_to_timestamp(...))` forms (bare + `date()`-wrapped). `days =
+  round(seconds / 86400)`; `sim = _date_diff_band(days)` (imported from `core.scorer` — one source
+  of truth, no band drift), `approx=True`.
+- Shared column atom `_COL_L`/`_COL_R` extended to accept Spark backticks, so exact/sim/dist/null
+  levels also recognize under Spark (a bonus beyond date).
+- `convert_comparison`: **domain-family-wins** rule (`_DOMAIN_KINDS` = date_diff/geo_haversine/
+  array_intersect/numeric_diff). A domain band + string-edit bands in one comparison → keep the
+  domain family + exact, drop the string-edit bands with a warn (DObComparison's damerau level).
+  >1 DISTINCT domain family → drop the whole comparison (defensive; not triggerable until a second
+  domain recognizer lands). The 10yr DOB band snaps to 0.0 → dropped by the existing out-of-range
+  guard, so DObComparison yields 4 levels [1.0, 0.80, 0.60].
+- `import_em`: unchanged — the dropped damerau/10yr levels' m/u resolve to no matching threshold
+  and are dropped + re-normalized (asserted in `test_from_splink_domain.py`).
+- Tests: `tests/test_from_splink_domain.py` (13). No parity-manifest change (`date_diff` is an
+  existing scorer from the 2026-07-23 FS work; P2 only adds a *recognizer*).

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -24,6 +24,7 @@ from goldenmatch.config.schemas import (
 )
 from goldenmatch.core._paths import safe_path
 from goldenmatch.core.probabilistic import EMResult, _training_config_manifest
+from goldenmatch.core.scorer import _date_diff_band
 
 Severity = Literal["info", "warning", "error"]
 
@@ -42,9 +43,10 @@ _LEV_ASSUMED_LEN = 10
 _PLACEHOLDER_PREFIX = "matchkeys[?].fields[?]"
 
 # Column atom: Splink serializes comparison-level columns as "col_l" / "col_r"
-# (the _l/_r suffix INSIDE the quotes) or bare col_l / col_r.
-_COL_L = r'"?([A-Za-z_]\w*)_l"?'
-_COL_R = r'"?([A-Za-z_]\w*)_r"?'
+# (DuckDB, double-quoted), `col_l` / `col_r` (Spark, backtick-quoted), or bare
+# col_l / col_r -- the _l/_r suffix sits INSIDE the quotes.
+_COL_L = r'["`]?([A-Za-z_]\w*)_l["`]?'
+_COL_R = r'["`]?([A-Za-z_]\w*)_r["`]?'
 
 _ELSE_RE = r'ELSE'
 _NULL_RE = rf'{_COL_L}\s+IS\s+NULL\s+OR\s+{_COL_R}\s+IS\s+NULL'
@@ -58,7 +60,31 @@ _DIST_RE = (
     rf'\s*\(\s*{_COL_L}\s*,\s*{_COL_R}\s*\)\s*<=\s*([0-9]+)'
 )
 
-LevelKind = Literal["null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard"]
+# Date/time-difference levels compare two parsed timestamps in SECONDS:
+#   DuckDB: ABS(EPOCH(try_strptime("c_l",'..')) - EPOCH(try_strptime("c_r",'..'))) <= <secs>
+#   Spark:  ABS(UNIX_TIMESTAMP([date(]try_to_timestamp(`c_l`,'..')[)]) - UNIX_TIMESTAMP(..)) <= <secs>
+# The column atom is pulled from the try_strptime / try_to_timestamp call (the
+# _l/_r operand); the seconds cutoff is converted to days and snapped to a
+# `_date_diff_band` value -- approximate, like the levenshtein distance->sim map.
+_DATE_DIFF_MARKER = re.compile(r'\bABS\s*\(.*(?:EPOCH|UNIX_TIMESTAMP)\s*\(', re.IGNORECASE)
+_DATE_DIFF_TAIL = re.compile(r'<=\s*([0-9]+(?:\.[0-9]+)?)\s*$')
+_DATE_DIFF_COL = re.compile(
+    r'(?:try_strptime|try_to_timestamp)\s*\(\s*["`]?([A-Za-z_]\w*)_([lr])["`]?\s*,',
+    re.IGNORECASE,
+)
+_SECONDS_PER_DAY = 86400.0
+
+LevelKind = Literal[
+    "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff"
+]
+
+# Domain comparators (magnitude-aware) take precedence over string-edit levels
+# in the same Splink comparison -- e.g. DateOfBirthComparison mixes a
+# damerau_levenshtein level with date-difference levels; the domain family wins
+# and the string-edit level is dropped (see convert_comparison).
+_DOMAIN_KINDS: frozenset[str] = frozenset(
+    {"date_diff", "geo_haversine", "array_intersect", "numeric_diff"}
+)
 
 _SIM_KIND: dict[str, tuple[LevelKind, bool]] = {
     "jaro_winkler_similarity": ("jaro_winkler", False),
@@ -124,6 +150,20 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
             return None
         sim = max(0.0, 1 - distance / _LEV_ASSUMED_LEN)
         return RecognizedLevel("levenshtein", col_l, sim, approx=True)
+
+    if _DATE_DIFF_MARKER.search(sql_norm):
+        tail = _DATE_DIFF_TAIL.search(sql_norm)
+        cols = _DATE_DIFF_COL.findall(sql_norm)
+        if tail and cols:
+            bases = {c for c, _ in cols}
+            sides = {s.lower() for _, s in cols}
+            if len(bases) == 1 and sides == {"l", "r"}:
+                days = round(float(tail.group(1)) / _SECONDS_PER_DAY)
+                return RecognizedLevel(
+                    "date_diff", next(iter(bases)), _date_diff_band(days), approx=True
+                )
+        # ABS(...EPOCH/UNIX_TIMESTAMP...) shape but no clean single-column
+        # date-difference -> fall through to None (level dropped + warned).
 
     return None
 
@@ -230,15 +270,45 @@ def convert_comparison(
             mapped_to=None,
         )
 
-    families = {r.kind for r, _, _ in bands if r.kind != "exact"}
-    if len(families) > 1:
+    agree_families = {r.kind for r, _, _ in bands if r.kind != "exact"}
+    domain_families = agree_families & _DOMAIN_KINDS
+    if len(domain_families) > 1:
         report.warn(
             comp_path,
-            f"mixed comparator families {sorted(families)} in one comparison, "
-            "comparison dropped",
+            f"multiple domain comparator families {sorted(domain_families)} in one "
+            "comparison, comparison dropped",
             mapped_to=None,
         )
         return None
+    if domain_families:
+        # Domain-family-wins: a magnitude-aware comparator (e.g. date_diff) and a
+        # string-edit level (e.g. damerau_levenshtein) co-occur in one Splink
+        # comparison (DateOfBirthComparison). Keep the domain family + exact and
+        # drop the string-edit bands rather than dropping the whole comparison.
+        winner = next(iter(domain_families))
+        kept: list[tuple[RecognizedLevel, dict, int]] = []
+        for r, level, j in bands:
+            if r.kind in ("exact", winner):
+                kept.append((r, level, j))
+            else:
+                report.warn(
+                    f"{comp_path}.comparison_levels[{j}]",
+                    f"domain comparator '{winner}' takes precedence; string-edit "
+                    f"level dropped: {level.get('sql_condition', '')}",
+                    mapped_to=None,
+                )
+        bands = kept
+        families = {winner}
+    else:
+        families = agree_families
+        if len(families) > 1:
+            report.warn(
+                comp_path,
+                f"mixed comparator families {sorted(families)} in one comparison, "
+                "comparison dropped",
+                mapped_to=None,
+            )
+            return None
 
     if not bands:
         report.warn(comp_path, "no usable agree levels, comparison dropped", mapped_to=None)
@@ -269,6 +339,11 @@ def convert_comparison(
                 message = (
                     f"approximate mapping: edit distance <= {distance} converted via "
                     f"sim = 1 - distance/{_LEV_ASSUMED_LEN} -> {r.sim_threshold} ({sql})"
+                )
+            elif r.kind == "date_diff":
+                message = (
+                    "approximate mapping: date-difference cutoff snapped to the nearest "
+                    f"day-distance band -> sim {r.sim_threshold} ({sql})"
                 )
             else:
                 message = (

--- a/packages/python/goldenmatch/tests/test_from_splink_domain.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_domain.py
@@ -1,0 +1,282 @@
+"""P2: Splink domain-comparator conversion -- date_diff recognizer +
+domain-family-wins rule.
+
+The SQL strings below are the REAL Splink 4 serializations (captured via
+`cl.DateOfBirthComparison(...).get_comparison('duckdb'|'spark').as_dict()`),
+not hand-written approximations -- see
+docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
+section 3. `AbsoluteTimeDifferenceAtThresholds` (bare) and
+`DateOfBirthComparison` (with a `date(...)` wrapper on Spark + a leading
+damerau_levenshtein level) are the two shapes that emit date-difference levels.
+"""
+import pytest
+from goldenmatch.config.from_splink import (
+    ConversionReport,
+    convert_comparison,
+    import_em,
+    recognize_level,
+)
+
+# --- real ground-truth level SQL (dob column) --------------------------------
+
+# DuckDB: EPOCH(try_strptime(...)) seconds; DObComparison cutoffs 1mo/1yr/10yr.
+_DUCK_1MO = (
+    'ABS(EPOCH(try_strptime("dob_l", \'%Y-%m-%d\')) - '
+    'EPOCH(try_strptime("dob_r", \'%Y-%m-%d\'))) <= 2629800.0'
+)
+_DUCK_1YR = (
+    'ABS(EPOCH(try_strptime("dob_l", \'%Y-%m-%d\')) - '
+    'EPOCH(try_strptime("dob_r", \'%Y-%m-%d\'))) <= 31557600.0'
+)
+_DUCK_10YR = (
+    'ABS(EPOCH(try_strptime("dob_l", \'%Y-%m-%d\')) - '
+    'EPOCH(try_strptime("dob_r", \'%Y-%m-%d\'))) <= 315576000.0'
+)
+# Spark DateOfBirthComparison: date(try_to_timestamp(...)) wrapper.
+_SPARK_DATE_1MO = (
+    "ABS(UNIX_TIMESTAMP(date(try_to_timestamp(`dob_l`, 'yyyy-MM-dd'))) - "
+    "UNIX_TIMESTAMP(date(try_to_timestamp(`dob_r`, 'yyyy-MM-dd')))) <= 2629800.0"
+)
+# Spark AbsoluteTimeDifferenceAtThresholds: no date() wrapper, integer seconds.
+_SPARK_BARE_30D = (
+    "ABS(UNIX_TIMESTAMP(try_to_timestamp(`dob_l`, '%Y-%m-%d')) - "
+    "UNIX_TIMESTAMP(try_to_timestamp(`dob_r`, '%Y-%m-%d'))) <= 2592000"
+)
+
+
+@pytest.mark.parametrize(
+    "sql,expected_band",
+    [
+        (_DUCK_1MO, 0.80),      # 2629800 s ~= 30.4 d -> <=31d band
+        (_DUCK_1YR, 0.60),      # 31557600 s ~= 365.25 d -> <=366d band
+        (_DUCK_10YR, 0.0),      # 315576000 s ~= 3652 d -> beyond 5y -> 0.0
+        (_SPARK_DATE_1MO, 0.80),
+        (_SPARK_BARE_30D, 0.80),  # 2592000 s == 30 d exactly
+    ],
+)
+def test_date_diff_recognized_both_dialects(sql, expected_band):
+    r = recognize_level(sql)
+    assert r is not None
+    assert r.kind == "date_diff"
+    assert r.column == "dob"
+    assert r.sim_threshold == pytest.approx(expected_band, abs=1e-9)
+    assert r.approx is True
+
+
+def test_non_date_abs_expression_not_recognized():
+    # An ABS() numeric difference with no EPOCH/UNIX_TIMESTAMP date parse is
+    # NOT a date_diff level -- must fall through to None (dropped + warned).
+    assert recognize_level('ABS("age_l" - "age_r") <= 5') is None
+
+
+def test_date_diff_mismatched_columns_dropped():
+    sql = (
+        'ABS(EPOCH(try_strptime("dob_l", \'%Y-%m-%d\')) - '
+        'EPOCH(try_strptime("born_r", \'%Y-%m-%d\'))) <= 2629800.0'
+    )
+    assert recognize_level(sql) is None
+
+
+# --- full-comparison conversion ----------------------------------------------
+
+
+def _dob_comparison_duckdb():
+    """Real DuckDB DateOfBirthComparison: null, exact, damerau_levenshtein,
+    then three date-difference levels (1mo/1yr/10yr), ELSE."""
+    return {
+        "output_column_name": "dob",
+        "comparison_levels": [
+            {
+                "sql_condition": (
+                    'try_strptime("dob_l", \'%Y-%m-%d\') IS NULL OR '
+                    'try_strptime("dob_r", \'%Y-%m-%d\') IS NULL'
+                ),
+                "is_null_level": True,
+            },
+            {"sql_condition": '"dob_l" = "dob_r"'},
+            {"sql_condition": 'damerau_levenshtein("dob_l", "dob_r") <= 1'},
+            {"sql_condition": _DUCK_1MO},
+            {"sql_condition": _DUCK_1YR},
+            {"sql_condition": _DUCK_10YR},
+            {"sql_condition": "ELSE"},
+        ],
+    }
+
+
+def test_dob_comparison_converts_to_date_diff_field():
+    report = ConversionReport()
+    field = convert_comparison(_dob_comparison_duckdb(), 0, report)
+
+    assert field is not None
+    assert field.field == "dob"
+    assert field.scorer == "date_diff"
+    # exact (1.0) + 1mo (0.80) + 1yr (0.60); the 10yr band snaps to 0.0 and is
+    # dropped as out-of-range, so 4 levels not 5.
+    assert field.levels == 4
+    assert field.level_thresholds == [1.0, 0.80, 0.60]
+
+
+def test_dob_comparison_drops_string_edit_level_with_warning():
+    report = ConversionReport()
+    convert_comparison(_dob_comparison_duckdb(), 0, report)
+    warns = [f.message for f in report.findings if f.severity == "warning"]
+
+    # domain-family-wins dropped the damerau_levenshtein level.
+    assert any("takes precedence" in w and "damerau_levenshtein" in w for w in warns)
+    # the 10yr band converted to 0.0 and was dropped as out-of-range.
+    assert any("out of range" in w for w in warns)
+    # the approximate snap is surfaced.
+    assert any("date-difference cutoff snapped" in w for w in warns)
+
+
+def test_spark_dob_comparison_converts_to_date_diff_field():
+    """Spark uses backtick-quoted columns + a date() wrapper; the shared column
+    atom now accepts backticks so exact + date levels both recognize."""
+    comp = {
+        "output_column_name": "dob",
+        "comparison_levels": [
+            {
+                "sql_condition": (
+                    "date(try_to_timestamp(`dob_l`, 'yyyy-MM-dd')) IS NULL OR "
+                    "date(try_to_timestamp(`dob_r`, 'yyyy-MM-dd')) IS NULL"
+                ),
+                "is_null_level": True,
+            },
+            {"sql_condition": "`dob_l` = `dob_r`"},
+            {"sql_condition": "damerau_levenshtein(`dob_l`, `dob_r`) <= 1"},
+            {"sql_condition": _SPARK_DATE_1MO},
+            {"sql_condition": "ELSE"},
+        ],
+    }
+    report = ConversionReport()
+    field = convert_comparison(comp, 0, report)
+
+    assert field is not None
+    assert field.field == "dob"
+    assert field.scorer == "date_diff"
+    # exact (1.0) + 1mo (0.80)
+    assert field.levels == 3
+    assert field.level_thresholds == [1.0, 0.80]
+
+
+def test_abs_time_diff_no_string_edit_level():
+    """AbsoluteTimeDifferenceAtThresholds has NO damerau level -- pure date."""
+    comp = {
+        "output_column_name": "dob",
+        "comparison_levels": [
+            {
+                "sql_condition": (
+                    'try_strptime("dob_l", \'%Y-%m-%d\') IS NULL OR '
+                    'try_strptime("dob_r", \'%Y-%m-%d\') IS NULL'
+                ),
+                "is_null_level": True,
+            },
+            {"sql_condition": '"dob_l" = "dob_r"'},
+            {"sql_condition": _DUCK_1MO},
+            {"sql_condition": _DUCK_1YR},
+            {"sql_condition": "ELSE"},
+        ],
+    }
+    report = ConversionReport()
+    field = convert_comparison(comp, 0, report)
+
+    assert field is not None
+    assert field.scorer == "date_diff"
+    assert field.levels == 4
+    # no string-edit level to drop.
+    assert not any(
+        "takes precedence" in f.message
+        for f in report.findings
+        if f.severity == "warning"
+    )
+
+
+def test_unrecognized_level_dropped_date_diff_still_wins():
+    """An unrecognized level (no array_intersect SQL recognizer exists yet --
+    P1 added the scorer, not a from_splink recognizer) is dropped with a
+    warning; the recognized date_diff bands still build a clean date field.
+    (The `len(domain_families) > 1` guard is defensive for future recognizers;
+    it can't be triggered through recognize_level today, since date_diff is the
+    only recognizable domain kind.)"""
+    comp = {
+        "output_column_name": "dob",
+        "comparison_levels": [
+            {"sql_condition": '"dob_l" = "dob_r"'},
+            {"sql_condition": _DUCK_1MO},
+            {
+                "sql_condition": (
+                    "array_length(list_intersect(\"dob_l\", \"dob_r\")) >= 2"
+                )
+            },
+            {"sql_condition": "ELSE"},
+        ],
+    }
+    report = ConversionReport()
+    field = convert_comparison(comp, 0, report)
+    assert field is not None
+    assert field.scorer == "date_diff"
+    assert any(
+        "unrecognized sql_condition" in f.message
+        for f in report.findings
+        if f.severity == "warning"
+    )
+
+
+# --- trained model import ----------------------------------------------------
+
+
+def _trained_dob_comparison():
+    """DObComparison with m/u on every non-null level. The damerau_levenshtein
+    level and the 10yr date level do NOT survive conversion, so their m/u mass
+    must be dropped (not misapplied to a surviving index)."""
+    comp = _dob_comparison_duckdb()
+    mu = {
+        1: (0.60, 0.02),   # exact
+        2: (0.10, 0.05),   # damerau_levenshtein  <- dropped
+        3: (0.15, 0.10),   # 1mo
+        4: (0.10, 0.20),   # 1yr
+        5: (0.02, 0.30),   # 10yr                 <- dropped
+        6: (0.03, 0.33),   # ELSE
+    }
+    for idx, (m, u) in mu.items():
+        comp["comparison_levels"][idx]["m_probability"] = m
+        comp["comparison_levels"][idx]["u_probability"] = u
+    return comp
+
+
+def _trained_settings(comparisons):
+    return {
+        "comparisons": comparisons,
+        "probability_two_random_records_match": 0.0002,
+    }
+
+
+def test_trained_dob_import_maps_bands_and_drops_string_edit_mass():
+    comp = _trained_dob_comparison()
+    settings = _trained_settings([comp])
+    report = ConversionReport()
+
+    field = convert_comparison(comp, 0, report)
+    assert field is not None and field.levels == 4
+
+    em = import_em([(comp, 0, field)], settings, report)
+    assert em is not None
+
+    m = em.m_probs["dob"]
+    assert len(m) == 4
+    # exact is index 3 (top), ELSE index 0; monotone through the surviving
+    # bands: exact > 1mo > 1yr for these m's.
+    assert m[3] > m[2] > m[1]
+    # the dropped damerau level's threshold does not match any converted level.
+    warns = [f for f in report.findings if f.severity == "warning"]
+    assert any(
+        "does not match any converted threshold" in f.message
+        and f.splink_path.endswith("comparison_levels[2]")  # damerau
+        for f in warns
+    )
+    # and the 10yr level (index 5) is likewise dropped.
+    assert any(
+        "does not match any converted threshold" in f.message
+        and f.splink_path.endswith("comparison_levels[5]")
+        for f in warns
+    )


### PR DESCRIPTION
## What and why

Builds on P1 (#2115). Splink's date/time-difference comparison levels (`AbsoluteTimeDifferenceAtThresholds`, `DateOfBirthComparison`) were silently dropped by `from_splink`, so a converted config lost the date-magnitude signal entirely. P2 recognizes those levels and maps them to the existing `date_diff` FS scorer, built against the REAL Splink 4 SQL (captured live in both dialects, not guessed).

## Changes

- **`date_diff` recognizer** (`config/from_splink.py`): new `date_diff` `LevelKind`. Matches the ground-truth SQL in both dialects -- DuckDB `ABS(EPOCH(try_strptime(...)) - ...) <= <secs>` and the Spark `UNIX_TIMESTAMP([date(]try_to_timestamp(...))` forms (bare and `date()`-wrapped). `days = round(seconds / 86400)`; `sim = _date_diff_band(days)` imported from `core.scorer` (one source of truth, no band drift); `approx=True`.
- **Spark backtick columns**: extended the shared `_COL_L`/`_COL_R` atom to accept backtick-quoting, so exact/sim/dist/null levels also recognize under Spark (a bonus beyond date).
- **Domain-family-wins** (`convert_comparison`): a domain band (`date_diff`/`geo_haversine`/`array_intersect`/`numeric_diff`) plus string-edit bands in one comparison keeps the domain family + exact and drops the string-edit bands with a warning (`DateOfBirthComparison`'s `damerau_levenshtein` level). >1 distinct domain family drops the whole comparison (defensive). The 10yr DOB band snaps to `0.0` and is dropped by the existing out-of-range guard, so `DateOfBirthComparison` yields 4 levels `[1.0, 0.80, 0.60]`.
- **`import_em` unchanged**: the dropped `damerau`/10yr levels' m/u resolve to no matching threshold and are dropped + re-normalized (asserted in the tests).
- **Plan doc**: recorded the two resolved decisions -- array count→ratio = approximate-overlap-ratio + warn; numeric = opportunistic (P2 = date only) -- and a P2-delivered section.

## Testing

- `uv run --group dev python -m pytest packages/python/goldenmatch/tests/test_from_splink_domain.py` -> 13 passed (recognizer both dialects, DObComparison conversion, domain-family-wins, trained m/u import).
- Full splink suite (10 files) -> 159 passed.
- Polars-free import of `from_splink` verified (the new `core.scorer` import doesn't drag polars -- protects the required `goldenmatch_nopolars` lane).
- `ruff check` clean; parity `check_structure` + `check_scorer_coverage` -> no errors.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff check`) clean on changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed (deferred until the domain-comparator conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (plan doc: decisions resolved + P2 delivered)

No parity-manifest change: `date_diff` is an existing scorer (2026-07-23 FS work); P2 adds a *recognizer* only. Follow-ons: P3 = geo + array (approximate-overlap-ratio), numeric opportunistic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_