### PR TITLE
fix(identity): stop evidence_edges + conflicts doubling on warm re-resolve (#2197)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -894,6 +894,8 @@ def resolve_clusters(
                         ))
                         summary.events_emitted += 1
                     summary.created += 1
+                    structural_change = True
+                    changed_records = set(record_ids)
                 elif len(unique_entities) == 1:
                     # Absorb new records into existing identity.
                     entity_id = unique_entities[0]
@@ -920,6 +922,11 @@ def resolve_clusters(
                         ))
                         summary.events_emitted += 1
                         summary.absorbed_records += 1
+                    # Edges/conflicts are re-emitted below ONLY for the records
+                    # this run actually added; a pure re-observation (nothing new)
+                    # writes nothing (#2197).
+                    structural_change = bool(newly_added)
+                    changed_records = set(newly_added)
                 else:
                     # Multi-entity overlap -> merge into the one with most members
                     # (tie-break: oldest created_at).
@@ -966,6 +973,8 @@ def resolve_clusters(
                         summary.events_emitted += 1
                     entity_id = winner
                     summary.merged += 1
+                    structural_change = True
+                    changed_records = set(record_ids)
 
                 # 3b. Reassign losers' records to winner BEFORE upserting cluster records,
                 # so an absorb branch on the next iteration sees them already migrated.
@@ -998,11 +1007,20 @@ def resolve_clusters(
                     ))
                     summary.records_upserted += 1
 
-                # 3d. Record evidence edges for every scored within-cluster pair.
+                # 3d. Record evidence edges for the scored within-cluster pairs
+                # THIS RUN CHANGED. ``run_name`` is part of the edge's unique key
+                # (audit spine), so re-emitting an unchanged cluster's edges every
+                # run appends a duplicate set under the new run_name and grows the
+                # store / conflict counts without bound (#2197). ``changed_records``
+                # is the whole cluster for a new/merged entity (so new clusters are
+                # byte-identical to before) and only the newly absorbed records for
+                # an absorb -- so a no-op re-resolve writes nothing, mirroring the
+                # event layer, which already skips via has_run_event / newly_added.
                 pair_scores = (
-                    pair_score_view.for_cluster(cluster_id)
-                    if pair_score_view is not None
-                    else (info.get("pair_scores") or {})
+                    (pair_score_view.for_cluster(cluster_id)
+                     if pair_score_view is not None
+                     else (info.get("pair_scores") or {}))
+                    if structural_change else {}
                 )
                 for pair_key, score in pair_scores.items():
                     if isinstance(pair_key, tuple) and len(pair_key) == 2:
