### PR TITLE
docs(design): correct ADBC spike to authoritative 64GB numbers

### DIFF
--- a/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
+++ b/docs/design/2026-07-24-adbc-sqlite-bulk-writes.md
@@ -221,38 +221,55 @@ than it is. Do not run the spike for a decision until #2111 has landed.
   `identity-graph.mdx` in #2111 should be revisited — the reason for the warning
   is exactly the per-row Python object this would remove.
 
-## Spike result (2026-07-25) — NO-GO
+## Spike result (2026-07-25) — NO-GO on the dependency
 
-The spike ran (local Linux + the `large-new-64GB` workflow; content-hash
-identical across all arms). Directional local numbers:
+The spike ran on the sanctioned `large-new-64GB` runner (the authoritative
+numbers below), content-hash identical across all three arms at every scale. (A
+local-Linux pre-run agreed on the RSS story but understated `adbc`'s wall
+advantage — a slower local `staging` — so the box numbers are what count.)
 
-| N | arm | wall | peak RSS | db |
-|---|---|---|---|---|
-| 100k | rowpath | 19.95 s | 0.555 GB | 212 MB |
-| 100k | staging | 8.88 s | 0.556 GB | 212 MB |
-| 100k | adbc | 6.24 s | 0.505 GB | 338 MB |
-| 1M | staging | 182.4 s | 4.761 GB | 2175 MB |
-| 1M | adbc | 125.2 s | 4.665 GB | 3430 MB |
+| N | arm | wall | peak RSS | db | adbc vs staging → harness |
+|---|---|---|---|---|---|
+| 100k | rowpath | 13.74 s | 0.662 GB | 212 MB | |
+| 100k | staging | 5.44 s | 0.659 GB | 212 MB | |
+| 100k | adbc | 3.29 s | 0.566 GB | 338 MB | 1.65× wall, 14% RSS → **GO** |
+| 1M | rowpath | 175.94 s | 5.714 GB | 2175 MB | |
+| 1M | staging | 65.65 s | 5.715 GB | 2175 MB | |
+| 1M | adbc | 41.32 s | 5.294 GB | 3430 MB | 1.59× wall, 7% RSS → **GO** |
+| 5M | rowpath | 987.39 s | 24.719 GB | 10906 MB | |
+| 5M | staging | 445.05 s | 26.039 GB | 10906 MB | |
+| 5M | adbc | 392.15 s | 24.543 GB | 17184 MB | 1.13× wall, 6% RSS → **NO-GO** |
 
-Against the pre-committed kill criteria:
+The per-scale harness verdicts are **GO / GO / NO-GO**. Reading them honestly:
 
-- **`staging` captures the win** — 2.25× over `rowpath` at 100k, identical RSS,
-  zero new dependency. The null hypothesis held.
-- **`adbc` vs `staging`: 1.42× wall / 9% RSS at 100k, 1.46× wall / 2% RSS at 1M.**
-  Both below the `≥1.5× wall OR ≥30% RSS` bar → **NO-GO**.
-- **The RSS gap *closes* with scale (9% → 2%)**, refuting "adbc clearly wins on
-  RSS at 5M." The memory floor is the materialised Arrow table itself, not the
+- **`staging` is the always-safe win, zero new dependency.** ~2.5× over `rowpath`
+  at 100k, ~2.7× at 1M, ~2.2× at 5M, byte-identical output, identical RSS. The
+  null hypothesis (ship `staging`) holds regardless of what ADBC does.
+- **The memory prize — the whole stated motivation — is refuted at every scale.**
+  `adbc` is only 14% → 7% → **6%** lower peak RSS than `staging`, never within
+  reach of the 30% bar, and the gap **narrows** with scale (at 5M, 24.5 vs 26.0
+  GB). The materialised Arrow table + engine write buffers are the floor, not the
   per-row Python object `adbc` skips — so Arrow-native ingest does **not** fix
-  `emit_singletons=True` at scale, which was the whole prize. `adbc` also writes a
-  larger DB (338 vs 212 MB; 3430 vs 2175 MB).
+  `emit_singletons=True` at scale, which was the entire reason to consider it.
+- **`adbc`'s wall advantage is real but at the wrong scale.** It clears the 1.5×
+  bar at 100k/1M (1.65× / 1.59×) but **decays to 1.13× at 5M** — precisely the
+  scale where a bulk path is actually needed; sub-1M SQLite already finishes in
+  under a minute with `staging`.
+- **`adbc` costs more where it counts.** It writes a **58% larger DB at 5M**
+  (17.2 vs 10.9 GB), needs a bundled-shared-library dependency, and carries the
+  single-writer / dual-connection complexity from the design above.
 
-**Decision: ship stdlib `staging` (staging table + `executemany` + the same
-`INSERT ... SELECT ... ON CONFLICT DO UPDATE`) as the SQLite bulk path; give the
+**Decision: ship stdlib `staging` for the SQLite bulk path (staging table +
+`executemany` + the same `INSERT ... SELECT ... ON CONFLICT DO UPDATE`); give the
 four `bulk_*` methods a real SQLite branch; do NOT take the `adbc-driver-sqlite`
-dependency.** Option A (whole-store-on-ADBC) is not justified — its only prize
-(Python-object elimination) does not move peak RSS.
+dependency.** This is a considered call, not a clean sub-threshold miss: ADBC's
+one durable win (wall at small N) is at scales that don't need it, its win
+evaporates at the scale that does, it never delivers the memory prize, and it
+costs a native dependency + larger files + a more confusing transaction model.
+Option A (whole-store-on-ADBC) is therefore not justified.
 
 The residual memory ceiling (the actual `emit_singletons` scaling problem) is not
-addressed by any in-memory-Arrow write path. The one remaining lever is a
+addressed by any in-memory-Arrow write path — confirmed: even `adbc`, which never
+builds a Python row, is within 6% of `staging` at 5M. The one remaining lever is a
 *streaming* ingest that never materialises the full frame — explored, with DuckDB
 as the vehicle, in `2026-07-25-duckdb-identity-backend.md`.

--- a/docs/design/2026-07-25-duckdb-identity-backend.md
+++ b/docs/design/2026-07-25-duckdb-identity-backend.md
@@ -32,36 +32,48 @@ batched `rowpath`, a stdlib `staging` table + `executemany` + upsert, and
 Arrow-native `adbc` ingest into the same staging table) measured, byte-identical
 output across all arms:
 
+Authoritative `large-new-64GB` numbers, content-hash identical across all arms:
+
 | N | arm | wall | peak RSS | db size |
 |---|---|---|---|---|
-| 100k (local, Linux) | rowpath | 19.95 s | 0.555 GB | 212 MB |
-| 100k | staging | 8.88 s | 0.556 GB | 212 MB |
-| 100k | adbc | 6.24 s | 0.505 GB | 338 MB |
-| 1M (local, Linux) | staging | 182.4 s | 4.761 GB | 2175 MB |
-| 1M | adbc | 125.2 s | 4.665 GB | 3430 MB |
+| 100k | rowpath | 13.74 s | 0.662 GB | 212 MB |
+| 100k | staging | 5.44 s | 0.659 GB | 212 MB |
+| 100k | adbc | 3.29 s | 0.566 GB | 338 MB |
+| 1M | rowpath | 175.94 s | 5.714 GB | 2175 MB |
+| 1M | staging | 65.65 s | 5.715 GB | 2175 MB |
+| 1M | adbc | 41.32 s | 5.294 GB | 3430 MB |
+| 5M | rowpath | 987.39 s | 24.719 GB | 10906 MB |
+| 5M | staging | 445.05 s | 26.039 GB | 10906 MB |
+| 5M | adbc | 392.15 s | 24.543 GB | 17184 MB |
 
-(The authoritative `large-new-64GB` run adds the 5M point and the 1M `rowpath`
-baseline; numbers here are local Linux and directional, but the *ratios* are the
-decision input and are stable across the two measured scales.)
+Per-scale harness verdict (`adbc` vs `staging`, GO if ≥1.5× wall OR ≥30% RSS):
+**GO / GO / NO-GO** — 1.65× wall·14% RSS, 1.59× wall·7% RSS, 1.13× wall·6% RSS.
 
 Two findings drive everything below:
 
 1. **`staging` (stdlib, zero new dependency) captures the bulk of the win.** It
-   is ~2.25× faster than `rowpath` at 100k with identical peak RSS. The
-   `emit_singletons=False` OOM was already removed by #2111; `staging` banks the
-   remaining per-statement throughput win with no dependency.
+   is ~2.5× over `rowpath` at 100k, ~2.7× at 1M, ~2.2× at 5M, with identical peak
+   RSS. The `emit_singletons=False` OOM was already removed by #2111; `staging`
+   banks the remaining per-statement throughput win with no dependency. (`adbc`
+   is a further ~1.6× faster than `staging` at 100k/1M, but that advantage decays
+   to 1.13× at 5M — the scale where a bulk path is actually needed — and it is
+   the *wall*, not the memory, that ADBC moves.)
 2. **Arrow-native ingest does *not* fix the memory ceiling.** `adbc` ingests the
    Arrow table directly — no `to_pylist()`, no per-row Python dict — yet its peak
-   RSS is within **2% of `staging` at 1M** (4.665 vs 4.761 GB), and the gap is
-   *closing* with scale (9% at 100k → 2% at 1M). The doc's headline hypothesis —
-   "eliminating the per-row Python object is the real prize" — is **refuted**:
-   the memory floor is the **materialised Arrow table itself** (~2.2 GB of
-   JSON-in-string payloads for 1M identities + 2.14M records), plus the engine's
-   write buffers, not the `to_pylist` delta on top of it.
+   RSS is only **14% → 7% → 6% below `staging`** across 100k/1M/5M, never within
+   reach of the 30% bar, and the gap **narrows** with scale (at 5M, 24.5 vs 26.0
+   GB). The doc's headline hypothesis — "eliminating the per-row Python object is
+   the real prize" — is **refuted**: the memory floor is the **materialised Arrow
+   table itself** (~JSON-in-string payloads across the identity + record columns)
+   plus the engine's write buffers, not the `to_pylist` delta on top of it.
 
