### PR TITLE
feat(from_splink): numeric_diff Splink recognizer (converter-side, the opportunistic gap)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -938,6 +938,7 @@
             "_agree_index_for",
             "_convert_one_blocking_rule",
             "_findings_preview",
+            "_fmt_band",
             "_load_settings",
             "_looks_like_date_diff",
             "_looks_like_haversine",

--- a/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
+++ b/docs/superpowers/plans/2026-07-25-splink-domain-comparator-conversion-plan.md
@@ -329,3 +329,36 @@ refinement remains a possible follow-on if a labeled/scored separation signal is
 
 **Roadmap now:** P1/P2/P3a/P3b/P4 shipped. Remaining: P5 Rust kernels (array_intersect/numeric_diff),
 P6 TS parity. Numeric stays opportunistic.
+
+## 14. numeric_diff Splink recognizer delivered (2026-07-25)
+The converter side of numeric (the "opportunistic" gap the kernel PRs don't touch). Splink has no
+first-class numeric comparison; magnitude arrives via a `CustomComparison` whose canonical shape —
+captured live from splink 4, **byte-identical DuckDB + Spark** — is `ABS("c_l" - "c_r") <= <eps>`.
+- **Recognizer** (`from_splink.py`): `_NUMERIC_DIFF_RE` (`ABS(col_l - col_r) <= n`, case-insensitive,
+  quoted/backtick/bare cols) + a `recognize_level` branch + `numeric_diff` added to `LevelKind`.
+  Emits `numeric_diff:abs:<band>` with **band = 2·eps** and **sim_threshold = 0.5**: a pair exactly
+  at the cutoff (dist = eps) scores `1 − eps/(2eps) = 0.5`, so under the `>=` level semantics
+  "score ≥ 0.5 ⟺ dist ≤ eps" reproduces `<= eps` EXACTLY (boundary inclusive) — mirroring
+  date_diff's "threshold = the score a pair at the cutoff earns". Placed after the haversine branch;
+  the date_diff gate (needs epoch/unix_timestamp) correctly declines a bare ABS, so no shadowing.
+- **Deterministic per level** (band + threshold from that level's OWN eps, no cross-level state), so
+  `recognize_level` yields the same 0.5 at field-build AND m/u-import time and `_agree_index_for`
+  aligns automatically — dodging the parity trap that cross-level band-normalization would create.
+- **Multi-cutoff**: every numeric level snaps to sim 0.5, so multiple Splink cutoffs collapse to ONE
+  numeric_diff level; `convert_comparison` keeps the LOOSEST band (largest 2·eps, recall-biased) and
+  warns. Single-cutoff (the common case) is exact.
+- **Scope**: only the ABSOLUTE form; a relative/pct `CustomComparison` (`ABS(a-b)/GREATEST(…) <= f`)
+  is too shape-variable and falls through (dropped + warned), matching today's behavior. `approx=True`
+  + a per-level "band = 2*eps" warn surfaces the ramp-vs-cutoff approximation.
+- Single-cutoff → field `numeric_diff:abs:<2eps>`, **3 levels [1.0, 0.5]** (exact / within-eps / else).
+  Trained m/u import round-trips (all levels survive, no dropped-mass warn). Scorer schema-valid
+  (`_is_valid_scorer`). from_splink stays polars-free.
+- Tests: `test_from_splink_numeric.py` (18) + updated one assertion in `test_from_splink_domain.py`
+  (a bare ABS is now numeric_diff, not None). Full from_splink suite 166 green; ruff + pyright clean;
+  codemap regenerated. No parity-manifest/config-matrix change (recognizer only, `numeric_diff` was
+  already a VALID_SCORERS member from the FS domain-comparator work).
+
+**Roadmap now:** the converter recognizes all four domain families (date_diff, geo_haversine,
+array_intersect, numeric_diff). Kernels: array_intersect (#2134) + date_diff/geo (#2130) shipped;
+numeric_diff kernel is #2138 (in flight). Remaining: P6 TS *converter* parity (the recognizers are
+Python-only; the TS port has its own `fromSplink`).

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -91,8 +91,37 @@ def _looks_like_haversine(sql_norm: str) -> bool:
 
 LevelKind = Literal[
     "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff",
-    "array_intersect", "geo_haversine",
+    "array_intersect", "geo_haversine", "numeric_diff",
 ]
+
+# Numeric magnitude levels. Splink's standard library has NO first-class numeric
+# comparison (date/time/DistanceInKM/ArrayIntersect + the string-distance family
+# are the built-ins); numeric magnitude arrives via a CustomComparison whose
+# canonical shape -- captured live from splink 4, byte-identical in DuckDB + Spark
+# -- is `ABS("c_l" - "c_r") <= <eps>`. GoldenMatch's `numeric_diff:abs:<band>`
+# scorer is a LINEAR RAMP (sim = 1 - dist/band, 0 beyond), not a hard cutoff, so
+# the conversion is approximate in shape (warn + approx=True). We set band = 2*eps
+# and sim_threshold = 0.5: a pair exactly at the Splink cutoff (dist = eps) then
+# scores 1 - eps/(2*eps) = 0.5, so under the `>=` level semantics "score >= 0.5
+# <=> dist <= eps" reproduces `<= eps` EXACTLY (boundary inclusive) -- mirroring
+# date_diff's "threshold = the score a pair at the cutoff earns" convention. The
+# mapping is deterministic PER LEVEL (band + threshold come only from that level's
+# own eps, no cross-level knowledge), so `recognize_level` yields the same value
+# at field-build AND m/u-import time and `_agree_index_for` aligns automatically.
+# Only the ABSOLUTE form is recognized; a relative/pct CustomComparison
+# (`ABS(a-b)/GREATEST(...) <= f`) is too shape-variable to match and falls through
+# (dropped + warned), matching today's behavior for unrecognized SQL.
+_NUMERIC_DIFF_RE = re.compile(
+    rf'ABS\s*\(\s*{_COL_L}\s*-\s*{_COL_R}\s*\)\s*<=\s*([0-9]*\.?[0-9]+)',
+    re.IGNORECASE,
+)
+
+
+def _fmt_band(x: float) -> str:
+    """Fixed-point band string for a `numeric_diff:abs:<band>` scorer -- no
+    scientific notation (which the schema's `_NUMERIC_DIFF_RE` rejects) and no
+    trailing zeros (`2.0` -> `"2"`, `0.5` -> `"0.5"`)."""
+    return f"{x:.6f}".rstrip("0").rstrip(".")
 
 # ArrayIntersectAtSizes levels count the intersection SIZE:
 #   DuckDB: array_length(list_intersect("c_l", "c_r")) >= <n>
@@ -247,6 +276,19 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
                 )
         # haversine-shaped but couldn't extract a clean lat/lng/km -> drop+warn.
 
+    m = _NUMERIC_DIFF_RE.fullmatch(sql_norm)
+    if m:
+        col_l, col_r, eps = m.group(1), m.group(2), float(m.group(3))
+        if col_l == col_r and eps > 0.0:
+            band = 2.0 * eps  # a pair at dist=eps scores 1 - eps/band = 0.5
+            return RecognizedLevel(
+                "numeric_diff",
+                col_l,
+                0.5,
+                approx=True,
+                scorer=f"numeric_diff:abs:{_fmt_band(band)}",
+            )
+
     return None
 
 
@@ -399,7 +441,25 @@ def convert_comparison(
     # A recognized band may carry a full scorer string (e.g. array_intersect's
     # ":overlap" mode) that differs from its family kind; prefer it, else use
     # the family kind (date_diff, jaro_winkler, ...) or "exact" for exact-only.
-    if families:
+    if families == {"numeric_diff"}:
+        # Every numeric_diff band snaps to sim 0.5 (band = 2*eps, so a pair AT the
+        # cutoff scores 0.5), so multiple Splink cutoffs collapse to ONE level.
+        # Keep the LOOSEST band (largest 2*eps -> widest match window, biased for
+        # recall) and warn when >1 distinct cutoff is collapsed. `band` is the
+        # trailing `numeric_diff:abs:<band>` value.
+        numeric_scorers = {
+            r.scorer for r, _, _ in bands if r.kind == "numeric_diff" and r.scorer
+        }
+        scorer = max(numeric_scorers, key=lambda s: float(s.rsplit(":", 1)[1]))
+        if len(numeric_scorers) > 1:
+            report.warn(
+                comp_path,
+                f"multiple numeric-distance cutoffs collapsed to the loosest band "
+                f"({scorer}); numeric_diff's linear ramp represents one band, so the "
+                "finer cutoffs' gradation is not preserved",
+                mapped_to=None,
+            )
+    elif families:
         scorer = next(
             (r.scorer for r, _, _ in bands if r.kind != "exact" and r.scorer),
             next(iter(families)),
@@ -435,6 +495,13 @@ def convert_comparison(
                 message = (
                     "approximate mapping: date-difference cutoff snapped to the nearest "
                     f"day-distance band -> sim {r.sim_threshold} ({sql})"
+                )
+            elif r.kind == "numeric_diff":
+                message = (
+                    "approximate mapping: numeric-distance cutoff ABS(a-b) <= eps "
+                    "converted to a numeric_diff linear ramp with band = 2*eps, so a "
+                    f"pair at the cutoff scores sim {r.sim_threshold} (Splink's hard "
+                    f"cutoff becomes a ramp; boundary reproduced exactly) ({sql})"
                 )
             elif r.kind == "array_intersect":
                 count = round((r.sim_threshold or 0.0) * _ARRAY_ASSUMED_SET_SIZE)

--- a/packages/python/goldenmatch/tests/test_from_splink_domain.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_domain.py
@@ -63,10 +63,13 @@ def test_date_diff_recognized_both_dialects(sql, expected_band):
     assert r.approx is True
 
 
-def test_non_date_abs_expression_not_recognized():
-    # An ABS() numeric difference with no EPOCH/UNIX_TIMESTAMP date parse is
-    # NOT a date_diff level -- must fall through to None (dropped + warned).
-    assert recognize_level('ABS("age_l" - "age_r") <= 5') is None
+def test_non_date_abs_expression_is_numeric_not_date():
+    # An ABS() numeric difference with no EPOCH/UNIX_TIMESTAMP date parse is NOT a
+    # date_diff level -- it is recognized as `numeric_diff` (the bare-ABS numeric
+    # recognizer; see test_from_splink_numeric.py). The date_diff gate correctly
+    # declines it (no epoch/unix_timestamp), which is what this asserts.
+    r = recognize_level('ABS("age_l" - "age_r") <= 5')
+    assert r is not None and r.kind == "numeric_diff"
 
 
 def test_date_diff_mismatched_columns_dropped():

--- a/packages/python/goldenmatch/tests/test_from_splink_numeric.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_numeric.py
@@ -1,0 +1,184 @@
+"""Splink numeric-magnitude comparison conversion -> `numeric_diff` scorer.
+
+Splink's standard library has NO first-class numeric comparison; numeric
+magnitude arrives via a `CustomComparison` whose canonical shape -- captured
+live from splink 4, BYTE-IDENTICAL in DuckDB + Spark -- is
+`ABS("c_l" - "c_r") <= <eps>`. The conversion maps that hard cutoff to
+GoldenMatch's `numeric_diff:abs:<band>` LINEAR RAMP with band = 2*eps, so a pair
+exactly at the cutoff scores 0.5; under the `>=` level semantics
+"score >= 0.5 <=> dist <= eps" reproduces `<= eps` exactly (boundary inclusive),
+mirroring date_diff's "threshold = the score a pair at the cutoff earns". The
+mapping is deterministic per level, so build-time and m/u-import-time recognition
+agree (parity is automatic).
+
+Ground truth (captured, both dialects identical):
+    ABS("amount_l" - "amount_r") <= 1
+"""
+import pytest
+from goldenmatch.config.from_splink import (
+    ConversionReport,
+    convert_comparison,
+    import_em,
+    recognize_level,
+)
+from goldenmatch.config.schemas import _is_valid_scorer
+from goldenmatch.core.scorer import score_field
+
+# --- recognizer --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql,expected_scorer",
+    [
+        ('ABS("amount_l" - "amount_r") <= 1', "numeric_diff:abs:2"),       # DuckDB quoted
+        ("ABS(`amount_l` - `amount_r`) <= 10", "numeric_diff:abs:20"),      # Spark backtick
+        ("abs(amount_l - amount_r) <= 0.5", "numeric_diff:abs:1"),          # lowercase, bare
+        ('ABS("amount_l" - "amount_r") <= 2.5', "numeric_diff:abs:5"),      # float eps
+        ('ABS( "amount_l"  -  "amount_r" )  <=  3', "numeric_diff:abs:6"),  # loose whitespace
+    ],
+)
+def test_numeric_diff_recognized_both_dialects(sql, expected_scorer):
+    r = recognize_level(sql)
+    assert r is not None
+    assert r.kind == "numeric_diff"
+    assert r.column == "amount"
+    assert r.scorer == expected_scorer          # band = 2*eps
+    assert r.sim_threshold == 0.5               # a pair AT the cutoff scores 0.5
+    assert r.approx is True
+
+
+def test_numeric_diff_mismatched_columns_dropped():
+    # Different base columns on the two sides -> not a same-column comparison.
+    assert recognize_level('ABS("amount_l" - "balance_r") <= 1') is None
+
+
+def test_numeric_diff_zero_or_negative_eps_dropped():
+    assert recognize_level('ABS("amount_l" - "amount_r") <= 0') is None
+
+
+def test_numeric_diff_relative_pct_shape_not_recognized():
+    # Only the ABSOLUTE form is recognized; a relative/pct CustomComparison is too
+    # shape-variable to match and must fall through (dropped + warned elsewhere).
+    assert recognize_level('ABS("amount_l" - "amount_r") / 2 <= 0.1') is None
+    assert (
+        recognize_level(
+            'ABS("amount_l" - "amount_r") / GREATEST(ABS("amount_l"), '
+            'ABS("amount_r")) <= 0.1'
+        )
+        is None
+    )
+
+
+def test_numeric_diff_is_not_a_date_diff():
+    # A bare ABS() numeric difference has no EPOCH/UNIX_TIMESTAMP date parse, so it
+    # is numeric_diff, NOT date_diff (the two share the ABS(...) <= n tail).
+    r = recognize_level('ABS("age_l" - "age_r") <= 5')
+    assert r is not None and r.kind == "numeric_diff"
+
+
+# --- full-comparison conversion ----------------------------------------------
+
+
+def _numeric_comparison(cutoffs, col="amount"):
+    """A CustomComparison numeric shape: null, exact, one ABS(diff) <= c level per
+    cutoff, ELSE."""
+    levels = [
+        {
+            "sql_condition": f'"{col}_l" IS NULL OR "{col}_r" IS NULL',
+            "is_null_level": True,
+        },
+        {"sql_condition": f'"{col}_l" = "{col}_r"'},
+    ]
+    levels += [{"sql_condition": f'ABS("{col}_l" - "{col}_r") <= {c}'} for c in cutoffs]
+    levels.append({"sql_condition": "ELSE"})
+    return {"output_column_name": col, "comparison_levels": levels}
+
+
+def test_single_cutoff_converts_to_numeric_diff_field():
+    report = ConversionReport()
+    field = convert_comparison(_numeric_comparison([1]), 0, report)
+
+    assert field is not None
+    assert field.field == "amount"
+    assert field.scorer == "numeric_diff:abs:2"       # band = 2 * eps(1)
+    # exact (1.0) + within-eps (0.5) -> 3 levels: exact / within-eps / else.
+    assert field.levels == 3
+    assert field.level_thresholds == [1.0, 0.5]
+
+
+def test_single_cutoff_field_scorer_is_schema_valid():
+    report = ConversionReport()
+    field = convert_comparison(_numeric_comparison([2.5]), 0, report)
+    assert field is not None
+    assert _is_valid_scorer(field.scorer)             # numeric_diff:abs:5
+
+
+def test_multi_cutoff_collapses_to_loosest_band_with_warn():
+    report = ConversionReport()
+    field = convert_comparison(_numeric_comparison([1, 10]), 0, report)
+
+    assert field is not None
+    # numeric_diff's single-band ramp can't hold two cutoffs; keep the LOOSEST
+    # (band = 2 * 10) for recall, and warn that the finer cutoff collapses.
+    assert field.scorer == "numeric_diff:abs:20"
+    assert field.levels == 3
+    assert field.level_thresholds == [1.0, 0.5]
+    warns = [f.message for f in report.findings if f.severity == "warning"]
+    assert any("collapsed to the loosest band" in w for w in warns)
+
+
+def test_approximate_mapping_is_surfaced():
+    report = ConversionReport()
+    convert_comparison(_numeric_comparison([1]), 0, report)
+    warns = [f.message for f in report.findings if f.severity == "warning"]
+    assert any("numeric-distance cutoff" in w and "band = 2*eps" in w for w in warns)
+
+
+# --- the crux invariant (the whole design rests on this) ---------------------
+
+
+def test_pair_at_cutoff_scores_exactly_half():
+    # With band = 2*eps, a pair exactly eps apart scores 1 - eps/(2*eps) = 0.5, so
+    # the `>= 0.5` level fires iff dist <= eps -- reproducing Splink's `<= eps`.
+    # scalar score_field IS the reference the vectorized path also calls.
+    assert score_field("10", "11", "numeric_diff:abs:2") == 0.5      # dist 1 == eps
+    assert score_field("10", "10.5", "numeric_diff:abs:2") == 0.75   # dist 0.5 < eps
+    assert score_field("10", "10", "numeric_diff:abs:2") == 1.0      # exact
+    assert score_field("10", "12", "numeric_diff:abs:2") == 0.0      # dist 2 == band
+
+
+# --- trained model import (build == import parity) ---------------------------
+
+
+def _trained_numeric_comparison():
+    comp = _numeric_comparison([1])
+    # levels: 0 null, 1 exact, 2 within-eps, 3 ELSE
+    comp["comparison_levels"][1]["m_probability"] = 0.70
+    comp["comparison_levels"][1]["u_probability"] = 0.02
+    comp["comparison_levels"][2]["m_probability"] = 0.20
+    comp["comparison_levels"][2]["u_probability"] = 0.10
+    comp["comparison_levels"][3]["m_probability"] = 0.10
+    comp["comparison_levels"][3]["u_probability"] = 0.88
+    return comp
+
+
+def test_trained_import_maps_every_numeric_level():
+    comp = _trained_numeric_comparison()
+    settings = {"comparisons": [comp], "probability_two_random_records_match": 0.0002}
+    report = ConversionReport()
+
+    field = convert_comparison(comp, 0, report)
+    assert field is not None and field.levels == 3
+
+    em = import_em([(comp, 0, field)], settings, report)
+    assert em is not None
+
+    m = em.m_probs["amount"]
+    assert len(m) == 3
+    # index 2 = exact (top), 1 = within-eps, 0 = else; monotone for these m's.
+    assert m[2] > m[1] > m[0]
+    assert m == pytest.approx([0.10, 0.20, 0.70])
+    # every level survived: no m/u mass dropped (build threshold == import
+    # threshold because recognition is deterministic per level).
+    warns = [f.message for f in report.findings if f.severity == "warning"]
+    assert not any("does not match any converted threshold" in w for w in warns)


### PR DESCRIPTION
## What and why

The **converter** side of numeric — the gap the parallel kernel PRs (#2130/#2134/#2138) don't touch. `from_splink` recognized date/geo/array Splink comparison levels but silently dropped numeric-magnitude ones. This adds the `numeric_diff` recognizer, built against **real captured Splink 4 SQL** per the series discipline.

## Ground truth

Splink's standard library has **no first-class numeric comparison**; magnitude arrives via a `CustomComparison`. Captured live from splink 4 (byte-identical DuckDB + Spark):

```
ABS("amount_l" - "amount_r") <= 1
```

## The mapping (mirrors date_diff's convention exactly)

GoldenMatch's `numeric_diff:abs:<band>` is a **linear ramp** (`sim = 1 − dist/band`), not a hard cutoff. So the recognizer emits **band = 2·eps** with **sim_threshold = 0.5**: a pair exactly at the Splink cutoff (`dist = eps`) scores `1 − eps/(2·eps) = 0.5`, so under the `>=` level semantics **"score ≥ 0.5 ⟺ dist ≤ eps" reproduces `<= eps` exactly, boundary inclusive** — the same "threshold = the score a pair at the cutoff earns" convention `date_diff` uses.

Crucially it's **deterministic per level** (band + threshold come only from that level's own eps, no cross-level state), so `recognize_level` yields the same `0.5` at field-build **and** m/u-import time and `_agree_index_for` aligns automatically — dodging the parity trap that any cross-level band-normalization would create.

## Changes

- **`from_splink.py`**: `_NUMERIC_DIFF_RE` (`ABS(col_l − col_r) <= n`, case-insensitive; quoted/backtick/bare cols) + a `recognize_level` branch + `numeric_diff` in `LevelKind` + `_fmt_band` helper. `convert_comparison` gains numeric-aware scorer selection (multi-cutoff → keep the **loosest** band, recall-biased, + warn) and the approximate-mapping warn. Placed after the haversine branch; the date_diff gate (needs epoch/unix_timestamp) correctly declines a bare `ABS`, so no shadowing.
- **Scope**: only the ABSOLUTE form; a relative/pct `CustomComparison` (`ABS(a-b)/GREATEST(…) <= f`) is too shape-variable and falls through (dropped + warned), matching today's behavior.
- Single-cutoff → field `numeric_diff:abs:<2eps>`, **3 levels `[1.0, 0.5]`** (exact / within-eps / else).

## Testing

- `tests/test_from_splink_numeric.py` (18): recognizer both dialects + edges (mismatched cols, eps=0, pct-shape, not-a-date), single/multi-cutoff conversion, the **pair-at-cutoff-scores-0.5 crux invariant** (via `score_field`), trained m/u **import round-trip** (all levels survive, no dropped mass), scorer schema-validity.
- Updated one assertion in `test_from_splink_domain.py` (a bare `ABS` is now `numeric_diff`, not `None`).
- Full from_splink suite → **166 passed**; `from_splink` stays **polars-free**; `ruff` + `pyright` clean; codemap regenerated.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff check`) + `pyright` clean on changed files
- [ ] Package `CHANGELOG.md` updated (deferred until the conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (plan doc §14)

No parity-manifest/config-matrix change: `numeric_diff` was already a `VALID_SCORERS` member (from the FS domain-comparator work); this is a recognizer only. Complements the numeric_diff **kernel** in #2138 (that's scoring; this is conversion) — they're independent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_