### PR TITLE
chore(goldenfuzz): post-release cleanup — fail-loud crates publish + badge graduation

### DIFF
--- a/.github/workflows/publish-goldenfuzz.yml
+++ b/.github/workflows/publish-goldenfuzz.yml
@@ -156,6 +156,20 @@ jobs:
         working-directory: packages/rust/extensions/goldenfuzz-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        # --allow-dirty is unnecessary (clean checkout); a duplicate version is a
-        # benign error on re-run, so don't fail the release on it.
-        run: cargo publish || echo "::warning::cargo publish returned non-zero (likely version already on crates.io)"
+        # Tolerate ONLY the idempotent "this version is already on crates.io" case
+        # (safe re-run of a release). Any other non-zero -- auth, unverified email,
+        # metadata, network -- is a real failure and MUST fail the job loudly. The
+        # old `cargo publish || echo warning` swallowed a genuine 400 (unverified
+        # email) and showed green; never disguise a real failure as success again.
+        run: |
+          set +e
+          out=$(cargo publish 2>&1); rc=$?
+          echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            if echo "$out" | grep -qiE "already (uploaded|exists)"; then
+              echo "::warning::goldenfuzz-core version already on crates.io -- idempotent re-run, treating as success"
+            else
+              echo "::error::cargo publish failed for a non-idempotent reason (see log above)"
+              exit "$rc"
+            fi
+          fi

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The headline package, **GoldenMatch**, does the matching — fuzzy + exact + pro
 [![DBLP-ACM F1](https://img.shields.io/badge/DBLP--ACM%20F1-96.4%25-d4a017)](packages/python/goldenmatch/README.md#benchmarks)
 
 <!-- Reach -->
-[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldengraph-native+goldenmatch-embed+golden-suite)
+[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenfuzz+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldengraph-native+goldenmatch-embed+golden-suite)
 [![npm downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fnpm-downloads.json)](https://www.npmjs.com/~benzsevern)
 [![GitHub stars](https://img.shields.io/github/stars/benseverndev-oss/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benseverndev-oss/goldenmatch/stargazers)
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -497,10 +497,7 @@ _PEPY_RE = re.compile(r"pepy\.tech/projects\?q=(?P<q>[A-Za-z0-9+._-]+)")
 # GitHub Release (not a PyPI/npm distribution -- no pypistats download API), so
 # like goldenmatch-pg it has a publish workflow but is excluded from the download
 # badge totals on purpose.
-# goldenfuzz has publish-goldenfuzz.yml but has not cut its first PyPI release
-# yet (pypistats 404s until then); move it into PYPI_PACKAGES + the README
-# pepy.tech ?q= list once published, same as the goldenmatch-hnsw note above.
-_PYPI_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-pg", "goldenmatch-hnsw", "infermap-native", "er-matcher", "goldenfuzz"}
+_PYPI_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-pg", "goldenmatch-hnsw", "infermap-native", "er-matcher"}
 
 
 def check_aggregate_badges(res: Result) -> None:

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -30,6 +30,10 @@ PYPI_PACKAGES = [
     "infermap",
     "goldencheck-types",
     "goldensuite-mcp",
+    # Standalone fuzzy-string product (our rapidfuzz replacement, byte-identical
+    # Rust kernel). Published via publish-goldenfuzz.yml; its crates.io twin is
+    # goldenfuzz-core. A distinct PyPI distribution, counted like the rest.
+    "goldenfuzz",
     # One-line meta-package (whole suite + native, on by default). A distinct PyPI
     # distribution whose downloads partially overlap its component packages --
     # counted here for the same reason as the *-native extras below.


### PR DESCRIPTION
Two follow-ups now that `goldenfuzz` 0.1.0 is live on **PyPI** (`goldenfuzz`) and **crates.io** (`goldenfuzz-core`), both verified against the registries.

## 1. Fail-loud crates publish (real footgun)
`publish-goldenfuzz.yml`'s crates_io step was `cargo publish || echo "::warning"`. During the 0.1.0 release that swallowed a genuine `400 Bad Request: A verified email address is required` and showed the job **green** while nothing landed on crates.io. Replaced with a guard that tolerates ONLY the idempotent `already uploaded/exists` case (safe release re-run) and **fails loudly** on anything else (auth, unverified email, metadata, network).

## 2. Badge graduation
goldenfuzz was parked in `_PYPI_PUBLISH_BADGE_EXCEPTIONS` while its first release was pending (pypistats 404s until published). It's published now, so it graduates into `PYPI_PACKAGES` (`suite_download_badges.py`) + the README pepy.tech `?q=` download list — exactly the move the exception comment described, mirroring `goldenmatch-hnsw`.

## Verification
Ran `check_docs_consistency.py` locally: `PyPI publishers <-> badge PYPI_PACKAGES`, `README pepy.tech ?q= link == PYPI_PACKAGES`, and `install claims resolve to a published dist` all PASS. `check_version_consistency.py` green (33 packages in lockstep). Workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd