### PR TITLE
feat(fs): reroute TS probabilistic scoring onto the shared fs-core kernel (fs-default-ts-path PR2)

### DIFF
--- a/packages/python/goldenmatch/scripts/emit_fs_wasm_fixture.py
+++ b/packages/python/goldenmatch/scripts/emit_fs_wasm_fixture.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
-"""Author the fs-wasm cross-surface parity fixture from the Python NATIVE kernel.
+"""Author the fs-wasm cross-surface parity fixtures from the Python NATIVE kernel.
 
 The native `score_block_pairs_fs` and the TS `fs-wasm` binding both call the SAME
 `goldenmatch-fs-core::score_fs_pair`, so their output is byte-identical by
-construction. This emits a small zero-config block scored by the native kernel as
-the ORACLE; `tests/parity/fs-wasm.parity.test.ts` feeds the identical inputs to
-fs-wasm and asserts the same pairs.
+construction. This emits small blocks scored by the native kernel as the ORACLE;
+`tests/parity/fs-wasm.parity.test.ts` feeds the identical inputs to fs-wasm and
+asserts the same pairs.
+
+Two fixtures:
+  * `fs_block_scoring.json` — the original zero-config block (no NE, no banding).
+  * `fs_block_scoring_ne_banding.json` — the fs-default-ts-path PR2 GATE: negative
+    evidence + custom level-banding + a partial-MISSING (null) field, the cases
+    where the reroute's FIXED full-field normalization differs from the pure-TS
+    per-pair shrinking range. Authored WITHOUT `require_positive_evidence` /
+    `missing_disagree` (both default off in the pyo3 kernel), matching the fs-wasm
+    entry's capabilities exactly, so TS-kernel == Python-native by construction.
 
 Run with the native ext available (scripts/build_native.py):
     python scripts/emit_fs_wasm_fixture.py
@@ -18,8 +27,14 @@ import pathlib
 
 from goldenmatch.core._native_loader import native_module
 
+_FIXTURE_DIR = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "packages/typescript/goldenmatch/tests/parity/fixtures/fs"
+)
+
 
 def _weight_range(match_weights: list[list[float]]) -> tuple[float, float]:
+    """Regular-field-only FIXED range (min sum, span)."""
     field_mins = [min(w) for w in match_weights]
     field_maxs = [max(w) for w in match_weights]
     regular_min = sum(field_mins)
@@ -27,9 +42,22 @@ def _weight_range(match_weights: list[list[float]]) -> tuple[float, float]:
     return regular_min, regular_max - regular_min
 
 
-def main() -> None:
-    mod = native_module()
+def _weight_range_with_ne(
+    match_weights: list[list[float]], ne_weights: list[float]
+) -> tuple[float, float]:
+    """FIXED full-field range INCLUDING negative evidence — mirrors Python
+    ``fs_weight_range``: regular sum(min)/sum(max) plus, per NE field, the
+    ``(min(w_fired, 0), max(w_fired, 0))`` envelope. Returns ``(min, span)``."""
+    reg_min = sum(min(w) for w in match_weights)
+    reg_max = sum(max(w) for w in match_weights)
+    ne_min = sum(min(w, 0.0) for w in ne_weights)
+    ne_max = sum(max(w, 0.0) for w in ne_weights)
+    total_min = reg_min + ne_min
+    total_max = reg_max + ne_max
+    return total_min, total_max - total_min
 
+
+def emit_basic(mod) -> None:
     # 2 fields: jaro_winkler (id 0), exact (id 3). 6 rows, one block.
     field0 = ["robert", "robert", "william", "willyam", "bob", "xyzzy"]
     field1 = ["smith", "smith", "jones", "jones", "brown", "zzz"]
@@ -86,13 +114,122 @@ def main() -> None:
         "expected_pairs": expected,
     }
 
-    out = (
-        pathlib.Path(__file__).resolve().parents[4]
-        / "packages/typescript/goldenmatch/tests/parity/fixtures/fs/fs_block_scoring.json"
-    )
+    out = _FIXTURE_DIR / "fs_block_scoring.json"
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(fixture, indent=2) + "\n")
     print(f"wrote {out} ({len(expected)} pairs)")
