### PR TITLE
feat(from_splink): ForenameSurname compound comparator recognizer

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -944,6 +944,7 @@
             "_looks_like_haversine",
             "_patch_field_placeholders",
             "_recognize_blocking_conjunct",
+            "_recognize_forename_surname",
             "_strip_outer_parens",
             "convert_blocking",
             "convert_comparison",

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -92,8 +92,105 @@ def _looks_like_haversine(sql_norm: str) -> bool:
 
 LevelKind = Literal[
     "null", "exact", "else", "jaro_winkler", "levenshtein", "jaccard", "date_diff",
-    "array_intersect", "geo_haversine", "numeric_diff", "cosine",
+    "array_intersect", "geo_haversine", "numeric_diff", "cosine", "token_sort",
 ]
+
+# ForenameSurname is Splink's OTHER cross-column comparator (geo_haversine is
+# the first): a compound name comparison over SEPARATE forename + surname
+# columns whose comparison levels AND two per-part conditions together. Captured
+# live from splink 4 (`ForenameSurnameComparison('forename','surname')`), the
+# non-null/else levels are:
+#   both exact:     ("forename_l" = "forename_r") AND ("surname_l" = "surname_r")
+#   transposition:  "forename_l" = "surname_r" AND "forename_r" = "surname_l"
+#   both fuzzy (t): (jw("forename_l","forename_r") >= t) AND (jw("surname_l","surname_r") >= t)
+#   surname only:   "surname_l" = "surname_r"
+#   forename only:  "forename_l" = "forename_r"
+# GoldenMatch has no per-part-AND comparator, but `token_sort` over a single
+# COMBINED "forename surname" field captures all three compound shapes in one
+# scorer: it is word-order robust, so the forename/surname TRANSPOSITION and the
+# both-exact case both score 1.0, and a per-part fuzzy level maps to a token_sort
+# threshold (approximate -- token_sort_ratio is not per-part jaro_winkler, but it
+# is the faithful single-field analogue). The field is synthesized via
+# MatchkeyField.derive_from=[forename, surname] + derive_separator=" " (the same
+# machinery geo_haversine uses with a "," separator). The two SINGLE-PART levels
+# (surname-only / forename-only) have no place on a combined-field threshold
+# scale and are dropped (subsumed by the synthesized field) in convert_comparison
+# / import_em. The combined column name is the two source columns sorted +
+# "__"-joined (deterministic, so build-time and m/u-import-time agree) --
+# token_sort is order-insensitive so the join order never affects the score.
+_FS_OPERAND = r'["`]?([A-Za-z_]\w*)_([lr])["`]?'
+_FS_EXACT_CONJ = re.compile(rf'{_FS_OPERAND}\s*=\s*{_FS_OPERAND}')
+_FS_JW_CONJ = re.compile(
+    rf'jaro_winkler(?:_similarity)?\s*\(\s*{_FS_OPERAND}\s*,\s*{_FS_OPERAND}\s*\)'
+    r'\s*>=\s*([0-9]*\.?[0-9]+)'
+)
+
+
+def _recognize_forename_surname(sql_norm: str) -> RecognizedLevel | None:
+    """Recognize a Splink ForenameSurname COMPOUND cross-column level.
+
+    Matches the three per-part-AND shapes (both-exact, transposition, both-fuzzy)
+    over two DISTINCT source columns; returns a ``token_sort`` RecognizedLevel on
+    the synthesized combined field. Any other AND-joined SQL (or a single
+    conjunct, which the single-column matchers already handle) returns None.
+    The split is on the literal ``' AND '`` -- ``sql_norm`` has collapsed
+    whitespace, so this is exact and cannot backtrack (py/polynomial-redos).
+    """
+    conjuncts = re.split(r' AND ', sql_norm, flags=re.IGNORECASE)
+    if len(conjuncts) != 2:
+        return None
+
+    parsed: list[tuple[str, str, str, str, str, float | None]] = []
+    for conjunct in conjuncts:
+        c = _strip_outer_parens(conjunct)
+        m = _FS_JW_CONJ.fullmatch(c)
+        if m:
+            parsed.append(("jw", m.group(1), m.group(2).lower(), m.group(3),
+                           m.group(4).lower(), float(m.group(5))))
+            continue
+        m = _FS_EXACT_CONJ.fullmatch(c)
+        if m:
+            parsed.append(("exact", m.group(1), m.group(2).lower(), m.group(3),
+                           m.group(4).lower(), None))
+            continue
+        return None
+
+    bases = {p[1] for p in parsed} | {p[3] for p in parsed}
+    if len(bases) != 2:
+        return None
+    cols = sorted(bases)
+    combined = f"{cols[0]}__{cols[1]}"
+
+    kinds = {p[0] for p in parsed}
+    if kinds == {"exact"}:
+        # both-parts-exact: each conjunct compares one base's _l to its own _r.
+        both_same = all(lc == rc and {ls, rs} == {"l", "r"}
+                        for _, lc, ls, rc, rs, _ in parsed)
+        # transposition: each conjunct compares the two DIFFERENT bases across
+        # the swap (A_l=B_r AND A_r=B_l).
+        both_cross = all(lc != rc and {ls, rs} == {"l", "r"}
+                         for _, lc, ls, rc, rs, _ in parsed)
+        if both_same or both_cross:
+            return RecognizedLevel(
+                "token_sort", combined, 1.0, approx=False,
+                derive_from=cols, derive_separator=" ",
+            )
+        return None
+
+    if kinds == {"jw"}:
+        # both-parts-fuzzy: each conjunct is a same-column jaro_winkler cutoff.
+        if not all(lc == rc and {ls, rs} == {"l", "r"}
+                   for _, lc, ls, rc, rs, _ in parsed):
+            return None
+        # Splink emits the same threshold on both parts; take the looser (min)
+        # if they ever differ, biased for recall.
+        threshold = min(p[5] for p in parsed if p[5] is not None)
+        return RecognizedLevel(
+            "token_sort", combined, threshold, approx=True,
+            derive_from=cols, derive_separator=" ",
+        )
+
+    return None
 
 # Numeric magnitude levels. Splink's standard library has NO first-class numeric
 # comparison (date/time/DistanceInKM/ArrayIntersect + the string-distance family
