### PR TITLE
feat(matchkey): field-level guards (weighted drop-and-renormalize) + polars-free capture

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4282,6 +4282,7 @@
             "_ensemble_score_single",
             "_ensemble_score_single_f32",
             "_exact_score_matrix",
+            "_field_guard_mask",
             "_filter_target_ids_df",
             "_find_exact_match_ids",
             "_fuzzy_score_matrix",

--- a/docs/superpowers/specs/2026-07-26-guarded-matchkeys-design.md
+++ b/docs/superpowers/specs/2026-07-26-guarded-matchkeys-design.md
@@ -66,9 +66,14 @@ tested carefully, and rejected loudly meanwhile so nothing is silently ignored).
   post-filter on the emitted pairs (uniform across the exact / bucket-fast / slow scoring paths). This is the
   headline SSN-placeholder case. A guard on a **probabilistic** matchkey raises a clear "planned follow-up" config
   error (the FS pair stream needs its own post-filter seam).
-- **Field-level** (`MatchkeyField.guard`) — DEFERRED. Well-defined only on **weighted** matchkeys (a guard-failing
-  field drops out of the weighted average, remaining weights renormalize); exact/probabilistic have no per-field
-  weight to renormalize. Raises a clear "planned follow-up" config error in v1.
+- **Field-level** (`MatchkeyField.guard`) — SHIPPED for **weighted** matchkeys. A guard-failing field drops out of
+  the weighted average and the remaining weights renormalize; if every field's guard fails, the pair is not
+  emitted. Implemented as a per-pair mask folded into each field's `valid` weighting term in `find_fuzzy_matches`
+  (a dropped field contributes 0 to BOTH the numerator and the denominator, so renormalization is automatic);
+  weighted matchkeys carrying a field guard route off the vectorized bucket path onto that slow path. Field-level
+  guards on **exact / probabilistic** matchkeys raise a clear config error (no per-field weight to renormalize).
+  Guards should be SYMMETRIC in a/b; the per-pair mask is `O(block²)` in guard evaluations, acceptable because
+  blocks are bounded (a columnar lowering is the future lever).
 
 ### Implementation seam (no kernel; uniform pair post-filter)
 
@@ -122,9 +127,9 @@ future optimization if a measured at-scale workload needs it.
 
 ## Boundaries (stated honestly)
 
-- **v1 = matchkey-level guards on exact + weighted matchkeys.** Field-level guards and probabilistic-matchkey
-  guards raise a clear "planned follow-up" config error — they are defined in the schema but not yet applied, so
-  a guard is never silently ignored.
+- **Shipped:** matchkey-level guards on exact + weighted matchkeys; field-level guards on weighted matchkeys.
+  Probabilistic-matchkey guards and field-level guards on exact/probabilistic raise a clear config error —
+  defined in the schema, not yet applied, so a guard is never silently ignored.
 - The guard is a per-pair post-filter over the guard's referenced columns; it's cheap but not vectorized (same
   cost profile as negative evidence). Columnar lowering is the future lever if an at-scale workload needs it.
 - TypeScript parity is a declared follow-up gap (config-schema fields are not an `api_parity`-gated surface).

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -704,11 +704,12 @@ class MatchkeyConfig(BaseModel):
                         "EM-learned NE weights; set penalty_bits to override."
                     )
         # Guards: parse + require a_/b_ prefixes at config time (column existence
-        # is checked later, where the frame's columns are known). v1 wires
-        # matchkey-level guards on exact + weighted matchkeys. Probabilistic
-        # matchkey guards and field-level guards (weighted-average
-        # drop-and-renormalize) are a planned follow-up -- reject them here so a
-        # guard is never SILENTLY ignored. Spec:
+        # is checked later, where the frame's columns are known). Matchkey-level
+        # guards are wired on exact + weighted; field-level guards are wired on
+        # weighted matchkeys (a guard-failing field drops out of the weighted
+        # average). Probabilistic matchkey guards and field-level guards on
+        # exact/probabilistic are a planned follow-up -- rejected here so a guard
+        # is never SILENTLY ignored. Spec:
         # docs/superpowers/specs/2026-07-26-guarded-matchkeys-design.md.
         from goldenmatch.core.guard import GuardError, guard_columns
 
@@ -734,12 +735,13 @@ class MatchkeyConfig(BaseModel):
                 raise ValueError(
                     f"Matchkey '{self.name}' field '{f.field}': {exc}"
                 ) from None
-            raise ValueError(
-                f"Matchkey '{self.name}' field '{f.field}': field-level guards "
-                "(dropping a field from the weighted average when its guard fails) "
-                "are a planned follow-up and not yet applied. Use the matchkey-level "
-                "'guard' to gate the whole matchkey for now."
-            )
+            if self.type != "weighted":
+                raise ValueError(
+                    f"Matchkey '{self.name}' (type={self.type!r}): field-level guards "
+                    f"(field '{f.field}') are only valid on weighted matchkeys (they "
+                    "drop a field from the weighted average). Use the matchkey-level "
+                    "'guard' to gate an exact/probabilistic matchkey."
+                )
         return self
 
     # ── Typed accessors ──

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2779,16 +2779,23 @@ def _run_dedupe_pipeline(
     # column breaks the quality scanner). No-op when no matchkey carries a guard.
     _raw_guard_values: dict[str, dict[int, Any]] = {}
     _guard_cols = _collect_guard_columns(matchkeys)
-    if _guard_cols and hasattr(combined_lf, "collect_schema"):
+    if _guard_cols:
+        # Read through the arrow-native seam (to_frame + Column protocol), NOT
+        # polars-specific ``collect_schema`` / ``.select`` / ``[c]`` indexing:
+        # goldenmatch ships polars-free and combined_lf is a seam frame on the
+        # arrow path. ``.collect()`` is the standard lazy->eager (safe on both
+        # reps); an already-materialized seam frame has no ``collect``.
         try:
-            _schema_names = set(combined_lf.collect_schema().names())
-            _want = [c for c in sorted(_guard_cols) if c in _schema_names]
-            if _want and "__row_id__" in _schema_names:
-                _snap = combined_lf.select(["__row_id__", *_want]).collect()
-                _rids = _snap["__row_id__"].to_list()
+            from goldenmatch.core.frame import to_frame as _to_frame_guard
+            _src = combined_lf.collect() if hasattr(combined_lf, "collect") else combined_lf
+            _gf = _to_frame_guard(_src)
+            _names = set(_gf.columns)
+            _want = [c for c in sorted(_guard_cols) if c in _names]
+            if _want and "__row_id__" in _names:
+                _rids = _gf.column("__row_id__").to_list()
                 for c in _want:
-                    _raw_guard_values[c] = dict(zip(_rids, _snap[c].to_list()))
-        except Exception:  # noqa: BLE001 -- best-effort; guard falls back to prepared col
+                    _raw_guard_values[c] = dict(zip(_rids, _gf.column(c).to_list()))
+        except Exception:  # noqa: BLE001 -- best-effort; guarded pairs fail closed
             _raw_guard_values = {}
 
     # ── Attack C cache lookup (map_elements spec Tier 2): quality + transform
@@ -3377,6 +3384,13 @@ def _run_dedupe_pipeline(
     _weighted_mks = [m for m in matchkeys if m.type == "weighted"]
     _last_weighted_mk = _weighted_mks[-1] if _weighted_mks else None
     _has_probabilistic_pass = any(m.type == "probabilistic" for m in matchkeys)
+    # Publish the raw guard-value snapshot so find_fuzzy_matches can build a
+    # field-level guard's per-pair mask off pre-prep values (module global; the
+    # block-scorer thread pool shares it). Every dedupe call overwrites this
+    # here, so a value never leaks meaningfully across runs; reset to {} right
+    # after the fuzzy stage below.
+    from goldenmatch.core import scorer as _scorer_mod
+    _scorer_mod._active_raw_guard_values = _raw_guard_values
     with stage("fuzzy_scoring"):
         for mk in matchkeys:
             if mk.type == "weighted":
@@ -3396,7 +3410,11 @@ def _run_dedupe_pipeline(
                 # memory on Linux runners (7 consecutive 5M bench runs
                 # hung at 62.99 GB RSS plateau before reaching real
                 # scoring).
-                if _use_bucket_scorer(config, collected_df):
+                # A field-level guard drops a field from the weighted average
+                # per pair -- implemented in find_fuzzy_matches (the slow path),
+                # so route such matchkeys off the vectorized bucket scorer.
+                _mk_field_guarded = any(f.guard for f in mk.fields)
+                if _use_bucket_scorer(config, collected_df) and not _mk_field_guarded:
                     from goldenmatch.backends.score_buckets import score_buckets
                     pairs = score_buckets(
                         collected_df,
@@ -3579,6 +3597,10 @@ def _run_dedupe_pipeline(
                     )
                 all_pairs.extend(pairs)
                 fuzzy_pair_count += len(pairs)
+
+    # Field-level guards consumed the raw snapshot above; clear the module global
+    # so it never lingers past this run.
+    _scorer_mod._active_raw_guard_values = {}
 
     record_metrics({
         "fuzzy_pair_count": fuzzy_pair_count,

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -715,6 +715,59 @@ def _apply_guard_to_exact_pairs(  # pyright: ignore[reportUnusedFunction]  # cal
     return filtered
 
 
+# Set by core/pipeline before scoring a weighted matchkey that carries
+# field-level guards, so find_fuzzy_matches can read RAW (pre-prep) values by
+# __row_id__ when building a field's guard mask. ThreadPoolExecutor workers
+# share this module global; matchkeys are scored sequentially in the pipeline
+# loop, so there is no cross-matchkey contamination.
+_active_raw_guard_values: dict[str, dict[int, Any]] = {}
+
+
+def _field_guard_mask(
+    guard_expr: str, row_ids: list, block_df: Any,
+) -> np.ndarray:
+    """Per-pair boolean mask (n x n) for a field-level guard.
+
+    ``mask[i, j]`` is True when the guard holds for the (row i, row j) pair.
+    Values come from the RAW snapshot (``_active_raw_guard_values``, by
+    ``__row_id__``) when available, else the prepared block column read through
+    the arrow-native ``to_frame`` + Column seam (NOT polars ``[c]`` indexing --
+    goldenmatch is polars-free). The guard should be SYMMETRIC in a/b (the a/b
+    assignment within an emitted pair is not canonically ordered).
+    """
+    import numpy as _np
+
+    from goldenmatch.core.frame import to_frame as _to_frame_guard
+    from goldenmatch.core.guard import guard_columns, guard_passes
+
+    cols = guard_columns(guard_expr)
+    n = len(row_ids)
+    _bf = _to_frame_guard(block_df)
+    _bf_names = set(_bf.columns)
+    prepared = {c: _bf.column(c).to_list() for c in cols if c in _bf_names}
+
+    def _rec(i: int) -> dict:
+        rid = row_ids[i]
+        rec: dict = {}
+        for c in cols:
+            raw = _active_raw_guard_values.get(c)
+            if raw is not None and rid in raw:
+                rec[c] = raw[rid]
+            elif c in prepared:
+                rec[c] = prepared[c][i]
+        return rec
+
+    recs = [_rec(i) for i in range(n)]
+    mask = _np.zeros((n, n), dtype=bool)
+    for i in range(n):
+        ri = recs[i]
+        for j in range(i + 1, n):
+            if guard_passes(guard_expr, cols, ri, recs[j]):
+                mask[i, j] = True
+                mask[j, i] = True
+    return mask
+
+
 def find_exact_matches(
     lf: Any, mk: MatchkeyConfig
 ) -> list[tuple[int, int, float]]:
@@ -1655,6 +1708,12 @@ def find_fuzzy_matches(
         else:  # alias_match
             scores = _alias_score_matrix(values)
 
+        # Field-level guard: drop this field for pairs whose guard fails (it
+        # contributes 0 to BOTH numerator and denominator, so the weighted
+        # average renormalizes over the surviving fields automatically).
+        if f.guard:
+            valid = valid & _field_guard_mask(f.guard, row_ids, block_df)
+
         cheap_numerator += scores * _w(f) * valid
         cheap_denominator += _w(f) * valid
 
@@ -1728,6 +1787,8 @@ def find_fuzzy_matches(
                     )
                     emb_row_null &= np.array([v is None for v in col_vals])
                 emb_valid = ~(emb_row_null[:, None] | emb_row_null[None, :])
+                if f.guard:
+                    emb_valid = emb_valid & _field_guard_mask(f.guard, row_ids, block_df)
                 fuzzy_numerator += scores * _w(f) * emb_valid
                 fuzzy_denominator += _w(f) * emb_valid
             else:
@@ -1740,6 +1801,10 @@ def find_fuzzy_matches(
                     values, f.scorer, model_name=f.model or "all-MiniLM-L6-v2",
                     tf_freqs=getattr(f, "tf_freqs", None),
                 )
+
+                # Field-level guard: drop this field for guard-failing pairs.
+                if f.guard:
+                    valid = valid & _field_guard_mask(f.guard, row_ids, block_df)
 
                 fuzzy_numerator += scores * _w(f) * valid
                 fuzzy_denominator += _w(f) * valid

--- a/packages/python/goldenmatch/tests/nopolars/test_polars_absent.py
+++ b/packages/python/goldenmatch/tests/nopolars/test_polars_absent.py
@@ -146,3 +146,40 @@ def test_blocking_risk_arrow_is_polars_free() -> None:
     assert risk is not None and "state" in risk
     assert abs(risk["state"] - 0.25) < 1e-9
     assert "polars" not in sys.modules
+
+
+def test_guarded_matchkey_arrow_is_polars_free() -> None:
+    """A guarded matchkey runs on a ``pa.Table`` polars-free. The pipeline's
+    raw-value capture (for the guard's ``a_``/``b_`` predicate) reads through the
+    arrow-native ``to_frame`` + Column seam, NOT polars ``collect_schema`` /
+    ``.select`` / ``[c]`` indexing -- so a guard evaluates correctly with polars
+    absent. Guarded configs are never exercised by the zero-config cases above,
+    so this is the only lane that covers the guard capture path polars-free."""
+    import goldenmatch as gm
+    import pyarrow as pa
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    # rows 0,1 share the placeholder ssn (guard must suppress); 2,3 share a real
+    # ssn (guard holds -> merge).
+    df = pa.table({
+        "ssn": ["000-00-0000", "000-00-0000", "111-22-3333", "111-22-3333"],
+        "name": ["A", "B", "C", "D"],
+    })
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="ssn", type="exact", fields=[MatchkeyField(field="ssn")],
+            guard="a_ssn != '000-00-0000' and b_ssn != '000-00-0000'",
+        )],
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["ssn"])]),
+    )
+    result = gm.dedupe_df(df, config=cfg)
+    # placeholder pair NOT merged; real-ssn pair merged
+    assert _cluster_of(result.clusters, 0) != _cluster_of(result.clusters, 1)
+    assert _cluster_of(result.clusters, 2) == _cluster_of(result.clusters, 3)
+    assert "polars" not in sys.modules

--- a/packages/python/goldenmatch/tests/test_guarded_matchkeys.py
+++ b/packages/python/goldenmatch/tests/test_guarded_matchkeys.py
@@ -84,12 +84,19 @@ def test_probabilistic_matchkey_guard_deferred():
         )
 
 
-def test_field_level_guard_deferred():
-    with pytest.raises(ValueError, match="planned follow-up"):
+def test_field_level_guard_accepted_on_weighted():
+    MatchkeyConfig(
+        name="w", type="weighted", threshold=0.8,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0,
+                              guard="a_country == b_country")],
+    )
+
+
+def test_field_level_guard_rejected_on_exact():
+    with pytest.raises(ValueError, match="only valid on weighted"):
         MatchkeyConfig(
-            name="w", type="weighted", threshold=0.8,
-            fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0,
-                                  guard="a_country == b_country")],
+            name="e", type="exact",
+            fields=[MatchkeyField(field="ssn", guard="a_country == b_country")],
         )
 
 
