### PR TITLE
chore(rapidfuzz-evict): goldenflow → goldenfuzz — suite is now rapidfuzz-free

### DIFF
--- a/packages/python/goldenflow/goldenflow/mapping/name_similarity.py
+++ b/packages/python/goldenflow/goldenflow/mapping/name_similarity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from rapidfuzz import fuzz
+import goldenfuzz
 
 # Common column name aliases
 ALIASES: dict[str, list[str]] = {
@@ -39,6 +39,7 @@ def name_similarity(source: str, target: str) -> float:
     if s_canonical and t_canonical and s_canonical == t_canonical:
         return 0.95
 
-    # Fuzzy match using Jaro-Winkler
-    score = fuzz.WRatio(s_lower, t_lower) / 100.0
+    # Fuzzy match using a weighted composite ratio (goldenfuzz's owned WRatio,
+    # byte-identical to rapidfuzz's fuzz.WRatio -- no rapidfuzz at runtime).
+    score = goldenfuzz.WRatio(s_lower, t_lower) / 100.0
     return score

--- a/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
+++ b/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterable
 
-from rapidfuzz import fuzz
+import goldenfuzz
 
 from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
@@ -74,7 +74,7 @@ def _build_canonical_map(
         best_score = 0.0
         best_match = ""
         for canon_low in canonical_list:
-            score = fuzz.ratio(low, canon_low)
+            score = goldenfuzz.ratio(low, canon_low)
             if score > best_score:
                 best_score = score
                 best_match = canon_low
@@ -113,8 +113,8 @@ def category_auto_correct(
     # value_counts returns a 2-column DataFrame: [<series.name>, "count"].
     # Native-first (goldenflow-core's ``autocorrect::build_canonical_map`` owns
     # the whole frequency->canonical->fuzzy algorithm); the pure-Python
-    # ``_build_canonical_map`` (rapidfuzz) is the byte-exact reference the kernel
-    # replicates. Feed the kernel the value_counts in order so its insertion-
+    # ``_build_canonical_map`` (goldenfuzz.ratio) is the byte-exact reference the
+    # kernel replicates. Feed the kernel the value_counts in order so its insertion-
     # ordered tie-breaking matches Python's Counter/dict.
     native = build_canonical_map_native(frequency_threshold, match_threshold)
     if native is not None:
@@ -146,7 +146,7 @@ def category_auto_correct_columnar(
     byte-identical to the Polars engine above (``value_counts`` -> ``build_canonical_map``
     -> apply). The Polars ``value_counts(sort=True)`` ORDER is reproduced by
     ``Counter.most_common()`` (count desc, ties first-seen) and the pure-Python
-    ``_build_canonical_map`` (rapidfuzz — a base dep, no Polars) builds the correction
+    ``_build_canonical_map`` (goldenfuzz.ratio — a base dep, no Polars) builds the correction
     map; both are validated equal to the native engine over a 600-case randomized parity
     stress. Empty map -> identity (no strip), exactly like ``if not corrections: return
     series``."""

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -39,7 +39,11 @@ dependencies = [
     "phonenumbers>=8.13",
     "python-dateutil>=2.9",
     "pyyaml>=6.0",
-    "rapidfuzz>=3.0",
+    # Composite fuzzy ratios (WRatio for column-name mapping, ratio for
+    # auto-correct). goldenfuzz is our owned rapidfuzz replacement -- its
+    # WRatio/ratio are byte-identical to rapidfuzz's fuzz.* (0.1.1 adds the
+    # fuzz.* composite family). Replaces the former rapidfuzz runtime dep.
+    "goldenfuzz>=0.1.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The final piece: migrates goldenflow's last two rapidfuzz call sites to the owned `goldenfuzz` kernel. **With this, rapidfuzz is gone from every runtime dependency in the suite.**

## Changes
- `mapping/name_similarity.py`: `fuzz.WRatio` → `goldenfuzz.WRatio` (column-name schema matching).
- `transforms/auto_correct.py`: `fuzz.ratio` → `goldenfuzz.ratio` (canonical-map fuzzy fallback).
- `pyproject`: `rapidfuzz>=3.0` runtime dep → `goldenfuzz>=0.1.1`.

Both use the `fuzz.*` composite family that goldenfuzz 0.1.1 now owns (PR #2229 + release).

## Verified against the PUBLISHED wheel
Installed `goldenfuzz==0.1.1` from PyPI and confirmed `WRatio`/`ratio` byte-identical to `rapidfuzz.fuzz` for goldenflow's actual column-name inputs (`WRatio(fname, first_name)` = 80.0 both). goldenflow `test_schema_mapper` + `test_auto_correct` + `test_autocorrect_kernels`: **12 passed** on the forced pure path; ruff clean. No rapidfuzz parity oracle retained.

## Suite status
rapidfuzz runtime deps: goldenmatch ✅ (already), goldencheck ✅ (#2227), infermap ✅ (#2227), goldenflow ✅ (this). rapidfuzz now survives only as a dev/bench comparison in `bench_vs_rapidfuzz.rs` and goldenfuzz-core's own port-fidelity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd