### PR TITLE
feat(er-matcher): multi-source data pipeline (Phase 1a)

### DIFF
--- a/docs/superpowers/plans/2026-07-27-er-matcher-data-pipeline.md
+++ b/docs/superpowers/plans/2026-07-27-er-matcher-data-pipeline.md
@@ -314,11 +314,46 @@ def test_leipzig_deterministic():
 - Create: `scripts/er_matcher/sources_config.py`
 - Test: `scripts/er_matcher/test_sources_config.py`
 
-- [ ] **Step 1: Write the failing test** — `load_sources(path)` returns validated entries; rejects unknown keys (mirror `train.load_config`'s strictness); every entry has `mechanism ∈ {bundle,generate,fetch}`, `license`, and (for CC-BY) `attribution`; `eval_only` sources are flagged.
+Each yaml entry must carry enough to **construct** its loader, not just describe it
+(the flagged gap: build_corpus needs a factory, and the 5 Leipzig datasets are 5
+entries → 5 `LeipzigSource` instances). Entry schema:
+
+```yaml
+sources:
+  abt_buy:
+    loader: leipzig                 # -> which PairSource class
+    mechanism: bundle
+    license: CC-BY
+    attribution: "Leipzig DB Group; VLDB2010"
+    domain: product
+    weight: 1.0                      # illustrative; blend deferred
+    kwargs: {root: data/er_matcher/raw/leipzig/abt_buy, block_fields: [title]}
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    domain: person
+    weight: 2.0                      # person upweight (illustrative)
+    kwargs: {root: data/er_matcher/raw/febrl}
+  magellan_dblp_acm:
+    loader: magellan
+    mechanism: fetch
+    license: cite-only
+    eval_only: true
+    kwargs: {name: dblp_acm}
+  ncvr:                              # deferred to sub-project 3; present for model-card completeness
+    loader: ncvr
+    mechanism: fetch
+    license: public-record
+    eval_only: true
+    kwargs: {}
+```
+
+- [ ] **Step 1: Write the failing test** — `load_sources(path)` returns validated entries; rejects unknown keys (mirror `train.load_config`'s strictness); every entry has `loader`, `mechanism ∈ {bundle,generate,fetch}`, `license`, and (for CC-BY) `attribution`; `eval_only` sources are flagged; `kwargs` is a dict. Add `build_source(entry)` (the factory) that maps `loader` → class and constructs it with `**kwargs` + `seed`; test it returns a registered `PairSource` whose `.name` == the yaml key.
 - [ ] **Step 2: Run to verify it fails.**
-- [ ] **Step 3: Author `sources.yaml`** (weights illustrative; blend deferred) and implement `sources_config.py` (PyYAML load + dataclass validate).
+- [ ] **Step 3: Author `sources.yaml`** (schema above; weights illustrative; blend deferred) and implement `sources_config.py` (PyYAML load + dataclass validate + `build_source` factory keyed on `loader`). The `ncvr` loader may be a thin fetch/`eval_only` stub (raises `NotImplementedError` until sub-project 3) so its entry validates for the model card without implementing the fetch now.
 - [ ] **Step 4: Run to verify pass.**
-- [ ] **Step 5: Commit** — `feat(er-matcher): sources.yaml + validated loader`
+- [ ] **Step 5: Commit** — `feat(er-matcher): sources.yaml + validated loader + build_source factory`
 
 ---
 
@@ -335,7 +370,7 @@ def test_leipzig_deterministic():
   - re-run with same seed → byte-identical output (determinism test).
 
 - [ ] **Step 2: Run to verify it fails.**
-- [ ] **Step 3: Implement `build_corpus.py`** — iterate bundled sources from `sources.yaml`, pull `splits()`, apply per-source blend cap/weight, concat per split, write JSONL (`json.dumps(sort_keys=True)` like `gen_pairs._write`), emit `manifest.json` with provenance + licenses. `fetch`/`eval_only` sources are skipped in the training corpus (they're for the eval harness, sub-project 3).
+- [ ] **Step 3: Implement `build_corpus.py`** — for each `sources.yaml` entry, construct+register the loader via `sources_config.build_source` (Task 7 factory), then for bundled/generate sources pull `splits()`, apply per-source blend cap/weight, concat per split, write JSONL (`json.dumps(sort_keys=True)` like `gen_pairs._write`), emit `manifest.json` with provenance + licenses. `fetch`/`eval_only` sources are constructed but skipped in the training corpus (they're for the eval harness, sub-project 3) — their license/attribution still flows into the manifest for the model card.
 - [ ] **Step 4: Run to verify pass.**
 - [ ] **Step 5: Commit** — `feat(er-matcher): build_corpus blends sources -> unified JSONL + license manifest`
 
@@ -392,6 +427,7 @@ def test_leipzig_deterministic():
 
 - **Box-safe only:** no test imports torch/transformers or hits the network. Fetch is guarded by `GOLDENMATCH_ALLOW_FETCH`; unit tests read committed fixtures.
 - **Fixture paths anchored to `__file__`** (CWD differs local vs CI — see repo CLAUDE.md).
+- **Each new test file opens with** `import os, sys; sys.path.insert(0, os.path.dirname(__file__))` (matches `test_gen_pairs.py:12`) so `import sources...` resolves under a direct `python test_x.py` run and survives a future `--import-mode=importlib` switch, not just pytest's default prepend mode.
 - **xdist isolation:** register sources *inside* the test that asserts them (no cross-test registry leakage).
 - **Determinism:** every source + `build_corpus` has a same-seed → byte-identical test (mirrors `test_gen_pairs.py`).
 - **Commits:** one per task step-group; PR per phase (1a, then 1b).

--- a/docs/superpowers/plans/2026-07-27-er-matcher-data-pipeline.md
+++ b/docs/superpowers/plans/2026-07-27-er-matcher-data-pipeline.md
@@ -1,0 +1,402 @@
+# ER-Matcher Multi-Source Data Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a license-clean, multi-source, provenance-tracked data pipeline that produces the ER-matcher training/eval corpus (person + product + citation), emitting the trainer's existing JSONL row contract so the trainer and Modal run need no change.
+
+**Architecture:** A small pluggable `PairSource` registry. Bundled license-clean loaders (FEBRL synthetic-person, Leipzig CC-BY product/citation/music) plus a Rich synthetic generator feed a `build_corpus` driver that blends per `sources.yaml`, writes `data/er_matcher/{train,val,test}.jsonl` + a provenance/license `manifest.json`. Real-PII/no-license sources (Magellan, NCVR) are fetch-at-build, eval-only, never committed. Everything is pure/deterministic and CPU/box-safe — no GPU, no network in the unit tests.
+
+**Tech Stack:** Python 3.11 stdlib (csv, json, hashlib, urllib, random), PyYAML (already a dep), pytest. Follows the existing `scripts/er_matcher/` pure-helper + `test_*.py` conventions.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md`
+
+---
+
+## File Structure
+
+**Phase 1a — benchmark ingestion (PR 1):**
+
+| Path | Responsibility |
+|---|---|
+| `scripts/er_matcher/sources/__init__.py` | Re-export `Row`, `PairSource`, `register`/`get_source`/`iter_sources` |
+| `scripts/er_matcher/sources/base.py` | `Row` TypedDict, `PairSource` Protocol, the loader registry |
+| `scripts/er_matcher/sources/splits.py` | Deterministic entity-level split (generalized `_split_of`, str-keyed) |
+| `scripts/er_matcher/sources/negatives.py` | Deterministic blocker + hard/easy negative synthesis |
+| `scripts/er_matcher/sources/leipzig.py` | Leipzig CC-BY loader (two tables + perfect mapping → labeled pairs) |
+| `scripts/er_matcher/sources/febrl.py` | FEBRL synthetic-person loader (ships match status) |
+| `scripts/er_matcher/sources/magellan.py` | Fetch-at-build DeepMatcher-CSV loader, **eval-only** |
+| `scripts/er_matcher/sources_config.py` | Load + validate `sources.yaml` |
+| `scripts/er_matcher/sources.yaml` | Per-source: mechanism, license, attribution, domain, blend weight |
+| `scripts/er_matcher/build_corpus.py` | Driver: run bundled sources → blend → write JSONL + `manifest.json` |
+| `scripts/er_matcher/tests/fixtures/leipzig_mini/` | Tiny 2-table + mapping fixture |
+| `scripts/er_matcher/tests/fixtures/febrl_mini/` | Tiny FEBRL fixture |
+| `scripts/er_matcher/tests/fixtures/magellan_mini/` | Tiny DeepMatcher train/valid/test fixture |
+| `scripts/er_matcher/test_sources_base.py` | Registry + Row contract tests |
+| `scripts/er_matcher/test_splits.py` | Split determinism / no-leak / str+int parity |
+| `scripts/er_matcher/test_negatives.py` | Blocker + negative-synthesis tests |
+| `scripts/er_matcher/test_leipzig.py` | Leipzig loader tests (mini fixture) |
+| `scripts/er_matcher/test_febrl.py` | FEBRL loader tests (mini fixture) |
+| `scripts/er_matcher/test_magellan.py` | Magellan CSV-parse tests (fixture; network behind marker) |
+| `scripts/er_matcher/test_build_corpus.py` | End-to-end blend + manifest tests |
+| `scripts/er_matcher/gen_pairs.py` | **Modify:** import `_split_of` from `sources/splits.py` (DRY) |
+
+**Phase 1b — Rich synthetic generator (PR 2):**
+
+| Path | Responsibility |
+|---|---|
+| `scripts/er_matcher/synthetic/__init__.py` | Package init |
+| `scripts/er_matcher/synthetic/vocab.py` | Census-scale name/place tables + Zipf sampler |
+| `scripts/er_matcher/synthetic/data/*.txt` | Vendored census name/place frequency lists (public-domain source) |
+| `scripts/er_matcher/synthetic/schemas.py` | Per-domain schemas: people/healthcare/business + crm_contact + organization |
+| `scripts/er_matcher/synthetic/corruption.py` | Parameterized error channels, calibrated to FEBRL `dsgen` |
+| `scripts/er_matcher/synthetic/generate.py` | Rich generator emitting `Row`s via the `PairSource` interface |
+| `scripts/er_matcher/synthetic/test_*.py` | Vocab / schema / corruption / generate tests + dsgen-calibration histogram test |
+| `scripts/er_matcher/gen_pairs.py` | **Modify:** delegate to `synthetic.generate` (keep CLI + determinism contract) |
+| `scripts/er_matcher/sources.yaml` | **Modify:** register `synthetic` source |
+
+**Design boundaries:** loaders never import torch/transformers (CPU/box-safe). `base.py` has zero source-specific logic. `negatives.py` and `splits.py` are pure and shared by every positives-only loader. Fetch loaders isolate all network in one function guarded by an env flag so unit tests hit fixtures only.
+
+---
+
+## Phase 1a — Benchmark ingestion
+
+### Task 1: Row contract, PairSource protocol, registry
+
+**Files:**
+- Create: `scripts/er_matcher/sources/base.py`
+- Create: `scripts/er_matcher/sources/__init__.py`
+- Test: `scripts/er_matcher/test_sources_base.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# test_sources_base.py
+from sources.base import Row, PairSource, register, get_source, iter_sources
+
+def test_row_has_dataset_provenance_field():
+    row: Row = {"a": {"x": "1"}, "b": {"x": "2"}, "label": "no_match",
+                "domain": "people", "source": "synthetic", "dataset": "febrl",
+                "eid_a": "1", "eid_b": "2"}
+    assert row["dataset"] == "febrl"          # the field this pipeline ADDS
+    assert set(row) >= {"a", "b", "label", "domain", "source", "dataset", "eid_a", "eid_b"}
+
+def test_registry_roundtrip_and_isolation():
+    class Dummy:
+        name = "dummy_ds"
+        def splits(self): return {"train": [], "val": [], "test": []}
+    register(Dummy())
+    assert get_source("dummy_ds").name == "dummy_ds"
+    assert "dummy_ds" in {s.name for s in iter_sources()}
+
+def test_get_unknown_source_raises():
+    import pytest
+    with pytest.raises(KeyError):
+        get_source("does_not_exist")
+```
+
+- [ ] **Step 2: Run to verify it fails** — `pytest scripts/er_matcher/test_sources_base.py -v` → FAIL (module missing).
+- [ ] **Step 3: Implement `base.py`**
+
+```python
+# sources/base.py
+"""Loader contract + registry for the multi-source ER data pipeline.
+CPU/box-safe: stdlib only, never imports torch/transformers."""
+from __future__ import annotations
+from typing import Any, Iterable, Protocol, TypedDict, runtime_checkable
+
+class Row(TypedDict):
+    a: dict[str, Any]
+    b: dict[str, Any]
+    label: str           # "match" | "no_match"
+    domain: str
+    source: str          # e.g. "leipzig", "febrl", "synthetic"
+    dataset: str         # PairSource.name; == registry key == sources.yaml key
+    eid_a: str
+    eid_b: str
+
+@runtime_checkable
+class PairSource(Protocol):
+    name: str
+    def splits(self) -> dict[str, Iterable[Row]]: ...
+
+_REGISTRY: dict[str, PairSource] = {}
+
+def register(source: PairSource) -> None:
+    _REGISTRY[source.name] = source
+
+def get_source(name: str) -> PairSource:
+    if name not in _REGISTRY:
+        raise KeyError(f"no registered source {name!r}; have {sorted(_REGISTRY)}")
+    return _REGISTRY[name]
+
+def iter_sources() -> Iterable[PairSource]:
+    return list(_REGISTRY.values())
+```
+
+`sources/__init__.py` re-exports the five names. Tests register inside the test (xdist worker isolation — see the repo CLAUDE.md note).
+
+- [ ] **Step 4: Run to verify pass** — `pytest scripts/er_matcher/test_sources_base.py -v` → PASS.
+- [ ] **Step 5: Commit** — `git add scripts/er_matcher/sources/ scripts/er_matcher/test_sources_base.py && git commit -m "feat(er-matcher): PairSource contract + registry"`
+
+---
+
+### Task 2: Deterministic entity-level splits (generalized `_split_of`)
+
+**Files:**
+- Create: `scripts/er_matcher/sources/splits.py`
+- Modify: `scripts/er_matcher/gen_pairs.py` (import `_split_of` from splits; delete local copy)
+- Test: `scripts/er_matcher/test_splits.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# test_splits.py
+from sources.splits import split_of
+
+def test_str_and_int_eid_parity():
+    # generalization requirement from spec: benchmark IDs are strings
+    assert split_of(7, seed=1, val_frac=.15, test_frac=.15, holdout_domain=None) == \
+           split_of("7", seed=1, val_frac=.15, test_frac=.15, holdout_domain=None)
+
+def test_holdout_domain_forced_to_test():
+    assert split_of("abc", seed=1, val_frac=.15, test_frac=.15,
+                    holdout_domain="business", domain="business") == "test"
+
+def test_deterministic_and_partitions():
+    got = {split_of(str(i), seed=9, val_frac=.15, test_frac=.15, holdout_domain=None)
+           for i in range(200)}
+    assert got == {"train", "val", "test"}
+    # same seed -> identical
+    assert split_of("k", seed=9, val_frac=.15, test_frac=.15, holdout_domain=None) == \
+           split_of("k", seed=9, val_frac=.15, test_frac=.15, holdout_domain=None)
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (module missing).
+- [ ] **Step 3: Implement `splits.py`** (lift `gen_pairs._split_of`, key on `str(eid)`):
+
+```python
+# sources/splits.py
+from __future__ import annotations
+import hashlib
+
+def split_of(eid, *, seed: int, val_frac: float, test_frac: float,
+             holdout_domain: str | None = None, domain: str | None = None) -> str:
+    """Deterministic entity-level split. Holdout domain -> 'test'; else hash
+    (seed, str(eid)) into train/val/test. str(eid) so benchmark string IDs work."""
+    if holdout_domain and domain == holdout_domain:
+        return "test"
+    h = hashlib.sha256(f"{seed}:{eid}".encode()).hexdigest()
+    frac = int(h[:8], 16) / 0xFFFFFFFF
+    if frac < test_frac:
+        return "test"
+    if frac < test_frac + val_frac:
+        return "val"
+    return "train"
+```
+
+- [ ] **Step 4: Update `gen_pairs.py`** — replace the local `_split_of` body with `from sources.splits import split_of` and delegate (keep the old signature as a thin wrapper so `test_gen_pairs.py` stays green). Run `pytest scripts/er_matcher/test_gen_pairs.py -v` → still PASS (regression guard).
+- [ ] **Step 5: Run new tests** — `pytest scripts/er_matcher/test_splits.py -v` → PASS.
+- [ ] **Step 6: Commit** — `feat(er-matcher): shared str-keyed entity split; gen_pairs reuses it`
+
+---
+
+### Task 3: Deterministic blocker + negative synthesis
+
+**Files:**
+- Create: `scripts/er_matcher/sources/negatives.py`
+- Test: `scripts/er_matcher/test_negatives.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# test_negatives.py
+from sources.negatives import blocking_key, synth_negatives
+
+def test_blocking_key_is_deterministic_prefix_token():
+    e = {"name": "Robert Smith", "city": "Newark"}
+    assert blocking_key(e, ["name"]) == blocking_key(dict(e), ["name"])
+    assert blocking_key(e, ["name"]) != ""
+
+def test_synth_negatives_balance_and_determinism():
+    ents = {f"e{i}": {"name": f"Person {i%5}", "phone": str(i)} for i in range(20)}
+    negs1 = synth_negatives(ents, block_keys=["name"], hard_frac=0.5, seed=3, n=10)
+    negs2 = synth_negatives(ents, block_keys=["name"], hard_frac=0.5, seed=3, n=10)
+    assert negs1 == negs2                                  # deterministic
+    assert all(a != b for a, b, _ in negs1)               # no self-pairs
+    assert {tag for _, _, tag in negs1} <= {"hard", "easy"}
+    hard = [n for n in negs1 if n[2] == "hard"]
+    assert all(blocking_key(ents[a], ["name"]) == blocking_key(ents[b], ["name"])
+               for a, b, _ in hard)                        # hard = same block
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement `negatives.py`** — `blocking_key` (lowercased first token of the joined block fields); `synth_negatives` builds a block index, samples hard negatives from within-block distinct-entity pairs and easy negatives cross-block, seeded `random.Random(seed)`, returns `list[(eid_a, eid_b, "hard"|"easy")]`. Pure stdlib.
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** — `feat(er-matcher): deterministic blocker + hard/easy negative synthesis`
+
+---
+
+### Task 4: Leipzig CC-BY loader
+
+**Files:**
+- Create: `scripts/er_matcher/sources/leipzig.py`
+- Create: `scripts/er_matcher/tests/fixtures/leipzig_mini/{tableA.csv,tableB.csv,mapping.csv}`
+- Test: `scripts/er_matcher/test_leipzig.py`
+
+- [ ] **Step 1: Build the mini fixture** — 4 rows in tableA, 4 in tableB, 2 perfect-mapping matches. Fields e.g. `id,title,manufacturer,price`.
+- [ ] **Step 2: Write the failing test**
+
+```python
+# test_leipzig.py — fixtures anchored to __file__ (CWD differs local vs CI)
+from pathlib import Path
+from sources.leipzig import LeipzigSource
+FIX = Path(__file__).parent / "tests" / "fixtures" / "leipzig_mini"
+
+def test_leipzig_emits_positives_and_negatives():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product",
+                        block_fields=["title"], seed=1)
+    rows = [r for split in src.splits().values() for r in split]
+    labels = {r["label"] for r in rows}
+    assert labels == {"match", "no_match"}
+    assert all(r["dataset"] == "abt_buy" and r["source"] == "leipzig" for r in rows)
+    # positives come from the perfect mapping (2 matches in the fixture)
+    assert sum(r["label"] == "match" for r in rows) == 2
+
+def test_leipzig_deterministic():
+    mk = lambda: [r for s in LeipzigSource("abt_buy", FIX, "product", ["title"], 1)
+                  .splits().values() for r in s]
+    assert mk() == mk()
+```
+
+- [ ] **Step 3: Run to verify it fails.**
+- [ ] **Step 4: Implement `LeipzigSource`** — read tableA/tableB (csv.DictReader), read mapping → positive `(idA,idB)` pairs → `Row(label="match")`; call `synth_negatives` over the union of records for negatives; assign split via `split_of(idA, ...)`; tag `source="leipzig"`, `dataset=name`, `domain=domain`. Attribution string carried as a class attr for the manifest.
+- [ ] **Step 5: Run to verify pass.**
+- [ ] **Step 6: Commit** — `feat(er-matcher): Leipzig CC-BY loader (positives + synthesized negatives)`
+
+---
+
+### Task 5: FEBRL synthetic-person loader
+
+**Files:**
+- Create: `scripts/er_matcher/sources/febrl.py`
+- Create: `scripts/er_matcher/tests/fixtures/febrl_mini/febrl_sample.csv`
+- Test: `scripts/er_matcher/test_febrl.py`
+
+- [ ] **Step 1: Build the mini fixture** — FEBRL-style rows with `rec_id` encoding original vs duplicate + the entity id (FEBRL `rec-<n>-org` / `rec-<n>-dup-<k>`), fields `given_name,surname,street,suburb,postcode,phone,soc_sec_id`.
+- [ ] **Step 2: Write the failing test** — assert person matches pair org↔dup of the same entity (label match), negatives synthesized cross-entity, `domain="person"`, `dataset="febrl"`, determinism, and split-no-leak (all rows of one entity in one split).
+- [ ] **Step 3: Run to verify it fails.**
+- [ ] **Step 4: Implement `FebrlSource`** — parse `rec_id` → entity id; group org+dup as positives; `synth_negatives` for negatives; `split_of(entity_id, ...)` (entity-level, no leak). License = MPL-1.1 attr.
+- [ ] **Step 5: Run to verify pass.**
+- [ ] **Step 6: Commit** — `feat(er-matcher): FEBRL synthetic-person loader`
+
+---
+
+### Task 6: Magellan fetch-at-build loader (eval-only)
+
+**Files:**
+- Create: `scripts/er_matcher/sources/magellan.py`
+- Create: `scripts/er_matcher/tests/fixtures/magellan_mini/{train,valid,test}.csv` + `tableA.csv,tableB.csv`
+- Test: `scripts/er_matcher/test_magellan.py`
+
+- [ ] **Step 1: Build the mini fixture** — DeepMatcher format: `tableA`/`tableB` + `train/valid/test.csv` with `ltable_id,rtable_id,label` rows.
+- [ ] **Step 2: Write the failing test** — `MagellanSource.load_from_dir(FIX)` yields labeled pairs joined against the two tables; canonical train/valid/test preserved; `eval_only is True`; asserts **no network** is touched when reading a local dir. A separate test asserts `fetch()` raises unless `GOLDENMATCH_ALLOW_FETCH=1` (guard so CI never downloads).
+- [ ] **Step 3: Run to verify it fails.**
+- [ ] **Step 4: Implement `MagellanSource`** — `load_from_dir(dir)` (pure parse, tested); `fetch(cache_dir)` (urllib download + sha256 verify, guarded by `GOLDENMATCH_ALLOW_FETCH`) → `load_from_dir`. Mark `eval_only=True`; `source="magellan"`, `dataset=<name>`. Document cite-only license in the class.
+- [ ] **Step 5: Run to verify pass.**
+- [ ] **Step 6: Commit** — `feat(er-matcher): Magellan fetch-at-build eval loader (network-guarded)`
+
+---
+
+### Task 7: `sources.yaml` + config loader
+
+**Files:**
+- Create: `scripts/er_matcher/sources.yaml`
+- Create: `scripts/er_matcher/sources_config.py`
+- Test: `scripts/er_matcher/test_sources_config.py`
+
+- [ ] **Step 1: Write the failing test** — `load_sources(path)` returns validated entries; rejects unknown keys (mirror `train.load_config`'s strictness); every entry has `mechanism ∈ {bundle,generate,fetch}`, `license`, and (for CC-BY) `attribution`; `eval_only` sources are flagged.
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Author `sources.yaml`** (weights illustrative; blend deferred) and implement `sources_config.py` (PyYAML load + dataclass validate).
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** — `feat(er-matcher): sources.yaml + validated loader`
+
+---
+
+### Task 8: `build_corpus` driver (blend + manifest)
+
+**Files:**
+- Create: `scripts/er_matcher/build_corpus.py`
+- Test: `scripts/er_matcher/test_build_corpus.py`
+
+- [ ] **Step 1: Write the failing test** — with the three mini fixtures registered, `build_corpus(sources_yaml, out_dir, seed)`:
+  - writes `data/.../ {train,val,test}.jsonl` containing only `bundle`/`generate` sources (NOT `fetch`/`eval_only`);
+  - `manifest.json` records per-source `{count, license, attribution, mechanism}` and a total;
+  - respects blend weights (cap/upweight) deterministically;
+  - re-run with same seed → byte-identical output (determinism test).
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement `build_corpus.py`** — iterate bundled sources from `sources.yaml`, pull `splits()`, apply per-source blend cap/weight, concat per split, write JSONL (`json.dumps(sort_keys=True)` like `gen_pairs._write`), emit `manifest.json` with provenance + licenses. `fetch`/`eval_only` sources are skipped in the training corpus (they're for the eval harness, sub-project 3).
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** — `feat(er-matcher): build_corpus blends sources -> unified JSONL + license manifest`
+
+---
+
+### Task 9: Phase 1a integration + docs
+
+- [ ] **Step 1** — Add a `README` section in `scripts/er_matcher/` documenting the pipeline, each source's license/attribution, and the fetch-only policy. Verify the CC-BY attribution + FEBRL MPL notice are present (required by license).
+- [ ] **Step 2** — Run the whole box-safe suite: `pytest scripts/er_matcher/ -v` (no GPU, no network) → all PASS.
+- [ ] **Step 3** — Run `build_corpus.py` locally against the real bundled FEBRL + Leipzig data (small); eyeball `manifest.json` counts + licenses.
+- [ ] **Step 4: Commit + open PR 1** — `feat(er-matcher): multi-source benchmark ingestion pipeline (Phase 1a)`. PR body links the spec and lists licenses/attributions.
+
+---
+
+## Phase 1b — Rich synthetic generator
+
+> Sequenced after 1a merges. Same `PairSource` interface, so it plugs into `build_corpus` by registering one more source. Full bite-sized steps are finalized at 1b kickoff; tasks + interfaces + test intent below.
+
+### Task 10: Census-scale vocab + Zipf sampler
+**Files:** `synthetic/vocab.py`, `synthetic/data/*.txt`, `synthetic/test_vocab.py`
+- [ ] Vendor public-domain census first/last-name frequency lists + city/state/zip tables into `synthetic/data/` (document source + public-domain status in the manifest/README).
+- [ ] `sample_name(rng)` draws by frequency (Zipf-like from the real counts); deterministic per seed.
+- [ ] Tests: determinism; distribution roughly follows the frequency table; vocab size >> the old 900-combo ceiling.
+
+### Task 11: Per-domain schemas
+**Files:** `synthetic/schemas.py`, `synthetic/test_schemas.py`
+- [ ] Schemas for people, healthcare, business + **crm_contact** (name, email, phone, company, title, address) + **organization** (legal name, dba, domain, ein-like id, address).
+- [ ] Tests: each schema yields the declared fields; strong-id keys declared per domain (for negative blocking + hard-negative conflicts).
+
+### Task 12: Error-channel corruption model (dsgen-calibrated)
+**Files:** `synthetic/corruption.py`, `synthetic/test_corruption.py`
+- [ ] Channels: typo, OCR-confusion, phonetic, transliteration, field-swap, token drop/add, formatting — each an independent, seeded, per-field-rate function.
+- [ ] **Calibration test (spec requirement):** generate a corruption-type histogram over N synthetic dups and assert it matches a committed FEBRL-`dsgen` reference histogram within tolerance (per-field probabilities + error-type mix), not "looks similar."
+
+### Task 13: Rich generator emitting `Row`s
+**Files:** `synthetic/generate.py`, `synthetic/test_generate.py`
+- [ ] `SyntheticSource(name="synthetic", ...)` implements `PairSource`; positives = entity vs corrupted self; negatives via `sources.negatives` (reuse — DRY); splits via `sources.splits.split_of`.
+- [ ] Tests: determinism (byte-identical per seed), ~50/50 balance, all 5 domains present, hard negatives share names but conflict on strong ids.
+
+### Task 14: Rewire `gen_pairs.py` + register source
+**Files:** `gen_pairs.py` (modify), `sources.yaml` (modify), `test_gen_pairs.py` (extend)
+- [ ] `gen_pairs.py` delegates to `synthetic.generate` while preserving its CLI + deterministic-output contract; keep a back-compat path so existing callers/tests don't break (regression guard: `test_gen_pairs.py` green).
+- [ ] Register `synthetic` in `sources.yaml`; `build_corpus` now includes it.
+- [ ] Tests: CLI parity; `build_corpus` manifest shows the synthetic source with its counts.
+
+### Task 15: Phase 1b integration + PR 2
+- [ ] Full box-safe suite green (`pytest scripts/er_matcher/ -v`).
+- [ ] Run `build_corpus` with synthetic enabled; verify manifest counts + person upweight.
+- [ ] Open PR 2 — `feat(er-matcher): rich synthetic generator (Phase 1b)`.
+
+---
+
+## Testing & conventions
+
+- **Box-safe only:** no test imports torch/transformers or hits the network. Fetch is guarded by `GOLDENMATCH_ALLOW_FETCH`; unit tests read committed fixtures.
+- **Fixture paths anchored to `__file__`** (CWD differs local vs CI — see repo CLAUDE.md).
+- **xdist isolation:** register sources *inside* the test that asserts them (no cross-test registry leakage).
+- **Determinism:** every source + `build_corpus` has a same-seed → byte-identical test (mirrors `test_gen_pairs.py`).
+- **Commits:** one per task step-group; PR per phase (1a, then 1b).
+
+## Out of scope (later sub-projects)
+- Sub-project 2 — re-architect the Modal run for the larger corpus (GPU tier, timeout, epochs, checkpoint/resume, real perf gate + learning-curve sweep).
+- Sub-project 3 — cross-benchmark eval harness (this is where `fetch`/`eval_only` Magellan + optional NCVR get consumed).
+- Sub-project 4 — release (quantize, publish, model card fed by `manifest.json`).

--- a/docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md
@@ -152,8 +152,8 @@ deps; byte-identical output per seed):
   merely "looks similar."
 - Deterministic in `--seed`; a `--profile` flag selects corruption intensity.
 
-This is the heaviest component; it may be split into its own spec/plan (1b) from
-benchmark ingestion (1a) if independent landing is preferred.
+This is the heaviest component and is Phase 1b (see "Plan structure (decided)"):
+sequenced after benchmark ingestion (1a) and landed as its own PR.
 
 ### 4. `sources.yaml`, blend, splits, manifest
 

--- a/docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md
@@ -37,6 +37,24 @@ Non-goals (separate sub-projects):
   comparable to published DeepMatcher/Ditto numbers).
 - Sub-project 4 — release (quantize, publish, model card).
 
+### Plan structure (decided)
+
+Sub-project 1 is **one spec, two sequential phases** under a single implementation
+plan, landing as two PRs:
+
+- **Phase 1a — benchmark ingestion:** the loader interface, febrl/leipzig loaders,
+  negative synthesis, fetch-at-build eval loaders, and `sources.yaml`/blend/splits/
+  manifest (Architecture §1, §2, §4). This is the foundation and unblocks a first
+  larger run on real+existing-synthetic data.
+- **Phase 1b — Rich synthetic generator:** the `gen_pairs.py` rewrite
+  (Architecture §3). Depends on nothing in 1a and can be developed in parallel, but
+  is sequenced *after* 1a so the first scaled run isn't blocked on the generator
+  rewrite.
+
+The 1a/1b boundary is fixed here (not left to the planner): both are in scope for
+this spec; the planner produces one plan with the two phases as distinct,
+independently-mergeable stages.
+
 ## Data slate (license-vetted)
 
 Verified against primary sources. The shipped model must be publishable
@@ -63,9 +81,14 @@ no license).
 
 ### 1. Unified row contract & loader interface
 
-Every source emits the row the trainer already consumes:
+Every source emits the trainer's existing row contract, **extended with one
+`dataset` provenance field** (the trainer ignores unknown keys — `read_jsonl` does
+no key validation and `example_to_messages` reads only `a`/`b`/`label` — so the
+added field is safe and requires no trainer change):
 
 ```
+# existing contract: {a, b, label, domain, source, eid_a, eid_b}
+# this pipeline adds:  dataset  (provenance; ignored by the trainer)
 {a: {..fields}, b: {..fields}, label: "match"|"no_match",
  domain: str, source: str, dataset: str, eid_a, eid_b}
 ```
@@ -80,12 +103,14 @@ A minimal pluggable interface (each loader is one focused, testable unit):
 
 ```python
 class PairSource(Protocol):
-    name: str
-    def splits(self) -> dict[str, Iterable[Row]]:  # {"train","val","test"}
+    name: str                                       # == the `dataset` provenance value + registry key
+    def splits(self) -> dict[str, Iterable[Row]]:   # {"train","val","test"}
         ...
 ```
 
-A registry maps `dataset -> loader`. Four loader families:
+`PairSource.name` is the single identifier used three ways: the registry key, the
+`dataset` field written on every row it emits, and the `sources.yaml` key — one
+string, no aliasing. A registry maps `dataset -> loader`. Four loader families:
 - `febrl` — synthetic person; match status ships with the data.
 - `leipzig` — one loader parametrized per CC-BY dataset (two source tables + a
   perfect-mapping gold file).
@@ -120,7 +145,11 @@ deps; byte-identical output per seed):
   phonetic, transliteration, field-swap, token drop/add, formatting variants —
   each with an independent, tunable rate, **calibrated to FEBRL's `dsgen`** so
   synthetic corruption matches an established person-matching benchmark rather
-  than being ad-hoc.
+  than being ad-hoc. *Calibration target (concrete):* match `dsgen`'s per-field
+  corruption **probabilities** and its **error-type mix** (the relative share of
+  typo / OCR / phonetic / swap / drop), verified by comparing the corruption-type
+  histogram of our generated pairs against a `dsgen`-generated reference set — not
+  merely "looks similar."
 - Deterministic in `--seed`; a `--profile` flag selects corruption intensity.
 
 This is the heaviest component; it may be split into its own spec/plan (1b) from
@@ -129,7 +158,8 @@ benchmark ingestion (1a) if independent landing is preferred.
 ### 4. `sources.yaml`, blend, splits, manifest
 
 One config is the single source of truth for **both the pipeline and the model
-card**:
+card**. The block below is **illustrative shape, not a literal schema** — the
+`weight` values are placeholders (blend ratios are deferred; see below):
 
 ```yaml
 sources:
@@ -142,7 +172,10 @@ sources:
 
 - **Splits**: preserve each benchmark's canonical train/val/test; for Leipzig
   (no fixed split) generate deterministic entity-level splits (reuse the current
-  `_split_of` hashing so no entity leaks across splits).
+  `_split_of` hashing so no entity leaks across splits). Note: `_split_of` today
+  takes an **int** `eid` (`f"{seed}:{eid}"`); benchmark entity IDs are strings, so
+  the reused helper must key on `str(eid)` — a required generalization, not an
+  optional one, or non-int IDs silently break the hash.
 - **Blend**: cap oversized sources (bundle MusicBrainz-**20K**; fetch larger
   variants only if ever needed) and **upweight person data** for the PII emphasis.
 - **Output**: unified `data/er_matcher/{train,val,test}.jsonl` + `manifest.json`

--- a/docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md
@@ -1,0 +1,171 @@
+# ER-Matcher Multi-Source Data Pipeline — Design
+
+**Date:** 2026-07-27
+**Status:** Design (approved for spec review)
+**Scope:** Sub-project 1 of the "production-grade OSS ER-matcher" effort.
+
+## Context
+
+The OSS ER-matcher (`scripts/er_matcher/`, Qwen2.5-3B LoRA SFT, plan §Phase 3)
+currently trains on a single synthetic source: `gen_pairs.py` emits ~2,844
+train pairs from 3,000 synthetic entities across 3 domains. A P3a smoke run has
+succeeded (GPU util 99.3%, fits A10G, ~7.2 s/step) and the full run on this data
+is trivially cheap (~$0.75, ~15 min on A100-40GB — computed, not multi-hour).
+
+The generator's diversity is capped well below what a *production-grade* matcher
+needs: the name space is 30 first × 30 last = 900 combos (people/healthcare) and
+8×8×6 = 384 (business); positives are self-corruptions over ~6 corruption types.
+Raising `--n-entities` alone just resamples that small space — the learning curve
+would flatten. Getting a genuinely capable model requires **more and more varied
+data**, from real benchmarks and a much richer synthetic generator.
+
+This sub-project builds the **multi-source data pipeline** that produces the
+training/eval corpus. The trainer and the Modal run are intentionally untouched
+here — they still consume `data/er_matcher/{train,val,test}.jsonl`. Re-sizing the
+run for the larger corpus is sub-project 2.
+
+## Goal
+
+Produce a license-clean, multi-source, provenance-tracked training + eval corpus
+for a production-grade person + product entity matcher, emitting the existing
+JSONL row contract so the trainer needs no change.
+
+Non-goals (separate sub-projects):
+- Sub-project 2 — run re-architecture for scale (GPU tier, timeout, epochs,
+  checkpoint/resume, the now-meaningful perf gate + learning-curve sweep).
+- Sub-project 3 — cross-benchmark eval harness (per-source match-F1 + calibration
+  comparable to published DeepMatcher/Ditto numbers).
+- Sub-project 4 — release (quantize, publish, model card).
+
+## Data slate (license-vetted)
+
+Verified against primary sources. The shipped model must be publishable
+(PyPI/HF), so only redistribution-clean data is bundled.
+
+| Source | License | Mechanism | Type | Role |
+|---|---|---|---|---|
+| **FEBRL** | ANUOS / MPL-1.1 | **bundle** | Person (synthetic) | Train + eval (person side) |
+| **Leipzig** (Abt-Buy, Amazon-Google, DBLP-ACM, DBLP-Scholar, MusicBrainz-20K) | CC-BY + attribution | **bundle** (w/ credit) | Product / Citation / Music | Train + eval |
+| **Rich synthetic** | project (MIT) | **generate** | Person / CRM / org / business | Train + eval, infinitely scalable |
+| DeepMatcher/Magellan | none stated (cite-only) | **fetch-at-build** | Product / Citation | Eval-parity only; never committed |
+| NCVR (NC voters) | public record, no grant; **real PII** | **fetch-at-build** | Person (real) | Optional eval-only generalization; never committed |
+
+**Key implication (accepted):** the only license-clean *person/PII* data is
+**synthetic** (FEBRL + the Rich generator). Real person data (NCVR) is precisely
+what cannot be bundled into a published model, so shipped person-matching training
+is synthetic-person; real PII benchmarks are fetch-at-build, eval-only, documented.
+Two license caveats carried from vetting: (1) cite Leipzig as "CC-BY" (exact
+version unconfirmed on-page) with attribution to the DB Group + VLDB2010 paper;
+(2) pull Abt-Buy / Amazon-Google from **Leipzig** (CC-BY), not Magellan (same rows,
+no license).
+
+## Architecture
+
+### 1. Unified row contract & loader interface
+
+Every source emits the row the trainer already consumes:
+
+```
+{a: {..fields}, b: {..fields}, label: "match"|"no_match",
+ domain: str, source: str, dataset: str, eid_a, eid_b}
+```
+
+The shared serializer (`goldenmatch.core.er_matcher.prompt.build_chat`) renders
+arbitrary fields, so **heterogeneous schemas are a feature** — mixing product
+`{title, brand, price}`, person `{name, address, dob}`, and citation
+`{authors, venue, year}` improves robustness. Native fields are preserved;
+`domain`/`source`/`dataset` carry provenance and let eval slice by source.
+
+A minimal pluggable interface (each loader is one focused, testable unit):
+
+```python
+class PairSource(Protocol):
+    name: str
+    def splits(self) -> dict[str, Iterable[Row]]:  # {"train","val","test"}
+        ...
+```
+
+A registry maps `dataset -> loader`. Four loader families:
+- `febrl` — synthetic person; match status ships with the data.
+- `leipzig` — one loader parametrized per CC-BY dataset (two source tables + a
+  perfect-mapping gold file).
+- `magellan_fetch` — fetch-at-build, DeepMatcher CSV format, **eval-only**.
+- `synthetic` — the Rich generator.
+
+### 2. Negative generation (positives-only sources)
+
+DeepMatcher/Magellan CSVs already contain labeled negatives (post-blocking
+candidate pairs) → direct read. Leipzig ships a perfect mapping (positives only)
++ the two source tables → negatives are synthesized:
+- **hard negatives**: same blocking key, different entity (the boundary case).
+- **easy negatives**: random cross-entity pairs.
+- deterministic, seeded, ratio-controlled to hold the ~50/50 balance the current
+  generator maintains.
+
+A simple deterministic token/prefix blocker is used for reproducibility.
+(Dogfooding goldenmatch's own blocker is a candidate enhancement but is kept out
+of scope to keep sub-project 1 self-contained.)
+
+### 3. Rich synthetic generator
+
+A rewrite of `gen_pairs.py` into its own well-tested module, preserving the
+current pure/deterministic discipline (pure helpers unit-tested without heavy
+deps; byte-identical output per seed):
+- **Census-scale vocab** with **Zipf-frequency sampling** (thousands of
+  first/last names; realistic city/state/zip joint distributions) — removes the
+  900-combo ceiling.
+- **Configurable schemas** per domain: existing people / healthcare / business
+  **+ CRM-contact + organization** (the PII/CRM emphasis).
+- **Parameterized error-channel corruption model** — typo, OCR-confusion,
+  phonetic, transliteration, field-swap, token drop/add, formatting variants —
+  each with an independent, tunable rate, **calibrated to FEBRL's `dsgen`** so
+  synthetic corruption matches an established person-matching benchmark rather
+  than being ad-hoc.
+- Deterministic in `--seed`; a `--profile` flag selects corruption intensity.
+
+This is the heaviest component; it may be split into its own spec/plan (1b) from
+benchmark ingestion (1a) if independent landing is preferred.
+
+### 4. `sources.yaml`, blend, splits, manifest
+
+One config is the single source of truth for **both the pipeline and the model
+card**:
+
+```yaml
+sources:
+  febrl:      {mechanism: bundle,   license: MPL-1.1,      domain: person,  weight: ...}
+  abt_buy:    {mechanism: bundle,   license: CC-BY, attribution: "...",     weight: ...}
+  synthetic:  {mechanism: generate, license: MIT,          weight: ...}
+  magellan_*: {mechanism: fetch,    license: cite-only,    eval_only: true}
+  ncvr:       {mechanism: fetch,    license: public-record, eval_only: true}
+```
+
+- **Splits**: preserve each benchmark's canonical train/val/test; for Leipzig
+  (no fixed split) generate deterministic entity-level splits (reuse the current
+  `_split_of` hashing so no entity leaks across splits).
+- **Blend**: cap oversized sources (bundle MusicBrainz-**20K**; fetch larger
+  variants only if ever needed) and **upweight person data** for the PII emphasis.
+- **Output**: unified `data/er_matcher/{train,val,test}.jsonl` + `manifest.json`
+  recording per-source provenance, counts, and licenses (feeds the model card).
+
+## Testing & boundaries
+
+Pure/deterministic where it matters — transform, negative sampling, splits, and
+each corruption channel are unit-tested with **no network, no GPU** (mirroring
+`test_gen_pairs.py`). Fetch loaders use committed fixtures and run behind a
+network marker. Determinism tests assert same-seed → byte-identical JSONL. The
+whole pipeline is CPU/box-safe; nothing here touches Modal.
+
+## Open questions / risks
+
+- **Bundle vs. Release asset**: FEBRL (~1–10k rows) and MusicBrainz-20K are small
+  enough to commit; if the blended corpus grows large, host it as a GitHub Release
+  asset (the existing `bench-dataset-v1` pattern) instead of committing raw JSONL.
+  Decide during planning based on measured sizes.
+- **Leipzig fetch script vs. vendored copy**: CC-BY permits bundling; prefer a
+  committed vendored copy + attribution for reproducibility over a fetch that can
+  rot. Confirm each file's size first.
+- **Blend ratios** are a modeling knob; start balanced with a person upweight and
+  tune once the sub-project 2 run + sub-project 3 eval exist.
+- **FEBRL access path**: bundled files vs. the `recordlinkage` library's copy —
+  pick the one with the clearest provenance during planning.

--- a/scripts/er_matcher/README.md
+++ b/scripts/er_matcher/README.md
@@ -1,0 +1,109 @@
+# ER-Matcher data pipeline
+
+Builds the training/eval corpus for the OSS ER-matcher (Qwen2.5-3B LoRA SFT) by
+blending multiple **license-clean** entity-matching sources into the unified
+JSONL row contract the trainer already consumes. This is Phase 1a of the
+production-grade data effort (see
+`docs/superpowers/specs/2026-07-27-er-matcher-multi-source-data-pipeline-design.md`
+and the plan alongside it).
+
+Everything here is **CPU / box-safe**: no `torch`/`transformers`, no network in
+the unit tests. The GPU trainer (`train.py`, `modal_train.py`) is unchanged and
+still reads `data/er_matcher/{train,val,test}.jsonl`.
+
+## Row contract
+
+Each source emits the trainer's existing row, extended with one `dataset`
+provenance field (the trainer ignores unknown keys):
+
+```
+{a: {...fields}, b: {...fields}, label: "match"|"no_match",
+ domain, source, dataset, eid_a, eid_b}
+```
+
+Heterogeneous schemas are intentional — mixing product `{title,brand,price}`,
+person `{name,address,dob}`, and citation `{authors,venue,year}` improves
+robustness. The shared serializer (`goldenmatch.core.er_matcher.prompt.build_chat`)
+renders arbitrary fields.
+
+## Sources
+
+| Source | Loader | License | Mechanism | Domain | In training corpus? |
+|---|---|---|---|---|---|
+| `febrl` | `FebrlSource` | MPL-1.1 (ANUOS) | **bundle** | person (synthetic) | yes |
+| `abt_buy`, `amazon_google` | `LeipzigSource` | **CC-BY** (attribution required) | **bundle** | product | yes |
+| `dblp_acm`, `dblp_scholar` | `LeipzigSource` | **CC-BY** (attribution required) | **bundle** | citation | yes |
+| `magellan_*` | `MagellanSource` | cite-only | **fetch** | product/citation | **no — eval-only** |
+| `ncvr` | `NcvrSource` (stub) | public-record (real PII) | **fetch** | person | **no — eval-only, never bundled** |
+
+**License obligations:**
+- **Leipzig (CC-BY):** redistribution is permitted *with attribution* — credit the
+  Leipzig DB Group + the VLDB2010 paper (carried in `sources.yaml` and the
+  manifest). Pull Abt-Buy / Amazon-Google from Leipzig, **not** Magellan (same
+  rows, Magellan has no license).
+- **FEBRL (MPL-1.1):** synthetic person data, redistributable.
+- **Magellan/DeepMatcher (cite-only):** no redistribution grant — **fetch at
+  build, never commit**; eval-parity only.
+- **NCVR (real voter PII):** legally public but no redistribution grant — **never
+  bundled** into a published model; fetch-only, eval-only, documented. The
+  license-clean *person* training data is synthetic (FEBRL + the Phase 1b rich
+  generator), by design.
+
+The `manifest.json` records every source's license + attribution (for the model
+card), including the eval-only ones that contribute no training rows.
+
+## Running it
+
+```bash
+# from the repo root
+python scripts/er_matcher/build_corpus.py \
+    --sources scripts/er_matcher/sources.yaml \
+    --out-dir data/er_matcher \
+    --seed 20260727
+# -> data/er_matcher/{train,val,test}.jsonl + manifest.json
+```
+
+`build_corpus` constructs every configured source (so a broken `sources.yaml`
+fails loudly), but only **bundle/generate, non-`eval_only`** sources contribute
+rows. `--cap N` limits each source to N rows per split (the "cap oversized
+sources" lever; ratio-blending by `weight` is deferred to a later sub-project).
+
+### Data acquisition (not committed)
+
+`sources.yaml` points each bundled source's `kwargs.root` at
+`data/er_matcher/raw/<source>/`. Those raw datasets are **not committed** —
+download the license-clean bundled sources (FEBRL, the Leipzig CC-BY sets) into
+those paths before running `build_corpus` against real data. Fetch-only sources
+(Magellan, NCVR) require `GOLDENMATCH_ALLOW_FETCH=1` and are consumed by the eval
+harness (a later sub-project), not the training build.
+
+## Module map
+
+- `sources/base.py` — `Row`, the `PairSource` protocol, the loader registry.
+- `sources/splits.py` — deterministic entity-level `split_of` (shared with `gen_pairs.py`).
+- `sources/negatives.py` — deterministic blocker + bounded hard/easy negative synthesis (optional cross-partition constraint).
+- `sources/csv_tables.py` — shared `read_id_table` (used by leipzig + magellan).
+- `sources/{leipzig,febrl,magellan,ncvr}.py` — the loaders.
+- `sources_config.py` — `sources.yaml` schema, strict validation, the `build_source` factory.
+- `build_corpus.py` — the blend driver → JSONL + manifest.
+
+## Testing
+
+```bash
+# box-safe: no GPU, no network (fetch is guarded by GOLDENMATCH_ALLOW_FETCH)
+pytest scripts/er_matcher/
+```
+Loaders/pipeline are deterministic (same seed → byte-identical JSONL) and unit-tested against tiny fixtures under `tests/fixtures/`.
+
+## Deferred / follow-ups
+
+- **Phase 1b:** the rich synthetic generator (census-scale vocab, CRM/org schemas,
+  dsgen-calibrated corruption) replacing `gen_pairs.py`'s internals, registered as
+  a `synthetic` source.
+- **MusicBrainz** (Leipzig, CC-BY): multi-source clustering shape — needs a loader
+  distinct from the two-table `LeipzigSource`.
+- `sources_config`: guard `kwargs` against keys that collide with the builder's
+  explicit args (`name`/`domain`/`seed`) so a bad entry raises a clear `ValueError`
+  instead of a `TypeError`.
+- Sub-project 2 (run re-architecture for scale) and sub-project 3 (cross-benchmark
+  eval harness — where Magellan/NCVR get consumed).

--- a/scripts/er_matcher/README.md
+++ b/scripts/er_matcher/README.md
@@ -67,6 +67,10 @@ python scripts/er_matcher/build_corpus.py \
 fails loudly), but only **bundle/generate, non-`eval_only`** sources contribute
 rows. `--cap N` limits each source to N rows per split (the "cap oversized
 sources" lever; ratio-blending by `weight` is deferred to a later sub-project).
+The cap preserves class balance: it interleaves each source's `match` and
+`no_match` rows round-robin before truncating, so a capped split still
+contains both labels (in roughly the source's original ratio) instead of
+degenerating into all-match rows.
 
 ### Data acquisition (not committed)
 

--- a/scripts/er_matcher/build_corpus.py
+++ b/scripts/er_matcher/build_corpus.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Corpus-builder driver for the multi-source ER data pipeline (Task 8).
+
+Blends every BUNDLED/GENERATED, non-eval-only source's `splits()` output
+into one unified `train.jsonl`/`val.jsonl`/`test.jsonl` (same
+`json.dumps(row, sort_keys=True, ensure_ascii=True)`-per-line style as
+`gen_pairs._write`, so downstream training code doesn't care which pipeline
+produced the JSONL) plus a `manifest.json` recording every configured
+source's provenance/license -- INCLUDING `fetch`/`eval_only` sources
+(Magellan, NCVR), which are still constructed (so a broken `sources.yaml`
+entry fails loudly at build time) but never contribute rows.
+
+Blend weights (`SourceEntry.weight`) are recorded in the manifest for the
+model card but ratio-blending by weight is DEFERRED -- this task only caps
+per-source row counts (the `cap` lever); it does not re-weight the mix.
+
+Box-safe: stdlib + `sources_config` (PyYAML) only. Never touches the
+network -- `fetch` sources contribute no rows here, so no download happens
+during a corpus build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from sources_config import build_source, load_sources
+
+_SPLITS = ("train", "val", "test")
+
+# Mechanisms whose splits() output is folded into the training corpus.
+# `fetch` sources (Magellan, NCVR) are excluded even when eval_only is
+# somehow False, since their data is either cite-only/eval-only by design
+# or not locally materialized.
+_ROW_MECHANISMS = {"bundle", "generate"}
+
+
+def build_corpus(
+    sources_yaml: Path, out_dir: Path, *, seed: int, cap: int | None = None
+) -> dict[str, Any]:
+    """Blend every bundled/generated, non-eval-only source into
+    `out_dir/{train,val,test}.jsonl` + `out_dir/manifest.json`. Returns the
+    manifest dict that was written.
+
+    `cap`, if given, limits EACH contributing source to at most `cap` rows
+    per split -- taken as the first `cap` rows after the source's own
+    deterministic `splits()` ordering (no re-shuffling), so results stay
+    reproducible. This is the "cap oversized sources" lever; proportional
+    weight-blending (`SourceEntry.weight`) is deferred to a later task.
+    """
+    entries = load_sources(sources_yaml)
+
+    corpus: dict[str, list[dict[str, Any]]] = {s: [] for s in _SPLITS}
+    manifest_sources: dict[str, Any] = {}
+
+    for entry in entries:
+        # Always construct -- a broken config (bad kwargs, missing fixture
+        # root, etc.) must fail loudly here regardless of whether the
+        # source ends up contributing rows.
+        src = build_source(entry, seed=seed)
+
+        contributes = entry.mechanism in _ROW_MECHANISMS and not entry.eval_only
+        counts = {s: 0 for s in _SPLITS}
+
+        if contributes:
+            splits = src.splits()
+            for split in _SPLITS:
+                rows = list(splits.get(split, []))
+                if cap is not None:
+                    rows = rows[:cap]
+                corpus[split].extend(rows)
+                counts[split] = len(rows)
+
+        manifest_sources[entry.name] = {
+            "mechanism": entry.mechanism,
+            # yaml overrides the loader's own citation; yaml only REQUIRES
+            # attribution for CC-BY (license-compliance), so a bundled
+            # non-CC-BY source (febrl, magellan, ncvr) that leaves
+            # `attribution:` unset in sources.yaml still gets its class's
+            # citation recorded here instead of `null`.
+            "license": entry.license or getattr(src, "license", None),
+            "attribution": entry.attribution or getattr(src, "attribution", None),
+            "eval_only": entry.eval_only,
+            "weight": entry.weight,
+            "domain": entry.domain,
+            "counts": counts,
+        }
+
+    _write_jsonl(corpus, out_dir)
+
+    totals = {s: sum(v["counts"][s] for v in manifest_sources.values()) for s in _SPLITS}
+    manifest = {"seed": seed, "sources": manifest_sources, "totals": totals}
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    return manifest
+
+
+def _write_jsonl(corpus: dict[str, list[dict[str, Any]]], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for split in _SPLITS:
+        path = out_dir / f"{split}.jsonl"
+        with path.open("w", encoding="utf-8") as fh:
+            for row in corpus[split]:
+                fh.write(json.dumps(row, sort_keys=True, ensure_ascii=True) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Blend bundled ER-matcher sources into the unified training corpus."
+    )
+    ap.add_argument("--sources", type=Path, default=Path("scripts/er_matcher/sources.yaml"))
+    ap.add_argument("--out-dir", type=Path, default=Path("data/er_matcher"))
+    ap.add_argument("--seed", type=int, default=20260727)
+    ap.add_argument("--cap", type=int, default=None)
+    args = ap.parse_args(argv)
+
+    manifest = build_corpus(args.sources, args.out_dir, seed=args.seed, cap=args.cap)
+    print(json.dumps(manifest["totals"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/er_matcher/build_corpus.py
+++ b/scripts/er_matcher/build_corpus.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,27 @@ _SPLITS = ("train", "val", "test")
 _ROW_MECHANISMS = {"bundle", "generate"}
 
 
+def _cap_preserving_balance(rows: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
+    """Truncate `rows` to at most `cap`, preserving BOTH labels instead of
+    `rows[:cap]` -- which would silently produce an all-`match` (or
+    all-`no_match`) slice whenever a loader emits every positive before any
+    negative (both bundled loaders do). Splits `rows` into `match`/`no_match`
+    (stable order preserved within each group), then interleaves the two
+    groups round-robin (match, no_match, match, no_match, ...) before
+    truncating -- deterministic given `rows`' own deterministic order, so
+    same seed + cap -> byte-identical output still holds."""
+    matches = [r for r in rows if r["label"] == "match"]
+    non_matches = [r for r in rows if r["label"] != "match"]
+    interleaved: list[dict[str, Any]] = []
+    for a, b in zip(matches, non_matches):
+        interleaved.append(a)
+        interleaved.append(b)
+    # Leftover tail from whichever group is longer.
+    interleaved.extend(matches[len(non_matches):])
+    interleaved.extend(non_matches[len(matches):])
+    return interleaved[:cap]
+
+
 def build_corpus(
     sources_yaml: Path, out_dir: Path, *, seed: int, cap: int | None = None
 ) -> dict[str, Any]:
@@ -45,9 +67,9 @@ def build_corpus(
     manifest dict that was written.
 
     `cap`, if given, limits EACH contributing source to at most `cap` rows
-    per split -- taken as the first `cap` rows after the source's own
-    deterministic `splits()` ordering (no re-shuffling), so results stay
-    reproducible. This is the "cap oversized sources" lever; proportional
+    per split -- via `_cap_preserving_balance` (interleaves match/no_match
+    before truncating, see its docstring), so results stay reproducible AND
+    class-balanced. This is the "cap oversized sources" lever; proportional
     weight-blending (`SourceEntry.weight`) is deferred to a later task.
     """
     entries = load_sources(sources_yaml)
@@ -61,6 +83,12 @@ def build_corpus(
         # source ends up contributing rows.
         src = build_source(entry, seed=seed)
 
+        if getattr(src, "eval_only", False) and not entry.eval_only:
+            raise ValueError(
+                f"{entry.name}: loader class is eval_only but sources.yaml entry isn't -- "
+                "refusing to fold eval-only data into the training corpus"
+            )
+
         contributes = entry.mechanism in _ROW_MECHANISMS and not entry.eval_only
         counts = {s: 0 for s in _SPLITS}
 
@@ -69,7 +97,7 @@ def build_corpus(
             for split in _SPLITS:
                 rows = list(splits.get(split, []))
                 if cap is not None:
-                    rows = rows[:cap]
+                    rows = _cap_preserving_balance(rows, cap)
                 corpus[split].extend(rows)
                 counts[split] = len(rows)
 
@@ -91,9 +119,35 @@ def build_corpus(
     _write_jsonl(corpus, out_dir)
 
     totals = {s: sum(v["counts"][s] for v in manifest_sources.values()) for s in _SPLITS}
-    manifest = {"seed": seed, "sources": manifest_sources, "totals": totals}
+    label_totals = _label_totals(corpus)
+    manifest = {
+        "seed": seed,
+        "sources": manifest_sources,
+        "totals": totals,
+        "label_totals": label_totals,
+    }
     (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+
+    for split, labels in label_totals.items():
+        nonzero = [label for label, n in labels.items() if n > 0]
+        if len(nonzero) == 1:
+            warnings.warn(
+                f"build_corpus: split {split!r} is single-class ({nonzero[0]} only) "
+                "-- check blend/cap",
+                stacklevel=2,
+            )
+
     return manifest
+
+
+def _label_totals(corpus: dict[str, list[dict[str, Any]]]) -> dict[str, dict[str, int]]:
+    totals: dict[str, dict[str, int]] = {}
+    for split in _SPLITS:
+        labels = {"match": 0, "no_match": 0}
+        for row in corpus[split]:
+            labels[row["label"]] = labels.get(row["label"], 0) + 1
+        totals[split] = labels
+    return totals
 
 
 def _write_jsonl(corpus: dict[str, list[dict[str, Any]]], out_dir: Path) -> None:

--- a/scripts/er_matcher/gen_pairs.py
+++ b/scripts/er_matcher/gen_pairs.py
@@ -24,12 +24,13 @@ Pure stdlib. Reuses the corruption ideas from tests/generate_synthetic.py.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import random
 import string
 from pathlib import Path
 from typing import Any
+
+from sources.splits import split_of
 
 # --- vendored compact reference data (stdlib-only; no faker) ----------------
 FIRST = [
@@ -173,16 +174,10 @@ def _split_of(eid: int, domain: str, seed: int, val_frac: float, test_frac: floa
               holdout_domain: str | None) -> str:
     """Deterministic entity-level split. The holdout domain is fully reserved to
     `test` (cross-domain generalization); all other entities hash into
-    train/val/test by a stable digest of (seed, eid)."""
-    if holdout_domain and domain == holdout_domain:
-        return "test"
-    h = hashlib.sha256(f"{seed}:{eid}".encode()).hexdigest()
-    frac = int(h[:8], 16) / 0xFFFFFFFF
-    if frac < test_frac:
-        return "test"
-    if frac < test_frac + val_frac:
-        return "val"
-    return "train"
+    train/val/test by a stable digest of (seed, eid). Thin wrapper: delegates to
+    the shared `sources.splits.split_of` helper (DRY) without changing behavior."""
+    return split_of(eid, seed=seed, val_frac=val_frac, test_frac=test_frac,
+                     holdout_domain=holdout_domain, domain=domain)
 
 
 def generate_dataset(

--- a/scripts/er_matcher/sources.yaml
+++ b/scripts/er_matcher/sources.yaml
@@ -1,0 +1,80 @@
+# Per-source config for the multi-source ER data pipeline (Task 7).
+# Loaded + strictly validated via `sources_config.load_sources`; each entry
+# is turned into a running loader via `sources_config.build_source`.
+# `weight` values are illustrative only -- blending these into one training
+# corpus is deferred to a later task.
+#
+# NOTE: MusicBrainz is a multi-source CLUSTERING benchmark (N-way entity
+# groups, not pairwise two-table matching like every source below) and needs
+# a different loader shape -- deferred.
+
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    domain: person
+    weight: 1.0
+    kwargs:
+      root: data/er_matcher/raw/febrl
+
+  abt_buy:
+    loader: leipzig
+    mechanism: bundle
+    license: CC-BY
+    attribution: "Leipzig DB Group; VLDB2010"
+    domain: product
+    weight: 1.0
+    kwargs:
+      root: data/er_matcher/raw/leipzig/abt_buy
+      block_fields: [title]
+
+  amazon_google:
+    loader: leipzig
+    mechanism: bundle
+    license: CC-BY
+    attribution: "Leipzig DB Group; VLDB2010"
+    domain: product
+    weight: 1.0
+    kwargs:
+      root: data/er_matcher/raw/leipzig/amazon_google
+      block_fields: [title]
+
+  dblp_acm:
+    loader: leipzig
+    mechanism: bundle
+    license: CC-BY
+    attribution: "Leipzig DB Group; VLDB2010"
+    domain: citation
+    weight: 1.0
+    kwargs:
+      root: data/er_matcher/raw/leipzig/dblp_acm
+      block_fields: [title]
+
+  dblp_scholar:
+    loader: leipzig
+    mechanism: bundle
+    license: CC-BY
+    attribution: "Leipzig DB Group; VLDB2010"
+    domain: citation
+    weight: 1.0
+    kwargs:
+      root: data/er_matcher/raw/leipzig/dblp_scholar
+      block_fields: [title]
+
+  magellan_abt_buy:
+    loader: magellan
+    mechanism: fetch
+    license: cite-only
+    eval_only: true
+    domain: product
+    kwargs:
+      root: data/er_matcher/raw/magellan/abt_buy
+
+  ncvr:
+    loader: ncvr
+    mechanism: fetch
+    license: public-record
+    eval_only: true
+    domain: person
+    kwargs: {}

--- a/scripts/er_matcher/sources/__init__.py
+++ b/scripts/er_matcher/sources/__init__.py
@@ -1,0 +1,7 @@
+"""Multi-source ER data pipeline: PairSource contract + registry."""
+
+from __future__ import annotations
+
+from sources.base import PairSource, Row, get_source, iter_sources, register
+
+__all__ = ["Row", "PairSource", "register", "get_source", "iter_sources"]

--- a/scripts/er_matcher/sources/base.py
+++ b/scripts/er_matcher/sources/base.py
@@ -1,0 +1,42 @@
+"""Loader contract + registry for the multi-source ER data pipeline.
+CPU/box-safe: stdlib only, never imports torch/transformers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Protocol, TypedDict, runtime_checkable
+
+
+class Row(TypedDict):
+    a: dict[str, Any]
+    b: dict[str, Any]
+    label: str  # "match" | "no_match"
+    domain: str
+    source: str  # e.g. "leipzig", "febrl", "synthetic"
+    dataset: str  # PairSource.name; == registry key == sources.yaml key
+    eid_a: str
+    eid_b: str
+
+
+@runtime_checkable
+class PairSource(Protocol):
+    name: str
+
+    def splits(self) -> dict[str, Iterable[Row]]: ...
+
+
+_REGISTRY: dict[str, PairSource] = {}
+
+
+def register(source: PairSource) -> None:
+    _REGISTRY[source.name] = source
+
+
+def get_source(name: str) -> PairSource:
+    if name not in _REGISTRY:
+        raise KeyError(f"no registered source {name!r}; have {sorted(_REGISTRY)}")
+    return _REGISTRY[name]
+
+
+def iter_sources() -> Iterable[PairSource]:
+    return list(_REGISTRY.values())

--- a/scripts/er_matcher/sources/csv_tables.py
+++ b/scripts/er_matcher/sources/csv_tables.py
@@ -1,0 +1,21 @@
+"""Shared CSV record-table reader used by the two-table PairSource loaders
+(Leipzig, Magellan). CPU/box-safe: stdlib only (csv, pathlib)."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def read_id_table(root: Path, filename: str, prefix: str) -> dict[str, dict]:
+    """Read a `id,<fields...>` record table, namespacing every id with
+    `prefix` (e.g. `"A"`/`"B"`) so A-side and B-side ids never collide when
+    merged into one shared entities/records dict for blocking, negative
+    sampling, or split lookup."""
+    entities: dict[str, dict] = {}
+    with open(root / filename, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            native_id = row["id"]
+            fields = {k: v for k, v in row.items() if k != "id"}
+            entities[f"{prefix}:{native_id}"] = fields
+    return entities

--- a/scripts/er_matcher/sources/febrl.py
+++ b/scripts/er_matcher/sources/febrl.py
@@ -1,0 +1,165 @@
+"""FEBRL synthetic-person loader (Task 5 of the multi-source ER data
+pipeline). FEBRL ships a SINGLE table of person records where each real
+entity appears as one "org" (original) record plus one or more "dup"
+(corrupted duplicate) records; matches are same-entity record pairs,
+non-matches are different-entity pairs. CPU/box-safe: stdlib only (csv,
+pathlib, warnings), never imports torch/transformers/network.
+
+Dataset shape expected under `root`:
+  febrl_sample.csv -- header
+    rec_id,given_name,surname,street,suburb,postcode,phone,soc_sec_id
+  `rec_id` encodes entity + role, e.g. `rec-0-org`, `rec-0-dup-0`,
+  `rec-1-dup-1`.
+"""
+
+from __future__ import annotations
+
+import csv
+import warnings
+from pathlib import Path
+
+from sources.base import Row
+from sources.negatives import synth_negatives
+from sources.splits import split_of
+
+
+def _entity_of(rec_id: str) -> str:
+    """Parse a FEBRL `rec_id` (e.g. `rec-0-org`, `rec-1-dup-0`) into its
+    entity id (`rec-0`, `rec-1`) by dropping the `-org`/`-dup-<k>` role
+    suffix -- the first two hyphen-joined tokens."""
+    parts = rec_id.split("-")
+    return "-".join(parts[:2])
+
+
+def _is_org(rec_id: str) -> bool:
+    """True if `rec_id`'s role token is `org` (the original record for its
+    entity) rather than `dup-<k>` (a corrupted duplicate)."""
+    parts = rec_id.split("-")
+    return len(parts) >= 3 and parts[2] == "org"
+
+
+class FebrlSource:
+    """PairSource for FEBRL-style synthetic person data: a single record
+    table where each entity contributes one "org" record plus zero or
+    more "dup" records. Splits are assigned at the ENTITY level (unlike
+    Leipzig's record/pair-level split) since every record belonging to a
+    FEBRL entity lives in the same source table -- clean entity-level
+    no-leak across train/val/test is both achievable and required here.
+    Positives and negatives are generated WITHIN each split so no
+    entity's records ever appear in more than one split.
+    """
+
+    license = "MPL-1.1"
+    attribution = "FEBRL (ANU); Christen 2005"
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        name: str = "febrl",
+        domain: str = "person",
+        block_fields: list[str] | None = None,
+        seed: int = 0,
+        val_frac: float = 0.15,
+        test_frac: float = 0.15,
+        hard_frac: float = 0.5,
+    ) -> None:
+        self.name = name
+        self.root = Path(root)
+        self.domain = domain
+        self.block_fields = block_fields if block_fields is not None else ["surname"]
+        self.seed = seed
+        self.val_frac = val_frac
+        self.test_frac = test_frac
+        self.hard_frac = hard_frac
+
+    def _read_records(self) -> dict[str, dict]:
+        records: dict[str, dict] = {}
+        with open(self.root / "febrl_sample.csv", newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                rec_id = row["rec_id"]
+                fields = {k: v for k, v in row.items() if k != "rec_id"}
+                records[rec_id] = fields
+        return records
+
+    def _row(self, records: dict[str, dict], eid_a: str, eid_b: str, label: str) -> Row:
+        return {
+            "a": records[eid_a],
+            "b": records[eid_b],
+            "label": label,
+            "domain": self.domain,
+            "source": "febrl",
+            "dataset": self.name,
+            "eid_a": eid_a,
+            "eid_b": eid_b,
+        }
+
+    def splits(self) -> dict[str, list[Row]]:
+        records = self._read_records()
+
+        entities: dict[str, list[str]] = {}
+        for rec_id in records:
+            entities.setdefault(_entity_of(rec_id), []).append(rec_id)
+
+        entity_split: dict[str, str] = {
+            eid: split_of(eid, seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac)
+            for eid in entities
+        }
+
+        out: dict[str, list[Row]] = {"train": [], "val": [], "test": []}
+
+        for eid, rec_ids in entities.items():
+            if len(rec_ids) < 2:
+                continue
+            split = entity_split[eid]
+            rec_ids_sorted = sorted(rec_ids)
+            org_ids = [r for r in rec_ids_sorted if _is_org(r)]
+            anchor = org_ids[0] if org_ids else rec_ids_sorted[0]
+            # Star topology: anchor paired with each OTHER record, not full
+            # pairwise -- e.g. dup-0 vs dup-1 is never itself emitted as a
+            # match. Acceptable simplification (every pair is still
+            # same-entity via the shared anchor, just not exhaustive).
+            for other in rec_ids_sorted:
+                if other == anchor:
+                    continue
+                out[split].append(self._row(records, anchor, other, "match"))
+
+        for split, split_rows in out.items():
+            n_positives = len(split_rows)
+            if n_positives == 0:
+                continue
+
+            split_rec_ids = [
+                rec_id
+                for eid, rec_ids in entities.items()
+                if entity_split[eid] == split
+                for rec_id in rec_ids
+            ]
+            split_records = {rid: records[rid] for rid in split_rec_ids}
+
+            candidates = synth_negatives(
+                split_records,
+                block_keys=self.block_fields,
+                hard_frac=self.hard_frac,
+                seed=self.seed,
+                n=n_positives,
+            )
+
+            kept = 0
+            for eid_a, eid_b, _tag in candidates:
+                if _entity_of(eid_a) == _entity_of(eid_b):
+                    # A sampled "negative" whose two records belong to the
+                    # SAME entity is actually a match, not a negative --
+                    # dropping it is correctness-critical, not cosmetic.
+                    continue
+                out[split].append(self._row(records, eid_a, eid_b, "no_match"))
+                kept += 1
+
+            if kept < n_positives:
+                warnings.warn(
+                    f"febrl[{self.name}]: only {kept}/{n_positives} negatives "
+                    f"in split {split!r} after same-entity filter",
+                    stacklevel=2,
+                )
+
+        return out

--- a/scripts/er_matcher/sources/leipzig.py
+++ b/scripts/er_matcher/sources/leipzig.py
@@ -1,0 +1,148 @@
+"""Leipzig CC-BY entity-matching benchmark loader (Task 4 of the multi-source
+ER data pipeline). Turns a Leipzig-style two-record-table + perfect-mapping
+gold file into labeled {a, b, label} `Row`s. CPU/box-safe: stdlib only
+(csv, pathlib), never imports torch/transformers/network.
+
+Dataset shape expected under `root`:
+  tableA.csv  -- header `id,<fields...>`
+  tableB.csv  -- header `id,<fields...>`
+  mapping.csv -- header `idA,idB`; one row per gold (true-match) pair.
+"""
+
+from __future__ import annotations
+
+import csv
+import warnings
+from pathlib import Path
+
+from sources.base import Row
+from sources.negatives import synth_negatives
+from sources.splits import split_of
+
+# synth_negatives is asked for a few extra candidates beyond the positive
+# count so that dropping any that coincide with a gold match (see below)
+# still leaves ~as many negatives as positives.
+_NEGATIVE_OVERSAMPLE_FRAC = 0.5
+_MIN_NEGATIVE_OVERSAMPLE = 2
+
+
+class LeipzigSource:
+    """PairSource for Leipzig-style CC-BY entity-matching benchmarks (e.g.
+    Abt-Buy, Amazon-GoogleProducts, DBLP-Scholar): two record tables plus a
+    perfect-mapping gold file of matches.
+
+    Split assignment is done at the record/pair level (keyed by `eid_a` via
+    `split_of`), NOT at a true cross-table entity-identity level. Strict
+    entity-level no-leak across two *different* tables is a known hard
+    problem and is out of scope here -- record/pair-level splitting is the
+    pragmatic approach these benchmarks use elsewhere.
+    """
+
+    license = "CC-BY"
+    attribution = "Leipzig DB Group; VLDB2010"
+
+    def __init__(
+        self,
+        name: str,
+        root: Path,
+        domain: str,
+        block_fields: list[str],
+        seed: int,
+        *,
+        val_frac: float = 0.15,
+        test_frac: float = 0.15,
+        hard_frac: float = 0.5,
+    ) -> None:
+        self.name = name
+        self.root = Path(root)
+        self.domain = domain
+        self.block_fields = block_fields
+        self.seed = seed
+        self.val_frac = val_frac
+        self.test_frac = test_frac
+        self.hard_frac = hard_frac
+
+    def _read_table(self, filename: str, prefix: str) -> dict[str, dict]:
+        """Read one Leipzig record table, namespacing every id with `prefix`
+        (`"A:"`/`"B:"`) so A-side and B-side ids never collide when merged
+        into one `entities` dict for blocking/negative-sampling."""
+        entities: dict[str, dict] = {}
+        with open(self.root / filename, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                native_id = row["id"]
+                fields = {k: v for k, v in row.items() if k != "id"}
+                entities[f"{prefix}:{native_id}"] = fields
+        return entities
+
+    def _read_gold_pairs(self) -> list[tuple[str, str]]:
+        pairs: list[tuple[str, str]] = []
+        with open(self.root / "mapping.csv", newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                pairs.append((f"A:{row['idA']}", f"B:{row['idB']}"))
+        return pairs
+
+    def _row(self, entities: dict[str, dict], eid_a: str, eid_b: str, label: str) -> Row:
+        return {
+            "a": entities[eid_a],
+            "b": entities[eid_b],
+            "label": label,
+            "domain": self.domain,
+            "source": "leipzig",
+            "dataset": self.name,
+            "eid_a": eid_a,
+            "eid_b": eid_b,
+        }
+
+    def splits(self) -> dict[str, list[Row]]:
+        entities: dict[str, dict] = {
+            **self._read_table("tableA.csv", "A"),
+            **self._read_table("tableB.csv", "B"),
+        }
+        gold_pairs = self._read_gold_pairs()
+        # Order-normalized so a sampled negative is caught regardless of
+        # which side synth_negatives happened to put first.
+        gold_set = {(a, b) for a, b in gold_pairs} | {(b, a) for a, b in gold_pairs}
+
+        out: dict[str, list[Row]] = {"train": [], "val": [], "test": []}
+
+        def assign(row: Row) -> None:
+            split = split_of(
+                row["eid_a"], seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac
+            )
+            out[split].append(row)
+
+        for eid_a, eid_b in gold_pairs:
+            assign(self._row(entities, eid_a, eid_b, "match"))
+
+        n_positives = len(gold_pairs)
+        oversample = max(_MIN_NEGATIVE_OVERSAMPLE, round(n_positives * _NEGATIVE_OVERSAMPLE_FRAC))
+        candidates = synth_negatives(
+            entities,
+            block_keys=self.block_fields,
+            hard_frac=self.hard_frac,
+            seed=self.seed,
+            n=n_positives + oversample,
+            # Namespace prefix ("A"/"B") is the partition -- negatives must
+            # be strictly cross-table, matching what the gold mapping pairs.
+            partition_of=lambda eid: eid[0],
+        )
+
+        kept = 0
+        for eid_a, eid_b, _tag in candidates:
+            if kept >= n_positives:
+                break
+            if (eid_a, eid_b) in gold_set:
+                # A sampled "negative" that is actually a true match --
+                # dropping it is correctness-critical, not cosmetic.
+                continue
+            assign(self._row(entities, eid_a, eid_b, "no_match"))
+            kept += 1
+
+        if kept < n_positives:
+            warnings.warn(
+                f"leipzig[{self.name}]: only {kept}/{n_positives} negatives "
+                "after gold-filter + cross-table constraint",
+                stacklevel=2,
+            )
+
+        return out

--- a/scripts/er_matcher/sources/leipzig.py
+++ b/scripts/er_matcher/sources/leipzig.py
@@ -16,6 +16,7 @@ import warnings
 from pathlib import Path
 
 from sources.base import Row
+from sources.csv_tables import read_id_table
 from sources.negatives import synth_negatives
 from sources.splits import split_of
 
@@ -62,18 +63,6 @@ class LeipzigSource:
         self.test_frac = test_frac
         self.hard_frac = hard_frac
 
-    def _read_table(self, filename: str, prefix: str) -> dict[str, dict]:
-        """Read one Leipzig record table, namespacing every id with `prefix`
-        (`"A:"`/`"B:"`) so A-side and B-side ids never collide when merged
-        into one `entities` dict for blocking/negative-sampling."""
-        entities: dict[str, dict] = {}
-        with open(self.root / filename, newline="", encoding="utf-8") as f:
-            for row in csv.DictReader(f):
-                native_id = row["id"]
-                fields = {k: v for k, v in row.items() if k != "id"}
-                entities[f"{prefix}:{native_id}"] = fields
-        return entities
-
     def _read_gold_pairs(self) -> list[tuple[str, str]]:
         pairs: list[tuple[str, str]] = []
         with open(self.root / "mapping.csv", newline="", encoding="utf-8") as f:
@@ -95,8 +84,8 @@ class LeipzigSource:
 
     def splits(self) -> dict[str, list[Row]]:
         entities: dict[str, dict] = {
-            **self._read_table("tableA.csv", "A"),
-            **self._read_table("tableB.csv", "B"),
+            **read_id_table(self.root, "tableA.csv", "A"),
+            **read_id_table(self.root, "tableB.csv", "B"),
         }
         gold_pairs = self._read_gold_pairs()
         # Order-normalized so a sampled negative is caught regardless of

--- a/scripts/er_matcher/sources/magellan.py
+++ b/scripts/er_matcher/sources/magellan.py
@@ -1,0 +1,124 @@
+"""Magellan/DeepMatcher fetch-at-build EVAL loader (Task 6 of the
+multi-source ER data pipeline). Unlike the Leipzig/FEBRL loaders, DeepMatcher
+datasets ship PRE-LABELED candidate pairs (train/valid/test CSVs with an
+explicit match label) -- there is NO negative synthesis here. This source is
+EVAL-ONLY (never part of the training corpus) and its data is FETCHED at
+build time under a cite-only license, so it is never committed to the repo.
+CPU/box-safe on the parse path: stdlib only (csv, pathlib, os); `urllib` is
+only imported inside `fetch`, below the network guard.
+
+Dataset shape expected under `root`:
+  tableA.csv -- header `id,<fields...>`
+  tableB.csv -- header `id,<fields...>`
+  train.csv, valid.csv, test.csv -- header `ltable_id,rtable_id,label`
+    (`label` is `1`=match, `0`=no_match). `valid.csv` maps to the canonical
+    `"val"` split key.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+
+from sources.base import Row
+
+# Split file name -> canonical split key. DeepMatcher's on-disk name for the
+# validation split is `valid.csv`, but the rest of the pipeline (and Row's
+# split dict) uses the canonical key "val" -- this table is where that
+# rename happens.
+_SPLIT_FILES: dict[str, str] = {"train": "train.csv", "val": "valid.csv", "test": "test.csv"}
+
+# TODO(#magellan-fetch): real DeepMatcher mirror URL + expected sha256 per
+# dataset. Left undocumented here since we can't exercise a real download in
+# CI; the network GUARD below is what's tested, not this download logic.
+_DEEPMATCHER_BASE_URL = "https://pages.cs.wisc.edu/~anhai/data/deepmatcher_data/"
+
+
+class MagellanSource:
+    """PairSource for Magellan/DeepMatcher benchmark datasets: two record
+    tables (tableA/tableB) plus pre-labeled train/valid/test candidate-pair
+    CSVs. `eval_only = True` -- callers must never fold this source's rows
+    into a training corpus.
+    """
+
+    eval_only = True
+    license = "cite-only"
+    attribution = "Magellan/DeepMatcher (anhaidgroup); Konda et al. 2016"
+
+    def __init__(self, name: str, root: Path, domain: str = "product") -> None:
+        self.name = name
+        self.root = Path(root)
+        self.domain = domain
+
+    def _read_table(self, filename: str, prefix: str) -> dict[str, dict]:
+        """Read one Magellan record table, namespacing every id with `prefix`
+        (`"A"`/`"B"`) so A-side and B-side ids never collide."""
+        records: dict[str, dict] = {}
+        with open(self.root / filename, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                native_id = row["id"]
+                fields = {k: v for k, v in row.items() if k != "id"}
+                records[f"{prefix}:{native_id}"] = fields
+        return records
+
+    def _read_split(self, filename: str, table_a: dict, table_b: dict) -> list[Row]:
+        rows: list[Row] = []
+        with open(self.root / filename, newline="", encoding="utf-8") as f:
+            for line in csv.DictReader(f):
+                ltable_id = line["ltable_id"]
+                rtable_id = line["rtable_id"]
+                eid_a = f"A:{ltable_id}"
+                eid_b = f"B:{rtable_id}"
+                rows.append(
+                    {
+                        "a": table_a[eid_a],
+                        "b": table_b[eid_b],
+                        "label": "match" if int(line["label"]) == 1 else "no_match",
+                        "domain": self.domain,
+                        "source": "magellan",
+                        "dataset": self.name,
+                        "eid_a": eid_a,
+                        "eid_b": eid_b,
+                    }
+                )
+        return rows
+
+    def _has_local_data(self) -> bool:
+        expected = ("tableA.csv", "tableB.csv", *_SPLIT_FILES.values())
+        return self.root.exists() and all((self.root / fname).is_file() for fname in expected)
+
+    def load_from_dir(self) -> dict[str, list[Row]]:
+        """PURE, no network: parse an already-fetched Magellan dataset
+        directory into the three canonical splits."""
+        table_a = self._read_table("tableA.csv", "A")
+        table_b = self._read_table("tableB.csv", "B")
+        return {
+            split: self._read_split(fname, table_a, table_b)
+            for split, fname in _SPLIT_FILES.items()
+        }
+
+    def splits(self) -> dict[str, list[Row]]:
+        if not self._has_local_data():
+            self.fetch()
+        return self.load_from_dir()
+
+    def fetch(self) -> None:
+        """Network fetch, GUARDED behind an explicit opt-in env var -- this
+        source's data is cite-only-licensed and must never be downloaded
+        (or committed) silently."""
+        if os.environ.get("GOLDENMATCH_ALLOW_FETCH") != "1":
+            raise RuntimeError(
+                "network fetch disabled; set GOLDENMATCH_ALLOW_FETCH=1 to download "
+                "Magellan data (eval-only, cite-only license)"
+            )
+
+        # TODO(#magellan-fetch): `import urllib.request` here and resolve the
+        # real per-dataset archive URL under _DEEPMATCHER_BASE_URL + self.name,
+        # download to self.root, verify against a known sha256, and unpack
+        # tableA/tableB/train/valid/test CSVs. Not exercised here (no real
+        # download in CI).
+        raise NotImplementedError(
+            f"Magellan fetch for dataset {self.name!r} is not yet implemented "
+            f"(target base URL: {_DEEPMATCHER_BASE_URL})"
+        )

--- a/scripts/er_matcher/sources/magellan.py
+++ b/scripts/er_matcher/sources/magellan.py
@@ -22,6 +22,7 @@ import os
 from pathlib import Path
 
 from sources.base import Row
+from sources.csv_tables import read_id_table
 
 # Split file name -> canonical split key. DeepMatcher's on-disk name for the
 # validation split is `valid.csv`, but the rest of the pipeline (and Row's
@@ -51,30 +52,19 @@ class MagellanSource:
         self.root = Path(root)
         self.domain = domain
 
-    def _read_table(self, filename: str, prefix: str) -> dict[str, dict]:
-        """Read one Magellan record table, namespacing every id with `prefix`
-        (`"A"`/`"B"`) so A-side and B-side ids never collide."""
-        records: dict[str, dict] = {}
-        with open(self.root / filename, newline="", encoding="utf-8") as f:
-            for row in csv.DictReader(f):
-                native_id = row["id"]
-                fields = {k: v for k, v in row.items() if k != "id"}
-                records[f"{prefix}:{native_id}"] = fields
-        return records
-
     def _read_split(self, filename: str, table_a: dict, table_b: dict) -> list[Row]:
         rows: list[Row] = []
         with open(self.root / filename, newline="", encoding="utf-8") as f:
-            for line in csv.DictReader(f):
-                ltable_id = line["ltable_id"]
-                rtable_id = line["rtable_id"]
+            for row in csv.DictReader(f):
+                ltable_id = row["ltable_id"]
+                rtable_id = row["rtable_id"]
                 eid_a = f"A:{ltable_id}"
                 eid_b = f"B:{rtable_id}"
                 rows.append(
                     {
                         "a": table_a[eid_a],
                         "b": table_b[eid_b],
-                        "label": "match" if int(line["label"]) == 1 else "no_match",
+                        "label": "match" if int(row["label"]) == 1 else "no_match",
                         "domain": self.domain,
                         "source": "magellan",
                         "dataset": self.name,
@@ -91,8 +81,8 @@ class MagellanSource:
     def load_from_dir(self) -> dict[str, list[Row]]:
         """PURE, no network: parse an already-fetched Magellan dataset
         directory into the three canonical splits."""
-        table_a = self._read_table("tableA.csv", "A")
-        table_b = self._read_table("tableB.csv", "B")
+        table_a = read_id_table(self.root, "tableA.csv", "A")
+        table_b = read_id_table(self.root, "tableB.csv", "B")
         return {
             split: self._read_split(fname, table_a, table_b)
             for split, fname in _SPLIT_FILES.items()

--- a/scripts/er_matcher/sources/ncvr.py
+++ b/scripts/er_matcher/sources/ncvr.py
@@ -1,0 +1,37 @@
+"""NCVR (North Carolina Voter Registration) eval-only stub loader (Task 7 of
+the multi-source ER data pipeline). NCVR is a real public-record dataset, but
+the actual fetch/parse implementation is deferred to sub-project 3 -- this
+stub exists purely so its `sources.yaml` entry validates and shows up in the
+model-card manifest now. CPU/box-safe: stdlib only, no torch/transformers/
+network (there is no fetch path to guard yet -- it just raises).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sources.base import Row
+
+_NOT_IMPLEMENTED_MSG = "NCVR eval loader is deferred to sub-project 3"
+
+
+class NcvrSource:
+    """PairSource stub for the NCVR public-record voter-registration
+    dataset. `eval_only = True` -- this source must never enter a training
+    corpus, even once implemented. `splits()`/`fetch()` both raise
+    NotImplementedError; the real loader lands in sub-project 3.
+    """
+
+    eval_only = True
+    license = "public-record"
+    attribution = "NC State Board of Elections (public record)"
+
+    def __init__(self, name: str = "ncvr", **kwargs: Any) -> None:
+        self.name = name
+        self.kwargs = kwargs
+
+    def splits(self) -> dict[str, list[Row]]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+
+    def fetch(self) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)

--- a/scripts/er_matcher/sources/negatives.py
+++ b/scripts/er_matcher/sources/negatives.py
@@ -10,7 +10,7 @@ at the ~64k-row scale some loaders (e.g. DBLP-Scholar) feed in."""
 from __future__ import annotations
 
 import random
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 
 _ATTEMPT_MULTIPLIER = 50
 _MIN_ATTEMPTS = 100
@@ -55,6 +55,7 @@ def synth_negatives(
     hard_frac: float,
     seed: int,
     n: int,
+    partition_of: Callable[[str], Hashable] | None = None,
 ) -> list[tuple[str, str, str]]:
     """Synthesize up to `n` negative pairs (eid_a, eid_b, tag) from
     `entities` (eid -> field dict). "hard" pairs share a blocking key
@@ -62,6 +63,12 @@ def synth_negatives(
     blocks. Deterministic given `seed`. No self-pairs, no duplicate pairs.
     Falls back to filling the remainder from the other pool when one pool
     is short rather than erroring.
+
+    `partition_of`, if given, maps an eid to a partition value; both hard
+    and easy candidates reject any pair whose two eids share a partition
+    (e.g. a Leipzig loader passes the "A"/"B" table-namespace prefix so
+    negatives are strictly cross-table). Default `None` preserves prior
+    behavior exactly -- no cross-partition constraint.
 
     Sampling is rejection-based and bounded to O(n) memory/attempts -- it
     never enumerates the full within-block or cross-block pair product."""
@@ -75,11 +82,16 @@ def synth_negatives(
 
     non_singleton_blocks = [blocks[k] for k in sorted(blocks) if len(blocks[k]) >= 2]
 
+    def same_partition(a: str, b: str) -> bool:
+        return partition_of is not None and partition_of(a) == partition_of(b)
+
     def hard_candidate() -> tuple[str, str] | None:
         if not non_singleton_blocks:
             return None
         members = rng.choice(non_singleton_blocks)
         a, b = rng.sample(members, 2)
+        if same_partition(a, b):
+            return None
         return (a, b)
 
     def easy_candidate() -> tuple[str, str] | None:
@@ -87,6 +99,8 @@ def synth_negatives(
             return None
         a, b = rng.sample(eids, 2)
         if blocking_key(entities[a], block_keys) == blocking_key(entities[b], block_keys):
+            return None
+        if same_partition(a, b):
             return None
         return (a, b)
 

--- a/scripts/er_matcher/sources/negatives.py
+++ b/scripts/er_matcher/sources/negatives.py
@@ -1,0 +1,118 @@
+"""Deterministic blocker + hard/easy negative-pair synthesis for the
+multi-source ER data pipeline (Task 3). Consumed by loaders whose source
+data ships only positive (matching) pairs -- e.g. Leipzig + FEBRL -- and by
+the synthetic generator. CPU/box-safe: stdlib only, never imports
+torch/transformers.
+
+Sampling is bounded to O(n) memory -- it never materializes the full
+within-block or cross-block pair product, which would be O(N^2) and OOM
+at the ~64k-row scale some loaders (e.g. DBLP-Scholar) feed in."""
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+
+_ATTEMPT_MULTIPLIER = 50
+_MIN_ATTEMPTS = 100
+
+
+def blocking_key(entity: dict, block_keys: list[str]) -> str:
+    """Deterministic blocking key: the lowercased first whitespace-token of
+    the space-joined values of `block_keys` on `entity`. Missing/empty
+    fields are tolerated (treated as empty string)."""
+    joined = " ".join(str(entity.get(k, "")) for k in block_keys)
+    tokens = joined.lower().split()
+    return tokens[0] if tokens else ""
+
+
+def _fill(
+    target: int,
+    cap: int,
+    candidate_fn: Callable[[], tuple[str, str] | None],
+    seen: set[tuple[str, str]],
+    result: list[tuple[str, str]],
+) -> None:
+    """Rejection-sample up to `target` distinct pairs into `result`/`seen`,
+    trying at most `cap` times total. Mutates `result`/`seen` in place so a
+    shortfall-fill call can resume from where an earlier call left off."""
+    attempts = 0
+    while len(result) < target and attempts < cap:
+        attempts += 1
+        cand = candidate_fn()
+        if cand is None:
+            continue
+        pair = (cand[0], cand[1]) if cand[0] < cand[1] else (cand[1], cand[0])
+        if pair in seen:
+            continue
+        seen.add(pair)
+        result.append(pair)
+
+
+def synth_negatives(
+    entities: dict[str, dict],
+    *,
+    block_keys: list[str],
+    hard_frac: float,
+    seed: int,
+    n: int,
+) -> list[tuple[str, str, str]]:
+    """Synthesize up to `n` negative pairs (eid_a, eid_b, tag) from
+    `entities` (eid -> field dict). "hard" pairs share a blocking key
+    (the deceptive boundary case); "easy" pairs come from different
+    blocks. Deterministic given `seed`. No self-pairs, no duplicate pairs.
+    Falls back to filling the remainder from the other pool when one pool
+    is short rather than erroring.
+
+    Sampling is rejection-based and bounded to O(n) memory/attempts -- it
+    never enumerates the full within-block or cross-block pair product."""
+    rng = random.Random(seed)
+    eids = sorted(entities)
+
+    blocks: dict[str, list[str]] = {}
+    for eid in eids:
+        key = blocking_key(entities[eid], block_keys)
+        blocks.setdefault(key, []).append(eid)
+
+    non_singleton_blocks = [blocks[k] for k in sorted(blocks) if len(blocks[k]) >= 2]
+
+    def hard_candidate() -> tuple[str, str] | None:
+        if not non_singleton_blocks:
+            return None
+        members = rng.choice(non_singleton_blocks)
+        a, b = rng.sample(members, 2)
+        return (a, b)
+
+    def easy_candidate() -> tuple[str, str] | None:
+        if len(eids) < 2:
+            return None
+        a, b = rng.sample(eids, 2)
+        if blocking_key(entities[a], block_keys) == blocking_key(entities[b], block_keys):
+            return None
+        return (a, b)
+
+    n_hard_target = round(n * hard_frac)
+    n_easy_target = n - n_hard_target
+
+    hard_seen: set[tuple[str, str]] = set()
+    hard_result: list[tuple[str, str]] = []
+    cap = max(_ATTEMPT_MULTIPLIER * n, _MIN_ATTEMPTS)
+    _fill(n_hard_target, cap, hard_candidate, hard_seen, hard_result)
+
+    easy_seen: set[tuple[str, str]] = set()
+    easy_result: list[tuple[str, str]] = []
+    _fill(n_easy_target, cap, easy_candidate, easy_seen, easy_result)
+
+    # Fill shortfall in one pool from the other, capped by a fresh attempt
+    # budget (never full enumeration).
+    shortfall = n - (len(hard_result) + len(easy_result))
+    if shortfall > 0:
+        extra_cap = max(_ATTEMPT_MULTIPLIER * shortfall, _MIN_ATTEMPTS)
+        _fill(len(easy_result) + shortfall, extra_cap, easy_candidate, easy_seen, easy_result)
+        shortfall = n - (len(hard_result) + len(easy_result))
+    if shortfall > 0:
+        extra_cap = max(_ATTEMPT_MULTIPLIER * shortfall, _MIN_ATTEMPTS)
+        _fill(len(hard_result) + shortfall, extra_cap, hard_candidate, hard_seen, hard_result)
+
+    result = [(a, b, "hard") for a, b in hard_result]
+    result += [(a, b, "easy") for a, b in easy_result]
+    return result

--- a/scripts/er_matcher/sources/splits.py
+++ b/scripts/er_matcher/sources/splits.py
@@ -1,0 +1,25 @@
+"""Shared deterministic entity-level split helper for the multi-source ER data
+pipeline (Task 2). CPU/box-safe: stdlib only, never imports torch/transformers.
+
+`gen_pairs.py` delegates its local `_split_of` to this module so the split
+logic has one source of truth across the synthetic generator and any
+benchmark/real-dataset `PairSource` that needs entity-level train/val/test
+partitioning."""
+from __future__ import annotations
+
+import hashlib
+
+
+def split_of(eid: int | str, *, seed: int, val_frac: float, test_frac: float,
+             holdout_domain: str | None = None, domain: str | None = None) -> str:
+    """Deterministic entity-level split. Holdout domain -> 'test'; else hash
+    (seed, str(eid)) into train/val/test. str(eid) so benchmark string IDs work."""
+    if holdout_domain and domain == holdout_domain:
+        return "test"
+    h = hashlib.sha256(f"{seed}:{eid}".encode()).hexdigest()
+    frac = int(h[:8], 16) / 0xFFFFFFFF
+    if frac < test_frac:
+        return "test"
+    if frac < test_frac + val_frac:
+        return "val"
+    return "train"

--- a/scripts/er_matcher/sources_config.py
+++ b/scripts/er_matcher/sources_config.py
@@ -1,0 +1,136 @@
+"""Validated per-source config loader + loader factory for the multi-source
+ER data pipeline (Task 7). `load_sources` mirrors `train.load_config`'s
+strict-validation style: unknown keys on a source entry are rejected
+outright (so a yaml typo can't silently no-op an override). `build_source`
+dispatches to an EXPLICIT per-loader builder rather than a generic **kwargs
+spray, because the loader constructors genuinely differ (Magellan takes no
+`seed`). CPU/box-safe: stdlib + PyYAML only, never torch/transformers/
+network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Any
+
+from sources.base import PairSource
+from sources.febrl import FebrlSource
+from sources.leipzig import LeipzigSource
+from sources.magellan import MagellanSource
+from sources.ncvr import NcvrSource
+
+_VALID_MECHANISMS = {"bundle", "generate", "fetch"}
+
+
+@dataclass
+class SourceEntry:
+    name: str  # the yaml key -- not itself a yaml body field
+    loader: str
+    mechanism: str  # "bundle" | "generate" | "fetch"
+    license: str
+    domain: str = "generic"
+    attribution: str | None = None
+    weight: float = 1.0
+    eval_only: bool = False
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+# Known per-entry body keys, i.e. every SourceEntry field except `name`
+# (which comes from the yaml mapping key, never from the entry body).
+_KNOWN_ENTRY_KEYS = {f.name for f in fields(SourceEntry)} - {"name"}
+
+
+def load_sources(path: Path) -> list[SourceEntry]:
+    """PyYAML-load a `{sources: {name: {...}}}` doc into `SourceEntry`s.
+
+    Raises `ValueError` with a clear message on:
+      - a missing/non-mapping top-level `sources` key,
+      - a non-mapping entry body,
+      - unknown keys on an entry,
+      - a missing `loader` / `mechanism` / `license`,
+      - a `mechanism` outside {bundle, generate, fetch},
+      - `license == "CC-BY"` without a non-empty `attribution`,
+      - a non-dict `kwargs`.
+    """
+    import yaml  # PyYAML; same light always-present dep as train.load_config
+
+    raw = yaml.safe_load(Path(path).read_text()) or {}
+    sources_raw = raw.get("sources")
+    if not isinstance(sources_raw, dict):
+        raise ValueError("sources.yaml must have a top-level `sources` mapping")
+
+    entries: list[SourceEntry] = []
+    for name, body in sources_raw.items():
+        if not isinstance(body, dict):
+            raise ValueError(f"source {name!r}: entry must be a mapping, got {type(body).__name__}")
+
+        unknown = set(body) - _KNOWN_ENTRY_KEYS
+        if unknown:
+            raise ValueError(
+                f"source {name!r}: unknown keys {sorted(unknown)} "
+                f"(known: {sorted(_KNOWN_ENTRY_KEYS)})"
+            )
+
+        for required in ("loader", "mechanism", "license"):
+            if not body.get(required):
+                raise ValueError(f"source {name!r}: missing required key {required!r}")
+
+        mechanism = body["mechanism"]
+        if mechanism not in _VALID_MECHANISMS:
+            raise ValueError(
+                f"source {name!r}: mechanism {mechanism!r} must be one of "
+                f"{sorted(_VALID_MECHANISMS)}"
+            )
+
+        license_ = body["license"]
+        attribution = body.get("attribution")
+        if license_ == "CC-BY" and not attribution:
+            raise ValueError(f"source {name!r}: license CC-BY requires a non-empty attribution")
+
+        kwargs = body.get("kwargs", {})
+        if not isinstance(kwargs, dict):
+            raise ValueError(
+                f"source {name!r}: kwargs must be a mapping, got {type(kwargs).__name__}"
+            )
+
+        entries.append(
+            SourceEntry(
+                name=name,
+                loader=body["loader"],
+                mechanism=mechanism,
+                license=license_,
+                domain=body.get("domain", "generic"),
+                attribution=attribution,
+                weight=body.get("weight", 1.0),
+                eval_only=body.get("eval_only", False),
+                kwargs=kwargs,
+            )
+        )
+
+    return entries
+
+
+# Per-loader builder dispatch. Explicit (not a generic **entry.kwargs spray)
+# because the constructors genuinely differ -- Magellan has NO `seed` param
+# (it's pre-labeled, eval-only, no negative synthesis) and Ncvr takes only
+# `name` + passthrough kwargs.
+_BUILDERS: dict[str, Callable[[SourceEntry, int], PairSource]] = {
+    "leipzig": lambda e, seed: LeipzigSource(name=e.name, domain=e.domain, seed=seed, **e.kwargs),
+    "febrl": lambda e, seed: FebrlSource(name=e.name, domain=e.domain, seed=seed, **e.kwargs),
+    "magellan": lambda e, seed: MagellanSource(name=e.name, domain=e.domain, **e.kwargs),
+    "ncvr": lambda e, seed: NcvrSource(name=e.name, **e.kwargs),
+}
+
+
+def build_source(entry: SourceEntry, *, seed: int) -> PairSource:
+    """Factory: construct the concrete loader for `entry`, dispatched by
+    `entry.loader`. Raises `ValueError` for an unrecognized loader name.
+    The returned source's `.name` always equals `entry.name` (the yaml key)
+    since every builder passes `name=e.name` explicitly.
+    """
+    builder = _BUILDERS.get(entry.loader)
+    if builder is None:
+        raise ValueError(f"unknown loader {entry.loader!r} (known: {sorted(_BUILDERS)})")
+    return builder(entry, seed)

--- a/scripts/er_matcher/sources_config.py
+++ b/scripts/er_matcher/sources_config.py
@@ -52,6 +52,8 @@ def load_sources(path: Path) -> list[SourceEntry]:
       - a missing `loader` / `mechanism` / `license`,
       - a `mechanism` outside {bundle, generate, fetch},
       - `license == "CC-BY"` without a non-empty `attribution`,
+      - a non-bool `eval_only`,
+      - a non-numeric (or bool) `weight`,
       - a non-dict `kwargs`.
     """
     import yaml  # PyYAML; same light always-present dep as train.load_config
@@ -89,6 +91,22 @@ def load_sources(path: Path) -> list[SourceEntry]:
         if license_ == "CC-BY" and not attribution:
             raise ValueError(f"source {name!r}: license CC-BY requires a non-empty attribution")
 
+        eval_only = body.get("eval_only", False)
+        if not isinstance(eval_only, bool):
+            raise ValueError(
+                f"source {name!r}: eval_only must be a bool, got {type(eval_only).__name__} "
+                f"({eval_only!r}) -- a yaml typo like `flase` silently becomes truthy otherwise"
+            )
+
+        weight = body.get("weight", 1.0)
+        # bool is an int subclass in Python; reject it explicitly so a typo'd
+        # `weight: true` doesn't silently pass as weight=1.
+        if isinstance(weight, bool) or not isinstance(weight, (int, float)):
+            raise ValueError(
+                f"source {name!r}: weight must be an int or float, got {type(weight).__name__} "
+                f"({weight!r})"
+            )
+
         kwargs = body.get("kwargs", {})
         if not isinstance(kwargs, dict):
             raise ValueError(
@@ -103,8 +121,8 @@ def load_sources(path: Path) -> list[SourceEntry]:
                 license=license_,
                 domain=body.get("domain", "generic"),
                 attribution=attribution,
-                weight=body.get("weight", 1.0),
-                eval_only=body.get("eval_only", False),
+                weight=weight,
+                eval_only=eval_only,
                 kwargs=kwargs,
             )
         )

--- a/scripts/er_matcher/test_build_corpus.py
+++ b/scripts/er_matcher/test_build_corpus.py
@@ -1,0 +1,211 @@
+"""Tests for `build_corpus` (Task 8 of the multi-source ER data pipeline):
+blends every bundled/generated, non-eval-only source into the unified
+training corpus JSONL + a provenance/license manifest. Stdlib + PyYAML
+only -- box-safe, no torch/transformers/network."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pathlib import Path
+
+from build_corpus import build_corpus, main
+
+FIX = Path(__file__).parent / "tests" / "fixtures"
+LEIPZIG_FIX = FIX / "leipzig_mini"
+FEBRL_FIX = FIX / "febrl_mini"
+MAGELLAN_FIX = FIX / "magellan_mini"
+
+_SOURCES_YAML = f"""
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    domain: person
+    weight: 1.0
+    kwargs:
+      root: {FEBRL_FIX.as_posix()!r}
+
+  abt_buy:
+    loader: leipzig
+    mechanism: bundle
+    license: CC-BY
+    attribution: "Leipzig DB Group; VLDB2010"
+    domain: product
+    weight: 1.0
+    kwargs:
+      root: {LEIPZIG_FIX.as_posix()!r}
+      block_fields: [title]
+
+  magellan_x:
+    loader: magellan
+    mechanism: fetch
+    license: cite-only
+    eval_only: true
+    domain: product
+    kwargs:
+      root: {MAGELLAN_FIX.as_posix()!r}
+
+  ncvr:
+    loader: ncvr
+    mechanism: fetch
+    license: public-record
+    eval_only: true
+    domain: person
+    kwargs: {{}}
+"""
+
+
+def _write_yaml(tmp_path: Path) -> Path:
+    p = tmp_path / "sources.yaml"
+    p.write_text(_SOURCES_YAML)
+    return p
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_writes_all_three_jsonl_files_with_valid_rows(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "out"
+    build_corpus(yaml_path, out_dir, seed=1)
+
+    for split in ("train", "val", "test"):
+        path = out_dir / f"{split}.jsonl"
+        assert path.exists()
+        rows = _read_jsonl(path)
+        for row in rows:
+            assert set(row) == {"a", "b", "label", "domain", "source", "dataset", "eid_a", "eid_b"}
+            assert row["label"] in ("match", "no_match")
+
+
+def test_eval_only_sources_excluded_from_corpus_rows(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "out"
+    build_corpus(yaml_path, out_dir, seed=1)
+
+    all_rows = [
+        r for split in ("train", "val", "test") for r in _read_jsonl(out_dir / f"{split}.jsonl")
+    ]
+    sources_present = {r["source"] for r in all_rows}
+    assert sources_present <= {"febrl", "leipzig"}
+    assert "magellan" not in sources_present
+    assert "ncvr" not in sources_present
+    assert sources_present  # sanity: bundled sources actually produced rows
+
+
+def test_manifest_records_every_source_incl_eval_only(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "out"
+    manifest = build_corpus(yaml_path, out_dir, seed=1)
+
+    assert set(manifest["sources"]) == {"febrl", "abt_buy", "magellan_x", "ncvr"}
+
+    febrl_entry = manifest["sources"]["febrl"]
+    assert febrl_entry["mechanism"] == "bundle"
+    assert febrl_entry["eval_only"] is False
+    assert febrl_entry["license"] == "MPL-1.1"
+    assert sum(febrl_entry["counts"].values()) > 0
+    # sources.yaml leaves `attribution:` unset for febrl (only CC-BY entries
+    # are required to set it) -- the manifest must fall back to
+    # FebrlSource's own class attribution rather than recording null.
+    assert febrl_entry["attribution"] is not None
+    assert "FEBRL" in febrl_entry["attribution"]
+
+    abt_buy_entry = manifest["sources"]["abt_buy"]
+    assert abt_buy_entry["license"] == "CC-BY"
+    assert abt_buy_entry["attribution"] == "Leipzig DB Group; VLDB2010"
+    assert sum(abt_buy_entry["counts"].values()) > 0
+
+    magellan_entry = manifest["sources"]["magellan_x"]
+    assert magellan_entry["eval_only"] is True
+    assert magellan_entry["license"] == "cite-only"
+    assert magellan_entry["counts"] == {"train": 0, "val": 0, "test": 0}
+
+    ncvr_entry = manifest["sources"]["ncvr"]
+    assert ncvr_entry["eval_only"] is True
+    assert ncvr_entry["license"] == "public-record"
+    assert ncvr_entry["counts"] == {"train": 0, "val": 0, "test": 0}
+
+
+def test_manifest_totals_equal_sum_of_source_counts(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "out"
+    manifest = build_corpus(yaml_path, out_dir, seed=1)
+
+    for split in ("train", "val", "test"):
+        expected = sum(v["counts"][split] for v in manifest["sources"].values())
+        assert manifest["totals"][split] == expected
+        actual_written = len(_read_jsonl(out_dir / f"{split}.jsonl"))
+        assert manifest["totals"][split] == actual_written
+
+
+def test_manifest_written_to_disk_and_matches_return_value(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "out"
+    manifest = build_corpus(yaml_path, out_dir, seed=1)
+
+    on_disk = json.loads((out_dir / "manifest.json").read_text())
+    assert on_disk == manifest
+
+
+def test_deterministic_same_seed_byte_identical(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_a = tmp_path / "out_a"
+    out_b = tmp_path / "out_b"
+    build_corpus(yaml_path, out_a, seed=42)
+    build_corpus(yaml_path, out_b, seed=42)
+
+    for split in ("train", "val", "test"):
+        a_bytes = (out_a / f"{split}.jsonl").read_bytes()
+        b_bytes = (out_b / f"{split}.jsonl").read_bytes()
+        assert a_bytes == b_bytes
+
+
+def test_cap_limits_rows_per_source_per_split(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+
+    out_uncapped = tmp_path / "uncapped"
+    build_corpus(yaml_path, out_uncapped, seed=1)
+    uncapped_rows = [
+        r
+        for split in ("train", "val", "test")
+        for r in _read_jsonl(out_uncapped / f"{split}.jsonl")
+    ]
+    # Sanity: at least one contributing source has >1 row in some split
+    # uncapped, else the cap=1 assertion below wouldn't prove anything.
+    assert len(uncapped_rows) > 2
+
+    out_capped = tmp_path / "capped"
+    manifest = build_corpus(yaml_path, out_capped, seed=1, cap=1)
+
+    for source_name, entry in manifest["sources"].items():
+        for split, n in entry["counts"].items():
+            assert n <= 1, f"{source_name}/{split} has {n} rows, cap=1 violated"
+
+    for split in ("train", "val", "test"):
+        rows = _read_jsonl(out_capped / f"{split}.jsonl")
+        # at most one row per contributing source per split
+        by_source: dict[str, int] = {}
+        for r in rows:
+            by_source[r["dataset"]] = by_source.get(r["dataset"], 0) + 1
+        assert all(n <= 1 for n in by_source.values())
+
+
+def test_cli_main_writes_corpus(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "cliout"
+
+    rc = main(["--sources", str(yaml_path), "--out-dir", str(out_dir), "--seed", "1"])
+
+    assert rc == 0
+    for split in ("train", "val", "test"):
+        path = out_dir / f"{split}.jsonl"
+        assert path.exists()
+    assert (out_dir / "manifest.json").exists()

--- a/scripts/er_matcher/test_build_corpus.py
+++ b/scripts/er_matcher/test_build_corpus.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 from pathlib import Path
 
+import pytest
 from build_corpus import build_corpus, main
 
 FIX = Path(__file__).parent / "tests" / "fixtures"
@@ -196,6 +197,64 @@ def test_cap_limits_rows_per_source_per_split(tmp_path):
         for r in rows:
             by_source[r["dataset"]] = by_source.get(r["dataset"], 0) + 1
         assert all(n <= 1 for n in by_source.values())
+
+
+def test_cap_preserves_class_balance(tmp_path):
+    """`--cap` must not silently produce an all-`match` (or all-`no_match`)
+    slice: both bundled loaders emit all positives before any negatives, so
+    a naive `rows[:cap]` would be label-degenerate. `abt_buy`/train has both
+    a match and a no_match row uncapped (2 rows total) -- with cap=2 both
+    labels must survive."""
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "capped_balance"
+    build_corpus(yaml_path, out_dir, seed=1, cap=2)
+
+    train_rows = _read_jsonl(out_dir / "train.jsonl")
+    abt_buy_train = [r for r in train_rows if r["dataset"] == "abt_buy"]
+    assert len(abt_buy_train) == 2
+    assert {r["label"] for r in abt_buy_train} == {"match", "no_match"}
+
+    test_rows = _read_jsonl(out_dir / "test.jsonl")
+    febrl_test = [r for r in test_rows if r["dataset"] == "febrl"]
+    assert len(febrl_test) == 2
+    assert {r["label"] for r in febrl_test} == {"match", "no_match"}
+
+
+def test_eval_only_class_attr_mismatch_raises(tmp_path):
+    """If a `bundle`/`generate` sources.yaml entry forgets to set
+    `eval_only: true` for a loader whose CLASS is eval_only (e.g. Magellan),
+    `build_corpus` must refuse to fold its (cite-only, eval-only-by-design)
+    rows into the training corpus rather than silently doing so."""
+    p = tmp_path / "sources.yaml"
+    p.write_text(
+        f"""
+sources:
+  magellan_x:
+    loader: magellan
+    mechanism: bundle
+    license: cite-only
+    eval_only: false
+    domain: product
+    kwargs:
+      root: {MAGELLAN_FIX.as_posix()!r}
+"""
+    )
+    with pytest.raises(ValueError, match="eval_only"):
+        build_corpus(p, tmp_path / "out", seed=1)
+
+
+def test_manifest_label_totals_present_and_correct(tmp_path):
+    yaml_path = _write_yaml(tmp_path)
+    out_dir = tmp_path / "out"
+    manifest = build_corpus(yaml_path, out_dir, seed=1)
+
+    assert set(manifest["label_totals"]) == {"train", "val", "test"}
+    for split in ("train", "val", "test"):
+        rows = _read_jsonl(out_dir / f"{split}.jsonl")
+        expected = {"match": 0, "no_match": 0}
+        for r in rows:
+            expected[r["label"]] += 1
+        assert manifest["label_totals"][split] == expected
 
 
 def test_cli_main_writes_corpus(tmp_path):

--- a/scripts/er_matcher/test_febrl.py
+++ b/scripts/er_matcher/test_febrl.py
@@ -1,0 +1,112 @@
+"""Tests for the FEBRL synthetic-person loader (Task 5 of the multi-source
+ER data pipeline). Stdlib only -- box-safe, no torch/transformers/network."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import warnings  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+from sources.febrl import FebrlSource, _entity_of  # noqa: E402
+
+FIX = Path(__file__).parent / "tests" / "fixtures" / "febrl_mini"
+
+# The tiny fixture is expected to fall short of its negative target in at
+# least one split (not enough same-split cross-entity same-block records
+# to fill "hard" negatives) -- see test_shortfall_warning_fires_on_tiny_fixture
+# for the dedicated, explicit assertion on that contract. Every other test
+# below suppresses it so it doesn't show up as ambient noise.
+
+
+def _all_rows(src):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return [r for split in src.splits().values() for r in split]
+
+
+def test_emits_both_labels_with_provenance():
+    src = FebrlSource(FIX, seed=1)
+    rows = _all_rows(src)
+    assert {r["label"] for r in rows} == {"match", "no_match"}
+    assert all(r["dataset"] == "febrl" and r["source"] == "febrl" for r in rows)
+    assert all(r["domain"] == "person" for r in rows)
+
+
+def test_positives_pair_same_entity():
+    src = FebrlSource(FIX, seed=1)
+    rows = _all_rows(src)
+    positives = [r for r in rows if r["label"] == "match"]
+    assert positives  # sanity: the fixture actually produces positives
+    for r in positives:
+        assert _entity_of(r["eid_a"]) == _entity_of(r["eid_b"])
+
+
+def test_negatives_pair_different_entities():
+    src = FebrlSource(FIX, seed=1)
+    rows = _all_rows(src)
+    negatives = [r for r in rows if r["label"] == "no_match"]
+    assert negatives  # sanity: non-vacuous -- the fixture must yield negatives
+    for r in negatives:
+        assert _entity_of(r["eid_a"]) != _entity_of(r["eid_b"])
+
+
+def test_entity_level_no_leak_across_splits():
+    src = FebrlSource(FIX, seed=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        splits = src.splits()
+    entity_to_splits: dict[str, set[str]] = {}
+    for split_name, rows in splits.items():
+        for r in rows:
+            for eid in (r["eid_a"], r["eid_b"]):
+                entity_to_splits.setdefault(_entity_of(eid), set()).add(split_name)
+    assert entity_to_splits  # sanity: rows were actually produced
+    for entity, split_set in entity_to_splits.items():
+        assert len(split_set) == 1, f"entity {entity} leaked across splits: {split_set}"
+
+
+def test_deterministic():
+    mk = lambda: _all_rows(FebrlSource(FIX, seed=1))  # noqa: E731
+    assert mk() == mk()
+
+
+def test_attribution_and_license_present():
+    src = FebrlSource(FIX, seed=1)
+    assert src.license == "MPL-1.1"
+    assert "FEBRL" in src.attribution
+
+
+def test_splits_are_nonempty_overall():
+    src = FebrlSource(FIX, seed=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        splits = src.splits()
+    assert set(splits) == {"train", "val", "test"}
+    assert sum(len(v) for v in splits.values()) > 0
+
+
+def test_shortfall_warning_fires_on_tiny_fixture():
+    src = FebrlSource(FIX, seed=1)
+    with pytest.warns(UserWarning, match=r"only \d+/\d+ negatives"):
+        src.splits()
+
+
+def test_anchor_fallback_when_no_org_record():
+    # rec-6 has only rec-6-dup-0 / rec-6-dup-1, no rec-6-org. The anchor
+    # falls back to the first record in sorted order, and that entity
+    # still yields a positive pair.
+    src = FebrlSource(FIX, seed=1)
+    rows = _all_rows(src)
+    match = [
+        r
+        for r in rows
+        if r["label"] == "match" and {r["eid_a"], r["eid_b"]} == {"rec-6-dup-0", "rec-6-dup-1"}
+    ]
+    assert len(match) == 1
+    assert match[0]["eid_a"] == "rec-6-dup-0"
+    assert match[0]["eid_b"] == "rec-6-dup-1"

--- a/scripts/er_matcher/test_leipzig.py
+++ b/scripts/er_matcher/test_leipzig.py
@@ -1,0 +1,89 @@
+"""Tests for the Leipzig CC-BY benchmark loader (Task 4 of the multi-source
+ER data pipeline). Stdlib only -- box-safe, no torch/transformers/network."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pathlib import Path
+
+from sources.leipzig import LeipzigSource
+
+FIX = Path(__file__).parent / "tests" / "fixtures" / "leipzig_mini"
+
+
+def _all_rows(src):
+    return [r for split in src.splits().values() for r in split]
+
+
+def test_emits_positives_and_negatives():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    rows = _all_rows(src)
+    assert {r["label"] for r in rows} == {"match", "no_match"}
+    assert all(r["dataset"] == "abt_buy" and r["source"] == "leipzig" for r in rows)
+    assert sum(r["label"] == "match" for r in rows) == 2  # 2 gold pairs in the fixture
+
+
+def test_negatives_exclude_gold_matches():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    gold = {("A:a1", "B:b1"), ("A:a2", "B:b2")}
+    negs = {(r["eid_a"], r["eid_b"]) for r in _all_rows(src) if r["label"] == "no_match"}
+    negs |= {(b, a) for a, b in negs}  # both orderings
+    assert gold.isdisjoint(negs)
+
+
+def test_deterministic():
+    mk = lambda: _all_rows(LeipzigSource("abt_buy", FIX, "product", ["title"], 1))  # noqa: E731
+    assert mk() == mk()
+
+
+def test_namespaced_ids_and_domain_provenance():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    rows = _all_rows(src)
+    for r in rows:
+        assert r["domain"] == "product"
+        assert r["eid_a"].startswith(("A:", "B:"))
+        assert r["eid_b"].startswith(("A:", "B:"))
+
+
+def test_positive_pairs_match_mapping_fixture():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    rows = _all_rows(src)
+    positives = {(r["eid_a"], r["eid_b"]) for r in rows if r["label"] == "match"}
+    assert positives == {("A:a1", "B:b1"), ("A:a2", "B:b2")}
+
+
+def test_splits_partition_and_are_nonempty_overall():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    splits = src.splits()
+    assert set(splits) == {"train", "val", "test"}
+    assert sum(len(v) for v in splits.values()) > 0
+
+
+def test_attribution_and_license_present():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    assert src.license == "CC-BY"
+    assert "Leipzig" in src.attribution
+
+
+def test_negatives_are_strictly_cross_table():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    rows = _all_rows(src)
+    no_match = [r for r in rows if r["label"] == "no_match"]
+    assert no_match  # sanity: the fixture actually produces negatives
+    assert all(r["eid_a"][0] != r["eid_b"][0] for r in no_match)
+
+
+def test_no_shortfall_warning_on_fixture():
+    import warnings
+
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        rows = _all_rows(src)
+    shortfall_warnings = [w for w in caught if "negatives after gold-filter" in str(w.message)]
+    assert not shortfall_warnings
+    assert sum(r["label"] == "no_match" for r in rows) == 2

--- a/scripts/er_matcher/test_magellan.py
+++ b/scripts/er_matcher/test_magellan.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 from pathlib import Path
 
+import pytest
 from sources.magellan import MagellanSource
 
 FIX = Path(__file__).parent / "tests" / "fixtures" / "magellan_mini"
@@ -93,10 +94,5 @@ def test_load_from_dir_no_network_on_local_fixture(monkeypatch):
 def test_fetch_guard_raises_without_env_var(monkeypatch):
     monkeypatch.delenv("GOLDENMATCH_ALLOW_FETCH", raising=False)
     src = MagellanSource(name="mini_products", root=Path("/nonexistent"), domain="product")
-    try:
+    with pytest.raises(RuntimeError, match="GOLDENMATCH_ALLOW_FETCH"):
         src.fetch()
-        raised = False
-    except RuntimeError as e:
-        raised = True
-        assert "GOLDENMATCH_ALLOW_FETCH" in str(e)
-    assert raised

--- a/scripts/er_matcher/test_magellan.py
+++ b/scripts/er_matcher/test_magellan.py
@@ -1,0 +1,102 @@
+"""Tests for the Magellan/DeepMatcher fetch-at-build EVAL loader (Task 6 of
+the multi-source ER data pipeline). Stdlib only -- box-safe, no
+torch/transformers. Never sets GOLDENMATCH_ALLOW_FETCH=1 -- we never
+actually download in these tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pathlib import Path
+
+from sources.magellan import MagellanSource
+
+FIX = Path(__file__).parent / "tests" / "fixtures" / "magellan_mini"
+
+
+def _all_rows(src):
+    return [r for split in src.splits().values() for r in split]
+
+
+def test_splits_present_and_valid_maps_to_val():
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    splits = src.load_from_dir()
+    assert set(splits) == {"train", "val", "test"}
+    assert "valid" not in splits
+
+
+def test_labels_mapped_from_0_1():
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    splits = src.load_from_dir()
+    train_labels = {(r["eid_a"], r["eid_b"]): r["label"] for r in splits["train"]}
+    assert train_labels[("A:a0", "B:b0")] == "match"
+    assert train_labels[("A:a0", "B:b1")] == "no_match"
+    assert train_labels[("A:a1", "B:b1")] == "no_match"
+    assert {r["label"] for rows in splits.values() for r in rows} == {"match", "no_match"}
+
+
+def test_a_b_fields_joined_from_tables():
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    splits = src.load_from_dir()
+    row = next(r for r in splits["train"] if r["eid_a"] == "A:a0" and r["eid_b"] == "B:b0")
+    assert row["a"] == {"title": "Widget Pro 12oz", "manufacturer": "Acme", "price": "19.99"}
+    assert row["b"] == {"title": "Widget Pro 12 oz", "manufacturer": "Acme Inc", "price": "19.99"}
+
+
+def test_namespaced_ids_and_provenance():
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    rows = _all_rows(src)
+    assert rows  # sanity: the fixture actually produces rows
+    for r in rows:
+        assert r["eid_a"].startswith("A:")
+        assert r["eid_b"].startswith("B:")
+        assert r["source"] == "magellan"
+        assert r["dataset"] == "mini_products"
+        assert r["domain"] == "product"
+
+
+def test_eval_only():
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    assert src.eval_only is True
+
+
+def test_attribution_and_license_present():
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    assert src.license == "cite-only"
+    assert "Magellan" in src.attribution or "DeepMatcher" in src.attribution
+
+
+def test_deterministic():
+    mk = lambda: _all_rows(MagellanSource("mini_products", FIX, "product"))  # noqa: E731
+    assert mk() == mk()
+
+
+def test_splits_no_network_on_local_fixture(monkeypatch):
+    """The parse path must never touch the network: calling splits() against
+    an existing fixture root succeeds with GOLDENMATCH_ALLOW_FETCH unset."""
+    monkeypatch.delenv("GOLDENMATCH_ALLOW_FETCH", raising=False)
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    splits = src.splits()
+    assert sum(len(v) for v in splits.values()) > 0
+
+
+def test_load_from_dir_no_network_on_local_fixture(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_ALLOW_FETCH", raising=False)
+    src = MagellanSource(name="mini_products", root=FIX, domain="product")
+    splits = src.load_from_dir()
+    assert sum(len(v) for v in splits.values()) > 0
+
+
+def test_fetch_guard_raises_without_env_var(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_ALLOW_FETCH", raising=False)
+    src = MagellanSource(name="mini_products", root=Path("/nonexistent"), domain="product")
+    try:
+        src.fetch()
+        raised = False
+    except RuntimeError as e:
+        raised = True
+        assert "GOLDENMATCH_ALLOW_FETCH" in str(e)
+    assert raised

--- a/scripts/er_matcher/test_negatives.py
+++ b/scripts/er_matcher/test_negatives.py
@@ -1,0 +1,33 @@
+"""Tests for the deterministic blocker + negative-pair synthesis (Task 3 of
+the multi-source ER data pipeline). Stdlib only -- box-safe, no
+torch/transformers/network."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from sources.negatives import blocking_key, synth_negatives  # noqa: E402
+
+
+def test_blocking_key_is_deterministic_prefix_token():
+    e = {"name": "Robert Smith", "city": "Newark"}
+    assert blocking_key(e, ["name"]) == blocking_key(dict(e), ["name"])
+    assert blocking_key(e, ["name"]) != ""
+
+
+def test_synth_negatives_balance_and_determinism():
+    names = ["Alice", "Bob", "Carol", "Dave", "Eve"]
+    ents = {f"e{i}": {"name": names[i % 5], "phone": str(i)} for i in range(20)}
+    negs1 = synth_negatives(ents, block_keys=["name"], hard_frac=0.5, seed=3, n=10)
+    negs2 = synth_negatives(ents, block_keys=["name"], hard_frac=0.5, seed=3, n=10)
+    assert negs1 == negs2                                  # deterministic
+    assert all(a != b for a, b, _ in negs1)               # no self-pairs
+    assert {tag for _, _, tag in negs1} == {"hard", "easy"}
+    hard = [n for n in negs1 if n[2] == "hard"]
+    easy = [n for n in negs1 if n[2] == "easy"]
+    assert all(blocking_key(ents[a], ["name"]) == blocking_key(ents[b], ["name"])
+               for a, b, _ in hard)                        # hard = same block
+    assert all(blocking_key(ents[a], ["name"]) != blocking_key(ents[b], ["name"])
+               for a, b, _ in easy)                        # easy = different block

--- a/scripts/er_matcher/test_negatives.py
+++ b/scripts/er_matcher/test_negatives.py
@@ -31,3 +31,18 @@ def test_synth_negatives_balance_and_determinism():
                for a, b, _ in hard)                        # hard = same block
     assert all(blocking_key(ents[a], ["name"]) != blocking_key(ents[b], ["name"])
                for a, b, _ in easy)                        # easy = different block
+
+
+def test_synth_negatives_partition_of_forces_cross_partition():
+    # eids like "A:1", "B:2" -- partition_of picks off the "A"/"B" prefix.
+    names = ["Alice", "Bob", "Carol", "Dave", "Eve"]
+    ents = {}
+    for i in range(10):
+        prefix = "A" if i % 2 == 0 else "B"
+        ents[f"{prefix}:{i}"] = {"name": names[i % 5], "phone": str(i)}
+    negs = synth_negatives(
+        ents, block_keys=["name"], hard_frac=0.5, seed=3, n=10,
+        partition_of=lambda eid: eid[0],
+    )
+    assert negs  # sanity: the constraint didn't starve sampling to empty
+    assert all(a[0] != b[0] for a, b, _ in negs)

--- a/scripts/er_matcher/test_sources_base.py
+++ b/scripts/er_matcher/test_sources_base.py
@@ -1,0 +1,48 @@
+"""Tests for the PairSource contract + registry (Task 1 of the multi-source
+ER data pipeline). Stdlib only -- box-safe, no torch/transformers/network."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(__file__)
+)  # so `import sources...` resolves (matches test_gen_pairs.py)
+
+from sources.base import PairSource, Row, get_source, iter_sources, register
+
+
+def test_row_has_dataset_provenance_field():
+    row: Row = {
+        "a": {"x": "1"},
+        "b": {"x": "2"},
+        "label": "no_match",
+        "domain": "people",
+        "source": "synthetic",
+        "dataset": "febrl",
+        "eid_a": "1",
+        "eid_b": "2",
+    }
+    assert row["dataset"] == "febrl"  # the field this pipeline ADDS
+    assert set(row) >= {"a", "b", "label", "domain", "source", "dataset", "eid_a", "eid_b"}
+
+
+def test_registry_roundtrip_and_isolation():
+    class Dummy:
+        name = "dummy_ds"
+
+        def splits(self):
+            return {"train": [], "val": [], "test": []}
+
+    register(Dummy())
+    assert get_source("dummy_ds").name == "dummy_ds"
+    assert "dummy_ds" in {s.name for s in iter_sources()}
+    assert isinstance(Dummy(), PairSource)
+
+
+def test_get_unknown_source_raises():
+    import pytest
+
+    with pytest.raises(KeyError):
+        get_source("does_not_exist")

--- a/scripts/er_matcher/test_sources_config.py
+++ b/scripts/er_matcher/test_sources_config.py
@@ -1,0 +1,282 @@
+"""Tests for the per-source config loader + build_source factory (Task 7 of
+the multi-source ER data pipeline). Stdlib + PyYAML only -- box-safe, no
+torch/transformers/network."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pathlib import Path
+
+import pytest
+from sources_config import SourceEntry, build_source, load_sources
+
+REAL_YAML = Path(__file__).parent / "sources.yaml"
+FIX = Path(__file__).parent / "tests" / "fixtures"
+LEIPZIG_FIX = FIX / "leipzig_mini"
+FEBRL_FIX = FIX / "febrl_mini"
+MAGELLAN_FIX = FIX / "magellan_mini"
+
+
+# --- load_sources on the real sources.yaml -----------------------------------
+
+
+def test_real_yaml_loads_expected_names_loaders_mechanisms():
+    entries = {e.name: e for e in load_sources(REAL_YAML)}
+    assert entries["febrl"].loader == "febrl"
+    assert entries["febrl"].mechanism == "bundle"
+    assert entries["abt_buy"].loader == "leipzig"
+    assert entries["amazon_google"].loader == "leipzig"
+    assert entries["dblp_acm"].loader == "leipzig"
+    assert entries["dblp_scholar"].loader == "leipzig"
+    assert entries["magellan_abt_buy"].loader == "magellan"
+    assert entries["magellan_abt_buy"].mechanism == "fetch"
+    assert entries["ncvr"].loader == "ncvr"
+    assert entries["ncvr"].mechanism == "fetch"
+
+
+def test_real_yaml_every_ccby_entry_has_attribution():
+    entries = load_sources(REAL_YAML)
+    for e in entries:
+        if e.license == "CC-BY":
+            assert e.attribution, f"{e.name}: CC-BY entry missing attribution"
+
+
+def test_real_yaml_eval_only_set_correctly():
+    entries = {e.name: e for e in load_sources(REAL_YAML)}
+    assert entries["magellan_abt_buy"].eval_only is True
+    assert entries["ncvr"].eval_only is True
+    assert entries["febrl"].eval_only is False
+    assert entries["abt_buy"].eval_only is False
+
+
+def test_real_yaml_names_match_yaml_keys():
+    entries = load_sources(REAL_YAML)
+    names = {e.name for e in entries}
+    assert names == {
+        "febrl",
+        "abt_buy",
+        "amazon_google",
+        "dblp_acm",
+        "dblp_scholar",
+        "magellan_abt_buy",
+        "ncvr",
+    }
+
+
+# --- strict validation --------------------------------------------------------
+
+
+def _write_yaml(tmp_path, text: str) -> Path:
+    p = tmp_path / "sources.yaml"
+    p.write_text(text)
+    return p
+
+
+def test_unknown_key_in_entry_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    bogus_key: true
+""",
+    )
+    with pytest.raises(ValueError, match="unknown keys"):
+        load_sources(p)
+
+
+def test_bad_mechanism_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    loader: febrl
+    mechanism: download
+    license: MPL-1.1
+""",
+    )
+    with pytest.raises(ValueError, match="mechanism"):
+        load_sources(p)
+
+
+def test_ccby_without_attribution_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  abt_buy:
+    loader: leipzig
+    mechanism: bundle
+    license: CC-BY
+""",
+    )
+    with pytest.raises(ValueError, match="attribution"):
+        load_sources(p)
+
+
+def test_missing_required_key_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    mechanism: bundle
+    license: MPL-1.1
+""",
+    )
+    with pytest.raises(ValueError, match="loader"):
+        load_sources(p)
+
+
+def test_non_dict_kwargs_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    kwargs: not_a_dict
+""",
+    )
+    with pytest.raises(ValueError, match="kwargs"):
+        load_sources(p)
+
+
+def test_missing_sources_key_raises(tmp_path):
+    p = _write_yaml(tmp_path, "not_sources: {}\n")
+    with pytest.raises(ValueError, match="sources"):
+        load_sources(p)
+
+
+def test_non_mapping_entry_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl: "not_a_mapping"
+""",
+    )
+    with pytest.raises(ValueError, match="mapping"):
+        load_sources(p)
+
+
+# --- build_source factory -----------------------------------------------------
+
+
+def test_build_source_leipzig_against_mini_fixture():
+    entry = SourceEntry(
+        name="abt_buy_mini",
+        loader="leipzig",
+        mechanism="bundle",
+        license="CC-BY",
+        domain="product",
+        attribution="Leipzig DB Group; VLDB2010",
+        kwargs={"root": LEIPZIG_FIX, "block_fields": ["title"]},
+    )
+    src = build_source(entry, seed=1)
+    assert src.name == "abt_buy_mini"
+    rows = [r for split in src.splits().values() for r in split]
+    assert rows
+    assert {r["label"] for r in rows} == {"match", "no_match"}
+
+
+def test_build_source_febrl_against_mini_fixture():
+    entry = SourceEntry(
+        name="febrl_mini",
+        loader="febrl",
+        mechanism="bundle",
+        license="MPL-1.1",
+        domain="person",
+        kwargs={"root": FEBRL_FIX},
+    )
+    src = build_source(entry, seed=1)
+    assert src.name == "febrl_mini"
+    rows = [r for split in src.splits().values() for r in split]
+    assert rows
+
+
+def test_build_source_magellan_against_mini_fixture_no_seed_needed():
+    entry = SourceEntry(
+        name="magellan_mini",
+        loader="magellan",
+        mechanism="fetch",
+        license="cite-only",
+        eval_only=True,
+        domain="product",
+        kwargs={"root": MAGELLAN_FIX},
+    )
+    # Magellan's constructor has no `seed` param; build_source must not pass
+    # one through to it despite the factory's uniform `seed=` kwarg.
+    src = build_source(entry, seed=1)
+    assert src.name == "magellan_mini"
+    rows = [r for split in src.splits().values() for r in split]
+    assert rows
+    assert src.eval_only is True
+
+
+def test_build_source_ncvr_stub_raises_not_implemented():
+    entry = SourceEntry(
+        name="ncvr",
+        loader="ncvr",
+        mechanism="fetch",
+        license="public-record",
+        eval_only=True,
+        domain="person",
+        kwargs={},
+    )
+    src = build_source(entry, seed=1)
+    assert src.name == "ncvr"
+    with pytest.raises(NotImplementedError):
+        src.splits()
+
+
+def test_build_source_unknown_loader_raises():
+    entry = SourceEntry(
+        name="whatever",
+        loader="not_a_real_loader",
+        mechanism="bundle",
+        license="MPL-1.1",
+    )
+    with pytest.raises(ValueError, match="unknown loader"):
+        build_source(entry, seed=1)
+
+
+def test_build_source_name_equals_entry_name_for_every_loader():
+    cases = [
+        SourceEntry(
+            name="n1",
+            loader="leipzig",
+            mechanism="bundle",
+            license="CC-BY",
+            attribution="x",
+            kwargs={"root": LEIPZIG_FIX, "block_fields": ["title"]},
+        ),
+        SourceEntry(
+            name="n2",
+            loader="febrl",
+            mechanism="bundle",
+            license="MPL-1.1",
+            kwargs={"root": FEBRL_FIX},
+        ),
+        SourceEntry(
+            name="n3",
+            loader="magellan",
+            mechanism="fetch",
+            license="cite-only",
+            kwargs={"root": MAGELLAN_FIX},
+        ),
+        SourceEntry(name="n4", loader="ncvr", mechanism="fetch", license="public-record"),
+    ]
+    for entry in cases:
+        src = build_source(entry, seed=0)
+        assert src.name == entry.name

--- a/scripts/er_matcher/test_sources_config.py
+++ b/scripts/er_matcher/test_sources_config.py
@@ -152,6 +152,54 @@ sources:
         load_sources(p)
 
 
+def test_eval_only_non_bool_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    eval_only: flase
+""",
+    )
+    with pytest.raises(ValueError, match="eval_only"):
+        load_sources(p)
+
+
+def test_weight_non_numeric_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    weight: heavy
+""",
+    )
+    with pytest.raises(ValueError, match="weight"):
+        load_sources(p)
+
+
+def test_weight_bool_raises(tmp_path):
+    p = _write_yaml(
+        tmp_path,
+        """
+sources:
+  febrl:
+    loader: febrl
+    mechanism: bundle
+    license: MPL-1.1
+    weight: true
+""",
+    )
+    with pytest.raises(ValueError, match="weight"):
+        load_sources(p)
+
+
 def test_missing_sources_key_raises(tmp_path):
     p = _write_yaml(tmp_path, "not_sources: {}\n")
     with pytest.raises(ValueError, match="sources"):

--- a/scripts/er_matcher/test_splits.py
+++ b/scripts/er_matcher/test_splits.py
@@ -1,0 +1,29 @@
+"""Tests for the shared entity-split helper (Task 2 of the multi-source ER
+data pipeline). Stdlib only -- box-safe, no torch/transformers/network."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from sources.splits import split_of  # noqa: E402
+
+
+def test_str_and_int_eid_parity():
+    # generalization requirement: benchmark IDs are strings; must match int behavior
+    assert split_of(7, seed=1, val_frac=.15, test_frac=.15, holdout_domain=None) == \
+           split_of("7", seed=1, val_frac=.15, test_frac=.15, holdout_domain=None)
+
+
+def test_holdout_domain_forced_to_test():
+    assert split_of("abc", seed=1, val_frac=.15, test_frac=.15,
+                    holdout_domain="business", domain="business") == "test"
+
+
+def test_deterministic_and_partitions():
+    got = {split_of(str(i), seed=9, val_frac=.15, test_frac=.15, holdout_domain=None)
+           for i in range(200)}
+    assert got == {"train", "val", "test"}
+    assert split_of("k", seed=9, val_frac=.15, test_frac=.15, holdout_domain=None) == \
+           split_of("k", seed=9, val_frac=.15, test_frac=.15, holdout_domain=None)

--- a/scripts/er_matcher/tests/fixtures/febrl_mini/febrl_sample.csv
+++ b/scripts/er_matcher/tests/fixtures/febrl_mini/febrl_sample.csv
@@ -1,0 +1,14 @@
+rec_id,given_name,surname,street,suburb,postcode,phone,soc_sec_id
+rec-0-org,john,smith,12 high st,sydney,2000,0298765432,1234567
+rec-0-dup-0,jon,smith,12 high street,sydney,2000,0298765432,1234567
+rec-1-org,mary,jones,45 park rd,melbourne,3000,0387654321,2345678
+rec-1-dup-0,mary,jones,45 park road,melbourne,3000,0387654321,2345678
+rec-1-dup-1,mari,jones,45 park rd,melbourne,3000,0387654322,2345678
+rec-2-org,peter,smith,78 queen st,brisbane,4000,0734567890,3456789
+rec-2-dup-0,pete,smith,78 queen street,brisbane,4000,0734567890,3456789
+rec-3-org,susan,brown,23 king st,perth,6000,0812345678,4567890
+rec-4-org,david,jones,56 elm st,adelaide,5000,0823456789,5678901
+rec-5-org,linda,taylor,89 oak ave,hobart,7000,0362345678,6789012
+rec-5-dup-0,lynda,taylor,89 oak avenue,hobart,7000,0362345678,6789012
+rec-6-dup-0,karen,wilson,10 river rd,darwin,800,0889876543,7890123
+rec-6-dup-1,caren,wilson,10 river road,darwin,800,0889876543,7890123

--- a/scripts/er_matcher/tests/fixtures/leipzig_mini/mapping.csv
+++ b/scripts/er_matcher/tests/fixtures/leipzig_mini/mapping.csv
@@ -1,0 +1,3 @@
+idA,idB
+a1,b1
+a2,b2

--- a/scripts/er_matcher/tests/fixtures/leipzig_mini/tableA.csv
+++ b/scripts/er_matcher/tests/fixtures/leipzig_mini/tableA.csv
@@ -1,0 +1,5 @@
+id,title,manufacturer,price
+a1,Canon PowerShot G9 Digital Camera,Canon,449.99
+a2,Sony Cyber-shot DSC-W300 Camera,Sony,299.99
+a3,Canon EOS Rebel T3 Camera,Canon,599.00
+a4,Sony Alpha A200 Camera,Sony,499.00

--- a/scripts/er_matcher/tests/fixtures/leipzig_mini/tableB.csv
+++ b/scripts/er_matcher/tests/fixtures/leipzig_mini/tableB.csv
@@ -1,0 +1,5 @@
+id,title,manufacturer,price
+b1,Canon PowerShot G9 12MP Digital Camera,Canon,459.99
+b2,Sony Cybershot W300 12.1MP Camera,Sony,289.99
+b3,Nikon D40 Digital SLR Camera,Nikon,529.00
+b4,Kodak EasyShare C143 Camera,Kodak,89.99

--- a/scripts/er_matcher/tests/fixtures/magellan_mini/tableA.csv
+++ b/scripts/er_matcher/tests/fixtures/magellan_mini/tableA.csv
@@ -1,0 +1,4 @@
+id,title,manufacturer,price
+a0,Widget Pro 12oz,Acme,19.99
+a1,Gadget Mini,Acme,9.99
+a2,Thingamajig XL,Bolt Co,29.99

--- a/scripts/er_matcher/tests/fixtures/magellan_mini/tableB.csv
+++ b/scripts/er_matcher/tests/fixtures/magellan_mini/tableB.csv
@@ -1,0 +1,4 @@
+id,title,manufacturer,price
+b0,Widget Pro 12 oz,Acme Inc,19.99
+b1,Gizmo Deluxe,Bolt Co,14.99
+b2,Thingamajig XL,Bolt Co,29.99

--- a/scripts/er_matcher/tests/fixtures/magellan_mini/test.csv
+++ b/scripts/er_matcher/tests/fixtures/magellan_mini/test.csv
@@ -1,0 +1,3 @@
+ltable_id,rtable_id,label
+a2,b1,0
+a0,b0,1

--- a/scripts/er_matcher/tests/fixtures/magellan_mini/train.csv
+++ b/scripts/er_matcher/tests/fixtures/magellan_mini/train.csv
@@ -1,0 +1,4 @@
+ltable_id,rtable_id,label
+a0,b0,1
+a0,b1,0
+a1,b1,0

--- a/scripts/er_matcher/tests/fixtures/magellan_mini/valid.csv
+++ b/scripts/er_matcher/tests/fixtures/magellan_mini/valid.csv
@@ -1,0 +1,3 @@
+ltable_id,rtable_id,label
+a2,b2,1
+a1,b0,0


### PR DESCRIPTION
## What and why

Phase 1a of the production-grade OSS ER-matcher effort. Replaces the single synthetic data source with a license-clean, multi-source, provenance-tracked pipeline that blends public entity-matching benchmarks (FEBRL person + Leipzig CC-BY product/citation, bundled) into the trainer's existing JSONL corpus, with Magellan/NCVR wired as fetch-only, eval-only sources. The trainer and Modal run are unchanged; they still read `data/er_matcher/{train,val,test}.jsonl`.

Design spec and implementation plan are included under `docs/superpowers/`.

## Changes

- Pluggable `PairSource` registry + a `dataset` provenance field on the row contract
- Loaders: FEBRL (clean entity-level splits, same-entity-excluded negatives), Leipzig CC-BY (gold-filtered, cross-table negatives, shortfall guard), Magellan/DeepMatcher (network-guarded fetch, eval-only), NCVR (eval-only stub; real PII never bundled)
- Shared primitives: str-keyed `split_of`, bounded O(n) hard/easy negative synthesis (no O(N^2) blowup at 64k), `read_id_table`
- `sources.yaml` + strict config validation + a `build_source` factory (handles the loaders' differing constructor signatures)
- `build_corpus`: blends bundled/non-eval-only sources into `{train,val,test}.jsonl` + a license/attribution `manifest.json` for the model card; eval-only sources are excluded from the corpus but recorded in the manifest; `--cap` preserves class balance
- README documenting each source's license/attribution obligations, the fetch-only policy, run instructions, and deferred follow-ups

Everything here is CPU / box-safe: no torch/transformers and no network in the unit tests (fetch is guarded by `GOLDENMATCH_ALLOW_FETCH`).

## Testing

- `pytest scripts/er_matcher/` -> 106 passed (box-safe; run with the worktree goldenmatch on PYTHONPATH)
- End-to-end `build_corpus` smoke run over the mini fixtures: produces the corpus + manifest, person data is FEBRL-only, product is Leipzig, Magellan/NCVR appear eval-only with counts 0 and full license/attribution; deterministic byte-identical output; `--cap 2` yields both labels
- Every task was spec-compliance reviewed; the loaders and the blend driver also got code-quality review; a final holistic review ran before this PR (its one must-fix, an all-positive `--cap`, is fixed here)

Deferred and documented in the README: Phase 1b rich synthetic generator, a MusicBrainz loader (different clustering shape), a `kwargs` collision guard, and sub-projects 2-4 (run re-architecture, eval harness, release).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on all touched files (pre-commit hooks ran on the code commits)
- [ ] Package `CHANGELOG.md` updated if behavior changed (N/A: scripts/ tooling, no package changelog)
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXyU2FtzzQ68AYMaNKTX81
