### PR TITLE
docs(design): ADBC-SQLite spike verdict (NO-GO) + DuckDB identity backend design

### DIFF
--- a/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
+++ b/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
@@ -1,6 +1,6 @@
 # Arrow-native SQLite bulk writes via ADBC — design + measurement plan
 
-**Date:** 2026-07-24 • **Status:** Proposed — spike NOT yet run, no dependency added
+**Date:** 2026-07-24 • **Status:** DECIDED 2026-07-25 — **NO-GO on ADBC. Ship the stdlib `staging` path.** See "Spike result" at the end.
 
 ## Question
 
@@ -220,3 +220,39 @@ than it is. Do not run the spike for a decision until #2111 has landed.
 - If option A lands, the `emit_singletons=True` guidance added to
   `identity-graph.mdx` in #2111 should be revisited — the reason for the warning
   is exactly the per-row Python object this would remove.
+
+## Spike result (2026-07-25) — NO-GO
+
+The spike ran (local Linux + the `large-new-64GB` workflow; content-hash
+identical across all arms). Directional local numbers:
+
+| N | arm | wall | peak RSS | db |
+|---|---|---|---|---|
+| 100k | rowpath | 19.95 s | 0.555 GB | 212 MB |
+| 100k | staging | 8.88 s | 0.556 GB | 212 MB |
+| 100k | adbc | 6.24 s | 0.505 GB | 338 MB |
+| 1M | staging | 182.4 s | 4.761 GB | 2175 MB |
+| 1M | adbc | 125.2 s | 4.665 GB | 3430 MB |
+
+Against the pre-committed kill criteria:
+
+- **`staging` captures the win** — 2.25× over `rowpath` at 100k, identical RSS,
+  zero new dependency. The null hypothesis held.
+- **`adbc` vs `staging`: 1.42× wall / 9% RSS at 100k, 1.46× wall / 2% RSS at 1M.**
+  Both below the `≥1.5× wall OR ≥30% RSS` bar → **NO-GO**.
+- **The RSS gap *closes* with scale (9% → 2%)**, refuting "adbc clearly wins on
+  RSS at 5M." The memory floor is the materialised Arrow table itself, not the
+  per-row Python object `adbc` skips — so Arrow-native ingest does **not** fix
+  `emit_singletons=True` at scale, which was the whole prize. `adbc` also writes a
+  larger DB (338 vs 212 MB; 3430 vs 2175 MB).
+
+**Decision: ship stdlib `staging` (staging table + `executemany` + the same
+`INSERT ... SELECT ... ON CONFLICT DO UPDATE`) as the SQLite bulk path; give the
+four `bulk_*` methods a real SQLite branch; do NOT take the `adbc-driver-sqlite`
+dependency.** Option A (whole-store-on-ADBC) is not justified — its only prize
+(Python-object elimination) does not move peak RSS.
+
+The residual memory ceiling (the actual `emit_singletons` scaling problem) is not
+addressed by any in-memory-Arrow write path. The one remaining lever is a
+*streaming* ingest that never materialises the full frame — explored, with DuckDB
+as the vehicle, in `2026-07-25-duckdb-identity-backend.md`.

