### PR TITLE
feat(identity): block-key compute + index population (C2 slice 2)

### DIFF
--- a/context-network/architecture/identity-control-plane-manifesto.md
+++ b/context-network/architecture/identity-control-plane-manifesto.md
@@ -117,8 +117,12 @@ incremental code below.
 > the persisted `identity_record_block_keys` index in the store (SQLite `_SCHEMA` +
 > Postgres `_pg_init_schema` + Alembic `0005` + schema v6) with the
 > `index_record_block_keys` / `candidates_by_block_keys` write/query API — additive,
-> nothing reads it yet. Next slices: block-key computation + population on write; the
-> bidirectional candidate query in `resolve_record_incremental`; the exact-matchkey fix.
+> nothing reads it yet. **Slice 2 (landed):** `identity/block_index.py` — the stateless
+> block-key compute (`compute_record_block_keys` / `compute_frame_block_keys`, reusing
+> the pipeline `_build_block_key_expr` + the multi_pass pass signature) + population
+> (`backfill_block_index`, keyed by the identity `derive_record_id`). Next slice: wire
+> the candidate QUERY into `resolve_record_incremental` (stop materializing the corpus)
+> + the exact-matchkey fix. Then C4: the bounded-RSS scale proof.
 
 ## 5. Transaction-native semantics to specify (Tier-5 scope)
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 409,
+      "module_count": 410,
       "modules": [
         {
           "module": "goldenmatch",
@@ -5677,6 +5677,26 @@
           ],
           "imports": [
             "goldenmatch.identity.model",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.block_index",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/block_index.py",
+          "purpose": "Block-key computation + population for the persisted blocking index (C2).",
+          "defines": [
+            "_pass_signature",
+            "_passes_of",
+            "backfill_block_index",
+            "compute_frame_block_keys",
+            "compute_record_block_keys"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.frame",
+            "goldenmatch.identity.resolve",
             "goldenmatch.identity.store"
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/identity/block_index.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/block_index.py
@@ -1,0 +1,139 @@
+"""Block-key computation + population for the persisted blocking index (C2).
+
+The control-plane-owned block-key index (manifesto §4(ii), decision 0047 §9.1)
+lets incremental resolution find candidate persisted records that share a block
+key WITHOUT re-blocking the whole corpus in RAM. Slice 1 added the store index +
+its write/query API (``IdentityStore.index_record_block_keys`` /
+``candidates_by_block_keys``). This slice adds:
+
+* ``compute_record_block_keys`` / ``compute_frame_block_keys`` -- the STATELESS
+  COMPUTE half: given a record (or frame) and the blocking config, produce the
+  ``(pass_sig, block_key)`` pairs it falls in. Reuses the pipeline's own
+  ``_build_block_key_expr`` + the multi_pass ``(fields, transforms)`` pass
+  signature, so a record's index keys match the batch blocker exactly.
+* ``backfill_block_index`` -- populate the store index for an existing corpus,
+  keying each row by the same ``derive_record_id`` the identity graph uses, so
+  the index record_ids line up with ``source_records``.
+
+Wiring the candidate QUERY into ``resolve_record_incremental`` (so it stops
+materializing the whole corpus) is the next slice; these primitives are what it
+will call. Additive -- nothing here changes existing resolve behavior.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from goldenmatch._polars_lazy import pl
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.identity.store import IdentityStore
+
+
+def _pass_signature(key_config: BlockingKeyConfig) -> str:
+    """Stable signature of a blocking pass -- its fields + transforms.
+
+    Mirrors the ``(tuple(fields), tuple(transforms))`` pass_sig the multi_pass
+    blocker dedups on (``blocker._agg_blocks``), serialized to a compact string
+    for the store's ``pass_sig`` column. Distinguishes passes whose block-key
+    STRINGS collide across a shared namespace (soundex vs substring vs numeric)."""
+    fields = ",".join(key_config.fields)
+    transforms = ",".join(key_config.transforms or [])
+    return f"{fields}::{transforms}"
+
+
+def _passes_of(blocking: BlockingConfig) -> list[BlockingKeyConfig]:
+    """The blocking passes to index: ``passes`` for multi_pass, else ``keys``."""
+    if getattr(blocking, "strategy", None) == "multi_pass":
+        return list(blocking.passes or [])
+    return list(blocking.keys or [])
+
+
+def compute_frame_block_keys(
+    df: Any, blocking: BlockingConfig
+) -> dict[int, list[tuple[str, str]]]:
+    """Per-``__row_id__`` ``(pass_sig, block_key)`` pairs over all blocking passes.
+
+    Computes each pass's block key with the pipeline's ``_build_block_key_expr``
+    (same transforms as batch blocking) and drops null block keys (the blocker's
+    own single-field null/sentinel filter). A pass whose fields aren't all
+    present in ``df`` is skipped rather than raising. Requires a ``__row_id__``
+    column.
+    """
+    from goldenmatch.core.blocker import _build_block_key_expr
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    if "__row_id__" not in frame.columns:
+        raise ValueError("compute_frame_block_keys requires a __row_id__ column")
+    native = frame.native if hasattr(frame, "native") else df
+    # Operate on polars for the block-key expression path.
+    pdf = native if isinstance(native, pl.DataFrame) else pl.from_arrow(native)
+    columns = set(pdf.columns)
+    row_ids = pdf["__row_id__"].to_list()
+
+    out: dict[int, list[tuple[str, str]]] = {}
+    for key_config in _passes_of(blocking):
+        if not all(f in columns for f in key_config.fields):
+            continue  # a pass this frame can't satisfy -> skip (not an error)
+        sig = _pass_signature(key_config)
+        keys = pdf.select(_build_block_key_expr(key_config)).to_series().to_list()
+        for rid, bk in zip(row_ids, keys):
+            if bk is None:  # null block key -> not indexable (matches blocker)
+                continue
+            out.setdefault(int(rid), []).append((sig, str(bk)))
+    return out
+
+
+def compute_record_block_keys(
+    record: dict[str, Any], blocking: BlockingConfig
+) -> list[tuple[str, str]]:
+    """The ``(pass_sig, block_key)`` pairs a single record falls in.
+
+    The stateless-compute step of the incremental candidate query: hand these to
+    ``store.candidates_by_block_keys`` to get the persisted block-mates. A
+    ``__row_id__`` is synthesized if absent (the record is a transient probe)."""
+    row = dict(record)
+    row.setdefault("__row_id__", -1)
+    keys = compute_frame_block_keys(pl.DataFrame([row]), blocking)
+    return keys.get(int(row["__row_id__"]), [])
+
+
+def backfill_block_index(
+    store: IdentityStore,
+    df: Any,
+    blocking: BlockingConfig,
+    *,
+    source: str = "dataframe",
+    source_pk_col: str | None = None,
+) -> int:
+    """Populate the store's block-key index for every row of ``df``.
+
+    Keys each row by the same ``derive_record_id`` the identity graph uses, so
+    the index record_ids match ``source_records``; carries each record's current
+    ``entity_id`` when it is already resolved (else NULL). Runs inside one
+    ``bulk_writes`` transaction. Returns the number of records indexed. Use this
+    to prepare an existing corpus for incremental resolution against the index.
+    """
+    from goldenmatch.core.frame import to_frame
+    from goldenmatch.identity.resolve import derive_record_id
+
+    frame = to_frame(df)
+    if "__row_id__" not in frame.columns:
+        raise ValueError("backfill_block_index requires a __row_id__ column")
+    native = frame.native if hasattr(frame, "native") else df
+    pdf = native if isinstance(native, pl.DataFrame) else pl.from_arrow(native)
+
+    keys_by_rid = compute_frame_block_keys(pdf, blocking)
+    indexed = 0
+    with store.bulk_writes():
+        for row in pdf.iter_rows(named=True):
+            rid = int(row["__row_id__"])
+            keys = keys_by_rid.get(rid)
+            if not keys:
+                continue
+            record_id, _ = derive_record_id(row, source, source_pk_col)
+            entity_id = store.find_entity_by_record(record_id)
+            store.index_record_block_keys(record_id, entity_id, keys)
+            indexed += 1
+    return indexed

--- a/packages/python/goldenmatch/tests/identity/test_block_index_compute.py
+++ b/packages/python/goldenmatch/tests/identity/test_block_index_compute.py
@@ -1,0 +1,139 @@
+"""Block-key computation + population for the persisted index (C2 slice 2).
+
+Locks the stateless-compute half of the bidirectional seam: a record's
+``(pass_sig, block_key)`` pairs (computed with the SAME expression the batch
+blocker uses) + backfill population of the store index, so incremental
+resolution can later query candidates without re-blocking the corpus.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.identity import IdentityStore
+from goldenmatch.identity.block_index import (
+    backfill_block_index,
+    compute_frame_block_keys,
+    compute_record_block_keys,
+)
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(path=str(tmp_path / "identity.db"))
+    yield s
+    s.close()
+
+
+def _static(fields, transforms=None):
+    return BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=fields, transforms=transforms or [])],
+    )
+
+
+def _multi_pass(*passes):
+    return BlockingConfig(
+        strategy="multi_pass",
+        passes=[BlockingKeyConfig(fields=f, transforms=t or []) for f, t in passes],
+    )
+
+
+def test_compute_record_block_keys_static():
+    blocking = _static(["last"], ["lowercase"])
+    keys = compute_record_block_keys({"last": "Smith"}, blocking)
+    assert keys == [("last::lowercase", "smith")]
+
+
+def test_compute_record_block_keys_multi_pass():
+    blocking = _multi_pass((["last"], ["lowercase"]), (["zip"], []))
+    keys = compute_record_block_keys({"last": "Smith", "zip": "10001"}, blocking)
+    assert ("last::lowercase", "smith") in keys
+    assert ("zip::", "10001") in keys
+    assert len(keys) == 2
+
+
+def test_pass_sig_disambiguates_different_fields():
+    """Two passes over DIFFERENT fields that happen to produce the same key
+    string must carry distinct pass_sigs."""
+    blocking = _multi_pass((["a"], []), (["b"], []))
+    keys = compute_record_block_keys({"a": "X", "b": "X"}, blocking)
+    sigs = {sig for sig, _ in keys}
+    assert sigs == {"a::", "b::"}
+
+
+def test_null_block_key_dropped():
+    blocking = _static(["last"])
+    assert compute_record_block_keys({"last": None}, blocking) == []
+
+
+def test_missing_field_pass_skipped():
+    """A pass whose field isn't present is skipped, not an error."""
+    blocking = _multi_pass((["last"], []), (["phone"], []))
+    keys = compute_record_block_keys({"last": "Smith"}, blocking)  # no phone col
+    assert keys == [("last::", "Smith")]
+
+
+def test_frame_keys_match_batch_blocker():
+    """The per-record block key equals what the batch blocker computes for the
+    same row (reuses _build_block_key_expr -> parity by construction)."""
+    from goldenmatch.core.blocker import _build_block_key_expr
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2],
+        "last": ["Smith", "smith", "Jones"],
+    })
+    kc = BlockingKeyConfig(fields=["last"], transforms=["lowercase"])
+    batch = df.select(_build_block_key_expr(kc)).to_series().to_list()
+    computed = compute_frame_block_keys(df, _static(["last"], ["lowercase"]))
+    for rid, expected in enumerate(batch):
+        assert computed[rid] == [("last::lowercase", expected)]
+
+
+def test_backfill_populates_and_queries(store):
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2],
+        "id": ["u0", "u1", "u2"],
+        "last": ["Smith", "Smith", "Jones"],
+    })
+    blocking = _static(["last"])
+    n = backfill_block_index(store, df, blocking, source="src", source_pk_col="id")
+    assert n == 3
+
+    # A new record blocking on "Smith" finds the two persisted Smiths.
+    keys = compute_record_block_keys({"last": "Smith"}, blocking)
+    cands = store.candidates_by_block_keys(keys)
+    assert cands == {"src:u0", "src:u1"}
+    # Jones finds only the Jones.
+    assert store.candidates_by_block_keys(
+        compute_record_block_keys({"last": "Jones"}, blocking)
+    ) == {"src:u2"}
+
+
+def test_backfill_carries_entity_id(store):
+    from datetime import datetime
+
+    from goldenmatch.identity.model import IdentityNode, SourceRecord
+
+    # Pre-write the identity node (source_records.entity_id FKs to it), then a
+    # source record pointing at it.
+    store.upsert_identity(IdentityNode(
+        entity_id="e-alice", status="active",
+        created_at=datetime.now(), updated_at=datetime.now(),
+    ))
+    store.upsert_record(SourceRecord(
+        record_id="src:u0", source="src", source_pk="u0",
+        record_hash="h", entity_id="e-alice",
+        first_seen_at=datetime.now(), last_seen_at=datetime.now(),
+    ))
+    df = pl.DataFrame({"__row_id__": [0], "id": ["u0"], "last": ["Smith"]})
+    backfill_block_index(store, df, _static(["last"]), source="src", source_pk_col="id")
+    row = store._conn.execute(
+        "SELECT entity_id FROM identity_record_block_keys WHERE record_id='src:u0'"
+    ).fetchone()
+    assert row["entity_id"] == "e-alice"
+
+
+def test_backfill_requires_row_id(store):
+    with pytest.raises(ValueError, match="__row_id__"):
+        backfill_block_index(store, pl.DataFrame({"last": ["x"]}), _static(["last"]))


### PR DESCRIPTION
## What and why

Second slice of the **critical** incremental-resolution fix (control-plane manifesto §4(ii), owner-confirmed). Builds on slice 1's persisted store index (#2156) by adding the **stateless-compute** half of the bidirectional seam plus index **population**.

## Changes — `identity/block_index.py`

- **`compute_record_block_keys(record, blocking)` / `compute_frame_block_keys(df, blocking)`** — a record's `(pass_sig, block_key)` pairs, computed with the pipeline's own `_build_block_key_expr` and the multi_pass `(fields, transforms)` pass signature. So a record's index keys match the **batch blocker exactly** (parity-tested against `_build_block_key_expr`). Null block keys are dropped (the blocker's own filter); a pass whose fields are absent from the record is skipped, not an error.
- **`backfill_block_index(store, df, blocking, *, source, source_pk_col)`** — populate the store index for an existing corpus, keying each row by the identity `derive_record_id` (so the index `record_id`s line up with `source_records`) and carrying each record's current `entity_id`. Runs in one `bulk_writes` transaction; returns the count indexed.

## Additive

Nothing here changes existing resolve behavior — these are the primitives the **next slice** will call to query candidates inside `resolve_record_incremental` (retiring the full-corpus re-block) and to fix the exact-matchkey gap. The critical inventory entry stays **OPEN** until that wiring lands; **C4** is the bounded-RSS scale proof.

## Testing

`uv run pytest packages/python/goldenmatch/tests/identity/` → **293 passed, 6 skipped**. New `test_block_index_compute.py` (9): static + multi_pass compute, `pass_sig` disambiguation across different fields, null-key drop, missing-field-pass skip, **batch-blocker parity** (`compute_frame_block_keys` == `_build_block_key_expr` per row), backfill populate→query roundtrip (a new record finds its persisted block-mates), `entity_id` carry, and the `__row_id__` guard. `ruff` clean. `test_config_matrix.py` + `test_agent_codemap.py` → 54 passed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [ ] Package `CHANGELOG.md` — N/A, additive infra with no behavior change yet (the incremental behavior change lands with the query-wiring slice)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / manifesto updated (slice-2 status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_