### PR TITLE
fix(bench): probe Sampler._stop shadowed threading.Thread._stop

### DIFF
--- a/scripts/bench_fs_single_mk_probe.py
+++ b/scripts/bench_fs_single_mk_probe.py
@@ -44,15 +44,15 @@ class Sampler(threading.Thread):
         super().__init__(daemon=True)
         self.interval = interval
         self.peak = 0.0
-        self._stop = threading.Event()
+        self._stopev = threading.Event()
 
     def run(self) -> None:
-        while not self._stop.is_set():
+        while not self._stopev.is_set():
             self.peak = max(self.peak, _vmrss_mb())
             time.sleep(self.interval)
 
     def halt(self) -> None:
-        self._stop.set()
+        self._stopev.set()
         self.join(timeout=1)
 
 


### PR DESCRIPTION
`Sampler(threading.Thread)` named its stop flag `self._stop`, shadowing `threading.Thread._stop` (called internally by `join()`) -> `TypeError: 'Event' object is not callable` on teardown. The 5M dedupe completed; the crash discarded the output. Rename to `_stopev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)