### PR TITLE
perf(cluster): native arrow group-by kernel for cluster_frames_to_dict

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2432,6 +2432,7 @@
             "_record_unmerge_corrections",
             "_severe_bridge_count",
             "_split_edge_work_budget",
+            "_try_native_group_members",
             "add_to_cluster",
             "build_cluster_frames",
             "build_clusters",

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -2027,7 +2027,7 @@ class LazyClusterDict(dict):
         return {k: _copy.deepcopy(v, memo) for k, v in dict.items(self)}
 
 
-def _try_native_group_members(assignments) -> tuple[list[int], list[list[int]]] | None:
+def _try_native_group_members(assignments: Any) -> tuple[list[int], list[list[int]]] | None:
     """Native arrow grouping of the assignments frame (``cluster_id`` ->
     per-cluster ``member_id`` lists), or ``None`` to fall back to the Python loop
     (kernel absent / stale wheel without the symbol). Feeds the cluster-dict

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -2027,6 +2027,32 @@ class LazyClusterDict(dict):
         return {k: _copy.deepcopy(v, memo) for k, v in dict.items(self)}
 
 
+def _try_native_group_members(assignments) -> tuple[list[int], list[list[int]]] | None:
+    """Native arrow grouping of the assignments frame (``cluster_id`` ->
+    per-cluster ``member_id`` lists), or ``None`` to fall back to the Python loop
+    (kernel absent / stale wheel without the symbol). Feeds the cluster-dict
+    ``by_cid`` build without a Python ``to_list`` + setdefault over every member.
+    """
+    from goldenmatch.core._native_loader import native_enabled, native_module
+
+    if not native_enabled("clustering"):
+        return None
+    fn = getattr(native_module(), "group_members_by_cluster_arrow", None)
+    if fn is None:  # stale wheel predating the symbol -> Python fallback
+        return None
+
+    def _single_array(col_name: str):
+        # PyArrowType<ArrayData> wants a single pa.Array, not a ChunkedArray.
+        a = assignments.column(col_name).to_arrow()
+        if hasattr(a, "combine_chunks"):  # ChunkedArray -> single-chunk -> Array
+            a = a.combine_chunks()
+        if hasattr(a, "num_chunks"):
+            a = a.chunk(0)
+        return a
+
+    return fn(_single_array("cluster_id"), _single_array("member_id"))
+
+
 def cluster_frames_to_dict(frames: ClusterFrames) -> dict[int, dict]:
     """Adapter: two-frame Phase-2 representation -> legacy
     ``dict[int, dict]`` shape. For migrating consumers during Phase 2b.
@@ -2045,14 +2071,22 @@ def cluster_frames_to_dict(frames: ClusterFrames) -> dict[int, dict]:
     if assignments.height == 0:
         return {}
 
-    # Build member lists by cluster_id from the assignments frame.
-    by_cid: dict[int, list[int]] = {}
-    for cid, mid in zip(
-        assignments.column("cluster_id").to_list(),
-        assignments.column("member_id").to_list(),
-        strict=True,
-    ):
-        by_cid.setdefault(int(cid), []).append(int(mid))
+    # Build member lists by cluster_id. Prefer the native arrow grouping kernel
+    # (zero-copy in; groups every member row in Rust) over the Python to_list +
+    # setdefault loop -- the flamegraph's cold-path cost when a caller
+    # materializes results["clusters"]. Byte-identical (first-appearance cid
+    # order, input-order members); falls back to Python when the kernel is absent.
+    _grouped = _try_native_group_members(assignments)
+    if _grouped is not None:
+        by_cid: dict[int, list[int]] = dict(zip(*_grouped, strict=True))
+    else:
+        by_cid = {}
+        for cid, mid in zip(
+            assignments.column("cluster_id").to_list(),
+            assignments.column("member_id").to_list(),
+            strict=True,
+        ):
+            by_cid.setdefault(int(cid), []).append(int(mid))
 
     # PERF (hotspot round 1): columnar reads + zip instead of per-row dict
     # materialization -- 950K metadata rows allocated 950K dicts and was 35%