@@ -294,6 +391,13 @@ def recognize_level(sql: str, *, is_null_level: bool = False) -> RecognizedLevel
                 scorer=f"numeric_diff:abs:{_fmt_band(band)}",
             )
 
+    # ForenameSurname compound cross-column level (both-exact / transposition /
+    # both-fuzzy). Tried last: single-column shapes match the matchers above and
+    # return first; only AND-joined per-part conditions reach here.
+    fs = _recognize_forename_surname(sql_norm)
+    if fs is not None:
+        return fs
+
     return None
 
 
@@ -398,6 +502,34 @@ def convert_comparison(
             "disagree -- behavior differs on sparse fields",
             mapped_to=None,
         )
+
+    # Synthesized-field subsumption (ForenameSurname). A compound cross-column
+    # comparison synthesizes a combined field (a band with derive_from set) AND
+    # also emits single-part levels on the SOURCE columns (surname-only /
+    # forename-only exact). Those single-column bands cannot map onto the
+    # combined field's threshold scale and would trip the inconsistent-columns
+    # guard below -- drop them (with a warn), keeping the synthesized field.
+    # No-op for single-column comparisons (empty derive_sources) and for geo
+    # (its levels ALL carry derive_from, so none is a subsumable single-column
+    # band).
+    derive_sources = {
+        s for r, _, _ in bands if r.derive_from for s in r.derive_from
+    }
+    if derive_sources:
+        kept_bands: list[tuple[RecognizedLevel, dict, int]] = []
+        for r, level, j in bands:
+            if r.derive_from is None and r.column in derive_sources:
+                report.warn(
+                    f"{comp_path}.comparison_levels[{j}]",
+                    f"single-column level on '{r.column}' subsumed by the "
+                    f"synthesized combined field {sorted(derive_sources)}; dropped "
+                    "(cannot map to the combined-field threshold scale): "
+                    f"{level.get('sql_condition', '')}",
+                    mapped_to=None,
+                )
+            else:
+                kept_bands.append((r, level, j))
+        bands = kept_bands
 
     agree_families = {r.kind for r, _, _ in bands if r.kind != "exact"}
     domain_families = agree_families & _DOMAIN_KINDS
