### PR TITLE
docs(thesis): close undeclared-divergences + deferral-provenance low items

### DIFF
--- a/context-network/decisions/0046-cross-language-phase-handoff-conformance.md
+++ b/context-network/decisions/0046-cross-language-phase-handoff-conformance.md
@@ -81,13 +81,20 @@ name — verified against `main` before recording:
   Reduction/recomposition order, same 1-ULP class as native↔pure-Python. The prior
   row read "byte-identical … with the shared Rust/WASM scorer", which over-claimed for
   these ids.
-- **The default TS Fellegi-Sunter path is pure-TS, not the shared kernel.**
-  `pipeline.ts` scores probabilistic matchkeys via `probabilistic.ts::scoreProbabilistic`;
-  `fs-wasm` (`goldenmatch-fs-core`, `src/core/fsWasm.ts`) exists and passes
-  `tests/parity/fs-wasm.parity.test.ts` but is called by **no pipeline/engine site**.
-  So FS scoring parity rests on the hand-written pure-TS port (at the string-scoring
-  tolerance), not the WASM kernel. Wiring the pipeline to `fs-wasm` is tracked as
-  weakness `fs-default-ts-path-unwired-second-source` (Wave D).
+- **FS scoring: the batteries `goldenmatch` import now runs the shared kernel by
+  default** (RESOLVED, Wave D, 2026-07-27). `pipeline.ts` reroutes probabilistic
+  block scoring onto the shared `fs-core` kernel via the `fsScoreBackend` registry,
+  and the batteries root entry (`src/index.ts`) auto-enables it on import — so the
+  DEFAULT bare-`goldenmatch` FS path is byte-aligned with Python-native (the #1854
+  fixed full-field operating point), measured F1-neutral vs the pure-TS path. The
+  lean `goldenmatch/core` entry keeps the pure-TS `probabilistic.ts` path as the
+  classified fallback (4-dp tolerance) unless `enableFsWasmScoring()` is called, and
+  for configs the kernel can't express (embedding / name-refdata / TF fields). Closed
+  weakness `fs-default-ts-path-unwired-second-source`.
+- **`array_intersect` `overlap` MODE is pure-TS-only.** The base `array_intersect`
+  scorer is kernel-backed, but its `overlap` mode is not expressible through the
+  fixed-id `score_matrix` boundary, so that mode runs pure-TS on both surfaces. A
+  per-mode divergence, not a whole-scorer one.
 - **PPRL CLKs diverge on float fields.** `str(5.0)`="5.0" (Python) vs `String(5.0)`="5"
   (JS) yields non-equal bloom filters; the `pprl.json` fixtures dodge it by using
   string fields. Guidance: cast floats to strings before PPRL if cross-language CLK

--- a/docs-site/concepts/cross-language-parity.mdx
+++ b/docs-site/concepts/cross-language-parity.mdx
@@ -61,10 +61,13 @@ concrete:
 - If you must hand off at the **`score`** boundary, enable the shared WASM scorer
   on the TypeScript side (byte-identical only for the byte-exact covered scorers:
   `jaro_winkler` / `levenshtein` / `token_sort` / `exact`) and **avoid
-  re-thresholding** across the boundary. Note: the default TS Fellegi–Sunter path
-  is pure-TS `probabilistic.ts`, **not** `fs-wasm` (that kernel ships and is
-  parity-gated but has no pipeline caller yet), so FS scoring is at the 4-dp
-  tolerance, not byte-identical.
+  re-thresholding** across the boundary. Note on Fellegi–Sunter: the batteries
+  `goldenmatch` import now runs FS block scoring through the shared `fs-wasm`
+  kernel **by default** (byte-aligned with Python-native — the #1854 fixed
+  full-field operating point), so hand off at `score` from the bare `goldenmatch`
+  entry for byte-safe FS. The lean `goldenmatch/core` entry keeps the pure-TS
+  `probabilistic.ts` path (4-dp tolerance) unless you opt in with
+  `enableFsWasmScoring()`.
 - **Do not** split a pipeline across `standardize` / dates, embeddings, or the
   auto-config controller and expect bit-exact reproduction. Run those phases in a
   single language, then hand off the durable artifact.

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -164,8 +164,15 @@ weaknesses:
       byte-divergence str(5.0)="5.0" vs String(5.0)="5"; (c) radial + ensemble scorers
       ~4dp even under WASM (reduction/recomposition order), contradicting the table's
       "byte-identical with WASM" claim; (d) goldenanalysis frame-kernel parity outside
-      0046 scope entirely. The verdict table should enumerate scorer-level and
-      package-level divergences, not just distributed/VLM/routing.
+      0046 scope entirely.
+      CLOSED 2026-07-27: the 0046 amendment now enumerates the scorer/package-level
+      divergences, not just distributed/VLM/routing -- (c) radial/ensemble ~4dp under
+      WASM, (b) PPRL float-field CLK, and (a) array_intersect `overlap` MODE pure-TS-only
+      are all named there; (d) the goldenanalysis frame-kernel is a goldenanalysis
+      boundary and is now SHARED (see standalone-ts-algorithms / analysis-wasm reroute),
+      not just fixture-locked. The amendment's prior FS bullet ("default TS FS is pure-TS,
+      not the shared kernel") was itself corrected in the same pass -- FS now runs the
+      shared kernel by default on the batteries entry (see fs-default-ts-path).
       (Note: numeric_diff was Python-only when this audit began; it is now kernel-backed
       on main -- an example of the live harvest catching curated drift.)
     evidence:
@@ -293,8 +300,16 @@ weaknesses:
     detail: >-
       scorer_kernels_deferred / blocking_kernels_deferred entries carry a prose reason
       (deferred/declined/n-a) but no measured evidence (the frame's tenet is 'kernelize
-      on measurement'). Low risk today (the coverage floor is satisfied: 20 backed + 3
-      classified), but the deferral rationale should cite a measurement when the reason
-      is perf/shape rather than model-backed.
+      on measurement'). The deferral rationale should cite a measurement WHEN THE REASON
+      IS PERF/SHAPE rather than model-backed.
+      REASSESSED 2026-07-27: the trigger is currently vacuous -- EVERY remaining deferral
+      is MODEL-BACKED, not perf/shape, so none needs a wall-clock citation. Scorers: 24
+      total, 22 kernel-backed, only `embedding` + `record_embedding` deferred ("n/a --
+      model-backed"; numeric_diff + cosine were kernelized 2026-07-25/26). Blocking:
+      `simhash` alone ("declined -- model-backed": needs a bundled edge model TS doesn't
+      ship). A model-backed scorer/blocker is NOT a kernel-perf decision, so "kernelize on
+      measurement" doesn't apply to it. The invariant stands as a tripwire for any FUTURE
+      perf/shape deferral -- which would then owe a measured wall-clock -- but there is
+      nothing to measure in the current set.
     evidence:
       - parity/goldenmatch.yaml


### PR DESCRIPTION
Closes two thesis-conformance **low** items via doc/ledger accuracy (no code change):

- **undeclared-cross-surface-divergences** (T2) -- 0046 amendment now enumerates scorer/package divergences (radial/ensemble ~4dp, PPRL float CLK, array_intersect overlap-mode pure-TS); corrected the stale FS bullet (FS now runs the shared kernel by default on the batteries entry) + the matching `cross-language-parity.mdx` claim.
- **deferrals-lack-measurement-provenance** (T3) -- reassessed vacuous: every remaining deferral is model-backed, not perf/shape, so nothing needs a wall-clock citation; invariant kept as a future tripwire.

Both gates green locally (`check_thesis_conformance.py --check`, `check_docs_consistency.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)