### PR TITLE
perf(identity): grouped aggregates for summary_stats + steward_worklist (#2198)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5973,6 +5973,8 @@
             "IdentitySummary",
             "WorklistItem",
             "_iter_entities",
+            "_summary_from_counts",
+            "_summary_stats_scan",
             "entity_profile",
             "identity_summary_stats",
             "steward_worklist",

--- a/packages/python/goldenmatch/goldenmatch/identity/profile.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/profile.py
@@ -183,39 +183,24 @@ class IdentitySummary:
         }
 
 
-def identity_summary_stats(
-    store: IdentityStore, dataset: str | None = None,
+def _summary_from_counts(
+    store: IdentityStore,
+    dataset: str | None,
+    by_status: dict[str, int],
+    per_entity: dict[str, int],
+    source_breakdown: dict[str, int],
 ) -> IdentitySummary:
-    """Graph-level health summary. Records live on active entities (merges
-    reassign them), so per-entity record stats are computed over active
-    entities; status counts cover every status."""
-    by_status: dict[str, int] = {}
-    total_entities = 0
-    for node in _iter_entities(store, dataset, None):
-        total_entities += 1
-        by_status[node.status] = by_status.get(node.status, 0) + 1
-
-    record_counts: list[int] = []
-    source_breakdown: dict[str, int] = {}
-    largest: list[tuple[str, int]] = []
-    for node in _iter_entities(store, dataset, IdentityStatus.ACTIVE.value):
-        recs = store.get_records_for_entity(node.entity_id)
-        record_counts.append(len(recs))
-        for rec in recs:
-            source_breakdown[rec.source] = source_breakdown.get(rec.source, 0) + 1
-        largest.append((node.entity_id, len(recs)))
-
+    record_counts = list(per_entity.values())
     total_records = sum(record_counts)
     singleton = sum(1 for c in record_counts if c == 1)
     multi = sum(1 for c in record_counts if c > 1)
     avg = (total_records / len(record_counts)) if record_counts else 0.0
     p50 = float(statistics.median(record_counts)) if record_counts else 0.0
     mx = max(record_counts) if record_counts else 0
-    largest.sort(key=lambda kv: (-kv[1], kv[0]))
-
+    largest = sorted(per_entity.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
     return IdentitySummary(
         dataset=dataset,
-        total_entities=total_entities,
+        total_entities=sum(by_status.values()),
         by_status=by_status,
         total_records=total_records,
         records_per_entity_avg=round(avg, 4),
@@ -226,9 +211,47 @@ def identity_summary_stats(
         total_conflicts=len(store.find_conflicts(dataset=dataset)),
         source_breakdown=source_breakdown,
         largest_entities=[
-            {"entity_id": eid, "record_count": n} for eid, n in largest[:10]
+            {"entity_id": eid, "record_count": n} for eid, n in largest
         ],
     )
+
+
+def _summary_stats_scan(
+    store: IdentityStore, dataset: str | None,
+) -> IdentitySummary:
+    """Per-entity fallback for stores without the grouped aggregates (mongo)."""
+    by_status: dict[str, int] = {}
+    for node in _iter_entities(store, dataset, None):
+        by_status[node.status] = by_status.get(node.status, 0) + 1
+
+    per_entity: dict[str, int] = {}
+    source_breakdown: dict[str, int] = {}
+    for node in _iter_entities(store, dataset, IdentityStatus.ACTIVE.value):
+        recs = store.get_records_for_entity(node.entity_id)
+        per_entity[node.entity_id] = len(recs)
+        for rec in recs:
+            source_breakdown[rec.source] = source_breakdown.get(rec.source, 0) + 1
+    return _summary_from_counts(store, dataset, by_status, per_entity, source_breakdown)
+
+
+def identity_summary_stats(
+    store: IdentityStore, dataset: str | None = None,
+) -> IdentitySummary:
+    """Graph-level health summary. Records live on active entities (merges
+    reassign them), so per-entity record stats are computed over active
+    entities; status counts cover every status.
+
+    On SQL backends this is a handful of grouped queries (#2198). It used to
+    call ``get_records_for_entity`` once per entity -- O(entities) round-trips
+    that dominated wall-clock at scale -- so it now asks the store for the same
+    tallies in two ``GROUP BY`` queries, falling back to the per-entity scan for
+    backends that don't implement them."""
+    try:
+        by_status = store.status_counts(dataset)
+        per_entity, source_breakdown = store.active_record_stats(dataset)
+    except (AttributeError, NotImplementedError):
+        return _summary_stats_scan(store, dataset)
+    return _summary_from_counts(store, dataset, by_status, per_entity, source_breakdown)
 
 
 # ── Stewardship worklist ────────────────────────────────────────────────────
@@ -267,6 +290,13 @@ def steward_worklist(
     for e in store.find_conflicts(dataset=dataset):
         conflicts_by_entity[e.entity_id] = conflicts_by_entity.get(e.entity_id, 0) + 1
 
+    # Record counts for every active entity in one grouped query, so the loop
+    # below doesn't issue a get_records_for_entity per flagged entity (#2198).
+    try:
+        record_counts, _ = store.active_record_stats(dataset)
+    except (AttributeError, NotImplementedError):
+        record_counts = None
+
     items: list[WorklistItem] = []
     for node in _iter_entities(store, dataset, IdentityStatus.ACTIVE.value):
         cc = conflicts_by_entity.get(node.entity_id, 0)
@@ -278,12 +308,14 @@ def steward_worklist(
             reasons.append("has_conflicts")
         if low_conf:
             reasons.append("low_confidence")
+        rc = (record_counts.get(node.entity_id, 0) if record_counts is not None
+              else len(store.get_records_for_entity(node.entity_id)))
         items.append(WorklistItem(
             entity_id=node.entity_id,
             reasons=reasons,
             conflict_count=cc,
             confidence=node.confidence,
-            record_count=len(store.get_records_for_entity(node.entity_id)),
+            record_count=rc,
         ))
 
     items.sort(key=lambda it: (

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -1434,6 +1434,61 @@ class IdentityStore:
             )
         return [self._row_to_edge(r) for r in rows]
 
+    def status_counts(self, dataset: str | None = None) -> dict[str, int]:
+        """Entity count per status in one grouped query.
+
+        Lets ``identity_summary_stats`` tally statuses without paging every node
+        (#2198). Raises on mongo so the caller keeps its paged fallback."""
+        if self._backend == "mongo":
+            raise NotImplementedError("status_counts: mongo uses the paged fallback")
+        if dataset is None:
+            rows = self._fetchall(
+                "SELECT status, COUNT(*) AS n FROM identity_nodes GROUP BY status", (),
+            )
+        else:
+            rows = self._fetchall(
+                "SELECT status, COUNT(*) AS n FROM identity_nodes "
+                "WHERE dataset = ? GROUP BY status", (dataset,),
+            )
+        return {r["status"]: int(r["n"]) for r in rows}
+
+    def active_record_stats(
+        self, dataset: str | None = None,
+    ) -> tuple[dict[str, int], dict[str, int]]:
+        """``(records_per_active_entity, records_per_source)`` in two grouped
+        queries instead of one ``get_records_for_entity`` per entity (#2198).
+
+        Records live on active entities (a merge reassigns them), matching
+        ``identity_summary_stats``' per-active-entity accounting. The entity map
+        LEFT JOINs so an active entity with zero records still appears (count 0),
+        preserving the prior ``len()``-based semantics. Raises on mongo so the
+        caller keeps its paged fallback."""
+        if self._backend == "mongo":
+            raise NotImplementedError(
+                "active_record_stats: mongo uses the paged fallback"
+            )
+        ds = "" if dataset is None else " AND n.dataset = ?"
+        params: tuple = () if dataset is None else (dataset,)
+        per_entity_rows = self._fetchall(
+            "SELECT n.entity_id AS eid, COUNT(sr.record_id) AS n "
+            "FROM identity_nodes n "
+            "LEFT JOIN source_records sr ON sr.entity_id = n.entity_id "
+            f"WHERE n.status = 'active'{ds} "
+            "GROUP BY n.entity_id",
+            params,
+        )
+        source_rows = self._fetchall(
+            "SELECT sr.source AS source, COUNT(*) AS n "
+            "FROM source_records sr "
+            "JOIN identity_nodes n ON sr.entity_id = n.entity_id "
+            f"WHERE n.status = 'active'{ds} "
+            "GROUP BY sr.source",
+            params,
+        )
+        per_entity = {r["eid"]: int(r["n"]) for r in per_entity_rows}
+        source_breakdown = {r["source"]: int(r["n"]) for r in source_rows}
+        return per_entity, source_breakdown
+
     def emit_event(
         self, event: IdentityEvent, *, return_id: bool = True
     ) -> int | None:

--- a/packages/python/goldenmatch/tests/identity/test_summary_stats_aggregate_2198.py
+++ b/packages/python/goldenmatch/tests/identity/test_summary_stats_aggregate_2198.py
@@ -1,0 +1,107 @@
+"""identity_summary_stats / steward_worklist use grouped aggregates (#2198).
+
+The SQL fast path (status_counts + active_record_stats) must return exactly what
+the per-entity scan fallback returns -- it just gets there in a few GROUP BY
+queries instead of one get_records_for_entity per entity.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.identity import IdentityStore, resolve_clusters
+from goldenmatch.identity.profile import (
+    _summary_stats_scan,
+    identity_summary_stats,
+    steward_worklist,
+)
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(path=str(tmp_path / "identity.db"))
+    yield s
+    s.close()
+
+
+def _df(rows):
+    out = []
+    for i, r in enumerate(rows):
+        rec = {"__row_id__": i, "__source__": r.get("src", "a")}
+        rec.update({k: v for k, v in r.items() if k != "src"})
+        out.append(rec)
+    return pl.DataFrame(out)
+
+
+def _seed(store):
+    """One 3-record entity across two sources, one singleton, one dataset."""
+    df = _df([
+        {"id": "1", "name": "Al", "src": "a"},
+        {"id": "2", "name": "Al", "src": "a"},
+        {"id": "3", "name": "Al", "src": "b"},
+        {"id": "9", "name": "Zo", "src": "a"},
+    ])
+    clusters = {
+        0: {"members": [0, 1, 2], "size": 3, "confidence": 1.0,
+            "pair_scores": {(0, 1): 0.9, (0, 2): 0.9, (1, 2): 0.9}},
+        1: {"members": [3], "size": 1, "confidence": 1.0, "pair_scores": {}},
+    }
+    resolve_clusters(clusters, df, [], "mk", store, run_name="r",
+                     source_pk_col="id", dataset="d", emit_singletons=True)
+
+
+def test_fast_path_matches_scan(store):
+    _seed(store)
+    fast = identity_summary_stats(store, "d")
+    scan = _summary_stats_scan(store, "d")
+    assert fast.as_dict() == scan.as_dict()
+
+
+def test_summary_values(store):
+    _seed(store)
+    s = identity_summary_stats(store, "d")
+    assert s.total_entities == 2
+    assert s.total_records == 4
+    assert s.multi_record_entities == 1
+    assert s.singleton_entities == 1
+    assert s.records_per_entity_max == 3
+    assert s.source_breakdown == {"a": 3, "b": 1}
+    assert s.largest_entities[0]["record_count"] == 3
+
+
+def test_dataset_scoping(store):
+    _seed(store)
+    # A second dataset the summary must not see (distinct record_id so it does
+    # not collide with the seed's records and cross datasets).
+    df2 = _df([{"id": "99", "name": "Q", "src": "c"}])
+    resolve_clusters(
+        {0: {"members": [0], "size": 1, "confidence": 1.0, "pair_scores": {}}},
+        df2, [], "mk", store, run_name="r2", source_pk_col="id",
+        dataset="other", emit_singletons=True,
+    )
+    s = identity_summary_stats(store, "d")
+    assert s.total_entities == 2          # only dataset "d"
+    assert s.total_records == 4
+
+
+def test_status_counts_and_active_record_stats(store):
+    _seed(store)
+    assert store.status_counts("d") == {"active": 2}
+    per_entity, sources = store.active_record_stats("d")
+    assert sorted(per_entity.values()) == [1, 3]
+    assert sources == {"a": 3, "b": 1}
+
+
+def test_steward_worklist_record_count(store):
+    """Weak cluster -> a worklist item whose record_count comes from the bulk
+    aggregate, matching what a per-entity read would give."""
+    df = _df([{"id": "1", "name": "Al"}, {"id": "2", "name": "Bo"}])
+    resolve_clusters(
+        {0: {"members": [0, 1], "size": 2, "confidence": 0.4,
+             "pair_scores": {(0, 1): 0.55}, "bottleneck_pair": (0, 1)}},
+        df, [], "mk", store, run_name="r", source_pk_col="id",
+        dataset="w", weak_confidence_threshold=0.6, emit_singletons=True,
+    )
+    wl = steward_worklist(store, "w")
+    assert len(wl) == 1
+    assert wl[0].conflict_count == 1
+    assert wl[0].record_count == 2


### PR DESCRIPTION
Closes #2198.

## The bottleneck
`identity_summary_stats` called `get_records_for_entity` once per entity -- O(entities) SQL round-trips. On a 184k-entity store that's ~184k queries and it dominated wall-clock (~900s, cold or warm, because it scans the whole store rather than the resolve delta). `steward_worklist` did the same per flagged entity.

The resolve itself is fast after #2111; this was purely the read side.

## The fix
Two grouped store methods, and the read functions use them:

- `IdentityStore.status_counts(dataset)` -- entity count per status in one `GROUP BY`.
- `IdentityStore.active_record_stats(dataset)` -- records-per-active-entity and records-per-source in two `GROUP BY` queries. The entity map `LEFT JOIN`s so a zero-record active entity still appears (count 0), preserving the prior `len()`-based semantics exactly.

`identity_summary_stats` now issues a handful of grouped queries instead of one per entity. `steward_worklist` pulls record counts from the same bulk map instead of a per-flagged-entity read.

Both keep the original per-entity scan as a fallback for backends that don't implement the aggregates (mongo) -- extracted as `_summary_stats_scan`, and the fast path is asserted byte-identical to it in tests. No schema change, works on SQLite and Postgres (`?` placeholders via the existing `_fetchall`).

## Tests
`test_summary_stats_aggregate_2198.py`: fast path == scan fallback, explicit value checks (multi/singleton/sources/largest), dataset scoping, the two new store methods, and steward_worklist record counts. The existing `test_profile.py` and the identity resolve suite still pass.
