### PR TITLE
feat(from_splink): auto-verify a conversion against a locally-installed Splink

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -715,6 +715,9 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `import-splink` | `--sample-cap` | integer | `100000` | Row cap for --upgrade lever computation and measurement (seeded subsample above it) |
 | `import-splink` | `--no-measure` | boolean | `False` | Skip the baseline-vs-upgraded measurement pass |
 | `import-splink` | `--id-column` | text | `None` | Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id) |
+| `import-splink` | `--verify` | text | `None` | Prove the conversion preserved behaviour: run BOTH the original Splink settings (needs `pip install splink`) AND the converted config on a sample of this dataset (parquet/csv) and report pairwise cluster agreement. Best-effort -- skipped with a notice if splink is absent or the settings can't run under DuckDB. |
+| `import-splink` | `--verify-sample` | integer | `5000` | Rows to run through both engines for --verify (seeded subsample above it) |
+| `import-splink` | `--verify-threshold` | float | `0.5` | Splink match-probability cut for --verify clustering |
 | `incremental` | `base_file` | text | **required** | Base dataset file path |
 | `incremental` | `--new-records` | path | **required** | New records CSV to match |
 | `incremental` | `--config` | path | **required** | Config YAML path |

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 405,
+      "module_count": 406,
       "modules": [
         {
           "module": "goldenmatch",
@@ -598,12 +598,15 @@
             "_baseline_path",
             "_render_delta_table",
             "_render_report_table",
+            "_render_verify_table",
+            "_run_verify",
             "_write_pair",
             "import_splink_cmd"
           ],
           "imports": [
             "goldenmatch.config.from_splink",
-            "goldenmatch.config.splink_upgrade"
+            "goldenmatch.config.splink_upgrade",
+            "goldenmatch.config.splink_verify"
           ]
         },
         {
@@ -1123,6 +1126,27 @@
             "goldenmatch._polars_lazy",
             "goldenmatch.config.schemas",
             "goldenmatch.config.splink_upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.splink_verify",
+          "file": "packages/python/goldenmatch/goldenmatch/config/splink_verify.py",
+          "purpose": "Auto-verify a Splink -> GoldenMatch conversion against a locally-installed Splink.",
+          "defines": [
+            "SplinkVerification",
+            "_multi_cluster_count",
+            "_run_goldenmatch",
+            "_run_splink",
+            "_splink_available",
+            "verify_against_splink"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.splink_upgrade",
+            "goldenmatch.config.splink_upgrade_measure",
+            "goldenmatch.core.probabilistic"
           ]
         },
         {

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -3196,6 +3196,27 @@
               "required": false,
               "default": "None",
               "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
+            },
+            {
+              "name": "--verify",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Prove the conversion preserved behaviour: run BOTH the original Splink settings (needs `pip install splink`) AND the converted config on a sample of this dataset (parquet/csv) and report pairwise cluster agreement. Best-effort -- skipped with a notice if splink is absent or the settings can't run under DuckDB."
+            },
+            {
+              "name": "--verify-sample",
+              "type": "integer",
+              "required": false,
+              "default": "5000",
+              "help": "Rows to run through both engines for --verify (seeded subsample above it)"
+            },
+            {
+              "name": "--verify-threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.5",
+              "help": "Splink match-probability cut for --verify clustering"
             }
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/cli/import_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/import_splink.py
@@ -13,15 +13,28 @@ goldenmatch.config.splink_upgrade.upgrade_splink_conversion(). With
 `--upgrade`, the faithful baseline conversion is written alongside the
 upgraded config/model as an `*.baseline.*` pair so the trust anchor stays
 on disk next to the tuned artifacts.
