### PR TITLE
feat(identity): persisted block-key index (C2 slice 1)

### DIFF
--- a/context-network/architecture/identity-control-plane-manifesto.md
+++ b/context-network/architecture/identity-control-plane-manifesto.md
@@ -113,6 +113,13 @@ engine owns as drawn. Three ways to home it:
 **Decision needed from the owner:** confirm (ii), or pick (i)/(iii). This gates all
 incremental code below.
 
+> **DECIDED 2026-07-26 — owner confirmed (ii).** C2 is unblocked. **Slice 1 (landed):**
+> the persisted `identity_record_block_keys` index in the store (SQLite `_SCHEMA` +
+> Postgres `_pg_init_schema` + Alembic `0005` + schema v6) with the
+> `index_record_block_keys` / `candidates_by_block_keys` write/query API — additive,
+> nothing reads it yet. Next slices: block-key computation + population on write; the
+> bidirectional candidate query in `resolve_record_incremental`; the exact-matchkey fix.
+
 ## 5. Transaction-native semantics to specify (Tier-5 scope)
 
 Each gets a spec entry + conformance fixtures (the frame's spec+conformance contract), not
@@ -131,7 +138,8 @@ sources of truth — the survivorship spec entry picks one authoritative owner.
 
 - **C1 (contract):** `ResolutionBatch v1` + `apply_batch`; `resolve_clusters` becomes its
   adapter (no behavior change); residency budget as a contract term. Closes the medium + low.
-- **C2 (persisted index):** store block-key/fingerprint index + population on write; the
+- **C2 (persisted index) — IN PROGRESS (§4 decided (ii) 2026-07-26; slice 1 store index landed):**
+  store block-key/fingerprint index + population on write; the
   §4(ii) bidirectional seam; exact-matchkey incremental. Closes the critical. *Needs the §4
   decision first.*
 - **C3 (conformance layer):** spec entries + fixtures for the §5 semantics; single-source the

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 408,
+      "module_count": 409,
       "modules": [
         {
           "module": "goldenmatch",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 407,
+      "module_count": 408,
       "modules": [
         {
           "module": "goldenmatch",
@@ -4781,6 +4781,15 @@
           "module": "goldenmatch.db.alembic.versions.0004_claim_authority",
           "file": "packages/python/goldenmatch/goldenmatch/db/alembic/versions/0004_claim_authority.py",
           "purpose": "Claim-authority tier: claim_type + evidence_ref + previous_claim_id.",
+          "defines": [
+            "downgrade",
+            "upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.alembic.versions.0005_record_block_keys",
+          "file": "packages/python/goldenmatch/goldenmatch/db/alembic/versions/0005_record_block_keys.py",
+          "purpose": "Persisted blocking index for incremental resolution (C2).",
           "defines": [
             "downgrade",
             "upgrade"

--- a/packages/python/goldenmatch/goldenmatch/db/alembic/versions/0005_record_block_keys.py
+++ b/packages/python/goldenmatch/goldenmatch/db/alembic/versions/0005_record_block_keys.py
@@ -1,0 +1,41 @@
+"""Persisted blocking index for incremental resolution (C2).
+
+Adds ``identity_record_block_keys`` -- one row per (record, blocking pass) with
+the block key that record fell in, so incremental resolution can find candidate
+persisted records that share a block key WITHOUT re-blocking the whole corpus in
+RAM (control-plane manifesto §4(ii) / decision 0047 §9.1). Mirrors the runtime
+``_pg_init_schema`` DDL in goldenmatch/identity/store.py, so this rev and the
+store's on-open DDL converge to the same shape. Additive.
+
+Revision ID: 0005
+Revises: 0004
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS identity_record_block_keys (
+            record_id  TEXT NOT NULL,
+            entity_id  TEXT,
+            block_key  TEXT NOT NULL,
+            pass_sig   TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (record_id, pass_sig, block_key)
+        );
+        CREATE INDEX IF NOT EXISTS idx_rbk_block  ON identity_record_block_keys(pass_sig, block_key);
+        CREATE INDEX IF NOT EXISTS idx_rbk_entity ON identity_record_block_keys(entity_id);
+        CREATE INDEX IF NOT EXISTS idx_rbk_record ON identity_record_block_keys(record_id);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS identity_record_block_keys;")

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -48,7 +48,7 @@ def _write_pipeline_enabled() -> bool:
     ).strip() != "0"
 
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS identity_nodes (
@@ -148,6 +148,23 @@ CREATE TABLE IF NOT EXISTS identity_aliases (
     PRIMARY KEY (alias, kind, dataset)
 );
 CREATE INDEX IF NOT EXISTS idx_aliases_entity ON identity_aliases(entity_id);
+
+-- Persisted blocking index (control-plane manifesto C2 / decision 0047 §9.1):
+-- one row per (record, blocking pass) -> the block key that record fell in, so a
+-- NEW record can find candidate persisted records that share a block key WITHOUT
+-- re-blocking the whole corpus in RAM. entity_id is the identity the record
+-- currently belongs to (nullable until resolved). pass_sig identifies which
+-- blocking pass produced the key (a record can sit in several passes' blocks).
+CREATE TABLE IF NOT EXISTS identity_record_block_keys (
+    record_id  TEXT NOT NULL,
+    entity_id  TEXT,
+    block_key  TEXT NOT NULL,
+    pass_sig   TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (record_id, pass_sig, block_key)
+);
+CREATE INDEX IF NOT EXISTS idx_rbk_block  ON identity_record_block_keys(pass_sig, block_key);
+CREATE INDEX IF NOT EXISTS idx_rbk_entity ON identity_record_block_keys(entity_id);
+CREATE INDEX IF NOT EXISTS idx_rbk_record ON identity_record_block_keys(record_id);
 """
 
 
@@ -352,6 +369,11 @@ class IdentityStore:
             # log. PRAGMA-guarded ADD COLUMN, idempotent on fresh (already carry
             # them from ``_SCHEMA``) and migrated DBs. Old rows read back None.
             self._ensure_claim_columns()
+        if version < 6:
+            # v5 -> v6: persisted blocking index (C2). CREATE TABLE IF NOT EXISTS
+            # + indexes, idempotent on fresh (already carries it from ``_SCHEMA``)
+            # and migrated DBs.
+            self._ensure_block_index_table()
         if version < SCHEMA_VERSION:
             self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
@@ -415,6 +437,24 @@ class IdentityStore:
             self._conn.execute(
                 "ALTER TABLE identity_events ADD COLUMN previous_claim_id INTEGER"
             )
+
+    def _ensure_block_index_table(self) -> None:
+        """Create the persisted blocking-index table + indexes if absent (C2).
+        Idempotent CREATE ... IF NOT EXISTS, safe on fresh and migrated DBs."""
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS identity_record_block_keys (
+                record_id  TEXT NOT NULL,
+                entity_id  TEXT,
+                block_key  TEXT NOT NULL,
+                pass_sig   TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (record_id, pass_sig, block_key)
+            );
+            CREATE INDEX IF NOT EXISTS idx_rbk_block  ON identity_record_block_keys(pass_sig, block_key);
+            CREATE INDEX IF NOT EXISTS idx_rbk_entity ON identity_record_block_keys(entity_id);
+            CREATE INDEX IF NOT EXISTS idx_rbk_record ON identity_record_block_keys(record_id);
+            """
+        )
 
     def _pg_init_schema(self) -> None:
         ddl = """
@@ -514,6 +554,18 @@ class IdentityStore:
             PRIMARY KEY (alias, kind, dataset)
         );
         CREATE INDEX IF NOT EXISTS idx_aliases_entity ON identity_aliases(entity_id);
+        -- Persisted blocking index (C2): candidate generation for incremental
+        -- resolution against persisted identities without re-blocking the corpus.
+        CREATE TABLE IF NOT EXISTS identity_record_block_keys (
+            record_id  TEXT NOT NULL,
+            entity_id  TEXT,
+            block_key  TEXT NOT NULL,
+            pass_sig   TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (record_id, pass_sig, block_key)
+        );
+        CREATE INDEX IF NOT EXISTS idx_rbk_block  ON identity_record_block_keys(pass_sig, block_key);
+        CREATE INDEX IF NOT EXISTS idx_rbk_entity ON identity_record_block_keys(entity_id);
+        CREATE INDEX IF NOT EXISTS idx_rbk_record ON identity_record_block_keys(record_id);
         """
         with self._conn.cursor() as cur:
             cur.execute(ddl)
@@ -1187,6 +1239,100 @@ class IdentityStore:
             )
             for r in rows:
                 out[r["record_id"]] = r["entity_id"]
+        return out
+
+    # ----- Persisted blocking index (C2, control-plane manifesto §4(ii)) -----
+    #
+    # The bidirectional-seam foundation: the control plane persists the block
+    # keys each record fell in, so incremental resolution (compute) can ask the
+    # store (control) for candidate records sharing a block key WITHOUT
+    # re-blocking the whole corpus in RAM. Slice 1 = the store index + its
+    # write/query API; wiring population-on-write + the incremental candidate
+    # query is the next slice.
+
+    def index_record_block_keys(
+        self,
+        record_id: str,
+        entity_id: str | None,
+        keys: Iterable[tuple[str, str]],
+    ) -> None:
+        """Persist the ``(pass_sig, block_key)`` pairs a record falls in.
+
+        Idempotent per (record_id, pass_sig, block_key): re-indexing refreshes
+        ``entity_id`` (so a record reassigned to a new entity on a later resolve
+        has its index rows re-pointed) without duplicating. ``keys`` is an
+        iterable of ``(pass_sig, block_key)``; null block keys are skipped.
+        """
+        if self._backend == "mongo":
+            raise NotImplementedError(
+                "block-key index is not supported on the mongo backend"
+            )
+        rows = [
+            (record_id, entity_id, str(bk), str(ps))
+            for ps, bk in keys
+            if bk is not None
+        ]
+        if not rows:
+            return
+        if self._backend == "sqlite":
+            self._conn.executemany(
+                "INSERT INTO identity_record_block_keys "
+                "(record_id, entity_id, block_key, pass_sig) VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(record_id, pass_sig, block_key) "
+                "DO UPDATE SET entity_id=excluded.entity_id",
+                rows,
+            )
+            # Bounded-WAL chunk commit inside ``bulk_writes`` (mirrors ``_exec``).
+            if self._sqlite_batch:
+                self._sqlite_pending += len(rows)
+                if self._sqlite_pending >= self._sqlite_batch:
+                    self._conn.execute("COMMIT")
+                    self._conn.execute("BEGIN")
+                    self._sqlite_pending = 0
+            return
+        with self._conn.cursor() as cur:
+            cur.executemany(
+                "INSERT INTO identity_record_block_keys "
+                "(record_id, entity_id, block_key, pass_sig) "
+                "VALUES (%s, %s, %s, %s) "
+                "ON CONFLICT (record_id, pass_sig, block_key) "
+                "DO UPDATE SET entity_id = EXCLUDED.entity_id",
+                rows,
+            )
+
+    def candidates_by_block_keys(
+        self, keys: Iterable[tuple[str, str]]
+    ) -> set[str]:
+        """Record ids sharing ANY ``(pass_sig, block_key)`` with ``keys``.
+
+        The persisted-index candidate set for an incoming record: the records a
+        blocking pass would co-locate it with, read from the durable index
+        instead of a full-corpus re-block. Excludes the query record only if the
+        caller filters it out (this returns raw block-mates). ``keys`` is an
+        iterable of ``(pass_sig, block_key)``."""
+        if self._backend == "mongo":
+            raise NotImplementedError(
+                "block-key index is not supported on the mongo backend"
+            )
+        pairs = [(str(ps), str(bk)) for ps, bk in keys if bk is not None]
+        if not pairs:
+            return set()
+        out: set[str] = set()
+        # Two host params per pair; chunk to stay under SQLite's ~999 cap.
+        _CHUNK = 450
+        for i in range(0, len(pairs), _CHUNK):
+            chunk = pairs[i:i + _CHUNK]
+            clause = " OR ".join(
+                "(pass_sig = ? AND block_key = ?)" for _ in chunk
+            )
+            flat = [v for pair in chunk for v in pair]
+            rows = self._fetchall(
+                "SELECT DISTINCT record_id FROM identity_record_block_keys "
+                f"WHERE {clause}",
+                tuple(flat),
+            )
+            for r in rows:
+                out.add(r["record_id"])
         return out
 
     def add_edge(self, edge: EvidenceEdge, *, return_id: bool = True) -> int | None:

--- a/packages/python/goldenmatch/tests/identity/test_block_index.py
+++ b/packages/python/goldenmatch/tests/identity/test_block_index.py
@@ -1,0 +1,115 @@
+"""Persisted blocking index (C2 slice 1) -- store table + write/query API.
+
+The control-plane-owned block-key index (manifesto §4(ii)) is the foundation for
+incremental resolution against persisted identities without re-blocking the
+corpus. This slice adds only the store index + its ``index_record_block_keys`` /
+``candidates_by_block_keys`` API; wiring it into the incremental resolve path is
+the next slice. These tests lock the index's write/query semantics.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.identity import IdentityStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(path=str(tmp_path / "identity.db"))
+    yield s
+    s.close()
+
+
+def test_table_exists_on_fresh_store(store):
+    """The v6 schema ships the index table on a fresh DB."""
+    row = store._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='identity_record_block_keys'"
+    ).fetchone()
+    assert row is not None
+    assert store._conn.execute("PRAGMA user_version").fetchone()[0] >= 6
+
+
+def test_index_and_query_roundtrip(store):
+    # r1 and r2 share block ("name", "smith"); r3 is alone.
+    store.index_record_block_keys("r1", "e1", [("name", "smith"), ("zip", "10001")])
+    store.index_record_block_keys("r2", "e2", [("name", "smith"), ("zip", "90210")])
+    store.index_record_block_keys("r3", "e3", [("name", "jones"), ("zip", "10001")])
+
+    # Query by the block a NEW record would fall in.
+    assert store.candidates_by_block_keys([("name", "smith")]) == {"r1", "r2"}
+    assert store.candidates_by_block_keys([("zip", "10001")]) == {"r1", "r3"}
+    # Union across passes.
+    assert store.candidates_by_block_keys(
+        [("name", "jones"), ("zip", "90210")]
+    ) == {"r3", "r2"}
+
+
+def test_pass_sig_disambiguates_colliding_keys(store):
+    """The same block_key STRING under different passes must NOT cross-match
+    (soundex/substring/numeric keys share a value namespace)."""
+    store.index_record_block_keys("r1", "e1", [("name_soundex", "S530")])
+    store.index_record_block_keys("r2", "e2", [("zip_prefix", "S530")])
+    assert store.candidates_by_block_keys([("name_soundex", "S530")]) == {"r1"}
+    assert store.candidates_by_block_keys([("zip_prefix", "S530")]) == {"r2"}
+
+
+def test_reindex_refreshes_entity_id_without_duplicating(store):
+    store.index_record_block_keys("r1", "e1", [("name", "smith")])
+    # r1 gets merged into e2 -> re-index with the new entity.
+    store.index_record_block_keys("r1", "e2", [("name", "smith")])
+    rows = store._conn.execute(
+        "SELECT record_id, entity_id FROM identity_record_block_keys "
+        "WHERE record_id='r1'"
+    ).fetchall()
+    assert len(rows) == 1  # no duplicate
+    assert rows[0]["entity_id"] == "e2"
+    # Still findable.
+    assert store.candidates_by_block_keys([("name", "smith")]) == {"r1"}
+
+
+def test_null_and_empty(store):
+    # Null block keys are skipped; empty inputs are no-ops.
+    store.index_record_block_keys("r1", "e1", [("name", None), ("zip", "10001")])
+    store.index_record_block_keys("r2", "e2", [])
+    assert store.candidates_by_block_keys([]) == set()
+    assert store.candidates_by_block_keys([("name", "missing")]) == set()
+    assert store.candidates_by_block_keys([("zip", "10001")]) == {"r1"}
+
+
+def test_default_pass_sig(store):
+    """pass_sig defaults to '' -- a single-pass index still round-trips."""
+    store.index_record_block_keys("r1", "e1", [("", "smith")])
+    assert store.candidates_by_block_keys([("", "smith")]) == {"r1"}
+
+
+def test_null_entity_id_allowed(store):
+    """A record can be indexed before it is resolved (entity_id NULL)."""
+    store.index_record_block_keys("r1", None, [("name", "smith")])
+    assert store.candidates_by_block_keys([("name", "smith")]) == {"r1"}
+
+
+def test_chunking_over_many_keys(store):
+    """Query keys beyond the SQLite host-parameter chunk still resolve."""
+    keys = [("p", f"k{i}") for i in range(1000)]
+    for i, (ps, bk) in enumerate(keys):
+        store.index_record_block_keys(f"r{i}", f"e{i}", [(ps, bk)])
+    got = store.candidates_by_block_keys(keys)
+    assert got == {f"r{i}" for i in range(1000)}
+
+
+def test_index_batches_inside_bulk_writes(store):
+    """Population runs inside the resolve write transaction (WAL-bounded)."""
+    with store.bulk_writes():
+        store.index_record_block_keys("r1", "e1", [("name", "smith")])
+        assert store._conn.in_transaction
+    assert not store._conn.in_transaction
+    assert store.candidates_by_block_keys([("name", "smith")]) == {"r1"}
+
+
+def test_mongo_backend_rejected():
+    store = IdentityStore.__new__(IdentityStore)
+    store._backend = "mongo"
+    with pytest.raises(NotImplementedError, match="block-key index"):
+        store.index_record_block_keys("r1", "e1", [("name", "smith")])
+    with pytest.raises(NotImplementedError, match="block-key index"):
+        store.candidates_by_block_keys([("name", "smith")])

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -39,12 +39,19 @@ weaknesses:
       identities is impossible. This is the frame's own OPEN 9.1 -- compute that reads
       durable state, which neither engine homes -- and it caps the product exactly
       where the thesis says it becomes most valuable.
+      IN PROGRESS (C2): §4 fork DECIDED (ii) control-plane-owned index by the owner
+      2026-07-26. Slice 1 LANDED -- the persisted `identity_record_block_keys` store
+      index (SQLite + Postgres + Alembic 0005, schema v6) + the
+      `index_record_block_keys`/`candidates_by_block_keys` write/query API. Still OPEN:
+      the incremental resolve path does not yet POPULATE or QUERY the index (nothing
+      reads it), so the full-corpus re-block remains until the next slices wire the
+      bidirectional seam + the exact-matchkey fix.
     evidence:
+      - packages/python/goldenmatch/goldenmatch/identity/store.py   # identity_record_block_keys + index API
       - packages/python/goldenmatch/goldenmatch/identity/resolve.py:1270
       - packages/python/goldenmatch/goldenmatch/core/streaming.py:129
       - packages/python/goldenmatch/goldenmatch/core/streaming.py:149
-      - packages/python/goldenmatch/goldenmatch/identity/store.py:79
-    owner_next: "context-network/architecture/identity-control-plane-manifesto.md (§4, milestone C2 -- needs the incremental-resolution fork decision)"
+    owner_next: "context-network/architecture/identity-control-plane-manifesto.md (§4 decided (ii); C2 slice 1 landed -- next: population + bidirectional query + exact-matchkey fix)"
 
   - id: no-versioned-resolution-batch-contract
     tenet: T4


### PR DESCRIPTION
## What and why

First slice of the **critical** thesis-conformance item — incremental resolution against a *persisted* index (`incremental-resolution-no-persisted-index`). The control-plane manifesto §4 fork was **owner-confirmed as option (ii)** (control-plane-owned index; the seam goes bidirectional). This lands the foundation.

Today "incremental" resolution is faked by re-blocking the whole prior corpus in RAM — `resolve_record_incremental` runs `match_one` over the entire `df`, and `StreamProcessor` `pl.concat`s the corpus every record — because the store has **no block-key index**. This adds that index.

## Changes

- **Store schema (v5 → v6):** new `identity_record_block_keys(record_id, entity_id, block_key, pass_sig)` on SQLite (`_SCHEMA` + `_ensure_block_index_table` migration) and Postgres (`_pg_init_schema` + **Alembic `0005`**), with `(pass_sig, block_key)`, entity, and record indexes. `PRIMARY KEY (record_id, pass_sig, block_key)`.
- **Store API:**
  - `index_record_block_keys(record_id, entity_id, keys)` — idempotent upsert of the `(pass_sig, block_key)` pairs a record falls in; refreshes `entity_id` on re-index (record reassigned to a new entity) without duplicating; WAL-chunk-committed inside `bulk_writes`.
  - `candidates_by_block_keys(keys) → set[record_id]` — the block-mates of an incoming record, read from the durable index instead of a full-corpus re-block; chunked for the SQLite host-param cap. `pass_sig` disambiguates colliding key strings across passes.
  - Mongo backend rejected (`NotImplementedError`).
- **Governance docs:** manifesto §4 records the owner's decision + slice-1 status; the thesis inventory's critical entry notes C2 is IN PROGRESS (stays **OPEN** — nothing reads the index yet).

## Additive / byte-identical

Nothing populates or queries the index yet, so this is a pure additive foundation — zero behavior change to any existing path. The next slices wire the bidirectional seam (compute block keys → populate on write → query candidates in `resolve_record_incremental`) and fix the exact-matchkey gap (`match_one` returns `[]` for exact matchkeys today); **C4** is the bounded-RSS scale proof.

## Testing

`uv run pytest packages/python/goldenmatch/tests/identity/` → **284 passed, 6 skipped**. New `test_block_index.py` (10) covers: table-on-fresh-store + schema v6, write/query roundtrip, `pass_sig` disambiguation of colliding key strings, idempotent re-index + entity refresh, null/empty handling, chunking beyond the param cap, txn-scoped population inside `bulk_writes`, mongo rejection. `check_thesis_conformance.py --check --strict` → OK. `ruff` clean. `test_config_matrix.py` + `test_agent_codemap.py` → 54 passed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [ ] Package `CHANGELOG.md` — N/A, additive infra with no behavior change yet (the incremental behavior change lands with the wiring slice)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / manifesto + inventory updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_