### PR TITLE
bench: FS 5M measure-first tooling (5M-safe bench-zero-config + controlled single-mk B2c probe)

### DIFF
--- a/.github/workflows/bench-zero-config.yml
+++ b/.github/workflows/bench-zero-config.yml
@@ -49,6 +49,11 @@ on:
         description: "GOLDENMATCH_FS_COLUMNAR_CLUSTER (B2c): blank = code default, '1'/'0' to A/B the flag"
         required: false
         default: ""
+      skip_cprofile:
+        description: "Skip the cProfile pass (set true at multi-M scale: its per-call overhead is prohibitive and distorts wall)"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -60,7 +65,7 @@ jobs:
     # 64-core variant (gm-bench-64c) provisions but jobs never receive a VM,
     # suspected quota cap on the very large size for newly-created orgs.
     runs-on: large-new-64GB
-    timeout-minutes: 180  # 3 hours; 500K typical ~30 min, 1M ~90 min
+    timeout-minutes: 350  # ~6h ceiling; 5M fixture-gen (~13m) + 5M dedupe passes
     env:
       GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
       # Pin the autoconfig backend threshold so 500K stays on polars-direct
@@ -124,6 +129,7 @@ jobs:
             --runs ${{ inputs.runs }} \
             --output .profile_tmp/bench_${{ inputs.label }}.json \
             --cprofile-output .profile_tmp/bench_${{ inputs.label }}.prof \
+            ${{ inputs.skip_cprofile && '--skip-cprofile' || '' }} \
             --ref "${{ github.sha }}"
 
       - name: Post headline to step summary


### PR DESCRIPTION
Follow-up to #2186. Adds a `skip_cprofile` input (wired to the script's existing `--skip-cprofile`) and bumps the job timeout 180 → 350 min so the FS columnar-cluster (B2c) measure-first A/B can run at 5M. At multi-M scale cProfile's per-call overhead is prohibitive and distorts wall, so it's skipped for those runs. Additive, dispatch-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)