--- a/docs/design/2026-07-25-duckdb-identity-backend.md
+++ b/docs/design/2026-07-25-duckdb-identity-backend.md
@@ -1,0 +1,215 @@
+# DuckDB as an Identity Store backend — design + decision
+
+**Date:** 2026-07-25 • **Status:** Proposed — perf motivation refuted by the ADBC spike; remaining case is strategic and needs its own measurement before building
+
+## Question
+
+`IdentityStore` supports three backends — `sqlite` (default, single-file),
+`postgres` (server, the only one with a bulk write fast path), and `mongo`
+(standalone class). There is **no DuckDB backend**: `store.py:278` raises
+`NotImplementedError` for any other `backend` value, and `goldenmatch/identity/`
+contains zero DuckDB code.
+
+DuckDB is attractive on paper for exactly the gap `sqlite` leaves: it is a
+single **file** with **no server** (like SQLite), but it has a columnar engine,
+native **Arrow** ingest, `INSERT ... SELECT ... ON CONFLICT DO UPDATE` (upsert),
+out-of-core execution that spills to disk, and it is already a first-class
+optional dependency in this repo (`goldenmatch[duckdb]`, `backends/duckdb_backend.py`,
+the chunked pipeline, the prepared-record store).
+
+So: **should the Identity Store gain a `backend="duckdb"` that gives single-node
+users the Postgres-class bulk write path — and the analytical read views — without
+standing up a server?**
+
+This doc is a companion to `2026-07-24-adbc-sqlite-bulk-writes.md`. That doc asked
+whether *SQLite* should get an Arrow-native bulk path via ADBC. Its spike has now
+run, and the result reshapes the DuckDB question below.
+
+## What the ADBC spike settled (and why it matters here)
+
+The ADBC spike (`scripts/spike_adbc_sqlite_ingest.py`, three arms — today's
+batched `rowpath`, a stdlib `staging` table + `executemany` + upsert, and
+Arrow-native `adbc` ingest into the same staging table) measured, byte-identical
+output across all arms:
+
+| N | arm | wall | peak RSS | db size |
+|---|---|---|---|---|
+| 100k (local, Linux) | rowpath | 19.95 s | 0.555 GB | 212 MB |
+| 100k | staging | 8.88 s | 0.556 GB | 212 MB |
+| 100k | adbc | 6.24 s | 0.505 GB | 338 MB |
+| 1M (local, Linux) | staging | 182.4 s | 4.761 GB | 2175 MB |
+| 1M | adbc | 125.2 s | 4.665 GB | 3430 MB |
+
+(The authoritative `large-new-64GB` run adds the 5M point and the 1M `rowpath`
+baseline; numbers here are local Linux and directional, but the *ratios* are the
+decision input and are stable across the two measured scales.)
+
+Two findings drive everything below:
+
+1. **`staging` (stdlib, zero new dependency) captures the bulk of the win.** It
+   is ~2.25× faster than `rowpath` at 100k with identical peak RSS. The
+   `emit_singletons=False` OOM was already removed by #2111; `staging` banks the
+   remaining per-statement throughput win with no dependency.
+2. **Arrow-native ingest does *not* fix the memory ceiling.** `adbc` ingests the
+   Arrow table directly — no `to_pylist()`, no per-row Python dict — yet its peak
+   RSS is within **2% of `staging` at 1M** (4.665 vs 4.761 GB), and the gap is
+   *closing* with scale (9% at 100k → 2% at 1M). The doc's headline hypothesis —
+   "eliminating the per-row Python object is the real prize" — is **refuted**:
+   the memory floor is the **materialised Arrow table itself** (~2.2 GB of
+   JSON-in-string payloads for 1M identities + 2.14M records), plus the engine's
+   write buffers, not the `to_pylist` delta on top of it.
+
+The ADBC verdict, by its own pre-committed kill criteria (`< 1.5× wall AND
+< 30% RSS at 1M ⇒ NO-GO; only proceed if Arrow ingest clearly wins on RSS at
+5M`): **NO-GO. Ship `staging`, drop the ADBC dependency.**
+
+**The load-bearing consequence for DuckDB:** DuckDB's bulk write, when handed the
+same in-memory Arrow table, sits behind the *same* Arrow-table memory floor as
+ADBC. Registering an Arrow table as a DuckDB view and running
+`INSERT ... SELECT ... ON CONFLICT` is the same shape as `adbc_ingest` + the same
+upsert — so on the metric the ADBC spike pre-committed to (peak RSS at scale),
+**DuckDB has no reason to beat `staging` either**, unless it does something ADBC
+did not: **stream the source instead of materialising it**.
+
+## Why DuckDB is still a candidate (a different case than ADBC)
+
+ADBC's only pitch was "Arrow-native write path." The spike killed that pitch on
+the numbers. DuckDB's pitch is broader and does not stand or fall on write
+throughput:
+
+1. **Server-less bulk path.** Today the ONLY backend with `bulk_upsert_identities`
+   / `bulk_upsert_records` / `bulk_add_edges` / `bulk_emit_events` is Postgres;
+   SQLite raises `NotImplementedError` and `resolve_clusters` gates on
+   `use_bulk_fast_path = _backend == "postgres"`. A DuckDB backend could give a
+   single-node user the bulk path **without a Postgres server** — one file, one
+   process. That is a product-positioning win independent of whether it beats
+   `staging` by a millisecond.
+2. **Native analytical read side.** The identity read surface is analytical —
+   `v_identities`, `v_identity_pairs`, `v_identity_timeline`
+   (`db/migrations/identity_v1.sql`), plus `entity_profile` / `identity_summary_stats`
+   / `steward_worklist` (`identity/profile.py`). Those are aggregation queries
+   DuckDB runs natively and SQLite runs slowly.
+3. **Potential to actually break the Arrow floor — the one perf angle left.**
+   Unlike the spike's in-memory arms, DuckDB can `read_parquet`/scan a source
+   lazily and spill, so an ingest that streams from the *source* (rather than a
+   fully-materialised in-memory Arrow table) could bound peak RSS below `staging`'s
+   4.7 GB at 1M. This is conditional on the write path handing DuckDB a lazy
+   source, which the current resolve path does not — see the measurement below.
+4. **Direction fit + already a dependency.** `duckdb>=0.9` and `pyarrow>=10` are
+   already present; the Frame seam has an Arrow lane; the chunked/prepared-record
+   subsystems already use DuckDB out-of-core. A DuckDB identity store is on the
+   existing grain, not a new axis.
+
+## Ceiling analysis — being explicit so we don't oversell
+
+**Throughput:** no order-of-magnitude left to win. `staging` already banks it;
+DuckDB's `INSERT ... SELECT ... ON CONFLICT` is the same accumulate-then-upsert
+shape. Expect parity-to-modest, not a multiple.
+
+**Memory, in-memory ingest:** DuckDB ≈ `staging` ≈ `adbc` — all gated by the
+materialised frame. No win.
+
+**Memory, streaming ingest:** *unknown and the only thing worth a spike.* If the
+resolve write path can stream cluster aggregates to DuckDB in bounded batches (or
+DuckDB scans a spilled source), peak RSS could drop below the frame floor. This
+is the same "bounded streaming on the ~2.2 GB live floor" lever the FS
+frame-residency work is chasing (`2026-07-20-fs-frame-residency-bucket-streaming-design.md`),
+applied to the identity write side.
+
+**Read latency:** clear DuckDB win on the analytical views; not why anyone
+picks a write backend, but it compounds the server-less case.
+
+## Options
+
+**A. First-class `backend="duckdb"` Identity Store.** A full third backend: schema
+DDL (translate `identity_v1.sql`), all CRUD, the four `bulk_*` methods (native via
+an Arrow view + `ON CONFLICT` upsert), `migrate-ids`, audit seal/verify, and the
+analytical views. `resolve_clusters` sets `use_bulk_fast_path` for `duckdb` too.
+Largest surface — `store.py` is deeply per-backend inlined, so this is a Mongo-class
+addition (its own branch or standalone class) plus a CI lane and the byte-identical
+parity gate. The strongest end state for the "server-less bulk + analytical" pitch.
+
+**B. DuckDB as a write *accelerator* for the SQLite store (`ATTACH`).** Keep SQLite
+as the on-disk format and the row path; for bulk flushes only, DuckDB `ATTACH`es
+the `.db` file and runs the Arrow-view `INSERT ... SELECT ... ON CONFLICT` into it.
+Smaller surface, reuses the SQLite schema and every existing SQLite reader. But it
+inherits the **single-writer sequencing** problem the ADBC doc's option B has
+(DuckDB's SQLite `ATTACH` write is a second writer against #2111's held
+transaction), the maturity of DuckDB's SQLite write path is a risk, and — given
+the spike — it is unlikely to beat stdlib `staging` on either axis. Hard to justify.
+
+**C. Do nothing DuckDB-specific.** Ship the ADBC spike's winner — stdlib `staging`
+for the SQLite bulk path — and keep routing past-the-low-millions users to Postgres.
+The null hypothesis, and consistent with the ADBC verdict. A DuckDB backend stays a
+future option gated on a real server-less-analytical user need.
+
+## The measurement that would decide (before building A)
+
+DuckDB's write path does **not** deserve the ADBC spike's benefit of the doubt on
+throughput — that question is answered. The only open, decision-changing question
+is **memory under a streaming ingest.** Add two arms to the existing harness
+(`spike_adbc_sqlite_ingest.py`) at 1M and 5M, byte-identical-gated like the rest:
+
+- `duckdb_inmem` — register the same `pyarrow.Table` as a view,
+  `INSERT INTO identity_nodes SELECT ... FROM v ON CONFLICT DO UPDATE`. Expected to
+  match `staging` on RSS (confirms the floor). Cheap to add; settles it.
+- `duckdb_stream` — write the source to Parquet first, then
+  `INSERT ... SELECT ... FROM read_parquet(...) ON CONFLICT DO UPDATE` so DuckDB
+  scans and spills instead of holding the frame. **This is the real test:** does
+  streaming ingest bound peak RSS below `staging`'s ~4.7 GB at 1M?
+
+**Kill criteria (pre-committed, mirroring the ADBC doc):**
+
+- If `duckdb_stream` does **not** beat `staging` by **≥ 30% peak RSS at 5M**, the
+  perf case is dead → **Option C**, and any DuckDB backend must be justified
+  purely by the server-less-analytical product need, not performance.
+- If `duckdb_stream` **does** clear ≥ 30% RSS at 5M, that is the first real lever
+  on the identity memory ceiling that does not require Postgres → pursue **Option
+  A**, gated behind the `[duckdb]` extra + a kill switch, with the parity gate as
+  the merge blocker.
+
+## Traps to carry into implementation
+
+1. **Byte-identical store parity is the merge gate.** Reuse
+   `tests/identity/test_resolve_scaling.py`'s `_dump` canonicalisation (identities
+   keyed by their record-id set, since `entity_id` is a random UUIDv7) — a faster
+   backend that writes different bytes is not a win. Same discipline the ADBC
+   spike's content-hash used.
+2. **The Postgres bulk path silently drops `payload`** (`bulk_upsert_records`'s
+   column list omits it; `bulk_emit_events` carries no event payload) while the
+   SQLite/row path stores it. Any DuckDB bulk path must carry payloads or it
+   reintroduces the ADBC doc's silent-data-regression trap. Decide whether to fix
+   Postgres to match at the same time.
+3. **DuckDB is also single-writer per file.** Unlike ADBC-alongside-SQLite this is
+   *one* connection if the whole backend is DuckDB (Option A), so no dual-writer
+   deadlock — but concurrent multi-process writers still serialise, same as the
+   SQLite WAL story. Don't advertise multi-writer.
+4. **Schema/type encodings must reproduce exactly.** `golden_record`, `payload`,
+   `field_scores`, `negative_evidence`, `controller_snapshot` are JSON-in-TEXT;
+   timestamps are ISO strings via `.isoformat()`. DuckDB has richer native types
+   (JSON, TIMESTAMP) — the backend must either store the same TEXT/ISO encodings
+   or the parity gate will flag drift. Prefer matching the existing encodings.
+5. **`ON CONFLICT ... FROM SELECT` parser quirk.** SQLite needs the `WHERE true`
+   workaround (ADBC doc); confirm DuckDB's `INSERT ... SELECT ... ON CONFLICT`
+   grammar and target-key requirements (DuckDB needs a UNIQUE/PK index on the
+   conflict target) up front.
+6. **New optional dependency discipline.** `backend="duckdb"` must degrade like
+   `[polars]` / `_native_loader` — a graceful error when `duckdb` is absent, never
+   a hard core dep. It is already a `[duckdb]` extra; the identity backend rides
+   that.
+
+## Recommendation
+
+**Adopt Option C now** (ship the ADBC spike's `staging` winner for the SQLite bulk
+path; keep Postgres for past-the-millions) and **do not build the DuckDB backend
+on a performance argument** — the ADBC spike refuted the Arrow-native-write-path
+motivation that DuckDB would otherwise inherit.
+
+Keep the DuckDB backend as a **live proposal with a single gating experiment**: the
+`duckdb_stream` arm above. It is the only path on which DuckDB could beat `staging`
+on the metric that matters (memory at scale), *and* it is the only lever that would
+hand a single-node user the bulk fast path without a Postgres server. If that arm
+clears ≥ 30% RSS at 5M, Option A becomes the most valuable identity-scale work on
+the board that does not require a server. If it does not, a DuckDB identity backend
+is a product decision about server-less analytical storage, to be prioritised on
+user demand — not a performance project.


### PR DESCRIPTION
## What and why

Follow-up to the identity-backend gap analysis. Two things: **(a)** ran the ADBC SQLite bulk-write spike now that #2111 has landed and recorded the verdict; **(b)** wrote a design doc weighing a DuckDB identity backend against that result.

## (a) ADBC spike — ran it, verdict is NO-GO

Ran `scripts/spike_adbc_sqlite_ingest.py` (local Linux with `adbc-driver-sqlite` installed so all three arms execute; the authoritative `large-new-64GB` workflow run is still finishing the 5M `rowpath` arm and will corroborate). Byte-identical output across arms.

| N | arm | wall | peak RSS | db |
|---|---|---|---|---|
| 100k | rowpath | 19.95s | 0.555 GB | 212 MB |
| 100k | staging | 8.88s | 0.556 GB | 212 MB |
| 100k | adbc | 6.24s | 0.505 GB | 338 MB |
| 1M | staging | 182.4s | 4.761 GB | 2175 MB |
| 1M | adbc | 125.2s | 4.665 GB | 3430 MB |

- **`staging` (stdlib, no new dependency) captures the win** — 2.25× over `rowpath` at 100k, identical RSS.
- **`adbc` vs `staging`: 1.42× wall / 9% RSS at 100k, 1.46× wall / 2% RSS at 1M** — both below the pre-committed `≥1.5× wall OR ≥30% RSS` bar → **NO-GO**.
- **The RSS gap *closes* with scale (9% → 2%)**, refuting the doc's core thesis that Arrow-native ingest removes the per-row memory. The floor is the materialised Arrow table itself, not the `to_pylist` delta — so ADBC does not fix `emit_singletons=True` at scale, which was the whole prize.

