### PR TITLE
fix(bench): build native kernel in bench-zero-config (was measuring pure-Python)

### DIFF
--- a/.github/workflows/bench-zero-config.yml
+++ b/.github/workflows/bench-zero-config.yml
@@ -99,6 +99,18 @@ jobs:
               f'goldenmatch resolves to {goldenmatch.__file__} — not the worktree'; \
             print('worktree install OK:', goldenmatch.__file__)"
 
+      - name: Build native extension (so FS scoring isn't pure-Python)
+        # Without this the FS path falls back to pure-Python scoring (~100x
+        # slower), so any wall/RSS number off this bench is meaningless at scale.
+        run: uv run python scripts/build_native.py
+
+      - name: Assert native FS kernel is loaded (fail loud, don't measure Python)
+        run: |
+          .venv/bin/python -c "from goldenmatch.core._native_loader import native_enabled; \
+            assert native_enabled('block_scoring'), \
+              'native block_scoring NOT loaded — this bench would measure the pure-Python fallback'; \
+            print('native block_scoring: ON')"
+
       - name: Generate ${{ inputs.n_records }}-row fixture
         run: |
           mkdir -p .profile_tmp/scale_fixtures


### PR DESCRIPTION
`bench-zero-config` had no native build step, so FS scoring fell back to pure-Python (~100x slower) — every number off this bench was meaningless at scale. A 5M run wedged for hours scoring ~219M candidate pairs in Python. Adds the `build_native` step + a hard assert that `native_enabled('block_scoring')`, so it fails loud instead of silently measuring the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)