### PR TITLE
chore(rapidfuzz-evict): goldencheck + infermap → goldenfuzz (own it, not clone it)

### DIFF
--- a/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
+++ b/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
@@ -17,12 +17,12 @@ targets), with trigram + prefix blocking and a Levenshtein-ratio scorer.
 Native (``goldencheck[native]``) runs the blocking + pairwise edit distance in
 Rust. The Python fallback (used when the ext is absent) computes the same
 clusters with the same trigram/prefix blocking and the same ``1 - dist/maxlen``
-Levenshtein-ratio metric, scored with rapidfuzz's C Levenshtein (~38x over the
-old pure-Python DP), so the two paths agree.
+Levenshtein-ratio metric, scored with goldenfuzz's Levenshtein (our owned Rust
+string-metric kernel), so the two paths agree.
 """
 from __future__ import annotations
 
-from rapidfuzz.distance import Levenshtein as _RFLevenshtein
+import goldenfuzz
 
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import to_frame
@@ -80,12 +80,10 @@ def _python_clusters(values: list[str], min_similarity: float) -> list[list[int]
     def lev_ratio(a: str, b: str) -> float:
         # `1 - dist/maxlen`, the identical metric to goldencheck_core::similarity,
         # so this Python path clusters match the native kernel exactly. Backed by
-        # rapidfuzz's C Levenshtein (~38x over the old pure-Python DP); rapidfuzz
-        # is a goldencheck dependency (same pin as the rest of the suite).
-        maxlen = max(len(a), len(b))
-        if maxlen == 0:
-            return 1.0
-        return 1.0 - _RFLevenshtein.distance(a, b) / maxlen
+        # `goldenfuzz.levenshtein` (our owned, byte-identical-to-rapidfuzz kernel),
+        # whose normalized similarity IS `1 - dist/max(len)` -- same value, no
+        # third-party string-metric dependency. Handles the empty/empty -> 1.0 case.
+        return goldenfuzz.levenshtein(a, b)
 
     linked = False
     for i, j in candidates:

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -41,10 +41,11 @@ dependencies = [
     "openpyxl>=3.1",
     "textual>=1.0",
     "goldencheck-types",
-    # Fast C Levenshtein for the fuzzy_values / cell_quality Python path (the
-    # fallback when goldencheck-native is absent). Same pin as the rest of the
-    # suite (goldenmatch/goldenflow). ~38x over the pure-Python DP it replaced.
-    "rapidfuzz>=3.0",
+    # Levenshtein for the fuzzy_values / cell_quality Python path (the fallback
+    # when goldencheck-native is absent). goldenfuzz is our owned string-metric
+    # kernel: its normalized similarity IS `1 - dist/max(len)`, the metric this
+    # profiler uses. Replaces the former rapidfuzz runtime dep.
+    "goldenfuzz>=0.1.0",
 ]
 
 [project.urls]

--- a/packages/python/goldencheck/tests/profilers/test_fuzzy_values.py
+++ b/packages/python/goldencheck/tests/profilers/test_fuzzy_values.py
@@ -51,8 +51,8 @@ def test_native_and_python_agree(monkeypatch: pytest.MonkeyPatch) -> None:
     assert py == nat
 
 
-def test_python_clusters_rapidfuzz_metric() -> None:
-    """The Python path scores candidate pairs with rapidfuzz's Levenshtein
+def test_python_clusters_levenshtein_metric() -> None:
+    """The Python path scores candidate pairs with goldenfuzz's Levenshtein
     (`1 - dist/maxlen`) -- the identical metric to the native kernel. Verify it
     groups near-duplicate variants and leaves distinct values apart."""
     from goldencheck.profilers.fuzzy_values import _python_clusters
@@ -70,10 +70,12 @@ def test_python_clusters_rapidfuzz_metric() -> None:
     assert all("Wonka" not in g for g in grouped)
 
 
-def test_rapidfuzz_ratio_matches_reference_levenshtein() -> None:
-    """Lock the metric: rapidfuzz's `1 - dist/maxlen` equals a plain DP
-    Levenshtein ratio, so clustering can't drift from the native kernel."""
-    from rapidfuzz.distance import Levenshtein as RL
+def test_levenshtein_ratio_matches_reference() -> None:
+    """Lock the metric against a self-owned reference: goldenfuzz's Levenshtein
+    normalized similarity equals a plain textbook DP `1 - dist/maxlen`, so
+    clustering can't drift from the native kernel. Correctness is pinned to the
+    algorithm (the DP below), not to any third-party library."""
+    import goldenfuzz
 
     def dp(a: str, b: str) -> int:
         prev = list(range(len(b) + 1))
@@ -87,4 +89,4 @@ def test_rapidfuzz_ratio_matches_reference_levenshtein() -> None:
     for a, b in [("acme corp", "acme corp."), ("globex inc", "globex incorporated"),
                  ("initech", "wonka"), ("", "x"), ("same", "same")]:
         m = max(len(a), len(b)) or 1
-        assert abs((1 - RL.distance(a, b) / m) - (1 - dp(a, b) / m)) < 1e-9
+        assert abs(goldenfuzz.levenshtein(a, b) - (1 - dp(a, b) / m)) < 1e-9

--- a/packages/python/infermap/infermap/scorers/fuzzy_name.py
+++ b/packages/python/infermap/infermap/scorers/fuzzy_name.py
@@ -1,7 +1,7 @@
 """Fuzzy name scorer — Jaro-Winkler similarity on normalized field names."""
 from __future__ import annotations
 
-from rapidfuzz.distance import JaroWinkler
+import goldenfuzz
 
 from infermap._native_loader import native_enabled, native_module
 from infermap.types import FieldInfo, ScorerResult
@@ -19,8 +19,11 @@ def _fuzzy_name_score(a: str, b: str) -> float:
 
 
 def _fuzzy_name_score_pure(a: str, b: str) -> float:
-    """Byte-identical reference for ``infermap-core::fuzzy_name_score`` (normalize + JW)."""
-    return JaroWinkler.similarity(_normalize(a), _normalize(b))
+    """Byte-identical reference for ``infermap-core::fuzzy_name_score`` (normalize + JW).
+
+    Uses ``goldenfuzz.jaro_winkler`` (our owned, byte-identical-to-rapidfuzz kernel)
+    rather than rapidfuzz -- same value, no third-party string-metric dependency."""
+    return goldenfuzz.jaro_winkler(_normalize(a), _normalize(b))
 
 
 class FuzzyNameScorer:

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -20,7 +20,10 @@ classifiers = [
 ]
 dependencies = [
     "polars>=1.0",
-    "rapidfuzz>=3.0",
+    # Jaro-Winkler for the FuzzyNameScorer pure-Python fallback. goldenfuzz is our
+    # owned string-metric kernel (replaces the former rapidfuzz runtime dep). The
+    # native infermap-core kernel is the primary path; this backs the pure fallback.
+    "goldenfuzz>=0.1.0",
     "scipy>=1.11",
     "pyyaml>=6.0",
     "typer>=0.12",

--- a/packages/python/infermap/tests/test_native_parity.py
+++ b/packages/python/infermap/tests/test_native_parity.py
@@ -85,7 +85,8 @@ def test_exact_parity(a, b):
 @native_only
 @pytest.mark.parametrize("a,b", _NAME_PAIRS)
 def test_fuzzy_parity(a, b):
-    # rapidfuzz-rs (score-core) vs Python rapidfuzz byte-equality re-validation (spec §6.1).
+    # Native infermap-core kernel vs the pure Python fallback (goldenfuzz-backed)
+    # byte-equality re-validation (spec §6.1). Both are our owned code now.
     assert native_module().fuzzy_name_score(a, b) == _fuzzy_name_score_pure(a, b)
 
 


### PR DESCRIPTION
Finishes the rapidfuzz eviction for the two sibling packages whose usage is fully covered by the published `goldenfuzz` wheel. **rapidfuzz is now gone from both — runtime *and* tests.**

## Changes
- **infermap** `FuzzyNameScorer` pure fallback: `JaroWinkler.similarity` → `goldenfuzz.jaro_winkler` (the native `infermap-core` kernel is still the primary path; this is the fallback).
- **goldencheck** `fuzzy_values` Python path: rapidfuzz `Levenshtein` → `goldenfuzz.levenshtein` (its normalized similarity IS `1 - dist/max(len)`, the exact metric this profiler uses).
- **pyproject** (both): `rapidfuzz>=3.0` runtime dep → `goldenfuzz>=0.1.0`.

## No parity oracle retained — on purpose
Jaro-Winkler / Levenshtein of two strings are *fixed mathematical values*; goldenfuzz computes the **same number faster**, so "better" is speed + cross-surface + more scorers, not a different score. Anchoring tests to rapidfuzz would keep a supply-chain tie to the thing we replaced and brand goldenfuzz as a permanent clone. So correctness is pinned to the **algorithm**:
- goldencheck's metric test now asserts `goldenfuzz.levenshtein` == a textbook DP reference (no third-party lib).
- infermap's parity test compares `infermap-core` (native) vs the goldenfuzz-backed pure path — both owned.
- Competitive *speed* is proven in `bench_vs_rapidfuzz.rs`, where referencing the competitor belongs.

## Verified
goldencheck `fuzzy_values` tests 6 passed on the forced pure path; `jaro_winkler`/`levenshtein` byte-equal to the published wheel; ruff clean on all four files; docs_consistency green. (infermap's native parity test is `@native_only`; the pure swap is a verified 2-liner — CI confirms with adequate memory.)

## Not in scope
`goldenflow` still calls `fuzz.WRatio` (a composite goldenfuzz doesn't own yet). Separate follow-up that owns WRatio in `goldenfuzz-core` first, then migrates goldenflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd