### PR TITLE
feat(parity): declare goldenanalysis frame-kernel WASM deferral at the surface (standalone-ts B)

### DIFF
--- a/parity/goldenanalysis.yaml
+++ b/parity/goldenanalysis.yaml
@@ -39,3 +39,23 @@ analyzers:
   - quality.rollup
   python_only: []
   ts_only: []
+# Frame-kernel cross-language boundary (distinct_count / null_ratio /
+# duplicate_row_ratio). Same classification-map idiom as goldenmatch's
+# blocking_kernels_deferred / scorer_kernels_deferred (skipped in check_structure;
+# not a shared/python_only/ts_only partition). The COUNTING primitives live in the
+# pyo3-free analysis-core, but the semantically load-bearing step is interning
+# heterogeneous Arrow values to canonical u64 ids (canon_f64_bits: -0.0/0.0,
+# NaN/NaN/null, int/float), which is Arrow-specific and has NO clean WASM boundary
+# -- Wave 1b was consciously DEFERRED (docs/superpowers/specs/
+# 2026-07-06-goldenanalysis-wave1b-deferred.md): arrow-in-wasm is heavy and a
+# second JS-value interner would be a new drift surface, with no established
+# in-browser frame-dedup workload to justify either. Instead the TS<->Python
+# equality semantics are locked by an ADVERSARIAL cross-surface fixture
+# (frame_kernels_adversarial.json + test_frame_kernels_parity.py /
+# frameKernels.parity.test.ts) -- which already caught a real NaN/null conflation
+# bug. Revisit only on a measured in-browser workload; then arrow-in-wasm is the
+# thesis-pure path. `deferred --` = will kernelize when that lands.
+frame_kernels_deferred:
+  distinct_count: "deferred -- Arrow-bound interning has no clean WASM boundary (Wave 1b); TS<->Python locked by frame_kernels_adversarial.json"
+  null_ratio: "deferred -- reads Arrow null buffers directly; no WASM boundary (Wave 1b); TS<->Python locked by frame_kernels_adversarial.json"
+  duplicate_row_ratio: "deferred -- Arrow-bound row interning has no clean WASM boundary (Wave 1b); TS<->Python locked by frame_kernels_adversarial.json"

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -168,18 +168,29 @@ weaknesses:
   - id: standalone-ts-algorithms-no-shared-kernel
     tenet: T1
     severity: medium
-    declared: true   # declared in TS CLAUDE.md / wave1b spec
+    declared: true   # declared in TS CLAUDE.md / wave1b spec + parity manifests
     title: "Clustering and goldenanalysis frame kernels are standalone TS, byte-safety rests on fixtures not a shared kernel"
     detail: >-
-      TS clustering (buildClusters + MST oversized-split) is a pure-TS reimplementation
-      of the Python clustering; its cross-language correctness rests entirely on the
-      cluster-conformance/split-run parity harness over two independent impls, not a
-      shared kernel. goldenanalysis frame kernels (distinct_count/null_ratio/
-      duplicate_row_ratio) have no WASM (Wave 1b consciously deferred) and are locked
-      only by a hand-authored fixture -- which itself caught a real NaN/null bug,
-      evidence the boundary was genuinely divergent before the fixture.
+      TWO families. (A) TS clustering: buildClusters' connected-components step is ALREADY
+      shared to WASM (graph-wasm, the same kernel as the Python native path), but the MST
+      oversized-split + confidence half (buildMst/splitOversizedCluster/
+      computeClusterConfidence) is pure-TS vs a pyo3-only Rust mirror (native/src/cluster.rs
+      mst_split_components/cluster_confidence) with no pyo3-free -core / no wasm -- locked
+      only by the cluster-conformance/split-run parity harness over two independent impls.
+      (B) goldenanalysis frame kernels (distinct_count/null_ratio/duplicate_row_ratio): the
+      counting is in the pyo3-free analysis-core, but the load-bearing Arrow-value interning
+      has no clean WASM boundary (Wave 1b consciously deferred), locked by an adversarial
+      fixture -- which itself caught a real NaN/null bug.
+      DECLARED-AT-SURFACE 2026-07-26 (Family B): the deferral is now asserted in
+      parity/goldenanalysis.yaml as a `frame_kernels_deferred` classification map (same idiom
+      as blocking_kernels_deferred/scorer_kernels_deferred), not only in the spec + this file.
+      REMAINING (Family A): extract mst_split_components + cluster_confidence to a pyo3-free
+      -core + a *-wasm surface and reroute splitOversizedCluster behind the backend registry
+      (mirroring the existing graph-wasm wiring) -- the one genuine shared-kernel gap.
     evidence:
-      - packages/typescript/goldenmatch/src/core/cluster
+      - packages/typescript/goldenmatch/src/core/cluster.ts
+      - packages/rust/extensions/native/src/cluster.rs
+      - parity/goldenanalysis.yaml
       - docs/superpowers/specs/2026-07-06-goldenanalysis-wave1b-deferred.md
       - packages/python/goldenanalysis/tests/test_frame_kernels_parity.py
 

--- a/scripts/check_api_parity.py
+++ b/scripts/check_api_parity.py
@@ -66,7 +66,16 @@ def check_structure(manifest: dict) -> list[ParityFailure]:
         # `scorer_kernels_deferred` is a classification MAP (scorer -> reason),
         # not a shared/python_only/ts_only partition surface; its shape is
         # validated by check_scorer_coverage, so skip the partition checks here.
-        if surface in ("scorer_kernels_deferred", "blocking_kernels_deferred"):
+        # `frame_kernels_deferred` is the same idiom for the goldenanalysis frame
+        # kernels (distinct/null_ratio/duplicate_row_ratio): the counting is in
+        # analysis-core but the Arrow-bound interning has no clean WASM boundary
+        # (Wave 1b deferred), so the TS<->Python boundary is locked by an
+        # adversarial fixture, not a shared kernel -- declared here at the surface.
+        if surface in (
+            "scorer_kernels_deferred",
+            "blocking_kernels_deferred",
+            "frame_kernels_deferred",
+        ):
             continue
         # Advisory SQL inventory surfaces are `{functions: [...]}`, not
         # shared/python_only/ts_only partitions — checked by check_sql_advisory.


### PR DESCRIPTION
## What and why

First half of the `standalone-ts-algorithms-no-shared-kernel` medium (Family B). The goldenanalysis frame kernels (`distinct_count` / `null_ratio` / `duplicate_row_ratio`) have their counting in the pyo3-free `analysis-core`, but the semantically load-bearing step — interning heterogeneous **Arrow** values to canonical `u64` ids (`canon_f64_bits`: `-0.0`/`0.0`, `NaN`/`NaN`/null, int/float) — has **no clean WASM boundary**. Wave 1b was consciously deferred (arrow-in-wasm is heavy; a second JS-value interner would be a new drift surface; no established in-browser frame-dedup workload). The boundary is instead locked by an **adversarial cross-surface fixture** (`frame_kernels_adversarial.json`), which already caught a real NaN/null conflation bug.

That deferral was declared only in the spec + `thesis_conformance.yaml`. This PR asserts it **at the surface**.

## Changes

- **`parity/goldenanalysis.yaml`** — new `frame_kernels_deferred` classification map (`distinct_count` / `null_ratio` / `duplicate_row_ratio` → `deferred -- …` reasons), the same idiom as `blocking_kernels_deferred` / `scorer_kernels_deferred`.
- **`scripts/check_api_parity.py`** — one line: add `frame_kernels_deferred` to the `check_structure` skip set (it's a classification map, not a shared/python_only/ts_only partition, so it's not a gated surface — exactly like the other two deferred maps).
- **`parity/thesis_conformance.yaml`** — fix the stale evidence path (`src/core/cluster` → `src/core/cluster.ts`) and rewrite the `standalone-ts-algorithms` entry to split the two families accurately: **Family A** clustering (connected-components is *already* shared to WASM via `graph-wasm`; only the MST oversized-split half is the genuine gap) and **Family B** frame kernels (declared here).

## Scope

Declaration only — no runtime change. The **Family A** MST kernel port (extract `mst_split_components` + `cluster_confidence` to a pyo3-free `-core` + a `-wasm` surface, reroute `splitOversizedCluster` behind the backend registry, mirroring the existing `graph-wasm` wiring) follows as its own PR.

## Testing

`check_structure` accepts the new map with no failures; `scripts/test_api_parity.py` → 53 passed; thesis-conformance gate (`--check --strict`) OK; suite-matrix / api-surface / llms-count gates OK. (The 2 pre-existing `ruff` I001s in `scripts/check_api_parity.py` are at an unrelated import block and outside CI's `packages/python/<pkg>` ruff scope.)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files (no new findings)
- [ ] Package `CHANGELOG.md` — N/A: parity-manifest + gate declaration, no runtime change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs — thesis inventory + parity manifest updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_