### PR TITLE
refactor(identity): single-source golden-record rollup through core.golden

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2955,7 +2955,8 @@
             "build_golden_records_df",
             "build_golden_records_from_frames",
             "golden_records_to_provenance",
-            "merge_field"
+            "merge_field",
+            "most_complete_value"
           ],
           "imports": [
             "goldenmatch._polars_lazy",
@@ -5851,6 +5852,7 @@
             "goldenmatch.core.cluster",
             "goldenmatch.core.cluster_pairscores",
             "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
             "goldenmatch.core.match_one",
             "goldenmatch.identity.fingerprint_batch",
             "goldenmatch.identity.model",

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -58,6 +58,30 @@ def _is_internal(col: str) -> bool:
     return any(col.startswith(p) for p in _INTERNAL_PREFIXES) or col == "__mk_"
 
 
+def most_complete_value(values: list) -> object:
+    """The ``most_complete`` survivor for a column's candidate values.
+
+    Picks the longest non-null string representation, ties broken by input
+    order; returns ``None`` when every candidate is null. This is the SINGLE
+    authoritative implementation of the "most complete" rollup rule (T1: one
+    authoritative semantic owner). The Identity Graph golden-record helpers
+    (``identity/resolve.py::_golden_record_from_members`` /
+    ``_from_payloads``) delegate here instead of hand-rolling the same
+    longest-non-null loop, so the rule cannot drift from the config-driven
+    pipeline path (``build_golden_record*``) or the provenance layer
+    (``identity/survivorship.py``, which already routes through
+    ``merge_field``).
+
+    Only the winning VALUE is returned; ``merge_field``'s confidence + source
+    index are dropped (the identity rollup tracks neither). Behaviourally
+    identical to ``merge_field(values, GoldenFieldRule("most_complete"))[0]``.
+    """
+    value, _confidence, _idx = merge_field(
+        values, GoldenFieldRule(strategy="most_complete")
+    )
+    return value
+
+
 def merge_field(
     values: list,
     rule: GoldenFieldRule,

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -244,9 +244,14 @@ def _golden_record_from_members(
 ) -> dict[str, Any]:
     """Roll up cluster members into a single representative row (most-complete).
 
-    A5: seam-driven both lanes (column reads + Python folds).
+    A5: seam-driven both lanes (column reads + Python folds). The per-column
+    rollup rule (longest non-null string, ties by input order) is
+    single-sourced through ``core.golden.most_complete_value`` -- the same
+    ``most_complete`` implementation the config-driven pipeline + the
+    survivorship provenance layer use -- instead of a hand-rolled loop (T1).
     """
     from goldenmatch.core.frame import to_frame
+    from goldenmatch.core.golden import most_complete_value
 
     members = to_frame(df).filter_in("__row_id__", row_ids)
     if members.height == 0:
@@ -255,31 +260,32 @@ def _golden_record_from_members(
     for col in members.columns:
         if col.startswith("__"):
             continue
-        non_null = [v for v in members.column(col).to_list() if v is not None]
-        if not non_null:
+        col_values = members.column(col).to_list()
+        if all(v is None for v in col_values):
             continue
-        # Pick the longest non-null string representation (most-complete)
-        values = [(str(v), v) for v in non_null]
-        values.sort(key=lambda x: len(x[0]), reverse=True)
-        out[col] = values[0][1]
+        out[col] = most_complete_value(col_values)
     return out
 
 
 def _golden_record_from_payloads(
     payload_by_row_id: dict[int, dict[str, Any]], row_ids: list[int]
 ) -> dict[str, Any]:
-    """Roll up pre-indexed member payloads without re-scanning the frame."""
+    """Roll up pre-indexed member payloads without re-scanning the frame.
+
+    Same ``most_complete`` rule as ``_golden_record_from_members``, single-
+    sourced through ``core.golden.most_complete_value`` (T1).
+    """
+    from goldenmatch.core.golden import most_complete_value
+
     members = [payload_by_row_id[row_id] for row_id in row_ids if row_id in payload_by_row_id]
     if not members:
         return {}
     out: dict[str, Any] = {}
     for col in members[0]:
-        non_null = [member[col] for member in members if member.get(col) is not None]
-        if not non_null:
+        col_values = [member.get(col) for member in members]
+        if all(v is None for v in col_values):
             continue
-        values = [(str(value), value) for value in non_null]
-        values.sort(key=lambda item: len(item[0]), reverse=True)
-        out[col] = values[0][1]
+        out[col] = most_complete_value(col_values)
     return out
 
 

--- a/packages/python/goldenmatch/tests/identity/test_golden_record_single_source.py
+++ b/packages/python/goldenmatch/tests/identity/test_golden_record_single_source.py
@@ -1,0 +1,97 @@
+"""Identity golden-record rollup is single-sourced through core.golden.
+
+Closes the thesis-conformance `three-golden-record-implementations` weakness:
+`identity/resolve.py` used to hand-roll a "longest non-null string" rollup that
+duplicated `core.golden`'s `most_complete` strategy. Both `_golden_record_from_*`
+helpers now delegate to `core.golden.most_complete_value`. These tests pin the
+delegation to BYTE-IDENTICAL output vs the retired inline rule, on adversarial
+cases (ties, mixed types, empty strings, all-null, heterogeneous keys).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.golden import most_complete_value
+from goldenmatch.identity.resolve import (
+    _golden_record_from_members,
+    _golden_record_from_payloads,
+)
+
+
+def _old_rule(non_null_values: list) -> object:
+    """The retired inline rule: longest str-rep, ties broken by input order."""
+    values = [(str(v), v) for v in non_null_values]
+    values.sort(key=lambda x: len(x[0]), reverse=True)
+    return values[0][1]
+
+
+# Each case is a column's candidate values (as they arrive in member order).
+_CASES = [
+    ["Carol", "Caroline", "Car"],          # clear longest
+    ["name", "n@me"],                       # same length -> first wins
+    ["n@me", "name"],                       # same length, order flipped
+    [None, "abc", "de"],                    # nulls ignored
+    ["", "", ""],                           # all empty strings (not null)
+    [123, "45"],                            # mixed types: str-rep length
+    [1000000, 42],                          # ints: "1000000" longer
+    ["only"],                               # singleton
+    ["dup", "dup"],                         # identical values
+    [None, None, "x"],                      # single non-null among nulls
+]
+
+
+@pytest.mark.parametrize("values", _CASES)
+def test_most_complete_value_matches_retired_inline_rule(values):
+    non_null = [v for v in values if v is not None]
+    assert most_complete_value(values) == _old_rule(non_null)
+
+
+def test_from_payloads_matches_old_rule_end_to_end():
+    payloads = {
+        0: {"name": "Bob", "city": "NYC", "note": None},
+        1: {"name": "Robert", "city": "NYC", "note": "hi"},
+        2: {"name": "Bo", "city": None, "note": None},
+    }
+    row_ids = [0, 1, 2]
+    got = _golden_record_from_payloads(payloads, row_ids)
+
+    # Reference: old rule per column, omit all-null columns, iterate members[0]'s keys.
+    members = [payloads[r] for r in row_ids]
+    expected = {}
+    for col in members[0]:
+        non_null = [m[col] for m in members if m.get(col) is not None]
+        if not non_null:
+            continue
+        expected[col] = _old_rule(non_null)
+    assert got == expected
+    assert got == {"name": "Robert", "city": "NYC", "note": "hi"}
+
+
+def test_from_members_matches_from_payloads():
+    """The frame path and the payload path must agree (both = most_complete)."""
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2],
+        "__source__": ["s", "s", "s"],
+        "name": ["Bob", "Robert", "Bo"],
+        "city": ["NYC", "NYC", None],
+    })
+    payloads = {
+        0: {"name": "Bob", "city": "NYC"},
+        1: {"name": "Robert", "city": "NYC"},
+        2: {"name": "Bo", "city": None},
+    }
+    from_frame = _golden_record_from_members(df, [0, 1, 2])
+    from_payload = _golden_record_from_payloads(payloads, [0, 1, 2])
+    assert from_frame == from_payload == {"name": "Robert", "city": "NYC"}
+
+
+def test_all_null_column_is_omitted():
+    payloads = {0: {"a": None, "b": "x"}, 1: {"a": None, "b": "yy"}}
+    got = _golden_record_from_payloads(payloads, [0, 1])
+    assert "a" not in got  # all-null column dropped, not carried as None
+    assert got == {"b": "yy"}
+
+
+def test_empty_inputs():
+    assert _golden_record_from_payloads({}, []) == {}
+    assert _golden_record_from_payloads({0: {"a": "x"}}, [99]) == {}

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -128,19 +128,28 @@ weaknesses:
 
   - id: three-golden-record-implementations
     tenet: T1
-    severity: medium
-    declared: false
-    title: "Three golden-record/survivorship implementations in Python"
+    severity: low   # was medium + declared:false (the dangerous class); RESOLVED --
+                    # single authoritative owner, only doc-follow-on (identity golden
+                    # is most_complete-only, not yet config-aware) remains
+    declared: true
+    title: "Golden-record rollup single-sourced through core.golden (was a 2nd hand-rolled rule in resolve.py)"
     detail: >-
-      resolve.py rolls cluster members via a "longest non-null string" rule
-      (_golden_record_from_members / _from_payloads), which is a DIFFERENT rollup from
-      both core.golden.merge_field and identity/survivorship.py::build_golden_with_provenance.
-      Three sources of truth for the same capability -- a live drift surface and a
-      compute-into-control leak.
+      RESOLVED. The audit found resolve.py's ``_golden_record_from_members`` /
+      ``_from_payloads`` hand-rolling a "longest non-null string" rollup that
+      DUPLICATED core.golden's ``most_complete`` strategy (survivorship.py was never a
+      third rule -- it already delegates to ``merge_field``). Both resolve helpers now
+      call the single authoritative ``core.golden.most_complete_value`` (byte-identical
+      to the retired inline loop -- ties by input order, all-null columns omitted --
+      locked by tests/identity/test_golden_record_single_source.py), so the rollup rule
+      cannot drift from the config-driven pipeline path or the provenance layer. ONE
+      owner (core.golden) for the capability. REMAINING (doc follow-on, not a divergence):
+      the identity golden path is most_complete-ONLY (ignores field_strategies / config),
+      unlike the config-driven builders -- a conscious scope, threading a survivorship
+      config through resolve_clusters is a separate feature, not a second source of truth.
     evidence:
-      - packages/python/goldenmatch/goldenmatch/identity/resolve.py:241
-      - packages/python/goldenmatch/goldenmatch/identity/survivorship.py
       - packages/python/goldenmatch/goldenmatch/core/golden.py
+      - packages/python/goldenmatch/goldenmatch/identity/resolve.py
+      - packages/python/goldenmatch/tests/identity/test_golden_record_single_source.py
 
   - id: standalone-ts-algorithms-no-shared-kernel
     tenet: T1


### PR DESCRIPTION
## What and why

Closes the thesis-conformance **`three-golden-record-implementations`** weakness — the last `declared: false` item in the inventory (the "dangerous class": a real divergence with no conformance level). Tenet T1: *one authoritative semantic owner per capability*.

The audit found `identity/resolve.py`'s `_golden_record_from_members` / `_from_payloads` hand-rolling a "longest non-null string" rollup that **duplicated** `core.golden`'s `most_complete` strategy. (`identity/survivorship.py` was never a third rule — it already delegates to `merge_field`.) So there were really **two** implementations of the same rollup rule; this makes it **one**.

## Changes

- **`core/golden.py`** — new `most_complete_value(values)`: the single authoritative entry point for the "longest non-null string, ties by input order" rollup. Thin wrapper over the existing `merge_field(..., most_complete)`; returns just the winning value.
- **`identity/resolve.py`** — both `_golden_record_from_members` (frame path) and `_golden_record_from_payloads` (bulk fast path) now delegate to `most_complete_value` instead of hand-rolling the sort. The rule can no longer drift from the config-driven pipeline path or the provenance layer.
- **`parity/thesis_conformance.yaml`** — the weakness drops `medium` + `declared:false` → `low` + `declared:true` (RESOLVED). Scorecard: **1 critical / 3 medium / 6 low** (was 1/3/4/2), and **no `declared:false` items remain** — every divergence is now declared.
- Codemap regenerated for the new public symbol.

## Parity contract (byte-identical, no behavior change)

The delegation is byte-identical to the retired inline loop: longest string representation, ties broken by input order, all-null columns omitted, mixed types compared by `str()` length. Locked by **`tests/identity/test_golden_record_single_source.py`**, which pins the new path against a reference of the old rule on adversarial cases (ties, same-length values, mixed int/str, empty strings, all-null columns, heterogeneous payload keys), and asserts the frame path == the payload path.

Not changed: identity golden stays `most_complete`-only (it ignores `field_strategies`/config, as it always has). Making it config-aware is a separate feature, noted as a doc-follow-on in the inventory — not a second source of truth.

## Testing

`uv run pytest packages/python/goldenmatch/tests/identity/ tests/test_golden.py tests/test_golden_partition_perf.py` → **280 + passed, 6 skipped**. New single-source test green. `check_thesis_conformance.py --check --strict` → OK. `ruff check` clean. `test_config_matrix.py` + `test_agent_codemap.py` → 54 passed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [ ] Package `CHANGELOG.md` updated — N/A, byte-identical internal refactor (no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / inventory updated (thesis_conformance.yaml + code comments self-document)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_