### PR TITLE
feat(bench): persist + reuse synthetic fixtures via a bench-fixtures release

### DIFF
--- a/.github/workflows/bench-fs-single-mk-probe.yml
+++ b/.github/workflows/bench-fs-single-mk-probe.yml
@@ -33,7 +33,7 @@ on:
         default: "single-mk"
 
 permissions:
-  contents: read
+  contents: write  # fetch_or_gen_fixture.sh caches the fixture as a release asset
 
 jobs:
   probe:
@@ -54,13 +54,13 @@ jobs:
         run: uv pip install -e packages/python/goldenmatch
       - name: Build native extension (FS native path measurable)
         run: uv run python scripts/build_native.py
-      - name: Generate ${{ inputs.n_records }}-row fixture
+      - name: Fetch-or-generate fixture (cached as a bench-fixtures release asset)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p .profile_tmp/scale_fixtures
-          .venv/bin/python scripts/scale_audit_5m_generate.py \
-            --n-records ${{ inputs.n_records }} \
-            --dupe-rate ${{ inputs.dupe_rate }} \
-            --output .profile_tmp/scale_fixtures/synthetic_bench.csv
+          bash scripts/fetch_or_gen_fixture.sh \
+            "${{ inputs.n_records }}" "${{ inputs.dupe_rate }}" \
+            .profile_tmp/scale_fixtures/synthetic_bench.csv
       - name: Apply FS columnar-cluster (B2c) override (if set)
         if: ${{ inputs.columnar != '' }}
         run: echo "GOLDENMATCH_FS_COLUMNAR_CLUSTER=${{ inputs.columnar }}" >> $GITHUB_ENV

--- a/scripts/fetch_or_gen_fixture.sh
+++ b/scripts/fetch_or_gen_fixture.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Fetch a synthetic bench fixture from the `bench-fixtures` prerelease, or
+# generate it and upload it there for reuse.
+#
+# The generator (scale_audit_5m_generate.py) is deterministic (fixed seed=42),
+# so (n_records, dupe_rate) fully keys a fixture. Generating 5M takes ~20 min on
+# the runner; this turns that into a ~1 min download on every subsequent run
+# (any ref -- release assets are not branch-scoped, unlike actions/cache).
+#
+# Usage: fetch_or_gen_fixture.sh <n_records> <dupe_rate> <out_csv>
+# Requires: GH_TOKEN with contents:write; a built .venv.
+set -euo pipefail
+
+N="${1:?n_records}"; DUPE="${2:?dupe_rate}"; OUT="${3:?out_csv}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY unset}"
+TAG="bench-fixtures"
+ASSET="synthetic_${N}_d${DUPE}.csv"
+GT_ASSET="synthetic_${N}_d${DUPE}.ground_truth.csv"
+OUTDIR="$(dirname "$OUT")"
+GT_OUT="${OUT%.csv}.ground_truth.csv"
+mkdir -p "$OUTDIR"
+
+if gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" --dir "$OUTDIR" --clobber 2>/dev/null; then
+  mv "$OUTDIR/$ASSET" "$OUT"
+  gh release download "$TAG" --repo "$REPO" --pattern "$GT_ASSET" --dir "$OUTDIR" --clobber 2>/dev/null \
+    && mv "$OUTDIR/$GT_ASSET" "$GT_OUT" || true
+  echo "fixture cache HIT: $ASSET ($(du -h "$OUT" | cut -f1))"
+  exit 0
+fi
+
+echo "fixture cache MISS: generating $ASSET (~20 min at 5M)..."
+.venv/bin/python scripts/scale_audit_5m_generate.py \
+  --n-records "$N" --dupe-rate "$DUPE" --output "$OUT"
+
+# Upload for reuse. Non-fatal: a failed upload just means the next run regenerates.
+gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
+  gh release create "$TAG" --repo "$REPO" --prerelease \
+    --title "bench fixtures (cached)" \
+    --notes "Deterministic synthetic bench fixtures, keyed by (n_records, dupe_rate). Auto-populated by bench workflows; safe to delete (regenerated on demand)." 2>/dev/null || true
+cp "$OUT" "/tmp/$ASSET"
+UPLOADS="/tmp/$ASSET"
+[ -f "$GT_OUT" ] && cp "$GT_OUT" "/tmp/$GT_ASSET" && UPLOADS="$UPLOADS /tmp/$GT_ASSET"
+# shellcheck disable=SC2086
+gh release upload "$TAG" --repo "$REPO" $UPLOADS --clobber 2>/dev/null \
+  && echo "fixture generated + cached: $ASSET" \
+  || echo "(cache upload failed -- non-fatal; next run regenerates)"


### PR DESCRIPTION
Generating the 5M fixture takes ~20-23 min on the runner and it's deterministic (fixed seed), so regenerating it on every A/B dispatch is pure waste (time + paid-runner cost).

`scripts/fetch_or_gen_fixture.sh`: download the fixture from a `bench-fixtures` prerelease keyed by `(n_records, dupe_rate)`, or generate + upload it on a miss. Release assets are reusable across any dispatch ref (unlike branch-scoped `actions/cache`). Wired into the single-mk probe (`contents: write`). First run generates + caches (~20 min); every run after downloads (~1 min).

bench-zero-config can adopt the same helper once #2193 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)