+
+
+def emit_ne_banding(mod) -> None:
+    """The PR2 GATE fixture: NE + custom banding + a partial-missing field.
+
+    3 regular fields + 1 negative-evidence field over 5 rows, one block:
+      * name  (jaro_winkler id 0, 3-level CUSTOM banding: level_thresholds
+        [0.95, 0.3] -> level = count of satisfied cutoffs, `>=` inclusive)
+      * code  (exact id 3, default 2-level banding)
+      * city  (jaro_winkler id 0, default 2-level banding) — row 2 is NULL
+        (MISSING: contributes no evidence, normalized against the FIXED range)
+      * dob   (NEGATIVE EVIDENCE, exact id 3, fires when sim < 0.5) — row 2
+        disagrees, so the NE fires against every pair involving row 2.
+
+    A wide-negative `threshold` emits every within-block pair so the fixture is a
+    thorough oracle. Authored with the level_thresholds + ne_* kwargs ONLY (no
+    require_positive_evidence / missing_disagree — both default off), matching the
+    fs-wasm entry.
+    """
+    name = ["robert", "robert", "rupert", "robert", "xyzzy"]
+    code = ["A1", "A1", "A1", "B2", "Z9"]
+    city = ["paris", "paris", None, "london", "tokyo"]  # row 2 missing
+    field_values = [name, code, city]
+    row_ids = list(range(5))
+    block_sizes = [5]
+
+    scorer_ids = [0, 3, 0]
+    levels = [3, 2, 2]
+    partial_thresholds = [0.8, 0.9, 0.8]
+    # name is 3-level (2 custom thresholds -> 3 weights); code/city 2-level.
+    match_weights = [[-2.0, 0.5, 3.0], [-1.5, 2.5], [-1.0, 2.0]]
+    # Custom banding for name only; None => default banding for code/city.
+    level_thresholds = [[0.95, 0.3], None, None]
+
+    # Negative evidence: dob (exact, fires when values disagree i.e. sim < 0.5).
+    dob = ["1990", "1990", "1985", "1990", "1971"]
+    ne_values = [dob]
+    ne_scorer_ids = [3]
+    ne_thresholds = [0.5]
+    ne_weights = [-3.0]  # EM-learned-style fired weight (negative)
+
+    calibrated = False
+    prior_w = 0.0
+    threshold = -1.0e9  # emit every within-block pair
+    min_weight, weight_range = _weight_range_with_ne(match_weights, ne_weights)
+
+    pairs = mod.score_block_pairs_fs(
+        row_ids,
+        block_sizes,
+        field_values,
+        scorer_ids,
+        levels,
+        partial_thresholds,
+        match_weights,
+        calibrated,
+        prior_w,
+        min_weight,
+        weight_range,
+        threshold,
+        [],  # exclude
+        level_thresholds=level_thresholds,
+        ne_values=ne_values,
+        ne_scorer_ids=ne_scorer_ids,
+        ne_thresholds=ne_thresholds,
+        ne_weights=ne_weights,
+    )
+    expected = [[int(a), int(b), round(float(s), 6)] for a, b, s in pairs]
+    assert expected, "NE/banding fixture must not be vacuous"
+    assert all(math.isfinite(s) for _, _, s in expected)
+    # Sanity: every within-block pair is emitted at the wide-negative threshold.
+    assert len(expected) == 5 * (5 - 1) // 2, expected
+
+    fixture = {
+        "_comment": (
+            "AUTHORED by the Python native score_block_pairs_fs (the oracle) with "
+            "negative evidence + custom level-banding + a partial-MISSING field. "
+            "fs-wasm calls the SAME fs-core::score_fs_pair -> byte-identical. This "
+            "is the fs-default-ts-path PR2 cross-language GATE. No "
+            "require_positive_evidence / missing_disagree (both default off), "
+            "matching the fs-wasm entry. Regenerate: python "
+            "scripts/emit_fs_wasm_fixture.py"
+        ),
+        "field_values": field_values,
+        "row_ids": row_ids,
+        "block_sizes": block_sizes,
+        "scorer_ids": scorer_ids,
+        "levels": levels,
+        "partial_thresholds": partial_thresholds,
+        "match_weights": match_weights,
+        "calibrated": calibrated,
+        "prior_w": prior_w,
+        "min_weight": min_weight,
+        "weight_range": weight_range,
+        "threshold": threshold,
+        "level_thresholds": level_thresholds,
+        "ne_values": ne_values,
+        "ne_scorer_ids": ne_scorer_ids,
+        "ne_thresholds": ne_thresholds,
+        "ne_weights": ne_weights,
+        "expected_pairs": expected,
+    }
+
+    out = _FIXTURE_DIR / "fs_block_scoring_ne_banding.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(fixture, indent=2) + "\n")
+    print(f"wrote {out} ({len(expected)} pairs)")
+
+
+def main() -> None:
+    mod = native_module()
+    emit_basic(mod)
+    emit_ne_banding(mod)
 
 
 if __name__ == "__main__":

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -17,6 +17,7 @@
     "./core/fingerprint-wasm": { "types": "./dist/core/fingerprintWasm.d.ts", "import": "./dist/core/fingerprintWasm.js", "require": "./dist/core/fingerprintWasm.cjs" },
     "./core/goldenembed-wasm": { "types": "./dist/core/goldenembedWasm.d.ts", "import": "./dist/core/goldenembedWasm.js", "require": "./dist/core/goldenembedWasm.cjs" },
     "./core/fs-wasm": { "types": "./dist/core/fsWasm.d.ts", "import": "./dist/core/fsWasm.js", "require": "./dist/core/fsWasm.cjs" },
+    "./core/fs-scoring": { "types": "./dist/core/fsScore.d.ts", "import": "./dist/core/fsScore.js", "require": "./dist/core/fsScore.cjs" },
     "./node": { "types": "./dist/node/index.d.ts", "import": "./dist/node/index.js", "require": "./dist/node/index.cjs" }
   },
   "bin": { "goldenmatch-js": "./dist/cli.cjs", "goldenmatch-mcp": "./dist/node/mcp/server.cjs" },