+
+The `--verify` flag runs an auto-verification (goldenmatch.config.
+splink_verify.verify_against_splink): on a sample of the given dataset it
+runs BOTH the original Splink settings (when `splink` is installed) and the
+converted config, then reports pairwise cluster agreement -- a one-command
+proof the conversion preserved Splink's linking decisions. Best-effort: it
+degrades to a skip notice when splink is absent or the settings can't run
+under the local DuckDB engine.
 """
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 import yaml
 from rich.console import Console
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from goldenmatch.config.from_splink import SplinkConversion
+    from goldenmatch.config.splink_verify import SplinkVerification
 
 console = Console()
 err_console = Console(stderr=True)
@@ -44,6 +57,67 @@ def _render_report_table(findings) -> Table | None:
             f.message,
             f.mapped_to or "",
         )
+    return table
+
+
+def _run_verify(
+    input_path: str,
+    conversion: SplinkConversion,
+    data: str,
+    sample: int,
+    threshold: float,
+) -> None:
+    """Run the auto-verify pass and print a table (or a skip notice).
+
+    Reloads the original settings (the converter doesn't retain the raw dict)
+    and hands them to ``verify_against_splink`` with the converted config +
+    imported model. Any skip reason is already recorded as a report finding;
+    a returned result is rendered as an agreement table.
+    """
+    from goldenmatch.config.from_splink import _load_settings
+    from goldenmatch.config.splink_verify import verify_against_splink
+
+    settings = _load_settings(input_path)
+    result = verify_against_splink(
+        settings,
+        data,
+        conversion.config,
+        em_model=conversion.em_model,
+        sample_size=sample,
+        match_threshold=threshold,
+        report=conversion.report,
+    )
+    if result is None:
+        console.print(
+            "[dim]Splink verification skipped (see findings for the reason).[/dim]"
+        )
+        return
+    console.print(_render_verify_table(result))
+
+
+def _render_verify_table(verification: SplinkVerification) -> Table:
+    """Render a SplinkVerification as an agreement summary table."""
+    a = verification.agreement
+    verdict = (
+        "[green]faithful[/green]"
+        if verification.is_faithful
+        else "[yellow]divergent[/yellow]"
+    )
+    table = Table(
+        title=f"Splink agreement ({verdict}) - splink {verification.splink_version}",
+        header_style="bold #d4a017",
+    )
+    table.add_column("Metric")
+    table.add_column("Value", justify="right")
+    table.add_row("pairwise F1 (GoldenMatch vs Splink)", f"{a['f1']:.3f}")
+    table.add_row("pairwise precision", f"{a['precision']:.3f}")
+    table.add_row("pairwise recall", f"{a['recall']:.3f}")
+    table.add_row("records compared", str(verification.n_shared_ids))
+    table.add_row(
+        "multi-record clusters (GM / Splink)",
+        f"{verification.gm_multi_clusters} / {verification.splink_multi_clusters}",
+    )
+    table.add_row("Splink match threshold", f"{verification.match_threshold:.2f}")
     return table
 
 
@@ -216,6 +290,27 @@ def import_splink_cmd(
             "joins (default: auto-detect unique_id/id/record_id)"
         ),
     ),
+    verify: str | None = typer.Option(
+        None,
+        "--verify",
+        help=(
+            "Prove the conversion preserved behaviour: run BOTH the original "
+            "Splink settings (needs `pip install splink`) AND the converted "
+            "config on a sample of this dataset (parquet/csv) and report "
+            "pairwise cluster agreement. Best-effort -- skipped with a notice "
+            "if splink is absent or the settings can't run under DuckDB."
+        ),
+    ),
+    verify_sample: int = typer.Option(
+        5000,
+        "--verify-sample",
+        help="Rows to run through both engines for --verify (seeded subsample above it)",
+    ),
+    verify_threshold: float = typer.Option(
+        0.5,
+        "--verify-threshold",
+        help="Splink match-probability cut for --verify clustering",
+    ),
 ) -> None:
     """Convert a Splink settings (or trained-model) JSON file into a GoldenMatch YAML config."""
     from goldenmatch.config.from_splink import SplinkConversionError, from_splink
@@ -244,6 +339,9 @@ def import_splink_cmd(
                 f"[green]Trained model persisted to[/green] [cyan]{model_out}[/cyan] "
                 f"(set as matchkeys[0].model_path)."
             )
+
+        if verify is not None:
+            _run_verify(input_path, conversion, verify, verify_sample, verify_threshold)
 
         table = _render_report_table(conversion.report.findings)
         if table is not None:

--- a/packages/python/goldenmatch/goldenmatch/config/splink_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_verify.py
@@ -153,15 +153,18 @@ def _run_goldenmatch(
         return mapping
 
     config = gm_config.model_copy(deep=True)
+    # get_matchkeys() returns the matchkey list (top-level or match_settings),
+    # never None -- mutating an element mutates the config dedupe_df reads.
+    matchkeys = config.get_matchkeys()
     covered = set(em_model.match_weights)
-    fully_covered = all(
-        f.field in covered for f in config.matchkeys[0].fields if f.field
+    fully_covered = bool(matchkeys) and all(
+        f.field in covered for f in matchkeys[0].fields if f.field
     )
     with tempfile.TemporaryDirectory() as tmp:
         if fully_covered:
             model_path = str(Path(tmp) / "em.json")
             em_model.save_json(model_path)
-            config.matchkeys[0].model_path = model_path
+            matchkeys[0].model_path = model_path
         mapping, _wall = _run_once(sample, config, ids)
     return mapping
 

--- a/packages/python/goldenmatch/goldenmatch/config/splink_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_verify.py
@@ -1,0 +1,282 @@
+"""Auto-verify a Splink -> GoldenMatch conversion against a locally-installed Splink.
+
+The converter (``from_splink``) proves WHICH Splink constructs it maps. This
+module proves the mapping PRESERVED BEHAVIOR: on a sample of the user's own
+data it runs BOTH the original Splink settings (when ``splink`` is importable)
+AND the converted GoldenMatch config, then reports pairwise cluster agreement
+(precision / recall / F1 of GoldenMatch's dedupe clusters against Splink's).
+That turns "trust the conversion warnings" into one measured number, without
+the user wiring Splink up or handing over cluster output.
+
+``splink`` is an OPTIONAL, heavy dependency with its own dep tree, so it is NOT
+a goldenmatch requirement. ``verify_against_splink`` returns ``None`` (with an
+info finding) when splink can't be imported, and fails soft (a warning finding,
+``None`` returned) when the original settings can't be executed under the local
+DuckDB engine -- e.g. a Spark-dialect settings export whose comparison SQL uses
+Spark functions. Verification is best-effort by design: a missing agreement
+number never blocks the conversion.
+
+This module DELIBERATELY imports polars + the full dedupe pipeline (via the
+reused ``splink_upgrade_measure`` helpers): unlike ``from_splink`` (which stays
+polars-free), verification is an explicitly opt-in operation that runs the
+pipeline, so ``from_splink`` must NOT import this module.
+"""
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from goldenmatch._polars_lazy import pl
+from goldenmatch.config.from_splink import ConversionReport
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.config.splink_upgrade import _load_frame
+from goldenmatch.config.splink_upgrade_measure import (
+    _resolve_ids,
+    _run_once,
+    pair_set,
+    pairwise_prf,
+)
+from goldenmatch.core.probabilistic import EMResult
+
+# A conversion whose GoldenMatch clusters agree with Splink's at or above this
+# pairwise F1 on the sample is reported as behaviourally faithful. 0.95 mirrors
+# the "numerically-equivalent" bar the conformance vocabulary uses for a port
+# that isn't byte-identical but preserves decisions.
+_FAITHFUL_F1 = 0.95
+
+# Reserved unique-id column injected into the Splink input frame so Splink's
+# cluster output keys align 1:1 with GoldenMatch's resolved ids regardless of
+# the settings' own unique_id_column_name.
+_VERIFY_UID = "__gm_verify_uid__"
+
+_DEFAULT_SAMPLE = 5000
+_DEFAULT_MATCH_THRESHOLD = 0.5
+
+
+@dataclass
+class SplinkVerification:
+    """Result of :func:`verify_against_splink`.
+
+    ``agreement`` is the pairwise precision/recall/F1 of the converted
+    GoldenMatch config's dedupe clusters vs the original Splink settings'
+    clusters, over the ids present in both runs. High F1 == the conversion
+    reproduces Splink's linking decisions on this data.
+    """
+
+    agreement: dict[str, float]
+    n_records: int          # rows actually run through both engines
+    n_shared_ids: int       # ids that clustered in BOTH runs (the metric base)
+    gm_cluster_count: int
+    splink_cluster_count: int
+    gm_multi_clusters: int
+    splink_multi_clusters: int
+    match_threshold: float
+    splink_version: str
+    id_source: str
+
+    @property
+    def is_faithful(self) -> bool:
+        return self.agreement.get("f1", 0.0) >= _FAITHFUL_F1
+
+
+def _splink_available() -> bool:
+    """True when ``splink`` can be imported (an OPTIONAL dependency)."""
+    import importlib.util
+
+    return importlib.util.find_spec("splink") is not None
+
+
+def _multi_cluster_count(mapping: dict[str, str]) -> int:
+    counts: dict[str, int] = {}
+    for cid in mapping.values():
+        counts[cid] = counts.get(cid, 0) + 1
+    return sum(1 for n in counts.values() if n > 1)
+
+
+def _run_splink(
+    settings: dict, sample: pl.DataFrame, ids: list[str], threshold: float
+) -> tuple[dict[str, str], str]:
+    """Run the ORIGINAL Splink settings on ``sample`` -> (id -> cluster_id, version).
+
+    Uses the DuckDB engine (the common Splink backend). A synthetic unique-id
+    column keyed to ``ids`` is injected so the returned map shares GoldenMatch's
+    id space exactly. ``link_type`` is forced to ``dedupe_only`` -- verification
+    compares single-frame dedupe clustering. The splink version is returned
+    alongside so the happy path never imports splink a second time. Any Splink
+    exception propagates to the caller, which converts it into a soft-fail
+    finding.
+    """
+    import splink as _splink  # pyright: ignore[reportMissingImports]  # optional heavy dep
+    from splink import DuckDBAPI, Linker  # pyright: ignore[reportMissingImports]
+
+    pdf = sample.to_pandas()
+    pdf[_VERIFY_UID] = [str(x) for x in ids]
+
+    # Copy the settings (never mutate the caller's dict) and pin the id column
+    # + single-frame dedupe. sql_dialect stays as the export declared it so the
+    # comparison SQL is interpreted as authored; a dialect the local DuckDB
+    # engine can't run surfaces as an exception -> soft fail upstream.
+    s = dict(settings)
+    s["unique_id_column_name"] = _VERIFY_UID
+    s["link_type"] = "dedupe_only"
+
+    linker = Linker(pdf, s, DuckDBAPI())
+    preds = linker.inference.predict()
+    clustered = linker.clustering.cluster_pairwise_predictions_at_threshold(
+        preds, threshold_match_probability=threshold
+    )
+    out = clustered.as_pandas_dataframe()
+    mapping = {
+        str(row[_VERIFY_UID]): f"s{row['cluster_id']}"
+        for _, row in out[[_VERIFY_UID, "cluster_id"]].iterrows()
+    }
+    return mapping, getattr(_splink, "__version__", "unknown")
+
+
+def _run_goldenmatch(
+    sample: pl.DataFrame,
+    gm_config: GoldenMatchConfig,
+    em_model: EMResult | None,
+    ids: list[str],
+) -> dict[str, str]:
+    """Run the converted GoldenMatch config on ``sample`` -> id -> cluster_id.
+
+    When ``em_model`` is provided (a trained Splink import), it is injected via
+    a temp ``model_path`` so ``dedupe_df`` uses the IMPORTED weights instead of
+    silently retraining EM on the sample -- otherwise the agreement would
+    measure a re-fit model, not the converted one. Mirrors the model-injection
+    seam ``splink_upgrade_measure`` uses.
+    """
+    if em_model is None:
+        mapping, _wall = _run_once(sample, gm_config, ids)
+        return mapping
+
+    config = gm_config.model_copy(deep=True)
+    covered = set(em_model.match_weights)
+    fully_covered = all(
+        f.field in covered for f in config.matchkeys[0].fields if f.field
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        if fully_covered:
+            model_path = str(Path(tmp) / "em.json")
+            em_model.save_json(model_path)
+            config.matchkeys[0].model_path = model_path
+        mapping, _wall = _run_once(sample, config, ids)
+    return mapping
+
+
+def verify_against_splink(
+    settings: dict,
+    data: pl.DataFrame | str | Path,
+    gm_config: GoldenMatchConfig,
+    *,
+    em_model: EMResult | None = None,
+    sample_size: int = _DEFAULT_SAMPLE,
+    id_column: str | None = None,
+    match_threshold: float = _DEFAULT_MATCH_THRESHOLD,
+    report: ConversionReport | None = None,
+) -> SplinkVerification | None:
+    """Measure behavioural agreement between the conversion and real Splink.
+
+    Runs the original ``settings`` (via a locally-installed Splink, DuckDB
+    engine) AND the converted ``gm_config`` on a deterministic sample of
+    ``data``, then reports pairwise cluster agreement.
+
+    Returns ``None`` -- best-effort, never raising on the verify path itself --
+    when: ``splink`` is not importable, the data is empty, or the original
+    settings cannot be executed under the local engine (each recorded as a
+    finding on ``report`` when one is supplied).
+
+    Args:
+        settings: the ORIGINAL Splink settings dict (what ``from_splink``
+            converted from).
+        data: a DataFrame or a ``.parquet`` / ``.csv`` path of the user's data.
+        gm_config: the converted ``GoldenMatchConfig``.
+        em_model: the imported ``EMResult`` for a trained Splink model, injected
+            so GoldenMatch scores with the imported weights (not a re-fit).
+        sample_size: rows to run through both engines (a seeded subsample above
+            this cap; the whole frame at or below it).
+        id_column: unique row-id column; defaults to
+            ``unique_id``/``id``/``record_id`` then positional indices.
+        match_threshold: Splink match-probability cut for its clustering (the
+            GoldenMatch side clusters at its config's own link threshold).
+        report: optional :class:`ConversionReport` to attach findings to.
+    """
+
+    def _note(kind: str, msg: str) -> None:
+        # ConversionReport exposes info/warn/error; accept "warning" as an alias.
+        if report is not None:
+            method = "warn" if kind == "warning" else kind
+            getattr(report, method)("verify", msg, None)
+
+    if not _splink_available():
+        _note(
+            "info",
+            "splink is not installed, so the conversion could not be verified "
+            "against real Splink; `pip install splink` to enable the agreement "
+            "check.",
+        )
+        return None
+
+    frame = _load_frame(data)
+    if frame.height == 0:
+        _note("warning", "verify data is empty; agreement not measured.")
+        return None
+
+    sample = (
+        frame.sample(n=sample_size, seed=0) if frame.height > sample_size else frame
+    )
+    if frame.height > sample_size:
+        _note(
+            "info",
+            f"verifying on a seeded {sample_size}-row sample of {frame.height} "
+            "rows (deterministic).",
+        )
+
+    ids, id_source = _resolve_ids(sample, id_column)
+
+    try:
+        splink_map, splink_version = _run_splink(
+            settings, sample, ids, match_threshold
+        )
+    except Exception as exc:  # noqa: BLE001 -- verify is best-effort
+        _note(
+            "warning",
+            "could not run the original Splink settings under the local DuckDB "
+            f"engine ({type(exc).__name__}: {exc}); the conversion was written "
+            "but not verified. This is expected for a Spark-dialect export whose "
+            "comparison SQL uses Spark-only functions.",
+        )
+        return None
+
+    gm_map = _run_goldenmatch(sample, gm_config, em_model, ids)
+
+    shared = gm_map.keys() & splink_map.keys()
+    gm_pairs, _c1 = pair_set({k: gm_map[k] for k in shared})
+    sp_pairs, _c2 = pair_set({k: splink_map[k] for k in shared})
+    agreement = pairwise_prf(gm_pairs, sp_pairs)
+
+    result = SplinkVerification(
+        agreement=agreement,
+        n_records=len(ids),
+        n_shared_ids=len(shared),
+        gm_cluster_count=len(set(gm_map.values())),
+        splink_cluster_count=len(set(splink_map.values())),
+        gm_multi_clusters=_multi_cluster_count(gm_map),
+        splink_multi_clusters=_multi_cluster_count(splink_map),
+        match_threshold=match_threshold,
+        splink_version=splink_version,
+        id_source=id_source,
+    )
+
+    verdict = "faithful" if result.is_faithful else "DIVERGENT"
+    _note(
+        "info" if result.is_faithful else "warning",
+        f"Splink agreement ({verdict}): pairwise F1={agreement['f1']:.3f} "
+        f"(P={agreement['precision']:.3f}, R={agreement['recall']:.3f}) over "
+        f"{len(shared)} records; GoldenMatch {result.gm_multi_clusters} vs "
+        f"Splink {result.splink_multi_clusters} multi-record clusters at "
+        f"match_threshold={match_threshold}.",
+    )
+    return result

--- a/packages/python/goldenmatch/tests/test_from_splink_verify.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_verify.py
@@ -1,0 +1,279 @@
+"""Auto-verify a Splink -> GoldenMatch conversion against real Splink.
+
+`verify_against_splink` runs BOTH the original Splink settings (when splink is
+installed) and the converted config on a sample, then reports pairwise cluster
+agreement. splink is an OPTIONAL dependency, so:
+
+- the graceful-degradation + agreement-assembly paths are tested WITHOUT splink
+  (patching the two engine-run helpers), so they run in the normal CI lane;
+- one real end-to-end test is guarded by ``importorskip("splink")`` and only
+  fires in an environment that has splink + pandas.
+"""
+from __future__ import annotations
+
+import json
+
+import polars as pl
+import pytest
+from goldenmatch.cli.main import app
+from goldenmatch.config import splink_verify
+from goldenmatch.config.from_splink import ConversionReport, from_splink
+from goldenmatch.config.splink_verify import (
+    SplinkVerification,
+    verify_against_splink,
+)
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+_DF = pl.DataFrame(
+    {
+        "unique_id": list(range(6)),
+        "first_name": ["john", "jon", "alice", "alicia", "bob", "bob"],
+        "surname": ["smith", "smith", "jones", "jones", "lee", "lee"],
+    }
+)
+
+_SETTINGS = {
+    "link_type": "dedupe_only",
+    "unique_id_column_name": "unique_id",
+    "comparisons": [
+        {
+            "output_column_name": "first_name",
+            "comparison_levels": [
+                {"sql_condition": '"first_name_l" IS NULL OR "first_name_r" IS NULL',
+                 "is_null_level": True},
+                {"sql_condition": '"first_name_l" = "first_name_r"'},
+                {"sql_condition": 'jaro_winkler_similarity("first_name_l","first_name_r") >= 0.8'},
+                {"sql_condition": "ELSE"},
+            ],
+        },
+        {
+            "output_column_name": "surname",
+            "comparison_levels": [
+                {"sql_condition": '"surname_l" IS NULL OR "surname_r" IS NULL',
+                 "is_null_level": True},
+                {"sql_condition": '"surname_l" = "surname_r"'},
+                {"sql_condition": "ELSE"},
+            ],
+        },
+    ],
+    "blocking_rules_to_generate_predictions": ["l.surname = r.surname"],
+}
+
+
+def _converted():
+    return from_splink(_SETTINGS)
+
+
+# ── graceful degradation (no splink) ─────────────────────────────────────────
+
+
+def test_returns_none_when_splink_absent(monkeypatch) -> None:
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: False)
+    report = ConversionReport()
+    result = verify_against_splink(
+        _SETTINGS, _DF, _converted().config, report=report
+    )
+    assert result is None
+    assert any(
+        f.splink_path == "verify" and "not installed" in f.message
+        for f in report.findings
+    )
+
+
+def test_returns_none_on_empty_data(monkeypatch) -> None:
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: True)
+    report = ConversionReport()
+    empty = _DF.head(0)
+    result = verify_against_splink(
+        _SETTINGS, empty, _converted().config, report=report
+    )
+    assert result is None
+    assert any(f.splink_path == "verify" and "empty" in f.message for f in report.findings)
+
+
+def test_soft_fails_when_splink_run_raises(monkeypatch) -> None:
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: True)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("duckdb cannot run spark SQL")
+
+    monkeypatch.setattr(splink_verify, "_run_splink", _boom)
+    report = ConversionReport()
+    result = verify_against_splink(
+        _SETTINGS, _DF, _converted().config, report=report
+    )
+    assert result is None
+    assert any(
+        f.splink_path == "verify" and "could not run the original Splink" in f.message
+        for f in report.findings
+    )
+
+
+# ── agreement assembly (patched engine runs, no splink needed) ───────────────
+
+
+def test_perfect_agreement_assembly(monkeypatch) -> None:
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: True)
+    # ids resolve from the `unique_id` column -> "0".."5". Both engines cluster
+    # {0,1}, {2,3}, {4,5} identically.
+    same = {"0": "a", "1": "a", "2": "b", "3": "b", "4": "c", "5": "c"}
+    monkeypatch.setattr(splink_verify, "_run_splink", lambda *a, **k: (dict(same), "4.0.16"))
+    monkeypatch.setattr(splink_verify, "_run_goldenmatch", lambda *a, **k: dict(same))
+
+    report = ConversionReport()
+    result = verify_against_splink(
+        _SETTINGS, _DF, _converted().config, report=report
+    )
+    assert isinstance(result, SplinkVerification)
+    assert result.agreement == {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    assert result.is_faithful
+    assert result.n_shared_ids == 6
+    assert result.gm_multi_clusters == 3
+    assert result.splink_multi_clusters == 3
+    assert result.splink_version == "4.0.16"
+
+
+def test_divergent_agreement_is_flagged(monkeypatch) -> None:
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: True)
+    # Splink links all three pairs; GoldenMatch links none -> recall 0.
+    splink_map = {"0": "a", "1": "a", "2": "b", "3": "b", "4": "c", "5": "c"}
+    gm_map = {str(i): f"solo{i}" for i in range(6)}
+    monkeypatch.setattr(splink_verify, "_run_splink", lambda *a, **k: (splink_map, "4.0.16"))
+    monkeypatch.setattr(splink_verify, "_run_goldenmatch", lambda *a, **k: gm_map)
+
+    report = ConversionReport()
+    result = verify_against_splink(
+        _SETTINGS, _DF, _converted().config, report=report
+    )
+    assert result is not None
+    assert result.agreement["recall"] == 0.0
+    assert not result.is_faithful
+    # a divergent verdict is surfaced as a warning finding
+    assert any(
+        f.splink_path == "verify" and "DIVERGENT" in f.message for f in report.findings
+    )
+
+
+def test_partial_agreement_math(monkeypatch) -> None:
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: True)
+    # Splink pairs: (0,1),(2,3),(4,5). GoldenMatch pairs: (0,1),(2,3) only.
+    splink_map = {"0": "a", "1": "a", "2": "b", "3": "b", "4": "c", "5": "c"}
+    gm_map = {"0": "a", "1": "a", "2": "b", "3": "b", "4": "s4", "5": "s5"}
+    monkeypatch.setattr(splink_verify, "_run_splink", lambda *a, **k: (splink_map, "4.0.16"))
+    monkeypatch.setattr(splink_verify, "_run_goldenmatch", lambda *a, **k: gm_map)
+
+    result = verify_against_splink(_SETTINGS, _DF, _converted().config)
+    assert result is not None
+    # 2 of GM's 2 pairs are correct -> precision 1.0; 2 of Splink's 3 -> recall 2/3
+    assert result.agreement["precision"] == 1.0
+    assert result.agreement["recall"] == pytest.approx(2 / 3)
+
+
+def test_is_faithful_threshold() -> None:
+    hi = SplinkVerification(
+        agreement={"precision": 1.0, "recall": 0.95, "f1": 0.95},
+        n_records=10, n_shared_ids=10, gm_cluster_count=2, splink_cluster_count=2,
+        gm_multi_clusters=1, splink_multi_clusters=1, match_threshold=0.5,
+        splink_version="4.0.16", id_source="unique_id",
+    )
+    lo = SplinkVerification(
+        agreement={"precision": 1.0, "recall": 0.5, "f1": 0.6},
+        n_records=10, n_shared_ids=10, gm_cluster_count=2, splink_cluster_count=2,
+        gm_multi_clusters=1, splink_multi_clusters=1, match_threshold=0.5,
+        splink_version="4.0.16", id_source="unique_id",
+    )
+    assert hi.is_faithful
+    assert not lo.is_faithful
+
+
+# ── real end-to-end (needs splink) ───────────────────────────────────────────
+
+
+# A TRAINED settings dict (m/u on every non-null level). Verification is
+# apples-to-apples only on a trained model -- both engines then score with the
+# imported weights. A BARE model legitimately diverges (Splink uses untrained
+# neutral weights; GoldenMatch's zero-config trains EM on the sample), so the
+# real end-to-end faithful-agreement assertion needs trained input.
+_TRAINED_SETTINGS = {
+    "link_type": "dedupe_only",
+    "unique_id_column_name": "unique_id",
+    "comparisons": [
+        {
+            "output_column_name": "first_name",
+            "comparison_levels": [
+                {"sql_condition": '"first_name_l" IS NULL OR "first_name_r" IS NULL',
+                 "is_null_level": True},
+                {"sql_condition": '"first_name_l" = "first_name_r"',
+                 "m_probability": 0.7, "u_probability": 0.02},
+                {"sql_condition": 'jaro_winkler_similarity("first_name_l","first_name_r") >= 0.8',
+                 "m_probability": 0.25, "u_probability": 0.05},
+                {"sql_condition": "ELSE", "m_probability": 0.05, "u_probability": 0.93},
+            ],
+        },
+        {
+            "output_column_name": "surname",
+            "comparison_levels": [
+                {"sql_condition": '"surname_l" IS NULL OR "surname_r" IS NULL',
+                 "is_null_level": True},
+                {"sql_condition": '"surname_l" = "surname_r"',
+                 "m_probability": 0.9, "u_probability": 0.1},
+                {"sql_condition": "ELSE", "m_probability": 0.1, "u_probability": 0.9},
+            ],
+        },
+    ],
+    "blocking_rules_to_generate_predictions": ["l.surname = r.surname"],
+    "probability_two_random_records_match": 0.1,
+}
+
+
+def test_end_to_end_agreement_with_real_splink() -> None:
+    pytest.importorskip("splink")
+    pytest.importorskip("pandas")
+
+    conversion = from_splink(_TRAINED_SETTINGS)
+    report = ConversionReport()
+    result = verify_against_splink(
+        _TRAINED_SETTINGS,
+        _DF,
+        conversion.config,
+        em_model=conversion.em_model,
+        sample_size=1000,
+        report=report,
+    )
+    assert result is not None
+    # On this clean, clearly-separable data both trained engines must agree.
+    assert result.is_faithful
+    assert result.agreement["f1"] >= 0.95
+    assert result.splink_version
+
+
+# ── CLI wiring (--verify degrades gracefully when splink is absent) ───────────
+
+
+def test_cli_verify_flag_degrades_when_splink_absent(tmp_path, monkeypatch) -> None:
+    # Force the splink-absent path so this runs in the normal (splink-free) lane.
+    monkeypatch.setattr(splink_verify, "_splink_available", lambda: False)
+
+    settings_path = tmp_path / "model.json"
+    settings_path.write_text(json.dumps(_SETTINGS))
+    data_path = tmp_path / "data.csv"
+    _DF.write_csv(data_path)
+    out_path = tmp_path / "config.yaml"
+
+    result = runner.invoke(
+        app,
+        [
+            "import-splink",
+            str(settings_path),
+            "-o",
+            str(out_path),
+            "--verify",
+            str(data_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # config is still written, and the verify skip is surfaced (not a crash)
+    assert out_path.exists()
+    assert "verification skipped" in result.output.lower()

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -3196,6 +3196,27 @@
               "required": false,
               "default": "None",
               "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
+            },
+            {
+              "name": "--verify",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Prove the conversion preserved behaviour: run BOTH the original Splink settings (needs `pip install splink`) AND the converted config on a sample of this dataset (parquet/csv) and report pairwise cluster agreement. Best-effort -- skipped with a notice if splink is absent or the settings can't run under DuckDB."
+            },
+            {
+              "name": "--verify-sample",
+              "type": "integer",
+              "required": false,
+              "default": "5000",
+              "help": "Rows to run through both engines for --verify (seeded subsample above it)"
+            },
+            {
+              "name": "--verify-threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.5",
+              "help": "Splink match-probability cut for --verify clustering"
             }
           ]
         },


### PR DESCRIPTION
## What and why

Makes migrating from Splink **trustworthy in one command**. The recognizer sweep proved *which* Splink constructs convert; this proves the mapping **preserved behaviour**. On a sample of the user's own data it runs **both** the original Splink settings (when `splink` is importable) **and** the converted GoldenMatch config, then reports pairwise cluster agreement — turning "trust the conversion warnings" into one measured number, with no wiring Splink up and no handing over cluster output.

This is lever #1 from the "how do we make the conversion easier" survey — the highest-value one because the hard part of any migration isn't the mechanics, it's *trusting the result*.

## The measurement

`verify_against_splink(settings, data, gm_config, *, em_model=…)` →

```
Splink agreement (faithful) - splink 4.0.16
  pairwise F1 (GoldenMatch vs Splink)     1.000
  pairwise precision                      1.000
  pairwise recall                         1.000
  records compared                            8
  multi-record clusters (GM / Splink)     4 / 4
```

- Runs the original settings via the **DuckDB engine** with a synthetic unique-id keyed to GoldenMatch's id space, so the two cluster maps share one id space exactly.
- Injects the imported `EMResult` via a temp `model_path` so the GoldenMatch side scores with the **imported weights**, not an EM re-fit on the sample (else the number would measure the wrong model).
- Reuses the pure agreement helpers (`pair_set` / `pairwise_prf` / `_resolve_ids` / `_run_once`) from `splink_upgrade_measure` — no new metric code.
- `is_faithful` at pairwise **F1 ≥ 0.95** (the numerically-equivalent conformance bar).

## Best-effort by design

`splink` is an **optional heavy dependency**, not a goldenmatch requirement. `verify_against_splink` returns `None` (recording a report finding) — never raising — when:
- splink isn't installed → *"`pip install splink` to enable the agreement check"*,
- the data is empty, or
- the original settings can't run under the local DuckDB engine (e.g. a **Spark-dialect** export whose comparison SQL uses Spark-only functions).

Verification never blocks the conversion. `splink_verify` is a **separate module** so `from_splink` stays polars-free / import-light (verified in a test).

## Surface

- **`config/splink_verify.py`**: `verify_against_splink()` + `SplinkVerification`.
- **`cli/import_splink.py`**: `--verify DATASET` (+ `--verify-sample N`, `--verify-threshold T`) on the plain conversion path; renders an agreement table or a skip notice.

## Testing

- `tests/test_from_splink_verify.py` (8 + 1 skipped): graceful degradation (splink absent), soft-fail (settings won't run), the agreement math (patched engines — runs in the normal splink-free CI lane), the `is_faithful` threshold, CLI wiring, **plus a real end-to-end guarded by `importorskip("splink")`** — verified locally against **splink 4.0.16**: F1 = 1.0 on a trained model, both engines producing 4/4 multi-record clusters.
- `ruff` + `pyright` clean on changed files (`splink_verify` 0 errors; `import_splink` adds 0 over its baseline). `from_splink` stays polars-free. Regenerated config-matrix / agent-manifest / codemap for the new CLI options.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Lint (`ruff`) + `pyright` clean on changed files
- [ ] Package `CHANGELOG.md` updated (deferred until the conversion surface is user-facing in a release)
- [x] No secrets, tokens, or `.env` files committed
- [x] Generated docs (config-matrix / agent-manifest / codemap) regenerated for the new options

Follow-on to the Splink-converter completeness sweep (date_diff, geo_haversine, array_intersect, numeric_diff, cosine, ForenameSurname). Next candidate easiness levers (not in this PR): accepting a live `Linker` object, and a one-shot `migrate-splink` convert-and-run command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_