### PR TITLE
feat(from_dbt): distill hand-rolled dbt ER into a GoldenMatch config + verify (MVP + design)

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -50,6 +50,7 @@
                   "goldenmatch/cli",
                   "goldenmatch/tui",
                   "goldenmatch/migrating-from-splink",
+                  "goldenmatch/migrating-from-dbt",
                   "goldenmatch/migrating-to-v3",
                   "goldenmatch/migrating-to-v2",
                   "goldenmatch/v1-to-v2",

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -705,6 +705,14 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `identity split` | `record_ids` | text | **required** | record_ids to move to a new identity |
 | `identity split` | `--reason` | text | `None` | Optional reason recorded in the event log. |
 | `identity split` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `import-dbt` | `manifest` | text | **required** | dbt manifest.json (from `dbt compile` / `dbt parse`) |
+| `import-dbt` | `--output` | text | `'goldenmatch.yaml'` | Output YAML config path |
+| `import-dbt` | `--strict` | boolean | `False` | Fail on any lossy finding (warnings), not just errors |
+| `import-dbt` | `--min-confidence` | float | `0.5` | ER-model identification confidence floor for signal extraction |
+| `import-dbt` | `--verify` | text | `None` | Prove the distillation reproduces your dbt pipeline: run the converted config on a sample of --source and report pairwise cluster agreement against this output table (parquet/csv; first two columns = id, cluster_id). Needs --source. |
+| `import-dbt` | `--source` | text | `None` | Source rows the dbt ER model consumed (parquet/csv), for --verify |
+| `import-dbt` | `--verify-sample` | integer | `5000` | Rows of --source to run through GoldenMatch for --verify |
+| `import-dbt` | `--id-column` | text | `None` | Column holding each source row's id (default: auto-detect unique_id/id/record_id) |
 | `import-splink` | `input_path` | text | **required** | Splink settings or trained-model JSON file |
 | `import-splink` | `--output` | text | `'goldenmatch.yaml'` | Output YAML config path |
 | `import-splink` | `--model-out` | text | `None` | Persist imported trained m/u as an FS model JSON; sets model_path in the config |

--- a/docs-site/goldenmatch/migrating-from-dbt.mdx
+++ b/docs-site/goldenmatch/migrating-from-dbt.mdx
@@ -1,0 +1,106 @@
+---
+title: "Migrating from hand-rolled dbt"
+description: "Distill a hand-rolled dbt entity-resolution pipeline down to one reusable GoldenMatch config — and prove it reproduces your existing clusters."
+keywords: ["goldenmatch", "dbt", "migration", "entity resolution", "dedup", "manifest.json", "from_dbt", "import-dbt", "distill", "consolidation"]
+---
+
+Got ~10k lines of hand-rolled entity-resolution SQL spread across dozens of dbt models? Almost all of it encodes a *small* set of real decisions — a few blocking keys, a handful of comparison fields and thresholds, some survivorship rules — buried in sprawl. GoldenMatch's dbt converter **ingests your dbt project and distills it into one reusable config**, then **measures how faithfully that config reproduces your pipeline's existing output**.
+
+The value is **distillation + proof**, not faithful SQL translation. Lossy extraction is fine *because it is verified* — exactly the posture the [Splink converter](/goldenmatch/migrating-from-splink) ships with.
+
+<Note>
+This complements the [GoldenMatch-in-dbt package](https://pypi.org/project/goldenmatch/): that adds GoldenMatch to a dbt pipeline going forward; this converter is for *replacing* hand-rolled ER a team already has. The emitted config drops straight into a `{{ goldenmatch_dedupe(...) }}` model.
+</Note>
+
+## The key enabler: the manifest, not raw SQL
+
+The converter reads your dbt **`manifest.json`** — the structured metadata `dbt compile` (or `dbt parse` / `dbt docs generate`) produces — not blind `.sql` files. The manifest carries every model's compiled SQL, the full `ref()`/`source()` DAG, columns, tests, and the warehouse adapter. That structure is what makes distillation tractable, and it needs **no warehouse credentials** (only the optional verify against a live output table does).
+
+```bash
+dbt compile           # produces target/manifest.json
+```
+
+## One command
+
+```bash
+goldenmatch import-dbt target/manifest.json -o goldenmatch.yaml
+```
+
+It:
+
+1. **identifies** the models that do entity resolution (DAG + naming + shape signals);
+2. **extracts** the recognizable ER idioms into ONE GoldenMatch config;
+3. prints a **coverage scorecard** + a `couldn't extract` list for human review.
+
+```text
+Distilled target/manifest.json -- 14/58 models analyzed as ER -- 4 blocking key(s)
+  -- 3 exact + 3 fuzzy comparison field(s) -- 2 survivorship rule(s)
+  -- 3 construct(s) flagged for review -- story: fuzzy-ER consolidation
+Wrote config to goldenmatch.yaml.
+```
+
+Add `--verify <output.parquet> --source <rows.parquet>` to prove it reproduces your existing clusters (below). Useful flags: `--min-confidence` tunes how aggressively models are identified as ER; `--strict` fails on any lossy finding.
+
+## Or one line of Python
+
+```python
+from goldenmatch.config.from_dbt import from_dbt
+
+conv = from_dbt("target/manifest.json")   # or an already-parsed manifest dict
+print(conv.coverage.line())
+
+if conv.config is not None:                # None on a non-ER project
+    import goldenmatch as gm
+    result = gm.dedupe_df(df, config=conv.config)
+```
+
+`conv.er_models` is the ranked list of identified ER models (each with a confidence + the signals that fired), and `conv.signals` is every recognized signal — including the `couldnt_extract` items — so you can audit exactly what carried over.
+
+## Two honest value stories
+
+The report tells you **which** applies, so it never over-claims an F1 win:
+
+- **Fuzzy / probabilistic ER sprawl** → an *accuracy + consolidation* story: GoldenMatch does the fuzzy matching the SQL did badly, in a tested engine.
+- **Exact keep-latest dedup sprinkled everywhere** (the common case) → a *consolidation + maintainability* story: 10k lines become a 20-line tested config. The "accuracy" number here is trivially ~1.0 — the win is consolidation, and `conv.coverage.story` says so (`exact-dedup`, not `fuzzy-er`).
+
+## What it recognizes
+
+Over each identified ER model's compiled SQL (dialect-aware — **DuckDB, Snowflake, BigQuery** in the MVP; others fall through to a dialect-agnostic core and are flagged):
+
+| dbt idiom | → GoldenMatch |
+|---|---|
+| `QUALIFY ROW_NUMBER() OVER (PARTITION BY … ORDER BY … DESC) = 1` | blocking keys + exact matchkey + most-recent survivorship |
+| `dbt_utils.deduplicate(partition_by=…, order_by=…)` | same |
+| `dbt_utils.generate_surrogate_key([…])` | blocking keys + exact matchkey |
+| `GROUP BY <natural key>` (inside an identified ER model) | blocking keys + exact matchkey |
+| `jaro_winkler_similarity(a, b) >= t` / `levenshtein(a, b) <= k` / `soundex(a) = soundex(b)` + a self-join `ON` key | comparison field + scorer + threshold, blocked on the join key |
+| `LOWER`/`UPPER`/`TRIM` wrapping a key column | a standardizer transform on that field |
+
+Everything else — arbitrary business logic, `CASE` ladders, priority hierarchies — is attached to the report as a `couldn't extract` finding with the model name + SQL excerpt, **never silently dropped**.
+
+## Verify it reproduces your pipeline (the trust step)
+
+Your hand-rolled dbt ER model already produces an output table — a surrogate-key→member mapping or a canonical/golden table. That existing output is **label-free ground truth**. `verify_against_dbt` runs the converted config on a sample of the source rows and reports pairwise cluster agreement against it:
+
+```python
+from goldenmatch.config.dbt_verify import verify_against_dbt
+
+v = verify_against_dbt(conv.config, source_df, dbt_output_df, id_column="id")
+if v is not None:                          # None on an empty / non-overlapping output
+    print(f"reproduces {v.agreement['f1'] * 100:.1f}% of existing clusters")
+    print(v.is_faithful)                   # True at pairwise F1 >= 0.95
+```
+
+```bash
+goldenmatch import-dbt target/manifest.json \
+  --verify dbt_output.parquet --source source_rows.parquet --id-column id
+```
+
+The `output_table` is a two-column `id, cluster_id` frame (name the columns with `output_id_column` / `output_cluster_column` if they differ). Verification is **best-effort**: a missing, empty, or non-overlapping output degrades to a skip notice, never a crash — the config is still written, it's just a *suggestion* until you point it at an output table.
+
+## Boundaries (stated honestly in the report)
+
+- **Extraction is heuristic → partial coverage.** The `couldn't extract` list is a first-class output for human review, not a footnote.
+- **Survivorship & conditional business rules** are the hardest to extract. The MVP recognizes most-recent (DESC window order-by) and reports it with the exact remediation (GoldenMatch applies `most_recent` per field); priority hierarchies and `CASE` ladders are flagged.
+- **Dialect variance** — the MVP covers DuckDB / Snowflake / BigQuery; the long tail is flagged.
+- **Verify needs the output table.** With it the proof is strong; without it the config is a reviewed suggestion.

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 90 | 201 | 47 | 38 | Yes | Yes |
+| `goldenmatch` | 90 | 201 | 47 | 39 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 83 | 7 | 0 |
-| `goldenmatch` | cli_commands | 32 | 6 | 0 |
+| `goldenmatch` | cli_commands | 32 | 7 | 0 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 23 | 1 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -67,7 +67,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `ingest-docs`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `import-dbt`, `ingest-docs`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — Python-only: `cosine`.

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 408,
+      "module_count": 411,
       "modules": [
         {
           "module": "goldenmatch",
@@ -591,6 +591,22 @@
           ]
         },
         {
+          "module": "goldenmatch.cli.import_dbt",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/import_dbt.py",
+          "purpose": "CLI command: distill a hand-rolled dbt project's ER logic into a config.",
+          "defines": [
+            "_render_report_table",
+            "_render_verify_table",
+            "_run_verify",
+            "import_dbt_cmd"
+          ],
+          "imports": [
+            "goldenmatch.config.dbt_verify",
+            "goldenmatch.config.from_dbt",
+            "goldenmatch.config.from_splink"
+          ]
+        },
+        {
           "module": "goldenmatch.cli.import_splink",
           "file": "packages/python/goldenmatch/goldenmatch/cli/import_splink.py",
           "purpose": "CLI command: convert a Splink settings or trained-model JSON file into a",
@@ -698,6 +714,7 @@
             "goldenmatch.cli.evaluate",
             "goldenmatch.cli.explain",
             "goldenmatch.cli.identity",
+            "goldenmatch.cli.import_dbt",
             "goldenmatch.cli.import_splink",
             "goldenmatch.cli.incremental",
             "goldenmatch.cli.ingest_docs",
@@ -943,6 +960,59 @@
         {
           "module": "goldenmatch.config",
           "file": "packages/python/goldenmatch/goldenmatch/config/__init__.py"
+        },
+        {
+          "module": "goldenmatch.config.dbt_verify",
+          "file": "packages/python/goldenmatch/goldenmatch/config/dbt_verify.py",
+          "purpose": "Auto-verify a dbt -> GoldenMatch conversion against the pipeline's own output.",
+          "defines": [
+            "DbtVerification",
+            "_load_output_mapping",
+            "_multi_cluster_count",
+            "verify_against_dbt"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.splink_upgrade",
+            "goldenmatch.config.splink_upgrade_measure"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.from_dbt",
+          "file": "packages/python/goldenmatch/goldenmatch/config/from_dbt.py",
+          "purpose": "Hand-rolled dbt -> GoldenMatch config converter (distill + verify).",
+          "defines": [
+            "DbtConversion",
+            "DbtConversionCoverage",
+            "DbtConversionError",
+            "ErModel",
+            "RecognizedSignal",
+            "_balanced_args",
+            "_blocking_signal_from_cols",
+            "_build_coverage",
+            "_col_field",
+            "_emit_config",
+            "_fuzzy_from_match",
+            "_fuzzy_predicate_re",
+            "_load_manifest",
+            "_manifest_dialect",
+            "_name_signal",
+            "_order_by_survivorship",
+            "_shape_signal",
+            "_split_top_level",
+            "_unique_test_columns",
+            "_unwrap_column",
+            "extract_signals",
+            "from_dbt",
+            "identify_er_models"
+          ],
+          "imports": [
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._paths"
+          ]
         },
         {
           "module": "goldenmatch.config.from_splink",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -3126,6 +3126,66 @@
           ]
         },
         {
+          "command": "import-dbt",
+          "options": [
+            {
+              "name": "manifest",
+              "type": "text",
+              "required": true,
+              "help": "dbt manifest.json (from `dbt compile` / `dbt parse`)"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "'goldenmatch.yaml'",
+              "help": "Output YAML config path"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Fail on any lossy finding (warnings), not just errors"
+            },
+            {
+              "name": "--min-confidence",
+              "type": "float",
+              "required": false,
+              "default": "0.5",
+              "help": "ER-model identification confidence floor for signal extraction"
+            },
+            {
+              "name": "--verify",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Prove the distillation reproduces your dbt pipeline: run the converted config on a sample of --source and report pairwise cluster agreement against this output table (parquet/csv; first two columns = id, cluster_id). Needs --source."
+            },
+            {
+              "name": "--source",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Source rows the dbt ER model consumed (parquet/csv), for --verify"
+            },
+            {
+              "name": "--verify-sample",
+              "type": "integer",
+              "required": false,
+              "default": "5000",
+              "help": "Rows of --source to run through GoldenMatch for --verify"
+            },
+            {
+              "name": "--id-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column holding each source row's id (default: auto-detect unique_id/id/record_id)"
+            }
+          ]
+        },
+        {
           "command": "import-splink",
           "options": [
             {

--- a/docs/superpowers/specs/2026-07-26-dbt-to-goldenmatch-converter-design.md
+++ b/docs/superpowers/specs/2026-07-26-dbt-to-goldenmatch-converter-design.md
@@ -1,0 +1,171 @@
+# Hand-rolled dbt → GoldenMatch config converter (distill + verify)
+
+**Date:** 2026-07-26
+**Status:** draft (design) — pending Ben's approval
+**Predecessors / reuse:**
+- Splink config converter — `specs/2026-07-13-splink-config-converter-design.md` (shipped) — the `from_splink` pattern (`ConversionReport`, `RecognizedLevel`, `CoverageSummary`).
+- Splink auto-verify — `goldenmatch/config/splink_verify.py` — the label-free engine-vs-engine agreement primitive (`pair_set` / `pairwise_prf`) this spec **reuses wholesale**.
+- dbt integration — `packages/dbt/goldensuite/` (`run_goldenmatch_dedupe()` for DuckDB) — the existing GM-in-dbt surface this converter complements.
+
+## The pitch (why this exists)
+
+> A company has ~10k lines of hand-rolled dbt implementing entity resolution / dedup spread across dozens of models. The converter ingests the dbt project and says: **"these 10k lines boil down to *this* 30-line reusable GoldenMatch config — and here's proof it reproduces 97% of your existing clusters."**
+
+The value is **distillation + proof**, NOT faithful SQL translation. A 10k-line hand-rolled ER pipeline almost always encodes a *small* set of real decisions (a few blocking keys, a handful of comparison fields + thresholds, some survivorship rules) buried in sprawl. The converter extracts that intent and **measures how close the resulting config gets to the pipeline's existing output**. Lossy extraction is acceptable *because it is verified*, exactly as the Splink converter's approximate mappings are acceptable because `--verify` measures agreement.
+
+### Audience & framing
+
+Far larger than the Splink converter's audience: **everyone deduping in dbt**, not just probabilistic-ER practitioners. The consolidation/legibility moment (*"your 10k lines are this config"*) plus a measured agreement number is the thing data teams need to justify replacing unmaintained SQL sprawl with a tested engine.
+
+Two distinct value stories, surfaced honestly per project:
+1. **Fuzzy/probabilistic ER sprawl** → an *accuracy + consolidation* story (GM does the fuzzy matching the SQL did badly, in a tested engine).
+2. **Exact keep-latest dedup sprinkled everywhere** (the common case) → a *consolidation + maintainability* story (10k lines → a 20-line tested config), NOT an F1 story. The report must say which applies.
+
+## Non-goals
+
+- **NOT a faithful SQL-to-config translator.** We do not attempt to reproduce every CTE, window, or business rule. Anything not recognized is *reported*, never silently dropped.
+- **NOT push-button.** Output is a *proposed* config + a coverage/agreement report for human review — an accelerator + audit, not a magic button.
+- **NOT a general SQL parser.** We parse the dbt **manifest** (structured), not blind `.sql` files.
+- **NOT a runtime dependency on dbt for GM.** The converter reads dbt artifacts; it does not embed dbt.
+
+## The key enabler: parse the manifest, not raw SQL
+
+The Splink converter was tractable because Splink hands you a *typed settings object*. Hand-rolled dbt is the opposite — arbitrary SQL — EXCEPT dbt compiles to structured metadata that recovers most of the structure we need:
+
+- **`manifest.json`** (`dbt compile` / `dbt docs generate` / `dbt parse`): every model's **compiled SQL**, the full **DAG** (`ref()`/`source()` lineage), columns, descriptions, and **tests** (`unique` / `not_null` / `relationships`).
+- **`catalog.json`** (`dbt docs generate`): column types + row counts per model (helps classify columns, and gives before/after row counts for the consolidation story).
+- **The DAG** localizes the ER step: we analyze the handful of models feeding the identity/master/dim/deduped tables, not the whole warehouse.
+
+So the input is `target/manifest.json` (+ optional `catalog.json`), produced by a single `dbt compile` the user already knows how to run. No warehouse credentials required for extraction (only for the optional verify against a live output table).
+
+## Architecture
+
+```
+dbt project ──(dbt compile)──▶ manifest.json (+ catalog.json)
+                                      │
+                    ┌─────────────────┼──────────────────┐
+                    ▼                 ▼                  ▼
+             1. IDENTIFY        2. EXTRACT          3. EMIT
+             ER models         ER signals          GoldenMatchConfig
+             (DAG + naming)    (per model)         + ConversionReport
+                                      │                  │
+                                      ▼                  ▼
+                             4. VERIFY (optional)  5. REPORT
+                             config vs the         CoverageSummary +
+                             pipeline's existing   agreement + "couldn't
+                             output table          extract" list
+```
+
+Mirrors `from_splink`'s shape: a recognizer layer (`RecognizedSignal` analogous to `RecognizedLevel`), a `ConversionReport` of findings, a `CoverageSummary`, and a `verify_against_dbt` that reuses the Splink verify math.
+
+### 1. Identify the ER models
+
+The DAG + naming heuristics pick the models that *do* entity resolution, so we don't analyze transformation models that aren't ER:
+
+- **Naming signals** (case-insensitive substrings): `dedup`, `dedupe`, `_dim`, `_master`, `golden`, `mdm`, `identity`, `_unique`, `canonical`, `_deduped`, `resolve`, `xref`, `crosswalk`, `survivor`.
+- **Shape signals** in the compiled SQL: window dedup (`ROW_NUMBER()`/`RANK()` + `QUALIFY`/outer filter), self-joins (a model joining a source to itself on non-PK columns), `dbt_utils.deduplicate` / `generate_surrogate_key`, `GROUP BY` collapsing a natural key with aggregates.
+- **Test signals**: a `unique` test on a non-surrogate column is a strong "this is the identity key" hint.
+- **DAG position**: models that are *terminal-ish* (feed marts / exposures) and *fan-in* from staging.
+
+Output: a ranked list of candidate ER models with a confidence + the signal(s) that fired. Low-confidence models are reported, not silently included.
+
+### 2. Extract ER signals per model
+
+Recognizers over the **compiled SQL** (dialect-aware, see below). Each emits a `RecognizedSignal(kind, columns, params, source_model, confidence, sql_excerpt)`:
+
+| dbt signal (in compiled SQL / manifest) | → GoldenMatch config element |
+|---|---|
+| `PARTITION BY <cols>` in a dedup window; `GROUP BY <natural key>`; `JOIN … ON <keys>`; `unique` test cols; `generate_surrogate_key([<cols>])` args | **blocking keys** (+ candidate exact matchkey) |
+| `jaro_winkler(...)`, `levenshtein(...)`, `edit_distance(...)`, `soundex(...)`, `jaro_similarity(...)` + a threshold literal in `WHERE`/`QUALIFY`/join predicate | **comparison field + scorer + threshold** (reuse the Splink scorer mapping) |
+| `LOWER`/`UPPER`/`TRIM`/`INITCAP`/`REGEXP_REPLACE`/`REPLACE`/`translate` wrapping a join/compare column | **standardizer / transform** on that field |
+| `ORDER BY <col> DESC` inside `ROW_NUMBER()`; `FIRST_VALUE`/`LAST_VALUE`/`MAX`/`COALESCE(a, b, …)` in the survivor select | **survivorship / golden-record rule** (most-recent / source-priority / non-null-coalesce) |
+| `QUALIFY ROW_NUMBER() OVER (…) = 1`; `dbt_utils.deduplicate`; `DISTINCT`; `GROUP BY` natural key with no fuzzy predicate | **exact / keep-latest matchkey** |
+
+Extraction is **best-effort and confidence-scored**. Unrecognized constructs (arbitrary business logic, conditional CASE hierarchies, nested subqueries) are attached to the report as `couldn't_extract` findings with the model name + SQL excerpt — the human-review surface.
+
+### 3. Emit the config
+
+Aggregate signals across the identified ER models into ONE `GoldenMatchConfig`:
+- de-duplicate blocking keys / comparison fields discovered in multiple models;
+- resolve conflicts (two models fuzzy-matching the same field at different thresholds → keep the looser, warn — the `numeric_diff`-collapse precedent);
+- attach standardizers as field transforms;
+- attach survivorship as `golden_rules`.
+
+The result is a validated `GoldenMatchConfig` + a `ConversionReport` (info/warning/error findings) + a `CoverageSummary`.
+
+### 4. Verify (the load-bearing trust step)
+
+**Reuse `splink_verify` wholesale.** The pipeline's *existing output* is the label-free ground truth:
+- the old dbt ER model already produces a table — either a **surrogate-key → member mapping** (window-dedup style) or a **canonical/golden table** (master-data style);
+- read it into an `id → cluster_id` map (the same shape `splink_verify._resolve_ids` + cluster maps use);
+- run GM's proposed config via `dedupe_df` on the *source* rows → GM's `id → cluster_id`;
+- compute pairwise agreement (`pair_set` / `pairwise_prf`) → **"reproduces N% of your existing clusters."**
+
+This is the exact engine-vs-engine primitive `verify_against_splink` uses, with the dbt output table as the reference instead of a live Splink run. No labels required (consistent with the fact that dbt dedup, like Splink, is unsupervised). `is_faithful` at pairwise F1 ≥ 0.95, same bar.
+
+Verify degrades gracefully: if the output table / dbt run isn't available, we emit the config + coverage without an agreement number (a warning finding), exactly as `verify_against_splink` returns `None` when splink is absent.
+
+### 5. Report
+
+A `DbtConversionCoverage` scorecard (analogous to `CoverageSummary`):
+```
+14 ER models analyzed -> 1 config: 4 blocking keys, 6 comparison fields (3 exact, 3 fuzzy),
+2 survivorship rules. 3 constructs flagged for review. Reproduces 97.2% of existing clusters
+(pairwise F1). Story: fuzzy-ER consolidation.
+```
+Plus the ranked list of `couldn't_extract` items so the human knows exactly what to check.
+
+## Surface
+
+- **Library:** `goldenmatch/config/from_dbt.py` — `from_dbt(manifest_path, *, catalog_path=None, output_table=None, source_table=None) -> DbtConversion`. Mirrors `SplinkConversion` (config + report + coverage + optional agreement).
+- **CLI:** `goldenmatch import-dbt <manifest.json> [-o config.yaml] [--verify <output.parquet> --source <rows.parquet>]` and a one-shot `migrate-dbt` mirroring `migrate-splink` (convert → coverage → verify → optionally run).
+- **Docs:** a "Migrating from hand-rolled dbt" page, mirroring "Migrating from Splink."
+- Manifest surfaces (`parity/goldenmatch.yaml` cli_commands.python_only, agent-codemap, config-matrix) updated in the same PR, per the api_parity discipline.
+
+## Dialect strategy
+
+Compiled SQL is warehouse-specific (Snowflake `EDITDISTANCE`, BigQuery `EDIT_DISTANCE`, DuckDB `levenshtein`, Postgres `levenshtein` via `fuzzystrmatch`, Redshift, Spark). The `adapter` is in the manifest metadata, so recognizers are **dialect-registered**: a small per-adapter table of fuzzy-function names + `QUALIFY`/window syntax. MVP ships **Snowflake + BigQuery + DuckDB** (the dominant analytics-warehouse trio for dbt); others fall through to a dialect-agnostic core (window-dedup + `GROUP BY` + the ANSI string funcs) and are flagged.
+
+## Boundaries / where it degrades (state honestly in the report)
+
+- **Extraction is heuristic → partial coverage.** Needs review, not blind trust. The `couldn't_extract` list is a first-class output, not a footnote.
+- **Survivorship & conditional business rules** are the hardest to extract faithfully (priority hierarchies, per-source overrides, CASE ladders). Recognize the common shapes (most-recent, source-priority, non-null-coalesce); flag the rest.
+- **Dialect variance** — MVP is 3 warehouses; the long tail is flagged.
+- **Exact-dedup sprawl** → the "accuracy" number is trivially ~1.0; the value is consolidation, and the report says so (no over-claiming an F1 win).
+- **Verify needs the output table (or a dbt run).** With it, the proof is strong; without it, the config is a *suggestion* and the report says so.
+
+## MVP scope (ship narrow, honest about the rest)
+
+1. `from_dbt` reading `manifest.json`: identify ER models (naming + window-dedup + `GROUP BY` + `generate_surrogate_key`), extract blocking + exact/keep-latest matchkeys + the common fuzzy predicates, emit a config + `DbtConversionCoverage`.
+2. `verify_against_dbt` reusing the Splink verify math against a provided output table.
+3. Dialects: DuckDB + Snowflake + BigQuery.
+4. Recognize ~5 idioms well (`QUALIFY ROW_NUMBER`, `dbt_utils.deduplicate`, `GROUP BY` natural key, `jaro_winkler`/`levenshtein` + threshold, `LOWER/TRIM` normalization); everything else → `couldn't_extract`.
+5. `import-dbt` CLI + tests (fixture manifests, no live warehouse) + a docs page.
+
+Same posture the Splink converter shipped with: high fidelity on the recognized set, loud + honest about the unrecognized set, verified against the user's own output.
+
+## Testing strategy
+
+- **Fixture manifests**: hand-authored `manifest.json` fragments for each recognized idiom per dialect (no live warehouse) — the analogue of the Splink converter's captured-SQL fixtures. Assert the extracted config + coverage.
+- **Round-trip verify**: a small synthetic source + a synthetic "old output" table where the config *should* reproduce the clusters → assert `is_faithful`, and a deliberately-diverging case → assert the agreement drops and is reported.
+- **`couldn't_extract` coverage**: feed a model with arbitrary business logic → assert it's flagged, not silently dropped.
+- Real-manifest smoke: run against a public dbt sample project (e.g. jaffle-shop-style) to confirm it doesn't crash and reports sensibly on a non-ER project (empty/low coverage, no false ER models).
+
+## Open questions / risks
+
+1. **Confidence calibration** — how aggressive is ER-model identification? False positives (calling a non-ER model "ER") waste review time; false negatives miss real logic. Start conservative + report the ranked list.
+2. **Multi-entity projects** — a dbt project may resolve *several* entities (customers, products, suppliers). One config vs several? MVP: emit one config per identified ER "family" (grouped by the entity's source table), not one giant config.
+3. **Incremental models** — dbt incremental ER models express *merge* logic (`is_incremental()` blocks). Recognizing incremental-merge → GM's incremental/identity path is a phase-2 lift.
+4. **jinja/macros beyond dbt_utils** — custom macros compile to SQL in the manifest (good), but package-specific macros (`dbt_utils.deduplicate`) need per-macro recognizers. Cover the popular packages; flag custom ones.
+5. **Verify without an output table** — is a config-only suggestion valuable enough on its own, or is the agreement number the whole point? (Lean: the number is the point; ship verify in the MVP, not phase 2.)
+
+## Relationship to the two existing dbt/Splink surfaces
+
+- **Complements the GM-in-dbt package** (`packages/dbt/goldensuite/`): that's for *adding* GM to a dbt pipeline going forward; this converter is for *replacing* hand-rolled ER a team already has. A natural pairing — the converter's emitted config can be dropped straight into a `{{ goldenmatch_dedupe(...) }}` model.
+- **Reuses the Splink converter's machinery** (`ConversionReport`, `CoverageSummary`, `RecognizedLevel`→`RecognizedSignal`, the scorer/threshold mapping) and the verify primitive (`splink_verify.pair_set`/`pairwise_prf`) — so the net-new surface is the manifest reader + ER-model identifier + SQL-idiom recognizers, not a second converter framework.
+
+## Phasing
+
+- **Phase 1 (MVP):** manifest reader + ER identification + exact/common-fuzzy extraction + verify + report + CLI + docs (DuckDB/Snowflake/BigQuery).
+- **Phase 2:** survivorship-rule extraction depth, more dialects, incremental-merge recognition, multi-entity families.
+- **Phase 3:** an LLM-assisted extraction fallback for the `couldn't_extract` tail (opt-in, same posture as the auto-config LLM tier) — propose a config for a model the heuristics couldn't parse, still gated by the verify agreement number so it can't hallucinate unchecked.

--- a/packages/python/goldenmatch/goldenmatch/cli/import_dbt.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/import_dbt.py
@@ -1,0 +1,192 @@
+"""CLI command: distill a hand-rolled dbt project's ER logic into a config.
+
+Spec: docs/superpowers/specs/2026-07-26-dbt-to-goldenmatch-converter-design.md
+
+Wraps goldenmatch.config.from_dbt.from_dbt(): reads a dbt ``manifest.json``,
+identifies the entity-resolution models, extracts the recognizable ER idioms
+into ONE GoldenMatchConfig, and prints a coverage scorecard + the findings
+(including the ``couldn't extract`` list for human review).
+
+The optional ``--verify`` flag proves the distillation reproduces the dbt
+pipeline's EXISTING output: on a sample of the source rows it runs the converted
+config and reports pairwise cluster agreement against the provided output table
+(goldenmatch.config.dbt_verify.verify_against_dbt) -- a one-command "reproduces
+N% of your existing clusters." Best-effort: it degrades to a skip notice when
+the output table is empty or shares no ids with the source.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+if TYPE_CHECKING:
+    from goldenmatch.config.dbt_verify import DbtVerification
+    from goldenmatch.config.from_dbt import DbtConversion
+    from goldenmatch.config.from_splink import ConversionFinding
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _render_report_table(findings: list[ConversionFinding]) -> Table | None:
+    if not findings:
+        return None
+    table = Table(title="dbt Conversion Findings", header_style="bold #d4a017")
+    table.add_column("Severity")
+    table.add_column("Location")
+    table.add_column("Message")
+    table.add_column("Mapped To")
+    severity_style = {"error": "red", "warning": "yellow", "info": "dim"}
+    for f in findings:
+        style = severity_style.get(f.severity, "")
+        table.add_row(
+            f"[{style}]{f.severity}[/{style}]" if style else f.severity,
+            f.splink_path,
+            f.message,
+            f.mapped_to or "",
+        )
+    return table
+
+
+def _render_verify_table(verification: DbtVerification) -> Table:
+    a = verification.agreement
+    verdict = (
+        "[green]faithful[/green]"
+        if verification.is_faithful
+        else "[yellow]divergent[/yellow]"
+    )
+    table = Table(
+        title=f"dbt agreement ({verdict})", header_style="bold #d4a017",
+    )
+    table.add_column("Metric")
+    table.add_column("Value", justify="right")
+    table.add_row("reproduces existing clusters", f"{a['f1'] * 100:.1f}%")
+    table.add_row("pairwise F1", f"{a['f1']:.3f}")
+    table.add_row("pairwise precision", f"{a['precision']:.3f}")
+    table.add_row("pairwise recall", f"{a['recall']:.3f}")
+    table.add_row("records compared", str(verification.n_shared_ids))
+    table.add_row(
+        "multi-record clusters (GM / dbt)",
+        f"{verification.gm_multi_clusters} / {verification.dbt_multi_clusters}",
+    )
+    return table
+
+
+def _run_verify(
+    conversion: DbtConversion,
+    source: str,
+    output_table: str,
+    sample: int,
+    id_column: str | None,
+) -> None:
+    """Run the auto-verify pass and print a table (or a skip notice)."""
+    from goldenmatch.config.dbt_verify import verify_against_dbt
+
+    if conversion.config is None:
+        console.print(
+            "[dim]dbt verification skipped: no config was extracted.[/dim]"
+        )
+        return
+    result = verify_against_dbt(
+        conversion.config,
+        source,
+        output_table,
+        id_column=id_column,
+        sample_size=sample,
+        report=conversion.report,
+    )
+    if result is None:
+        console.print(
+            "[dim]dbt verification skipped (see findings for the reason).[/dim]"
+        )
+        return
+    console.print(_render_verify_table(result))
+
+
+def import_dbt_cmd(
+    manifest: str = typer.Argument(
+        ..., help="dbt manifest.json (from `dbt compile` / `dbt parse`)"
+    ),
+    output: str = typer.Option(
+        "goldenmatch.yaml", "--output", "-o", help="Output YAML config path"
+    ),
+    strict: bool = typer.Option(
+        False, "--strict", help="Fail on any lossy finding (warnings), not just errors"
+    ),
+    min_confidence: float = typer.Option(
+        0.5,
+        "--min-confidence",
+        help="ER-model identification confidence floor for signal extraction",
+    ),
+    verify: str | None = typer.Option(
+        None,
+        "--verify",
+        help=(
+            "Prove the distillation reproduces your dbt pipeline: run the "
+            "converted config on a sample of --source and report pairwise "
+            "cluster agreement against this output table (parquet/csv; first "
+            "two columns = id, cluster_id). Needs --source."
+        ),
+    ),
+    source: str | None = typer.Option(
+        None,
+        "--source",
+        help="Source rows the dbt ER model consumed (parquet/csv), for --verify",
+    ),
+    verify_sample: int = typer.Option(
+        5000,
+        "--verify-sample",
+        help="Rows of --source to run through GoldenMatch for --verify",
+    ),
+    id_column: str | None = typer.Option(
+        None,
+        "--id-column",
+        help="Column holding each source row's id (default: auto-detect unique_id/id/record_id)",
+    ),
+) -> None:
+    """Distill a hand-rolled dbt project's ER logic into a GoldenMatch config."""
+    from goldenmatch.config.from_dbt import DbtConversionError, from_dbt
+
+    try:
+        conversion = from_dbt(manifest, strict=strict, min_confidence=min_confidence)
+    except DbtConversionError as exc:
+        err_console.print(f"[red]dbt conversion failed:[/red] {exc}")
+        raise typer.Exit(code=1) from None
+
+    cov = conversion.coverage
+    style = "green" if cov.has_config else "yellow"
+    console.print(f"[{style}]Distilled[/{style}] [cyan]{manifest}[/cyan] -- {cov.line()}")
+
+    if conversion.config is not None:
+        dumped = conversion.config.model_dump(exclude_none=True, exclude_defaults=True)
+        try:
+            with open(output, "w", encoding="utf-8") as fh:
+                yaml.safe_dump(dumped, fh, sort_keys=False)
+        except OSError as exc:
+            err_console.print(
+                f"[red]Could not write config to[/red] [cyan]{output}[/cyan]: {exc}"
+            )
+            raise typer.Exit(code=1) from None
+        console.print(f"Wrote config to [cyan]{output}[/cyan].")
+    else:
+        console.print(
+            "[yellow]No config written[/yellow] -- no entity-resolution logic was "
+            "recognized in this project."
+        )
+
+    if verify is not None:
+        if source is None:
+            err_console.print(
+                "[red]--verify needs --source[/red] (the rows the dbt model consumed)."
+            )
+            raise typer.Exit(code=1)
+        _run_verify(conversion, source, verify, verify_sample, id_column)
+
+    table = _render_report_table(conversion.report.findings)
+    if table is not None:
+        console.print(table)
+    console.print(conversion.report.summary())

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -20,6 +20,7 @@ from goldenmatch.cli.demo import demo_cmd
 from goldenmatch.cli.evaluate import evaluate_cmd
 from goldenmatch.cli.explain import explain_cmd
 from goldenmatch.cli.identity import identity_app
+from goldenmatch.cli.import_dbt import import_dbt_cmd
 from goldenmatch.cli.import_splink import import_splink_cmd
 from goldenmatch.cli.incremental import incremental_cmd
 from goldenmatch.cli.ingest_docs import ingest_docs_app
@@ -125,6 +126,7 @@ app.command("runs", help="List previous runs for rollback.")(runs_cmd)
 app.command("unmerge", help="Remove a record from its cluster (per-entity unmerge).")(unmerge_cmd)
 app.command("schedule", help="Run deduplication on a schedule.")(schedule_cmd)
 app.command("evaluate", help="Evaluate matching quality against ground truth pairs.")(evaluate_cmd)
+app.command("import-dbt", help="Distill a hand-rolled dbt project's ER logic (manifest.json) into a GoldenMatch config.")(import_dbt_cmd)
 app.command("import-splink", help="Convert a Splink settings or trained-model JSON to a GoldenMatch config.")(import_splink_cmd)
 app.command("migrate-splink", help="One-shot Splink migration: convert a model, verify it against Splink, and run the dedupe.")(migrate_splink_cmd)
 app.add_typer(pprl_app, name="pprl")

--- a/packages/python/goldenmatch/goldenmatch/config/dbt_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/config/dbt_verify.py
@@ -1,0 +1,227 @@
+"""Auto-verify a dbt -> GoldenMatch conversion against the pipeline's own output.
+
+Spec: docs/superpowers/specs/2026-07-26-dbt-to-goldenmatch-converter-design.md
+
+``from_dbt`` proves WHICH dbt idioms it maps. This module proves the mapping
+REPRODUCES BEHAVIOR: the hand-rolled dbt ER model already produces an output
+table -- either a surrogate-key -> member mapping (window-dedup style) or a
+canonical/golden table (master-data style). That existing output is the
+LABEL-FREE ground truth. We read it into an ``id -> cluster_id`` map, run the
+converted GoldenMatch config via ``dedupe_df`` on the SOURCE rows, and report
+pairwise cluster agreement -- "reproduces N% of your existing clusters."
+
+This is the exact engine-vs-engine primitive ``verify_against_splink`` uses
+(``pair_set`` / ``pairwise_prf`` from ``splink_upgrade_measure``), with the dbt
+output table as the reference instead of a live Splink run. No labels required
+(dbt dedup, like Splink, is unsupervised). ``is_faithful`` at pairwise F1 >=
+0.95, the same "numerically-equivalent" bar.
+
+Verification is best-effort: it returns ``None`` (with a warning finding) when
+the output table is empty or shares no ids with the source, rather than
+reporting all-0.0 garbage. Like ``splink_verify``, this module imports polars +
+the full pipeline, so ``from_dbt`` (polars-free) must NOT import it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from goldenmatch._polars_lazy import pl
+from goldenmatch.config.from_splink import ConversionReport
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.config.splink_upgrade import _load_frame
+from goldenmatch.config.splink_upgrade_measure import (
+    _POSITIONAL_ID_SOURCE,
+    _resolve_ids,
+    _run_once,
+    pair_set,
+    pairwise_prf,
+)
+
+# Same faithfulness bar as the Splink verify: a converted config whose clusters
+# agree with the dbt output at or above this pairwise F1 is behaviourally
+# faithful.
+_FAITHFUL_F1 = 0.95
+_DEFAULT_SAMPLE = 5000
+
+
+@dataclass
+class DbtVerification:
+    """Result of :func:`verify_against_dbt`.
+
+    ``agreement`` is the pairwise precision/recall/F1 of the converted
+    GoldenMatch config's dedupe clusters vs the dbt pipeline's existing output
+    clusters, over the ids present in both. High F1 == the converted config
+    reproduces the hand-rolled pipeline's linking decisions.
+    """
+
+    agreement: dict[str, float]
+    n_source_rows: int      # rows actually run through GoldenMatch
+    n_shared_ids: int       # ids present in BOTH the GM run and the dbt output
+    gm_cluster_count: int
+    dbt_cluster_count: int
+    gm_multi_clusters: int
+    dbt_multi_clusters: int
+    id_source: str
+
+    @property
+    def is_faithful(self) -> bool:
+        return self.agreement.get("f1", 0.0) >= _FAITHFUL_F1
+
+
+def _multi_cluster_count(mapping: dict[str, str]) -> int:
+    counts: dict[str, int] = {}
+    for cid in mapping.values():
+        counts[cid] = counts.get(cid, 0) + 1
+    return sum(1 for n in counts.values() if n > 1)
+
+
+def _load_output_mapping(
+    output: pl.DataFrame | str | Path,
+    sample_ids: set[str],
+    id_column: str | None,
+    cluster_column: str | None,
+) -> tuple[dict[str, str], int]:
+    """Read the dbt output table into ``id -> cluster_id``, restricted to
+    ``sample_ids``.
+
+    ``id_column`` / ``cluster_column`` name the two columns; when unset they
+    default to the first two columns (the ``splink_upgrade_measure`` reference
+    convention). Returns ``(mapping, total_output_rows)`` -- the raw count lets
+    the caller distinguish an EMPTY output from a zero-id-overlap join failure.
+    """
+    frame = _load_frame(output)
+    if len(frame.columns) < 2:
+        raise ValueError(
+            "dbt output table needs at least two columns (id, cluster_id); got "
+            + repr(frame.columns)
+        )
+    id_col = id_column or frame.columns[0]
+    cluster_col = cluster_column or frame.columns[1]
+    for name, role in ((id_col, "id"), (cluster_col, "cluster")):
+        if name not in frame.columns:
+            raise ValueError(
+                f"dbt output {role} column '{name}' not in the output table "
+                f"columns {frame.columns}"
+            )
+    mapping: dict[str, str] = {}
+    for rid, cid in zip(frame[id_col].to_list(), frame[cluster_col].to_list()):
+        key = str(rid)
+        if key in sample_ids:
+            mapping[key] = str(cid)
+    return mapping, len(frame)
+
+
+def verify_against_dbt(
+    config: GoldenMatchConfig,
+    source: pl.DataFrame | str | Path,
+    output_table: pl.DataFrame | str | Path,
+    *,
+    id_column: str | None = None,
+    output_id_column: str | None = None,
+    output_cluster_column: str | None = None,
+    sample_size: int = _DEFAULT_SAMPLE,
+    report: ConversionReport | None = None,
+) -> DbtVerification | None:
+    """Measure how faithfully the converted config reproduces the dbt output.
+
+    Runs the converted ``config`` via ``dedupe_df`` on a deterministic sample
+    of ``source`` and compares its clusters against the dbt pipeline's existing
+    ``output_table`` (an ``id, cluster_id`` mapping -- a surrogate-key->member
+    table or a canonical/golden table), reporting pairwise cluster agreement.
+
+    Returns ``None`` (best-effort, never raising on the verify path) when the
+    source or output is empty, or shares no ids with the source sample -- each
+    recorded as a finding on ``report`` when supplied.
+
+    Args:
+        config: the converted ``GoldenMatchConfig`` (from :func:`from_dbt`).
+        source: the SOURCE rows the dbt ER model consumed (DataFrame or
+            ``.parquet`` / ``.csv`` path).
+        output_table: the dbt model's EXISTING output (id -> cluster_id).
+        id_column: unique row-id column in ``source``; defaults to
+            ``unique_id``/``id``/``record_id`` then positional indices.
+        output_id_column / output_cluster_column: the id + cluster columns in
+            ``output_table``; default to its first two columns.
+        sample_size: rows of ``source`` to run through GoldenMatch (a seeded
+            subsample above this cap; the whole frame at or below it).
+        report: optional :class:`ConversionReport` to attach findings to.
+    """
+
+    def _note(kind: str, msg: str) -> None:
+        if report is not None:
+            method = "warn" if kind == "warning" else kind
+            getattr(report, method)("verify", msg, None)
+
+    frame = _load_frame(source)
+    if frame.height == 0:
+        _note("warning", "verify source is empty; agreement not measured.")
+        return None
+
+    sample = (
+        frame.sample(n=sample_size, seed=0) if frame.height > sample_size else frame
+    )
+    if frame.height > sample_size:
+        _note(
+            "info",
+            f"verifying on a seeded {sample_size}-row sample of {frame.height} "
+            "rows (deterministic).",
+        )
+
+    ids, id_source = _resolve_ids(sample, id_column)
+
+    try:
+        dbt_map, n_output_rows = _load_output_mapping(
+            output_table, set(ids), output_id_column, output_cluster_column
+        )
+    except ValueError as exc:
+        _note("warning", f"could not read the dbt output table ({exc}); "
+              "the conversion was written but not verified.")
+        return None
+
+    if n_output_rows == 0:
+        _note("warning", "dbt output table is empty (0 rows); agreement not measured.")
+        return None
+    if not dbt_map:
+        source_desc = (
+            "positional row indices"
+            if id_source == _POSITIONAL_ID_SOURCE
+            else f"column '{id_source}'"
+        )
+        _note(
+            "warning",
+            f"the dbt output table ({n_output_rows} rows) shares no ids with the "
+            f"source sample (ids came from {source_desc}) -- an id-join failure, "
+            "so agreement is skipped rather than reported as 0.0; pass "
+            "id_column= / output_id_column= naming the matching id columns.",
+        )
+        return None
+
+    gm_map, _wall = _run_once(sample, config, ids)
+
+    shared = gm_map.keys() & dbt_map.keys()
+    gm_pairs, _c1 = pair_set({k: gm_map[k] for k in shared})
+    dbt_pairs, _c2 = pair_set({k: dbt_map[k] for k in shared})
+    agreement = pairwise_prf(gm_pairs, dbt_pairs)
+
+    result = DbtVerification(
+        agreement=agreement,
+        n_source_rows=len(ids),
+        n_shared_ids=len(shared),
+        gm_cluster_count=len(set(gm_map.values())),
+        dbt_cluster_count=len(set(dbt_map.values())),
+        gm_multi_clusters=_multi_cluster_count(gm_map),
+        dbt_multi_clusters=_multi_cluster_count(dbt_map),
+        id_source=id_source,
+    )
+
+    verdict = "faithful" if result.is_faithful else "DIVERGENT"
+    _note(
+        "info" if result.is_faithful else "warning",
+        f"dbt agreement ({verdict}): reproduces {agreement['f1'] * 100:.1f}% of "
+        f"existing clusters (pairwise F1={agreement['f1']:.3f}, "
+        f"P={agreement['precision']:.3f}, R={agreement['recall']:.3f}) over "
+        f"{len(shared)} records; GoldenMatch {result.gm_multi_clusters} vs dbt "
+        f"{result.dbt_multi_clusters} multi-record clusters.",
+    )
+    return result

--- a/packages/python/goldenmatch/goldenmatch/config/from_dbt.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_dbt.py
@@ -1,0 +1,970 @@
+"""Hand-rolled dbt -> GoldenMatch config converter (distill + verify).
+
+Spec: docs/superpowers/specs/2026-07-26-dbt-to-goldenmatch-converter-design.md
+
+The value is DISTILLATION + PROOF, not faithful SQL translation. A ~10k-line
+hand-rolled entity-resolution pipeline spread across dozens of dbt models
+almost always encodes a *small* set of real decisions (a few blocking keys, a
+handful of comparison fields + thresholds, some survivorship rules) buried in
+sprawl. ``from_dbt`` reads the dbt ``manifest.json`` (structured metadata, NOT
+blind ``.sql``), identifies the models that do entity resolution, extracts the
+recognizable ER idioms into ONE ``GoldenMatchConfig``, and reports what it
+could and could NOT extract. The optional ``verify_against_dbt`` measures how
+faithfully the emitted config reproduces the pipeline's EXISTING output table
+(label-free engine-vs-engine agreement, reusing the Splink verify math).
+
+Design posture mirrors ``from_splink``: high fidelity on the recognized idiom
+set, loud + honest (``couldnt_extract`` findings) about the unrecognized set,
+verified against the user's own output. This module stays import-light +
+polars-free (it only parses JSON + regexes SQL); ``verify_against_dbt`` lives in
+``dbt_verify.py`` and pulls in the pipeline only when verification runs.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+from pathlib import Path
+from typing import Literal
+
+from goldenmatch.config.from_splink import (
+    _LEV_ASSUMED_LEN,
+    ConversionReport,
+)
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core._paths import safe_path
+
+
+class DbtConversionError(ValueError):
+    """Raised on a malformed manifest or (in strict mode) any lossy finding."""
+
+
+# ── ER-model identification signals ──────────────────────────────────────────
+#
+# Case-insensitive substrings in a model NAME that hint at an entity-resolution
+# / master-data / dedup model. These localize the ER step so transformation
+# models that aren't ER are never analyzed.
+_ER_NAME_SUBSTRINGS: tuple[str, ...] = (
+    "dedup", "dedupe", "_dim", "dim_", "_master", "master_", "golden", "mdm",
+    "identity", "_unique", "canonical", "_deduped", "resolve", "xref",
+    "crosswalk", "survivor",
+)
+
+# The MVP dialect trio (dbt ``metadata.adapter_type``). Others fall through to a
+# dialect-agnostic core (window-dedup + GROUP BY + the ANSI string funcs) and
+# are flagged so the user knows recognition was partial.
+_MVP_DIALECTS: frozenset[str] = frozenset({"duckdb", "snowflake", "bigquery"})
+
+# Fuzzy similarity funcs -> (GoldenMatch scorer, scale). The literal threshold in
+# the SQL is divided by ``scale`` (Snowflake's JAROWINKLER_SIMILARITY returns
+# 0-100, DuckDB's jaro_winkler_similarity returns 0-1). Names are distinct
+# across warehouses so a global table needs no per-dialect disambiguation.
+_FUZZY_SIM_FUNCS: dict[str, tuple[str, float]] = {
+    "jaro_winkler_similarity": ("jaro_winkler", 1.0),
+    "jaro_winkler": ("jaro_winkler", 1.0),
+    "jaro_similarity": ("jaro_winkler", 1.0),
+    "jarowinkler_similarity": ("jaro_winkler", 100.0),  # snowflake, 0-100
+    "jaccard": ("jaccard", 1.0),
+}
+
+# Edit-distance funcs -> GoldenMatch scorer. These are DISTANCES (smaller =
+# closer), so a `<= k` predicate maps to a similarity via the same assumed-length
+# approximation ``from_splink`` uses (sim = 1 - k/_LEV_ASSUMED_LEN).
+_FUZZY_DIST_FUNCS: dict[str, str] = {
+    "levenshtein": "levenshtein",
+    "damerau_levenshtein": "levenshtein",
+    "editdistance": "levenshtein",   # snowflake
+    "edit_distance": "levenshtein",  # bigquery
+}
+
+# SQL string-normalization funcs -> GoldenMatch transform. INITCAP / REGEXP_*
+# have no clean single-transform equivalent and are reported as couldnt_extract
+# (the base column is still used).
+_TRANSFORM_FUNCS: dict[str, str] = {
+    "lower": "lowercase",
+    "upper": "uppercase",
+    "trim": "strip",
+    "btrim": "strip",
+    "ltrim": "strip",
+    "rtrim": "strip",
+}
+_UNRECOGNIZED_WRAP_FUNCS: frozenset[str] = frozenset(
+    {"initcap", "regexp_replace", "replace", "translate", "substr", "substring",
+     "left", "right", "coalesce"}
+)
+
+
+SignalKind = Literal[
+    "blocking", "exact_matchkey", "fuzzy_field", "transform", "survivorship",
+    "couldnt_extract",
+]
+
+
+@dataclass
+class RecognizedSignal:
+    """One ER decision extracted from a dbt model's compiled SQL / metadata.
+
+    Analogous to ``from_splink``'s ``RecognizedLevel``: the recognizer layer's
+    unit of output, aggregated into the emitted config by :func:`from_dbt`.
+    """
+
+    kind: SignalKind
+    columns: list[str]
+    params: dict
+    source_model: str
+    confidence: float = 1.0
+    sql_excerpt: str = ""
+
+
+# ── SQL parsing helpers ──────────────────────────────────────────────────────
+
+
+def _split_top_level(s: str, sep: str = ",") -> list[str]:
+    """Split ``s`` on ``sep`` at paren depth 0 (so ``lower(a, b), c`` -> two)."""
+    parts: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    for ch in s:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        if ch == sep and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        parts.append("".join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+_BARE_COL_RE = re.compile(r'^(?:[A-Za-z_]\w*\.)?["`]?([A-Za-z_]\w*)["`]?$')
+_FUNC_WRAP_RE = re.compile(r'^([A-Za-z_]\w*)\s*\((.*)\)$', re.DOTALL)
+
+
+def _unwrap_column(expr: str) -> tuple[str | None, list[str], list[str]]:
+    """Peel normalization funcs off a column expression.
+
+    ``lower(trim(a.email))`` -> ``("email", ["strip", "lowercase"], [])``. The
+    transform list is in APPLY order (innermost SQL func first == GoldenMatch
+    left-to-right). Returns ``(base_column, transforms, unrecognized_funcs)``;
+    ``base_column`` is ``None`` when the expression isn't a (wrapped) single
+    column (an arithmetic/CASE expression, a literal, ``*`` -- not extractable).
+    """
+    expr = expr.strip()
+    transforms: list[str] = []       # outer-to-inner; reversed before return
+    unrecognized: list[str] = []
+    # Peel at most a few layers -- realistic normalization nests shallowly, and a
+    # bound guards against pathological input.
+    for _ in range(8):
+        m = _BARE_COL_RE.match(expr)
+        if m:
+            transforms.reverse()  # outer-to-inner -> apply order (inner first)
+            return m.group(1), transforms, unrecognized
+        wrap = _FUNC_WRAP_RE.match(expr)
+        if not wrap:
+            return None, [], unrecognized
+        func = wrap.group(1).lower()
+        args = _split_top_level(wrap.group(2))
+        if func in _TRANSFORM_FUNCS:
+            # trim(a, 'x') / a normalize func with extra args isn't a plain wrap.
+            if len(args) != 1:
+                return None, [], unrecognized
+            transforms.append(_TRANSFORM_FUNCS[func])
+            expr = args[0].strip()
+            continue
+        if func in _UNRECOGNIZED_WRAP_FUNCS:
+            # Wrapping we can't represent as a single transform. Keep peeling to
+            # recover the base column (still usable as a blocking/match field);
+            # record the func so the report flags the lost normalization.
+            unrecognized.append(func)
+            if len(args) >= 1 and _split_top_level(args[0]):
+                expr = args[0].strip()
+                continue
+            return None, [], unrecognized
+        # Unknown func -> not a recognizable column expression.
+        return None, [], unrecognized
+    return None, [], unrecognized
+
+
+def _col_field(expr: str) -> str | None:
+    """Base column name of a plain (optionally alias-qualified) column ref."""
+    m = _BARE_COL_RE.match(expr.strip())
+    return m.group(1) if m else None
+
+
+# ── Idiom recognizers over compiled SQL ──────────────────────────────────────
+#
+# QUALIFY ROW_NUMBER() OVER (PARTITION BY <cols> [ORDER BY <col> [DESC]]) = 1
+# -- the canonical window-dedup: keep one row per partition key. The partition
+# columns are the natural key (blocking + exact matchkey); a DESC order-by date
+# column is a most-recent survivorship rule.
+_QUALIFY_ROWNUM_RE = re.compile(
+    r'qualify\s+row_number\s*\(\s*\)\s+over\s*\(\s*'
+    r'partition\s+by\s+(?P<partition>.+?)'
+    r'(?:\s+order\s+by\s+(?P<order>.+?))?\s*\)\s*=\s*1',
+    re.IGNORECASE | re.DOTALL,
+)
+
+# GROUP BY <natural key> -- collapse-by-key dedup (master-data style). Only
+# treated as ER inside an already-identified ER model (GROUP BY is ubiquitous in
+# non-ER rollups), so it carries lower confidence. Terminated by the next clause.
+_GROUP_BY_RE = re.compile(
+    r'group\s+by\s+(?P<cols>.+?)'
+    r'(?=\s+(?:order\s+by|having|qualify|limit|window|union)\b|\s*\)|\s*$)',
+    re.IGNORECASE | re.DOTALL,
+)
+
+# JOIN ... ON <a.col> = <b.col> equality conjuncts -- the blocking keys of a
+# matching self-join (paired with a fuzzy predicate in WHERE/ON).
+_ON_EQUALITY_RE = re.compile(
+    r'([A-Za-z_]\w*)\.["`]?([A-Za-z_]\w*)["`]?\s*=\s*'
+    r'([A-Za-z_]\w*)\.["`]?([A-Za-z_]\w*)["`]?',
+    re.IGNORECASE,
+)
+
+# soundex(<a>) = soundex(<b>) -- phonetic equality, GoldenMatch soundex_match.
+_SOUNDEX_EQ_RE = re.compile(
+    r'soundex\s*\(\s*(?P<a>[^()]+?)\s*\)\s*=\s*soundex\s*\(\s*(?P<b>[^()]+?)\s*\)',
+    re.IGNORECASE,
+)
+
+# generate_surrogate_key([...]) / surrogate_key([...]) in RAW (jinja) code -- the
+# argument list is the natural key the surrogate is built from.
+_SURROGATE_KEY_RE = re.compile(
+    r'(?:dbt_utils\.)?(?:generate_surrogate_key|surrogate_key)\s*\(\s*\[(?P<args>[^\]]*)\]',
+    re.IGNORECASE,
+)
+
+# dbt_utils.deduplicate(..., partition_by='a, b', order_by='c desc', ...) in RAW
+# code -- partition_by is the natural key, order_by drives survivorship. The
+# call arguments nest parens (`relation=ref("stg")`), so the arg list is scanned
+# with a balanced-paren matcher, NOT a `.*?` regex (which stops at the first `)`).
+_DEDUPLICATE_CALL = re.compile(r'dbt_utils\.deduplicate\s*\(', re.IGNORECASE)
+_KWARG_RE = re.compile(
+    r'''(\w+)\s*=\s*(['"])(?P<val>.*?)\2''', re.IGNORECASE | re.DOTALL,
+)
+
+
+def _balanced_args(text: str, open_idx: int) -> str:
+    """Return the substring inside the parens opening at ``text[open_idx]``.
+
+    ``open_idx`` points at the ``(``; scanning stops at its matching ``)`` even
+    across nested parens. Returns the inner text (empty if unbalanced)."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        ch = text[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx + 1:i]
+    return ""
+
+_JINJA_STRING_LITERAL_RE = re.compile(r"""^['"](.*)['"]$""", re.DOTALL)
+
+
+def _fuzzy_predicate_re(func: str) -> re.Pattern:
+    """`func(<a>, <b>) <op> <literal>` recognizer for one fuzzy function."""
+    return re.compile(
+        re.escape(func) + r'\s*\(\s*(?P<a>[^(),]+?)\s*,\s*(?P<b>[^(),]+?)\s*\)'
+        r'\s*(?P<op>>=|<=|>|<|=)\s*(?P<lit>[0-9]*\.?[0-9]+)',
+        re.IGNORECASE,
+    )
+
+
+def _order_by_survivorship(order_expr: str, model: str) -> RecognizedSignal | None:
+    """A DESC order-by date/updated column in a window-dedup is most-recent."""
+    first = _split_top_level(order_expr)[:1]
+    if not first:
+        return None
+    tokens = first[0].split()
+    col = _col_field(tokens[0])
+    if col is None:
+        return None
+    descending = len(tokens) > 1 and tokens[1].lower() == "desc"
+    if not descending:
+        # ASC / unspecified: the winner is the FIRST row, not most-recent -- we
+        # can't name a survivorship strategy for it. Report, don't guess.
+        return RecognizedSignal(
+            "couldnt_extract", [col],
+            {"reason": "window-dedup ORDER BY is not DESC; survivorship strategy "
+                       "not inferred (would need per-column priority logic)"},
+            model, confidence=0.3, sql_excerpt=order_expr.strip()[:200],
+        )
+    return RecognizedSignal(
+        "survivorship", [col],
+        {"strategy": "most_recent", "date_column": col},
+        model, confidence=0.7, sql_excerpt=order_expr.strip()[:200],
+    )
+
+
+def _blocking_signal_from_cols(
+    col_exprs: list[str], model: str, confidence: float, excerpt: str,
+) -> tuple[RecognizedSignal | None, list[RecognizedSignal]]:
+    """Turn a natural-key column list into a blocking signal (+ transform /
+    couldnt_extract side signals). Returns ``(blocking_signal, extras)``."""
+    fields: list[str] = []
+    field_transforms: dict[str, list[str]] = {}
+    extras: list[RecognizedSignal] = []
+    for expr in col_exprs:
+        base, transforms, unrecognized = _unwrap_column(expr)
+        if base is None:
+            extras.append(RecognizedSignal(
+                "couldnt_extract", [],
+                {"reason": f"could not extract a column from key expression {expr!r}"},
+                model, confidence=0.2, sql_excerpt=expr[:200],
+            ))
+            continue
+        fields.append(base)
+        if transforms:
+            field_transforms[base] = transforms
+            extras.append(RecognizedSignal(
+                "transform", [base], {"transforms": transforms},
+                model, confidence=confidence, sql_excerpt=expr[:200],
+            ))
+        for func in unrecognized:
+            extras.append(RecognizedSignal(
+                "couldnt_extract", [base],
+                {"reason": f"normalization {func}(...) on key column {base!r} has no "
+                           "single GoldenMatch transform; base column used, "
+                           "normalization dropped"},
+                model, confidence=0.3, sql_excerpt=expr[:200],
+            ))
+    if not fields:
+        return None, extras
+    blocking = RecognizedSignal(
+        "blocking", fields,
+        {"field_transforms": field_transforms},
+        model, confidence=confidence, sql_excerpt=excerpt[:200],
+    )
+    return blocking, extras
+
+
+def extract_signals(
+    node: dict, dialect: str, is_er: bool,
+) -> list[RecognizedSignal]:
+    """Recognize ER idioms in one model node's compiled + raw SQL.
+
+    ``is_er`` gates the weaker GROUP BY signal (fires only inside an identified
+    ER model). Unrecognized-but-ER-looking constructs are NOT emitted here as
+    couldnt_extract wholesale (that would be noise); only the specific parse
+    failures inside a recognized idiom are.
+    """
+    model = node.get("name", node.get("unique_id", "?"))
+    compiled = node.get("compiled_code") or node.get("compiled_sql") or ""
+    raw = node.get("raw_code") or node.get("raw_sql") or ""
+    signals: list[RecognizedSignal] = []
+    saw_window_key = False
+
+    # 1. QUALIFY ROW_NUMBER window-dedup.
+    for m in _QUALIFY_ROWNUM_RE.finditer(compiled):
+        partition_cols = _split_top_level(m.group("partition"))
+        blocking, extras = _blocking_signal_from_cols(
+            partition_cols, model, 0.9, m.group(0),
+        )
+        if blocking is not None:
+            signals.append(blocking)
+            signals.append(RecognizedSignal(
+                "exact_matchkey", blocking.columns, {}, model, 0.9,
+                m.group(0)[:200],
+            ))
+            saw_window_key = True
+        signals.extend(extras)
+        order = m.group("order")
+        if order:
+            surv = _order_by_survivorship(order, model)
+            if surv is not None:
+                signals.append(surv)
+
+    # 2. dbt_utils.deduplicate(...) in raw jinja.
+    for m in _DEDUPLICATE_CALL.finditer(raw):
+        args = _balanced_args(raw, m.end() - 1)
+        kwargs = {km.group(1).lower(): km.group("val")
+                  for km in _KWARG_RE.finditer(args)}
+        pby = kwargs.get("partition_by")
+        if pby:
+            blocking, extras = _blocking_signal_from_cols(
+                _split_top_level(pby), model, 0.9, m.group(0),
+            )
+            if blocking is not None:
+                signals.append(blocking)
+                signals.append(RecognizedSignal(
+                    "exact_matchkey", blocking.columns, {}, model, 0.9,
+                    m.group(0)[:200],
+                ))
+                saw_window_key = True
+            signals.extend(extras)
+        oby = kwargs.get("order_by")
+        if oby:
+            surv = _order_by_survivorship(oby, model)
+            if surv is not None:
+                signals.append(surv)
+
+    # 3. generate_surrogate_key([...]) in raw jinja.
+    for m in _SURROGATE_KEY_RE.finditer(raw):
+        args = [
+            (sm.group(1) if (sm := _JINJA_STRING_LITERAL_RE.match(a.strip())) else a.strip())
+            for a in _split_top_level(m.group("args"))
+        ]
+        args = [a for a in args if a]
+        if not args:
+            continue
+        blocking, extras = _blocking_signal_from_cols(args, model, 0.7, m.group(0))
+        if blocking is not None:
+            signals.append(blocking)
+            signals.append(RecognizedSignal(
+                "exact_matchkey", blocking.columns, {}, model, 0.7, m.group(0)[:200],
+            ))
+        signals.extend(extras)
+
+    # 4. Fuzzy predicates (similarity + edit-distance funcs) + phonetic equality.
+    fuzzy_seen: set[tuple[str, str]] = set()
+    for func, (scorer, scale) in _FUZZY_SIM_FUNCS.items():
+        for m in _fuzzy_predicate_re(func).finditer(compiled):
+            sig = _fuzzy_from_match(m, scorer, model, scale=scale, distance=False)
+            if sig is not None and (key := (sig.columns[0], scorer)) not in fuzzy_seen:
+                fuzzy_seen.add(key)
+                signals.append(sig)
+    for func, scorer in _FUZZY_DIST_FUNCS.items():
+        for m in _fuzzy_predicate_re(func).finditer(compiled):
+            sig = _fuzzy_from_match(m, scorer, model, scale=1.0, distance=True)
+            if sig is not None and (key := (sig.columns[0], scorer)) not in fuzzy_seen:
+                fuzzy_seen.add(key)
+                signals.append(sig)
+    for m in _SOUNDEX_EQ_RE.finditer(compiled):
+        col_a, col_b = _col_field(m.group("a")), _col_field(m.group("b"))
+        if col_a and col_a == col_b and (col_a, "soundex_match") not in fuzzy_seen:
+            fuzzy_seen.add((col_a, "soundex_match"))
+            signals.append(RecognizedSignal(
+                "fuzzy_field", [col_a],
+                {"scorer": "soundex_match", "partial_threshold": None},
+                model, 0.8, m.group(0)[:200],
+            ))
+
+    # 5. Self-join ON equalities -> blocking keys, but only when a fuzzy predicate
+    #    is present (an ON-equality in a plain transform join is not a blocking
+    #    key). Avoids treating every dimensional join as ER.
+    if any(s.kind == "fuzzy_field" for s in signals) and not saw_window_key:
+        on_cols: list[str] = []
+        for m in _ON_EQUALITY_RE.finditer(compiled):
+            la, lc, ra, rc = m.groups()
+            if la != ra and lc == rc:  # a.col = b.col (distinct aliases, same col)
+                on_cols.append(lc)
+        on_cols = list(dict.fromkeys(on_cols))
+        if on_cols:
+            signals.append(RecognizedSignal(
+                "blocking", on_cols, {"field_transforms": {}}, model, 0.7,
+                "join ... on " + " and ".join(f"{c} = {c}" for c in on_cols),
+            ))
+
+    # 6. GROUP BY natural key -- weak signal, ER-model-gated.
+    if is_er and not saw_window_key:
+        for m in _GROUP_BY_RE.finditer(compiled):
+            cols = _split_top_level(m.group("cols"))
+            # Positional group-by (`group by 1, 2`) carries no column names.
+            if any(re.fullmatch(r"\d+", c) for c in cols):
+                signals.append(RecognizedSignal(
+                    "couldnt_extract", [],
+                    {"reason": "positional GROUP BY (group by 1, 2, ...) -- "
+                               "column names not recoverable from the manifest"},
+                    model, 0.3, m.group(0)[:200],
+                ))
+                continue
+            blocking, extras = _blocking_signal_from_cols(cols, model, 0.5, m.group(0))
+            if blocking is not None:
+                signals.append(blocking)
+                signals.append(RecognizedSignal(
+                    "exact_matchkey", blocking.columns, {}, model, 0.5, m.group(0)[:200],
+                ))
+            signals.extend(extras)
+            break  # one dedup GROUP BY per model is enough
+
+    return signals
+
+
+def _fuzzy_from_match(
+    m: re.Match, scorer: str, model: str, *, scale: float, distance: bool,
+) -> RecognizedSignal | None:
+    """Build a fuzzy_field signal from a fuzzy-predicate regex match."""
+    col_a, col_b = _col_field(m.group("a")), _col_field(m.group("b"))
+    if not col_a or col_a != col_b:
+        return None  # cross-column comparison -- not a single-field scorer
+    literal = float(m.group("lit"))
+    op = m.group("op")
+    if distance:
+        # `<= k` distance -> similarity via the assumed-length approximation.
+        if op not in ("<=", "<"):
+            return None
+        threshold = max(0.0, 1.0 - literal / _LEV_ASSUMED_LEN)
+    else:
+        # `>= t` similarity -> threshold directly (scaled: Snowflake 0-100).
+        if op not in (">=", ">"):
+            return None
+        threshold = literal / scale
+    if not (0.0 < threshold <= 1.0):
+        return None
+    return RecognizedSignal(
+        "fuzzy_field", [col_a],
+        {"scorer": scorer, "partial_threshold": threshold,
+         "approx": distance or scale != 1.0},
+        model, 0.85, m.group(0)[:200],
+    )
+
+
+# ── ER-model identification ──────────────────────────────────────────────────
+
+
+@dataclass
+class ErModel:
+    """An identified entity-resolution model, with the signals that fired."""
+
+    unique_id: str
+    name: str
+    confidence: float
+    reasons: list[str]
+
+
+def _name_signal(name: str) -> str | None:
+    low = name.lower()
+    for sub in _ER_NAME_SUBSTRINGS:
+        if sub in low:
+            return sub
+    return None
+
+
+def _shape_signal(node: dict) -> list[str]:
+    """Compiled/raw-SQL shape hints that a model does entity resolution."""
+    compiled = (node.get("compiled_code") or node.get("compiled_sql") or "").lower()
+    raw = (node.get("raw_code") or node.get("raw_sql") or "").lower()
+    reasons: list[str] = []
+    if _QUALIFY_ROWNUM_RE.search(compiled):
+        reasons.append("window-dedup (QUALIFY ROW_NUMBER)")
+    if "dbt_utils.deduplicate" in raw:
+        reasons.append("dbt_utils.deduplicate")
+    if _SURROGATE_KEY_RE.search(raw):
+        reasons.append("generate_surrogate_key")
+    for func in (*_FUZZY_SIM_FUNCS, *_FUZZY_DIST_FUNCS):
+        if _fuzzy_predicate_re(func).search(compiled):
+            reasons.append(f"fuzzy predicate ({func})")
+            break
+    if _SOUNDEX_EQ_RE.search(compiled):
+        reasons.append("phonetic equality (soundex)")
+    return reasons
+
+
+def _unique_test_columns(manifest: dict) -> dict[str, list[str]]:
+    """Map model unique_id -> columns carrying a dbt ``unique`` test.
+
+    A ``unique`` test on a non-surrogate column is a strong "this is the
+    identity key" hint. dbt test nodes carry ``test_metadata.name == 'unique'``
+    plus ``attached_node`` (the model) and ``column_name``.
+    """
+    out: dict[str, list[str]] = {}
+    for node in manifest.get("nodes", {}).values():
+        if node.get("resource_type") != "test":
+            continue
+        meta = node.get("test_metadata") or {}
+        if (meta.get("name") or "").lower() != "unique":
+            continue
+        attached = node.get("attached_node")
+        col = node.get("column_name") or (meta.get("kwargs") or {}).get("column_name")
+        if attached and col:
+            out.setdefault(attached, []).append(col)
+    return out
+
+
+def identify_er_models(manifest: dict) -> list[ErModel]:
+    """Rank the manifest's models by how strongly they look like ER models."""
+    unique_tests = _unique_test_columns(manifest)
+    models: list[ErModel] = []
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "model":
+            continue
+        name = node.get("name", uid)
+        reasons: list[str] = []
+        confidence = 0.0
+        if (sub := _name_signal(name)) is not None:
+            reasons.append(f"name contains '{sub}'")
+            confidence = max(confidence, 0.5)
+        shape = _shape_signal(node)
+        if shape:
+            reasons.extend(shape)
+            confidence = max(confidence, 0.8)
+        if uid in unique_tests:
+            reasons.append(f"unique test on {unique_tests[uid]}")
+            confidence = max(confidence, 0.6)
+        if reasons:
+            models.append(ErModel(uid, name, confidence, reasons))
+    models.sort(key=lambda mdl: (-mdl.confidence, mdl.name))
+    return models
+
+
+# ── Coverage scorecard ───────────────────────────────────────────────────────
+
+
+@dataclass
+class DbtConversionCoverage:
+    """A scannable scorecard for a dbt->GoldenMatch conversion.
+
+    Analogous to ``from_splink``'s ``CoverageSummary``: how many models were
+    analyzed, what the emitted config contains, how many constructs were flagged
+    for review, and which value STORY applies (fuzzy-ER consolidation vs
+    exact-dedup consolidation) -- so the report never over-claims an F1 win on a
+    pure exact-dedup project.
+    """
+
+    total_models: int
+    er_models_analyzed: int
+    blocking_keys: int
+    exact_matchkeys: int
+    fuzzy_fields: int
+    transforms: int
+    survivorship_rules: int
+    couldnt_extract: int
+
+    @property
+    def story(self) -> Literal["fuzzy-er", "exact-dedup", "none"]:
+        if self.fuzzy_fields > 0:
+            return "fuzzy-er"
+        if self.exact_matchkeys > 0 or self.blocking_keys > 0:
+            return "exact-dedup"
+        return "none"
+
+    @property
+    def has_config(self) -> bool:
+        """True when at least one blocking key or matchkey was extracted."""
+        return self.blocking_keys > 0 or self.exact_matchkeys > 0 or self.fuzzy_fields > 0
+
+    def line(self) -> str:
+        """One-line human summary."""
+        story_text = {
+            "fuzzy-er": "fuzzy-ER consolidation (accuracy + consolidation)",
+            "exact-dedup": "exact-dedup consolidation (maintainability, not an F1 story)",
+            "none": "no entity-resolution logic recognized",
+        }[self.story]
+        parts = [
+            f"{self.er_models_analyzed}/{self.total_models} models analyzed as ER",
+            f"{self.blocking_keys} blocking key(s)",
+            f"{self.exact_matchkeys} exact + {self.fuzzy_fields} fuzzy comparison field(s)",
+            f"{self.survivorship_rules} survivorship rule(s)",
+        ]
+        if self.couldnt_extract:
+            parts.append(f"{self.couldnt_extract} construct(s) flagged for review")
+        return " -- ".join(parts) + f" -- story: {story_text}"
+
+
+@dataclass
+class DbtConversion:
+    """Result of :func:`from_dbt`.
+
+    ``config`` is ``None`` when no ER logic could be extracted (a non-ER
+    project) -- the report + coverage still describe what was seen, so a caller
+    can distinguish "empty project" from a crash. ``signals`` is the full list
+    of recognized (and couldnt_extract) signals for auditing; ``er_models`` is
+    the ranked identification result.
+    """
+
+    config: GoldenMatchConfig | None
+    report: ConversionReport
+    coverage: DbtConversionCoverage
+    er_models: list[ErModel] = dc_field(default_factory=list)
+    signals: list[RecognizedSignal] = dc_field(default_factory=list)
+
+
+def _load_manifest(source: dict | str | Path) -> dict:
+    if isinstance(source, dict):
+        return source
+    path = safe_path(source)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DbtConversionError(f"could not read dbt manifest {path}: {exc}") from exc
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise DbtConversionError(f"malformed JSON in dbt manifest {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DbtConversionError(
+            f"dbt manifest {path} must contain a JSON object at the top level, "
+            f"got {type(data).__name__}"
+        )
+    return data
+
+
+def _manifest_dialect(manifest: dict, report: ConversionReport) -> str:
+    adapter = str((manifest.get("metadata") or {}).get("adapter_type") or "").lower()
+    if not adapter:
+        report.info("metadata", "manifest declares no adapter_type; using the "
+                    "dialect-agnostic recognizer core", mapped_to=None)
+        return "unknown"
+    if adapter not in _MVP_DIALECTS:
+        report.warn(
+            "metadata",
+            f"adapter '{adapter}' is outside the MVP dialect trio "
+            f"{sorted(_MVP_DIALECTS)}; recognition falls through to the "
+            "dialect-agnostic core (window-dedup + GROUP BY + ANSI string funcs) "
+            "and warehouse-specific idioms may be missed",
+            mapped_to=None,
+        )
+    return adapter
+
+
+def from_dbt(
+    source: dict | str | Path,
+    *,
+    strict: bool = False,
+    min_confidence: float = 0.5,
+) -> DbtConversion:
+    """Distill a dbt project's hand-rolled ER logic into a GoldenMatch config.
+
+    Args:
+        source: a dbt ``manifest.json`` path (``str``/``Path``) or an
+            already-parsed manifest dict (produced by ``dbt compile`` /
+            ``dbt parse`` / ``dbt docs generate``).
+        strict: when True, ANY warning or error finding raises
+            :class:`DbtConversionError`. When False (default), only a malformed
+            manifest raises -- a partial extraction is the expected outcome.
+        min_confidence: models identified below this ER-confidence are reported
+            (in ``er_models``) but NOT analyzed for signal extraction.
+
+    Returns:
+        A :class:`DbtConversion` with a validated ``GoldenMatchConfig`` (or
+        ``None`` when nothing ER-shaped was found), the ``ConversionReport``,
+        a ``DbtConversionCoverage`` scorecard, the ranked ER-model list, and
+        every recognized signal.
+    """
+    manifest = _load_manifest(source)
+    report = ConversionReport()
+    dialect = _manifest_dialect(manifest, report)
+
+    total_models = sum(
+        1 for n in manifest.get("nodes", {}).values()
+        if n.get("resource_type") == "model"
+    )
+    er_models = identify_er_models(manifest)
+    analyzed = [m for m in er_models if m.confidence >= min_confidence]
+    for m in er_models:
+        if m.confidence >= min_confidence:
+            report.info(
+                f"model:{m.name}",
+                f"identified as ER (confidence {m.confidence:.2f}): "
+                + "; ".join(m.reasons),
+                mapped_to=None,
+            )
+        else:
+            report.info(
+                f"model:{m.name}",
+                f"low-confidence ER candidate ({m.confidence:.2f}), NOT analyzed: "
+                + "; ".join(m.reasons),
+                mapped_to=None,
+            )
+
+    nodes = manifest.get("nodes", {})
+    all_signals: list[RecognizedSignal] = []
+    for m in analyzed:
+        node = nodes.get(m.unique_id, {})
+        all_signals.extend(extract_signals(node, dialect, is_er=True))
+
+    config = _emit_config(all_signals, report)
+
+    coverage = _build_coverage(total_models, len(analyzed), all_signals, config)
+
+    for sig in all_signals:
+        if sig.kind == "couldnt_extract":
+            report.warn(
+                f"model:{sig.source_model}",
+                f"couldn't extract: {sig.params.get('reason', 'unrecognized construct')}"
+                + (f" ({sig.sql_excerpt})" if sig.sql_excerpt else ""),
+                mapped_to=None,
+            )
+
+    if config is None:
+        report.warn(
+            "manifest",
+            "no entity-resolution logic could be extracted into a config; the "
+            "project may not do ER, or its idioms are outside the recognized set "
+            "(see couldn't-extract findings)",
+            mapped_to=None,
+        )
+
+    if strict and (report.has_warnings or report.has_errors):
+        raise DbtConversionError(
+            f"from_dbt(strict=True): lossy conversion -- {report.summary()}"
+        )
+
+    return DbtConversion(
+        config=config,
+        report=report,
+        coverage=coverage,
+        er_models=er_models,
+        signals=all_signals,
+    )
+
+
+def _emit_config(
+    signals: list[RecognizedSignal], report: ConversionReport,
+) -> GoldenMatchConfig | None:
+    """Aggregate recognized signals across ER models into ONE config."""
+    # Blocking keys: de-duplicate by (fields tuple), union field_transforms.
+    blocking_keys: list[BlockingKeyConfig] = []
+    seen_block: set[tuple[str, ...]] = set()
+    for sig in signals:
+        if sig.kind != "blocking" or not sig.columns:
+            continue
+        key = tuple(sig.columns)
+        if key in seen_block:
+            continue
+        seen_block.add(key)
+        ft = {k: v for k, v in (sig.params.get("field_transforms") or {}).items() if v}
+        blocking_keys.append(BlockingKeyConfig(
+            fields=list(sig.columns), transforms=[], field_transforms=ft,
+        ))
+
+    # Exact matchkey fields: union of all exact-matchkey column sets.
+    exact_fields: list[str] = []
+    for sig in signals:
+        if sig.kind != "exact_matchkey":
+            continue
+        for col in sig.columns:
+            if col not in exact_fields:
+                exact_fields.append(col)
+
+    # Fuzzy fields: one per (column, scorer); on a threshold conflict keep the
+    # LOOSER (lower) threshold and warn -- the numeric_diff-collapse precedent.
+    fuzzy: dict[tuple[str, str], float | None] = {}
+    for sig in signals:
+        if sig.kind != "fuzzy_field":
+            continue
+        col = sig.columns[0]
+        scorer = sig.params["scorer"]
+        thr = sig.params.get("partial_threshold")
+        k = (col, scorer)
+        if k in fuzzy:
+            prev = fuzzy[k]
+            if prev is not None and thr is not None and abs(prev - thr) > 1e-9:
+                looser = min(prev, thr)
+                report.warn(
+                    f"field:{col}",
+                    f"field '{col}' fuzzy-matched by '{scorer}' at two thresholds "
+                    f"({prev}, {thr}) across models; keeping the looser ({looser})",
+                    mapped_to=None,
+                )
+                fuzzy[k] = looser
+        else:
+            fuzzy[k] = thr
+
+    matchkeys: list[MatchkeyConfig] = []
+    if exact_fields:
+        matchkeys.append(MatchkeyConfig(
+            name="dbt_exact",
+            type="exact",
+            fields=[MatchkeyField(field=f) for f in exact_fields],
+        ))
+    for (col, scorer), thr in fuzzy.items():
+        # A single-field weighted matchkey: the field score (weight 1.0) is
+        # compared directly to the matchkey threshold, reproducing the SQL
+        # predicate `scorer(col) >= thr`. soundex_match is binary (no threshold);
+        # default it to 1.0 (phonetic-equal).
+        threshold = thr if thr is not None else 1.0
+        matchkeys.append(MatchkeyConfig(
+            name=f"dbt_fuzzy_{col}",
+            type="weighted",
+            threshold=threshold,
+            fields=[MatchkeyField(
+                field=col, scorer=scorer, weight=1.0, partial_threshold=threshold,
+            )],
+        ))
+
+    if not matchkeys and not blocking_keys:
+        return None
+
+    blocking: BlockingConfig | None = None
+    if blocking_keys:
+        if len(blocking_keys) == 1:
+            blocking = BlockingConfig(strategy="static", keys=blocking_keys)
+        else:
+            blocking = BlockingConfig(
+                strategy="multi_pass", keys=blocking_keys, passes=blocking_keys,
+            )
+    elif any(mk.type == "weighted" for mk in matchkeys):
+        # A weighted matchkey needs blocking; none was discovered -> block on the
+        # exact fields if any, else warn (the pipeline auto-blocks at runtime).
+        if exact_fields:
+            blocking = BlockingConfig(
+                strategy="static",
+                keys=[BlockingKeyConfig(fields=exact_fields, transforms=[])],
+            )
+        else:
+            report.warn(
+                "blocking",
+                "a fuzzy comparison was extracted but no blocking key was found; "
+                "the emitted config relies on GoldenMatch's auto-blocking",
+                mapped_to=None,
+            )
+
+    # Survivorship. A window-dedup's `ORDER BY <date> DESC` is a most-recent
+    # rule, but GoldenMatch applies `most_recent` PER FIELD (each needs its
+    # date_column) -- there is no runnable global-default form (the golden-record
+    # builder constructs the default rule from `default_strategy` alone, dropping
+    # the date_column). We don't read the column list at convert time, so we
+    # REPORT the recognized rule + the exact remediation instead of emitting an
+    # un-runnable `golden_rules.default`. It still counts toward the coverage
+    # scorecard (a distilled decision), just isn't auto-wired into the config.
+    surv = next((s for s in signals if s.kind == "survivorship"), None)
+    if surv is not None and surv.params.get("strategy") == "most_recent":
+        date_col = surv.params["date_column"]
+        report.info(
+            f"model:{surv.source_model}",
+            f"recognized most-recent survivorship (keep the latest row by "
+            f"'{date_col}'). GoldenMatch applies most_recent per field, so add a "
+            f"golden_rules.field_rules entry for each surviving column: "
+            f"{{strategy: most_recent, date_column: {date_col}}} "
+            "(not auto-wired -- the converter doesn't read the column list).",
+            mapped_to="golden_rules.field_rules",
+        )
+
+    return GoldenMatchConfig(
+        matchkeys=matchkeys or None,
+        blocking=blocking,
+    )
+
+
+def _build_coverage(
+    total_models: int,
+    er_analyzed: int,
+    signals: list[RecognizedSignal],
+    config: GoldenMatchConfig | None,
+) -> DbtConversionCoverage:
+    blocking_keys = 0
+    exact = 0
+    fuzzy = 0
+    if config is not None:
+        blocking_keys = len(config.blocking.keys) if config.blocking else 0
+        for mk in config.matchkeys or []:
+            if mk.type == "exact":
+                exact += len(mk.fields)
+            elif mk.type == "weighted":
+                fuzzy += len(mk.fields)
+    transforms = sum(1 for s in signals if s.kind == "transform")
+    survivorship = sum(1 for s in signals if s.kind == "survivorship")
+    couldnt = sum(1 for s in signals if s.kind == "couldnt_extract")
+    return DbtConversionCoverage(
+        total_models=total_models,
+        er_models_analyzed=er_analyzed,
+        blocking_keys=blocking_keys,
+        exact_matchkeys=exact,
+        fuzzy_fields=fuzzy,
+        transforms=transforms,
+        survivorship_rules=survivorship,
+        couldnt_extract=couldnt,
+    )

--- a/packages/python/goldenmatch/tests/test_cli_import_dbt.py
+++ b/packages/python/goldenmatch/tests/test_cli_import_dbt.py
@@ -1,0 +1,95 @@
+"""Tests for the ``goldenmatch import-dbt`` CLI command."""
+from __future__ import annotations
+
+import json
+
+import polars as pl
+import yaml
+from goldenmatch.cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _write_manifest(tmp_path, nodes, adapter="duckdb"):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"metadata": {"adapter_type": adapter}, "nodes": nodes}))
+    return path
+
+
+_DIM = {
+    "model.s.dim_customers": {
+        "resource_type": "model", "name": "dim_customers",
+        "compiled_code": "select * from s qualify row_number() over "
+        "(partition by lower(trim(email)) order by updated_at desc) = 1",
+        "raw_code": "",
+    }
+}
+
+
+def test_import_dbt_writes_config(tmp_path):
+    manifest = _write_manifest(tmp_path, _DIM, adapter="snowflake")
+    out = tmp_path / "gm.yaml"
+    result = runner.invoke(app, ["import-dbt", str(manifest), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "Distilled" in result.output
+    assert out.exists()
+    cfg = yaml.safe_load(out.read_text())
+    assert cfg["matchkeys"][0]["type"] == "exact"
+    assert cfg["matchkeys"][0]["fields"][0]["field"] == "email"
+    assert cfg["blocking"]["keys"][0]["field_transforms"] == {"email": ["strip", "lowercase"]}
+
+
+def test_import_dbt_non_er_project_writes_no_config(tmp_path):
+    nodes = {
+        "model.j.orders": {"resource_type": "model", "name": "orders",
+                           "compiled_code": "select order_id from raw", "raw_code": ""},
+    }
+    manifest = _write_manifest(tmp_path, nodes)
+    out = tmp_path / "gm.yaml"
+    result = runner.invoke(app, ["import-dbt", str(manifest), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "No config written" in result.output
+    assert not out.exists()
+
+
+def test_import_dbt_verify_needs_source(tmp_path):
+    manifest = _write_manifest(tmp_path, _DIM)
+    out_table = tmp_path / "out.parquet"
+    pl.DataFrame({"id": [1], "cluster_id": ["c1"]}).write_parquet(out_table)
+    result = runner.invoke(
+        app, ["import-dbt", str(manifest), "-o", str(tmp_path / "g.yaml"),
+              "--verify", str(out_table)]
+    )
+    assert result.exit_code == 1
+    assert "needs --source" in result.output
+
+
+def test_import_dbt_verify_reports_agreement(tmp_path):
+    manifest = _write_manifest(tmp_path, _DIM)
+    src = tmp_path / "src.csv"
+    pl.DataFrame({
+        "id": [1, 2, 3, 4],
+        "email": ["a@x.com", "a@x.com", "b@y.com", "c@z.com"],
+        "updated_at": ["2020", "2021", "2020", "2020"],
+    }).write_csv(src)
+    out_table = tmp_path / "out.csv"
+    pl.DataFrame({"id": [1, 2, 3, 4], "cluster_id": ["c1", "c1", "c2", "c3"]}).write_csv(out_table)
+    result = runner.invoke(
+        app,
+        ["import-dbt", str(manifest), "-o", str(tmp_path / "g.yaml"),
+         "--verify", str(out_table), "--source", str(src), "--id-column", "id"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "agreement" in result.output.lower()
+
+
+def test_import_dbt_strict_fails_on_lossy(tmp_path):
+    nodes = {
+        "model.p.dim_x": {"resource_type": "model", "name": "dim_x",
+                          "compiled_code": "select 1 from s group by 1", "raw_code": ""},
+    }
+    manifest = _write_manifest(tmp_path, nodes, adapter="redshift")
+    result = runner.invoke(app, ["import-dbt", str(manifest), "--strict"])
+    assert result.exit_code == 1
+    assert "conversion failed" in result.output.lower()

--- a/packages/python/goldenmatch/tests/test_dbt_verify.py
+++ b/packages/python/goldenmatch/tests/test_dbt_verify.py
@@ -1,0 +1,102 @@
+"""Tests for the dbt conversion auto-verify (``verify_against_dbt``).
+
+A small synthetic source + a synthetic "old output" table where the converted
+config SHOULD reproduce the clusters -> assert ``is_faithful``; a deliberately
+diverging output -> assert the agreement drops and is reported; missing/empty/
+no-overlap output -> assert the graceful degrade (None, warning finding).
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.dbt_verify import verify_against_dbt
+from goldenmatch.config.from_dbt import from_dbt
+from goldenmatch.config.from_splink import ConversionReport
+
+
+def _email_dedupe_config():
+    m = {
+        "metadata": {"adapter_type": "duckdb"},
+        "nodes": {
+            "model.s.dim_customers": {
+                "resource_type": "model", "name": "dim_customers",
+                "compiled_code": "select * from s qualify row_number() over "
+                "(partition by email order by updated_at desc) = 1",
+                "raw_code": "",
+            }
+        },
+    }
+    return from_dbt(m).config
+
+
+def _source():
+    return pl.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6],
+        "email": ["a@x.com", "a@x.com", "b@y.com", "b@y.com", "c@z.com", "d@w.com"],
+        "name": ["Al", "Al", "Bo", "Bo", "Cy", "Di"],
+        "updated_at": ["2020", "2021", "2020", "2021", "2020", "2020"],
+    })
+
+
+def test_verify_faithful_when_output_matches():
+    config = _email_dedupe_config()
+    out = pl.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                        "cluster_id": ["c1", "c1", "c2", "c2", "c3", "c4"]})
+    rep = ConversionReport()
+    v = verify_against_dbt(config, _source(), out, id_column="id", report=rep)
+    assert v is not None
+    assert v.is_faithful
+    assert v.agreement["f1"] == 1.0
+    assert v.n_shared_ids == 6
+    assert any("faithful" in f.message for f in rep.findings)
+
+
+def test_verify_reports_divergence_when_output_overmerges():
+    config = _email_dedupe_config()
+    out = pl.DataFrame({"id": [1, 2, 3, 4, 5, 6], "cluster_id": ["c1"] * 6})
+    rep = ConversionReport()
+    v = verify_against_dbt(config, _source(), out, id_column="id", report=rep)
+    assert v is not None
+    assert not v.is_faithful
+    assert v.agreement["f1"] < 0.95
+    assert any(f.severity == "warning" and "DIVERGENT" in f.message for f in rep.findings)
+
+
+def test_verify_degrades_on_empty_output():
+    config = _email_dedupe_config()
+    out = pl.DataFrame({"id": [], "cluster_id": []}, schema={"id": pl.Int64, "cluster_id": pl.Utf8})
+    rep = ConversionReport()
+    v = verify_against_dbt(config, _source(), out, id_column="id", report=rep)
+    assert v is None
+    assert any("empty" in f.message for f in rep.findings)
+
+
+def test_verify_degrades_on_no_id_overlap():
+    config = _email_dedupe_config()
+    out = pl.DataFrame({"id": [100, 200], "cluster_id": ["c1", "c1"]})
+    rep = ConversionReport()
+    v = verify_against_dbt(config, _source(), out, id_column="id", report=rep)
+    assert v is None
+    assert any("shares no ids" in f.message for f in rep.findings)
+
+
+def test_verify_degrades_on_empty_source():
+    config = _email_dedupe_config()
+    src = pl.DataFrame({"id": [], "email": []}, schema={"id": pl.Int64, "email": pl.Utf8})
+    out = pl.DataFrame({"id": [1], "cluster_id": ["c1"]})
+    rep = ConversionReport()
+    v = verify_against_dbt(config, src, out, id_column="id", report=rep)
+    assert v is None
+    assert any("source is empty" in f.message for f in rep.findings)
+
+
+def test_verify_named_output_columns():
+    config = _email_dedupe_config()
+    out = pl.DataFrame({
+        "row_pk": [1, 2, 3, 4, 5, 6],
+        "surrogate_id": ["c1", "c1", "c2", "c2", "c3", "c4"],
+    })
+    v = verify_against_dbt(
+        config, _source(), out, id_column="id",
+        output_id_column="row_pk", output_cluster_column="surrogate_id",
+    )
+    assert v is not None and v.is_faithful

--- a/packages/python/goldenmatch/tests/test_from_dbt.py
+++ b/packages/python/goldenmatch/tests/test_from_dbt.py
@@ -1,0 +1,378 @@
+"""Tests for the hand-rolled dbt -> GoldenMatch converter (``from_dbt``).
+
+Fixture manifests (no live warehouse) exercise each recognized idiom per
+dialect, the ER-model identification heuristics, the coverage scorecard, and
+the honest ``couldn't extract`` path -- the analogue of the Splink converter's
+captured-SQL fixtures.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from goldenmatch.config.from_dbt import (
+    DbtConversionError,
+    RecognizedSignal,
+    _unwrap_column,
+    extract_signals,
+    from_dbt,
+    identify_er_models,
+)
+
+
+def _model(name, compiled="", raw="", uid=None, resource_type="model"):
+    return {
+        "resource_type": resource_type,
+        "name": name,
+        "unique_id": uid or f"model.p.{name}",
+        "compiled_code": compiled,
+        "raw_code": raw,
+    }
+
+
+def _manifest(nodes, adapter="duckdb"):
+    return {"metadata": {"adapter_type": adapter}, "nodes": nodes}
+
+
+# ── _unwrap_column ───────────────────────────────────────────────────────────
+
+
+def test_unwrap_plain_column():
+    base, transforms, unrec = _unwrap_column("a.email")
+    assert base == "email"
+    assert transforms == []
+    assert unrec == []
+
+
+def test_unwrap_nested_normalizers_apply_order():
+    # lower(trim(email)) -> strip then lowercase (inner SQL func applied first)
+    base, transforms, unrec = _unwrap_column("lower(trim(a.email))")
+    assert base == "email"
+    assert transforms == ["strip", "lowercase"]
+
+
+def test_unwrap_unrecognized_wrap_keeps_base_flags_func():
+    base, transforms, unrec = _unwrap_column("initcap(name)")
+    assert base == "name"
+    assert transforms == []
+    assert "initcap" in unrec
+
+
+def test_unwrap_non_column_expression_returns_none():
+    base, _t, _u = _unwrap_column("case when x then y else z end")
+    assert base is None
+
+
+# ── ER-model identification ──────────────────────────────────────────────────
+
+
+def test_identify_by_name_substring():
+    m = _manifest({"model.p.customer_master": _model("customer_master")})
+    models = identify_er_models(m)
+    assert [x.name for x in models] == ["customer_master"]
+    assert any("name contains" in r for r in models[0].reasons)
+
+
+def test_identify_by_shape_signal_beats_name_only_confidence():
+    m = _manifest({
+        "model.p.thing": _model(
+            "thing",
+            compiled="select * from s qualify row_number() over "
+            "(partition by email order by x desc) = 1",
+        ),
+    })
+    models = identify_er_models(m)
+    assert models[0].confidence >= 0.8
+
+
+def test_identify_unique_test_hint():
+    m = _manifest({
+        "model.p.people": _model("people", compiled="select 1"),
+        "test.p.u": _model("u", resource_type="test"),
+    })
+    m["nodes"]["test.p.u"].update(
+        {"test_metadata": {"name": "unique"}, "attached_node": "model.p.people",
+         "column_name": "ssn"}
+    )
+    models = identify_er_models(m)
+    assert models and models[0].name == "people"
+    assert any("unique test" in r for r in models[0].reasons)
+
+
+def test_non_er_models_not_identified():
+    m = _manifest({
+        "model.p.orders": _model("orders", compiled="select order_id from raw"),
+        "model.p.line_items": _model("line_items", compiled="select 1"),
+    })
+    assert identify_er_models(m) == []
+
+
+# ── Idiom extraction ─────────────────────────────────────────────────────────
+
+
+def test_qualify_rownum_blocking_exact_transform_survivorship():
+    node = _model(
+        "dim_customers",
+        compiled="select * from s qualify row_number() over "
+        "(partition by lower(trim(email)) order by updated_at desc) = 1",
+    )
+    signals = extract_signals(node, "snowflake", is_er=True)
+    kinds = {s.kind for s in signals}
+    assert {"blocking", "exact_matchkey", "transform", "survivorship"} <= kinds
+    block = next(s for s in signals if s.kind == "blocking")
+    assert block.columns == ["email"]
+    assert block.params["field_transforms"] == {"email": ["strip", "lowercase"]}
+    surv = next(s for s in signals if s.kind == "survivorship")
+    assert surv.params == {"strategy": "most_recent", "date_column": "updated_at"}
+
+
+def test_qualify_rownum_asc_order_is_couldnt_extract():
+    node = _model(
+        "dedup_x",
+        compiled="select * from s qualify row_number() over "
+        "(partition by k order by seq) = 1",
+    )
+    signals = extract_signals(node, "duckdb", is_er=True)
+    assert not any(s.kind == "survivorship" for s in signals)
+    assert any(s.kind == "couldnt_extract" for s in signals)
+
+
+def test_deduplicate_macro_partition_and_order():
+    node = _model(
+        "master_products",
+        raw='{{ dbt_utils.deduplicate(relation=ref("stg"), '
+            'partition_by="sku, upc", order_by="loaded_at desc") }}',
+    )
+    signals = extract_signals(node, "duckdb", is_er=True)
+    block = next(s for s in signals if s.kind == "blocking")
+    assert block.columns == ["sku", "upc"]
+    surv = next(s for s in signals if s.kind == "survivorship")
+    assert surv.params["date_column"] == "loaded_at"
+
+
+def test_generate_surrogate_key_args():
+    node = _model(
+        "identity_key",
+        raw="select {{ dbt_utils.generate_surrogate_key(['first_name', 'last_name']) }} as id",
+    )
+    signals = extract_signals(node, "bigquery", is_er=True)
+    block = next(s for s in signals if s.kind == "blocking")
+    assert block.columns == ["first_name", "last_name"]
+
+
+def test_fuzzy_jaro_winkler_threshold_direct():
+    node = _model(
+        "matches",
+        compiled="select a.id from t a join t b on a.zip=b.zip where "
+        "jaro_winkler_similarity(a.name, b.name) >= 0.9",
+    )
+    signals = extract_signals(node, "duckdb", is_er=True)
+    fuzzy = next(s for s in signals if s.kind == "fuzzy_field")
+    assert fuzzy.columns == ["name"]
+    assert fuzzy.params["scorer"] == "jaro_winkler"
+    assert fuzzy.params["partial_threshold"] == 0.9
+    # self-join ON equality becomes a blocking key
+    assert any(s.kind == "blocking" and s.columns == ["zip"] for s in signals)
+
+
+def test_fuzzy_snowflake_jarowinkler_0_100_scaled():
+    node = _model(
+        "matches",
+        compiled="select 1 from t a join t b on a.z=b.z where "
+        "jarowinkler_similarity(a.name, b.name) >= 90",
+    )
+    signals = extract_signals(node, "snowflake", is_er=True)
+    fuzzy = next(s for s in signals if s.kind == "fuzzy_field")
+    assert fuzzy.params["scorer"] == "jaro_winkler"
+    assert fuzzy.params["partial_threshold"] == pytest.approx(0.9)
+
+
+def test_fuzzy_edit_distance_to_similarity():
+    node = _model(
+        "matches",
+        compiled="select 1 from t a join t b on a.z=b.z where "
+        "levenshtein(a.city, b.city) <= 2",
+    )
+    signals = extract_signals(node, "duckdb", is_er=True)
+    fuzzy = next(s for s in signals if s.kind == "fuzzy_field" and s.columns == ["city"])
+    assert fuzzy.params["scorer"] == "levenshtein"
+    # 1 - 2/10 = 0.8 (assumed-length approximation, from_splink's constant)
+    assert fuzzy.params["partial_threshold"] == pytest.approx(0.8)
+
+
+def test_soundex_equality_phonetic():
+    node = _model(
+        "matches",
+        compiled="select 1 from t a join t b on a.z=b.z where "
+        "soundex(a.surname) = soundex(b.surname)",
+    )
+    signals = extract_signals(node, "duckdb", is_er=True)
+    fuzzy = next(s for s in signals if s.kind == "fuzzy_field")
+    assert fuzzy.columns == ["surname"]
+    assert fuzzy.params["scorer"] == "soundex_match"
+
+
+def test_cross_column_fuzzy_not_extracted():
+    node = _model(
+        "matches",
+        compiled="select 1 from t a join t b on a.z=b.z where "
+        "jaro_winkler_similarity(a.first, b.last) >= 0.9",
+    )
+    signals = extract_signals(node, "duckdb", is_er=True)
+    assert not any(s.kind == "fuzzy_field" for s in signals)
+
+
+def test_group_by_only_fires_for_er_model():
+    node = _model("customer_dim", compiled="select customer_id, max(name) from s group by customer_id")
+    # is_er False -> GROUP BY not treated as ER
+    assert not any(s.kind == "blocking" for s in extract_signals(node, "duckdb", is_er=False))
+    # is_er True -> GROUP BY natural key becomes blocking + exact
+    er_signals = extract_signals(node, "duckdb", is_er=True)
+    assert any(s.kind == "blocking" and s.columns == ["customer_id"] for s in er_signals)
+
+
+def test_positional_group_by_is_couldnt_extract():
+    node = _model("dim_x", compiled="select 1 from s group by 1, 2")
+    signals = extract_signals(node, "duckdb", is_er=True)
+    assert any(s.kind == "couldnt_extract" for s in signals)
+    assert not any(s.kind == "blocking" for s in signals)
+
+
+# ── Full conversion ──────────────────────────────────────────────────────────
+
+
+def test_from_dbt_exact_dedup_story():
+    m = _manifest({
+        "model.s.dim_customers": _model(
+            "dim_customers",
+            compiled="select * from s qualify row_number() over "
+            "(partition by email order by updated_at desc) = 1",
+        ),
+    })
+    conv = from_dbt(m)
+    assert conv.config is not None
+    assert conv.coverage.story == "exact-dedup"
+    mk = conv.config.matchkeys[0]
+    assert mk.type == "exact"
+    assert [f.field for f in mk.fields] == ["email"]
+    assert conv.config.blocking.strategy == "static"
+
+
+def test_from_dbt_fuzzy_story_multi_pass_blocking():
+    m = _manifest({
+        "model.p.matches": _model(
+            "customer_matches",
+            compiled="select 1 from c a join c b on a.zip=b.zip where "
+            "jaro_winkler_similarity(a.name, b.name) >= 0.9",
+        ),
+        "model.p.master": _model(
+            "master_products",
+            raw='{{ dbt_utils.deduplicate(relation=ref("s"), partition_by="sku", order_by="t desc") }}',
+        ),
+    })
+    conv = from_dbt(m)
+    assert conv.coverage.story == "fuzzy-er"
+    types = {mk.type for mk in conv.config.matchkeys}
+    assert types == {"exact", "weighted"}
+    assert conv.config.blocking.strategy == "multi_pass"
+
+
+def test_from_dbt_threshold_conflict_keeps_looser():
+    m = _manifest({
+        "model.p.m1": _model(
+            "resolve_a",
+            compiled="select 1 from t a join t b on a.z=b.z where "
+            "jaro_winkler_similarity(a.name, b.name) >= 0.95",
+        ),
+        "model.p.m2": _model(
+            "resolve_b",
+            compiled="select 1 from t a join t b on a.z=b.z where "
+            "jaro_winkler_similarity(a.name, b.name) >= 0.85",
+        ),
+    })
+    conv = from_dbt(m)
+    fuzzy_mk = next(mk for mk in conv.config.matchkeys if mk.type == "weighted")
+    assert fuzzy_mk.threshold == pytest.approx(0.85)
+    assert conv.report.has_warnings
+
+
+def test_from_dbt_non_er_project_returns_none_config():
+    m = _manifest({
+        "model.j.orders": _model("orders", compiled="select order_id from raw"),
+        "model.j.customers": _model("customers", compiled="select * from raw"),
+    })
+    conv = from_dbt(m)
+    assert conv.config is None
+    assert conv.coverage.story == "none"
+    assert not conv.coverage.has_config
+    assert conv.report.has_warnings  # the "no ER logic" warning
+
+
+def test_from_dbt_unknown_dialect_warns():
+    m = _manifest({
+        "model.p.dim_x": _model(
+            "dim_x",
+            compiled="select * from s qualify row_number() over (partition by k) = 1",
+        ),
+    }, adapter="redshift")
+    conv = from_dbt(m)
+    assert any(
+        f.severity == "warning" and "redshift" in f.message for f in conv.report.findings
+    )
+
+
+def test_from_dbt_min_confidence_gates_analysis():
+    # A name-only match (confidence 0.5) is skipped when the floor is raised.
+    m = _manifest({"model.p.xref": _model("xref", compiled="select * from a join b on a.k=b.k")})
+    conv_low = from_dbt(m, min_confidence=0.5)
+    conv_high = from_dbt(m, min_confidence=0.7)
+    assert conv_low.coverage.er_models_analyzed == 1
+    assert conv_high.coverage.er_models_analyzed == 0
+
+
+def test_from_dbt_strict_raises_on_warning():
+    m = _manifest({
+        "model.p.dim_x": _model("dim_x", compiled="select 1 from s group by 1"),
+    }, adapter="redshift")
+    with pytest.raises(DbtConversionError):
+        from_dbt(m, strict=True)
+
+
+def test_from_dbt_malformed_manifest_raises():
+    with pytest.raises(DbtConversionError):
+        from_dbt("this is not a path and not a dict")  # type: ignore[arg-type]
+
+
+def test_from_dbt_reads_manifest_file(tmp_path):
+    m = _manifest({
+        "model.s.dim_customers": _model(
+            "dim_customers",
+            compiled="select * from s qualify row_number() over (partition by email) = 1",
+        ),
+    })
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(m))
+    conv = from_dbt(str(path))
+    assert conv.config is not None
+    assert conv.coverage.story == "exact-dedup"
+
+
+def test_couldnt_extract_surfaces_case_partition():
+    m = _manifest({
+        "model.p.dedup_x": _model(
+            "dedup_x",
+            compiled="select * from s qualify row_number() over "
+            "(partition by case when a then b else c end order by t desc) = 1",
+        ),
+    })
+    conv = from_dbt(m)
+    assert conv.coverage.couldnt_extract >= 1
+    assert any(
+        "couldn't extract" in f.message for f in conv.report.findings if f.severity == "warning"
+    )
+
+
+def test_signals_are_recognized_signal_instances():
+    node = _model("dim_x", compiled="select * from s qualify row_number() over (partition by k) = 1")
+    signals = extract_signals(node, "duckdb", is_er=True)
+    assert all(isinstance(s, RecognizedSignal) for s in signals)

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -3126,6 +3126,66 @@
           ]
         },
         {
+          "command": "import-dbt",
+          "options": [
+            {
+              "name": "manifest",
+              "type": "text",
+              "required": true,
+              "help": "dbt manifest.json (from `dbt compile` / `dbt parse`)"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "'goldenmatch.yaml'",
+              "help": "Output YAML config path"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Fail on any lossy finding (warnings), not just errors"
+            },
+            {
+              "name": "--min-confidence",
+              "type": "float",
+              "required": false,
+              "default": "0.5",
+              "help": "ER-model identification confidence floor for signal extraction"
+            },
+            {
+              "name": "--verify",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Prove the distillation reproduces your dbt pipeline: run the converted config on a sample of --source and report pairwise cluster agreement against this output table (parquet/csv; first two columns = id, cluster_id). Needs --source."
+            },
+            {
+              "name": "--source",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Source rows the dbt ER model consumed (parquet/csv), for --verify"
+            },
+            {
+              "name": "--verify-sample",
+              "type": "integer",
+              "required": false,
+              "default": "5000",
+              "help": "Rows of --source to run through GoldenMatch for --verify"
+            },
+            {
+              "name": "--id-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column holding each source row's id (default: auto-detect unique_id/id/record_id)"
+            }
+          ]
+        },
+        {
           "command": "import-splink",
           "options": [
             {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -174,6 +174,7 @@ cli_commands:
   - tui
   - unmerge
   python_only:
+  - import-dbt
   - ingest-docs
   - migrate-splink
   - serve-ui


### PR DESCRIPTION
## What and why

Distill a company's **hand-rolled dbt entity-resolution pipeline** (~10k lines across many models) into **one reusable GoldenMatch config**, and prove it reproduces the pipeline's existing clusters with a measured agreement number. This bundles the design spec with its Phase 1 (MVP) implementation.

The value is **distillation + proof**, not faithful SQL translation: a 10k-line hand-rolled ER pipeline almost always encodes a *small* set of real decisions buried in sprawl. The converter extracts that intent heuristically, and lossy extraction is acceptable because it is **verified** against the pipeline's existing output (label-free), reusing the Splink verify math. The key enabler is parsing the dbt `manifest.json` (structured DAG + compiled SQL + tests), not raw `.sql`.

Applies the same "distill + verify" pattern that shipped for Splink to a much larger audience — everyone deduping in dbt — and complements the GM-in-dbt package (`packages/dbt/goldensuite/`): that adds GM to a pipeline going forward; this replaces hand-rolled ER a team already has.

## Changes

- **`config/from_dbt.py`** — `from_dbt(manifest) -> DbtConversion` (config + `ConversionReport` + `DbtConversionCoverage` scorecard + ranked ER models + `RecognizedSignal`s). Identifies ER models via naming + shape + `unique` test signals, then extracts recognized idioms: `QUALIFY ROW_NUMBER` window-dedup, `dbt_utils.deduplicate`, `generate_surrogate_key`, ER-gated `GROUP BY` natural key, `jaro_winkler`/`levenshtein`/`soundex` fuzzy predicates + self-join `ON` blocking, and `LOWER`/`TRIM` normalization transforms. Everything else becomes an honest `couldnt_extract` finding. Dialects: DuckDB/Snowflake/BigQuery (others flagged). Reuses `from_splink`'s `ConversionReport` + edit-distance mapping; stays polars-free.
- **`config/dbt_verify.py`** — `verify_against_dbt()` reuses the Splink verify math (`pair_set`/`pairwise_prf`/`_run_once`) to report pairwise cluster agreement against the dbt pipeline's existing output table; degrades gracefully (returns `None` + a warning) on empty/non-overlapping output.
- **`cli/import_dbt.py`** — `goldenmatch import-dbt <manifest.json> [-o config.yaml] [--verify <output> --source <rows>]`.
- **Design spec** — `docs/superpowers/specs/2026-07-26-dbt-to-goldenmatch-converter-design.md`.
- **Docs page** — "Migrating from hand-rolled dbt" (`docs-site/goldenmatch/migrating-from-dbt.mdx`) + nav.
- **Parity/manifest lockstep** — `import-dbt` added to `parity/goldenmatch.yaml` (`cli_commands.python_only`); regenerated agent-codemap, config-matrix, agent-manifest, suite-matrix.

## Honest boundaries (stated in the report + docs)

- Accelerator + human-in-the-loop, not push-button; partial coverage; unrecognized constructs are **reported**, never silently dropped.
- Survivorship: the MVP recognizes most-recent (DESC window order-by) and reports it with the exact remediation (GoldenMatch applies `most_recent` per field, and the converter doesn't read the column list); `CASE` ladders / priority hierarchies are flagged.
- Exact-dedup sprawl → a consolidation/maintainability story, not an F1 story — `coverage.story` says which applies.

## Testing

- `uv run pytest packages/python/goldenmatch/tests/test_from_dbt.py tests/test_dbt_verify.py tests/test_cli_import_dbt.py` — 41 passed (fixture manifests, no live warehouse; verify round-trip faithful + divergent + degrade; CLI).
- `ruff check packages/python/goldenmatch` — clean. `pyright` on the new modules — clean.
- Parity structural tests + agent-codemap/config-matrix/suite-matrix drift checks — green.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean; pyright clean on new modules
- [ ] Package `CHANGELOG.md` updated (deferred — additive opt-in surface; will fold into the next release entry)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / parity manifests updated in lockstep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x