--- a/packages/typescript/goldenmatch/src/core/fsScore.ts
+++ b/packages/typescript/goldenmatch/src/core/fsScore.ts
@@ -1,0 +1,210 @@
+/**
+ * fsScore.ts — the Fellegi-Sunter block-scoring REROUTE adapter.
+ *
+ * Builds the JSON-boundary `FsBlockScoringInput` the shared `fs-core` wasm
+ * kernel takes from the SAME `(rows, matchkey, EMResult)` the pure-TS
+ * `scoreProbabilistic` consumes, then calls `scoreBlockPairsFs`. This is the TS
+ * mirror of the Python-native input construction in
+ * `goldenmatch/core/probabilistic.py::_score_fs_native_frame` — so TS FS block
+ * scoring becomes byte-aligned with Python-native (same kernel, same inputs).
+ *
+ * THE F1-MOVING DELTA vs pure-TS `scoreProbabilistic`: normalization uses the
+ * FIXED full-field weight range (`fsWeightRange`, the #1854 fix Python ships),
+ * NOT the pure-TS per-pair SHRINKING range (only-observed-fields). This is the
+ * intended alignment onto Python's operating point — see PR "fs-default-ts-path".
+ *
+ * HEAVY module (imports the inlined `fs-wasm` kernel) — a separate tsup subpath
+ * (`goldenmatch/core/fs-scoring`) so the ~187 KB wasm never enters the default
+ * `core` bundle. `pipeline.ts` reaches this only through the lean
+ * `fsScoreBackend` registry, which importing this module + calling
+ * `enableFsWasmScoring()` populates.
+ */
+import type {
+  Row,
+  MatchkeyConfig,
+  MatchkeyField,
+  NegativeEvidenceField,
+  ScoredPair,
+} from "./types.js";
+import { makeScoredPair } from "./types.js";
+import { asString } from "./scorer.js";
+import { applyTransforms } from "./transforms.js";
+import { fsWeightRange } from "./probabilistic.js";
+import type { EMResult } from "./probabilistic.js";
+import { scoreBlockPairsFs } from "./fsWasm.js";
+import type { FsBlockScoringInput } from "./fsWasm.js";
+import {
+  setFsScoreBackend,
+  disableFsWasmScoring,
+} from "./fsScoreBackend.js";
+
+// ---------------------------------------------------------------------------
+// Scorer-name -> `fs_core` kernel id (mirrors the Python
+// `_NATIVE_FS_SCORER_IDS` subset the TS kernel can express). score_one ids
+// 0..=3 + ensemble (6). The reference-data name scorers (4/5) need the process
+// registered census/alias tables and embedding (7) needs marshaled vectors —
+// neither is wired on the TS surface, so a field/NE using them DECLINES the
+// reroute to the pure-TS fallback (exactly like Python declines to numpy).
+// ---------------------------------------------------------------------------
+const FS_SCORER_IDS: Readonly<Record<string, number>> = {
+  jaro_winkler: 0,
+  levenshtein: 1,
+  token_sort: 2,
+  exact: 3,
+  ensemble: 6,
+};
+
+/** Python-parity default `partial_threshold` (schemas.py MatchkeyField). */
+const DEFAULT_PARTIAL_THRESHOLD = 0.8;
+
+function fieldLevelCount(f: MatchkeyField): number {
+  if (f.levelThresholds !== undefined) return f.levelThresholds.length + 1;
+  return f.levels ?? 2;
+}
+
+/**
+ * The post-transform value column for one field over the block, `null` where the
+ * value is missing. Mirrors Python `_field_values_for_block` / the pure-TS
+ * `buildComparisonVector` operand computation (`asString` -> `applyTransforms`),
+ * so the kernel bands the identical similarity the pure-TS path would.
+ */
+function fieldValueColumn(
+  blockRows: readonly Row[],
+  field: string,
+  transforms: readonly string[],
+): (string | null)[] {
+  return blockRows.map((row) => {
+    let v = asString(row[field]);
+    if (v !== null && transforms.length > 0) v = applyTransforms(v, transforms);
+    return v;
+  });
+}
+
+/**
+ * Whether `mk` can be scored by the shared `fs_core` kernel on the TS surface.
+ * Mirrors the field/NE-scorer + TF checks of Python `_fs_native_eligible`
+ * (minus the wheel-capability probes — the committed fs-wasm always carries the
+ * NE + level-banding entry). A non-probabilistic matchkey, or any field/NE using
+ * a scorer the TS kernel can't express, or any `tfAdjustment` field, declines.
+ */
+export function fsRerouteEligible(mk: MatchkeyConfig): boolean {
+  if (mk.type !== "probabilistic") return false;
+  if (mk.fields.length === 0) return false;
+  for (const f of mk.fields) {
+    if (!(f.scorer in FS_SCORER_IDS)) return false;
+    if (f.tfAdjustment) return false;
+  }
+  for (const ne of mk.negativeEvidence ?? []) {
+    if (!(ne.scorer in FS_SCORER_IDS)) return false;
+  }
+  return true;
+}
+
+/**
+ * Build the `FsBlockScoringInput` for a single block from the SAME inputs
+ * `scoreProbabilistic` takes. Caller guarantees `fsRerouteEligible(mk)`.
+ * `threshold` is the emit cutoff (review/link threshold). Normalization scalars
+ * come from the FIXED-range `fsWeightRange` (Python operating point).
+ */
+export function buildFsBlockScoringInput(
+  blockRows: readonly Row[],
+  mk: Extract<MatchkeyConfig, { type: "probabilistic" }>,
+  em: EMResult,
+  threshold: number,
+): FsBlockScoringInput {
+  const fields = mk.fields;
+  const rowIds: number[] = [];
+  for (const row of blockRows) {
+    const id = row["__row_id__"];
+    rowIds.push(typeof id === "number" ? id : Number(id));
+  }
+
+  const fieldValues = fields.map((f) =>
+    fieldValueColumn(blockRows, f.field, f.transforms),
+  );
+  const scorerIds = fields.map((f) => FS_SCORER_IDS[f.scorer]!);
+  const levels = fields.map((f) => fieldLevelCount(f));
+  const partialThresholds = fields.map(
+    (f) => f.partialThreshold ?? DEFAULT_PARTIAL_THRESHOLD,
+  );
+  const matchWeights = fields.map((f) => [...(em.matchWeights[f.field] ?? [])]);
+
+  // Custom banding: one entry per regular field; null => default banding.
+  const levelThresholds = fields.map((f) =>
+    f.levelThresholds !== undefined ? [...f.levelThresholds] : null,
+  );
+  const hasBanding = levelThresholds.some((t) => t !== null);
+
+  // FIXED full-field weight range (the #1854 alignment) — NOT the per-pair
+  // shrinking range the pure-TS scorer uses.
+  const { minWeight, maxWeight } = fsWeightRange(em, mk);
+
+  // Negative evidence (mirrors Python's ne_* opt_kwargs construction). w_fired:
+  // -abs(penaltyBits) override, else the EM-learned __ne__<field> fired weight.
+  const neFields: readonly NegativeEvidenceField[] = mk.negativeEvidence ?? [];
+  const neValues = neFields.map((ne) =>
+    fieldValueColumn(blockRows, ne.field, ne.transforms),
+  );
+  const neScorerIds = neFields.map((ne) => FS_SCORER_IDS[ne.scorer]!);
+  const neThresholds = neFields.map((ne) => ne.threshold);
+  const neWeights = neFields.map((ne) =>
+    ne.penaltyBits !== undefined
+      ? -Math.abs(ne.penaltyBits)
+      : em.matchWeights[`__ne__${ne.field}`]![0]!,
+  );
+
+  const input: FsBlockScoringInput = {
+    rowIds,
+    blockSizes: [blockRows.length],
+    fieldValues,
+    scorerIds,
+    levels,
+    partialThresholds,
+    matchWeights,
+    calibrated: false, // linear normalization (Python default; posterior stays host-side)
+    priorW: 0.0,
+    minWeight,
+    weightRange: maxWeight - minWeight,
+    threshold,
+    ...(hasBanding ? { levelThresholds } : {}),
+    ...(neFields.length > 0
+      ? { neValues, neScorerIds, neThresholds, neWeights }
+      : {}),
+  };
+  return input;
+}
+
+/**
+ * Score one block via the shared `fs_core` wasm kernel and return the pairs
+ * at/above `threshold` as `ScoredPair`s (scores rounded to 4dp — the same
+ * convention Python-native and the pure-TS scorer use). Caller guarantees
+ * `fsRerouteEligible(mk)`.
+ */
+export function scoreProbabilisticFsBlock(
+  blockRows: readonly Row[],
+  mk: MatchkeyConfig,
+  em: EMResult,
+  threshold: number,
+): ScoredPair[] {
+  if (mk.type !== "probabilistic") return [];
+  if (mk.fields.length === 0 || blockRows.length < 2) return [];
+  const input = buildFsBlockScoringInput(blockRows, mk, em, threshold);
+  const pairs = scoreBlockPairsFs(input);
+  return pairs.map(([a, b, s]) =>
+    makeScoredPair(a, b, Math.round(s * 10000) / 10000),
+  );
+}
+
+/**
+ * Register the FS wasm reroute so `scoreProbabilisticBlocks` (pipeline.ts) runs
+ * the shared kernel for kernel-expressible probabilistic matchkeys. Idempotent.
+ * Mirrors `enableClusterWasm()` / `enableWasm()`.
+ */
+export function enableFsWasmScoring(): void {
+  setFsScoreBackend({
+    eligible: fsRerouteEligible,
+    scoreBlock: scoreProbabilisticFsBlock,
+  });
+}
+
+export { disableFsWasmScoring };

--- a/packages/typescript/goldenmatch/src/core/fsScoreBackend.ts
+++ b/packages/typescript/goldenmatch/src/core/fsScoreBackend.ts
@@ -1,0 +1,77 @@
+/**
+ * fsScoreBackend.ts — lean runtime registry for the Fellegi-Sunter block-scoring
+ * reroute onto the shared `goldenmatch-fs-core` wasm kernel.
+ *
+ * Edge-safe and BUNDLE-LEAN: unlike the heavy `fsScore` / `fsWasm` loaders it
+ * pulls ZERO wasm bytes into the default `core` bundle — it owns only the
+ * registry singleton + the backend shape + an opt-out flag. `pipeline.ts`
+ * (always-on, edge-safe) value-imports ONLY this module; it `import type`s
+ * nothing heavy.
+ *
+ * The heavy `goldenmatch/core/fs-scoring` subpath registers a backend here via
+ * `enableFsWasmScoring()`. When a backend is registered AND the matchkey is
+ * kernel-expressible (`backend.eligible(mk)`), `scoreProbabilisticBlocks` runs
+ * the shared Rust FS kernel — the SAME `fs_core::score_fs_pair` the Python
+ * `goldenmatch-native` wheel runs — so TS FS block scoring aligns byte-for-byte
+ * with Python-native (the #1854 FIXED full-field weight range, not the pure-TS
+ * per-pair shrinking range). Until registered, or for a config the kernel can't
+ * express (embedding / name-refdata / TF fields), the pure-TS
+ * `scoreProbabilistic` runs as the classified, conformance-tested FALLBACK.
+ *
+ * Note on the "default": the reroute is DEFAULT-PREFERRING — the moment the
+ * kernel is loaded (one `enableFsWasmScoring()` call, mirroring the sibling
+ * wasm reroutes) it takes over. It is not statically wired into `core/index`
+ * because `tsup` builds with `splitting:false`, so a static/dynamic import of
+ * the inlined kernel from the edge-safe core would bloat `dist/core/index.js`
+ * with the ~187 KB wasm — the documented "no wasm in the default core bundle"
+ * discipline. `disableFsWasmScoring()` clears it (test isolation / opt-out).
+ */
+import type { Row, MatchkeyConfig, ScoredPair } from "./types.js";
+import type { EMResult } from "./probabilistic.js";
+
+/** The FS block-scoring primitive the wasm reroute implements. */
+export interface FsScoreBackend {
+  /**
+   * True iff `mk` is expressible by the shared `fs_core` kernel (every field +
+   * negative-evidence scorer is one the kernel's `score_one` / `field_similarity`
+   * implements, and no field opts into TF adjustment). When false the caller
+   * MUST use the pure-TS `scoreProbabilistic` fallback.
+   */
+  eligible(mk: MatchkeyConfig): boolean;
+  /**
+   * Score every within-block pair of `blockRows` via the shared FS kernel and
+   * return those at/above `threshold` as `ScoredPair`s (scores rounded to 4dp,
+   * matching Python-native + the pure-TS scorer). `em` is the trained
+   * `EMResult`; normalization uses the FIXED full-field weight range
+   * (`fsWeightRange`), i.e. the Python operating point. Caller guarantees
+   * `eligible(mk)`.
+   */
+  scoreBlock(
+    blockRows: readonly Row[],
+    mk: MatchkeyConfig,
+    em: EMResult,
+    threshold: number,
+  ): ScoredPair[];
+}
+
+let _backend: FsScoreBackend | null = null;
+
+/** Register the wasm FS-scoring backend (called by the opt-in subpath's enable fn). */
+export function setFsScoreBackend(backend: FsScoreBackend): void {
+  _backend = backend;
+}
+
+/** The registered backend, or null when the reroute is not enabled (default). */
+export function getFsScoreBackend(): FsScoreBackend | null {
+  return _backend;
+}
+
+/** Clear the backend — restores the pure-TS path (test isolation / opt-out). */
+export function disableFsWasmScoring(): void {
+  _backend = null;
+}
+
+/** True when the FS wasm reroute is currently registered. */
+export function isFsWasmScoringEnabled(): boolean {
+  return _backend !== null;
+}

--- a/packages/typescript/goldenmatch/src/core/pipeline.ts
+++ b/packages/typescript/goldenmatch/src/core/pipeline.ts
@@ -28,6 +28,7 @@ import {
 } from "./scorer.js";
 import { applyNegativeEvidenceToExactPairs } from "./autoconfigNegativeEvidence.js";
 import { scoreProbabilistic, trainEM } from "./probabilistic.js";
+import { getFsScoreBackend } from "./fsScoreBackend.js";
 import { buildClusters, pairKey } from "./cluster.js";
 import { buildGoldenRecord } from "./golden.js";
 import { postflight } from "./autoconfigVerify.js";
@@ -113,6 +114,17 @@ function scoreProbabilisticBlocks(
   const linked: ScoredPair[] = [];
   const review: ScoredPair[] = [];
 
+  // FS-wasm reroute (fs-default-ts-path PR2): when the shared `fs_core` kernel is
+  // registered (via `enableFsWasmScoring()`) AND the matchkey is kernel-
+  // expressible, score each block through it — the SAME kernel Python-native
+  // runs, so TS FS scoring lands on Python's operating point (FIXED full-field
+  // weight range, the #1854 alignment). Otherwise the pure-TS `scoreProbabilistic`
+  // (per-pair shrinking-range normalization) is the classified fallback. The
+  // kernel path takes no exclude set — the loop's `matchedPairs.has(key)` guard
+  // (matchedPairs IS the exclude set) drops already-matched pairs identically.
+  const fsBackend = getFsScoreBackend();
+  const useKernel = fsBackend !== null && fsBackend.eligible(mk);
+
   for (const block of blocks) {
     if (options.acrossFilesOnly) {
       const sources = new Set(
@@ -124,10 +136,12 @@ function scoreProbabilisticBlocks(
       if (sources.size < 2) continue;
     }
 
-    let pairs = scoreProbabilistic(block.rows, mk, em, {
-      excludePairs: matchedPairs,
-      threshold: reviewThreshold,
-    });
+    let pairs = useKernel
+      ? fsBackend!.scoreBlock(block.rows, mk, em, reviewThreshold)
+      : scoreProbabilistic(block.rows, mk, em, {
+          excludePairs: matchedPairs,
+          threshold: reviewThreshold,
+        });
     if (options.acrossFilesOnly) {
       pairs = pairs.filter(
         (pair) =>

--- a/packages/typescript/goldenmatch/tests/parity/fixtures/fs/fs_block_scoring_ne_banding.json
+++ b/packages/typescript/goldenmatch/tests/parity/fixtures/fs/fs_block_scoring_ne_banding.json
@@ -1,0 +1,149 @@
+{
+  "_comment": "AUTHORED by the Python native score_block_pairs_fs (the oracle) with negative evidence + custom level-banding + a partial-MISSING field. fs-wasm calls the SAME fs-core::score_fs_pair -> byte-identical. This is the fs-default-ts-path PR2 cross-language GATE. No require_positive_evidence / missing_disagree (both default off), matching the fs-wasm entry. Regenerate: python scripts/emit_fs_wasm_fixture.py",
+  "field_values": [
+    [
+      "robert",
+      "robert",
+      "rupert",
+      "robert",
+      "xyzzy"
+    ],
+    [
+      "A1",
+      "A1",
+      "A1",
+      "B2",
+      "Z9"
+    ],
+    [
+      "paris",
+      "paris",
+      null,
+      "london",
+      "tokyo"
+    ]
+  ],
+  "row_ids": [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  "block_sizes": [
+    5
+  ],
+  "scorer_ids": [
+    0,
+    3,
+    0
+  ],
+  "levels": [
+    3,
+    2,
+    2
+  ],
+  "partial_thresholds": [
+    0.8,
+    0.9,
+    0.8
+  ],
+  "match_weights": [
+    [
+      -2.0,
+      0.5,
+      3.0
+    ],
+    [
+      -1.5,
+      2.5
+    ],
+    [
+      -1.0,
+      2.0
+    ]
+  ],
+  "calibrated": false,
+  "prior_w": 0.0,
+  "min_weight": -7.5,
+  "weight_range": 15.0,
+  "threshold": -1000000000.0,
+  "level_thresholds": [
+    [
+      0.95,
+      0.3
+    ],
+    null,
+    null
+  ],
+  "ne_values": [
+    [
+      "1990",
+      "1990",
+      "1985",
+      "1990",
+      "1971"
+    ]
+  ],
+  "ne_scorer_ids": [
+    3
+  ],
+  "ne_thresholds": [
+    0.5
+  ],
+  "ne_weights": [
+    -3.0
+  ],
+  "expected_pairs": [
+    [
+      0,
+      1,
+      1.0
+    ],
+    [
+      0,
+      2,
+      0.5
+    ],
+    [
+      0,
+      3,
+      0.533333
+    ],
+    [
+      0,
+      4,
+      0.0
+    ],
+    [
+      1,
+      2,
+      0.5
+    ],
+    [
+      1,
+      3,
+      0.533333
+    ],
+    [
+      1,
+      4,
+      0.0
+    ],
+    [
+      2,
+      3,
+      0.233333
+    ],
+    [
+      2,
+      4,
+      0.066667
+    ],
+    [
+      3,
+      4,
+      0.0
+    ]
+  ]
+}

--- a/packages/typescript/goldenmatch/tests/parity/fs-wasm.parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/fs-wasm.parity.test.ts
@@ -91,6 +91,64 @@ describe("fs-wasm cross-surface parity", () => {
 });
 
 // ---------------------------------------------------------------------------
+// PR2 cross-language GATE: NE + custom banding + a partial-MISSING field. The
+// fixture (`fs_block_scoring_ne_banding.json`) is AUTHORED by the SAME Python
+// native `score_block_pairs_fs` (the reroute's oracle,
+// `scripts/emit_fs_wasm_fixture.py`) with the level_thresholds + ne_* kwargs the
+// fs-wasm entry marshals — and NO require_positive_evidence / missing_disagree
+// (both default off), so the TS kernel reproduces Python-native EXACTLY. This is
+// the case where the reroute's FIXED full-field normalization differs from the
+// pure-TS per-pair shrinking range — the intended #1854 alignment.
+// ---------------------------------------------------------------------------
+interface NeBandingFixture extends Fixture {
+  level_thresholds: (number[] | null)[];
+  ne_values: (string | null)[][];
+  ne_scorer_ids: number[];
+  ne_thresholds: number[];
+  ne_weights: number[];
+}
+
+const neFixture: NeBandingFixture = JSON.parse(
+  readFileSync(
+    resolve(here, "fixtures/fs/fs_block_scoring_ne_banding.json"),
+    "utf8",
+  ),
+);
+
+describe("fs-wasm NE + banding + missing cross-surface parity", () => {
+  it("reproduces the native score_block_pairs_fs oracle with NE + custom banding + a missing field", () => {
+    const pairs = scoreBlockPairsFs({
+      rowIds: neFixture.row_ids,
+      blockSizes: neFixture.block_sizes,
+      fieldValues: neFixture.field_values,
+      scorerIds: neFixture.scorer_ids,
+      levels: neFixture.levels,
+      partialThresholds: neFixture.partial_thresholds,
+      matchWeights: neFixture.match_weights,
+      calibrated: neFixture.calibrated,
+      priorW: neFixture.prior_w,
+      minWeight: neFixture.min_weight,
+      weightRange: neFixture.weight_range,
+      threshold: neFixture.threshold,
+      levelThresholds: neFixture.level_thresholds,
+      neValues: neFixture.ne_values,
+      neScorerIds: neFixture.ne_scorer_ids,
+      neThresholds: neFixture.ne_thresholds,
+      neWeights: neFixture.ne_weights,
+    });
+
+    const got = pairs
+      .map(([a, b, s]) => [a, b, Number(s.toFixed(6))] as const)
+      .sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+    const want = neFixture.expected_pairs
+      .map(([a, b, s]) => [a, b, Number(s.toFixed(6))] as const)
+      .sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+
+    expect(got).toEqual(want);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ADDITIVE-marshaling proof: the widened fs-wasm entry carries Fellegi-Sunter
 // negative evidence + custom level-banding through to the shared
 // `fs_core::score_fs_pair` kernel. Oracle = the pure-TS `scoreProbabilistic`

--- a/packages/typescript/goldenmatch/tests/unit/fs-reroute.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/fs-reroute.test.ts
@@ -1,0 +1,215 @@
+/**
+ * fs-reroute.test.ts — the fs-default-ts-path PR2 reroute: the fs-wasm FS kernel
+ * as the SOURCE OF TRUTH for TS probabilistic scoring, with pure-TS
+ * `scoreProbabilistic` as the fallback.
+ *
+ * Covers: (1) eligibility gating, (2) the lean registry (default-off + enable/
+ * disable), (3) the adapter builds correct kernel inputs (kernel-path == pure-TS
+ * on a fully-observed block, where the two normalizations coincide), (4) the
+ * intended #1854 DIVERGENCE on a partial-missing block (fixed full-field range
+ * vs pure-TS per-pair shrinking range), (5) the pipeline reroute is wired and
+ * behavior-preserving where the normalizations coincide.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { MatchkeyConfig, Row } from "../../src/core/index.js";
+import { runDedupePipeline, makeConfig, makeBlockingConfig } from "../../src/core/index.js";
+import {
+  fallbackResult,
+  scoreProbabilistic,
+} from "../../src/core/probabilistic.js";
+import {
+  fsRerouteEligible,
+  buildFsBlockScoringInput,
+  scoreProbabilisticFsBlock,
+  enableFsWasmScoring,
+  disableFsWasmScoring,
+} from "../../src/core/fsScore.js";
+import {
+  getFsScoreBackend,
+  isFsWasmScoringEnabled,
+} from "../../src/core/fsScoreBackend.js";
+
+afterEach(() => {
+  // The registry is a module singleton — clear it so the reroute never leaks
+  // into other test files (which expect the pure-TS default).
+  disableFsWasmScoring();
+});
+
+function round4(pairs: readonly { idA: number; idB: number; score: number }[]) {
+  return pairs
+    .map((p) => [p.idA, p.idB, Number(p.score.toFixed(4))] as const)
+    .sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+}
+
+describe("fsRerouteEligible", () => {
+  const base = (fields: MatchkeyConfig["fields"], extra: Partial<MatchkeyConfig> = {}): MatchkeyConfig => ({
+    name: "mk",
+    type: "probabilistic",
+    fields,
+    ...extra,
+  }) as MatchkeyConfig;
+
+  it("accepts kernel-expressible field scorers", () => {
+    for (const scorer of ["jaro_winkler", "levenshtein", "token_sort", "exact", "ensemble"]) {
+      expect(
+        fsRerouteEligible(base([{ field: "f", transforms: [], scorer, weight: 1 }])),
+      ).toBe(true);
+    }
+  });
+
+  it("declines embedding / name-refdata / tf-adjustment fields (kernel can't express on TS)", () => {
+    expect(fsRerouteEligible(base([{ field: "f", transforms: [], scorer: "embedding", weight: 1 }]))).toBe(false);
+    expect(fsRerouteEligible(base([{ field: "f", transforms: [], scorer: "record_embedding", weight: 1 }]))).toBe(false);
+    expect(fsRerouteEligible(base([{ field: "f", transforms: [], scorer: "name_freq_weighted_jw", weight: 1 }]))).toBe(false);
+    expect(fsRerouteEligible(base([{ field: "f", transforms: [], scorer: "soundex_match", weight: 1 }]))).toBe(false);
+    expect(
+      fsRerouteEligible(base([{ field: "f", transforms: [], scorer: "jaro_winkler", weight: 1, tfAdjustment: true }])),
+    ).toBe(false);
+  });
+
+  it("declines when a negative-evidence field uses a non-kernel scorer", () => {
+    const mk = base(
+      [{ field: "f", transforms: [], scorer: "jaro_winkler", weight: 1 }],
+      { negativeEvidence: [{ field: "dob", scorer: "embedding", transforms: [], threshold: 0.5 }] },
+    );
+    expect(fsRerouteEligible(mk)).toBe(false);
+  });
+
+  it("declines non-probabilistic and empty-field matchkeys", () => {
+    expect(fsRerouteEligible({ name: "x", type: "exact", fields: [{ field: "e", transforms: [], scorer: "exact", weight: 1 }] } as MatchkeyConfig)).toBe(false);
+    expect(fsRerouteEligible(base([]))).toBe(false);
+  });
+});
+
+describe("fs-scoring lean registry", () => {
+  it("is default-off and enable/disable toggles it", () => {
+    expect(getFsScoreBackend()).toBeNull();
+    expect(isFsWasmScoringEnabled()).toBe(false);
+    enableFsWasmScoring();
+    expect(getFsScoreBackend()).not.toBeNull();
+    expect(isFsWasmScoringEnabled()).toBe(true);
+    disableFsWasmScoring();
+    expect(getFsScoreBackend()).toBeNull();
+  });
+});
+
+// A fully-observed NE + custom-banding block (mirrors the fs-wasm additive parity
+// setup): every field present, band edges chosen so the mid-band similarity can't
+// flip a level, so the kernel's FIXED full-field range EQUALS the pure-TS per-pair
+// range (all fields observed) -> the reroute reproduces pure-TS exactly here.
+const observedRows: Row[] = [
+  { __row_id__: 0, name: "robert", code: "A1", dob: "1990" },
+  { __row_id__: 1, name: "robert", code: "A1", dob: "1990" },
+  { __row_id__: 2, name: "rupert", code: "A1", dob: "1985" },
+];
+const observedMk: MatchkeyConfig = {
+  name: "fs_ne_banding",
+  type: "probabilistic",
+  fields: [
+    { field: "name", scorer: "jaro_winkler", transforms: [], weight: 1.0, levels: 3, levelThresholds: [0.95, 0.3] },
+    { field: "code", scorer: "exact", transforms: [], weight: 1.0, levels: 2, partialThreshold: 0.9 },
+  ],
+  negativeEvidence: [{ field: "dob", scorer: "exact", transforms: [], threshold: 0.5 }],
+  linkThreshold: 0.5,
+};
+
+describe("fsScore adapter", () => {
+  it("builds a kernel input mirroring the matchkey + EM (ids, banding, NE marshaling)", () => {
+    const em = fallbackResult(observedMk);
+    const input = buildFsBlockScoringInput(
+      observedRows,
+      observedMk as Extract<MatchkeyConfig, { type: "probabilistic" }>,
+      em,
+      0.0,
+    );
+    // scorer ids: jaro_winkler=0, exact=3.
+    expect(input.scorerIds).toEqual([0, 3]);
+    expect(input.levels).toEqual([3, 2]);
+    // custom banding carried for name only (null for the default-banded code).
+    expect(input.levelThresholds).toEqual([[0.95, 0.3], null]);
+    // NE marshaled: exact scorer (3), threshold 0.5, fired weight = EM __ne__dob[0].
+    expect(input.neScorerIds).toEqual([3]);
+    expect(input.neThresholds).toEqual([0.5]);
+    expect(input.neWeights).toEqual([em.matchWeights["__ne__dob"]![0]]);
+    // linear normalization (posterior stays host-side).
+    expect(input.calibrated).toBe(false);
+    expect(input.priorW).toBe(0);
+    expect(input.blockSizes).toEqual([observedRows.length]);
+  });
+
+  it("reproduces pure-TS scoreProbabilistic on a fully-observed block (normalizations coincide)", () => {
+    const em = fallbackResult(observedMk);
+    const kernel = round4(scoreProbabilisticFsBlock(observedRows, observedMk, em, 0.0));
+    const pureTs = round4(scoreProbabilistic(observedRows, observedMk, em, { threshold: 0.0 }));
+    expect(kernel.length).toBe(3);
+    expect(kernel).toEqual(pureTs);
+  });
+
+  it("DIVERGES from pure-TS on a partial-missing block (the #1854 fixed-range alignment)", () => {
+    // city is null on row 2 -> pure-TS normalizes that pair over a SHRUNKEN
+    // per-pair range (city excluded), while the kernel uses the FIXED full-field
+    // range -> different normalized scores for pairs touching the missing cell.
+    const rows: Row[] = [
+      { __row_id__: 0, name: "robert", city: "paris" },
+      { __row_id__: 1, name: "robert", city: "paris" },
+      { __row_id__: 2, name: "robert", city: null },
+    ];
+    const mk: MatchkeyConfig = {
+      name: "fs_missing",
+      type: "probabilistic",
+      fields: [
+        { field: "name", scorer: "jaro_winkler", transforms: [], weight: 1.0, levels: 2, partialThreshold: 0.8 },
+        { field: "city", scorer: "jaro_winkler", transforms: [], weight: 1.0, levels: 2, partialThreshold: 0.8 },
+      ],
+      linkThreshold: 0.5,
+    };
+    const em = fallbackResult(mk);
+    const kernel = round4(scoreProbabilisticFsBlock(rows, mk, em, -1));
+    const pureTs = round4(scoreProbabilistic(rows, mk, em, { threshold: -1 }));
+    // The (0,2)/(1,2) pairs (city missing) must score DIFFERENTLY under the two
+    // normalizations; the fully-observed (0,1) pair is identical.
+    expect(kernel).not.toEqual(pureTs);
+    const p01k = kernel.find((p) => p[0] === 0 && p[1] === 1)!;
+    const p01t = pureTs.find((p) => p[0] === 0 && p[1] === 1)!;
+    expect(p01k[2]).toBe(p01t[2]);
+    const p02k = kernel.find((p) => p[0] === 0 && p[1] === 2)!;
+    const p02t = pureTs.find((p) => p[0] === 0 && p[1] === 2)!;
+    expect(p02k[2]).not.toBe(p02t[2]);
+  });
+});
+
+describe("pipeline reroute wiring", () => {
+  it("uses the kernel when enabled and is behavior-preserving on a fully-observed block", async () => {
+    const rows: Row[] = [
+      { name: "John", zip: "x" },
+      { name: "Jon", zip: "x" },
+      { name: "John", zip: "x" },
+      { name: "Mary", zip: "y" },
+      { name: "Mary", zip: "y" },
+    ];
+    const mk: MatchkeyConfig = {
+      name: "fs",
+      type: "probabilistic",
+      fields: [{ field: "name", transforms: [], scorer: "jaro_winkler", weight: 1, levels: 3, partialThreshold: 0.8 }],
+      linkThreshold: 0.5,
+    };
+    const config = makeConfig({
+      matchkeys: [mk],
+      blocking: makeBlockingConfig({ strategy: "static", keys: [{ fields: ["zip"], transforms: [] }] }),
+    });
+
+    // Fully-observed single-field block: kernel FIXED range == pure-TS per-pair
+    // range, so clustering is identical whether the reroute is on or off — proves
+    // the branch is wired AND safe.
+    disableFsWasmScoring();
+    const off = await runDedupePipeline(rows, config);
+    enableFsWasmScoring();
+    expect(isFsWasmScoringEnabled()).toBe(true);
+    const on = await runDedupePipeline(rows, config);
+
+    const clusterSig = (r: Awaited<ReturnType<typeof runDedupePipeline>>) =>
+      [...r.clusters.values()].map((c) => [...c.members].sort((a, b) => a - b)).sort((a, b) => (a[0] ?? 0) - (b[0] ?? 0));
+    expect(clusterSig(on)).toEqual(clusterSig(off));
+    expect(round4(on.scoredPairs)).toEqual(round4(off.scoredPairs));
+  });
+});

--- a/packages/typescript/goldenmatch/tsup.config.ts
+++ b/packages/typescript/goldenmatch/tsup.config.ts
@@ -53,6 +53,13 @@ export default defineConfig({
     // wheel. ~187 KB inlined base64 as a separate subpath
     // (`goldenmatch/core/fs-wasm`), out of the default core bundle.
     "core/fsWasm": "src/core/fsWasm.ts",
+    // Opt-in entry: the FS block-scoring REROUTE adapter — builds the kernel
+    // inputs from (rows, matchkey, EMResult) and registers the fs-wasm backend
+    // (`enableFsWasmScoring()`), so the probabilistic pipeline runs the shared
+    // fs-core kernel. Imports `fsWasm` (the inlined ~187 KB wasm), so it stays a
+    // separate subpath (`goldenmatch/core/fs-scoring`), out of the default core
+    // bundle.
+    "core/fsScore": "src/core/fsScore.ts",
     "node/index": "src/node/index.ts",
     "node/mcp/server": "src/node/mcp/server.ts",
     "node/a2a/server": "src/node/a2a/server.ts",


### PR DESCRIPTION
## What and why

**PR 2 of 2** for the last thesis item, `fs-default-ts-path`. Makes the shared Rust `fs-core` kernel (via `fs-wasm`) the source of truth for TS Fellegi-Sunter block scoring, with pure-TS `scoreProbabilistic` retained intact as the classified fallback. Both drive the identical `fs_core::score_fs_pair`, so **TS == Python-native by construction** — TS lands on Python's operating point (the #1854 FIXED full-field weight range vs the old pure-TS per-pair shrinking range).

## Changes

- **`fsScoreBackend.ts`** (new) — lean, edge-safe registry (zero wasm bytes in the default core bundle); `pipeline.ts` value-imports only this.
- **`fsScore.ts`** (new, heavy `./core/fs-scoring` subpath) — the adapter: `buildFsBlockScoringInput` mirrors Python's `_score_fs_native_frame` (scorerIds/levels/partialThresholds/matchWeights, `fsWeightRange` FIXED range, `levelThresholds`, NE arrays), `scoreProbabilisticFsBlock`, `fsRerouteEligible`, `enableFsWasmScoring`.
- **`pipeline.ts`** — `scoreProbabilisticBlocks` scores each block through the kernel when a backend is registered **and** `eligible(mk)`, else pure-TS. Exclude set preserved via the `matchedPairs` guard.
- **`tsup`/`package.json`** — new `core/fsScore` entry + `./core/fs-scoring` subpath so the ~187 KB wasm never enters `dist/core/index.js`.
- **`emit_fs_wasm_fixture.py`** — extended to emit the NE+banding+missing gate fixture from the native kernel.

## Cross-language parity gate (proven)

`scoreBlockPairsFs` (TS) == `score_block_pairs_fs` (Python-native) to **6 dp** on a block with custom level-banding + a missing cell + a firing negative-evidence field (all 10 pairs). The adapter matches pure-TS on fully-observed blocks and diverges on partial-missing (the intended #1854 alignment). `cargo test fs-core` 20 passed; `tsc` clean; new fs tests 14 passed; **full `vitest` 3525 passed, no regressions** (registry default-off, so the existing suite exercises the pure-TS path unchanged).

## ⚠️ Design decision needed — opt-in vs bundle-default-on

This ships as **opt-in / default-preferring** (the kernel takes over after one `enableFsWasmScoring()` call), **not** statically bundle-default-on — because `tsup` builds `splitting:false` and the edge-safe `core` bundle has a documented "no wasm bytes" discipline that **every** sibling wasm reroute (cluster/graph/fingerprint/hnsw/suggest) respects. True default-on for every `dedupe()` caller would need a structural change (a batteries-included non-edge entry that auto-enables it, keeping `goldenmatch/core` lean), which also flips TS's default F1 for all callers. That's the owner call; see the linked discussion. The thesis-ledger update is deferred until that's decided.

## Checklist

- [x] Tests added/updated and passing (cargo + full vitest); cross-language parity proven
- [x] Default path unchanged (registry default-off); pure-TS fallback retained
- [ ] Package `CHANGELOG.md` — pending the opt-in-vs-default decision
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_