@@ -520,6 +652,14 @@ def convert_comparison(
                     "approximate mapping: great-circle km cutoff snapped to the nearest "
                     f"geo_haversine band -> sim {r.sim_threshold}; lat+lng synthesized into "
                     f"a comma-joined field {r.derive_from} ({sql})"
+                )
+            elif r.kind == "token_sort":
+                message = (
+                    "approximate mapping: ForenameSurname per-part jaro_winkler "
+                    f">= {r.sim_threshold} on both name parts converted to a token_sort "
+                    f"threshold {r.sim_threshold} on the synthesized combined field "
+                    f"{r.derive_from} (word-order robust; handles the forename/surname "
+                    f"transposition) ({sql})"
                 )
             else:
                 message = (
@@ -974,6 +1114,29 @@ def import_em(
                     level_path,
                     "unrecognized level carried m/u probabilities; dropped, "
                     f"surviving levels for field '{fld.field}' re-normalized",
+                    mapped_to=f"em.m_probs.{fld.field}",
+                )
+                continue
+
+            # Synthesized-field subsumption (ForenameSurname): a single-column
+            # level on a SOURCE column of a synthesized combined field was
+            # dropped by convert_comparison; drop its m/u here too (re-normalize)
+            # -- else _agree_index_for, which resolves by threshold alone, would
+            # misassign a surname-only/forename-only exact (threshold 1.0) onto
+            # the combined field's strongest level. Mirrors the convert_comparison
+            # subsumption exactly. No-op for geo (its levels carry derive_from).
+            if (
+                fld.derive_from
+                and r.derive_from is None
+                and r.column in set(fld.derive_from)
+            ):
+                lost_m += m_p or 0.0
+                lost_u += u_p or 0.0
+                report.warn(
+                    level_path,
+                    f"single-column level on '{r.column}' subsumed by the "
+                    f"synthesized field '{fld.field}'; m/u dropped, surviving "
+                    "levels re-normalized",
                     mapped_to=f"em.m_probs.{fld.field}",
                 )
                 continue

--- a/packages/python/goldenmatch/tests/test_from_splink_forename_surname.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_forename_surname.py
@@ -162,7 +162,7 @@ def test_combined_column_name_is_deterministic_across_shapes() -> None:
         '"name_l" = "name_r"',
         # a mixed exact+fuzzy AND is not a recognized ForenameSurname shape
         '("forename_l" = "forename_r") AND '
-        '(jaro_winkler_similarity("surname_l", "surname_r") >= 0.9)',
+        + '(jaro_winkler_similarity("surname_l", "surname_r") >= 0.9)',
         # three-conjunct AND is not the two-part shape
         '("a_l" = "a_r") AND ("b_l" = "b_r") AND ("c_l" = "c_r")',
         # same base column on both conjuncts -> only one source column

--- a/packages/python/goldenmatch/tests/test_from_splink_forename_surname.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_forename_surname.py
@@ -1,0 +1,273 @@
+"""ForenameSurname converter recognizer (Splink -> GoldenMatch).
+
+Splink's ``ForenameSurnameComparison`` is a COMPOUND cross-column comparator: its
+levels AND two per-part conditions over separate forename + surname columns. There
+is no per-part-AND scorer in GoldenMatch, so the converter synthesizes a single
+combined ``forename__surname`` field (via ``derive_from`` + a space separator) and
+scores it with ``token_sort`` -- word-order robust, so both-exact AND the
+forename/surname transposition score 1.0, and each per-part fuzzy level maps to a
+token_sort threshold. The two single-part levels (surname-only / forename-only)
+are subsumed by the synthesized field and dropped.
+
+SQL fixtures are the shapes captured live from splink 4
+(``ForenameSurnameComparison('forename','surname')``) in both the DuckDB
+(double-quoted) and Spark (backtick-quoted) dialects.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.from_splink import (
+    from_splink,
+    recognize_level,
+)
+
+# ── Captured splink 4 SQL (DuckDB dialect) ───────────────────────────────────
+_NULL = (
+    '("forename_l" IS NULL OR "forename_r" IS NULL) AND '
+    '("surname_l" IS NULL OR "surname_r" IS NULL)'
+)
+_BOTH_EXACT = '("forename_l" = "forename_r") AND ("surname_l" = "surname_r")'
+_TRANSPOSE = '"forename_l" = "surname_r" AND "forename_r" = "surname_l"'
+_BOTH_JW92 = (
+    '(jaro_winkler_similarity("forename_l", "forename_r") >= 0.92) AND '
+    '(jaro_winkler_similarity("surname_l", "surname_r") >= 0.92)'
+)
+_BOTH_JW88 = (
+    '(jaro_winkler_similarity("forename_l", "forename_r") >= 0.88) AND '
+    '(jaro_winkler_similarity("surname_l", "surname_r") >= 0.88)'
+)
+_SURNAME_ONLY = '"surname_l" = "surname_r"'
+_FORENAME_ONLY = '"forename_l" = "forename_r"'
+
+
+def _level(sql: str, *, is_null: bool = False, m=None, u=None) -> dict:
+    d: dict = {"sql_condition": sql}
+    if is_null:
+        d["is_null_level"] = True
+    if m is not None:
+        d["m_probability"] = m
+    if u is not None:
+        d["u_probability"] = u
+    return d
+
+
+def _fs_levels(*, trained: bool = False) -> list[dict]:
+    """The eight ForenameSurname comparison levels (null .. ELSE)."""
+    if trained:
+        return [
+            _level(_NULL, is_null=True),
+            _level(_BOTH_EXACT, m=0.50, u=0.001),
+            _level(_TRANSPOSE, m=0.02, u=0.001),
+            _level(_BOTH_JW92, m=0.20, u=0.01),
+            _level(_BOTH_JW88, m=0.10, u=0.02),
+            _level(_SURNAME_ONLY, m=0.08, u=0.05),
+            _level(_FORENAME_ONLY, m=0.05, u=0.05),
+            _level("ELSE", m=0.05, u=0.878),
+        ]
+    return [
+        _level(_NULL, is_null=True),
+        _level(_BOTH_EXACT),
+        _level(_TRANSPOSE),
+        _level(_BOTH_JW92),
+        _level(_BOTH_JW88),
+        _level(_SURNAME_ONLY),
+        _level(_FORENAME_ONLY),
+        _level("ELSE"),
+    ]
+
+
+def _settings(*, trained: bool = False) -> dict:
+    return {
+        "comparisons": [
+            {
+                "output_column_name": "forename_surname",
+                "comparison_levels": _fs_levels(trained=trained),
+            }
+        ],
+        "blocking_rules_to_generate_predictions": ['l."surname" = r."surname"'],
+    }
+
+
+# ── recognize_level: the compound shapes ─────────────────────────────────────
+
+
+def test_both_exact_recognized_as_token_sort_1() -> None:
+    r = recognize_level(_BOTH_EXACT)
+    assert r is not None
+    assert r.kind == "token_sort"
+    assert r.column == "forename__surname"
+    assert r.sim_threshold == 1.0
+    assert r.approx is False
+    assert r.derive_from == ["forename", "surname"]
+    assert r.derive_separator == " "
+
+
+def test_transposition_recognized_as_token_sort_1() -> None:
+    r = recognize_level(_TRANSPOSE)
+    assert r is not None
+    assert r.kind == "token_sort"
+    assert r.column == "forename__surname"
+    assert r.sim_threshold == 1.0
+    assert r.approx is False  # token_sort is word-order robust -> exact, not approx
+    assert r.derive_from == ["forename", "surname"]
+
+
+@pytest.mark.parametrize("sql,thr", [(_BOTH_JW92, 0.92), (_BOTH_JW88, 0.88)])
+def test_both_fuzzy_recognized_as_token_sort_threshold(sql: str, thr: float) -> None:
+    r = recognize_level(sql)
+    assert r is not None
+    assert r.kind == "token_sort"
+    assert r.column == "forename__surname"
+    assert r.sim_threshold == thr
+    assert r.approx is True  # per-part jaro_winkler -> token_sort is approximate
+    assert r.derive_from == ["forename", "surname"]
+
+
+def test_spark_backtick_dialect_recognized() -> None:
+    sql = (
+        "(jaro_winkler(`forename_l`, `forename_r`) >= 0.92) AND "
+        "(jaro_winkler(`surname_l`, `surname_r`) >= 0.92)"
+    )
+    r = recognize_level(sql)
+    assert r is not None
+    assert r.kind == "token_sort"
+    assert r.column == "forename__surname"
+    assert r.sim_threshold == 0.92
+    assert r.derive_from == ["forename", "surname"]
+
+
+def test_single_part_levels_are_plain_exact() -> None:
+    # A single-part level is NOT a compound shape -- it recognizes as a normal
+    # single-column exact (subsumption happens later, in convert_comparison).
+    assert recognize_level(_SURNAME_ONLY).kind == "exact"
+    assert recognize_level(_SURNAME_ONLY).column == "surname"
+    assert recognize_level(_FORENAME_ONLY).column == "forename"
+
+
+def test_combined_column_name_is_deterministic_across_shapes() -> None:
+    # All compound shapes must synthesize the SAME combined field name so the
+    # levels align on one field (and m/u import aligns build vs import time).
+    names = {
+        recognize_level(sql).column
+        for sql in (_BOTH_EXACT, _TRANSPOSE, _BOTH_JW92, _BOTH_JW88)
+    }
+    assert names == {"forename__surname"}
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # single-column shapes must NOT be captured by the compound recognizer
+        'jaro_winkler_similarity("name_l", "name_r") >= 0.9',
+        '"name_l" = "name_r"',
+        # a mixed exact+fuzzy AND is not a recognized ForenameSurname shape
+        '("forename_l" = "forename_r") AND '
+        '(jaro_winkler_similarity("surname_l", "surname_r") >= 0.9)',
+        # three-conjunct AND is not the two-part shape
+        '("a_l" = "a_r") AND ("b_l" = "b_r") AND ("c_l" = "c_r")',
+        # same base column on both conjuncts -> only one source column
+        '("forename_l" = "forename_r") AND ("forename_l" = "forename_r")',
+    ],
+)
+def test_non_forename_surname_and_shapes_rejected(sql: str) -> None:
+    r = recognize_level(sql)
+    # Either None (dropped) or a non-token_sort single-column recognition, but
+    # never a spurious synthesized combined field.
+    if r is not None:
+        assert not (r.kind == "token_sort" and r.derive_from is not None)
+
+
+# ── convert_comparison: full bare conversion ─────────────────────────────────
+
+
+def test_bare_conversion_builds_combined_token_sort_field() -> None:
+    res = from_splink(_settings())
+    fields = res.config.matchkeys[0].fields
+    assert len(fields) == 1
+    f = fields[0]
+    assert f.field == "forename__surname"
+    assert f.scorer == "token_sort"
+    assert f.levels == 4
+    assert f.level_thresholds == [1.0, 0.92, 0.88]
+    assert f.derive_from == ["forename", "surname"]
+    assert f.derive_separator == " "
+    assert res.em_model is None
+
+
+def test_single_part_levels_dropped_with_warning() -> None:
+    res = from_splink(_settings())
+    subsumed = [
+        fnd
+        for fnd in res.report.findings
+        if fnd.severity == "warning" and "subsumed" in fnd.message
+    ]
+    # exactly the surname-only + forename-only levels are subsumed
+    assert len(subsumed) == 2
+    cols = {"surname", "forename"}
+    assert all(any(c in fnd.message for c in cols) for fnd in subsumed)
+
+
+def test_fuzzy_levels_flagged_approximate() -> None:
+    res = from_splink(_settings())
+    approx = [
+        fnd
+        for fnd in res.report.findings
+        if fnd.severity == "warning" and "token_sort threshold" in fnd.message
+    ]
+    assert len(approx) == 2  # the two per-part jaro_winkler levels
+
+
+def test_conversion_is_polars_free() -> None:
+    # from_splink must not import polars (the package is arrow-native).
+    import sys
+
+    sys.modules.pop("polars", None)
+    from_splink(_settings())
+    assert "polars" not in sys.modules
+
+
+# ── import_em: trained m/u round-trip ────────────────────────────────────────
+
+
+def test_trained_import_round_trips_probabilities() -> None:
+    res = from_splink(_settings(trained=True))
+    em = res.em_model
+    assert em is not None
+    f = "forename__surname"
+    assert f in em.m_probs
+    m, u = em.m_probs[f], em.u_probs[f]
+    assert len(m) == 4 and len(u) == 4
+    # normalized
+    assert abs(sum(m) - 1.0) < 1e-9
+    assert abs(sum(u) - 1.0) < 1e-9
+    # match weights strictly increase from disagree -> strongest agree
+    assert em.match_weights[f] == sorted(em.match_weights[f])
+
+
+def test_trained_import_collapses_exact_and_transposition() -> None:
+    # both-exact (m=0.50) + transposition (m=0.02) both map to token_sort 1.0
+    # (the strongest level) and their m mass is SUMMED.
+    res = from_splink(_settings(trained=True))
+    em = res.em_model
+    f = "forename__surname"
+    # surname-only(0.08) + forename-only(0.05) dropped; kept sum = 0.87
+    # strongest level raw m = 0.50 + 0.02 = 0.52 -> 0.52/0.87
+    assert em.m_probs[f][3] == pytest.approx(0.52 / 0.87, abs=1e-6)
+    collapse = [
+        fnd
+        for fnd in res.report.findings
+        if fnd.severity == "warning" and "collapsed onto" in fnd.message
+    ]
+    assert len(collapse) == 1
+
+
+def test_trained_import_drops_single_part_mu() -> None:
+    res = from_splink(_settings(trained=True))
+    dropped = [
+        fnd
+        for fnd in res.report.findings
+        if fnd.severity == "warning"
+        and "subsumed" in fnd.message
+        and "m/u dropped" in fnd.message
+    ]
+    assert len(dropped) == 2  # surname-only + forename-only m/u dropped

--- a/packages/python/goldenmatch/tests/test_from_splink_recognizers.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_recognizers.py
@@ -109,9 +109,23 @@ def test_else_level():
     assert result_lower == RecognizedLevel("else", None, None)
 
 
-def test_cross_column_returns_none():
-    result = recognize_level('"first_name_l" = "surname_r" AND "surname_l" = "first_name_r"')
+def test_single_cross_column_equality_returns_none():
+    # A lone cross-column equality (not the two-part ForenameSurname AND shape)
+    # is still unrecognized.
+    result = recognize_level('"first_name_l" = "surname_r"')
     assert result is None
+
+
+def test_forename_surname_transposition_recognized():
+    # The A_l=B_r AND A_r=B_l transposition is the ForenameSurname cross-column
+    # shape: now recognized as a token_sort on the synthesized combined field
+    # (previously returned None).
+    result = recognize_level('"first_name_l" = "surname_r" AND "surname_l" = "first_name_r"')
+    assert result is not None
+    assert result.kind == "token_sort"
+    assert result.column == "first_name__surname"
+    assert result.sim_threshold == 1.0
+    assert result.derive_from == ["first_name", "surname"]
 
 
 def test_mismatched_columns_in_function_returns_none():


### PR DESCRIPTION
## What and why

Closes the **last** Splink-library converter gap (from the survey). `ForenameSurnameComparison` is Splink's **compound cross-column** comparator — its levels **AND two per-part conditions** over separate `forename` + `surname` columns — so `from_splink` dropped it entirely (the inconsistent-columns guard fired on the single-part levels). Built against **real captured Splink 4 SQL** (both DuckDB double-quoted + Spark backtick dialects), per the series discipline.

## The mapping — one synthesized `token_sort` field

GoldenMatch has no per-part-AND comparator, but `token_sort` over a single **combined** `forename__surname` field captures all three compound shapes in one scorer (it's word-order robust):

| Splink compound level | → GoldenMatch |
|---|---|
| both-parts exact — `(f_l=f_r) AND (s_l=s_r)` | `token_sort` **1.0** (exact) |
| **transposition** — `f_l=s_r AND f_r=s_l` | `token_sort` **1.0** — word-order robust, so **not** an approximation |
| both-parts fuzzy — `jw(f)>=t AND jw(s)>=t` | `token_sort` **t** (approx: token_sort_ratio ≠ per-part jw; `approx=True` + warn) |
| surname-only / forename-only | **dropped** (subsumed by the combined field) |

The combined field is synthesized via `MatchkeyField.derive_from=[forename, surname]` + a space separator — the same machinery `geo_haversine` uses with `,`. The combined name is the two source columns **sorted + `__`-joined** (deterministic, so build-time and m/u-import-time agree; `token_sort` is order-insensitive so the join order never affects the score).

## Subsumption (the crux)

The two single-part levels (surname-only / forename-only) have no place on a combined-field threshold scale, and would otherwise trip the inconsistent-columns guard. They're dropped **in two places, with warnings**:
- **`convert_comparison`** — else the `{surname, forename, forename__surname}` column set trips the guard and the whole comparison is dropped.
- **`import_em`** — else `_agree_index_for` (which resolves by threshold alone) would misassign a single-part exact (threshold 1.0) onto the combined field's strongest level.

Trained m/u round-trips cleanly: both-exact + transposition **collapse** onto the strongest level (m summed), single-part mass re-normalized, weights monotonic. Verified end-to-end.

## Changes

- **`config/from_splink.py`**: `token_sort` in `LevelKind`; `_recognize_forename_surname` (three shapes, both dialects); `convert_comparison` + `import_em` synthesized-field subsumption; `token_sort` approx-warn branch.
- **`tests/test_from_splink_forename_surname.py`** (19): recognizer, bare conversion, subsumption warnings, trained round-trip + collapse, polars-free.
- **`tests/test_from_splink_recognizers.py`**: the transposition shape now recognizes (was asserted `None`); a lone cross-column equality stays `None`.

## Testing

- 136 from_splink/recognizer/cosine/numeric/domain tests pass; `from_splink` stays **polars-free**; `ruff` + `pyright` clean on changed files.
- **No parity/config-matrix manifest change** — reuses the existing shared, kernel-backed `token_sort` scorer (recognizer-only, no new scorer).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff`) + `pyright` clean on changed files
- [ ] Package `CHANGELOG.md` updated (deferred until the conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] No parity-manifest/config-matrix change needed (recognizer reuses an existing scorer)

Final gap in the Splink-converter completeness sweep (after date_diff, geo_haversine, array_intersect, numeric_diff, cosine).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_