### PR TITLE
bench(bucket_score): GOLDENMATCH_BUCKET_DEBUG split for the probabilistic FS path

### DIFF
--- a/.github/workflows/bench-fs-single-mk-probe.yml
+++ b/.github/workflows/bench-fs-single-mk-probe.yml
@@ -27,6 +27,10 @@ on:
         description: "GOLDENMATCH_FS_COLUMNAR_CLUSTER (B2c): '1'/'0' to A/B; blank = code default"
         required: false
         default: ""
+      bucket_debug:
+        description: "GOLDENMATCH_BUCKET_DEBUG: '1' prints the bucket_score prep/kernel/post split"
+        required: false
+        default: "0"
       label:
         description: "Tag for the output filename"
         required: false
@@ -65,6 +69,8 @@ jobs:
         if: ${{ inputs.columnar != '' }}
         run: echo "GOLDENMATCH_FS_COLUMNAR_CLUSTER=${{ inputs.columnar }}" >> $GITHUB_ENV
       - name: Run probe
+        env:
+          GOLDENMATCH_BUCKET_DEBUG: ${{ inputs.bucket_debug }}
         run: |
           set -o pipefail
           .venv/bin/python scripts/bench_fs_single_mk_probe.py \

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -3940,6 +3940,8 @@
             "_fs_link_threshold",
             "_fs_monotonic_mode",
             "_fs_name_refdata_available",