--- a/packages/python/goldenmatch/tests/test_cluster.py
+++ b/packages/python/goldenmatch/tests/test_cluster.py
@@ -398,3 +398,47 @@ def test_lazy_cluster_dict_len_is_o1_from_count():
     # count=0 -> empty, falsy, no build.
     d3 = LazyClusterDict(builder, count=0)
     assert len(d3) == 0 and not d3 and calls["n"] == 2
+
+
+def test_group_members_kernel_matches_python_fallback(monkeypatch):
+    """The native arrow grouping kernel (group_members_by_cluster_arrow, wired
+    into cluster_frames_to_dict) must produce a byte-identical cluster dict to
+    the Python to_list + setdefault fallback. Builds real ClusterFrames and
+    compares the kernel path against the fallback forced via monkeypatch."""
+    import goldenmatch.core.cluster as cl
+
+    pairs = [
+        (0, 1, 0.97),
+        (1, 2, 0.96),  # cluster {0,1,2}
+        (5, 6, 0.95),  # cluster {5,6}
+        (8, 9, 0.94),
+        (9, 10, 0.93),  # cluster {8,9,10}
+        (3, 4, 0.92),  # cluster {3,4}
+    ]
+    all_ids = list(range(11))
+    frames = cl.build_cluster_frames(
+        pairs,
+        all_ids,
+        max_cluster_size=100,
+        weak_cluster_threshold=0.0,
+        auto_split=False,
+        backend="arrow",
+    )
+
+    from goldenmatch.core._native_loader import native_enabled, native_module
+
+    have_kernel = native_enabled("clustering") and hasattr(
+        native_module(), "group_members_by_cluster_arrow"
+    )
+    if not have_kernel:  # kernel unavailable in this env -> nothing to compare
+        import pytest
+
+        pytest.skip("native grouping kernel not loaded")
+
+    kernel_dict = cl.cluster_frames_to_dict(frames)
+
+    # Force the pure-Python fallback and rebuild.
+    monkeypatch.setattr(cl, "_try_native_group_members", lambda _a: None)
+    fallback_dict = cl.cluster_frames_to_dict(frames)
+
+    assert kernel_dict == fallback_dict, "kernel dict diverged from Python fallback"

--- a/packages/rust/extensions/cluster-core/src/lib.rs
+++ b/packages/rust/extensions/cluster-core/src/lib.rs
@@ -327,3 +327,55 @@ mod tests {
         assert_eq!(parent[&1], 4);
     }
 }
+
+/// Group `member_id`s by `cluster_id`, preserving Python's
+/// `dict.setdefault(cid, []).append(mid)` semantics EXACTLY: cluster_ids in
+/// first-appearance order, members per cluster in input order. Byte-identical to
+/// the `by_cid` build in `cluster_frames_to_dict`. Returns
+/// `(cluster_ids, member_lists)` aligned by index (so Python zips them into the
+/// dict). The assignments frame is sorted by cluster_id in practice, but this
+/// does not rely on it -- the first-appearance HashMap index handles any order.
+pub fn group_members_by_cluster(
+    cluster_id: &[i64],
+    member_id: &[i64],
+) -> (Vec<i64>, Vec<Vec<i64>>) {
+    use std::collections::HashMap;
+    let n = cluster_id.len().min(member_id.len());
+    let mut index: HashMap<i64, usize> = HashMap::new();
+    let mut cids: Vec<i64> = Vec::new();
+    let mut lists: Vec<Vec<i64>> = Vec::new();
+    for i in 0..n {
+        let cid = cluster_id[i];
+        let mid = member_id[i];
+        match index.get(&cid) {
+            Some(&slot) => lists[slot].push(mid),
+            None => {
+                index.insert(cid, lists.len());
+                cids.push(cid);
+                lists.push(vec![mid]);
+            }
+        }
+    }
+    (cids, lists)
+}
+
+#[cfg(test)]
+mod group_tests {
+    use super::group_members_by_cluster;
+
+    #[test]
+    fn matches_setdefault_semantics() {
+        // first-appearance cid order, input-order members (incl. unsorted input).
+        let cids = [1i64, 1, 2, 1, 3, 2];
+        let mids = [10i64, 11, 20, 12, 30, 21];
+        let (out_cids, lists) = group_members_by_cluster(&cids, &mids);
+        assert_eq!(out_cids, vec![1, 2, 3]);
+        assert_eq!(lists, vec![vec![10, 11, 12], vec![20, 21], vec![30]]);
+    }
+
+    #[test]
+    fn empty() {
+        let (c, l) = group_members_by_cluster(&[], &[]);
+        assert!(c.is_empty() && l.is_empty());
+    }
+}

--- a/packages/rust/extensions/native/src/cluster.rs
+++ b/packages/rust/extensions/native/src/cluster.rs
@@ -22,6 +22,7 @@ use pyo3::prelude::*;
 // keep the original names (which the pymodule exports to Python).
 use goldenmatch_cluster_core::{
     cluster_confidence as core_cluster_confidence, find,
+    group_members_by_cluster as core_group_members_by_cluster,
     mst_split_components as core_mst_split_components,
     severe_bridge_count as core_severe_bridge_count, ConfidenceResult,
 };
@@ -64,6 +65,23 @@ pub fn severe_bridge_count(members: Vec<i64>, edges: Vec<(i64, i64, f64)>) -> us
 #[pyfunction]
 pub fn cluster_confidence(edges: Vec<(i64, i64, f64)>, size: usize) -> ConfidenceResult {
     core_cluster_confidence(edges, size)
+}
+
+/// Group `member_id`s by `cluster_id` over the ClusterFrames `assignments`
+/// columns (Arrow C-Data i64 arrays, zero-copy in), returning
+/// `(cluster_ids, member_lists)` so `cluster_frames_to_dict` builds `by_cid`
+/// without a Python `to_list` + setdefault loop over every member row.
+/// Byte-identical to the Python grouping (first-appearance cid order, input-order
+/// members -- see the core crate). Assignments are dense int64; a stray null
+/// would read its buffer value, which the caller's null-free contract excludes.
+#[pyfunction]
+pub fn group_members_by_cluster_arrow(
+    cluster_id: PyArrowType<ArrayData>,
+    member_id: PyArrowType<ArrayData>,
+) -> PyResult<(Vec<i64>, Vec<Vec<i64>>)> {
+    let cid = Int64Array::from(cluster_id.0);
+    let mid = Int64Array::from(member_id.0);
+    Ok(core_group_members_by_cluster(cid.values(), mid.values()))
 }
 
 // =============================================================================

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -99,6 +99,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cluster::build_clusters_native, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::build_clusters_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        cluster::group_members_by_cluster_arrow,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(pairs::canonicalize_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_max_score, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_arrow, m)?)?;


### PR DESCRIPTION
## What

Replaces the Python `to_list` + `setdefault` loop in `cluster_frames_to_dict` (groups every assignment row `cluster_id -> member_id`) with a zero-copy Arrow group-by kernel. This is the cold-path cost when a caller materializes `results["clusters"]` -- post-#2219 the dict is off the hot path (`len()`/`bool()` answer from the count), but when a consumer *does* build it, the grouping still ran a full per-member Python loop over the 10M+ assignment frame.

## How

- **`goldenmatch-cluster-core`** (pyo3-free): `group_members_by_cluster(&[i64], &[i64])` -- pure grouping, preserves Python's `setdefault` semantics exactly (first-appearance cluster order, input-order members).
- **`goldenmatch-native`**: `group_members_by_cluster_arrow` pyfunction reads the Arrow C-Data i64 arrays zero-copy (same pattern as `dedup_pairs_arrow`) and delegates to the core crate.
- **`cluster_frames_to_dict`**: `_try_native_group_members` prefers the kernel, falls back to the Python loop when native is off or the wheel predates the symbol. Byte-identical output on both paths.

## Parity

- `cluster-core` unit test: setdefault semantics incl. unsorted input.
- Python test `test_group_members_kernel_matches_python_fallback`: kernel dict == Python-fallback dict over real `ClusterFrames` (skips cleanly when the kernel isn't loaded).

Verified locally: native built in-tree, `test_cluster.py` green native-on (29 passed) and native-off (28 passed, 1 skipped).

## Notes

Split out from #2219 per "take the dict grouping into the Rust cluster-core kernel as its own change." No behavior change -- pure marshaling win on the cold clusters-dict path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)