### PR TITLE
chore(golden-suite): 0.3.5 -- bump goldenmatch floor to >=3.10

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.5] - 2026-07-27
+
+- Floor bump: `goldenmatch[polars]>=3.10` (was `>=3.8`). 3.9.0 + 3.10.0 close the
+  MCP surface parity gap in both directions -- +5 core-primitive tools (3.9.0:
+  `score_strings`/`score_pair`/`find_exact_matches`/`find_fuzzy_matches`/`build_clusters`)
+  + 3 host-helper tools (3.10.0: `server_info`/`read_file`/`write_csv`), taking the
+  goldenmatch MCP surface 82 -> 90 tools with `mcp_tools.ts_only` now empty (the TS
+  MCP server is a strict subset of Python). No other member floors changed.
+
 ## [0.3.4] - 2026-07-22
 
 - Floor bump: `goldenmatch[polars]>=3.8`. 3.8.0 adds the opt-in FS columnar-cluster

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.3.4"
+version = "0.3.5"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.8",         # entity resolution: dedupe, match, golden records (>=3.7: zero-config Fellegi-Sunter scale-recall fix — saturation-aware candidate-pair projection + recall-safe identity-field compounding + memory-aware pair budget, F1 0.03->1.0 at 25M single-box; plus out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.10",        # entity resolution: dedupe, match, golden records (>=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.2",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
Lockstep floor bump after the goldenmatch 3.10.0 release. golden-suite `goldenmatch[polars]>=3.8` -> `>=3.10`; version 0.3.4 -> 0.3.5 (pyproject + `__version__` + CHANGELOG in lockstep). No other member floors changed (only Python goldenmatch released this wave). Cut golden-suite 0.3.5 to PyPI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)