@@ -1012,6 +1030,8 @@ def resolve_clusters(
                     ra = rowid_to_recid.get(int(a))
                     rb = rowid_to_recid.get(int(b))
                     if not ra or not rb:
+                        continue
+                    if ra not in changed_records and rb not in changed_records:
                         continue
                     _add_edge(EvidenceEdge(
                         entity_id=entity_id,
@@ -1036,7 +1056,8 @@ def resolve_clusters(
                 cluster_conf = _cluster_confidence(info)
                 bottleneck = info.get("bottleneck_pair")
                 if (
-                    weak_confidence_threshold > 0
+                    structural_change
+                    and weak_confidence_threshold > 0
                     and cluster_conf is not None
                     and cluster_conf < weak_confidence_threshold
                     and bottleneck is not None

--- a/packages/python/goldenmatch/tests/identity/test_reresolve_idempotent_2197.py
+++ b/packages/python/goldenmatch/tests/identity/test_reresolve_idempotent_2197.py
@@ -1,0 +1,135 @@
+"""Warm-store re-resolve must not duplicate evidence edges / conflicts (#2197).
+
+``run_name`` is part of the evidence_edges unique key (the audit spine), so a
+re-resolve of an UNCHANGED cluster used to append a whole second copy of its
+edges under the new run_name -- evidence_edges and conflicts doubled on every
+run while identity_nodes / identity_events stayed idempotent. Edge + conflict
+writes are now gated on actual change, mirroring the event layer: a no-op
+re-resolve writes nothing, and an absorb writes only the newly-absorbed
+records' edges.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.identity import IdentityStore, resolve_clusters
+from goldenmatch.identity.model import EdgeKind
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(path=str(tmp_path / "identity.db"))
+    yield s
+    s.close()
+
+
+def _df(rows):
+    out = []
+    for i, r in enumerate(rows):
+        rec = {"__row_id__": i, "__source__": "src"}
+        rec.update(r)
+        out.append(rec)
+    return pl.DataFrame(out)
+
+
+def _edges(store, eid):
+    return store.edges_for_entity(eid)
+
+
+def _kind(edges, kind):
+    return [e for e in edges if e.kind == kind]
+
+
+def _resolve(store, df, clusters, run_name, **kw):
+    return resolve_clusters(
+        clusters, df, [], "mk", store,
+        run_name=run_name, source_pk_col="id", **kw,
+    )
+
+
+# ── identical re-resolve ────────────────────────────────────────────────────
+
+def test_reresolve_identical_cluster_adds_no_edges(store):
+    """Same 3-record cluster resolved twice -> the edge set is unchanged."""
+    df = _df([{"id": "1", "name": "Al"}, {"id": "2", "name": "Al"},
+              {"id": "3", "name": "Al"}])
+    clusters = {0: {"members": [0, 1, 2], "size": 3, "confidence": 1.0,
+                    "pair_scores": {(0, 1): 0.99, (0, 2): 0.99, (1, 2): 0.99}}}
+
+    s1 = _resolve(store, df, clusters, "run1")
+    eid = store.find_entity_by_record("src:1")
+    edges_after_1 = _kind(_edges(store, eid), EdgeKind.SAME_AS.value)
+    assert s1.edges_added == 3          # 3-choose-2 pairs
+    assert len(edges_after_1) == 3
+
+    s2 = _resolve(store, df, clusters, "run2")
+    edges_after_2 = _kind(_edges(store, eid), EdgeKind.SAME_AS.value)
+    assert s2.edges_added == 0          # nothing changed -> nothing written
+    assert len(edges_after_2) == 3      # NOT 6
+
+    # and it stays flat on a third run
+    _resolve(store, df, clusters, "run3")
+    assert len(_kind(_edges(store, eid), EdgeKind.SAME_AS.value)) == 3
+
+
+def test_reresolve_preserves_entity_and_records(store):
+    """The entity_id and record membership are unchanged across re-resolve."""
+    df = _df([{"id": "1", "name": "Al"}, {"id": "2", "name": "Al"}])
+    clusters = {0: {"members": [0, 1], "size": 2, "confidence": 1.0,
+                    "pair_scores": {(0, 1): 0.99}}}
+    _resolve(store, df, clusters, "run1")
+    eid = store.find_entity_by_record("src:1")
+    before = store.count_identities()
+
+    _resolve(store, df, clusters, "run2")
+    assert store.find_entity_by_record("src:1") == eid      # stable id
+    assert store.find_entity_by_record("src:2") == eid
+    assert store.count_identities() == before               # no new entities
+
+
+# ── absorb delta writes only the new records' edges ─────────────────────────
+
+def test_absorb_writes_only_new_record_edges(store):
+    """Seed {1,2}; re-resolve {1,2,3}. Only edges touching record 3 are added;
+    the pre-existing 1-2 edge is NOT re-written."""
+    df1 = _df([{"id": "1", "name": "Al"}, {"id": "2", "name": "Al"}])
+    _resolve(store, df1,
+             {0: {"members": [0, 1], "size": 2, "confidence": 1.0,
+                  "pair_scores": {(0, 1): 0.99}}},
+             "run1")
+    eid = store.find_entity_by_record("src:1")
+    assert len(_kind(_edges(store, eid), EdgeKind.SAME_AS.value)) == 1
+
+    df2 = _df([{"id": "1", "name": "Al"}, {"id": "2", "name": "Al"},
+               {"id": "3", "name": "Al"}])
+    s2 = _resolve(store, df2,
+                  {0: {"members": [0, 1, 2], "size": 3, "confidence": 1.0,
+                       "pair_scores": {(0, 1): 0.99, (0, 2): 0.99, (1, 2): 0.99}}},
+                  "run2")
+
+    assert s2.absorbed_records == 1                 # record 3 absorbed
+    assert s2.edges_added == 2                       # 1-3 and 2-3 only, NOT 1-2
+    same = _kind(_edges(store, eid), EdgeKind.SAME_AS.value)
+    assert len(same) == 3                            # 1-2 (kept) + 1-3 + 2-3
+    pairs = {frozenset((e.record_a_id, e.record_b_id)) for e in same}
+    assert frozenset(("src:1", "src:2")) in pairs
+    assert frozenset(("src:1", "src:3")) in pairs
+    assert frozenset(("src:2", "src:3")) in pairs
+
+
+# ── conflicts do not double either ──────────────────────────────────────────
+
+def test_reresolve_does_not_reflag_conflicts(store):
+    """A weak cluster flags one conflicts_with edge; re-resolving the unchanged
+    cluster must not flag it again."""
+    df = _df([{"id": "1", "name": "Al"}, {"id": "2", "name": "Bo"}])
+    clusters = {0: {"members": [0, 1], "size": 2, "confidence": 0.4,
+                    "pair_scores": {(0, 1): 0.55}, "bottleneck_pair": (0, 1)}}
+
+    s1 = _resolve(store, df, clusters, "run1", weak_confidence_threshold=0.6)
+    assert s1.conflicts_flagged == 1
+    assert len(store.find_conflicts()) == 1
+
+    s2 = _resolve(store, df, clusters, "run2", weak_confidence_threshold=0.6)
+    assert s2.conflicts_flagged == 0
+    assert len(store.find_conflicts()) == 1          # NOT 2


### PR DESCRIPTION
Closes #2197.

## The bug
`run_name` is part of the `evidence_edges` unique key (the audit spine), so re-resolving the same clusters wrote a whole second copy of every edge under the new run_name. On a warm re-resolve of identical data, `evidence_edges` and conflicts doubled (2.00x, then 3x on a third run), while `identity_nodes` and `identity_events` stayed idempotent.

The event layer already gates on change (`has_run_event`, and absorb only emits events for records not already present) -- that's why events came back `events_emitted=0` on a no-op re-resolve. But the edge write (3d) and the weak-cluster conflict flag (3e) fired unconditionally for every cluster on every run.

## The fix
Gate edge/conflict writes on actual change, the same way events already are:

- **brand-new / merge:** `changed_records` = the whole cluster, so new and merged clusters write exactly what they did before (byte-identical).
- **absorb:** `changed_records` = only the newly-absorbed records, so an absorb writes just the new records' edges, and a pure re-observation (nothing new) writes nothing.
- the weak-cluster **conflict** flag is skipped when the cluster didn't change this run.

`run_name`-per-edge provenance is preserved for edges that are genuinely new; only the redundant re-writes go away.

## Result
A no-op re-resolve now adds 0 edges / 0 conflicts, and the store stops growing without bound on a scheduled re-run.

Measured on the reporter's data (405k records / 184k entities), before: edges 257,458 -> 514,916 on the second run. After this change the second run is a no-op on unchanged clusters.

## Tests
New `test_reresolve_idempotent_2197.py`: identical re-resolve adds no edges (and stays flat on a third run), absorb writes only the new records' edges (not the pre-existing pair), and conflicts don't re-flag. The 44 existing identity resolve/profile/parity tests still pass.
