### PR TITLE
spike(identity): let duckdb_stream self-manage memory (measure true peak)

### DIFF
--- a/packages/python/goldenmatch/scripts/spike_duckdb_identity_ingest.py
+++ b/packages/python/goldenmatch/scripts/spike_duckdb_identity_ingest.py
@@ -292,8 +292,14 @@ def _run_duckdb_stream(path: str, n: int) -> str:
     _write_parquet_streaming(n, nodes_pq, records_pq)  # bounded-memory source
     conn = duckdb.connect(path)
     try:
-        # Force DuckDB to stream + spill rather than buffer the scan in RAM.
-        conn.execute("SET memory_limit='4GB'")
+        # Enable spilling for the scan/hash; let DuckDB self-manage the budget
+        # (default ~80% RAM) so we measure its TRUE peak RSS. A hard low cap
+        # (e.g. 4GB) OOMs at >=5M because the ON CONFLICT primary-key ART index
+        # is unspillable and grows with N -- itself a finding, exposed via the
+        # optional GOLDENMATCH_SPIKE_DUCKDB_MEMLIMIT override.
+        _memlimit = os.environ.get("GOLDENMATCH_SPIKE_DUCKDB_MEMLIMIT")
+        if _memlimit:
+            conn.execute(f"SET memory_limit='{_memlimit}'")
         conn.execute(f"SET temp_directory='{spill}'")
         conn.execute(_DUCKDB_DDL)
         conn.execute(_UPSERT_NODES_DUCKDB.format(


### PR DESCRIPTION
## What and why

Fix to the DuckDB spike harness (#2126). The `duckdb_stream` arm hard-capped `memory_limit=4GB` to force spilling — but that **OOMs at ≥5M**: DuckDB's `ON CONFLICT` upsert holds the entire primary-key **ART index in RAM (indexes are not spillable)**, and it grows with N. Verified locally: `OutOfMemory at 3.7/3.7 GiB` at 5M. That's itself a real finding, but it prevents measuring the arm's **true peak RSS** — the actual decision metric.

**Fix:** don't set a hard `memory_limit` by default; keep `temp_directory` so the scan/hash still spill, and let DuckDB self-manage (~80% RAM). The tight-budget behavior is preserved behind an optional `GOLDENMATCH_SPIKE_DUCKDB_MEMLIMIT` override so the index-residency finding stays reproducible.

Landing so the 64GB run re-dispatched from `main` measures `duckdb_stream`'s real peak (the first run capped it and will fail `stream` at 5M).

## Testing

Spike harness only (`workflow_dispatch` lane, not in `ci-required`). Parses clean; local 1M `duckdb_stream` completes at 4.5 GB.

## Checklist

- [x] No secrets committed
- [ ] Tests — n/a (spike harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_