### PR TITLE
Splink domain-comparator conversion P4: domain_bands upgrade lever

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1050,10 +1050,12 @@
             "_estimate_within_block_prior",
             "_lever_calibration",
             "_lever_distance_thresholds",
+            "_lever_domain_bands",
             "_lever_fan_out",
             "_lever_tf_tables",
             "_load_frame",
             "_measure_mean_length",
+            "_measure_mean_token_set_size",
             "_resolve_levers",
             "_sample",
             "_validate_columns",
@@ -1069,6 +1071,7 @@
             "goldenmatch.core.blocker",
             "goldenmatch.core.frame",
             "goldenmatch.core.probabilistic",
+            "goldenmatch.core.scorer",
             "goldenmatch.utils.transforms"
           ]
         },

--- a/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
+++ b/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
@@ -299,3 +299,33 @@ synthesized-field mechanism on `MatchkeyField`:
 **Roadmap now:** P1 array_intersect scorer + P2 date_diff + P3a array_intersect recognizer + P3b
 geo/derive_from all shipped. Numeric = opportunistic. Remaining: P4 `domain_bands` upgrade lever,
 P5 Rust kernels (array_intersect/numeric_diff), P6 TS parity.
+
+## 12. P4 delivered — domain_bands upgrade lever (2026-07-25)
+New `domain_bands` lever in `config/splink_upgrade.py`, registered after `distance_thresholds`,
+before `fan_out`/`calibration` (Stage D). Data-aware refinement of the converter's approximate
+domain bands:
+- **array_intersect** (the one data-refinable approximation): P3a snapped Splink's intersection
+  COUNT `>= n` to an overlap RATIO `n / 10` (`_ARRAY_ASSUMED_SET_SIZE`, a guess).
+  `_lever_domain_bands` measures the ACTUAL mean token-set size K on the sample
+  (`_measure_mean_token_set_size`, reusing `core.scorer._parse_token_set`) and recomputes each band
+  `ratio = min(1, n / K)` — exactly mirroring `distance_thresholds` measuring mean string length L.
+  Copy-on-write; per-band finding (old→new + measured K); band-collapse merges + re-normalizes m/u
+  (same machinery as `distance_thresholds`); applies regardless of `em_model` (config-level bands).
+- **date_diff / geo_haversine**: the Splink cutoff→band conversion is EXACT (seconds→days / km carry
+  no assumed constant), so there's nothing to refine — info-note and passthrough.
+- **`_validate_columns` fix**: also taught the upgrade orchestrator's upfront column check to require
+  a `derive_from` field's SOURCES (geo lat+lng), not the synthesized `lat__lng` — mirrors the P3b
+  `pipeline._get_required_columns` fix, so a geo-converted config can now run `--upgrade`.
+- Tests: `test_splink_upgrade_levers.py` (+7: refine, copy-on-write, skip-empty, collapse+m/u remap,
+  date/geo exact passthrough, bare-settings applies) + updated the two lever-order assertions.
+  Full upgrade+splink suites 128 green; ruff + pyright clean; codemap regenerated.
+
+**Design-scope note:** the spec (Stage D) also envisioned refining date/geo bands from measured
+day-diff/km *distributions*. Those conversions are exact (no assumed constant to fix), and an
+unlabeled distance distribution has no match/non-match separation signal to refine against without
+the scored candidate-pair machinery — so P4 ships the well-defined array-set-size measurement (the
+genuine refinable approximation) and treats date/geo as exact passthrough. A distribution-based
+refinement remains a possible follow-on if a labeled/scored separation signal is wired in.
+
+**Roadmap now:** P1/P2/P3a/P3b/P4 shipped. Remaining: P5 Rust kernels (array_intersect/numeric_diff),
+P6 TS parity. Numeric stays opportunistic.

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -143,11 +143,15 @@ def _validate_columns(config: GoldenMatchConfig, df: pl.DataFrame) -> None:
         return
     mk = mks[0]
     columns = set(df.columns)
-    missing = [
-        f.field
-        for f in mk.fields
-        if f.field is not None and f.field != "__record__" and f.field not in columns
-    ]
+    missing: list[str] = []
+    for f in mk.fields:
+        derive_from = getattr(f, "derive_from", None)
+        if derive_from:
+            # A synthesized field (geo_haversine "lat,long") is materialized by
+            # the pipeline from derive_from; require its SOURCES, not itself.
+            missing.extend(c for c in derive_from if c not in columns)
+        elif f.field is not None and f.field != "__record__" and f.field not in columns:
+            missing.append(f.field)
     if missing:
         raise SplinkUpgradeError(
             "upgrade_splink_conversion(): matchkey field(s) missing from data "
@@ -302,6 +306,37 @@ def _measure_mean_length(df: pl.DataFrame, field: str, transforms: list[str]) ->
     return total_len / count
 
 
+def _measure_mean_token_set_size(
+    df: pl.DataFrame, field: str, transforms: list[str]
+) -> float | None:
+    """Mean token-set size of ``field``'s non-null values, parsed the SAME way
+    the ``array_intersect`` scorer parses them (``core.scorer._parse_token_set``:
+    first separator in ``| ; ,``). Mirrors ``_measure_mean_length`` but counts
+    distinct tokens per value instead of characters. Returns ``None`` when the
+    column is absent or every value yields an empty set."""
+    from goldenmatch.core.scorer import _parse_token_set
+    from goldenmatch.utils.transforms import apply_transforms
+
+    if field not in df.columns:
+        return None
+    total = 0
+    count = 0
+    for v in df[field].to_list():
+        if v is None:
+            continue
+        s = str(v)
+        if transforms:
+            s = apply_transforms(s, transforms)
+        toks = _parse_token_set(s)
+        if not toks:
+            continue
+        total += len(toks)
+        count += 1
+    if count == 0:
+        return None
+    return total / count
+
+
 def _lever_distance_thresholds(ctx: _LeverContext) -> None:
     # Applies regardless of em_model presence (band thresholds are
     # config-level, fixed before training) -- see spec "Bare-settings inputs".
@@ -443,6 +478,120 @@ def _lever_distance_thresholds(ctx: _LeverContext) -> None:
             if sum_u > 0:
                 new_u = [v / sum_u for v in new_u]
 
+            ctx.em_model.m_probs[field_name] = new_m
+            ctx.em_model.u_probs[field_name] = new_u
+            ctx.em_model.match_weights[field_name] = [
+                math.log2(max(m, 1e-10) / max(u, 1e-10)) for m, u in zip(new_m, new_u)
+            ]
+
+
+def _lever_domain_bands(ctx: _LeverContext) -> None:
+    # Data-aware refinement of the domain-comparator bands the converter emits.
+    #
+    # date_diff / geo_haversine: the Splink cutoff -> band conversion is EXACT
+    #   (seconds->days / km carry no assumed constant), so there is nothing to
+    #   refine -- info-note and leave unchanged.
+    # array_intersect: the converter snapped Splink's intersection COUNT (`>= n`)
+    #   to an overlap RATIO n / _ARRAY_ASSUMED_SET_SIZE (10, a guess). We measure
+    #   the ACTUAL mean token-set size K on the data and recompute each band
+    #   ratio = min(1, n / K) -- exactly mirroring _lever_distance_thresholds,
+    #   which measures mean string length L to fix the levenshtein assumed length.
+    #   Applies regardless of em_model (band thresholds are config-level); m/u is
+    #   remapped when a band collapses onto another level (as distance_thresholds).
+    from goldenmatch.config.from_splink import _ARRAY_ASSUMED_SET_SIZE
+
+    mk = ctx.upgraded_config.get_matchkeys()[0]
+
+    for f in mk.fields:
+        sc = f.scorer or ""
+        if sc.startswith(("date_diff", "geo_haversine")):
+            ctx.report.info(
+                "upgrade:domain_bands",
+                f"field '{f.field}' ({sc}): Splink cutoff->band conversion is exact "
+                "(no assumed constant), bands unchanged",
+                mapped_to=f"matchkeys[0].fields[{f.field}]",
+            )
+
+    array_fields = [
+        f for f in mk.fields
+        if (f.scorer or "").startswith("array_intersect") and f.field is not None
+    ]
+    if not array_fields:
+        if not any((f.scorer or "").startswith(("date_diff", "geo_haversine")) for f in mk.fields):
+            ctx.report.info(
+                "upgrade:domain_bands", "no domain-comparator fields in config",
+                mapped_to=None,
+            )
+        return
+
+    for f in array_fields:
+        field_name = f.field
+        assert field_name is not None
+        mapped_to = f"matchkeys[0].fields[{field_name}]"
+
+        K = _measure_mean_token_set_size(ctx.df, field_name, f.transforms)
+        if K is None or K <= 0:
+            ctx.report.warn(
+                "upgrade:domain_bands",
+                f"field '{field_name}' has no measurable token sets to size the "
+                "overlap bands from, skipped (bands unchanged)",
+                mapped_to=mapped_to,
+            )
+            continue
+
+        is_two_level = f.level_thresholds is None
+        old_thresholds = [f.partial_threshold] if is_two_level else list(f.level_thresholds or [])
+        old_levels = [f.levels - 1 - i for i in range(len(old_thresholds))]
+
+        # Invert the converter's ratio -> count (n = round(t * assumed_size)),
+        # then recompute against measured K. new_t is monotone non-increasing
+        # (old_t descending), so collisions are always adjacent -- one forward
+        # pass dedupes without a sort. n>=1 and K>0 => new_t in (0, 1] always
+        # (no out-of-range drop, unlike the levenshtein lever).
+        groups: list[dict] = []
+        for old_level, old_t in zip(old_levels, old_thresholds):
+            n = max(1, round(old_t * _ARRAY_ASSUMED_SET_SIZE))
+            new_t = min(1.0, n / K)
+            if groups and math.isclose(groups[-1]["new_t"], new_t, abs_tol=1e-9):
+                groups[-1]["members"].append(old_level)
+                ctx.report.warn(
+                    "upgrade:domain_bands",
+                    f"field '{field_name}': recomputed overlap threshold for count "
+                    f">= {n} collapsed onto an adjacent level ({new_t:.4f}); m/u "
+                    "probabilities summed with the earlier level's",
+                    mapped_to=mapped_to,
+                )
+            else:
+                groups.append({"new_t": new_t, "members": [old_level]})
+                ctx.report.info(
+                    "upgrade:domain_bands",
+                    f"field '{field_name}': count >= {n} overlap threshold "
+                    f"{old_t:.4f} -> {new_t:.4f} (measured mean set size K={K:.2f})",
+                    mapped_to=mapped_to,
+                )
+
+        new_thresholds = [g["new_t"] for g in groups]
+        if is_two_level:
+            f.partial_threshold = new_thresholds[0]
+        else:
+            f.level_thresholds = new_thresholds
+            f.levels = len(groups) + 1
+
+        if ctx.em_model is not None and field_name in ctx.em_model.m_probs:
+            old_m = ctx.em_model.m_probs[field_name]
+            old_u = ctx.em_model.u_probs[field_name]
+            merged_m = [old_m[0]]
+            merged_u = [old_u[0]]
+            for g in groups:
+                merged_m.append(sum(old_m[j] for j in g["members"]))
+                merged_u.append(sum(old_u[j] for j in g["members"]))
+            new_m = [merged_m[0]] + list(reversed(merged_m[1:]))
+            new_u = [merged_u[0]] + list(reversed(merged_u[1:]))
+            sum_m, sum_u = sum(new_m), sum(new_u)
+            if sum_m > 0:
+                new_m = [v / sum_m for v in new_m]
+            if sum_u > 0:
+                new_u = [v / sum_u for v in new_u]
             ctx.em_model.m_probs[field_name] = new_m
             ctx.em_model.u_probs[field_name] = new_u
             ctx.em_model.match_weights[field_name] = [
@@ -697,6 +846,7 @@ def _lever_fan_out(ctx: _LeverContext) -> None:
 _LEVER_REGISTRY: dict[str, Callable[[_LeverContext], None]] = {
     "tf_tables": _lever_tf_tables,
     "distance_thresholds": _lever_distance_thresholds,
+    "domain_bands": _lever_domain_bands,
     "fan_out": _lever_fan_out,
     "calibration": _lever_calibration,
 }
@@ -704,6 +854,7 @@ _LEVER_REGISTRY: dict[str, Callable[[_LeverContext], None]] = {
 _LEVER_ORDER: tuple[str, ...] = (
     "tf_tables",
     "distance_thresholds",
+    "domain_bands",
     "fan_out",
     "calibration",
 )

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
@@ -98,6 +98,7 @@ def test_fan_out_in_default_lever_order():
     assert _resolve_levers(None) == [
         "tf_tables",
         "distance_thresholds",
+        "domain_bands",
         "fan_out",
         "calibration",
     ]

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -1078,6 +1078,7 @@ def test_lever_order_canonical():
     assert _LEVER_ORDER == (
         "tf_tables",
         "distance_thresholds",
+        "domain_bands",
         "fan_out",
         "calibration",
     )
@@ -1139,3 +1140,147 @@ def test_measure_false_records_skip_note():
         f.splink_path == "upgrade:measure" and "skipped" in f.message
         for f in result.report.findings
     )
+
+
+# ── Lever: domain_bands (P4) ──────────────────────────────────────────────────
+#
+# The array_intersect converter (P3a) snapped Splink's intersection COUNT
+# (`>= n`) to an overlap RATIO n / 10 (an assumed set size). domain_bands
+# measures the ACTUAL mean token-set size K on the data and recomputes n / K --
+# mirroring distance_thresholds measuring mean string length L. date_diff /
+# geo_haversine conversions are exact (no assumed constant): passthrough + note.
+
+
+def _array_settings(sizes=(3, 1), column="skills"):
+    """ArrayIntersectAtSizes(sizes) settings -> array_intersect:overlap field."""
+    levels = [
+        {
+            "sql_condition": f'"{column}_l" IS NULL OR "{column}_r" IS NULL',
+            "is_null_level": True,
+        }
+    ]
+    for n in sizes:
+        levels.append({
+            "sql_condition": (
+                f'array_length(list_intersect("{column}_l", "{column}_r")) >= {n}'
+            )
+        })
+    levels.append({"sql_condition": "ELSE"})
+    return {
+        "comparisons": [{"output_column_name": column, "comparison_levels": levels}],
+        "blocking_rules_to_generate_predictions": [f'l."{column}" = r."{column}"'],
+    }
+
+
+def _skills_df(n_tokens, rows=20, column="skills"):
+    toks = "|".join(chr(ord("a") + i) for i in range(n_tokens))
+    return pl.DataFrame({column: [toks] * rows})
+
+
+def test_domain_bands_refines_array_overlap_from_measured_set_size():
+    conversion = from_splink(_array_settings((3, 1)))
+    assert _field(conversion.config, "skills").level_thresholds == [0.3, 0.1]  # n/10
+
+    result = upgrade_splink_conversion(
+        conversion, _skills_df(5), levers={"domain_bands"}, measure=False
+    )
+    # measured mean set size K=5 -> n=3 -> 0.6, n=1 -> 0.2
+    assert _field(result.upgraded_config, "skills").level_thresholds == pytest.approx([0.6, 0.2])
+
+
+def test_domain_bands_copy_on_write_leaves_baseline():
+    conversion = from_splink(_array_settings((3, 1)))
+    upgrade_splink_conversion(
+        conversion, _skills_df(5), levers={"domain_bands"}, measure=False
+    )
+    # the conversion's own config is untouched by the lever.
+    assert _field(conversion.config, "skills").level_thresholds == [0.3, 0.1]
+
+
+def test_domain_bands_skips_array_with_no_tokens():
+    conversion = from_splink(_array_settings((3, 1)))
+    df = pl.DataFrame({"skills": [None] * 10})
+    result = upgrade_splink_conversion(
+        conversion, df, levers={"domain_bands"}, measure=False
+    )
+    # unchanged; a skip warning explains why.
+    assert _field(result.upgraded_config, "skills").level_thresholds == [0.3, 0.1]
+    warns = [f for f in result.report.findings if f.severity == "warning"]
+    assert any("no measurable token sets" in f.message for f in warns)
+
+
+def test_domain_bands_collapse_remaps_mu():
+    """A tiny measured set size clamps both bands to 1.0 -> collapse onto one
+    level; trained m/u must be summed + re-normalized (like distance_thresholds)."""
+    settings = _array_settings((3, 1))
+    # add m/u to the two size levels + ELSE so import_em produces a trained model.
+    mu = {1: (0.55, 0.05), 2: (0.30, 0.15), 3: (0.15, 0.80)}
+    for idx, (m, u) in mu.items():
+        settings["comparisons"][0]["comparison_levels"][idx]["m_probability"] = m
+        settings["comparisons"][0]["comparison_levels"][idx]["u_probability"] = u
+    settings["probability_two_random_records_match"] = 0.01
+
+    conversion = from_splink(settings)
+    assert conversion.em_model is not None
+
+    # K=1 -> n=3 and n=1 both give min(1, n/1)=1.0 -> the two overlap bands
+    # collapse onto one level.
+    result = upgrade_splink_conversion(
+        conversion, _skills_df(1), levers={"domain_bands"}, measure=False
+    )
+    field = _field(result.upgraded_config, "skills")
+    assert field.level_thresholds == pytest.approx([1.0])
+    assert field.levels == 2
+    m = result.em_model.m_probs["skills"]
+    assert len(m) == 2  # ELSE + the single collapsed agree band
+    assert sum(m) == pytest.approx(1.0)
+
+
+def test_domain_bands_date_geo_exact_passthrough():
+    """date_diff / geo_haversine conversions are exact -> unchanged + info note.
+    Also exercises the geo derive_from column-validation path."""
+    date_sql = (
+        'ABS(EPOCH(try_strptime("dob_l", \'%Y-%m-%d\')) - '
+        'EPOCH(try_strptime("dob_r", \'%Y-%m-%d\'))) <= 2629800.0'
+    )
+    settings = {
+        "comparisons": [{
+            "output_column_name": "dob",
+            "comparison_levels": [
+                {
+                    "sql_condition": (
+                        'try_strptime("dob_l", \'%Y-%m-%d\') IS NULL OR '
+                        'try_strptime("dob_r", \'%Y-%m-%d\') IS NULL'
+                    ),
+                    "is_null_level": True,
+                },
+                {"sql_condition": '"dob_l" = "dob_r"'},
+                {"sql_condition": date_sql},
+                {"sql_condition": "ELSE"},
+            ],
+        }],
+        "blocking_rules_to_generate_predictions": ['l."dob" = r."dob"'],
+    }
+    conversion = from_splink(settings)
+    before = list(_field(conversion.config, "dob").level_thresholds or [])
+
+    df = pl.DataFrame({"dob": ["1990-01-01", "1985-06-15"] * 10})
+    result = upgrade_splink_conversion(
+        conversion, df, levers={"domain_bands"}, measure=False
+    )
+    assert _field(result.upgraded_config, "dob").level_thresholds == before
+    infos = [f for f in result.report.findings if f.severity == "info"]
+    assert any("conversion is exact" in f.message for f in infos)
+
+
+def test_domain_bands_applies_without_em_model():
+    """Bare settings (no m/u): array band refinement still applies -- overlap
+    thresholds are config-level, fixed before training (like distance_thresholds)."""
+    conversion = from_splink(_array_settings((3, 1)))
+    assert conversion.em_model is None
+    result = upgrade_splink_conversion(
+        conversion, _skills_df(4), levers={"domain_bands"}, measure=False
+    )
+    # K=4 -> 3/4=0.75, 1/4=0.25
+    assert _field(result.upgraded_config, "skills").level_thresholds == pytest.approx([0.75, 0.25])
+    assert result.em_model is None


### PR DESCRIPTION
## What and why

Continues the series (P1 array scorer #2115, P2 date_diff #2121, P3a array recognizer #2122, P3b geo #2125). The converter's domain bands are **approximate** where Splink's threshold has no exact goldenmatch equivalent. P4 adds a data-aware `--upgrade` lever that refines them against the user's actual data — mirroring the existing `distance_thresholds` lever (which measures mean string length to fix the levenshtein assumed-length).

## Changes

- **`domain_bands` lever** (`config/splink_upgrade.py`), registered after `distance_thresholds`, before `fan_out`/`calibration`:
  - **`array_intersect`**: P3a snapped Splink's intersection *count* `>= n` to an overlap *ratio* `n / 10` (`_ARRAY_ASSUMED_SET_SIZE`, a guess). The lever measures the **actual mean token-set size K** on the sample (`_measure_mean_token_set_size`, reusing `core.scorer._parse_token_set`) and recomputes `ratio = min(1, n / K)`. Copy-on-write; per-band finding with the measured K; a band that collapses onto another level merges + re-normalizes m/u (same machinery as `distance_thresholds`); applies regardless of `em_model` (config-level bands).
  - **`date_diff` / `geo_haversine`**: the Splink cutoff→band conversion is **exact** (seconds→days / km carry no assumed constant) — nothing to refine, so info-note + passthrough.
- **`_validate_columns` fix**: the upgrade orchestrator's upfront column check now requires a `derive_from` field's *sources* (geo `lat`+`lng`), not the synthesized `lat__lng` — mirrors the P3b `pipeline._get_required_columns` fix, so a geo-converted config can actually run `--upgrade`.

## Design-scope note

The spec (Stage D) also envisioned refining date/geo bands from measured day-diff/km *distributions*. Those conversions are exact (no assumed constant to fix), and an unlabeled distance distribution has no match/non-match separation signal to refine against without wiring in the scored candidate-pair machinery. So P4 ships the well-defined **array-set-size** measurement (the genuine refinable approximation) and treats date/geo as exact passthrough. A distribution-based refinement remains a possible follow-on if a labeled/scored separation signal is added.

## Testing

- `test_splink_upgrade_levers.py` (+7): array threshold refinement (n/10 → n/K), copy-on-write, skip-on-empty, band-collapse + m/u remap, date/geo exact passthrough, bare-settings applies. Updated the two lever-order assertions (`test_lever_order_canonical`, `test_fan_out_in_default_lever_order`).
- Full upgrade + splink suites → **128 passed**.
- `ruff` clean; `pyright` 0 errors; parity gate clean; codemap regenerated (all `config_matrix` gates green locally).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff check`) clean on changed files
- [ ] Package `CHANGELOG.md` updated (deferred until the conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (plan doc §12; codemap regenerated)

No parity-manifest change (no new scorer/surface). Remaining roadmap: P5 Rust kernels (array_intersect/numeric_diff), P6 TS parity; numeric stays opportunistic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_