@@ -200,3 +207,44 @@ def test_weighted_guard_suppresses_cross_country_match():
     multi = _run(df, cfg)
     assert [0, 1] in multi          # same country -> merged
     assert all(2 not in c for c in multi)   # CA row never merged across the border
+
+
+# ── field-level guard (drop-and-renormalize) ─────────────────────────────────
+
+
+def _two_field_cfg(email_guard):
+    fields = [
+        MatchkeyField(field="name", scorer="jaro_winkler", weight=0.5),
+        MatchkeyField(field="email", scorer="exact", weight=0.5,
+                      **({"guard": email_guard} if email_guard else {})),
+    ]
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="ne", type="weighted", threshold=0.75, fields=fields)],
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["zip"])]),
+    )
+
+
+_ROLE = "a_email not in ('info@x.com', 'sales@x.com') and b_email not in ('info@x.com', 'sales@x.com')"
+
+
+def test_field_guard_drops_field_and_renormalizes():
+    # Same name, different role emails. Without the guard the exact-email
+    # mismatch drags the weighted average to 0.5 (< 0.75) -> no merge. With a
+    # field guard that drops the email field for role addresses, the score
+    # renormalizes to the name-only 1.0 -> merge.
+    df = pl.DataFrame({
+        "id": [0, 1], "name": ["Acme Corp", "Acme Corp"],
+        "email": ["info@x.com", "sales@x.com"], "zip": ["1", "1"],
+    })
+    assert _run(df, _two_field_cfg(None)) == []          # mismatch blocks the merge
+    assert _run(df, _two_field_cfg(_ROLE)) == [[0, 1]]     # guarded field drops out -> merge
+
+
+def test_field_guard_keeps_field_when_guard_holds():
+    # Distinct real emails: the guard holds (neither is a role address), so the
+    # email field is NOT dropped and its exact mismatch still blocks the merge.
+    df = pl.DataFrame({
+        "id": [0, 1], "name": ["Acme Corp", "Acme Corp"],
+        "email": ["ann@acme.com", "bob@acme.com"], "zip": ["1", "1"],
+    })
+    assert _run(df, _two_field_cfg(_ROLE)) == []   # field counted -> mismatch blocks merge


