### PR TITLE
fix(bench): surface per-stage peak RSS + fix empty stage breakdown in bench-zero-config

### DIFF
--- a/.github/workflows/bench-zero-config.yml
+++ b/.github/workflows/bench-zero-config.yml
@@ -45,6 +45,10 @@ on:
         description: "Tag for the output filename (e.g. 'post-pr239', 'post-attack-a')"
         required: false
         default: "ad-hoc"
+      columnar:
+        description: "GOLDENMATCH_FS_COLUMNAR_CLUSTER (B2c): blank = code default, '1'/'0' to A/B the flag"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -109,6 +113,10 @@ jobs:
         if: ${{ inputs.frame != '' }}
         run: echo "GOLDENMATCH_FRAME=${{ inputs.frame }}" >> $GITHUB_ENV
 
+      - name: Apply FS columnar-cluster (B2c) override (if set)
+        if: ${{ inputs.columnar != '' }}
+        run: echo "GOLDENMATCH_FS_COLUMNAR_CLUSTER=${{ inputs.columnar }}" >> $GITHUB_ENV
+
       - name: Run bench
         run: |
           .venv/bin/python scripts/bench_1m_zero_config.py \
@@ -140,14 +148,23 @@ jobs:
           print()
           print(f"**{d['wall_seconds_median']:.1f}s** ({d['wall_seconds_min']:.1f}–{d['wall_seconds_max']:.1f}s)")
           print()
-          timings = (d.get("stage_breakdown") or {}).get("timings", {})
-          if timings:
-              print("## bench_capture stage breakdown")
+          sb = d.get("stage_breakdown") or {}
+          # BenchmarkRecorder.to_dict() emits stage_timings_seconds +
+          # stage_peak_rss_kb (the old `.get("timings")` here rendered empty).
+          timings = sb.get("stage_timings_seconds", {})
+          peaks_kb = sb.get("stage_peak_rss_kb", {})
+          if timings or peaks_kb:
+              print("## bench_capture stage breakdown (sorted by peak RSS)")
               print()
-              print("| stage | seconds |")
-              print("|---|---|")
-              for name, secs in sorted(timings.items(), key=lambda kv: -kv[1]):
-                  print(f"| `{name}` | {secs:.2f} |")
+              print("| stage | seconds | peak RSS (MB) |")
+              print("|---|---|---|")
+              order = sorted(set(timings) | set(peaks_kb),
+                             key=lambda k: -(peaks_kb.get(k, 0) or timings.get(k, 0.0) * 1e6))
+              for name in order:
+                  secs = timings.get(name)
+                  ss = f"{secs:.2f}" if secs is not None else "-"
+                  mb = peaks_kb.get(name, 0) / 1024.0
+                  print(f"| `{name}` | {ss} | {mb:.0f} |")
               print()
           top = d.get("cprofile_top") or []
           if top:

--- a/scripts/bench_1m_zero_config.py
+++ b/scripts/bench_1m_zero_config.py
@@ -181,11 +181,24 @@ def main() -> None:
     if not args.skip_stages:
         print("\n[stages run] starting (bench_capture)...")
         stage_wall, stage_dict = run_with_bench_capture(df)
-        timings = stage_dict.get("timings", {})
+        # BenchmarkRecorder.to_dict() emits `stage_timings_seconds` +
+        # `stage_peak_rss_kb` (NOT `timings`); the old `.get("timings")` here and
+        # in the workflow summary silently rendered an EMPTY breakdown and never
+        # surfaced peak RSS -- the whole point of the per-stage attribution.
+        timings = stage_dict.get("stage_timings_seconds", {})
+        peaks_kb = stage_dict.get("stage_peak_rss_kb", {})
         print(f"  wall={stage_wall:.2f}s  ({len(timings)} stages recorded)")
-        for name, secs in sorted(timings.items(), key=lambda kv: -kv[1]):
-            pct = 100.0 * secs / stage_wall if stage_wall else 0.0
-            print(f"  {name:<40s} {secs:>8.2f}s  ({pct:5.1f}%)")
+        # Sort by peak RSS when available (the memory bottleneck), else by wall.
+        order = sorted(
+            set(timings) | set(peaks_kb),
+            key=lambda k: -(peaks_kb.get(k, 0) or (timings.get(k, 0.0) * 1e6)),
+        )
+        for name in order:
+            secs = timings.get(name)
+            pct = 100.0 * secs / stage_wall if (secs and stage_wall) else 0.0
+            peak_mb = peaks_kb.get(name, 0) / 1024.0
+            ws = f"{secs:>8.2f}s ({pct:4.1f}%)" if secs is not None else f"{'-':>8s}        "
+            print(f"  {name:<40s} {ws}  peak_rss={peak_mb:>8.0f} MB")
         metrics = stage_dict.get("metrics", {})
         if metrics:
             print("  metrics:")


### PR DESCRIPTION
The measure-first profiler was blind to the numbers it exists to produce.

`BenchmarkRecorder.to_dict()` emits `stage_timings_seconds` + `stage_peak_rss_kb`, but `bench_1m_zero_config.py` and the `bench-zero-config` workflow summary both read `.get("timings")` — a key that never existed. So the per-stage stage breakdown rendered **empty** ("0 stages recorded") and the per-stage peak RSS the recorder already captures (`ru_maxrss` at each stage exit) was **never surfaced**.

- Reads the correct keys; adds a peak-RSS column, sorted by peak RSS so the dominant stage is obvious.
- Adds a `columnar` workflow input to A/B `GOLDENMATCH_FS_COLUMNAR_CLUSTER` (B2c) — lets the FS columnar-cluster path's per-stage wall + RSS be measured on the 64GB runner.

Additive + dispatch-only; no gating changes. Needed on main to be dispatchable for the FS scale measure-first sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)