### PR TITLE
fix(identity): Postgres bulk COPY must run outside pipeline mode (#2216)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1266,8 +1266,8 @@ def _resolve_identities(
             )
             return summary.as_dict()
         except Exception as e:
-            logger.warning("Distributed identity resolution failed: %s", e)
-            return None
+            logger.error("Distributed identity resolution failed: %s", e)
+            raise
 
     # In-memory path (legacy, unchanged).
     store = _open_identity_store(config)
@@ -1293,8 +1293,13 @@ def _resolve_identities(
         )
         return summary.as_dict()
     except Exception as e:
-        logger.warning("Identity resolution failed: %s", e)
-        return None
+        # A REQUESTED identity resolution (config.identity.enabled) that fails must
+        # not masquerade as success -- silently returning None commits no graph
+        # while dedupe_df reports ok (this once made a broken Postgres write, "COPY
+        # cannot be used in pipeline mode", look like a fast successful write).
+        # Surface it so a failed write is a failed run, not silent data loss.
+        logger.error("Identity resolution failed: %s", e)
+        raise
     finally:
         try:
             store.close()

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -12,6 +12,7 @@ duplicate events. Edges deduplicate on the UNIQUE constraint in storage.
 """
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -917,9 +918,13 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                     summary.created += 1
                     bulk_cluster_ids.add(cluster_id)
                     # Flush at a cluster boundary once the accumulator reaches the
-                    # batch bound -- keeps the write side O(batch), not O(N).
+                    # batch bound -- keeps the write side O(batch), not O(N). The
+                    # barrier suspends the psycopg pipeline so the bulk COPY can run
+                    # (COPY is forbidden in pipeline mode); no-op off Postgres.
                     if len(bulk_record_rows) >= bulk_flush_threshold:
-                        _flush_bulk()
+                        with getattr(store, "bulk_copy_barrier",
+                                     contextlib.nullcontext)():
+                            _flush_bulk()
                     continue
 
 
@@ -1188,7 +1193,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
         # remainder. Order inside ``_flush_bulk`` puts identities first so the
         # source_records FK is valid.
         if use_bulk_fast_path:
-            _flush_bulk()
+            with getattr(store, "bulk_copy_barrier", contextlib.nullcontext)():
+                _flush_bulk()
             if bulk_totals["nodes"]:
                 log.info(
                     "resolve_clusters bulk fast-path (%s): %d clusters / "

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -238,6 +238,9 @@ class IdentityStore:
         # commit. Set for every backend so ``_exec`` needs no hasattr guard.
         self._sqlite_batch = 0
         self._sqlite_pending = 0
+        # The active psycopg pipeline (Postgres) while inside ``write_pipeline``;
+        # ``bulk_copy_barrier`` suspends/reopens it around bulk COPY flushes.
+        self._active_pipeline = None
         # Optional psycopg_pool.ConnectionPool for postgres. When set, methods
         # check out a pooled conn for each call. Default None preserves the
         # legacy per-store single-conn behavior the existing tests rely on.
@@ -645,19 +648,56 @@ class IdentityStore:
         per-statement round-trip (see ``_write_pipeline_enabled``). No-op for
         SQLite / Mongo and when the kill-switch is set.
 
-        COPY is not permitted in pipeline mode, so the caller must flush any bulk
-        COPY accumulators OUTSIDE this block (still inside ``bulk_writes``). Reads
-        issued inside a pipeline still work -- psycopg auto-syncs to fetch a
-        result -- but each such sync forfeits batching, so callers should
-        pre-fetch reads (e.g. ``get_identities``) before the write loop and pass
-        ``return_id=False`` to the write helpers that would otherwise read back a
-        generated id.
+        COPY is not permitted in pipeline mode, so bulk-COPY flushes must run
+        OUTSIDE this block; ``bulk_copy_barrier`` suspends the pipeline around each
+        flush so ``resolve_clusters`` (which interleaves per-record writes and bulk
+        flushes in one loop) can flush unconditionally. Reads issued inside a
+        pipeline still work -- psycopg auto-syncs to fetch a result -- but each such
+        sync forfeits batching, so callers should pre-fetch reads (e.g.
+        ``get_identities``) before the write loop and pass ``return_id=False`` to
+        the write helpers that would otherwise read back a generated id.
         """
         if self._backend == "postgres" and _write_pipeline_enabled():
-            with self._conn.pipeline():
+            self._active_pipeline = self._conn.pipeline()
+            self._active_pipeline.__enter__()
+            try:
                 yield
+            finally:
+                # A bulk_copy_barrier may have swapped in a fresh pipeline; exit
+                # whatever is currently active, not the one captured on entry.
+                pipe = self._active_pipeline
+                self._active_pipeline = None
+                if pipe is not None:
+                    pipe.__exit__(None, None, None)
         else:
             yield
+
+    @contextlib.contextmanager
+    def bulk_copy_barrier(self) -> Iterator[None]:
+        """Suspend an active psycopg pipeline for the duration of a bulk COPY.
+
+        COPY cannot run inside psycopg pipeline mode ("COPY cannot be used in
+        pipeline mode"), yet ``resolve_clusters`` flushes its bulk-COPY
+        accumulators from WITHIN the ``write_pipeline`` loop. This exits the active
+        pipeline (syncing any pending statements), runs the COPY in normal mode,
+        then reopens a fresh pipeline inside the same ``bulk_writes`` transaction.
+        No-op when no pipeline is active (SQLite / Mongo / the kill-switch), so the
+        caller wraps every ``_flush_bulk`` unconditionally. Before this, the COPY
+        raised inside the pipeline and the caller (pipeline.py) swallowed it,
+        committing zero rows while reporting success.
+        """
+        pipe = getattr(self, "_active_pipeline", None)
+        if pipe is None:
+            yield
+            return
+        self._active_pipeline = None
+        pipe.__exit__(None, None, None)      # sync + close the current pipeline
+        try:
+            yield
+        finally:
+            newpipe = self._conn.pipeline()
+            newpipe.__enter__()
+            self._active_pipeline = newpipe
 
     def _sqlite_stage(self, stage: str, cols: list[str], df: Any) -> None:
         """Load ``df[cols]`` into a per-connection TEMP staging table, replacing

--- a/packages/python/goldenmatch/tests/identity/test_postgres_bulk.py
+++ b/packages/python/goldenmatch/tests/identity/test_postgres_bulk.py
@@ -162,3 +162,58 @@ def test_resolve_clusters_bulk_fast_path_writes_brand_new(pg_url: str) -> None:
     assert summary.events_emitted == n_clusters
     assert store.count_identities() == n_clusters
     store.close()
+
+
+def test_bulk_mid_loop_flush_commits_under_write_pipeline(
+    pg_url: str, monkeypatch,
+) -> None:
+    """Regression: a MID-LOOP bulk COPY flush must commit even while
+    ``write_pipeline`` (psycopg pipeline mode) is active.
+
+    COPY is forbidden in pipeline mode, and ``resolve_clusters`` flushes its bulk
+    accumulators from INSIDE the ``write_pipeline`` loop when the accumulator hits
+    the flush threshold. Without ``bulk_copy_barrier`` the COPY raised "COPY cannot
+    be used in pipeline mode", the pipeline aborted, and (until pipeline.py stopped
+    swallowing it) 0 rows committed while the run reported success -- the exact
+    failure seen on a 14M resolve. The 20-row happy-path test never triggered a
+    mid-loop flush (only the final flush, which runs OUTSIDE the pipeline). Force a
+    tiny flush threshold with the pipeline explicitly ON so the mid-loop flush
+    fires; the fix must leave the rows committed."""
+    import polars as pl
+    from goldenmatch.identity.resolve import resolve_clusters
+    from goldenmatch.identity.store import IdentityStore
+
+    monkeypatch.setenv("GOLDENMATCH_IDENTITY_WRITE_PIPELINE", "1")   # pipeline ON
+    monkeypatch.setenv("GOLDENMATCH_IDENTITY_BULK_FLUSH_ROWS", "2")  # -> mid-loop flush
+
+    store = IdentityStore(backend="postgres", connection=pg_url)
+    n_clusters = 6
+    n_rows = n_clusters * 2
+    df = pl.DataFrame(
+        {
+            "__row_id__": list(range(n_rows)),
+            "__source__": ["bench"] * n_rows,
+            "name": [f"mid_{i}" for i in range(n_rows)],
+            "email": [f"m{i}@x.com" for i in range(n_rows)],
+        }
+    )
+    clusters = {
+        i: {
+            "members": [i * 2, i * 2 + 1],
+            "size": 2,
+            "confidence": 0.95,
+            "pair_scores": {(i * 2, i * 2 + 1): 0.95},
+        }
+        for i in range(n_clusters)
+    }
+    scored_pairs = [(i * 2, i * 2 + 1, 0.95) for i in range(n_clusters)]
+
+    summary = resolve_clusters(
+        clusters, df, scored_pairs, "weighted", store,
+        run_name="mid-flush-test", source_pk_col=None, dataset="midflush",
+    )
+
+    assert summary.created == n_clusters
+    # The write COMMITTED (was 0 before the fix: the in-pipeline COPY rolled back).
+    assert store.count_identities(dataset="midflush") == n_clusters
+    store.close()


### PR DESCRIPTION
Closes #2216.

## The bug
A 14M `resolve_clusters` on `backend=postgres` returned "success" but committed **0 nodes** -- the identity store was empty, downstream reads saw nothing, and it silently skewed a PG-vs-SQLite benchmark (PG looked fast because it wasn't writing). Two compounding bugs:

1. **COPY inside pipeline mode.** The resolve wraps its write loop in `store.write_pipeline()` (psycopg pipeline), and the **mid-loop** `_flush_bulk()` flushes bulk-COPY accumulators from *inside* it. psycopg forbids COPY in pipeline mode, so `bulk_upsert_*` raised `COPY cannot be used in pipeline mode` -- violating `write_pipeline`'s own contract ("flush COPY OUTSIDE this block"). The **final** flush *is* outside the pipeline, so a small resolve (final-flush-only) passed while 14M (which triggers mid-loop flushes at the 250k threshold) failed. That's why the 20-row unit test never caught it.
2. **The failure was swallowed.** `pipeline.py::_resolve_identity` caught it, logged a warning, and `return None` -- so a *requested* identity resolution that failed masqueraded as success.

## The fix
- **`IdentityStore.bulk_copy_barrier()`** -- suspends the active psycopg pipeline for the duration of a bulk COPY (syncing pending statements, exiting pipeline mode), runs the COPY, then reopens a fresh pipeline inside the same `bulk_writes` transaction. `resolve_clusters` wraps both `_flush_bulk()` sites via `getattr(store, "bulk_copy_barrier", nullcontext)` so it's a no-op off Postgres and tolerant of minimal fake stores. `write_pipeline` now tracks the active pipeline so its `finally` closes whatever the barrier last reopened.
- **`_resolve_identity`** (in-memory + distributed) -- log at ERROR and re-raise. A failed identity write is now a failed run, not silent data loss. (Behavior change: an identity resolution that raises will now surface instead of being swallowed -- which is the point.)

## Tests
`test_bulk_mid_loop_flush_commits_under_write_pipeline` forces a mid-loop flush (`GOLDENMATCH_IDENTITY_WRITE_PIPELINE=1`, tiny `FLUSH_ROWS`) and asserts the rows committed -- 0 before the fix, `n_clusters` after. Runs on the CI Postgres service. The 44 SQLite identity resolve/incremental/batch-parity tests are unaffected (the barrier is a no-op there); 312 SQLite identity tests pass.

## Note
This is why node counts must be verified after a store write -- `resolve_s` / cluster count / F1 all come from *matching*, not the *write*, so a rolled-back write looked identical to a successful one.
