### PR TITLE
feat(bench): controlled single-FS-matchkey scale probe (clean B2c A/B)

### DIFF
--- a/.github/workflows/bench-fs-single-mk-probe.yml
+++ b/.github/workflows/bench-fs-single-mk-probe.yml
@@ -1,0 +1,85 @@
+# Controlled single-FS-matchkey scale probe — workflow_dispatch only.
+#
+# Isolates B2c (the FS columnar-cluster path) from the zero-config confounds:
+# pins a FIXED single-probabilistic-matchkey config on the `bucket` route (the
+# exact shape B2c is eligible for) so GOLDENMATCH_FS_COLUMNAR_CLUSTER 1-vs-0 is a
+# clean A/B. Dumps per-stage {wall, peak RSS} on the 64GB runner.
+#
+# To run: GitHub -> Actions -> "bench-fs-single-mk-probe" -> Run workflow.
+name: bench-fs-single-mk-probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      n_records:
+        description: "Synthetic fixture record count"
+        required: false
+        default: "5000000"
+      dupe_rate:
+        description: "Fraction of records that are duplicates (0..1)"
+        required: false
+        default: "0.12"
+      block:
+        description: "Blocking field for the fixed single matchkey"
+        required: false
+        default: "last_name"
+      columnar:
+        description: "GOLDENMATCH_FS_COLUMNAR_CLUSTER (B2c): '1'/'0' to A/B; blank = code default"
+        required: false
+        default: ""
+      label:
+        description: "Tag for the output filename"
+        required: false
+        default: "single-mk"
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: large-new-64GB
+    timeout-minutes: 350
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: pip install uv
+      - name: Sync workspace
+        run: uv sync --all-packages
+      - name: Editable-install goldenmatch (defensive)
+        run: uv pip install -e packages/python/goldenmatch
+      - name: Build native extension (FS native path measurable)
+        run: uv run python scripts/build_native.py
+      - name: Generate ${{ inputs.n_records }}-row fixture
+        run: |
+          mkdir -p .profile_tmp/scale_fixtures
+          .venv/bin/python scripts/scale_audit_5m_generate.py \
+            --n-records ${{ inputs.n_records }} \
+            --dupe-rate ${{ inputs.dupe_rate }} \
+            --output .profile_tmp/scale_fixtures/synthetic_bench.csv
+      - name: Apply FS columnar-cluster (B2c) override (if set)
+        if: ${{ inputs.columnar != '' }}
+        run: echo "GOLDENMATCH_FS_COLUMNAR_CLUSTER=${{ inputs.columnar }}" >> $GITHUB_ENV
+      - name: Run probe
+        run: |
+          set -o pipefail
+          .venv/bin/python scripts/bench_fs_single_mk_probe.py \
+            .profile_tmp/scale_fixtures/synthetic_bench.csv \
+            --block "${{ inputs.block }}" | tee /tmp/probe_${{ inputs.label }}.txt
+          {
+            echo "## bench-fs-single-mk-probe (${{ inputs.label }}, columnar=${{ inputs.columnar }})"
+            echo '```'
+            cat /tmp/probe_${{ inputs.label }}.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload probe output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bench-fs-single-mk-probe-${{ inputs.label }}
+          path: /tmp/probe_${{ inputs.label }}.txt
+          retention-days: 90

--- a/scripts/bench_fs_single_mk_probe.py
+++ b/scripts/bench_fs_single_mk_probe.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""Controlled single-FS-matchkey scale probe — isolates B2c (the FS
+columnar-cluster path) from the zero-config confounds.
+
+The zero-config path at 5M emits a MULTI-matchkey config (exact cols + a
+probabilistic one), which B2c's single-matchkey eligibility gate excludes, so
+`bench-zero-config` can't cleanly measure B2c. This probe pins a FIXED
+single-probabilistic-matchkey config on the `bucket` route — the exact shape
+B2c is eligible for — so `GOLDENMATCH_FS_COLUMNAR_CLUSTER` 1-vs-0 is a real A/B.
+
+Runs one `dedupe_df` under `bench_capture()` with a VmRSS sampler thread and
+dumps per-stage {wall, peak RSS} (reading the recorder's real keys,
+`stage_timings_seconds` / `stage_peak_rss_kb`). Linux only (ru_maxrss / /proc).
+
+Usage:
+    python scripts/bench_fs_single_mk_probe.py <fixture.csv> [--block last_name]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+# env BEFORE importing goldenmatch (native loader reads these)
+os.environ.setdefault("ARROW_DEFAULT_MEMORY_POOL", "system")
+os.environ.setdefault("GOLDENMATCH_NATIVE", "1")
+os.environ.setdefault("GOLDENMATCH_FS_NATIVE", "1")
+
+import resource  # noqa: E402
+
+
+def _vmrss_mb() -> float:
+    for line in Path("/proc/self/status").read_text().splitlines():
+        if line.startswith("VmRSS:"):
+            return int(line.split()[1]) / 1024.0
+    return 0.0
+
+
+class Sampler(threading.Thread):
+    def __init__(self, interval: float = 0.05) -> None:
+        super().__init__(daemon=True)
+        self.interval = interval
+        self.peak = 0.0
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop.is_set():
+            self.peak = max(self.peak, _vmrss_mb())
+            time.sleep(self.interval)
+
+    def halt(self) -> None:
+        self._stop.set()
+        self.join(timeout=1)
+
+
+def _single_mk_config(block_field: str):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="fs", type="probabilistic", fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.85),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.85),
+            MatchkeyField(field="email", scorer="exact", levels=2),
+        ])],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=[block_field])]),
+        backend="bucket",  # the in-memory FS bucket route B2c is eligible for
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("fixture", type=Path)
+    ap.add_argument("--block", default="last_name",
+                    help="blocking field (default last_name — the generator tunes its block sizes)")
+    args = ap.parse_args()
+
+    import polars as pl
+    from goldenmatch.core._native_loader import native_enabled
+    from goldenmatch.core.bench import bench_capture
+
+    try:
+        from goldenmatch import dedupe_df
+    except ImportError:
+        from goldenmatch._api import dedupe_df
+
+    df = pl.read_csv(args.fixture, ignore_errors=True, infer_schema_length=0)
+    for drop in ("id", "cluster_id"):
+        if drop in df.columns:
+            df = df.drop(drop)
+    n = df.height
+    rss_after_load = _vmrss_mb()
+    cfg = _single_mk_config(args.block)
+
+    sampler = Sampler()
+    sampler.start()
+    t0 = time.perf_counter()
+    with bench_capture() as bench:
+        res = dedupe_df(df, config=cfg)
+    wall = time.perf_counter() - t0
+    sampler.halt()
+
+    ru_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    bd = bench.to_dict() if hasattr(bench, "to_dict") else {}
+    timings = bd.get("stage_timings_seconds") or {}
+    peaks_kb = bd.get("stage_peak_rss_kb") or {}
+    metrics = bd.get("metrics") or {}
+
+    columnar = os.environ.get("GOLDENMATCH_FS_COLUMNAR_CLUSTER", "(unset->default)")
+    n_clusters = len(res.clusters or {}) if hasattr(res, "clusters") else "?"
+
+    print(f"=== single-FS-mk probe  N={n:,}  block={args.block} ===")
+    print(f"GOLDENMATCH_FS_COLUMNAR_CLUSTER={columnar}  block_scoring_native={native_enabled('block_scoring')}")
+    print(f"rss_after_load_mb={rss_after_load:.0f}")
+    print(f"dedupe_wall_s={wall:.2f}  clusters={n_clusters}")
+    print(f"peak_rss_sampled_mb={sampler.peak:.0f}  ru_maxrss_mb={ru_peak:.0f}")
+    print(f"peak_over_baseload_mb={sampler.peak - rss_after_load:.0f}")
+    for k in ("record_count", "scored_pair_count", "cluster_count", "block_count"):
+        if k in metrics:
+            print(f"metric {k}={metrics[k]}")
+    print(f"\n{'stage':36s} {'wall_s':>9s} {'peak_rss_mb':>12s}")
+    for k in sorted(set(timings) | set(peaks_kb), key=lambda k: -(peaks_kb.get(k, 0))):
+        t = timings.get(k)
+        p = peaks_kb.get(k, 0) / 1024.0
+        ts = f"{t:.2f}" if isinstance(t, (int, float)) else "-"
+        print(f"  {k:34s} {ts:>9s} {p:>12.0f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The zero-config path at 5M emits a MULTI-matchkey config, which B2c's single-matchkey eligibility gate excludes — so `bench-zero-config` can't cleanly measure the FS columnar-cluster path. This adds `bench_fs_single_mk_probe.py` + `bench-fs-single-mk-probe.yml`: a FIXED single-probabilistic-matchkey config on the bucket route (the exact shape B2c is eligible for), run under `bench_capture` + a VmRSS sampler, dumping per-stage {wall, peak RSS}. `GOLDENMATCH_FS_COLUMNAR_CLUSTER` 1-vs-0 is then a real A/B at 5M.

(Recovers the probe commit that was stranded when #2187 squash-merged its first commit only.)

Additive, dispatch-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)