### PR TITLE
feat(identity): entity<->entity relationship edges from shared attributes (#2210)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -373,7 +373,7 @@ _Identity Graph configuration._
 | `source_pk_column` | str \| None | `None` | Column supplying each record's source primary key for stable record ids; a payload hash is used when unset. |
 | `emit_singletons` | bool | `True` | Whether single-record clusters also get a durable entity id. |
 | `weak_confidence_threshold` | float | `0.6` | Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it. |
-| `relationships` | list[RelationshipRule] | `[]` | [`RelationshipRule`](#relationshiprule) -- Rules deriving entity&lt;->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged. |
+| `relationships` | list[RelationshipRule] | `[]` | [`RelationshipRule`](#relationshiprule) -- Rules deriving entity-to-entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged. |
 | `stitching` | ChannelStitchConfig \| None | `None` | [`ChannelStitchConfig`](#channelstitchconfig) -- Cross-device/channel stitching configuration; None leaves identity resolution unchanged. |
 | `survivorship` | SurvivorshipConfig \| None | `None` | [`SurvivorshipConfig`](#survivorshipconfig) -- Identity golden-record survivorship configuration; None keeps the default flat golden record. |
 | `stabilization` | StabilizationConfig \| None | `None` | [`StabilizationConfig`](#stabilizationconfig) -- Cross-run entity stabilization configuration; None runs no stabilize pass. |
@@ -542,7 +542,7 @@ _Learning Memory learning parameters._
 | `weights_min_corrections` | int | `50` | Minimum stored corrections before learned field weights are tuned from them. |
 
 ### `RelationshipRule`
-_One rule for deriving entity<->entity relationship edges from a shared,_
+_One rule for deriving entity-to-entity relationship edges from a shared,_
 
 | Field | Type | Default | Choices / notes |
 |---|---|---|---|

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -373,6 +373,7 @@ _Identity Graph configuration._
 | `source_pk_column` | str \| None | `None` | Column supplying each record's source primary key for stable record ids; a payload hash is used when unset. |
 | `emit_singletons` | bool | `True` | Whether single-record clusters also get a durable entity id. |
 | `weak_confidence_threshold` | float | `0.6` | Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it. |
+| `relationships` | list[RelationshipRule] | `[]` | [`RelationshipRule`](#relationshiprule) -- Rules deriving entity&lt;->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged. |
 | `stitching` | ChannelStitchConfig \| None | `None` | [`ChannelStitchConfig`](#channelstitchconfig) -- Cross-device/channel stitching configuration; None leaves identity resolution unchanged. |
 | `survivorship` | SurvivorshipConfig \| None | `None` | [`SurvivorshipConfig`](#survivorshipconfig) -- Identity golden-record survivorship configuration; None keeps the default flat golden record. |
 | `stabilization` | StabilizationConfig \| None | `None` | [`StabilizationConfig`](#stabilizationconfig) -- Cross-run entity stabilization configuration; None runs no stabilize pass. |
@@ -539,6 +540,16 @@ _Learning Memory learning parameters._
 |---|---|---|---|
 | `threshold_min_corrections` | int | `10` | Minimum stored corrections before learned thresholds are tuned from them. |
 | `weights_min_corrections` | int | `50` | Minimum stored corrections before learned field weights are tuned from them. |
+
+### `RelationshipRule`
+_One rule for deriving entity<->entity relationship edges from a shared,_
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `field` | str | **required** | Payload field whose shared value relates two entities (e.g. 'phone_number', 'zip5', 'employer'). |
+| `kind` | str | **required** | Relationship label for the emitted edge (e.g. 'shares_phone', 'same_address'). |
+| `min_entities` | int | `2` | A shared value must be held by at least this many distinct entities to emit edges. |
+| `max_fanout` | int | `50` | Skip values shared by more than this many distinct entities (hub values like a switchboard line are not pairwise relationships). |
 
 ### `ChannelStitchConfig`
 _Cross-device / channel stitching configuration (#1110, epic #1108)._

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 420,
+      "module_count": 421,
       "modules": [
         {
           "module": "goldenmatch",
@@ -1103,6 +1103,7 @@
             "OutputConfig",
             "PerceptualKeyConfig",
             "QualityConfig",
+            "RelationshipRule",
             "RulesPayload",
             "SemanticBlockingConfig",
             "SimHashKeyConfig",
@@ -5839,6 +5840,7 @@
             "goldenmatch.identity.model",
             "goldenmatch.identity.profile",
             "goldenmatch.identity.query",
+            "goldenmatch.identity.relationships",
             "goldenmatch.identity.resolve",
             "goldenmatch.identity.stabilize",
             "goldenmatch.identity.stitching",
@@ -6043,6 +6045,18 @@
           ]
         },
         {
+          "module": "goldenmatch.identity.relationships",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/relationships.py",
+          "purpose": "Semantic-graph: entity<->entity relationship edges (#semantic-graph).",
+          "defines": [
+            "build_relationships"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
           "module": "goldenmatch.identity.resolution_batch",
           "file": "packages/python/goldenmatch/goldenmatch/identity/resolution_batch.py",
           "purpose": "The versioned compute->control seam contract (Wave C, milestone C1).",
@@ -6097,6 +6111,7 @@
             "goldenmatch.identity.block_index",
             "goldenmatch.identity.fingerprint_batch",
             "goldenmatch.identity.model",
+            "goldenmatch.identity.relationships",
             "goldenmatch.identity.resolution_batch",
             "goldenmatch.identity.store"
           ]

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -6049,7 +6049,9 @@
           "file": "packages/python/goldenmatch/goldenmatch/identity/relationships.py",
           "purpose": "Semantic-graph: entity<->entity relationship edges (#semantic-graph).",
           "defines": [
-            "build_relationships"
+            "_entity_name",
+            "build_relationships",
+            "to_graph_batch"
           ],
           "imports": [
             "goldenmatch.config.schemas",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -1330,6 +1330,16 @@
               "description": "Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it."
             },
             {
+              "name": "relationships",
+              "type": "list[RelationshipRule]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "RelationshipRule"
+              ],
+              "description": "Rules deriving entity<->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged."
+            },
+            {
               "name": "stitching",
               "type": "ChannelStitchConfig | None",
               "required": false,
@@ -2063,6 +2073,38 @@
             }
           ],
           "doc": "Learning Memory learning parameters."
+        },
+        {
+          "name": "RelationshipRule",
+          "fields": [
+            {
+              "name": "field",
+              "type": "str",
+              "required": true,
+              "description": "Payload field whose shared value relates two entities (e.g. 'phone_number', 'zip5', 'employer')."
+            },
+            {
+              "name": "kind",
+              "type": "str",
+              "required": true,
+              "description": "Relationship label for the emitted edge (e.g. 'shares_phone', 'same_address')."
+            },
+            {
+              "name": "min_entities",
+              "type": "int",
+              "required": false,
+              "default": "2",
+              "description": "A shared value must be held by at least this many distinct entities to emit edges."
+            },
+            {
+              "name": "max_fanout",
+              "type": "int",
+              "required": false,
+              "default": "50",
+              "description": "Skip values shared by more than this many distinct entities (hub values like a switchboard line are not pairwise relationships)."
+            }
+          ],
+          "doc": "One rule for deriving entity<->entity relationship edges from a shared,"
         },
         {
           "name": "ChannelStitchConfig",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -1337,7 +1337,7 @@
               "nested": [
                 "RelationshipRule"
               ],
-              "description": "Rules deriving entity<->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged."
+              "description": "Rules deriving entity-to-entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged."
             },
             {
               "name": "stitching",
@@ -2104,7 +2104,7 @@
               "description": "Skip values shared by more than this many distinct entities (hub values like a switchboard line are not pairwise relationships)."
             }
           ],
-          "doc": "One rule for deriving entity<->entity relationship edges from a shared,"
+          "doc": "One rule for deriving entity-to-entity relationship edges from a shared,"
         },
         {
           "name": "ChannelStitchConfig",

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -1915,6 +1915,33 @@ class MediationConfig(BaseModel):
     )
 
 
+class RelationshipRule(BaseModel):
+    """One rule for deriving entity<->entity relationship edges from a shared,
+    NON-identity attribute (#semantic-graph).
+
+    Identity resolution collapses records that are the SAME entity. The same
+    blocking data also surfaces DIFFERENT entities that share a non-identity
+    attribute -- two prescribers on one clinic phone, two people at one address --
+    which is a relationship, not a merge. This rule emits those as edges keyed on
+    the stable ``entity_id``s, turning the identity graph into a semantic graph
+    maintained in the same pass.
+    """
+    field: str = Field(
+        description="Payload field whose shared value relates two entities (e.g. 'phone_number', 'zip5', 'employer').",
+    )
+    kind: str = Field(
+        description="Relationship label for the emitted edge (e.g. 'shares_phone', 'same_address').",
+    )
+    min_entities: int = Field(
+        default=2,
+        description="A shared value must be held by at least this many distinct entities to emit edges.",
+    )
+    max_fanout: int = Field(
+        default=50,
+        description="Skip values shared by more than this many distinct entities (hub values like a switchboard line are not pairwise relationships).",
+    )
+
+
 class IdentityConfig(BaseModel):
     """Identity Graph configuration.
 
@@ -1955,6 +1982,13 @@ class IdentityConfig(BaseModel):
     weak_confidence_threshold: float = Field(
         default=0.6,
         description="Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it.",
+    )
+    # semantic-graph: derive entity<->entity relationship edges from shared
+    # non-identity attributes, in the same resolve pass. Empty (default) = no
+    # relationships emitted; identity resolution is unchanged.
+    relationships: list[RelationshipRule] = Field(
+        default_factory=list,
+        description="Rules deriving entity<->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged.",
     )
     # #1110: cross-device / channel stitching (CDP/MDM epic #1108). None ->
     # stitching is not configured (the default; identity resolution is

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -1916,7 +1916,7 @@ class MediationConfig(BaseModel):
 
 
 class RelationshipRule(BaseModel):
-    """One rule for deriving entity<->entity relationship edges from a shared,
+    """One rule for deriving entity-to-entity relationship edges from a shared,
     NON-identity attribute (#semantic-graph).
 
     Identity resolution collapses records that are the SAME entity. The same
@@ -1983,12 +1983,12 @@ class IdentityConfig(BaseModel):
         default=0.6,
         description="Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it.",
     )
-    # semantic-graph: derive entity<->entity relationship edges from shared
+    # semantic-graph: derive entity-to-entity relationship edges from shared
     # non-identity attributes, in the same resolve pass. Empty (default) = no
     # relationships emitted; identity resolution is unchanged.
     relationships: list[RelationshipRule] = Field(
         default_factory=list,
-        description="Rules deriving entity<->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged.",
+        description="Rules deriving entity-to-entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged.",
     )
     # #1110: cross-device / channel stitching (CDP/MDM epic #1108). None ->
     # stitching is not configured (the default; identity resolution is

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1288,6 +1288,7 @@ def _resolve_identities(
             source_pk_col=config.identity.source_pk_column,
             emit_singletons=config.identity.emit_singletons,
             weak_confidence_threshold=config.identity.weak_confidence_threshold,
+            relationships=config.identity.relationships,
             pair_score_view=pair_score_view,
             cluster_frames=cluster_frames,
         )

--- a/packages/python/goldenmatch/goldenmatch/identity/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/__init__.py
@@ -59,6 +59,7 @@ from goldenmatch.identity.query import (
     promote_claim,
     revoke_claim,
 )
+from goldenmatch.identity.relationships import build_relationships
 from goldenmatch.identity.resolve import (
     ResolveSummary,
     match_record_to_entity,
@@ -125,6 +126,7 @@ __all__ = [
     "revoke_claim",
     "match_record_to_entity",
     "migrate_record_ids",
+    "build_relationships",
     "resolve_clusters",
     "resolve_record_incremental",
     "DEFAULT_CHANNEL_TRUST",

--- a/packages/python/goldenmatch/goldenmatch/identity/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/__init__.py
@@ -59,7 +59,7 @@ from goldenmatch.identity.query import (
     promote_claim,
     revoke_claim,
 )
-from goldenmatch.identity.relationships import build_relationships
+from goldenmatch.identity.relationships import build_relationships, to_graph_batch
 from goldenmatch.identity.resolve import (
     ResolveSummary,
     match_record_to_entity,
@@ -127,6 +127,7 @@ __all__ = [
     "match_record_to_entity",
     "migrate_record_ids",
     "build_relationships",
+    "to_graph_batch",
     "resolve_clusters",
     "resolve_record_incremental",
     "DEFAULT_CHANNEL_TRUST",

--- a/packages/python/goldenmatch/goldenmatch/identity/relationships.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/relationships.py
@@ -47,3 +47,69 @@ def build_relationships(
         if edges:
             total += store.add_relationships(edges)
     return total
+
+
+def _entity_name(node: object, name_field: str | None) -> str | None:
+    """A display name for an entity: the configured golden-record field, else the
+    first non-empty string value of the golden record."""
+    golden = getattr(node, "golden_record", None)
+    if not isinstance(golden, dict):
+        return None
+    if name_field is not None:
+        v = golden.get(name_field)
+        return str(v) if v not in (None, "") else None
+    for v in golden.values():
+        if isinstance(v, str) and v.strip():
+            return v
+    return None
+
+
+def to_graph_batch(
+    store: IdentityStore,
+    dataset: str | None = None,
+    *,
+    name_field: str | None = None,
+    valid_from: int = 0,
+) -> dict:
+    """Export the identity relationship graph as a GoldenGraph ``StoreBatch`` dict
+    -- the ``{entities, edges}`` JSON shape that ``goldengraph``'s ``PyStore.append``
+    consumes -- so the durable identity graph feeds GoldenGraph's path-retrieval /
+    answer (GraphRAG) layer.
+
+    Each entity carries the stable ``entity_id`` in ``record_keys``, which is
+    exactly how GoldenGraph's store reconciles the same node across appends
+    (``store.rs::append``): re-exporting after a later resolve updates the same
+    node instead of minting a new one. Edges become ``(subj_local, predicate=kind,
+    obj_local)`` triples. Pure data -- no ``goldengraph`` import required. Append
+    with ``pystore.append(json.dumps(to_graph_batch(store)))``.
+    """
+    rels = store.list_relationships(dataset)
+    eids = sorted({e for r in rels for e in (r["entity_a_id"], r["entity_b_id"])})
+    local = {eid: i for i, eid in enumerate(eids)}
+    nodes = store.get_identities(set(eids)) if eids else {}
+    refs = [dataset] if dataset else []
+
+    entities = []
+    for eid in eids:
+        name = _entity_name(nodes.get(eid), name_field) or eid
+        entities.append({
+            "local_id": local[eid],
+            "canonical_name": name,
+            "typ": "entity",
+            "surface_names": [name],
+            "record_keys": [eid],          # stable cross-append reconciliation key
+            "source_refs": list(refs),
+        })
+
+    edges = []
+    for r in rels:
+        edges.append({
+            "subj_local": local[r["entity_a_id"]],
+            "predicate": r["kind"],
+            "obj_local": local[r["entity_b_id"]],
+            "valid_from": valid_from,
+            "valid_to": None,
+            "source_refs": [r["shared_value"]] if r.get("shared_value") else list(refs),
+        })
+
+    return {"entities": entities, "edges": edges}

--- a/packages/python/goldenmatch/goldenmatch/identity/relationships.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/relationships.py
@@ -1,0 +1,49 @@
+"""Semantic-graph: entity<->entity relationship edges (#semantic-graph).
+
+Identity resolution collapses records that are the SAME entity. The same blocking
+data also surfaces DIFFERENT entities that share a NON-identity attribute -- two
+prescribers on one clinic phone, two people at one address -- which is a
+relationship, not a merge, and today it is discarded. ``build_relationships``
+turns those shared attributes into edges between the durable ``entity_id``s,
+turning the identity graph into a semantic graph maintained in the same pass.
+
+Edges are stored in ``identity_relationships`` (entity-level, distinct from the
+record-level ``evidence_edges``) and de-duped by primary key, so a re-resolve is
+idempotent. Hub values (a switchboard line shared by hundreds of entities) are
+skipped via ``RelationshipRule.max_fanout`` -- they are not pairwise relationships.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from goldenmatch.config.schemas import RelationshipRule
+    from goldenmatch.identity.store import IdentityStore
+
+
+def build_relationships(
+    store: IdentityStore,
+    rules: list[RelationshipRule] | None,
+    dataset: str | None = None,
+) -> int:
+    """Derive entity<->entity relationship edges from shared non-identity
+    attributes and write them to ``store``. Idempotent across runs. Returns the
+    number of edges written (attempted; duplicates are ignored)."""
+    if not rules:
+        return 0
+    total = 0
+    for rule in rules:
+        groups = store.relationship_groups(
+            rule.field, dataset, rule.min_entities, rule.max_fanout,
+        )
+        edges: list[tuple] = []
+        for value, eids in groups:
+            uniq = sorted({e for e in eids if e})
+            for i in range(len(uniq)):
+                for j in range(i + 1, len(uniq)):
+                    edges.append(
+                        (uniq[i], uniq[j], rule.kind, rule.field, value, dataset)
+                    )
+        if edges:
+            total += store.add_relationships(edges)
+    return total

--- a/packages/python/goldenmatch/goldenmatch/identity/resolution_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolution_batch.py
@@ -56,6 +56,10 @@ class ResolutionBatch:
     # identity golden record honors the configured strategy per column instead of
     # most_complete-only; None keeps the most_complete default (byte-identical).
     field_strategies: dict[str, Any] | None = None
+    # semantic-graph: rules deriving entity<->entity relationship edges from shared
+    # non-identity attributes, run as a post-pass. None/empty leaves resolution
+    # unchanged. list[RelationshipRule] (kept loosely typed to avoid a config import).
+    relationships: list | None = None
     # Frame-residency budget: the write side flushes every ``flush_rows`` records so
     # it never stacks a second O(N) term on the compute prep floor (manifesto §3).
     # A contract term now, not just ``GOLDENMATCH_IDENTITY_BULK_FLUSH_ROWS``.
@@ -118,6 +122,7 @@ class ResolutionBatch:
         weak_confidence_threshold: float = 0.6,
         flush_rows: int | None = None,
         field_strategies: dict[str, Any] | None = None,
+        relationships: list | None = None,
     ) -> ResolutionBatch:
         """Build a batch from the loose resolve args, filling the residency budget
         from the env default when unspecified. This is the adapter seam:
@@ -133,6 +138,7 @@ class ResolutionBatch:
             weak_confidence_threshold=weak_confidence_threshold,
             flush_rows=_default_flush_rows() if flush_rows is None else flush_rows,
             field_strategies=field_strategies,
+            relationships=relationships,
         )
 
 

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -136,6 +136,8 @@ class ResolveSummary:
     # v2.1: count of ``conflicts_with`` edges emitted automatically by the
     # resolver (weak bottlenecks + merges with prior conflicts).
     conflicts_flagged: int = 0
+    # semantic-graph: entity<->entity relationship edges written this run.
+    relationships_added: int = 0
 
     def as_dict(self) -> dict[str, int]:
         return {
@@ -147,6 +149,7 @@ class ResolveSummary:
             "events_emitted": self.events_emitted,
             "records_upserted": self.records_upserted,
             "conflicts_flagged": self.conflicts_flagged,
+            "relationships_added": self.relationships_added,
         }
 
 
@@ -420,6 +423,7 @@ def resolve_clusters(
     controller_snapshot: dict[str, Any] | None = None,
     emit_singletons: bool = True,
     weak_confidence_threshold: float = 0.6,
+    relationships: list | None = None,
     pair_score_view: ClusterPairScores | None = None,
     cluster_frames: ClusterFrames | None = None,
     actor: str = "pipeline",
@@ -469,6 +473,7 @@ def resolve_clusters(
             actor=actor, emit_singletons=emit_singletons,
             weak_confidence_threshold=weak_confidence_threshold,
             field_strategies=field_strategies,
+            relationships=relationships,
         )
     # C1 follow-on: fold the bulk DATA parts (cluster partition / record frame /
     # scored-pair stream / pair-score view) into the batch, so the whole
@@ -504,6 +509,7 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     emit_singletons = batch.emit_singletons
     weak_confidence_threshold = batch.weak_confidence_threshold
     field_strategies = batch.field_strategies
+    relationships = batch.relationships
 
     summary = ResolveSummary()
     from goldenmatch.core.frame import to_frame as _tf_a5e
@@ -1197,6 +1203,19 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                     bulk_totals["records"], bulk_totals["edges"],
                     bulk_totals["events"],
                 )
+
+    # 3r. Semantic-graph: derive entity<->entity relationship edges from shared
+    # non-identity attributes, keyed on the entity_ids just written. A post-pass
+    # (cross-entity, so it can't run inside the per-cluster loop); idempotent, so
+    # a warm re-resolve does not duplicate. Opt-in via config.identity.relationships.
+    if relationships:
+        from goldenmatch.identity.relationships import build_relationships
+        try:
+            summary.relationships_added = build_relationships(
+                store, relationships, dataset,
+            )
+        except Exception as e:  # never fail resolution over the relationship pass
+            log.warning("relationship derivation failed: %s", e)
 
     # 4. Split detection: records that previously had an entity_id but did
     # NOT appear in any cluster this run should not be retired here -- they

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -1643,6 +1643,27 @@ class IdentityStore:
         row = self._fetchone("SELECT COUNT(*) AS n FROM identity_relationships", ())
         return int(row["n"]) if row else 0
 
+    def list_relationships(
+        self, dataset: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """All relationship edges as ``{entity_a_id, entity_b_id, kind, field,
+        shared_value}`` (optionally dataset-scoped). Used by the GoldenGraph
+        export."""
+        if self._backend == "mongo":
+            raise NotImplementedError("list_relationships: not supported on mongo")
+        where = "" if dataset is None else " WHERE dataset = ?"
+        params: tuple = () if dataset is None else (dataset,)
+        rows = self._fetchall(
+            "SELECT entity_a_id, entity_b_id, kind, field, shared_value "
+            f"FROM identity_relationships{where}",
+            params,
+        )
+        return [
+            {"entity_a_id": r["entity_a_id"], "entity_b_id": r["entity_b_id"],
+             "kind": r["kind"], "field": r["field"], "shared_value": r["shared_value"]}
+            for r in rows
+        ]
+
     def emit_event(
         self, event: IdentityEvent, *, return_id: bool = True
     ) -> int | None:

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -10,6 +10,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from collections.abc import Iterable, Iterator
@@ -48,7 +49,11 @@ def _write_pipeline_enabled() -> bool:
     ).strip() != "0"
 
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
+
+# Relationship field names are interpolated into a JSON path / column expression,
+# so they are validated against this before use (never user free-text at the SQL).
+_SAFE_FIELD = re.compile(r"[A-Za-z0-9_]+")
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS identity_nodes (
@@ -165,6 +170,26 @@ CREATE TABLE IF NOT EXISTS identity_record_block_keys (
 CREATE INDEX IF NOT EXISTS idx_rbk_block  ON identity_record_block_keys(pass_sig, block_key);
 CREATE INDEX IF NOT EXISTS idx_rbk_entity ON identity_record_block_keys(entity_id);
 CREATE INDEX IF NOT EXISTS idx_rbk_record ON identity_record_block_keys(record_id);
+
+-- semantic-graph: entity<->entity relationship edges derived from a shared
+-- NON-identity attribute (two entities on one clinic phone, one address, ...).
+-- Distinct from evidence_edges (which is record-level, WITHIN an entity); this is
+-- entity-level, BETWEEN entities. The UNIQUE key omits run_name on purpose so a
+-- re-resolve is idempotent (INSERT OR IGNORE de-dupes across runs). Endpoints are
+-- canonicalized entity_a_id < entity_b_id so each pair is stored once.
+CREATE TABLE IF NOT EXISTS identity_relationships (
+    entity_a_id   TEXT NOT NULL,
+    entity_b_id   TEXT NOT NULL,
+    kind          TEXT NOT NULL,
+    field         TEXT NOT NULL,
+    shared_value  TEXT,
+    dataset       TEXT,
+    recorded_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (entity_a_id, entity_b_id, kind, shared_value)
+);
+CREATE INDEX IF NOT EXISTS idx_rel_a    ON identity_relationships(entity_a_id);
+CREATE INDEX IF NOT EXISTS idx_rel_b    ON identity_relationships(entity_b_id);
+CREATE INDEX IF NOT EXISTS idx_rel_kind ON identity_relationships(kind);
 """
 
 
@@ -374,6 +399,27 @@ class IdentityStore:
             # + indexes, idempotent on fresh (already carries it from ``_SCHEMA``)
             # and migrated DBs.
             self._ensure_block_index_table()
+        if version < 7:
+            # v6 -> v7: entity<->entity relationship edges (semantic-graph). CREATE
+            # TABLE IF NOT EXISTS + indexes, idempotent on fresh (already in
+            # ``_SCHEMA``) and migrated DBs.
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS identity_relationships (
+                    entity_a_id   TEXT NOT NULL,
+                    entity_b_id   TEXT NOT NULL,
+                    kind          TEXT NOT NULL,
+                    field         TEXT NOT NULL,
+                    shared_value  TEXT,
+                    dataset       TEXT,
+                    recorded_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (entity_a_id, entity_b_id, kind, shared_value)
+                );
+                CREATE INDEX IF NOT EXISTS idx_rel_a    ON identity_relationships(entity_a_id);
+                CREATE INDEX IF NOT EXISTS idx_rel_b    ON identity_relationships(entity_b_id);
+                CREATE INDEX IF NOT EXISTS idx_rel_kind ON identity_relationships(kind);
+                """
+            )
         if version < SCHEMA_VERSION:
             self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
@@ -566,6 +612,21 @@ class IdentityStore:
         CREATE INDEX IF NOT EXISTS idx_rbk_block  ON identity_record_block_keys(pass_sig, block_key);
         CREATE INDEX IF NOT EXISTS idx_rbk_entity ON identity_record_block_keys(entity_id);
         CREATE INDEX IF NOT EXISTS idx_rbk_record ON identity_record_block_keys(record_id);
+
+        -- semantic-graph: entity<->entity relationship edges (see _SCHEMA).
+        CREATE TABLE IF NOT EXISTS identity_relationships (
+            entity_a_id   TEXT NOT NULL,
+            entity_b_id   TEXT NOT NULL,
+            kind          TEXT NOT NULL,
+            field         TEXT NOT NULL,
+            shared_value  TEXT,
+            dataset       TEXT,
+            recorded_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (entity_a_id, entity_b_id, kind, shared_value)
+        );
+        CREATE INDEX IF NOT EXISTS idx_rel_a    ON identity_relationships(entity_a_id);
+        CREATE INDEX IF NOT EXISTS idx_rel_b    ON identity_relationships(entity_b_id);
+        CREATE INDEX IF NOT EXISTS idx_rel_kind ON identity_relationships(kind);
         """
         with self._conn.cursor() as cur:
             cur.execute(ddl)
@@ -1488,6 +1549,99 @@ class IdentityStore:
         per_entity = {r["eid"]: int(r["n"]) for r in per_entity_rows}
         source_breakdown = {r["source"]: int(r["n"]) for r in source_rows}
         return per_entity, source_breakdown
+
+    # ----- Semantic-graph: entity<->entity relationships -----
+
+    def relationship_groups(
+        self, field: str, dataset: str | None,
+        min_entities: int, max_entities: int,
+    ) -> list[tuple[str, list[str]]]:
+        """Distinct entities that share a value of ``field`` (a payload key),
+        grouped in ONE query. Returns ``[(shared_value, [entity_id, ...]), ...]``
+        for values held by between ``min_entities`` and ``max_entities`` distinct
+        entities. The field is read out of the JSON ``payload`` column; the
+        cardinality gate runs in SQL so only qualifying groups come back."""
+        if self._backend == "mongo":
+            raise NotImplementedError("relationship_groups: not supported on mongo")
+        if not _SAFE_FIELD.fullmatch(field):
+            raise ValueError(f"unsafe relationship field name: {field!r}")
+        if self._backend == "postgres":
+            vexpr = f"((sr.payload)::jsonb ->> '{field}')"
+            agg = "string_agg(DISTINCT sr.entity_id, ',')"
+        else:
+            vexpr = f"json_extract(sr.payload, '$.{field}')"
+            agg = "group_concat(DISTINCT sr.entity_id)"
+        ds = "" if dataset is None else " AND sr.dataset = ?"
+        params: tuple = () if dataset is None else (dataset,)
+        sql = (
+            f"SELECT {vexpr} AS v, {agg} AS eids "
+            "FROM source_records sr "
+            f"WHERE sr.entity_id IS NOT NULL AND {vexpr} IS NOT NULL "
+            f"AND {vexpr} != ''{ds} "
+            f"GROUP BY {vexpr} "
+            "HAVING COUNT(DISTINCT sr.entity_id) >= ? "
+            "AND COUNT(DISTINCT sr.entity_id) <= ?"
+        )
+        rows = self._fetchall(sql, params + (min_entities, max_entities))
+        return [(r["v"], str(r["eids"]).split(",")) for r in rows]
+
+    def add_relationships(self, rows: list[tuple]) -> int:
+        """Insert ``(entity_a, entity_b, kind, field, shared_value, dataset)``
+        relationship edges, idempotently. Endpoints are canonicalized
+        (a < b) and the PRIMARY KEY de-dupes across runs. Returns rows attempted."""
+        if not rows:
+            return 0
+        norm = []
+        for a, b, kind, field, val, dataset in rows:
+            if a == b:
+                continue
+            lo, hi = (a, b) if a < b else (b, a)
+            norm.append((lo, hi, kind, field, val, dataset))
+        if not norm:
+            return 0
+        if self._backend == "mongo":
+            raise NotImplementedError("add_relationships: not supported on mongo")
+        if self._backend == "postgres":
+            sql = (
+                "INSERT INTO identity_relationships "
+                "(entity_a_id, entity_b_id, kind, field, shared_value, dataset) "
+                "VALUES (%s, %s, %s, %s, %s, %s) "
+                "ON CONFLICT (entity_a_id, entity_b_id, kind, shared_value) DO NOTHING"
+            )
+            with self._conn.cursor() as cur:
+                cur.executemany(sql, norm)
+        else:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO identity_relationships "
+                "(entity_a_id, entity_b_id, kind, field, shared_value, dataset) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                norm,
+            )
+        return len(norm)
+
+    def get_relationships(self, entity_id: str) -> list[dict[str, Any]]:
+        """Every relationship edge touching ``entity_id`` (either endpoint),
+        as ``{other_entity_id, kind, field, shared_value}``."""
+        if self._backend == "mongo":
+            raise NotImplementedError("get_relationships: not supported on mongo")
+        rows = self._fetchall(
+            "SELECT entity_a_id, entity_b_id, kind, field, shared_value "
+            "FROM identity_relationships "
+            "WHERE entity_a_id = ? OR entity_b_id = ?",
+            (entity_id, entity_id),
+        )
+        out = []
+        for r in rows:
+            other = r["entity_b_id"] if r["entity_a_id"] == entity_id else r["entity_a_id"]
+            out.append({"other_entity_id": other, "kind": r["kind"],
+                        "field": r["field"], "shared_value": r["shared_value"]})
+        return out
+
+    def count_relationships(self) -> int:
+        if self._backend == "mongo":
+            raise NotImplementedError("count_relationships: not supported on mongo")
+        row = self._fetchone("SELECT COUNT(*) AS n FROM identity_relationships", ())
+        return int(row["n"]) if row else 0
 
     def emit_event(
         self, event: IdentityEvent, *, return_id: bool = True

--- a/packages/python/goldenmatch/tests/identity/test_relationships.py
+++ b/packages/python/goldenmatch/tests/identity/test_relationships.py
@@ -1,0 +1,121 @@
+"""Semantic-graph: entity<->entity relationship edges from shared attributes.
+
+Different entities that share a NON-identity attribute (a clinic phone, an
+address) get a relationship edge keyed on their stable entity_ids, emitted in the
+same resolve pass, idempotent across runs, and fan-out-capped.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import RelationshipRule
+from goldenmatch.identity import IdentityStore, resolve_clusters
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(path=str(tmp_path / "identity.db"))
+    yield s
+    s.close()
+
+
+def _df(rows):
+    out = []
+    for i, r in enumerate(rows):
+        rec = {"__row_id__": i, "__source__": "src"}
+        rec.update(r)
+        out.append(rec)
+    return pl.DataFrame(out)
+
+
+def _singletons(n):
+    return {i: {"members": [i], "size": 1, "confidence": 1.0, "pair_scores": {}}
+            for i in range(n)}
+
+
+def _resolve(store, df, clusters, rules, run_name="r"):
+    return resolve_clusters(
+        clusters, df, [], "mk", store, run_name=run_name, source_pk_col="id",
+        dataset="d", emit_singletons=True, relationships=rules,
+    )
+
+
+PHONE = [RelationshipRule(field="phone", kind="shares_phone")]
+
+
+def test_shared_attribute_relates_distinct_entities(store):
+    # 1 and 2 are different people sharing phone 555; 3 has its own phone.
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "555"},
+              {"id": "3", "name": "Cy", "phone": "999"}])
+    s = _resolve(store, df, _singletons(3), PHONE)
+
+    a = store.find_entity_by_record("src:1")
+    b = store.find_entity_by_record("src:2")
+    c = store.find_entity_by_record("src:3")
+    assert a != b != c
+    assert s.relationships_added == 1
+    assert store.count_relationships() == 1
+
+    rels = store.get_relationships(a)
+    assert len(rels) == 1
+    assert rels[0]["other_entity_id"] == b
+    assert rels[0]["kind"] == "shares_phone"
+    assert rels[0]["shared_value"] == "555"
+    # symmetric
+    assert store.get_relationships(b)[0]["other_entity_id"] == a
+    # c is unrelated (unique phone)
+    assert store.get_relationships(c) == []
+
+
+def test_reresolve_is_idempotent(store):
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "555"}])
+    _resolve(store, df, _singletons(2), PHONE, run_name="r1")
+    assert store.count_relationships() == 1
+    s2 = _resolve(store, df, _singletons(2), PHONE, run_name="r2")
+    assert store.count_relationships() == 1          # NOT 2
+    assert s2.relationships_added in (0, 1)          # attempted, but de-duped in store
+
+
+def test_same_entity_records_do_not_self_relate(store):
+    # two records of the SAME person sharing a phone -> one entity, no self-edge.
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Al", "phone": "555"}])
+    clusters = {0: {"members": [0, 1], "size": 2, "confidence": 1.0,
+                    "pair_scores": {(0, 1): 0.99}}}
+    _resolve(store, df, clusters, PHONE)
+    assert store.count_relationships() == 0
+
+
+def test_max_fanout_skips_hub_values(store):
+    # 3 entities share a switchboard line; max_fanout=2 skips it as a hub.
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "555"},
+              {"id": "3", "name": "Cy", "phone": "555"}])
+    rules = [RelationshipRule(field="phone", kind="shares_phone", max_fanout=2)]
+    _resolve(store, df, _singletons(3), rules)
+    assert store.count_relationships() == 0
+    # with a higher cap, all 3 pairwise edges appear
+    store2_rules = [RelationshipRule(field="phone", kind="shares_phone", max_fanout=10)]
+    _resolve(store, df, _singletons(3), store2_rules, run_name="r2")
+    assert store.count_relationships() == 3          # 3 choose 2
+
+
+def test_no_rules_no_relationships(store):
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "555"}])
+    s = _resolve(store, df, _singletons(2), None)
+    assert s.relationships_added == 0
+    assert store.count_relationships() == 0
+
+
+def test_multiple_rules(store):
+    df = _df([{"id": "1", "name": "Al", "phone": "555", "zip": "07001"},
+              {"id": "2", "name": "Bo", "phone": "555", "zip": "07001"}])
+    rules = [RelationshipRule(field="phone", kind="shares_phone"),
+             RelationshipRule(field="zip", kind="same_area")]
+    _resolve(store, df, _singletons(2), rules)
+    kinds = {r["kind"] for r in store.get_relationships(
+        store.find_entity_by_record("src:1"))}
+    assert kinds == {"shares_phone", "same_area"}

--- a/packages/python/goldenmatch/tests/identity/test_relationships.py
+++ b/packages/python/goldenmatch/tests/identity/test_relationships.py
@@ -6,10 +6,12 @@ same resolve pass, idempotent across runs, and fan-out-capped.
 """
 from __future__ import annotations
 
+import json
+
 import polars as pl
 import pytest
 from goldenmatch.config.schemas import RelationshipRule
-from goldenmatch.identity import IdentityStore, resolve_clusters
+from goldenmatch.identity import IdentityStore, resolve_clusters, to_graph_batch
 
 
 @pytest.fixture()
@@ -119,3 +121,63 @@ def test_multiple_rules(store):
     kinds = {r["kind"] for r in store.get_relationships(
         store.find_entity_by_record("src:1"))}
     assert kinds == {"shares_phone", "same_area"}
+
+
+# ── GoldenGraph export ──────────────────────────────────────────────────────
+
+def test_to_graph_batch_shape(store):
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "555"}])
+    _resolve(store, df, _singletons(2), PHONE)
+    a = store.find_entity_by_record("src:1")
+    b = store.find_entity_by_record("src:2")
+
+    batch = to_graph_batch(store, "d", name_field="name")
+
+    # GoldenGraph StoreBatch shape + JSON-serializable (the append contract).
+    assert set(batch) == {"entities", "edges"}
+    json.dumps(batch)  # must not raise
+    assert len(batch["entities"]) == 2
+    assert len(batch["edges"]) == 1
+
+    # each entity carries its stable entity_id as the reconciliation record_key
+    by_key = {e["record_keys"][0]: e for e in batch["entities"]}
+    assert set(by_key) == {a, b}
+    assert {e["canonical_name"] for e in batch["entities"]} == {"Al", "Bo"}
+    for e in batch["entities"]:
+        assert e["typ"] == "entity"
+        assert isinstance(e["local_id"], int)
+
+    # the edge is the (subj_local, predicate, obj_local) triple over local ids
+    edge = batch["edges"][0]
+    assert edge["predicate"] == "shares_phone"
+    locals_ = {e["local_id"]: e["record_keys"][0] for e in batch["entities"]}
+    assert {locals_[edge["subj_local"]], locals_[edge["obj_local"]]} == {a, b}
+    assert edge["source_refs"] == ["555"]
+
+
+def test_to_graph_batch_empty(store):
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "999"}])
+    _resolve(store, df, _singletons(2), PHONE)  # no shared phone -> no edges
+    batch = to_graph_batch(store, "d")
+    assert batch == {"entities": [], "edges": []}
+
+
+def test_to_graph_batch_roundtrips_into_goldengraph(store):
+    """If goldengraph is installed, the exported batch appends into its PyStore
+    and the edge is queryable -- i.e. it feeds the path-retrieval layer."""
+    gg_store = pytest.importorskip("goldengraph.core")
+    PyStore = getattr(gg_store, "PyStore", None)
+    if PyStore is None:
+        pytest.skip("goldengraph PyStore unavailable")
+    df = _df([{"id": "1", "name": "Al", "phone": "555"},
+              {"id": "2", "name": "Bo", "phone": "555"}])
+    _resolve(store, df, _singletons(2), PHONE)
+    batch = to_graph_batch(store, "d", name_field="name")
+
+    ps = PyStore()
+    ps.append(json.dumps(batch))
+    dump = json.loads(ps.query())
+    preds = {e["predicate"] for e in dump.get("edges", [])}
+    assert "shares_phone" in preds

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -1330,6 +1330,16 @@
               "description": "Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it."
             },
             {
+              "name": "relationships",
+              "type": "list[RelationshipRule]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "RelationshipRule"
+              ],
+              "description": "Rules deriving entity<->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged."
+            },
+            {
               "name": "stitching",
               "type": "ChannelStitchConfig | None",
               "required": false,
@@ -2063,6 +2073,38 @@
             }
           ],
           "doc": "Learning Memory learning parameters."
