### PR TITLE
Splink domain-comparator conversion P3a: array_intersect recognizer

### DIFF
--- a/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
+++ b/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
@@ -243,3 +243,32 @@ Revised roadmap: **P2 = date recognizer (DONE — this branch)**, **P3 = geo + a
   and are dropped + re-normalized (asserted in `test_from_splink_domain.py`).
 - Tests: `tests/test_from_splink_domain.py` (13). No parity-manifest change (`date_diff` is an
   existing scorer from the 2026-07-23 FS work; P2 only adds a *recognizer*).
+
+## 9. P3a delivered — array_intersect recognizer (2026-07-25)
+`ArrayIntersectAtSizes` (`array_length(list_intersect(...)) >= n` DuckDB /
+`SIZE(ARRAY_INTERSECT(...)) >= n` Spark) now recognized. Per the resolved decision (7.1):
+- `_ARRAY_INTERSECT_LEVEL_RE` extracts column + count. Count `>= n` snaps to overlap ratio
+  `min(1.0, n / _ARRAY_ASSUMED_SET_SIZE)` (`_ARRAY_ASSUMED_SET_SIZE = 10`, biased low for recall),
+  emits scorer `array_intersect:overlap` (P1's scorer), `approx=True` + a warn naming the snap.
+- `RecognizedLevel` gained an optional `scorer` override (kind stays `array_intersect` for the
+  single-domain-family check; the scorer STRING carries the `:overlap` mode). `convert_comparison`
+  resolves the field scorer from that override, else the family kind.
+- `ArrayIntersectAtSizes([3,1])` → `array_intersect:overlap`, 3 levels `[0.3, 0.1]`.
+- Tests added to `test_from_splink_domain.py` (recognizer both dialects, conversion, snap warn,
+  trained import, + the now-triggerable two-distinct-domain-families guard). No parity-manifest
+  change (`array_intersect` is P1's existing scorer). Full splink suite 166 green; polars-free.
+
+## 10. Geo (geo_haversine) — BLOCKED on a schema decision (P3b)
+Deferred from P3a: the plan (3) assumed a `MatchkeyField` with `derive_from=[lat,lng]` + a comma
+concat. VERIFIED that assumption is WRONG in two ways:
+1. `derive_from` lives on `NegativeEvidenceField`, NOT `MatchkeyField` — the converter emits
+   `MatchkeyField`, which has no synthesized-field mechanism.
+2. `NegativeEvidenceField.derive_from` **space-joins** its sources, but `geo_haversine`'s
+   `_parse_latlong` requires a **comma/semicolon** separator ("lat,long"). Space-join wouldn't parse.
+So geo is NOT just a recognizer — `geo_haversine` scores ONE combined "lat,long" field, while Splink
+gives two SEPARATE columns. Making it work end-to-end needs a NEW `MatchkeyField` synthesized-field
+mechanism (`derive_from` + a `,` separator) AND pipeline materialization of that field before
+scoring. That's a cross-cutting schema + pipeline feature (higher-risk, own tests + parity), not a
+recognizer. **Decision needed from Ben** (see the session hand-off): (a) add the derive_from+separator
+plumbing to MatchkeyField as P3b, or (b) recognize the haversine level but emit it as a DROPPED
+comparison with a clear "cross-column geo not yet representable" warning until the plumbing lands.

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -75,8 +75,25 @@ _DATE_DIFF_COL = re.compile(
 _SECONDS_PER_DAY = 86400.0
 
 LevelKind = Literal[
-    "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff"
+    "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff",
+    "array_intersect",
 ]
+
+# ArrayIntersectAtSizes levels count the intersection SIZE:
+#   DuckDB: array_length(list_intersect("c_l", "c_r")) >= <n>
+#   Spark:  SIZE(ARRAY_INTERSECT(`c_l`, `c_r`)) >= <n>
+# GoldenMatch's array_intersect scorer returns a RATIO, not a count, so there is
+# no exact count->ratio map without set sizes at convert time. We snap `>= n` to
+# an overlap-coefficient threshold n / _ARRAY_ASSUMED_SET_SIZE (biased LOW to
+# preserve recall) and emit `array_intersect:overlap` (overlap is closer to an
+# absolute-intersection count than Jaccard) with approx=True + a warn.
+_ARRAY_INTERSECT_LEVEL_RE = re.compile(
+    r'(?:array_length\s*\(\s*list_intersect|size\s*\(\s*array_intersect)\s*\(\s*'
+    rf'{_COL_L}\s*,\s*{_COL_R}\s*\)\s*\)\s*>=\s*([0-9]+)',
+    re.IGNORECASE,
+)
+_ARRAY_ASSUMED_SET_SIZE = 10.0
+_ARRAY_INTERSECT_SCORER = "array_intersect:overlap"
 
 # Domain comparators (magnitude-aware) take precedence over string-edit levels
 # in the same Splink comparison -- e.g. DateOfBirthComparison mixes a
@@ -100,6 +117,7 @@ class RecognizedLevel:
     column: str | None
     sim_threshold: float | None
     approx: bool = False      # True when the mapping is an approximation (jaro->jw, distance->similarity)
+    scorer: str | None = None  # full scorer string when it differs from `kind` (e.g. "array_intersect:overlap")
 
 
 def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel | None:
@@ -164,6 +182,16 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
                 )
         # ABS(...EPOCH/UNIX_TIMESTAMP...) shape but no clean single-column
         # date-difference -> fall through to None (level dropped + warned).
+
+    m = _ARRAY_INTERSECT_LEVEL_RE.fullmatch(sql_norm)
+    if m:
+        col_l, col_r, count = m.group(1), m.group(2), int(m.group(3))
+        if col_l != col_r:
+            return None
+        ratio = min(1.0, count / _ARRAY_ASSUMED_SET_SIZE)
+        return RecognizedLevel(
+            "array_intersect", col_l, ratio, approx=True, scorer=_ARRAY_INTERSECT_SCORER
+        )
 
     return None
 
@@ -314,7 +342,16 @@ def convert_comparison(
         report.warn(comp_path, "no usable agree levels, comparison dropped", mapped_to=None)
         return None
 
-    scorer = next(iter(families)) if families else "exact"
+    # A recognized band may carry a full scorer string (e.g. array_intersect's
+    # ":overlap" mode) that differs from its family kind; prefer it, else use
+    # the family kind (date_diff, jaro_winkler, ...) or "exact" for exact-only.
+    if families:
+        scorer = next(
+            (r.scorer for r, _, _ in bands if r.kind != "exact" and r.scorer),
+            next(iter(families)),
+        )
+    else:
+        scorer = "exact"
 
     columns = {r.column for r, _, _ in bands if r.column is not None}
     if len(columns) > 1:
@@ -344,6 +381,13 @@ def convert_comparison(
                 message = (
                     "approximate mapping: date-difference cutoff snapped to the nearest "
                     f"day-distance band -> sim {r.sim_threshold} ({sql})"
+                )
+            elif r.kind == "array_intersect":
+                count = round((r.sim_threshold or 0.0) * _ARRAY_ASSUMED_SET_SIZE)
+                message = (
+                    f"approximate mapping: array-intersection count >= {count} snapped "
+                    f"to overlap-ratio threshold {r.sim_threshold} (assumed set size "
+                    f"{int(_ARRAY_ASSUMED_SET_SIZE)}, biased low for recall) ({sql})"
                 )
             else:
                 message = (

--- a/packages/python/goldenmatch/tests/test_from_splink_domain.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_domain.py
@@ -191,13 +191,10 @@ def test_abs_time_diff_no_string_edit_level():
     )
 
 
-def test_unrecognized_level_dropped_date_diff_still_wins():
-    """An unrecognized level (no array_intersect SQL recognizer exists yet --
-    P1 added the scorer, not a from_splink recognizer) is dropped with a
-    warning; the recognized date_diff bands still build a clean date field.
-    (The `len(domain_families) > 1` guard is defensive for future recognizers;
-    it can't be triggered through recognize_level today, since date_diff is the
-    only recognizable domain kind.)"""
+def test_two_distinct_domain_families_drops_comparison():
+    """A comparison mixing two DIFFERENT recognized domain families (date_diff +
+    array_intersect -- an impossible real Splink shape, but the guard must hold)
+    is dropped, not silently coerced onto one scorer."""
     comp = {
         "output_column_name": "dob",
         "comparison_levels": [
@@ -205,7 +202,7 @@ def test_unrecognized_level_dropped_date_diff_still_wins():
             {"sql_condition": _DUCK_1MO},
             {
                 "sql_condition": (
-                    "array_length(list_intersect(\"dob_l\", \"dob_r\")) >= 2"
+                    'array_length(list_intersect("dob_l", "dob_r")) >= 2'
                 )
             },
             {"sql_condition": "ELSE"},
@@ -213,10 +210,9 @@ def test_unrecognized_level_dropped_date_diff_still_wins():
     }
     report = ConversionReport()
     field = convert_comparison(comp, 0, report)
-    assert field is not None
-    assert field.scorer == "date_diff"
+    assert field is None
     assert any(
-        "unrecognized sql_condition" in f.message
+        "multiple domain comparator families" in f.message
         for f in report.findings
         if f.severity == "warning"
     )
@@ -280,3 +276,99 @@ def test_trained_dob_import_maps_bands_and_drops_string_edit_mass():
         and f.splink_path.endswith("comparison_levels[5]")
         for f in warns
     )
+
+
+# --- array_intersect (ArrayIntersectAtSizes) ---------------------------------
+#
+# Splink counts the intersection SIZE (`>= n`); GoldenMatch's array_intersect
+# scorer returns a RATIO, so `>= n` is snapped to an overlap-coefficient
+# threshold n / 10 (assumed set size, biased low for recall) + a warn. Decision:
+# docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md 7.
+
+_DUCK_ARRAY_3 = 'array_length(list_intersect("skills_l", "skills_r")) >= 3'
+_DUCK_ARRAY_1 = 'array_length(list_intersect("skills_l", "skills_r")) >= 1'
+_SPARK_ARRAY_3 = "SIZE(ARRAY_INTERSECT(`skills_l`, `skills_r`)) >= 3"
+
+
+@pytest.mark.parametrize(
+    "sql,expected_ratio",
+    [
+        (_DUCK_ARRAY_3, 0.3),
+        (_DUCK_ARRAY_1, 0.1),
+        (_SPARK_ARRAY_3, 0.3),   # Spark SIZE(ARRAY_INTERSECT(...)) form
+    ],
+)
+def test_array_intersect_recognized_both_dialects(sql, expected_ratio):
+    r = recognize_level(sql)
+    assert r is not None
+    assert r.kind == "array_intersect"
+    assert r.column == "skills"
+    assert r.scorer == "array_intersect:overlap"
+    assert r.sim_threshold == pytest.approx(expected_ratio, abs=1e-9)
+    assert r.approx is True
+
+
+def test_array_intersect_mismatched_columns_dropped():
+    assert (
+        recognize_level('array_length(list_intersect("skills_l", "tags_r")) >= 1')
+        is None
+    )
+
+
+def _array_comparison():
+    """Real DuckDB ArrayIntersectAtSizes([3, 1]): null, two size levels, ELSE."""
+    return {
+        "output_column_name": "skills",
+        "comparison_levels": [
+            {
+                "sql_condition": '"skills_l" IS NULL OR "skills_r" IS NULL',
+                "is_null_level": True,
+            },
+            {"sql_condition": _DUCK_ARRAY_3},
+            {"sql_condition": _DUCK_ARRAY_1},
+            {"sql_condition": "ELSE"},
+        ],
+    }
+
+
+def test_array_comparison_converts_to_overlap_field():
+    report = ConversionReport()
+    field = convert_comparison(_array_comparison(), 0, report)
+
+    assert field is not None
+    assert field.field == "skills"
+    # the ":overlap" scorer string (not the bare "array_intersect" family kind).
+    assert field.scorer == "array_intersect:overlap"
+    assert field.levels == 3
+    assert field.level_thresholds == [0.3, 0.1]
+
+
+def test_array_comparison_warns_on_count_to_ratio_snap():
+    report = ConversionReport()
+    convert_comparison(_array_comparison(), 0, report)
+    warns = [f.message for f in report.findings if f.severity == "warning"]
+
+    assert any("count >= 3" in w and "overlap-ratio" in w for w in warns)
+    assert any("count >= 1" in w for w in warns)
+    assert any("biased low for recall" in w for w in warns)
+
+
+def test_trained_array_import_maps_ratio_bands():
+    comp = _array_comparison()
+    comp["comparison_levels"][1]["m_probability"] = 0.55
+    comp["comparison_levels"][1]["u_probability"] = 0.05
+    comp["comparison_levels"][2]["m_probability"] = 0.30
+    comp["comparison_levels"][2]["u_probability"] = 0.15
+    comp["comparison_levels"][3]["m_probability"] = 0.15
+    comp["comparison_levels"][3]["u_probability"] = 0.80
+    settings = _trained_settings([comp])
+
+    report = ConversionReport()
+    field = convert_comparison(comp, 0, report)
+    em = import_em([(comp, 0, field)], settings, report)
+    assert em is not None
+
+    m = em.m_probs["skills"]
+    assert len(m) == 3
+    # >=3 band (ratio 0.3) is the top level (index 2); >=1 band index 1; ELSE 0.
+    assert m[2] > m[1] > m[0]


### PR DESCRIPTION
## What and why

Builds on P1 (#2115, `array_intersect` scorer) and P2 (#2121, `date_diff` recognizer). Splink's `ArrayIntersectAtSizes` comparison levels were dropped by `from_splink`; P3a recognizes them and maps them to P1's `array_intersect` scorer, built against the REAL Splink 4 SQL (both dialects).

## Changes

- **`array_intersect` recognizer** (`config/from_splink.py`): matches `array_length(list_intersect("c_l", "c_r")) >= n` (DuckDB) and `SIZE(ARRAY_INTERSECT(\`c_l\`, \`c_r\`)) >= n` (Spark). Extracts the column + intersection count.
- **Count → ratio, per the resolved decision** (array count→ratio fidelity, deferred to me): Splink counts the intersection *size* (`>= n`) but `array_intersect` returns a *ratio*, so `>= n` is snapped to an overlap-coefficient threshold `min(1.0, n / 10)` (`_ARRAY_ASSUMED_SET_SIZE = 10`, biased low to preserve recall) and emitted as `array_intersect:overlap` with `approx=True` + a warning naming the approximation. Not adding a new `count:<n>` scorer mode (disproportionate surface for a rare comparison; revisit only if a measured recall gap appears).
- **`RecognizedLevel.scorer` override**: array's `:overlap` mode rides through `convert_comparison` while the family kind stays `array_intersect` for the single-domain-family check. `convert_comparison` resolves the field scorer from that override, else the family kind.
- **Result**: `ArrayIntersectAtSizes([3, 1])` → `array_intersect:overlap`, 3 levels `[0.3, 0.1]`.

## Geo deferred (P3b) — blocked on a schema decision

The plan assumed geo would emit a `MatchkeyField` with `derive_from=[lat, lng]` + a comma concat. **Verified that's wrong**: `derive_from` is on `NegativeEvidenceField` (not `MatchkeyField`) and it **space-joins**, whereas `geo_haversine` needs a **comma**-separated `"lat,lng"` field. Making geo work end-to-end needs a new synthesized-field mechanism on `MatchkeyField` + pipeline materialization — a cross-cutting schema/pipeline feature, not a recognizer. Documented in the plan (§10) with two options for a follow-up decision.

## Testing

- `test_from_splink_domain.py`: array recognizer (both dialects), conversion to `:overlap`, count→ratio snap warning, trained m/u import, + the now-triggerable two-distinct-domain-families guard.
- Full splink suite (10 files) → 166 passed.
- Polars-free import of `from_splink` verified.
- `ruff check` clean; parity `check_structure` + `check_scorer_coverage` → no errors; codemap regenerated + all `config_matrix` gates green locally.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff check`) clean on changed files
- [ ] Package `CHANGELOG.md` updated (deferred until the conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (plan doc §9 P3a delivered, §10 geo decision)

No parity-manifest change: `array_intersect` is P1's existing scorer; P3a adds a recognizer only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_