+            "_fs_native_dbg_on",
+            "_fs_native_dbg_record",
             "_fs_native_eligible",
             "_fs_native_enabled",
             "_fs_ne_extend_cols",

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -2491,17 +2491,24 @@ def score_buckets(
             # (`[(a,b,round(float(s),4)) ...]`), recorded in probabilistic.py.
             from goldenmatch.core.probabilistic import _FS_NATIVE_DBG as _fnd
 
+            _pre = _fnd["prep_s"]
             _nat = _fnd["native_s"]
             _mar = _fnd["marshal_s"]
-            _kt = _nat + _mar
+            _kt = _pre + _nat + _mar
             if _kt > 0:
+                def _kp(x: float) -> float:
+                    return 100.0 * x / _kt
                 print(
                     "[score_buckets][DEBUG] kernel split "
-                    f"({_fnd['n_calls']} native calls / {_fnd['n_pairs']} pairs):\n"
-                    f"  rust  (mod.score_block_pairs_fs* incl pyo3 tuple conv): "
-                    f"{_nat:7.3f}s ({100.0 * _nat / _kt:5.1f}%)\n"
-                    f"  marshal (Python [(a,b,round(float(s),4)) ...] loop):    "
-                    f"{_mar:7.3f}s ({100.0 * _mar / _kt:5.1f}%)",
+                    f"({_fnd['n_calls']} native calls, {_fnd['n_single_block']} "
+                    f"single-block / {_fnd['n_pairs']} pairs):\n"
+                    f"  input-prep (row_ids+field_arrays+const rebuild): "
+                    f"{_pre:7.3f}s ({_kp(_pre):5.1f}%)  "
+                    f"[single-block share {_fnd['single_block_prep_s']:.3f}s]\n"
+                    f"  rust (mod.score_block_pairs_fs* incl pyo3 out):  "
+                    f"{_nat:7.3f}s ({_kp(_nat):5.1f}%)\n"
+                    f"  out-marshal (Python round(float()) loop):        "
+                    f"{_mar:7.3f}s ({_kp(_mar):5.1f}%)",
                     flush=True,
                 )
     if _arrow:

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -2486,6 +2486,24 @@ def score_buckets(
                 f"  total in-worker: {tot_s:.3f}s; slowest single kernel call: {slowest[1]:.3f}s",
                 flush=True,
             )
+            # Split the `kernel` bar into the Rust call (compute + pyo3
+            # Vec<tuple> conversion) vs the Python pair-marshal loop
+            # (`[(a,b,round(float(s),4)) ...]`), recorded in probabilistic.py.
+            from goldenmatch.core.probabilistic import _FS_NATIVE_DBG as _fnd
+
+            _nat = _fnd["native_s"]
+            _mar = _fnd["marshal_s"]
+            _kt = _nat + _mar
+            if _kt > 0:
+                print(
+                    "[score_buckets][DEBUG] kernel split "
+                    f"({_fnd['n_calls']} native calls / {_fnd['n_pairs']} pairs):\n"
+                    f"  rust  (mod.score_block_pairs_fs* incl pyo3 tuple conv): "
+                    f"{_nat:7.3f}s ({100.0 * _nat / _kt:5.1f}%)\n"
+                    f"  marshal (Python [(a,b,round(float(s),4)) ...] loop):    "
+                    f"{_mar:7.3f}s ({100.0 * _mar / _kt:5.1f}%)",
+                    flush=True,
+                )
     if _arrow:
         import pyarrow as _pa
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1889,6 +1889,12 @@ def score_buckets(
         # fragments glibc's malloc arena on Linux (1.4 GB / 30s RSS climb).
         from goldenmatch.core.frame import to_frame as _tf
 
+        # BUCKET_DEBUG: the probabilistic (FS) worker records the same
+        # prep/kernel/post split as the fast path (_dbg_rows) -- the fast-path
+        # _dbg mechanism (thread-safe list) is used, NOT bench.stage(), because
+        # workers run in a ThreadPoolExecutor whose threads don't inherit the
+        # recorder ContextVar. `kernel` here is score_probabilistic_bucket_native.
+        _t_prep0 = time.perf_counter() if _bucket_debug else 0.0
         sorted_frame = _tf(bucket_df).sort(["__block_key__"])
         sorted_df = sorted_frame.native
         # Pre-materialized run sizes (seam run_lengths == the old
@@ -1981,6 +1987,10 @@ def score_buckets(
                 score_probabilistic_bucket_native,
             )
 
+            # prep = entry through the keep-mask filter; kernel = the native
+            # score call(s); post = source/target pair filters (BUCKET_DEBUG).
+            _prep_s = (time.perf_counter() - _t_prep0) if _bucket_debug else 0.0
+            _t_kern0 = time.perf_counter() if _bucket_debug else 0.0
             pairs: list[tuple[int, int, float]] = []
             local_blocks = 0
             if kept_size_list:
@@ -2004,7 +2014,12 @@ def score_buckets(
                         )
                         local_blocks += 1
                 offset += s
+            _kern_s = (time.perf_counter() - _t_kern0) if _bucket_debug else 0.0
+            _t_post0 = time.perf_counter() if _bucket_debug else 0.0
             if not pairs and local_blocks == 0:
+                if _bucket_debug:
+                    with _dbg_lock:
+                        _dbg_rows.append((_prep_s, _kern_s, 0.0, local_blocks, 0))
                 return [], 0
             # Same post-filters as the per-block loop below (the native kernel
             # doesn't know about source_lookup / target_ids).
@@ -2018,6 +2033,10 @@ def score_buckets(
                     (a, b, s) for a, b, s in pairs
                     if (a in target_ids) != (b in target_ids)
                 ]
+            if _bucket_debug:
+                _post_s = time.perf_counter() - _t_post0
+                with _dbg_lock:
+                    _dbg_rows.append((_prep_s, _kern_s, _post_s, local_blocks, len(pairs)))
             return pairs, local_blocks
 
         def _score_block_frame(block_df) -> list[tuple[int, int, float]] | None:
@@ -2462,7 +2481,7 @@ def score_buckets(
                 f"{n_calls} calls / {n_blocks} blocks / {n_pairs} pairs "
                 f"(set GOLDENMATCH_BUCKET_DEBUG=0 to silence):\n"
                 f"  prep   (sort+group_by+to_arrow): {prep_s:7.3f}s ({_pct(prep_s):5.1f}%)\n"
-                f"  kernel (score_block_pairs_arrow): {kern_s:7.3f}s ({_pct(kern_s):5.1f}%)\n"
+                f"  kernel (native score_block/bucket): {kern_s:7.3f}s ({_pct(kern_s):5.1f}%)\n"
                 f"  post   (match-mode filter):       {post_s:7.3f}s ({_pct(post_s):5.1f}%)\n"
                 f"  total in-worker: {tot_s:.3f}s; slowest single kernel call: {slowest[1]:.3f}s",
                 flush=True,

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -17,6 +17,8 @@ import logging
 import math
 import os
 import random
+import threading
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from itertools import combinations
@@ -3608,6 +3610,29 @@ def _fs_embedding_vectors(frame, mk: MatchkeyConfig, n: int):
     return emb_vectors, emb_dims
 
 
+# BUCKET_DEBUG: split the native FS scoring kernel into the Rust call (compute +
+# pyo3 Vec<tuple> conversion) vs the Python pair-marshal loop
+# (`[(a,b,round(float(s),4)) ...]` over every emitted pair). Thread-safe because
+# the bucket workers run in a ThreadPoolExecutor. score_buckets prints this in
+# its BUCKET_DEBUG summary. Zero cost when off (one env read per bucket call).
+_FS_NATIVE_DBG = {"native_s": 0.0, "marshal_s": 0.0, "n_pairs": 0, "n_calls": 0}
+_FS_NATIVE_DBG_LOCK = threading.Lock()
+
+
+def _fs_native_dbg_on() -> bool:
+    return os.environ.get("GOLDENMATCH_BUCKET_DEBUG", "0") not in (
+        "0", "", "false", "False", "no", "off",
+    )
+
+
+def _fs_native_dbg_record(native_s: float, marshal_s: float, n_pairs: int) -> None:
+    with _FS_NATIVE_DBG_LOCK:
+        _FS_NATIVE_DBG["native_s"] += native_s
+        _FS_NATIVE_DBG["marshal_s"] += marshal_s
+        _FS_NATIVE_DBG["n_pairs"] += n_pairs
+        _FS_NATIVE_DBG["n_calls"] += 1
+
+
 def _score_fs_native_frame(
     frame,
     size_list,
@@ -3804,6 +3829,8 @@ def _score_fs_native_frame(
                 field_arrays[_i] = _pa.array([""] * n, type=_pa.large_string())
         if use_handle:
             opt_kwargs["exclude_set"] = exclude_handle
+        _dbg = _fs_native_dbg_on()
+        _t0 = time.perf_counter() if _dbg else 0.0
         pairs = mod.score_block_pairs_fs_arrow(
             row_ids_arrow, field_arrays, [int(s) for s in size_list],
             scorer_ids, levels, partials, weights, calibrated, prior_w,
@@ -3811,7 +3838,11 @@ def _score_fs_native_frame(
             exclude=excl if excl else None,
             **opt_kwargs,
         )
-        return [(a, b, round(float(s), 4)) for a, b, s in pairs]
+        _t1 = time.perf_counter() if _dbg else 0.0
+        out = [(a, b, round(float(s), 4)) for a, b, s in pairs]
+        if _dbg:
+            _fs_native_dbg_record(_t1 - _t0, time.perf_counter() - _t1, len(out))
+        return out
 
     field_values = [_field_values_for_block(frame, f, n) for f in mk.fields]
     # record_embedding is always observed (see the arrow branch above) — pin its
@@ -3821,13 +3852,19 @@ def _score_fs_native_frame(
             field_values[_i] = [""] * n
     if use_handle:
         opt_kwargs["exclude_set"] = exclude_handle
+    _dbg = _fs_native_dbg_on()
+    _t0 = time.perf_counter() if _dbg else 0.0
     pairs = mod.score_block_pairs_fs(
         row_ids, [int(s) for s in size_list], field_values, scorer_ids, levels,
         partials, weights, calibrated, prior_w, min_weight, weight_range,
         link_threshold, excl,
         **opt_kwargs,
     )
-    return [(a, b, round(float(s), 4)) for a, b, s in pairs]
+    _t1 = time.perf_counter() if _dbg else 0.0
+    out = [(a, b, round(float(s), 4)) for a, b, s in pairs]
+    if _dbg:
+        _fs_native_dbg_record(_t1 - _t0, time.perf_counter() - _t1, len(out))
+    return out
 
 
 def score_probabilistic_native(

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -3615,7 +3615,10 @@ def _fs_embedding_vectors(frame, mk: MatchkeyConfig, n: int):
 # (`[(a,b,round(float(s),4)) ...]` over every emitted pair). Thread-safe because
 # the bucket workers run in a ThreadPoolExecutor. score_buckets prints this in
 # its BUCKET_DEBUG summary. Zero cost when off (one env read per bucket call).
-_FS_NATIVE_DBG = {"native_s": 0.0, "marshal_s": 0.0, "n_pairs": 0, "n_calls": 0}
+_FS_NATIVE_DBG = {
+    "prep_s": 0.0, "native_s": 0.0, "marshal_s": 0.0,
+    "n_pairs": 0, "n_calls": 0, "n_single_block": 0, "single_block_prep_s": 0.0,
+}
 _FS_NATIVE_DBG_LOCK = threading.Lock()
 
 
@@ -3625,12 +3628,18 @@ def _fs_native_dbg_on() -> bool:
     )
 
 
-def _fs_native_dbg_record(native_s: float, marshal_s: float, n_pairs: int) -> None:
+def _fs_native_dbg_record(
+    prep_s: float, native_s: float, marshal_s: float, n_pairs: int, single_block: bool
+) -> None:
     with _FS_NATIVE_DBG_LOCK:
+        _FS_NATIVE_DBG["prep_s"] += prep_s
         _FS_NATIVE_DBG["native_s"] += native_s
         _FS_NATIVE_DBG["marshal_s"] += marshal_s
         _FS_NATIVE_DBG["n_pairs"] += n_pairs
         _FS_NATIVE_DBG["n_calls"] += 1
+        if single_block:
+            _FS_NATIVE_DBG["n_single_block"] += 1
+            _FS_NATIVE_DBG["single_block_prep_s"] += prep_s
 
 
 def _score_fs_native_frame(
@@ -3659,6 +3668,9 @@ def _score_fs_native_frame(
     """
     from goldenmatch.core._native_loader import native_module
     from goldenmatch.core.frame import to_frame as _tf_w6
+
+    _dbg_entry = _fs_native_dbg_on()
+    _t_entry = time.perf_counter() if _dbg_entry else 0.0
 
     if exclude_pairs is None:
         exclude_pairs = set()
@@ -3829,8 +3841,7 @@ def _score_fs_native_frame(
                 field_arrays[_i] = _pa.array([""] * n, type=_pa.large_string())
         if use_handle:
             opt_kwargs["exclude_set"] = exclude_handle
-        _dbg = _fs_native_dbg_on()
-        _t0 = time.perf_counter() if _dbg else 0.0
+        _t0 = time.perf_counter() if _dbg_entry else 0.0
         pairs = mod.score_block_pairs_fs_arrow(
             row_ids_arrow, field_arrays, [int(s) for s in size_list],
             scorer_ids, levels, partials, weights, calibrated, prior_w,
@@ -3838,10 +3849,13 @@ def _score_fs_native_frame(
             exclude=excl if excl else None,
             **opt_kwargs,
         )
-        _t1 = time.perf_counter() if _dbg else 0.0
+        _t1 = time.perf_counter() if _dbg_entry else 0.0
         out = [(a, b, round(float(s), 4)) for a, b, s in pairs]
-        if _dbg:
-            _fs_native_dbg_record(_t1 - _t0, time.perf_counter() - _t1, len(out))
+        if _dbg_entry:
+            _fs_native_dbg_record(
+                _t0 - _t_entry, _t1 - _t0, time.perf_counter() - _t1,
+                len(out), len(size_list) == 1,
+            )
         return out
 
     field_values = [_field_values_for_block(frame, f, n) for f in mk.fields]
@@ -3852,18 +3866,20 @@ def _score_fs_native_frame(
             field_values[_i] = [""] * n
     if use_handle:
         opt_kwargs["exclude_set"] = exclude_handle
-    _dbg = _fs_native_dbg_on()
-    _t0 = time.perf_counter() if _dbg else 0.0
+    _t0 = time.perf_counter() if _dbg_entry else 0.0
     pairs = mod.score_block_pairs_fs(
         row_ids, [int(s) for s in size_list], field_values, scorer_ids, levels,
         partials, weights, calibrated, prior_w, min_weight, weight_range,
         link_threshold, excl,
         **opt_kwargs,
     )
-    _t1 = time.perf_counter() if _dbg else 0.0
+    _t1 = time.perf_counter() if _dbg_entry else 0.0
     out = [(a, b, round(float(s), 4)) for a, b, s in pairs]
-    if _dbg:
-        _fs_native_dbg_record(_t1 - _t0, time.perf_counter() - _t1, len(out))
+    if _dbg_entry:
+        _fs_native_dbg_record(
+            _t0 - _t_entry, _t1 - _t0, time.perf_counter() - _t1,
+            len(out), len(size_list) == 1,
+        )
     return out
 
 


### PR DESCRIPTION
## What

Diagnostic-only instrumentation (gated on `GOLDENMATCH_BUCKET_DEBUG`, zero cost when off) that made the bucket_score decomposition possible. No behavior change.

- **`bench-fs-single-mk-probe.yml`**: new `bucket_debug` dispatch input (default `0`) wiring `GOLDENMATCH_BUCKET_DEBUG` into the probe.
- **`score_buckets.py`**: `BUCKET_DEBUG` only recorded the prep/kernel/post split on the fast `score_block_pairs_arrow` path; the **probabilistic FS worker** (`_score_one_bucket` → `score_probabilistic_bucket_native`) recorded nothing. Add the same thread-safe `_dbg_rows` timing (prep = sort+run_lengths+keep-mask; kernel = native score call(s); post = source/target filters) so the split prints for FS.
- **`probabilistic.py`**: split the `kernel` bar further inside `_score_fs_native_frame` — **input-prep** (row_ids + field_arrays + const rebuild) vs **rust** (`mod.score_block_pairs_fs*` incl pyo3 tuple conv) vs **out-marshal** (`round(float())` loop) — plus a single-block-call counter, printed in the BUCKET_DEBUG summary.

## Why keep it

This is how we established bucket_score is **rust-compute-bound** (rust 94.7% of a 45s stage, genuine FS scoring over 10.68M pairs) rather than marshaling-bound: the coarse "99.5% kernel" bar hid an input-prep segment amplified by 57k single-block native calls (oversized surname fragmentation). The output `round()` loop was 2% — a red herring the split killed. Thread-safe (`_dbg_rows` / a locked accumulator) because bucket workers run in a `ThreadPoolExecutor` whose threads don't inherit the bench recorder ContextVar.

Runs at `GOLDENMATCH_BUCKET_DEBUG=1`: 30383632044 (prep/kernel/post), 30384306409 (rust vs marshal), 30384983098 (input-prep/rust/marshal + single-block count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)