-The ADBC verdict, by its own pre-committed kill criteria (`< 1.5× wall AND
-< 30% RSS at 1M ⇒ NO-GO; only proceed if Arrow ingest clearly wins on RSS at
-5M`): **NO-GO. Ship `staging`, drop the ADBC dependency.**
+The per-scale harness verdict is GO / GO / NO-GO (adbc clears the 1.5× wall bar
+at 100k/1M but decays to 1.13× at 5M, and never approaches the 30% RSS bar). The
+**net** ADBC decision is still **NO-GO on the dependency** — the wall win is at
+scales that don't need a bulk path and evaporates at 5M, the memory prize never
+materialises, and it costs a native dependency + 58%-larger files + the
+single-writer complexity. Ship stdlib `staging`. (Full reasoning in the ADBC
+doc's "Spike result".)
 
 **The load-bearing consequence for DuckDB:** DuckDB's bulk write, when handed the
 same in-memory Arrow table, sits behind the *same* Arrow-table memory floor as
@@ -93,7 +105,7 @@ throughput:
    Unlike the spike's in-memory arms, DuckDB can `read_parquet`/scan a source
    lazily and spill, so an ingest that streams from the *source* (rather than a
    fully-materialised in-memory Arrow table) could bound peak RSS below `staging`'s
-   4.7 GB at 1M. This is conditional on the write path handing DuckDB a lazy
+   ~5.7 GB at 1M / ~26 GB at 5M. This is conditional on the write path handing DuckDB a lazy
    source, which the current resolve path does not — see the measurement below.
 4. **Direction fit + already a dependency.** `duckdb>=0.9` and `pyarrow>=10` are
    already present; the Frame seam has an Arrow lane; the chunked/prepared-record
@@ -156,7 +168,7 @@ is **memory under a streaming ingest.** Add two arms to the existing harness
 - `duckdb_stream` — write the source to Parquet first, then
   `INSERT ... SELECT ... FROM read_parquet(...) ON CONFLICT DO UPDATE` so DuckDB
   scans and spills instead of holding the frame. **This is the real test:** does
-  streaming ingest bound peak RSS below `staging`'s ~4.7 GB at 1M?
+  streaming ingest bound peak RSS below `staging`'s ~5.7 GB at 1M / ~26 GB at 5M?
 
 **Kill criteria (pre-committed, mirroring the ADBC doc):**
 


### PR DESCRIPTION
## What and why

The ADBC spike design docs (merged in #2123) recorded a local-Linux **pre-run** whose unusually slow `staging` arm understated `adbc`'s wall advantage. The sanctioned `large-new-64GB` spike run (`spike-adbc-sqlite-ingest.yml`, run 30164295600) has now finished — this swaps in its authoritative numbers and corrects the reading.

## Authoritative numbers (content-hash identical across arms)

| N | adbc vs staging | harness |
|---|---|---|
| 100k | 1.65× wall, 14% RSS | GO |
| 1M | 1.59× wall, 7% RSS | GO |
| 5M | 1.13× wall, 6% RSS | NO-GO |

## What changed vs the local read

- **Wall (corrected):** `adbc` *is* ~1.6× faster than `staging` at 100k/1M (harness **GO**) — not the sub-1.5× the slow-local `staging` implied — but the advantage **decays to 1.13× at 5M**, the scale a bulk path is actually for.
- **Memory (confirmed, now at 5M):** `adbc` is only 14%→7%→**6%** lower RSS, gap **narrowing** with scale, never near the 30% bar → the "eliminate the per-row Python object" prize is refuted at every scale; the materialized Arrow table is the floor. `adbc` also writes a **58%-larger DB at 5M** (17.2 vs 10.9 GB).
- Fixed a mis-stated kill-criterion line in the DuckDB doc (at 1M `adbc` clears 1.5× wall → GO, not NO-GO).

## Net decision — unchanged

Ship stdlib `staging`, don't take the `adbc-driver-sqlite` dependency — now framed honestly as a **considered judgment** (wall win at scales that don't need it + evaporates at 5M + no memory win + native dep + larger files), not a clean sub-threshold miss. The DuckDB doc's memory/streaming thesis is unaffected — the RSS refutation is confirmed at 5M, which is exactly what motivates the `duckdb_stream` experiment.

## Testing

Docs-only (`docs/design/`). No code.

## Checklist

- [x] No secrets, tokens, or `.env` files committed
- [ ] Tests — n/a (design docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_