### PR DESCRIPTION
## What and why

Follow-up to #2165 (matchkey-level guards). Two things:

### 1. Field-level guards on weighted matchkeys

A `MatchkeyField.guard` gates whether **that field** participates for a pair. When the pair-predicate fails, the field **drops out of the weighted average** — it contributes 0 to **both** the numerator and the denominator, so the average **renormalizes over the surviving fields automatically**, and if every field's guard fails the pair isn't emitted. E.g. a two-field `name + email` matchkey where the `email` field is guarded to drop for shared role addresses (`info@`, `sales@`): a same-name pair with different role emails merges on name alone, but real distinct emails still count and block the merge.

Implemented as a per-pair mask folded into each field's `valid` weighting term in `find_fuzzy_matches` — the exact seam the null-mask already uses, so **no new scoring math**. Weighted matchkeys carrying a field guard route off the vectorized bucket path onto that slow path. Field-level guards on **exact/probabilistic** still raise a clear error (no per-field weight to renormalize). Schema un-defers field guards on weighted.

### 2. Polars-free guard capture (addresses the review note "there shouldn't be any polars")

goldenmatch is arrow-native and ships **no polars dependency** (`goldenmatch_nopolars` CI lane enforces it). The matchkey-level guard's raw-value capture (merged in #2165) used polars-shaped `collect_schema` / `.select` / `[c]` indexing — and because it only runs when a guard is present, the nopolars lane (which uses no guards) never exercised it, so a guarded config on the polars-free arrow path could silently drop every pair. Rewrote the capture to read through the arrow-native `to_frame` + Column seam (identical on both reps); the field-guard mask reads the same way. Added a **guarded-matchkey case to `tests/nopolars/`** so the lane now covers the guard path with polars uninstalled, and verified a guarded config runs on a `pa.Table` input.

## Testing

- Field-guard drop-and-renormalize end-to-end (+ keeps-field-when-guard-holds), schema accept-on-weighted / reject-on-exact, and the nopolars guarded case. 19 guard + bridge-ledger tests green; scorer + pipeline regression green; `ruff` + `pyright` clean; codemap regenerated.
- **Bridge ledger stays at 6** — the guard filter is raw-values-only (no `_as_polars_df`), and the new capture + field-mask use the dual-rep seam, not a polars bridge.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` + `pyright` clean; no polars coupling (arrow-native seam; nopolars lane covers guards)
- [ ] Package `CHANGELOG.md` — deferred to the next release entry (additive, opt-in)
- [x] No secrets, tokens, or `.env` files committed
- [x] Design spec + codemap updated in lockstep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjdG9DKrLsgnxBetRSeR4x)_