### PR TITLE
feat(goldenfuzz): publishable wheel + crates.io release + retrieve_similar_fuzzy

### DIFF
--- a/.github/workflows/publish-goldenfuzz.yml
+++ b/.github/workflows/publish-goldenfuzz.yml
@@ -1,0 +1,161 @@
+name: Publish goldenfuzz (PyPI + crates.io)
+
+# Publishes the standalone `goldenfuzz` fuzzy-string product on BOTH surfaces:
+#   * PyPI: the `goldenfuzz` maturin/abi3 wheel (pure Rust, zero C deps) built
+#     across platforms, wrapping the pyo3-free `goldenfuzz-core` crate.
+#   * crates.io: the `goldenfuzz-core` Rust crate itself (zero deps, so it
+#     publishes standalone).
+#
+# Fires on a release tagged `goldenfuzz-v*` (kept distinct from every other
+# publish tag so nothing cross-triggers). workflow_dispatch with a `ref` allows a
+# manual/retro build; the `publish` toggle turns the matrix into a dry run.
+#
+# Secrets required (configure once): PYPI_TOKEN (already used by the suite) and
+# CRATES_IO_TOKEN (crates.io API token). Both jobs `skip-existing`/tolerate an
+# already-published version so a re-run is safe.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      publish:
+        description: "Upload to PyPI / crates.io (uncheck for a build-only dry run)"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  # One manifest drives every wheel job; abi3 = one wheel per platform (3.11+).
+  MANIFEST: packages/rust/extensions/goldenfuzz-py/Cargo.toml
+
+jobs:
+  linux:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheels (maturin, abi3, manylinux)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: "2_28"
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: x64
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  macos:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    # macos-14 (Apple Silicon) cross-builds the x86_64 wheel too; pure Rust, so
+    # the cross-compile links cleanly (no prebuilt-runtime constraint).
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64, x86_64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          command: sdist
+          args: --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  pypi:
+    needs: [linux, windows, macos, sdist]
+    if: github.event_name != 'workflow_dispatch' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true
+
+  crates_io:
+    # Publish the pyo3-free `goldenfuzz-core` Rust crate to crates.io. Zero deps,
+    # so it publishes standalone. Independent of the PyPI wheel jobs.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - name: cargo publish goldenfuzz-core
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
+        working-directory: packages/rust/extensions/goldenfuzz-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        # --allow-dirty is unnecessary (clean checkout); a duplicate version is a
+        # benign error on re-run, so don't fail the release on it.
+        run: cargo publish || echo "::warning::cargo publish returned non-zero (likely version already on crates.io)"

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,10 @@ packages/python/goldenmatch/goldenmatch/_native*.pyd
 # python/goldenmatch_native/. Ignore ONLY the artifacts, not the source dir.
 packages/rust/extensions/native/python/goldenmatch_native/*.pyd
 packages/rust/extensions/native/python/goldenmatch_native/*.so
+# goldenfuzz-py: maturin drops the compiled ext next to the tracked source
+# python/goldenfuzz/__init__.py. Ignore ONLY the artifacts, not the source dir.
+packages/rust/extensions/goldenfuzz-py/python/goldenfuzz/*.pyd
+packages/rust/extensions/goldenfuzz-py/python/goldenfuzz/*.so
 # GoldenCheck's counterpart (packages/rust/extensions/goldencheck-native via
 # scripts/build_goldencheck_native.py). Same rationale.
 packages/python/goldencheck/goldencheck/_native*.so

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 90 | 201 | 50 | 39 | Yes | Yes |
+| `goldenmatch` | 90 | 202 | 50 | 39 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4169,10 +4169,13 @@
           "purpose": "Semantic retrieval -- find records similar to a query string (#1089).",
           "defines": [
             "RetrievedRecord",
+            "_fuzzy_extract",
+            "retrieve_similar_fuzzy",
             "retrieve_similar_records"
           ],
           "imports": [
             "goldenmatch._polars_lazy",
+            "goldenmatch.core",
             "goldenmatch.core.ann_blocker",
             "goldenmatch.core.embedder"
           ]

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -9369,6 +9369,10 @@
       "path": "packages/rust/extensions/goldenfuzz-core"
     },
     {
+      "name": "goldenfuzz-py",
+      "path": "packages/rust/extensions/goldenfuzz-py"
+    },
+    {
       "name": "goldengraph-cabi",
       "path": "packages/rust/extensions/goldengraph-cabi"
     },

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -237,7 +237,11 @@ from goldenmatch.core.recall_certificate import (
     certify_recall_df,
     estimate_recall,
 )
-from goldenmatch.core.retrieval import RetrievedRecord, retrieve_similar_records
+from goldenmatch.core.retrieval import (
+    RetrievedRecord,
+    retrieve_similar_fuzzy,
+    retrieve_similar_records,
+)
 from goldenmatch.core.review_queue import ReviewQueue, gate_pairs
 from goldenmatch.core.rollback import rollback_run
 
@@ -373,7 +377,7 @@ __all__ = [
     "match_one", "StreamProcessor", "run_stream",
     "screen_record", "screen_records",
     "ScreeningResult", "ScreeningHit", "FieldReason",
-    "retrieve_similar_records", "RetrievedRecord",
+    "retrieve_similar_records", "retrieve_similar_fuzzy", "RetrievedRecord",
     "entity_aware_retrieve", "Entity", "EntityRetrievalResult",
     "VectorIndex", "DuckDBVectorIndex", "PgVectorIndex", "VectorStore", "open_vector_index",
     # Evaluation

--- a/packages/python/goldenmatch/goldenmatch/core/retrieval.py
+++ b/packages/python/goldenmatch/goldenmatch/core/retrieval.py
@@ -134,3 +134,107 @@ def retrieve_similar_records(
         record = {k2: v2 for k2, v2 in rows[pos].items() if not k2.startswith("__")}
         out.append(RetrievedRecord(row_id=row_ids[pos], score=float(score), record=record))
     return out
+
+
+_FUZZY_SCORERS = ("jaro_winkler", "levenshtein", "indel")
+
+
+def _fuzzy_extract(
+    query: str, values: list[str], scorer: str, cutoff: float, limit: int
+) -> list[tuple[int, float]]:
+    """One-vs-many top-k lexical ranking of ``values`` against ``query``.
+
+    Prefers the ``goldenfuzz`` wheel (native, builds the query bitmap once and
+    reuses it across every value -- see ``goldenfuzz.extract``). Falls back to the
+    vendored pure-Python ``core.strsim`` when the wheel is absent; the two are
+    byte-identical (both are the ``goldenfuzz-core`` math), so the ranking is the
+    same either way -- the wheel is just faster.
+    """
+    try:
+        import goldenfuzz  # optional: pip install goldenfuzz
+
+        return goldenfuzz.extract(query, values, scorer=scorer, score_cutoff=cutoff, limit=limit)
+    except ImportError:
+        from goldenmatch.core import strsim
+
+        fn = {
+            "jaro_winkler": strsim.jaro_winkler_normalized_similarity,
+            "levenshtein": strsim.levenshtein_normalized_similarity,
+            "indel": strsim.indel_normalized_similarity,
+        }[scorer]
+        scored = [(i, fn(query, v)) for i, v in enumerate(values)]
+        scored = [(i, s) for (i, s) in scored if s >= cutoff]
+        scored.sort(key=lambda t: (-t[1], t[0]))
+        return scored[:limit] if limit else scored
+
+
+def retrieve_similar_fuzzy(
+    df: pl.DataFrame,
+    query: str,
+    column: str,
+    *,
+    k: int = 20,
+    scorer: str = "jaro_winkler",
+    threshold: float = 0.0,
+    filters: dict[str, Any] | None = None,
+) -> list[RetrievedRecord]:
+    """Lexical (fuzzy-string) sibling of :func:`retrieve_similar_records`.
+
+    Ranks the records in ``df`` by fuzzy similarity of ``column`` to ``query`` --
+    typos, abbreviations, near-duplicates -- with NO embeddings and NO
+    torch/cloud dependency. Complements the semantic path: use this when the
+    signal is lexical (names, addresses, SKUs) rather than meaning.
+
+    Powered by ``goldenfuzz`` (byte-identical to rapidfuzz; the query bitmap is
+    built once and reused across the corpus), with a pure-Python fallback.
+
+    Args:
+        df/query/column/k/threshold/filters: as in
+            :func:`retrieve_similar_records`, but ``threshold`` is a
+            normalized-similarity cutoff in ``[0, 1]``.
+        scorer: one of ``jaro_winkler`` | ``levenshtein`` | ``indel``.
+
+    Returns:
+        ``list[RetrievedRecord]`` ranked highest-similarity first.
+
+    Raises:
+        ValueError: if ``column`` is not in ``df`` or ``scorer`` is unknown.
+    """
+    if column not in df.columns:
+        raise ValueError(
+            f"retrieve_similar_fuzzy: column {column!r} not in dataframe (have {df.columns})"
+        )
+    if scorer not in _FUZZY_SCORERS:
+        raise ValueError(f"retrieve_similar_fuzzy: scorer must be one of {_FUZZY_SCORERS}, got {scorer!r}")
+    if not query or df.is_empty():
+        return []
+
+    work = df
+    if filters:
+        cond: pl.Expr | None = None
+        for col, val in filters.items():
+            if col not in work.columns:
+                return []
+            pred = pl.col(col) == val
+            cond = pred if cond is None else (cond & pred)
+        if cond is not None:
+            work = work.filter(cond)
+    if work.is_empty():
+        return []
+
+    values = ["" if v is None else str(v) for v in work[column].to_list()]
+    ranked = _fuzzy_extract(str(query), values, scorer, threshold, k)
+
+    if "__row_id__" in work.columns:
+        row_ids = [int(r) for r in work["__row_id__"].to_list()]
+    else:
+        row_ids = list(range(work.height))
+    rows = work.to_dicts()
+
+    out: list[RetrievedRecord] = []
+    for pos, score in ranked:
+        if pos < 0 or pos >= work.height:
+            continue
+        record = {k2: v2 for k2, v2 in rows[pos].items() if not k2.startswith("__")}
+        out.append(RetrievedRecord(row_id=row_ids[pos], score=float(score), record=record))
+    return out

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -10,7 +10,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (90 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (50 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
-- Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~201 exports
+- Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~202 exports
 - TypeScript / Edge: `npm install goldenmatch` — same API in browsers, Cloudflare Workers, Vercel Edge, Deno; optional WASM via `await enableWasm()` swaps in the Rust score-core kernel, and `enableSuggestWasm()` brings the config-suggestion "healer" (`dedupe({suggest, heal})`) to TS via suggest-core (pure-TS stays the default + byte-identical fallback)
 - REST API: `goldenmatch serve` on port 8000
 - SQL: Postgres (pgrx extension) + DuckDB UDFs — dedupe / match / score / auto-config + telemetry / identity graph
@@ -148,6 +148,6 @@ GoldenMatch is the headline package of a 6-package suite that composes into one 
 
 ## Docs
 - [Full docs](https://docs.bensevern.dev/goldenmatch/overview): 22 guides
-- [Full API reference](https://docs.bensevern.dev/goldenmatch/python-api): 201 exports
+- [Full API reference](https://docs.bensevern.dev/goldenmatch/python-api): 202 exports
 - [PyPI](https://pypi.org/project/goldenmatch/)
 - [GitHub](https://github.com/benseverndev-oss/goldenmatch)

--- a/packages/python/goldenmatch/tests/test_retrieval.py
+++ b/packages/python/goldenmatch/tests/test_retrieval.py
@@ -127,7 +127,6 @@ def test_result_as_dict_serializable():
 
 def test_retrieve_similar_fuzzy_ranks_lexically():
     import polars as pl
-
     from goldenmatch.core.retrieval import retrieve_similar_fuzzy
 
     df = pl.DataFrame(
@@ -179,7 +178,6 @@ def test_retrieve_similar_fuzzy_fallback_matches_goldenfuzz():
 
 def test_retrieve_similar_fuzzy_bad_scorer():
     import polars as pl
-
     from goldenmatch.core.retrieval import retrieve_similar_fuzzy
 
     with pytest.raises(ValueError):

--- a/packages/python/goldenmatch/tests/test_retrieval.py
+++ b/packages/python/goldenmatch/tests/test_retrieval.py
@@ -120,3 +120,67 @@ def test_result_as_dict_serializable():
     res = retrieve_similar_records(_corpus(), "green apple tart bake", "title")
     blob = json.dumps([r.as_dict() for r in res])
     assert "row_id" in blob and "score" in blob
+
+
+# --- fuzzy (lexical) retrieval, powered by goldenfuzz with a pure-Python fallback
+
+
+def test_retrieve_similar_fuzzy_ranks_lexically():
+    import polars as pl
+
+    from goldenmatch.core.retrieval import retrieve_similar_fuzzy
+
+    df = pl.DataFrame(
+        {
+            "name": ["Jonathan Smith", "Jon Smyth", "Jane Doe", "J. Smith", "Johnathan Smithe"],
+            "city": ["NYC", "NYC", "LA", "NYC", "SF"],
+        }
+    )
+    res = retrieve_similar_fuzzy(df, "Jonathan Smith", "name", k=3, scorer="jaro_winkler")
+    assert [r.record["name"] for r in res][:1] == ["Jonathan Smith"]  # exact match first
+    assert res[0].score == 1.0
+    assert all(res[i].score >= res[i + 1].score for i in range(len(res) - 1))  # descending
+    assert len(res) <= 3
+
+    # metadata pre-filter + threshold
+    nyc = retrieve_similar_fuzzy(
+        df, "Jonathan Smith", "name", k=5, scorer="jaro_winkler", filters={"city": "NYC"}, threshold=0.7
+    )
+    assert {r.record["city"] for r in nyc} == {"NYC"}
+    assert all(r.score >= 0.7 for r in nyc)
+
+
+def test_retrieve_similar_fuzzy_fallback_matches_goldenfuzz():
+    # The pure-Python fallback must rank bit-identically to the goldenfuzz wheel
+    # (both are the goldenfuzz-core math).
+    import builtins
+
+    from goldenmatch.core.retrieval import _fuzzy_extract
+
+    vals = ["Jonathan Smith", "Jon Smyth", "Jane Doe", "J. Smith", "Johnathan Smithe"]
+    goldenfuzz = pytest.importorskip("goldenfuzz")
+    native = goldenfuzz.extract("Jonathan Smith", vals, scorer="jaro_winkler", score_cutoff=0.0, limit=0)
+
+    real_import = builtins.__import__
+
+    def _no_goldenfuzz(name, *a, **k):
+        if name == "goldenfuzz":
+            raise ImportError
+        return real_import(name, *a, **k)
+
+    builtins.__import__ = _no_goldenfuzz
+    try:
+        fallback = _fuzzy_extract("Jonathan Smith", vals, "jaro_winkler", 0.0, 0)
+    finally:
+        builtins.__import__ = real_import
+
+    assert native == fallback  # same indices AND same float bits
+
+
+def test_retrieve_similar_fuzzy_bad_scorer():
+    import polars as pl
+
+    from goldenmatch.core.retrieval import retrieve_similar_fuzzy
+
+    with pytest.raises(ValueError):
+        retrieve_similar_fuzzy(pl.DataFrame({"n": ["a"]}), "a", "n", scorer="nope")

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -9369,6 +9369,10 @@
       "path": "packages/rust/extensions/goldenfuzz-core"
     },
     {
+      "name": "goldenfuzz-py",
+      "path": "packages/rust/extensions/goldenfuzz-py"
+    },
+    {
       "name": "goldengraph-cabi",
       "path": "packages/rust/extensions/goldengraph-cabi"
     },

--- a/packages/rust/extensions/goldenfuzz-core/Cargo.toml
+++ b/packages/rust/extensions/goldenfuzz-core/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]
 description = "Cross-surface, byte-identical fuzzy-string primitives (jaro-winkler / levenshtein / indel / damerau), bit-parallel + single-word fast path, pyo3-free."
+repository = "https://github.com/benseverndev-oss/goldenmatch"
+keywords = ["fuzzy", "string-matching", "levenshtein", "jaro-winkler", "rapidfuzz"]
+categories = ["text-processing", "algorithms"]
 
 [lib]
 name = "goldenfuzz_core"

--- a/packages/rust/extensions/goldenfuzz-py/Cargo.toml
+++ b/packages/rust/extensions/goldenfuzz-py/Cargo.toml
@@ -1,0 +1,35 @@
+# goldenfuzz — the thin pyo3/maturin WRAPPER over the pyo3-free `goldenfuzz-core`
+# crate. Same pattern as the sibling `hnsw-py` / `embed-py` wheels: the core
+# stays pyo3-free (usable from Rust cores / DataFusion / wasm), and the pyo3
+# dependency is confined to THIS wheel. `pip install goldenfuzz` gets the
+# rapidfuzz-compatible, byte-identical fuzzy-string scorers + one-vs-many
+# `extract`/`cdist`/`BatchComparator`.
+#
+# Standalone workspace (empty [workspace]) so pyo3's `extension-module` feature
+# is not unified with any embedding crate's `auto-initialize` (mutually
+# incompatible), mirroring the sibling wheels.
+[workspace]
+
+[package]
+name = "goldenfuzz-py"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "PyO3 extension module for goldenfuzz (fuzzy-string scorers + process.extract) over goldenfuzz-core"
+
+[lib]
+# Produces the ext; installed as goldenfuzz/_goldenfuzz.abi3.so. The #[pymodule]
+# is `_goldenfuzz`, so the init symbol is PyInit__goldenfuzz.
+name = "_goldenfuzz"
+crate-type = ["cdylib"]
+
+[dependencies]
+# abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
+pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+# The pyo3-free kernel this wheel wraps. Zero C deps.
+goldenfuzz-core = { path = "../goldenfuzz-core" }
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/packages/rust/extensions/goldenfuzz-py/README.md
+++ b/packages/rust/extensions/goldenfuzz-py/README.md
@@ -1,0 +1,31 @@
+# goldenfuzz
+
+Fast, **byte-identical-to-rapidfuzz** fuzzy-string scorers, plus a one-vs-many
+`extract` / `cdist` / `BatchComparator` API. A thin PyO3 wheel over the pyo3-free
+`goldenfuzz-core` Rust crate.
+
+```python
+import goldenfuzz as gf
+
+gf.jaro_winkler("jonathan", "jonathon")      # -> 0.95...
+gf.levenshtein("kitten", "sitting")          # normalized similarity in [0, 1]
+gf.indel("fuzzy wuzzy", "wuzzy fuzzy")
+
+# one-vs-many top-k (query bitmap built once)
+gf.extract("jonathan smith",
+           ["jon smith", "jane doe", "jonathan smith"],
+           scorer="jaro_winkler", score_cutoff=0.7, limit=2)
+# -> [(2, 1.0), (0, 0.9...)]
+
+# reuse a prepared query across many choices
+bc = gf.BatchComparator("acme corporation")
+[bc.jaro_winkler(c) for c in choices]
+```
+
+Scorers: `jaro_winkler` | `levenshtein` | `indel`, each returning normalized
+similarity in `[0, 1]`, byte-identical to the corresponding rapidfuzz metric
+(proven by an oracle fuzz in `goldenfuzz-core`). On short strings (names,
+addresses) goldenfuzz is faster than rapidfuzz; on documents it matches/beats on
+jaro-winkler and levenshtein.
+
+Part of the [golden suite](https://github.com/benseverndev-oss/goldenmatch).

--- a/packages/rust/extensions/goldenfuzz-py/pyproject.toml
+++ b/packages/rust/extensions/goldenfuzz-py/pyproject.toml
@@ -1,0 +1,36 @@
+# goldenfuzz — rapidfuzz-compatible fuzzy-string scorers, shipped as a maturin/
+# abi3 wheel that wraps the pyo3-free `goldenfuzz-core` Rust crate. Byte-identical
+# to rapidfuzz on jaro-winkler / levenshtein / indel, faster on short strings,
+# plus one-vs-many `extract` / `cdist` / `BatchComparator`.
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "goldenfuzz"
+version = "0.1.0"
+description = "Fast, byte-identical-to-rapidfuzz fuzzy-string scorers (jaro-winkler / levenshtein / indel) + one-vs-many extract/cdist"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+keywords = ["fuzzy", "string-matching", "levenshtein", "jaro-winkler", "rapidfuzz", "record-linkage"]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Text Processing :: General",
+]
+
+[project.urls]
+Homepage = "https://github.com/benseverndev-oss/goldenmatch"
+Repository = "https://github.com/benseverndev-oss/goldenmatch"
+
+[tool.maturin]
+# Mixed layout: the thin Python wrapper lives in python/goldenfuzz/; the compiled
+# abi3 ext lands at goldenfuzz/_goldenfuzz (pymodule `_goldenfuzz`, so the last
+# path component matches and no Rust rename is needed).
+python-source = "python"
+module-name = "goldenfuzz._goldenfuzz"

--- a/packages/rust/extensions/goldenfuzz-py/python/goldenfuzz/__init__.py
+++ b/packages/rust/extensions/goldenfuzz-py/python/goldenfuzz/__init__.py
@@ -1,0 +1,40 @@
+"""goldenfuzz: fast, byte-identical-to-rapidfuzz fuzzy-string scorers.
+
+Wraps the pyo3-free ``goldenfuzz-core`` Rust crate. Per-pair scorers are
+byte-identical to rapidfuzz on jaro-winkler / levenshtein / indel (and faster on
+short strings); ``extract`` / ``cdist`` / :class:`BatchComparator` provide the
+one-vs-many API (the query bitmap is built once and reused across choices).
+
+    >>> import goldenfuzz as gf
+    >>> gf.jaro_winkler("jonathan", "jonathon")
+    0.95...
+    >>> gf.extract("jonathan smith", ["jon smith", "jane doe", "jonathan smith"],
+    ...            scorer="jaro_winkler", limit=2)
+    [(2, 1.0), (0, 0.9...)]
+    >>> bc = gf.BatchComparator("acme corporation")
+    >>> bc.jaro_winkler("acme corp")
+    0.9...
+
+Scorers accept the names ``jaro_winkler`` | ``levenshtein`` | ``indel`` (all
+return normalized similarity in ``[0, 1]``).
+"""
+
+from goldenfuzz._goldenfuzz import (
+    BatchComparator,
+    __version__,
+    cdist,
+    extract,
+    indel,
+    jaro_winkler,
+    levenshtein,
+)
+
+__all__ = [
+    "BatchComparator",
+    "__version__",
+    "cdist",
+    "extract",
+    "indel",
+    "jaro_winkler",
+    "levenshtein",
+]

--- a/packages/rust/extensions/goldenfuzz-py/python/tests/test_goldenfuzz.py
+++ b/packages/rust/extensions/goldenfuzz-py/python/tests/test_goldenfuzz.py
@@ -1,0 +1,57 @@
+"""goldenfuzz (pyo3 wheel) smoke + byte-identity-vs-rapidfuzz tests.
+
+rapidfuzz is a TEST-only oracle here (not a runtime dep of goldenfuzz); these
+assert the wheel is bit-for-bit identical to it on the scalar scorers, and that
+the one-vs-many API (extract / cdist / BatchComparator) matches the per-pair
+scorers and honours cutoff/limit/order.
+"""
+from __future__ import annotations
+
+import goldenfuzz as gf
+import pytest
+
+rapidfuzz = pytest.importorskip("rapidfuzz")
+from rapidfuzz.distance import Indel, JaroWinkler, Levenshtein  # noqa: E402
+
+PAIRS = [
+    ("jonathan", "jonathon"),
+    ("kitten", "sitting"),
+    ("acme corporation", "acme corp"),
+    ("", ""),
+    ("a", ""),
+    ("café münchen", "cafe munchen"),
+    ("the quick brown fox " * 30, "the quick brown fox " * 29 + "dog"),
+]
+
+
+@pytest.mark.parametrize("a,b", PAIRS)
+def test_byte_identical_to_rapidfuzz(a: str, b: str) -> None:
+    assert gf.jaro_winkler(a, b) == JaroWinkler.normalized_similarity(a, b)
+    assert gf.levenshtein(a, b) == Levenshtein.normalized_similarity(a, b)
+    assert gf.indel(a, b) == Indel.normalized_similarity(a, b)
+
+
+def test_extract_topk_cutoff_order() -> None:
+    choices = ["johnathan smith", "jonathan smith", "jon smith", "jane doe", "j smith"]
+    got = gf.extract("jonathan smith", choices, scorer="jaro_winkler", score_cutoff=0.5, limit=3)
+    assert len(got) <= 3 and got
+    assert got[0][0] == 1  # the exact match ranks first
+    assert all(got[i][1] >= got[i + 1][1] for i in range(len(got) - 1))  # descending
+    assert all(s >= 0.5 for _, s in got)  # cutoff
+
+
+def test_batch_matches_per_pair_and_cdist() -> None:
+    choices = ["jon smith", "jane doe", "jonathan smith"]
+    bc = gf.BatchComparator("jonathan smith")
+    for c in choices:
+        assert bc.jaro_winkler(c) == gf.jaro_winkler("jonathan smith", c)
+        assert bc.score(c, scorer="indel") == gf.indel("jonathan smith", c)
+    mat = gf.cdist(["abc", "jon"], choices, scorer="levenshtein")
+    for i, q in enumerate(["abc", "jon"]):
+        for j, c in enumerate(choices):
+            assert mat[i][j] == gf.levenshtein(q, c)
+
+
+def test_bad_scorer_raises() -> None:
+    with pytest.raises(ValueError):
+        gf.extract("a", ["b"], scorer="nope")

--- a/packages/rust/extensions/goldenfuzz-py/src/lib.rs
+++ b/packages/rust/extensions/goldenfuzz-py/src/lib.rs
@@ -1,0 +1,113 @@
+//! `goldenfuzz._goldenfuzz` — PyO3 extension module for the goldenfuzz fuzzy-string
+//! scorers. A thin wrapper over the pyo3-free `goldenfuzz-core` crate: byte-identical
+//! to rapidfuzz on jaro-winkler / levenshtein / indel, with a one-vs-many
+//! `extract` / `cdist` / `BatchComparator` that builds the query bitmap once.
+//! All of pyo3 is confined to this wheel; the core stays pyo3-free.
+
+use goldenfuzz_core as gf;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Map a scorer name to the core enum. Accepts the canonical names plus a couple
+/// of short aliases so `extract(..., scorer="jw")` reads naturally.
+fn parse_scorer(s: &str) -> PyResult<gf::Scorer> {
+    match s {
+        "jaro_winkler" | "jaro" | "jw" => Ok(gf::Scorer::JaroWinkler),
+        "levenshtein" | "lev" => Ok(gf::Scorer::Levenshtein),
+        "indel" | "ratio" => Ok(gf::Scorer::Indel),
+        other => Err(PyValueError::new_err(format!(
+            "unknown scorer {other:?}; expected one of jaro_winkler | levenshtein | indel"
+        ))),
+    }
+}
+
+/// Jaro-Winkler normalized similarity in `[0, 1]` (== rapidfuzz).
+#[pyfunction]
+fn jaro_winkler(a: &str, b: &str) -> f64 {
+    gf::jaro_winkler(a, b)
+}
+
+/// Levenshtein normalized similarity in `[0, 1]` (== rapidfuzz).
+#[pyfunction]
+fn levenshtein(a: &str, b: &str) -> f64 {
+    gf::levenshtein_normalized_similarity(a, b)
+}
+
+/// Indel normalized similarity in `[0, 1]` (== rapidfuzz `fuzz.ratio`).
+#[pyfunction]
+fn indel(a: &str, b: &str) -> f64 {
+    gf::indel_ratio(a, b)
+}
+
+/// One-vs-many top-k: score `query` against every choice (query bitmap built
+/// once), keep scores `>= score_cutoff`, return up to `limit` `(index, score)`
+/// pairs best-first. `limit == 0` means no limit.
+#[pyfunction]
+#[pyo3(signature = (query, choices, scorer="jaro_winkler", score_cutoff=0.0, limit=0))]
+fn extract(
+    query: &str,
+    choices: Vec<String>,
+    scorer: &str,
+    score_cutoff: f64,
+    limit: usize,
+) -> PyResult<Vec<(usize, f64)>> {
+    let sc = parse_scorer(scorer)?;
+    let refs: Vec<&str> = choices.iter().map(String::as_str).collect();
+    Ok(gf::extract(query, &refs, sc, score_cutoff, limit))
+}
+
+/// Full one-vs-many score matrix `out[i][j] = scorer(queries[i], choices[j])`;
+/// each query's bitmap is built once.
+#[pyfunction]
+#[pyo3(signature = (queries, choices, scorer="jaro_winkler"))]
+fn cdist(queries: Vec<String>, choices: Vec<String>, scorer: &str) -> PyResult<Vec<Vec<f64>>> {
+    let sc = parse_scorer(scorer)?;
+    let qr: Vec<&str> = queries.iter().map(String::as_str).collect();
+    let cr: Vec<&str> = choices.iter().map(String::as_str).collect();
+    Ok(gf::cdist(&qr, &cr, sc))
+}
+
+/// A query prepared for one-vs-many scoring: build once, score many choices.
+#[pyclass(name = "BatchComparator", module = "goldenfuzz._goldenfuzz")]
+struct PyBatchComparator {
+    inner: gf::BatchComparator,
+}
+
+#[pymethods]
+impl PyBatchComparator {
+    #[new]
+    fn new(query: &str) -> Self {
+        PyBatchComparator {
+            inner: gf::BatchComparator::new(query),
+        }
+    }
+
+    fn jaro_winkler(&self, choice: &str) -> f64 {
+        self.inner.jaro_winkler(choice)
+    }
+
+    fn levenshtein(&self, choice: &str) -> f64 {
+        self.inner.levenshtein(choice)
+    }
+
+    fn indel(&self, choice: &str) -> f64 {
+        self.inner.indel(choice)
+    }
+
+    #[pyo3(signature = (choice, scorer="jaro_winkler"))]
+    fn score(&self, choice: &str, scorer: &str) -> PyResult<f64> {
+        Ok(self.inner.score(choice, parse_scorer(scorer)?))
+    }
+}
+
+#[pymodule]
+fn _goldenfuzz(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(jaro_winkler, m)?)?;
+    m.add_function(wrap_pyfunction!(levenshtein, m)?)?;
+    m.add_function(wrap_pyfunction!(indel, m)?)?;
+    m.add_function(wrap_pyfunction!(extract, m)?)?;
+    m.add_function(wrap_pyfunction!(cdist, m)?)?;
+    m.add_class::<PyBatchComparator>()?;
+    Ok(())
+}

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -497,7 +497,10 @@ _PEPY_RE = re.compile(r"pepy\.tech/projects\?q=(?P<q>[A-Za-z0-9+._-]+)")
 # GitHub Release (not a PyPI/npm distribution -- no pypistats download API), so
 # like goldenmatch-pg it has a publish workflow but is excluded from the download
 # badge totals on purpose.
-_PYPI_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-pg", "goldenmatch-hnsw", "infermap-native", "er-matcher"}
+# goldenfuzz has publish-goldenfuzz.yml but has not cut its first PyPI release
+# yet (pypistats 404s until then); move it into PYPI_PACKAGES + the README
+# pepy.tech ?q= list once published, same as the goldenmatch-hnsw note above.
+_PYPI_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-pg", "goldenmatch-hnsw", "infermap-native", "er-matcher", "goldenfuzz"}
 
 
 def check_aggregate_badges(res: Result) -> None:


### PR DESCRIPTION
Stacked follow-up to #2218 (which extracted `goldenfuzz-core`). Two things: **publish** the fuzzy-string product, and **utilize** it inside goldenmatch.

## Publish
- **`goldenfuzz` PyPI wheel** (`packages/rust/extensions/goldenfuzz-py`) — a thin pyo3/maturin abi3 wrapper over the pyo3-free `goldenfuzz-core` crate. Exposes `jaro_winkler` / `levenshtein` / `indel`, plus `extract` / `cdist` / `BatchComparator` (one-vs-many). 10 tests assert byte-identical output vs rapidfuzz's `distance.{Indel,JaroWinkler,Levenshtein}`.
- **`publish-goldenfuzz.yml`** — fires on a `goldenfuzz-v*` release: multi-platform maturin wheel jobs → PyPI (`PYPI_TOKEN`), plus a `crates_io` job that `cargo publish`es `goldenfuzz-core` (zero deps, publishes standalone). `workflow_dispatch` has a dry-run toggle.
- `goldenfuzz-core/Cargo.toml` gains `repository` / `keywords` / `categories` for crates.io.

## Utilize
- **`goldenmatch.retrieve_similar_fuzzy`** — a lexical (fuzzy-string) sibling of the semantic `retrieve_similar_records`: ranks a frame's column against a query via jaro_winkler / levenshtein / indel, no embeddings, no torch/cloud dep. Powered by the native `goldenfuzz` wheel when installed (query bitmap built once, reused across the corpus via `extract`), with a **byte-identical pure-Python fallback** (`core.strsim` — same `goldenfuzz-core` math). Exported publicly; 3 tests, one asserting native == fallback bit-for-bit.
- `agent-manifest.json` (both copies) regenerated: `rust_crates` now includes `goldenfuzz-core` and `goldenfuzz-py`.

## Not shipping (assessed, flagged for a scoped follow-up)
Wiring `BatchComparator` into a native *block* scorer has no clean seam today — `score-core` is per-pair primitives and GM's NxN block scoring lives Python-side and already dedups. The genuine one-vs-many native win is already delivered through `retrieve_similar_fuzzy` calling the wheel. `match_one` (incremental one-vs-store) is the one place a dedicated comparator would fit; that's a separate change.

## Publish still needs (maintainer)
Add `CRATES_IO_TOKEN` repo secret, confirm the `goldenfuzz` name is free on PyPI + crates.io, then cut a `goldenfuzz-v0.1.0` release. Everything fires off that tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd