### PR TITLE
docs(0047): wire conformance v2 into frame doc, ledger, and checker

### DIFF
--- a/context-network/architecture/one-product-two-engines.md
+++ b/context-network/architecture/one-product-two-engines.md
@@ -137,6 +137,33 @@ not by calling the same library.**
 
 This makes compatibility explicit rather than rhetorical.
 
+### 3.4 Conformance v2 — behavioral, default-routing, deferral re-validation
+
+Once structural single-sourcing has largely landed (an owner exists; a fixture test
+exists), the frontier moves to *behavioral* and *temporal* conformance. Decision 0047's
+2026-07-27 amendment sharpens three tests (the tenets' wording is unchanged):
+
+- **Default-routing (T1).** One authoritative owner **and the default caller path routes
+  to it**. A correct-but-unwired kernel — the shared owner exists but a second
+  implementation is the default — is a *latent second source of truth*, not a resolved
+  item. Recorded per weakness as `default_routed:` (`true` = owner is the default;
+  `opt-in` = a deliberate fallback-default, e.g. edge-bundle discipline; `false` = flagged
+  by `check_thesis_conformance.py`).
+- **Behavioral equivalence (T2).** A conformance test for a two-engine capability must
+  check the operating point / decision output on a *representative* workload (e.g. dedupe
+  F1-neutrality), not only byte/tolerance parity on canned inputs. Fixture parity is
+  necessary, not sufficient — it is what missed the fs-default operating-point shift; and
+  the behavioral check itself must run on a non-degenerate workload to mean anything.
+- **Deferral re-validation (T3).** Every deferral names the explicit condition that would
+  *un-defer* it (recorded as `un_defer:`) and that premise is re-checked, not assumed
+  permanent; a deferral whose premise has already lifted is an OPEN divergence. The
+  scorecard renders these under "RE-VALIDATE" so they are re-examined each audit.
+
+The static harvest + gates stay as the floor; this behavioral/temporal layer augments them
+(it leans on measurement and adversarial review, which are advisory by nature). See ADR
+`context-network/decisions/0047-one-product-two-engines-architecture.md` (2026-07-27
+amendment).
+
 ## 4. Arrow: bulk contract, not universal calling convention
 
 Arrow is the preferred **data-plane** boundary for bulk/columnar work. Anything that

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -89,6 +89,9 @@ weaknesses:
                     # stays lean + opt-in. The owner-gated default flip landed and was
                     # measured F1-neutral (see below). No open follow-up remains.
     declared: true   # Wave A: declared in the 0046 amendment (2026-07-26)
+    default_routed: true   # conformance v2 (0047 amendment): the batteries `goldenmatch`
+                           # import auto-enables the shared kernel, so the DEFAULT caller
+                           # routes to the owner -- not a correct-but-unwired latent 2nd source
     title: "TS Fellegi-Sunter scoring runs the shared fs-core kernel by default (batteries entry); pure-TS is the classified fallback"
     detail: >-
       RESOLVED-as-wired. The pipeline (scoreProbabilisticBlocks) now routes FS block
@@ -211,6 +214,9 @@ weaknesses:
                     # Family B (goldenanalysis frame kernels) NOW shares one too
                     # (analysis-wasm intern reroute; Wave 1b un-deferred via #1788)
     declared: true   # declared in TS CLAUDE.md / wave1b spec + parity manifests
+    default_routed: opt-in   # conformance v2: both kernels are SHARED but reached via opt-in
+                             # enable (cluster-wasm / enableAnalysisWasm), pure-TS is the default
+                             # fallback -- an intentional edge-bundle choice, not a latent gap
     title: "Clustering + goldenanalysis frame kernels: both families now share a kernel (cluster-wasm + analysis-wasm)"
     detail: >-
       TWO families, both resolved. (A) TS clustering: connected-components was already shared
@@ -296,6 +302,12 @@ weaknesses:
     tenet: T3
     severity: low
     declared: true
+    un_defer: >-
+      RE-VALIDATE (conformance v2, 0047 amendment): re-fires the moment a scorer/blocking
+      deferral is added whose reason is PERF/SHAPE rather than model-backed -- that entry then
+      owes a MEASURED wall-clock (kernelize on measurement). Currently vacuous: every deferral
+      (embedding / record_embedding / simhash) is model-backed. Re-check on any new
+      scorer_kernels_deferred / blocking_kernels_deferred entry.
     title: "Kernel deferrals state a reason but not measured wall-clock provenance"
     detail: >-
       scorer_kernels_deferred / blocking_kernels_deferred entries carry a prose reason

--- a/scripts/check_thesis_conformance.py
+++ b/scripts/check_thesis_conformance.py
@@ -205,6 +205,16 @@ def run_check(card: dict, strict: bool) -> int:
         if pt not in ("__unset__", None) and not (REPO / pt).exists():
             problems.append(f"weakness '{w['id']}' names parity_test '{pt}' that does not exist")
 
+    # Conformance v2 (0047 amendment) -- T1 default-routing: a shared owner that the
+    # DEFAULT caller path does NOT route to is a LATENT second source (opt-in while a
+    # second impl is the default). `default_routed: true` = owner is the default;
+    # `opt-in` = deliberate fallback-default (edge-bundle discipline); `false` = flag.
+    for w in card["weaknesses"]:
+        if w.get("default_routed") is False:
+            problems.append(
+                f"LATENT second source: '{w['id']}' has a shared owner but the default "
+                f"path does not route to it (default_routed: false) -- conformance v2 T1")
+
     if problems:
         print("THESIS-CONFORMANCE DRIFT:")
         for p in problems:
@@ -244,6 +254,27 @@ def render(card: dict) -> None:
         for w in items:
             flag = "" if w.get("declared", True) else "  !!UNDECLARED"
             print(f"     - ({w['severity']}) {w['title']}{flag}")
+        print()
+
+    routed = [w for w in ws if "default_routed" in w]
+    revalidate = [w for w in ws if w.get("un_defer")]
+    if routed or revalidate:
+        print("-" * 78)
+        print("CONFORMANCE v2 (0047 amendment: behavioral + default-routing + re-validation)")
+        print("-" * 78)
+        if routed:
+            print("Default-routing (T1: does the DEFAULT caller path route to the owner?)")
+            for w in routed:
+                dr = w["default_routed"]
+                tag = {True: "DEFAULT", "opt-in": "opt-in (classified fallback is default)"}.get(
+                    dr, str(dr))
+                mark = "  !!LATENT-2ND-SOURCE" if dr is False else ""
+                print(f"    [{tag}] {w['id']}{mark}")
+        if revalidate:
+            print("Re-validate (deferral premises -- re-check the un-defer trigger):")
+            for w in revalidate:
+                first = " ".join(str(w["un_defer"]).split())
+                print(f"    - {w['id']}: {first[:110]}{'...' if len(first) > 110 else ''}")
         print()
 
     print("-" * 78)


### PR DESCRIPTION
Mechanical propagation of the ADR 0047 conformance-v2 amendment (#2194, merged) into its instrumentation -- the wiring you asked for once it landed.

- **Frame doc** section 3.4: the three sharpened decision tests (T1 default-routing, T2 behavioral equivalence, T3 deferral re-validation); static gates kept as the floor.
- **thesis_conformance.yaml**: `default_routed:` on the T1 shared-owner items (fs-default = `true`; frame kernels = `opt-in`) + an `un_defer:` re-validation trigger on deferrals-provenance.
- **check_thesis_conformance.py**: renders a CONFORMANCE v2 section (default-routing + re-validate list) and advisory-flags `default_routed: false` as a latent second source.

Verified: scorecard renders the v2 block, `--check` OK, docs gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)