Recorded in `2026-07-24-adbc-sqlite-bulk-writes.md` (status → **DECIDED / NO-GO**): ship the stdlib `staging` path, give the four `bulk_*` methods a real SQLite branch, don't take the `adbc-driver-sqlite` dependency.

## (b) DuckDB identity backend — design doc

`2026-07-25-duckdb-identity-backend.md`. Because the spike refuted the Arrow-native-write performance motivation a DuckDB backend would inherit, the doc reframes the DuckDB case honestly:

- **Not** a throughput/memory play for in-memory ingest (DuckDB sits behind the same Arrow-table floor as ADBC).
- The real cases: **(1)** a *server-less* bulk write path — today the bulk fast path is Postgres-only — plus native analytical read views; **(2)** one open perf question worth a spike: whether a **streaming** DuckDB ingest (scan+spill from a source, not a materialised Arrow table) can bound peak RSS below `staging`'s ~4.7 GB at 1M — the only lever left on the identity memory ceiling that doesn't require Postgres.
- Options A (first-class `backend="duckdb"`) / B (DuckDB `ATTACH` write accelerator for the SQLite store) / C (do nothing, ship `staging`), a pre-committed `duckdb_stream` spike arm, kill criteria mirroring the ADBC doc, and the payload-drop / byte-parity / single-writer / encoding traps carried over.

**Recommendation:** adopt C now (ship `staging`); keep the DuckDB backend a live proposal gated on the single `duckdb_stream` experiment.

## Testing

Docs-only (design docs under `docs/design/`, git-tracked). No code changes.

## Checklist

- [x] No secrets, tokens, or `.env` files committed
- [ ] Tests — n/a (design docs)
- [ ] `CHANGELOG.md` — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_