+        },
+        {
+          "name": "RelationshipRule",
+          "fields": [
+            {
+              "name": "field",
+              "type": "str",
+              "required": true,
+              "description": "Payload field whose shared value relates two entities (e.g. 'phone_number', 'zip5', 'employer')."
+            },
+            {
+              "name": "kind",
+              "type": "str",
+              "required": true,
+              "description": "Relationship label for the emitted edge (e.g. 'shares_phone', 'same_address')."
+            },
+            {
+              "name": "min_entities",
+              "type": "int",
+              "required": false,
+              "default": "2",
+              "description": "A shared value must be held by at least this many distinct entities to emit edges."
+            },
+            {
+              "name": "max_fanout",
+              "type": "int",
+              "required": false,
+              "default": "50",
+              "description": "Skip values shared by more than this many distinct entities (hub values like a switchboard line are not pairwise relationships)."
+            }
+          ],
+          "doc": "One rule for deriving entity<->entity relationship edges from a shared,"
         },
         {
           "name": "ChannelStitchConfig",

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -1337,7 +1337,7 @@
               "nested": [
                 "RelationshipRule"
               ],
-              "description": "Rules deriving entity<->entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged."
+              "description": "Rules deriving entity-to-entity relationship edges from shared non-identity attributes; empty leaves identity resolution unchanged."
             },
             {
               "name": "stitching",
@@ -2104,7 +2104,7 @@
               "description": "Skip values shared by more than this many distinct entities (hub values like a switchboard line are not pairwise relationships)."
             }
           ],
-          "doc": "One rule for deriving entity<->entity relationship edges from a shared,"
+          "doc": "One rule for deriving entity-to-entity relationship edges from a shared,"
         },
         {
           "name": "ChannelStitchConfig",

--- a/packages/typescript/goldenmatch/src/core/identity/resolve.ts
+++ b/packages/typescript/goldenmatch/src/core/identity/resolve.ts
@@ -32,6 +32,10 @@ export interface ResolveSummary {
   eventsEmitted: number;
   recordsUpserted: number;
   conflictsFlagged: number;
+  // semantic-graph: entity-to-entity relationship edges written this run. The TS
+  // port does not run the relationship post-pass (Python-only), so it stays 0 --
+  // present for cross-language ResolveSummary parity.
+  relationshipsAdded: number;
 }
 
 export interface ResolveOptions {
@@ -56,6 +60,7 @@ function emptySummary(): ResolveSummary {
     eventsEmitted: 0,
     recordsUpserted: 0,
     conflictsFlagged: 0,
+    relationshipsAdded: 0,
   };
 }
 

--- a/packages/typescript/goldenmatch/tests/parity/fixtures/resolve-clusters.json
+++ b/packages/typescript/goldenmatch/tests/parity/fixtures/resolve-clusters.json
@@ -66,7 +66,8 @@
         "edges_added": 1,
         "events_emitted": 3,
         "records_upserted": 4,
-        "conflicts_flagged": 0
+        "conflicts_flagged": 0,
+        "relationships_added": 0
       }
     },
     {
@@ -112,7 +113,8 @@
         "edges_added": 1,
         "events_emitted": 1,
         "records_upserted": 2,
-        "conflicts_flagged": 0
+        "conflicts_flagged": 0,
+        "relationships_added": 0
       }
     },
     {
@@ -158,7 +160,8 @@
         "edges_added": 1,
         "events_emitted": 2,
         "records_upserted": 2,
-        "conflicts_flagged": 0
+        "conflicts_flagged": 0,
+        "relationships_added": 0
       }
     }
   ],

--- a/packages/typescript/goldenmatch/tests/parity/resolve-clusters.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/resolve-clusters.test.ts
@@ -75,6 +75,7 @@ describe("resolveClusters parity (Python fixture)", () => {
         events_emitted: summary.eventsEmitted,
         records_upserted: summary.recordsUpserted,
         conflicts_flagged: summary.conflictsFlagged,
+        relationships_added: summary.relationshipsAdded,
       };
     }
   });


### PR DESCRIPTION
Closes #2210.

## The gap
Identity resolution collapses records that are the SAME entity. The same blocking data also surfaces DIFFERENT entities that share a NON-identity attribute -- two prescribers on one clinic phone, two people at one address -- which is a relationship, not a merge, and today it's discarded (used only negatively, as `conflicts_with` / the fan-out veto). So there's no path from the structured identity graph (records -> entities) to a semantic relationship graph (entity <-> entity), even though the identity graph already produces the hard part -- clean, stable entity nodes -- and the resolver already computes the signal.

## What this adds
A relationship layer, opt-in, maintained in the same resolve pass:

- **config:** `RelationshipRule {field, kind, min_entities, max_fanout}` and `IdentityConfig.relationships`. Empty (default) leaves identity resolution byte-identical.
- **store:** a new `identity_relationships` table -- entity-level, distinct from the record-level `evidence_edges` (sqlite + postgres + a `v6 -> v7` migration). Idempotent across runs (the PK omits `run_name`, so a warm re-resolve doesn't duplicate). `relationship_groups` does the cardinality gate in one grouped SQL query per rule; `add_relationships` canonicalizes endpoints (`a < b`) and de-dupes; `get_relationships` / `count_relationships` are the read side. Field names are validated before they're interpolated into the JSON path.
- **resolve:** a post-resolve pass (cross-entity, so it can't run inside the per-cluster loop), threaded through `ResolutionBatch`, wrapped so it never fails resolution. New `ResolveSummary.relationships_added`. Auto-runs from the pipeline when `config.identity.relationships` is set.

The two edge semantics stay separate: `same_as` collapses records INTO an entity; relationships connect DISTINCT entities. Hub values (a switchboard line shared by hundreds of entities) are skipped via `max_fanout` -- they aren't pairwise relationships.

## Why
The identity graph is the right foundation for a semantic graph -- a relationship graph is only as good as its nodes, and ER is what makes the nodes clean. This turns the resolved entities into a relationship graph keyed on the stable `entity_id`s, updated incrementally alongside absorb/merge/split, with no separate ER pass. (GoldenGraph builds relationship graphs from *text*; this is the structured-record complement.)

## Tests
`test_relationships.py`: shared attribute relates distinct entities (+ symmetry, unrelated entities excluded), idempotent re-resolve, same-entity records don't self-relate, `max_fanout` skips hubs, multiple rules, no-rules no-op. Existing identity resolve/incremental/profile/batch-parity suites and the config-matrix/codemap/api-surface suites pass; docs regenerated.

## Follow-ups (not in this PR)
- An export helper to GoldenGraph's node/edge (`subj`/`predicate`/`obj`) shape so the relationship graph feeds its path-retrieval / answer layer.
- Distributed (Ray/Postgres) path currently emits relationships only on the in-memory path; wiring the distributed resolve is a follow-up.
