### PR TITLE
Splink domain-comparator conversion P3b: geo_haversine + MatchkeyField.derive_from

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -413,6 +413,8 @@ _Identity Graph configuration._
 | `type` | Literal \| None | `None` | `exact`, `weighted`, `probabilistic` -- Workbench hint for which matchkey kind to wrap this field in when translating a flat field list. |
 | `em_iterations` | int \| None | `None` | Per-field cap on EM training iterations for a probabilistic comparison. |
 | `level_thresholds` | list[float] \| None | `None` | Descending similarity cutoffs defining each custom probabilistic band; must hold levels-1 entries. |
+| `derive_from` | list[str] \| None | `None` | Source columns joined with derive_separator to synthesize the compared field when it is not present in the raw frame. |
+| `derive_separator` | str | `' '` | Separator used to join derive_from source columns (space for names, ',' for geo_haversine lat,long). |
 
 ### `NegativeEvidenceField`
 _v1.11: a field whose disagreement subtracts from a weighted matchkey's_

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -938,6 +938,8 @@
             "_convert_one_blocking_rule",
             "_findings_preview",
             "_load_settings",
+            "_looks_like_date_diff",
+            "_looks_like_haversine",
             "_patch_field_placeholders",
             "_recognize_blocking_conjunct",
             "_strip_outer_parens",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -1565,6 +1565,20 @@
               "required": false,
               "default": "None",
               "description": "Descending similarity cutoffs defining each custom probabilistic band; must hold levels-1 entries."
+            },
+            {
+              "name": "derive_from",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Source columns joined with derive_separator to synthesize the compared field when it is not present in the raw frame."
+            },
+            {
+              "name": "derive_separator",
+              "type": "str",
+              "required": false,
+              "default": "' '",
+              "description": "Separator used to join derive_from source columns (space for names, ',' for geo_haversine lat,long)."
             }
           ]
         },

--- a/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
+++ b/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
@@ -272,3 +272,30 @@ scoring. That's a cross-cutting schema + pipeline feature (higher-risk, own test
 recognizer. **Decision needed from Ben** (see the session hand-off): (a) add the derive_from+separator
 plumbing to MatchkeyField as P3b, or (b) recognize the haversine level but emit it as a DROPPED
 comparison with a clear "cross-column geo not yet representable" warning until the plumbing lands.
+
+## 11. P3b delivered — geo_haversine + MatchkeyField.derive_from (2026-07-25)
+Ben chose "add the derive_from plumbing." `DistanceInKMAtThresholds` now converts, via a NEW
+synthesized-field mechanism on `MatchkeyField`:
+- **Schema:** `MatchkeyField.derive_from: list[str] | None` + `derive_separator: str = " "` (validated
+  >=2 sources). Splink gives separate lat+lng; geo_haversine scores one "lat,long" field, so the
+  converter emits `derive_from=[lat,lng]`, `derive_separator=","`.
+- **Materialization (BOTH lanes):** `precompute_matchkey_transforms` (polars) + `..._frame` (arrow,
+  the goldenmatch default) now synthesize `MatchkeyField.derive_from` fields, not just NE ones,
+  honoring the per-field separator. Threaded a `separator=` param through `Column.derive_ne_joined`
+  (protocol/polars/arrow) + `arrow_derive.ne_joined_column` (default " " keeps NE byte-identical).
+- **Required-columns:** `pipeline._get_required_columns` requires a derive_from field's SOURCES, not
+  the synthesized name (else the raw-frame column check fails on `lat__lng`).
+- **Recognizer:** `_GEO_MARKER`/`_GEO_LAT`/`_GEO_LNG`/`_GEO_KM` match the haversine signature
+  (`acos ... radians ... * 6371 ... <= km`) both dialects; lat = the bare `radians(col_l|col_r)`,
+  lng = the `radians(col_r - col_l)` difference, km -> `_geo_haversine_band`. `RecognizedLevel` gained
+  `derive_from`/`derive_separator`; `convert_comparison` threads them into the MatchkeyField.
+  `DistanceInKM([1,10])` -> `geo_haversine`, field `lat__lng`, levels `[0.85, 0.5]`, derive `,`.
+- **Tests:** `test_from_splink_geo.py` (13) incl. an END-TO-END `dedupe_df` proving nearby coords
+  cluster + far coords don't (the synthesized field really scores). NE space-join unchanged
+  (`test_facility_fullname_ne` green). Full affected suites 319 green; polars-free; codemap +
+  config-matrix + agent-manifest regenerated. No parity-manifest change (geo_haversine is an
+  existing scorer).
+
+**Roadmap now:** P1 array_intersect scorer + P2 date_diff + P3a array_intersect recognizer + P3b
+geo/derive_from all shipped. Numeric = opportunistic. Remaining: P4 `domain_bands` upgrade lever,
+P5 Rust kernels (array_intersect/numeric_diff), P6 TS parity.

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -66,13 +66,28 @@ _DIST_RE = (
 # The column atom is pulled from the try_strptime / try_to_timestamp call (the
 # _l/_r operand); the seconds cutoff is converted to days and snapped to a
 # `_date_diff_band` value -- approximate, like the levenshtein distance->sim map.
-_DATE_DIFF_MARKER = re.compile(r'\bABS\s*\(.*(?:EPOCH|UNIX_TIMESTAMP)\s*\(', re.IGNORECASE)
+# The "looks like" gate is a LINEAR substring check (not a `.*` regex -- these
+# run on arbitrary Splink SQL, so a backtracking marker is a ReDoS risk); the
+# anchored TAIL/COL regexes below are the real structural validators.
 _DATE_DIFF_TAIL = re.compile(r'<=\s*([0-9]+(?:\.[0-9]+)?)\s*$')
 _DATE_DIFF_COL = re.compile(
     r'(?:try_strptime|try_to_timestamp)\s*\(\s*["`]?([A-Za-z_]\w*)_([lr])["`]?\s*,',
     re.IGNORECASE,
 )
 _SECONDS_PER_DAY = 86400.0
+
+
+def _looks_like_date_diff(sql_norm: str) -> bool:
+    """Linear (ReDoS-safe) gate for a date/time-difference level."""
+    low = sql_norm.lower()
+    return "abs" in low and ("epoch" in low or "unix_timestamp" in low)
+
+
+def _looks_like_haversine(sql_norm: str) -> bool:
+    """Linear (ReDoS-safe) gate for a great-circle distance level."""
+    low = sql_norm.lower()
+    return "acos" in low and "radians" in low and "6371" in low
+
 
 LevelKind = Literal[
     "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff",
@@ -103,8 +118,9 @@ _ARRAY_INTERSECT_SCORER = "array_intersect:overlap"
 # conversion synthesizes that field via MatchkeyField.derive_from=[lat,lng] +
 # derive_separator="," (materialized by the pipeline). The lat column is the arg
 # of a bare radians(col_l|col_r); the lng column is the two operands of the
-# radians(col_r - col_l) difference; the km cutoff is the trailing "<= n".
-_GEO_MARKER = re.compile(r'acos\s*\(.*\*\s*6371', re.IGNORECASE)
+# radians(col_r - col_l) difference; the km cutoff is the trailing "<= n". The
+# entry gate is the linear `_looks_like_haversine` above; the anchored regexes
+# below do the real extraction.
 _GEO_LAT = re.compile(r'radians\s*\(\s*["`]?([A-Za-z_]\w*)_[lr]["`]?\s*\)', re.IGNORECASE)
 _GEO_LNG = re.compile(
     r'radians\s*\(\s*["`]?([A-Za-z_]\w*)_r["`]?\s*-\s*["`]?([A-Za-z_]\w*)_l["`]?\s*\)',
@@ -188,7 +204,7 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
         sim = max(0.0, 1 - distance / _LEV_ASSUMED_LEN)
         return RecognizedLevel("levenshtein", col_l, sim, approx=True)
 
-    if _DATE_DIFF_MARKER.search(sql_norm):
+    if _looks_like_date_diff(sql_norm):
         tail = _DATE_DIFF_TAIL.search(sql_norm)
         cols = _DATE_DIFF_COL.findall(sql_norm)
         if tail and cols:
@@ -212,7 +228,7 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
             "array_intersect", col_l, ratio, approx=True, scorer=_ARRAY_INTERSECT_SCORER
         )
 
-    if _GEO_MARKER.search(sql_norm):
+    if _looks_like_haversine(sql_norm):
         km = _GEO_KM.search(sql_norm)
         lat_bases = {b for b in _GEO_LAT.findall(sql_norm)}
         lng_m = _GEO_LNG.search(sql_norm)

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -24,7 +24,7 @@ from goldenmatch.config.schemas import (
 )
 from goldenmatch.core._paths import safe_path
 from goldenmatch.core.probabilistic import EMResult, _training_config_manifest
-from goldenmatch.core.scorer import _date_diff_band
+from goldenmatch.core.scorer import _date_diff_band, _geo_haversine_band
 
 Severity = Literal["info", "warning", "error"]
 
@@ -76,7 +76,7 @@ _SECONDS_PER_DAY = 86400.0
 
 LevelKind = Literal[
     "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff",
-    "array_intersect",
+    "array_intersect", "geo_haversine",
 ]
 
 # ArrayIntersectAtSizes levels count the intersection SIZE:
@@ -94,6 +94,23 @@ _ARRAY_INTERSECT_LEVEL_RE = re.compile(
 )
 _ARRAY_ASSUMED_SET_SIZE = 10.0
 _ARRAY_INTERSECT_SCORER = "array_intersect:overlap"
+
+# DistanceInKMAtThresholds is the ONE cross-column comparison: a great-circle
+# (haversine) distance over SEPARATE lat + lng columns, capped in km:
+#   cast( acos( ... radians("lat_l") ... radians("lat_r") ...
+#               radians("lng_r" - "lng_l") ... ) * 6371 as float ) <= <km>
+# goldenmatch's geo_haversine scores ONE combined "lat,long" field, so the
+# conversion synthesizes that field via MatchkeyField.derive_from=[lat,lng] +
+# derive_separator="," (materialized by the pipeline). The lat column is the arg
+# of a bare radians(col_l|col_r); the lng column is the two operands of the
+# radians(col_r - col_l) difference; the km cutoff is the trailing "<= n".
+_GEO_MARKER = re.compile(r'acos\s*\(.*\*\s*6371', re.IGNORECASE)
+_GEO_LAT = re.compile(r'radians\s*\(\s*["`]?([A-Za-z_]\w*)_[lr]["`]?\s*\)', re.IGNORECASE)
+_GEO_LNG = re.compile(
+    r'radians\s*\(\s*["`]?([A-Za-z_]\w*)_r["`]?\s*-\s*["`]?([A-Za-z_]\w*)_l["`]?\s*\)',
+    re.IGNORECASE,
+)
+_GEO_KM = re.compile(r'<=\s*([0-9]+(?:\.[0-9]+)?)\s*$')
 
 # Domain comparators (magnitude-aware) take precedence over string-edit levels
 # in the same Splink comparison -- e.g. DateOfBirthComparison mixes a
@@ -118,6 +135,8 @@ class RecognizedLevel:
     sim_threshold: float | None
     approx: bool = False      # True when the mapping is an approximation (jaro->jw, distance->similarity)
     scorer: str | None = None  # full scorer string when it differs from `kind` (e.g. "array_intersect:overlap")
+    derive_from: list[str] | None = None  # cross-column source cols to synthesize `column` (geo lat+lng)
+    derive_separator: str = " "           # separator joining derive_from (geo needs ",")
 
 
 def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel | None:
@@ -192,6 +211,25 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
         return RecognizedLevel(
             "array_intersect", col_l, ratio, approx=True, scorer=_ARRAY_INTERSECT_SCORER
         )
+
+    if _GEO_MARKER.search(sql_norm):
+        km = _GEO_KM.search(sql_norm)
+        lat_bases = {b for b in _GEO_LAT.findall(sql_norm)}
+        lng_m = _GEO_LNG.search(sql_norm)
+        if km and len(lat_bases) == 1 and lng_m and lng_m.group(1) == lng_m.group(2):
+            lat, lng = next(iter(lat_bases)), lng_m.group(1)
+            if lat != lng:
+                # Synthesize a combined "lat,long" field the geo_haversine
+                # scorer parses; the band comes from the km cutoff.
+                return RecognizedLevel(
+                    "geo_haversine",
+                    f"{lat}__{lng}",
+                    _geo_haversine_band(float(km.group(1))),
+                    approx=True,
+                    derive_from=[lat, lng],
+                    derive_separator=",",
+                )
+        # haversine-shaped but couldn't extract a clean lat/lng/km -> drop+warn.
 
     return None
 
@@ -389,6 +427,12 @@ def convert_comparison(
                     f"to overlap-ratio threshold {r.sim_threshold} (assumed set size "
                     f"{int(_ARRAY_ASSUMED_SET_SIZE)}, biased low for recall) ({sql})"
                 )
+            elif r.kind == "geo_haversine":
+                message = (
+                    "approximate mapping: great-circle km cutoff snapped to the nearest "
+                    f"geo_haversine band -> sim {r.sim_threshold}; lat+lng synthesized into "
+                    f"a comma-joined field {r.derive_from} ({sql})"
+                )
             else:
                 message = (
                     f"approximate mapping: jaro_similarity treated as jaro_winkler "
@@ -425,6 +469,13 @@ def convert_comparison(
 
     mapped_to = f"{_PLACEHOLDER_PREFIX} ({col})"
 
+    # A cross-column band (geo_haversine) carries the source columns to
+    # synthesize `col` from; None for every single-column comparator.
+    derive_from = next((r.derive_from for r, _, _ in bands if r.derive_from), None)
+    derive_separator = next(
+        (r.derive_separator for r, _, _ in bands if r.derive_from), " "
+    )
+
     if levels_count == 2:
         if scorer == "exact":
             field = MatchkeyField(field=col, scorer="exact", levels=2, tf_adjustment=tf_adjustment)
@@ -435,6 +486,8 @@ def convert_comparison(
                 levels=2,
                 partial_threshold=thresholds[0],
                 tf_adjustment=tf_adjustment,
+                derive_from=derive_from,
+                derive_separator=derive_separator,
             )
     else:
         field = MatchkeyField(
@@ -443,6 +496,8 @@ def convert_comparison(
             levels=levels_count,
             level_thresholds=thresholds,
             tf_adjustment=tf_adjustment,
+            derive_from=derive_from,
+            derive_separator=derive_separator,
         )
 
     report.info(comp_path, f"converted to field '{col}' (scorer={scorer})", mapped_to=mapped_to)

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -236,6 +236,20 @@ class MatchkeyField(BaseModel):
         default=None,
         description="Descending similarity cutoffs defining each custom probabilistic band; must hold levels-1 entries.",
     )
+    # When set, ``field`` is SYNTHESIZED by the pipeline before scoring by
+    # joining ``derive_from`` with ``derive_separator`` (e.g. a geo_haversine
+    # "lat,long" field from ['lat','lng'] with separator ","). Mirrors
+    # NegativeEvidenceField.derive_from, but the separator is configurable (NE
+    # space-joins; geo needs comma so _parse_latlong reads it). None => ``field``
+    # must already exist in the frame.
+    derive_from: list[str] | None = Field(
+        default=None,
+        description="Source columns joined with derive_separator to synthesize the compared field when it is not present in the raw frame.",
+    )
+    derive_separator: str = Field(
+        default=" ",
+        description="Separator used to join derive_from source columns (space for names, ',' for geo_haversine lat,long).",
+    )
 
     @model_validator(mode="after")
     def _resolve_field_column(self) -> MatchkeyField:
@@ -265,6 +279,10 @@ class MatchkeyField(BaseModel):
             self.field = self.column
         elif self.field is None and self.column is None:
             raise ValueError("MatchkeyField requires 'field' or 'column'.")
+        if self.derive_from is not None and len(self.derive_from) < 2:
+            raise ValueError(
+                "derive_from must name at least 2 source columns to synthesize the field"
+            )
         for t in self.transforms:
             FieldTransform(transform=t)  # reuse validation
         if self.scorer is not None and not _is_valid_scorer(self.scorer):

--- a/packages/python/goldenmatch/goldenmatch/core/arrow_derive.py
+++ b/packages/python/goldenmatch/goldenmatch/core/arrow_derive.py
@@ -396,16 +396,17 @@ def matchkey_composite(
     return pc.binary_join_element_wise(*cols, sep_scalar, null_handling="emit_null")
 
 
-def ne_joined_column(field_arrs: Sequence[Any]) -> Any:
-    """precompute_matchkey_transforms' derived-NE source join
-    (matchkey.py:381-386): per-field Utf8 cast + fill_null("") + space-join.
-    fill_null means the join NEVER null-propagates -- a missing part joins as
-    the empty string, exactly like the Polars expression."""
+def ne_joined_column(field_arrs: Sequence[Any], separator: str = " ") -> Any:
+    """precompute_matchkey_transforms' derived source join
+    (matchkey.py:381-386): per-field Utf8 cast + fill_null("") + separator-join
+    (space for NE, "," for a geo_haversine lat,long field). fill_null means the
+    join NEVER null-propagates -- a missing part joins as the empty string,
+    exactly like the Polars expression."""
     import pyarrow as pa
     import pyarrow.compute as pc
 
     filled = [pc.fill_null(cast_utf8(a), "") for a in field_arrs]
     if len(filled) == 1:
         return filled[0]
-    sep_scalar = pa.scalar(" ", type=pa.large_string())
+    sep_scalar = pa.scalar(separator, type=pa.large_string())
     return pc.binary_join_element_wise(*filled, sep_scalar, null_handling="emit_null")

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -208,7 +208,7 @@ class Frame(Protocol):
     def derive_matchkey(
         self, fields_with_chains: Sequence[tuple[str, Sequence[str]]], sep: str = "||"
     ) -> Column: ...
-    def derive_ne_joined(self, fields: Sequence[str]) -> Column: ...
+    def derive_ne_joined(self, fields: Sequence[str], separator: str = " ") -> Column: ...
     # W4a tail/distributed ops (fixtures: tests/test_frame_w4_ops.py). Probed
     # semantics: filter_in DROPS null rows on both backends (polars null mask,
     # pc.is_in False); with_pair_canonical min/max_horizontal SKIP nulls;
@@ -721,9 +721,11 @@ class PolarsFrame:
         out = field_exprs[0] if len(field_exprs) == 1 else pl.concat_str(field_exprs, separator=sep)
         return PolarsColumn(self._df.select(out.alias("__mk__"))["__mk__"])
 
-    def derive_ne_joined(self, fields: Sequence[str]) -> PolarsColumn:
+    def derive_ne_joined(self, fields: Sequence[str], separator: str = " ") -> PolarsColumn:
         # precompute_matchkey_transforms' derived-NE join (matchkey.py:381-386).
-        expr = pl.concat_str([pl.col(c).cast(pl.Utf8).fill_null("") for c in fields], separator=" ")
+        expr = pl.concat_str(
+            [pl.col(c).cast(pl.Utf8).fill_null("") for c in fields], separator=separator
+        )
         return PolarsColumn(self._df.select(expr.alias("__ne__"))["__ne__"])
 
     # -- W4a tail/distributed ops --------------------------------------------
@@ -1546,10 +1548,14 @@ class ArrowFrame:
         pairs = [(self._tbl.column(f), list(t)) for f, t in fields_with_chains]
         return ArrowColumn(arrow_derive.matchkey_composite(pairs, sep=sep))
 
-    def derive_ne_joined(self, fields: Sequence[str]) -> ArrowColumn:
+    def derive_ne_joined(self, fields: Sequence[str], separator: str = " ") -> ArrowColumn:
         from goldenmatch.core import arrow_derive
 
-        return ArrowColumn(arrow_derive.ne_joined_column([self._tbl.column(f) for f in fields]))
+        return ArrowColumn(
+            arrow_derive.ne_joined_column(
+                [self._tbl.column(f) for f in fields], separator=separator
+            )
+        )
 
     # -- W4a tail/distributed ops --------------------------------------------
 

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -371,20 +371,30 @@ def precompute_matchkey_transforms(
     # => skip (the NE no-ops safely rather than raising).
     _derived_exprs: list[pl.Expr] = []
     _seen_derived: set[str] = set()
+
+    def _add_derived(obj: object, separator: str) -> None:
+        src = getattr(obj, "derive_from", None)
+        fld = getattr(obj, "field", None)
+        if not src or fld is None or fld in df.columns or fld in _seen_derived:
+            return
+        if not all(c in df.columns for c in src):
+            return
+        _seen_derived.add(fld)
+        _derived_exprs.append(
+            pl.concat_str(
+                [pl.col(c).cast(pl.Utf8).fill_null("") for c in src],
+                separator=separator,
+            ).alias(fld)
+        )
+
     for mk in matchkeys:
         for ne in (getattr(mk, "negative_evidence", None) or []):
-            src = getattr(ne, "derive_from", None)
-            if not src or ne.field in df.columns or ne.field in _seen_derived:
-                continue
-            if not all(c in df.columns for c in src):
-                continue
-            _seen_derived.add(ne.field)
-            _derived_exprs.append(
-                pl.concat_str(
-                    [pl.col(c).cast(pl.Utf8).fill_null("") for c in src],
-                    separator=" ",
-                ).alias(ne.field)
-            )
+            _add_derived(ne, " ")
+        # MatchkeyField.derive_from (e.g. geo_haversine "lat,long" from a Splink
+        # DistanceInKM conversion) synthesizes its scorer field too, with a
+        # configurable separator (NE always space-joins).
+        for field in mk.fields:
+            _add_derived(field, getattr(field, "derive_separator", " ") or " ")
     if _derived_exprs:
         df = df.with_columns(_derived_exprs)
 
@@ -446,15 +456,22 @@ def precompute_matchkey_transforms_frame(frame, matchkeys: list[MatchkeyConfig])
     # Synthesized NE columns first (matchkey.py legacy order): a derived NE
     # field must exist before its xform signature materializes below.
     seen_derived: set[str] = set()
+
+    def _maybe_derive(f, obj, separator):
+        src = getattr(obj, "derive_from", None)
+        fld = getattr(obj, "field", None)
+        if not src or fld is None or fld in f.columns or fld in seen_derived:
+            return f
+        if not all(c in f.columns for c in src):
+            return f
+        seen_derived.add(fld)
+        return f.with_column(fld, f.derive_ne_joined(list(src), separator=separator))
+
     for mk in matchkeys:
         for ne in (getattr(mk, "negative_evidence", None) or []):
-            src = getattr(ne, "derive_from", None)
-            if not src or ne.field in f.columns or ne.field in seen_derived:
-                continue
-            if not all(c in f.columns for c in src):
-                continue
-            seen_derived.add(ne.field)
-            f = f.with_column(ne.field, f.derive_ne_joined(list(src)))
+            f = _maybe_derive(f, ne, " ")
+        for field in mk.fields:
+            f = _maybe_derive(f, field, getattr(field, "derive_separator", " ") or " ")
 
     seen: set[str] = set()
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1620,6 +1620,13 @@ def _get_required_columns(config: GoldenMatchConfig) -> list[str]:
                     c for c in f.columns
                     if not (c.startswith("__") and c.endswith("__"))
                 )
+            elif getattr(f, "derive_from", None):
+                # A synthesized field (e.g. geo_haversine "lat,long") is built by
+                # the pipeline from derive_from; require its SOURCES, not itself.
+                cols.update(
+                    c for c in f.derive_from
+                    if not (c.startswith("__") and c.endswith("__"))
+                )
             elif f.field and f.field != "__record__":
                 if not (f.field.startswith("__") and f.field.endswith("__")):
                     cols.add(f.field)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1620,7 +1620,7 @@ def _get_required_columns(config: GoldenMatchConfig) -> list[str]:
                     c for c in f.columns
                     if not (c.startswith("__") and c.endswith("__"))
                 )
-            elif getattr(f, "derive_from", None):
+            elif f.derive_from:
                 # A synthesized field (e.g. geo_haversine "lat,long") is built by
                 # the pipeline from derive_from; require its SOURCES, not itself.
                 cols.update(

--- a/packages/python/goldenmatch/tests/test_from_splink_geo.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_geo.py
@@ -1,0 +1,155 @@
+"""P3b: Splink DistanceInKMAtThresholds -> geo_haversine conversion.
+
+Geo is the ONE cross-column comparison: Splink gives SEPARATE lat + lng columns,
+but goldenmatch's geo_haversine scores ONE comma-joined "lat,long" field. The
+conversion emits a MatchkeyField.derive_from=[lat,lng] + derive_separator=","
+that the pipeline materializes before scoring. SQL below is the REAL splink 4
+serialization (cl.DistanceInKMAtThresholds('lat','lng',[1,10]).get_comparison).
+"""
+import pyarrow as pa
+import pytest
+from goldenmatch.config.from_splink import (
+    ConversionReport,
+    convert_comparison,
+    recognize_level,
+)
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.frame import to_frame
+from goldenmatch.core.matchkey import precompute_matchkey_transforms_frame
+
+
+def _geo_level(km, quote='"'):
+    """Real DuckDB (quote=\") / Spark (quote=`) haversine level SQL at <km>."""
+    c = lambda n: f"{quote}{n}{quote}"  # noqa: E731
+    return (
+        f"cast( acos( case when ( sin( radians({c('lat_l')}) ) * sin( radians({c('lat_r')}) ) "
+        f"+ cos( radians({c('lat_l')}) ) * cos( radians({c('lat_r')}) ) "
+        f"* cos( radians({c('lng_r')} - {c('lng_l')}) ) ) > 1 then 1 "
+        f"when ( sin( radians({c('lat_l')}) ) * sin( radians({c('lat_r')}) ) "
+        f"+ cos( radians({c('lat_l')}) ) * cos( radians({c('lat_r')}) ) "
+        f"* cos( radians({c('lng_r')} - {c('lng_l')}) ) ) < -1 then -1 "
+        f"else ( sin( radians({c('lat_l')}) ) * sin( radians({c('lat_r')}) ) "
+        f"+ cos( radians({c('lat_l')}) ) * cos( radians({c('lat_r')}) ) "
+        f"* cos( radians({c('lng_r')} - {c('lng_l')}) ) ) end ) * 6371 as float ) <= {km}"
+    )
+
+
+@pytest.mark.parametrize("quote", ['"', "`"])
+@pytest.mark.parametrize("km,band", [(1, 0.85), (10, 0.5), (100, 0.2)])
+def test_geo_recognized_both_dialects(quote, km, band):
+    r = recognize_level(_geo_level(km, quote))
+    assert r is not None
+    assert r.kind == "geo_haversine"
+    assert r.column == "lat__lng"
+    assert r.derive_from == ["lat", "lng"]
+    assert r.derive_separator == ","
+    assert r.sim_threshold == pytest.approx(band, abs=1e-9)
+    assert r.approx is True
+
+
+def test_geo_mismatched_lat_lng_dropped():
+    # lat operands disagree (lat vs latitude) -> not a clean single-lat haversine.
+    sql = _geo_level(1).replace('radians("lat_r")', 'radians("latitude_r")')
+    assert recognize_level(sql) is None
+
+
+def test_non_geo_acos_not_recognized():
+    # acos present but no "* 6371" earth-radius marker -> not haversine.
+    assert recognize_level('cast( acos("x_l") as float ) <= 1') is None
+
+
+def _distance_comparison():
+    """Real DuckDB DistanceInKMAtThresholds([1, 10]): compound null, two km
+    levels, ELSE."""
+    return {
+        "output_column_name": "location",
+        "comparison_levels": [
+            {
+                "sql_condition": (
+                    '("lat_l" IS NULL OR "lat_r" IS NULL) OR '
+                    '("lng_l" IS NULL OR "lng_r" IS NULL)'
+                ),
+                "is_null_level": True,
+            },
+            {"sql_condition": _geo_level(1)},
+            {"sql_condition": _geo_level(10)},
+            {"sql_condition": "ELSE"},
+        ],
+    }
+
+
+def test_distance_comparison_converts_to_geo_field():
+    report = ConversionReport()
+    field = convert_comparison(_distance_comparison(), 0, report)
+
+    assert field is not None
+    assert field.field == "lat__lng"
+    assert field.scorer == "geo_haversine"
+    assert field.levels == 3
+    assert field.level_thresholds == [0.85, 0.5]
+    assert field.derive_from == ["lat", "lng"]
+    assert field.derive_separator == ","
+
+
+def test_distance_comparison_warns_on_km_snap():
+    report = ConversionReport()
+    convert_comparison(_distance_comparison(), 0, report)
+    warns = [f.message for f in report.findings if f.severity == "warning"]
+    assert any("great-circle km cutoff snapped" in w for w in warns)
+
+
+def test_derive_from_requires_two_columns():
+    with pytest.raises(ValueError, match="at least 2 source columns"):
+        MatchkeyField(field="lat__lng", scorer="geo_haversine", weight=1.0,
+                      derive_from=["lat"])
+
+
+def test_geo_field_materializes_on_arrow_lane():
+    """The synthesized 'lat,long' field is built (comma-joined) by the pipeline's
+    arrow-lane transform precompute -- the goldenmatch-default path."""
+    field = MatchkeyField(field="lat__lng", scorer="geo_haversine", weight=1.0,
+                          derive_from=["lat", "lng"], derive_separator=",")
+    mk = MatchkeyConfig(name="geo", type="weighted", threshold=0.5, fields=[field])
+    tbl = pa.table({"lat": ["40.7", "51.5", None], "lng": ["-74.0", "-0.12", "5.0"]})
+
+    out = to_frame(precompute_matchkey_transforms_frame(tbl, [mk])).to_arrow().to_pydict()
+    assert out["lat__lng"] == ["40.7,-74.0", "51.5,-0.12", ",5.0"]
+
+
+def test_geo_conversion_scores_end_to_end():
+    """A converted geo config actually resolves: two coordinates ~0.7 km apart
+    cluster; a coordinate ~900 km away does not."""
+    import goldenmatch as gm
+
+    report = ConversionReport()
+    field = convert_comparison(_distance_comparison(), 0, report)
+    # Score it on the weighted path (a converted field carries level_thresholds,
+    # not a weight); one field, weight 1.0 -> match score == the geo sim.
+    field.weight = 1.0
+    mk = MatchkeyConfig(
+        name="geo", type="weighted", threshold=0.6, fields=[field]
+    )
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+    )
+
+    config = GoldenMatchConfig(
+        matchkeys=[mk],
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["country"])]
+        ),
+    )
+    # rows 0 & 1: ~0.7 km apart in London; row 2: Paris (~340 km).
+    df = pa.table({
+        "id": ["a", "b", "c"],
+        "lat": ["51.5074", "51.5010", "48.8566"],
+        "lng": ["-0.1278", "-0.1200", "2.3522"],
+        "country": ["gb", "gb", "gb"],
+    })
+    result = gm.dedupe_df(df, config=config)
+    # rows 0 (a) & 1 (b) share a cluster; row 2 (c, Paris) is a singleton.
+    multi = [set(c["members"]) for c in result.clusters.values() if c["size"] > 1]
+    assert {0, 1} in multi, (multi, [dict(c) for c in result.clusters.values()])
+    assert not any(2 in m for m in multi)

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -1565,6 +1565,20 @@
               "required": false,
               "default": "None",
               "description": "Descending similarity cutoffs defining each custom probabilistic band; must hold levels-1 entries."
+            },
+            {
+              "name": "derive_from",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Source columns joined with derive_separator to synthesize the compared field when it is not present in the raw frame."
+            },
+            {
+              "name": "derive_separator",
+              "type": "str",
+              "required": false,
+              "default": "' '",
+              "description": "Separator used to join derive_from source columns (space for names, ',' for geo_haversine lat,long)."
             }
           ]
         },


### PR DESCRIPTION
## What and why

Completes the domain-comparator conversion series (P1 array scorer #2115, P2 date_diff #2121, P3a array recognizer #2122). `DistanceInKMAtThresholds` — the one **cross-column** Splink comparison — now converts. Splink gives *separate* `lat` + `lng` columns, but goldenmatch's `geo_haversine` scores *one* comma-joined `"lat,long"` field, so this adds a synthesized-field mechanism to `MatchkeyField` (the approach you chose over recognize-and-drop). Built against the REAL Splink 4 SQL, both dialects.

## Changes

- **Schema** (`config/schemas.py`): `MatchkeyField.derive_from: list[str] | None` + `derive_separator: str = " "` (validated ≥2 sources). Mirrors `NegativeEvidenceField.derive_from` but with a configurable separator — NE space-joins; geo needs `,` so `_parse_latlong` reads it.
- **Materialization, both lanes** (`core/matchkey.py`): `precompute_matchkey_transforms` (polars) and `..._frame` (arrow — the goldenmatch default) now synthesize `MatchkeyField.derive_from` fields, not just NE ones, honoring the per-field separator. Threaded a `separator=` param through `Column.derive_ne_joined` (protocol/polars/arrow in `core/frame.py`) + `arrow_derive.ne_joined_column`; default `" "` keeps every NE path byte-identical.
- **Required-columns** (`core/pipeline.py`): `_get_required_columns` requires a `derive_from` field's *sources*, not the synthesized name (else the raw-frame column check fails on `lat__lng`).
- **Recognizer** (`config/from_splink.py`): `_GEO_MARKER`/`_GEO_LAT`/`_GEO_LNG`/`_GEO_KM` match the haversine signature (`acos … radians … * 6371 … <= km`) in both dialects — lat is the bare `radians(col_l|col_r)`, lng is the `radians(col_r - col_l)` difference, km → `_geo_haversine_band`. `RecognizedLevel` gains `derive_from`/`derive_separator`; `convert_comparison` threads them into the field. `DistanceInKM([1,10])` → `geo_haversine`, field `lat__lng`, levels `[0.85, 0.5]`, separator `,`.

## Testing

- `test_from_splink_geo.py` (13): recognizer both dialects, malformed-geo drops, full conversion, schema validation, arrow-lane materialization, and an **end-to-end `dedupe_df`** proving two ~0.7 km-apart London coordinates cluster while Paris (~340 km) stays separate — i.e. the synthesized field really scores through the pipeline.
- NE space-join unchanged (`test_facility_fullname_ne` + 319 affected-suite tests green).
- Polars-free import of `from_splink` verified.
- `ruff` clean; parity gate clean; codemap + config-matrix + agent-manifest regenerated (all `config_matrix` gates green locally).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff check`) clean on changed files
- [ ] Package `CHANGELOG.md` updated (deferred until the conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (plan doc §11 P3b delivered; config-matrix + agent-manifest regenerated)

No parity-manifest change: `geo_haversine` is an existing scorer; P3b adds a recognizer + the derive_from plumbing. Remaining roadmap: P4 `domain_bands` upgrade lever, P5 Rust kernels, P6 TS parity; numeric stays opportunistic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_