### PR TITLE
feat(er-matcher): honest yardstick (SP3.5) - entity splits + FS-mined negatives + soft targets

### DIFF
--- a/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
+++ b/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
@@ -435,7 +435,7 @@ def _make_candidates(records: list[dict], blocking_cfg):
 
 - [ ] **Step 2b: Verify the score is in [0,1] AND separates** (spec risk: garbage-in). After building the scorer for one split, assert every score is within `[0,1]`, then score ~200 known-match and ~200 known-non-match pairs and print `mean(score|match)` vs `mean(score|non-match)`. If scores fall outside `[0,1]`, or the means don't separate, STOP and surface — the config/EM fit is wrong and soft targets built on it would be garbage (use the Step 1 fallback or fix the config before proceeding).
 
-- [ ] **Step 3: Call `fs_enrich.enrich` per split** in `build_corpus.py`, threading the cache. Get the per-split record pool from the source's new `record_pools()` (Task 1 Step 6b): `pools = source.record_pools()`. For each split, build the scorer over that split's pool and enrich that split's pairs:
+- [ ] **Step 3: Call `fs_enrich.enrich` per split** in `build_corpus.py`, threading the cache. Get the per-split record pools defensively (Task 1 Step 6b) via `getattr(source, "record_pools", lambda: {})()` — `{}` for sources without it (magellan/ncvr), so they are skipped, not crashed on. Fit the scorer once on the train pool and enrich each split's pairs:
 
 ```python
 pools = getattr(source, "record_pools", lambda: {})()   # {} for magellan/ncvr -> no mining

--- a/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
+++ b/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
@@ -1,0 +1,461 @@
+# ER-Matcher Honest Yardstick Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the ER-matcher's training signal and metric honest — entity-level splits, FS-mined hard negatives, and FS-score-driven soft confidence targets — then confirm with a retrain measured against the SP3 zero-shot held-out suite.
+
+**Architecture:** A new pure, box-testable module `fs_enrich.py` runs one post-blend pass over the blended corpus: it attaches an FS-score-driven soft confidence to every pair and mines near-threshold gold non-matches as extra hard negatives, using an *injected* `scorer(a,b)->float`. `build_corpus.py` builds that scorer from goldenmatch's own FS pipeline (`auto_configure_df` -> `score_pair`/`build_blocks`). Entity-level splits (connected components over gold match edges) replace record-level splits in `splits.py`/`leipzig.py`. `train.py` reads per-row confidence instead of the fixed 0.9/0.1. A final Modal run rebuilds, retrains on the frozen SP2 config, and re-measures.
+
+**Tech Stack:** Python 3.11 stdlib for the pure logic; goldenmatch's FS scorer/blocker for the real enrichment; torch/transformers on the Modal GPU path; pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-er-matcher-honest-yardstick-design.md`
+
+---
+
+## File Structure
+
+| Path | Change | Responsibility |
+|---|---|---|
+| `scripts/er_matcher/sources/splits.py` | **Modify** | Add `entity_keys_from_edges` (connected-components entity keying); keep `split_of` |
+| `scripts/er_matcher/sources/leipzig.py` | **Modify** | Build gold edges, key records to entities, split on the entity key, generate negatives per-split |
+| `scripts/er_matcher/fs_enrich.py` | **Create** | Pure: `soft_confidence`, `select_hard_negatives`, `enrich` orchestration, cache key |
+| `scripts/er_matcher/build_corpus.py` | **Modify** | Build the real goldenmatch FS scorer/blocker closure; call `fs_enrich.enrich` |
+| `scripts/er_matcher/train.py` | **Modify** | Read per-row `confidence`; drop the fixed 0.9/0.1 default path |
+| `scripts/er_matcher/modal_train.py` | **Modify** | Nothing structural; the frozen-config retrain uses existing `train_full` |
+| `scripts/er_matcher/test_splits.py` | **Modify** | Entity-keying + anti-leakage invariant tests |
+| `scripts/er_matcher/test_fs_enrich.py` | **Create** | Soft-target + mining + orchestration tests (injected fake scorer) |
+| `scripts/er_matcher/test_train_helpers.py` | **Modify** | Per-row confidence read test |
+
+**Boundary:** Tasks 1-5 are pure and box-tested (no GPU, no goldenmatch import — a fake scorer is injected). Task 6 (goldenmatch wiring) is verified by a real corpus build. Task 7 (retrain + measure) is verified by the real Modal run, same boundary as SP2/SP3.
+
+**Leakage-free ordering (applies across Tasks 1 + 6):** split records into train/val/test FIRST (by entity), THEN generate/mine negatives WITHIN each split's record pool only. This guarantees both endpoints of every negative live in the same split, so no entity crosses the split boundary through a pair.
+
+---
+
+## Task 1: Entity-level splits (pure, TDD)
+
+**Files:**
+- Modify: `scripts/er_matcher/sources/splits.py`
+- Modify: `scripts/er_matcher/sources/leipzig.py`
+- Test: `scripts/er_matcher/test_splits.py`
+
+- [ ] **Step 1: Read the current split logic.** Read `sources/splits.py` (the `split_of` hash) and `sources/leipzig.py:30-100` (the record-level `split_of(eid_a)` call the design flags as leaky). Confirm the gold match mapping available in `leipzig.py` (the perfect-match pairs) so you know the edge source.
+
+- [ ] **Step 2: Write the failing test** for connected-components entity keying + the anti-leakage invariant. Header: `import os, sys; sys.path.insert(0, os.path.join(os.path.dirname(__file__), "sources")); sys.path.insert(0, os.path.dirname(__file__))`.
+
+```python
+from splits import entity_keys_from_edges, split_of
+
+def test_connected_components_merges_transitively():
+    # A1-B1 and B1-A2 gold edges => {A1,B1,A2} are ONE entity
+    keys = entity_keys_from_edges(
+        ["A1", "A2", "B1", "B2"],
+        [("A1", "B1"), ("B1", "A2")],
+    )
+    assert keys["A1"] == keys["B1"] == keys["A2"]
+    assert keys["B2"] != keys["A1"]          # unconnected -> own entity
+    # deterministic canonical key (min member), order-independent
+    assert keys["A1"] == "A1"
+
+def test_singletons_get_own_key():
+    keys = entity_keys_from_edges(["X", "Y"], [])
+    assert keys["X"] == "X" and keys["Y"] == "Y" and keys["X"] != keys["Y"]
+
+def test_entity_split_has_no_leakage():
+    # every record of an entity must land in exactly one split
+    ids = [f"A{i}" for i in range(50)] + [f"B{i}" for i in range(50)]
+    edges = [(f"A{i}", f"B{i}") for i in range(50)]        # 50 two-record entities
+    keys = entity_keys_from_edges(ids, edges)
+    split = {rid: split_of(keys[rid]) for rid in ids}
+    for i in range(50):                                    # both records share a split
+        assert split[f"A{i}"] == split[f"B{i}"]
+```
+
+- [ ] **Step 3: Run the test to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_splits.py -k "connected or singletons or leakage" -v`. Expected: FAIL (`entity_keys_from_edges` undefined).
+
+- [ ] **Step 4: Implement `entity_keys_from_edges` in `sources/splits.py`** (union-find, deterministic canonical key = min member):
+
+```python
+from collections.abc import Iterable
+
+def entity_keys_from_edges(
+    record_ids: Iterable[str], edges: Iterable[tuple[str, str]]
+) -> dict[str, str]:
+    """Map each record id to a stable entity key via connected components over the
+    gold match edges. Records with no edges are their own singleton entity. The key
+    is the min member id, so it is deterministic regardless of union order."""
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        while parent[x] != root:  # path halving
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for rid in record_ids:
+        find(rid)
+    for a, b in edges:
+        union(a, b)
+
+    groups: dict[str, list[str]] = {}
+    for rid in list(parent):
+        groups.setdefault(find(rid), []).append(rid)
+    key_of: dict[str, str] = {}
+    for members in groups.values():
+        canonical = min(members)
+        for m in members:
+            key_of[m] = canonical
+    return key_of
+```
+
+- [ ] **Step 5: Run the test to verify it passes.** Run the same command. Expected: PASS.
+
+- [ ] **Step 6: Wire entity splits into `leipzig.py`.** Replace the record-level `split_of(eid_a)` with: build gold edges from the perfect-match pairs, compute `key_of = entity_keys_from_edges(all_record_ids, gold_edges)`, and assign each record's split via `split_of(key_of[record_id])`. Move negative generation to happen AFTER records are split, over each split's record pool only (per the leakage-free ordering). Keep the FEBRL loader unchanged (it already splits at entity level).
+
+- [ ] **Step 7: Run the full sources test suite.** Run: `uv run python -m pytest scripts/er_matcher/test_splits.py scripts/er_matcher/test_leipzig.py scripts/er_matcher/test_febrl.py -q`. Expected: PASS (fix any leipzig test that assumed record-level splits — update the assertion to the entity-level behavior, do not weaken the invariant).
+
+- [ ] **Step 8: Commit.** `git add scripts/er_matcher/sources/splits.py scripts/er_matcher/sources/leipzig.py scripts/er_matcher/test_splits.py && git commit -m "feat(er-matcher): entity-level splits (connected components, no leakage)"`
+
+---
+
+## Task 2: FS score -> soft confidence (pure, TDD)
+
+**Files:**
+- Create: `scripts/er_matcher/fs_enrich.py`
+- Test: `scripts/er_matcher/test_fs_enrich.py`
+
+- [ ] **Step 1: Write the failing test.** Header: `import os, sys; sys.path.insert(0, os.path.dirname(__file__))`.
+
+```python
+from fs_enrich import soft_confidence
+
+def test_soft_confidence_monotonic_and_clamped():
+    # match: higher FS score -> higher confidence, never > 0.97, floor 0.55 near/below tau
+    assert soft_confidence(1.0, True, tau=0.5) == 0.97
+    assert soft_confidence(0.5, True, tau=0.5) == 0.55          # at threshold -> uncertain
+    assert soft_confidence(0.1, True, tau=0.5) == 0.55          # matcher missed it -> floor, not 0
+    mid = soft_confidence(0.75, True, tau=0.5)
+    assert 0.55 < mid < 0.97
+    # non-match: lower FS score -> lower confidence, never < 0.03, ceiling 0.45 near/above tau
+    assert soft_confidence(0.0, False, tau=0.5) == 0.03
+    assert soft_confidence(0.5, False, tau=0.5) == 0.45         # at threshold -> uncertain
+    assert soft_confidence(0.9, False, tau=0.5) == 0.45         # matcher wrongly high -> ceiling
+    nm = soft_confidence(0.25, False, tau=0.5)
+    assert 0.03 < nm < 0.45
+
+def test_soft_confidence_never_hits_0_or_1():
+    for s in (0.0, 0.5, 1.0):
+        for m in (True, False):
+            c = soft_confidence(s, m, tau=0.5)
+            assert 0.0 < c < 1.0
+```
+
+- [ ] **Step 2: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_fs_enrich.py -k soft_confidence -v`. Expected: FAIL (module/function missing).
+
+- [ ] **Step 3: Implement `soft_confidence` in `fs_enrich.py`.**
+
+```python
+"""Post-blend FS enrichment: FS-score-driven soft confidence targets + hard-negative
+mining. Pure and box-testable; the FS matcher is injected as scorer(a,b)->float."""
+
+
+def soft_confidence(
+    score: float,
+    is_match: bool,
+    *,
+    tau: float = 0.5,
+    hi: float = 0.97,
+    lo: float = 0.03,
+    mid_hi: float = 0.55,
+    mid_lo: float = 0.45,
+) -> float:
+    """Map an FS match-probability to a P(match) training target, compressed toward
+    0.5 near the decision threshold tau. Gold label picks the direction; the score's
+    distance from tau picks how extreme. Never 0 or 1."""
+    s = min(max(score, 0.0), 1.0)
+    if is_match:
+        frac = max((s - tau) / (1.0 - tau), 0.0) if tau < 1.0 else 0.0
+        return mid_hi + (hi - mid_hi) * min(frac, 1.0)
+    frac = min(s / tau, 1.0) if tau > 0.0 else 0.0
+    return lo + (mid_lo - lo) * frac
+```
+
+- [ ] **Step 4: Run to verify it passes.** Same command. Expected: PASS.
+
+- [ ] **Step 5: Commit.** `git add scripts/er_matcher/fs_enrich.py scripts/er_matcher/test_fs_enrich.py && git commit -m "feat(er-matcher): FS-score-driven soft confidence target"`
+
+---
+
+## Task 3: Hard-negative selection (pure, TDD)
+
+**Files:**
+- Modify: `scripts/er_matcher/fs_enrich.py`
+- Test: `scripts/er_matcher/test_fs_enrich.py`
+
+- [ ] **Step 1: Write the failing test.**
+
+```python
+from fs_enrich import select_hard_negatives
+
+def _cand(a, b, score, gold):  # helper: a scored candidate with its gold label
+    return {"a_id": a, "b_id": b, "score": score, "gold_match": gold}
+
+def test_select_keeps_near_threshold_gold_nonmatches_only():
+    cands = [
+        _cand("a", "b", 0.52, False),   # near tau, gold NON-match -> KEEP (hard neg)
+        _cand("c", "d", 0.99, True),    # gold MATCH -> reject (not a negative)
+        _cand("e", "f", 0.05, False),   # far below band -> reject (easy)
+        _cand("g", "h", 0.48, False),   # near tau, gold NON-match -> KEEP
+    ]
+    out = select_hard_negatives(cands, tau=0.5, delta=0.1, cap=10)
+    kept = {(c["a_id"], c["b_id"]) for c in out}
+    assert kept == {("a", "b"), ("g", "h")}
+
+def test_select_caps_and_is_deterministic():
+    cands = [_cand(f"a{i}", f"b{i}", 0.5, False) for i in range(20)]
+    out = select_hard_negatives(cands, tau=0.5, delta=0.1, cap=5)
+    assert len(out) == 5
+    assert out == select_hard_negatives(cands, tau=0.5, delta=0.1, cap=5)  # deterministic
+```
+
+- [ ] **Step 2: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_fs_enrich.py -k select -v`. Expected: FAIL.
+
+- [ ] **Step 3: Implement `select_hard_negatives`.**
+
+```python
+def select_hard_negatives(
+    scored_candidates: list[dict],
+    *,
+    tau: float = 0.5,
+    delta: float = 0.1,
+    cap: int,
+) -> list[dict]:
+    """Keep candidates whose FS score is within [tau-delta, tau+delta] AND whose gold
+    label is non-match. Sort by closeness to tau (hardest first) for a deterministic
+    cap. Gold label is the truth; FS only selects difficulty."""
+    band = [
+        c for c in scored_candidates
+        if not c["gold_match"] and abs(c["score"] - tau) <= delta
+    ]
+    band.sort(key=lambda c: (abs(c["score"] - tau), c["a_id"], c["b_id"]))
+    return band[:cap]
+```
+
+- [ ] **Step 4: Run to verify it passes.** Same command. Expected: PASS.
+
+- [ ] **Step 5: Commit.** `git add -A scripts/er_matcher/fs_enrich.py scripts/er_matcher/test_fs_enrich.py && git commit -m "feat(er-matcher): near-threshold hard-negative selection"`
+
+---
+
+## Task 4: `enrich` orchestration + cache key (pure, TDD, injected scorer)
+
+**Files:**
+- Modify: `scripts/er_matcher/fs_enrich.py`
+- Test: `scripts/er_matcher/test_fs_enrich.py`
+
+- [ ] **Step 1: Write the failing test** (fake scorer + fake candidate generator, no goldenmatch).
+
+```python
+from fs_enrich import enrich, cache_key
+
+def test_enrich_attaches_soft_conf_and_appends_mined_negs():
+    pairs = [
+        {"a": {"id": "a"}, "b": {"id": "b"}, "label": "match", "eid_a": "a", "eid_b": "b"},
+        {"a": {"id": "c"}, "b": {"id": "d"}, "label": "no_match", "eid_a": "c", "eid_b": "d"},
+    ]
+    # fake FS scorer: match->0.9, the mined candidate scores 0.5 (near tau)
+    def scorer(x, y):
+        return {("a", "b"): 0.9, ("c", "d"): 0.1, ("e", "f"): 0.5}[(x["id"], y["id"])]
+    # fake candidate gen yields one near-threshold gold non-match
+    def candidates(records):
+        return [{"a": {"id": "e"}, "b": {"id": "f"}, "gold_match": False,
+                 "eid_a": "e", "eid_b": "f"}]
+    out = enrich(pairs, records=[{"id": "e"}, {"id": "f"}], scorer=scorer,
+                 candidates_fn=candidates, tau=0.5, delta=0.1, mine_cap=10)
+    # every original pair now carries a per-row confidence in (0,1)
+    assert all(0.0 < p["confidence"] < 1.0 for p in out)
+    # the mined near-threshold non-match was appended as a hard negative
+    mined = [p for p in out if (p["eid_a"], p["eid_b"]) == ("e", "f")]
+    assert len(mined) == 1 and mined[0]["label"] == "no_match"
+
+def test_cache_key_stable_and_sensitive():
+    a = cache_key(corpus_hash="h1", scorer_cfg="c1", tau=0.5, delta=0.1)
+    assert a == cache_key(corpus_hash="h1", scorer_cfg="c1", tau=0.5, delta=0.1)
+    assert a != cache_key(corpus_hash="h2", scorer_cfg="c1", tau=0.5, delta=0.1)
+```
+
+- [ ] **Step 2: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_fs_enrich.py -k "enrich or cache_key" -v`. Expected: FAIL.
+
+- [ ] **Step 3: Implement `enrich` + `cache_key`.**
+
+```python
+import hashlib
+
+
+def cache_key(*, corpus_hash: str, scorer_cfg: str, tau: float, delta: float) -> str:
+    raw = f"{corpus_hash}|{scorer_cfg}|{tau:.4f}|{delta:.4f}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def enrich(
+    pairs: list[dict],
+    *,
+    records: list[dict],
+    scorer,
+    candidates_fn,
+    tau: float = 0.5,
+    delta: float = 0.1,
+    mine_cap: int,
+) -> list[dict]:
+    """Attach FS-score-driven soft confidence to every pair, and append near-threshold
+    gold non-matches mined from candidates_fn(records). Pure given injected scorer +
+    candidates_fn. Records must already be within a single split (leakage-free ordering)."""
+    enriched = []
+    for p in pairs:
+        s = scorer(p["a"], p["b"])
+        conf = soft_confidence(s, p["label"] == "match", tau=tau)
+        enriched.append({**p, "confidence": round(conf, 4), "fs_score": round(s, 4)})
+
+    scored_cands = [
+        {**c, "score": scorer(c["a"], c["b"])} for c in candidates_fn(records)
+    ]
+    for c in select_hard_negatives(scored_cands, tau=tau, delta=delta, cap=mine_cap):
+        conf = soft_confidence(c["score"], False, tau=tau)
+        enriched.append({
+            "a": c["a"], "b": c["b"], "label": "no_match",
+            "eid_a": c["eid_a"], "eid_b": c["eid_b"],
+            "confidence": round(conf, 4), "fs_score": round(c["score"], 4),
+            "negative_kind": "fs_mined",
+        })
+    return enriched
+```
+
+- [ ] **Step 4: Run to verify it passes.** Same command. Expected: PASS. Then run the whole module: `uv run python -m pytest scripts/er_matcher/test_fs_enrich.py -q`.
+
+- [ ] **Step 5: Commit.** `git add -A scripts/er_matcher/fs_enrich.py scripts/er_matcher/test_fs_enrich.py && git commit -m "feat(er-matcher): fs_enrich orchestration + cache key"`
+
+---
+
+## Task 5: `train.py` reads per-row confidence (pure, TDD)
+
+**Files:**
+- Modify: `scripts/er_matcher/train.py`
+- Test: `scripts/er_matcher/test_train_helpers.py`
+
+- [ ] **Step 1: Read** `train.py` around the `render_target`/`DEFAULT_MATCH_CONF`/`DEFAULT_NOMATCH_CONF` usage (the fixed 0.9/0.1 path) and the function that turns a corpus row into an SFT example.
+
+- [ ] **Step 2: Write the failing test** asserting the per-row confidence is used when present, falling back to the constant only when absent.
+
+```python
+# in test_train_helpers.py, matching its existing import header
+def test_row_confidence_overrides_constant():
+    row = {"a": {...}, "b": {...}, "label": "match", "confidence": 0.62}
+    ex = build_sft_example(row)            # the existing row->example helper
+    assert '"confidence":0.62' in ex["target"]   # compact JSON, per render_target
+
+def test_missing_confidence_falls_back_to_constant():
+    row = {"a": {...}, "b": {...}, "label": "match"}   # no confidence
+    ex = build_sft_example(row)
+    assert '"confidence":0.9' in ex["target"]     # DEFAULT_MATCH_CONF
+```
+(Adapt `build_sft_example`/field names to the actual helper in `train.py`; fill the `{...}` records with a minimal valid pair.)
+
+- [ ] **Step 3: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_train_helpers.py -k confidence -v`. Expected: FAIL.
+
+- [ ] **Step 4: Implement.** In the row->example helper, use `row.get("confidence", DEFAULT_MATCH_CONF if match else DEFAULT_NOMATCH_CONF)` as the confidence passed to `render_target`. Keep the constants as the fallback only.
+
+- [ ] **Step 5: Run to verify it passes**, then the train-helper suite: `uv run python -m pytest scripts/er_matcher/test_train_helpers.py -q`. Expected: PASS.
+
+- [ ] **Step 6: Commit.** `git add scripts/er_matcher/train.py scripts/er_matcher/test_train_helpers.py && git commit -m "feat(er-matcher): train reads per-row confidence, constant is fallback"`
+
+---
+
+## Task 6: Wire the real goldenmatch FS scorer into `build_corpus` (integration)
+
+**Files:**
+- Modify: `scripts/er_matcher/build_corpus.py`
+
+This task uses the heavy goldenmatch package, so it is verified by a real corpus build, not a box test. Keep the goldenmatch imports INSIDE the scorer-builder function (not at module top level) so the box suite stays clean.
+
+- [ ] **Step 1: Discovery — resolve the MatchkeyConfig -> MatchkeyField bridge.** `score_pair(a, b, fields: list[MatchkeyField])` (`goldenmatch/core/scorer.py:536`) wants runtime `MatchkeyField`s, but `auto_configure_df` returns a `GoldenMatchConfig` whose `.matchkeys` are `MatchkeyConfig` (schema). Grep for where the pipeline compiles config matchkeys into `MatchkeyField` (try: `grep -rn "MatchkeyField(" packages/python/goldenmatch/goldenmatch/core/ | head` and look in `scorer.py`/`pipeline.py` for a `build_fields`/`compile`/`to_field` helper). Record the exact call. If none exists as a public helper, construct `MatchkeyField` from each `MatchkeyConfig` following the pattern the pipeline uses.
+
+- [ ] **Step 2: Write `_make_fs_scorer(records, domain)`** in `build_corpus.py`:
+
+```python
+def _make_fs_scorer(records: list[dict], domain: str):
+    """Build (scorer, candidates_fn, scorer_cfg_str) from goldenmatch's FS pipeline for
+    a single split's record pool. Heavy imports stay local (box-safety)."""
+    import pyarrow as pa
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.scorer import score_pair
+    from goldenmatch.core.blocker import build_blocks
+    # <MatchkeyConfig -> MatchkeyField> per Step 1 discovery
+
+    table = pa.Table.from_pylist(records)
+    cfg = auto_configure_df(table, confidence_required=False)   # tolerate a RED config here
+    fields = _fields_from_config(cfg)          # from Step 1
+    tau = _threshold_from_config(cfg)          # the FS decision threshold; default 0.5 if absent
+
+    def scorer(a: dict, b: dict) -> float:
+        return score_pair(a, b, fields)
+
+    def candidates_fn(recs: list[dict]) -> list[dict]:
+        blocks = build_blocks(pa.Table.from_pylist(recs), cfg.blocking)
+        # expand each block into within-block pairs, tag gold_match from the known labels
+        return _pairs_from_blocks(blocks, recs)
+
+    scorer_cfg = cfg.model_dump_json()         # stable string for the cache key
+    return scorer, candidates_fn, tau, scorer_cfg
+```
+(Implement `_fields_from_config`, `_threshold_from_config`, `_pairs_from_blocks` per the Step 1 discovery + the `BlockResult` shape at `blocker.py:266`. `_pairs_from_blocks` sets `gold_match` from the source's gold mapping — a mined pair is a non-match iff the two records are not gold-linked.)
+
+- [ ] **Step 2b: Verify the FS score distribution before trusting it** (spec risk: garbage-in). After building the scorer for one split, score ~200 known match and ~200 known non-match pairs and print `mean(score|match)` vs `mean(score|non-match)`. If they do not separate, STOP and surface — the matchkey config is wrong, and soft targets built on it would be garbage.
+
+- [ ] **Step 3: Call `fs_enrich.enrich` per split** in `build_corpus.py`, threading the cache. For each split's blended pairs + record pool: `enrich(pairs, records=split_records, scorer=scorer, candidates_fn=candidates_fn, tau=tau, delta=<cfg>, mine_cap=<cfg>)`. Cache the enriched output under `fs_enrich.cache_key(corpus_hash=..., scorer_cfg=scorer_cfg, tau=tau, delta=delta)` so rebuilds skip the FS pass. Write the enriched pairs (now carrying `confidence`) to the corpus JSONL.
+
+- [ ] **Step 4: Guard `eval_only` sources.** Confirm the enrichment loop only runs over `bundle`/`generate` sources; `magellan`/`ncvr` stay untouched (they never enter training). Re-run `test_build_corpus.py` to confirm the eval_only contribution invariant still holds.
+
+- [ ] **Step 5: Real corpus build (small).** Run the corpus build over a small slice (e.g. FEBRL dataset1 + one Leipzig benchmark). Confirm: it completes, the JSONL rows carry a `confidence` field with a spread of values (not all 0.9/0.1), the separation check in Step 2b passed, and mined `fs_mined` negatives appear. Capture the counts.
+
+- [ ] **Step 6: Commit.** `git add scripts/er_matcher/build_corpus.py && git commit -m "feat(er-matcher): wire goldenmatch FS scorer into corpus enrichment"`
+
+---
+
+## Task 7: Retrain + re-measure (execution — real Modal GPU, NOT box-tested)
+
+> Execute step (real Modal GPU + on-disk `benzsevern` token). NOT CI. Same boundary as SP3 T6. Set `PYTHONUTF8=1 PYTHONIOENCODING=utf-8` for the local Modal CLI on Windows.
+
+- [ ] **Step 1: Build the full enriched corpus** (FEBRL + 4 Leipzig, entity-split, soft targets, mined negatives). Confirm the leakage invariant (no entity id in two splits) and the FS-score separation check on the logs.
+
+- [ ] **Step 2: Retrain on the FROZEN SP2 config.** Qwen2.5-3B-Instruct, bf16 LoRA, 2 epochs, all hyperparams identical to SP2 — the ONLY changes are the data (entity splits + mined negatives) and the per-row soft confidence targets. Run via the existing `modal_train.py::full` / `train_full` entrypoint against the new corpus.
+
+- [ ] **Step 3: Measure.** Run in-distribution eval (`modal_train.py::evaluate`) AND the SP3 held-out zero-shot suite (`modal_train.py::zeroshot --dataset walmart_amazon`, `--dataset beer`). Pull the scorecards.
+
+- [ ] **Step 4: Check the success criteria** (from the spec):
+  - In-distribution F1 should DROP from 0.983 (honest metric).
+  - SP3 zero-shot F1 (WA 0.640 / Beer 0.897 baseline) should HOLD or IMPROVE.
+  - Raw ECE should improve sharply vs SP2's 0.46 (soft targets), ideally near the post-hoc calibrated level without temp scaling.
+  - Confirm the mined-negative and leakage watch-items on the logs before trusting the numbers.
+
+- [ ] **Step 5: Report + open the PR.** Summarize before/after (in-distribution F1, zero-shot F1 vs SP3 baseline, raw + calibrated ECE) and open the SP3.5 PR (Tasks 1-6 code). The PR push is outward-facing — confirm with the user first, then arm merge-on-green.
+
+---
+
+## Testing & conventions
+- Box-safe: Tasks 1-5 fully unit-tested, no GPU/goldenmatch import. Task 6 verified by the real corpus build; Task 7 by the real Modal run.
+- `sys.path.insert(0, os.path.dirname(__file__))` test header; add `sources/` to the path for split tests.
+- `ruff check --fix` on touched files; NEVER `ruff format`. Commit per task.
+- Leakage-free ordering (split records first, then generate/mine negatives within each split) is load-bearing — do not reorder.
+
+## Out of scope
+- 7B base model / hyperparameter sweep (epochs, lr, LoRA rank).
+- Rich Synthetic Generator (Phase 1b data diversity) — the next step.
+- New sources (MusicBrainz-20K, NCVR real-person loader).

--- a/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
+++ b/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
@@ -17,9 +17,10 @@
 | Path | Change | Responsibility |
 |---|---|---|
 | `scripts/er_matcher/sources/splits.py` | **Modify** | Add `entity_keys_from_edges` (connected-components entity keying); keep `split_of` |
-| `scripts/er_matcher/sources/leipzig.py` | **Modify** | Build gold edges, key records to entities, split on the entity key, generate negatives per-split, expose `record_pools()` |
-| `scripts/er_matcher/sources/base.py` | **Modify** | Add `record_pools()` to the source protocol/ABC |
-| `scripts/er_matcher/sources/febrl.py` | **Modify** | Expose `record_pools()` (group by `_entity_of`'s split); split logic unchanged |
+| `scripts/er_matcher/sources/leipzig.py` | **Modify** | Build gold edges, key records to entities, split on the entity key, generate negatives per-split, add concrete `record_pools()` |
+| `scripts/er_matcher/sources/febrl.py` | **Modify** | Add concrete `record_pools()` (group by `_entity_of`'s split); split logic unchanged |
+| `scripts/er_matcher/test_leipzig.py` | **Modify** | Entity-split + `record_pools` leakage tests |
+| `scripts/er_matcher/test_febrl.py` | **Modify** | `record_pools` leakage test |
 | `scripts/er_matcher/fs_enrich.py` | **Create** | Pure: `soft_confidence`, `select_hard_negatives`, `enrich` orchestration, cache key |
 | `scripts/er_matcher/build_corpus.py` | **Modify** | Build the real goldenmatch FS scorer/blocker closure; call `fs_enrich.enrich` |
 | `scripts/er_matcher/train.py` | **Modify** | Read per-row `confidence`; drop the fixed 0.9/0.1 default path |
@@ -122,7 +123,7 @@ def entity_keys_from_edges(
 
 - [ ] **Step 6: Wire entity splits into `leipzig.py`.** Replace the record-level `split_of(eid_a, ...)` with: build gold edges from `_read_gold_pairs` (the perfect-match mapping), compute `key_of = entity_keys_from_edges(all_record_ids, gold_edges)`, and assign each record's split via `split_of(key_of[record_id], seed=..., val_frac=..., test_frac=...)` (reuse the seed/fracs the loader already passes). Move negative generation to happen AFTER records are split, over each split's record pool only (per the leakage-free ordering). Keep the FEBRL loader's split logic unchanged (it already splits at entity level via `_entity_of`).
 
-- [ ] **Step 6b: Expose per-split record pools (needed by Task 6 mining).** `PairSource.splits()` yields labeled *pairs* only; hard-negative mining needs the raw per-split *record pool* (including never-paired records). Add a method to the source protocol — `record_pools(self) -> dict[str, list[dict]]` returning `{split: [record dicts]}`, where each record is assigned to the split of its entity (the same `split_of(key_of[record_id], ...)` used in Step 6, so pools are leakage-consistent with the pairs). Implement it in `sources/base.py` (protocol/ABC), `sources/leipzig.py` (group `tableA`+`tableB` records by their entity's split), and `sources/febrl.py` (group records by `_entity_of`'s split). Sources with no meaningful record pool may return `{}`.
+- [ ] **Step 6b: Expose per-split record pools (needed by Task 6 mining).** `PairSource.splits()` yields labeled *pairs* only; hard-negative mining needs the raw per-split *record pool* (including never-paired records). Add a CONCRETE method `record_pools(self) -> dict[str, list[dict]]` returning `{split: [record dicts]}` to `sources/leipzig.py` (group `tableA`+`tableB` records by their entity's split) and `sources/febrl.py` (group records by `_entity_of`'s split), each record assigned via the same `split_of(key_of[record_id], ...)` used in Step 6 so pools are leakage-consistent with the pairs. **Do NOT add it to the `PairSource` Protocol in `base.py`** — that Protocol is `runtime_checkable` and the existing `test_sources_base.py::Dummy` would fail `isinstance`. Instead, Task 6 calls it defensively via `getattr(source, "record_pools", lambda: {})()`, so only bundle/generate sources that define it get mined; magellan/ncvr are untouched.
 
 - [ ] **Step 6c: Test `record_pools` leakage-consistency.** Add a test asserting: (a) every record id in `record_pools()` appears in exactly one split, and (b) for a known gold-linked record pair, both records land in the same split as their pairs do. Run: `uv run python -m pytest scripts/er_matcher/test_leipzig.py scripts/er_matcher/test_febrl.py -k record_pool -v`. Expected: PASS.
 
@@ -365,18 +366,20 @@ def _assistant(msgs):
     return next(m["content"] for m in msgs if m["role"] == "assistant")
 
 def test_row_confidence_overrides_constant():
-    cfg = _make_cfg()                       # same TrainConfig the other tests build
-    row = {"a": _rec(), "b": _rec(), "label": "match", "confidence": 0.62}
-    msgs = example_to_messages(row, cfg)
+    cfg = tr.TrainConfig()                    # the file already builds cfg inline this way
+    row = _row(match=True)                    # existing helper -> a fully-merged row
+    row["confidence"] = 0.62
+    msgs = tr.example_to_messages(row, cfg)
     assert '"confidence":0.62' in _assistant(msgs)
 
 def test_missing_confidence_falls_back_to_constant():
-    cfg = _make_cfg()
-    row = {"a": _rec(), "b": _rec(), "label": "match"}    # no confidence
-    msgs = example_to_messages(row, cfg)
+    cfg = tr.TrainConfig()
+    row = _row(match=True)                     # _row does not set confidence
+    row.pop("confidence", None)
+    msgs = tr.example_to_messages(row, cfg)
     assert '"confidence":0.9' in _assistant(msgs)         # DEFAULT_MATCH_CONF
 ```
-(`_make_cfg`/`_rec` = the minimal `TrainConfig` + record helpers already used in `test_train_helpers.py`; reuse them, don't invent new shapes.)
+(`tr` = the `train` module alias and `_row(match: bool)` = the row helper, both already in `test_train_helpers.py`. Reuse them; do not invent `_make_cfg`/`_rec`.)
 
 - [ ] **Step 3: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_train_helpers.py -k confidence -v`. Expected: FAIL (the current code ignores `row["confidence"]`).
 
@@ -400,46 +403,50 @@ This task uses the heavy goldenmatch package, so it is verified by a real corpus
 - [ ] **Step 2: Write `_make_fs_scorer(records, domain)`** in `build_corpus.py` using the Step 1 posterior path. Heavy goldenmatch imports stay INSIDE the function (box-safety):
 
 ```python
-def _make_fs_scorer(records: list[dict], domain: str):
-    """Build (scorer, candidates_fn, tau, scorer_cfg_str) from goldenmatch's FS
-    posterior for a single split's record pool. scorer(a,b) MUST return P(match) in
-    [0,1]. Heavy imports local."""
+def _make_fs_scorer(train_records: list[dict], domain: str):
+    """Fit goldenmatch's FS posterior ONCE on the TRAIN record pool; return the scorer
+    plus the config needed to block/score any split. scorer(a,b) MUST return P(match) in
+    [0,1]. Heavy imports local (box-safety)."""
     import pyarrow as pa
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
-    from goldenmatch.core.blocker import build_blocks
     # + score_pair_probabilistic and the fields/EMResult per Step 1 discovery
 
-    table = pa.Table.from_pylist(records)
-    cfg, em = _fit_fs_posterior(table)         # auto_configure_probabilistic_df (Step 1)
+    cfg, em = _fit_fs_posterior(pa.Table.from_pylist(train_records))  # Step 1
     fields = _fields_from_config(cfg)          # runtime MatchkeyFields (Step 1)
-    tau = _threshold_from_config(cfg, em)      # FS threshold; 0.5 if absent
+    tau = _threshold_from_config(cfg, em)      # EMResult.calibrated_link_threshold; 0.5 if None
 
     def scorer(a: dict, b: dict) -> float:
         p = _score_posterior(a, b, fields, em)  # score_pair_probabilistic (Step 1)
         return min(max(float(p), 0.0), 1.0)     # guaranteed [0,1]
 
-    def candidates_fn(recs: list[dict]) -> list[dict]:
-        blocks = build_blocks(pa.Table.from_pylist(recs), cfg.blocking)
-        return _pairs_from_blocks(blocks, recs)  # within-block pairs; gold_match from labels
-
     scorer_cfg = cfg.model_dump_json()          # stable string for the cache key
-    return scorer, candidates_fn, tau, scorer_cfg
+    return scorer, tau, cfg.blocking, scorer_cfg
+
+
+def _make_candidates(records: list[dict], blocking_cfg):
+    """Block WITHIN a single split's record pool (leakage-safe) -> candidate pairs
+    tagged with gold_match from the source's gold mapping."""
+    import pyarrow as pa
+    from goldenmatch.core.blocker import build_blocks
+    blocks = build_blocks(pa.Table.from_pylist(records), blocking_cfg)
+    return _pairs_from_blocks(blocks, records)   # gold_match = not gold-linked
 ```
-(Implement `_fit_fs_posterior`, `_fields_from_config`, `_threshold_from_config`, `_score_posterior`, `_pairs_from_blocks` per Step 1 + the `BlockResult` shape at `blocker.py:266`. `_pairs_from_blocks` sets `gold_match` from the source's gold mapping — a mined pair is a non-match iff the two records are not gold-linked.)
+(Implement `_fit_fs_posterior`, `_fields_from_config`, `_threshold_from_config`, `_score_posterior`, `_pairs_from_blocks` per Step 1 + the `BlockResult` shape at `blocker.py:266`. `_pairs_from_blocks` sets `gold_match` from the source's gold mapping — a mined pair is a non-match iff the two records are not gold-linked. Fitting the EM on TRAIN only avoids refitting on held-out val/test and dodges EM degeneracy on the smaller pools.)
 
 - [ ] **Step 2b: Verify the score is in [0,1] AND separates** (spec risk: garbage-in). After building the scorer for one split, assert every score is within `[0,1]`, then score ~200 known-match and ~200 known-non-match pairs and print `mean(score|match)` vs `mean(score|non-match)`. If scores fall outside `[0,1]`, or the means don't separate, STOP and surface — the config/EM fit is wrong and soft targets built on it would be garbage (use the Step 1 fallback or fix the config before proceeding).
 
 - [ ] **Step 3: Call `fs_enrich.enrich` per split** in `build_corpus.py`, threading the cache. Get the per-split record pool from the source's new `record_pools()` (Task 1 Step 6b): `pools = source.record_pools()`. For each split, build the scorer over that split's pool and enrich that split's pairs:
 
 ```python
-pools = source.record_pools()
+pools = getattr(source, "record_pools", lambda: {})()   # {} for magellan/ncvr -> no mining
+scorer, tau, blocking_cfg, scorer_cfg = _make_fs_scorer(pools.get("train", []), source.domain)
 for split, split_pairs in blended_by_split.items():
     recs = pools.get(split, [])
-    scorer, candidates_fn, tau, scorer_cfg = _make_fs_scorer(recs, source.domain)
+    candidates_fn = (lambda r: _make_candidates(r, blocking_cfg)) if recs else (lambda r: [])
     enriched = enrich(split_pairs, records=recs, scorer=scorer,
                       candidates_fn=candidates_fn, tau=tau, delta=DELTA, mine_cap=MINE_CAP)
 ```
-Cache the enriched output under `fs_enrich.cache_key(corpus_hash=..., scorer_cfg=scorer_cfg, tau=tau, delta=DELTA)` so rebuilds skip the FS pass. Write the enriched pairs (now carrying `confidence`) to the corpus JSONL. `DELTA`/`MINE_CAP` are module constants (start `DELTA=0.1`, `MINE_CAP` ~= the count of existing synthetic hard negatives per split so mined negatives augment rather than dominate).
+Cache the enriched output under `fs_enrich.cache_key(corpus_hash=..., scorer_cfg=scorer_cfg, tau=tau, delta=DELTA)` so rebuilds skip the FS pass. Write the enriched pairs (now carrying `confidence`) to the corpus JSONL. `DELTA`/`MINE_CAP` are module constants (start `DELTA=0.1`). **To honor the spec's "reduced share of synthetic negatives":** when mining is active for a source, reduce that source's synthetic hard-negative generation (lower its `hard_frac` or count) by roughly the mined count so total negatives stay balanced rather than growing — set `MINE_CAP` and the synthetic reduction as a matched pair (both tunable knobs).
 
 - [ ] **Step 4: Guard `eval_only` sources.** Confirm the enrichment loop only runs over `bundle`/`generate` sources; `magellan`/`ncvr` stay untouched (they never enter training). Re-run `test_build_corpus.py` to confirm the eval_only contribution invariant still holds.
 

--- a/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
+++ b/docs/superpowers/plans/2026-07-28-er-matcher-honest-yardstick.md
@@ -17,7 +17,9 @@
 | Path | Change | Responsibility |
 |---|---|---|
 | `scripts/er_matcher/sources/splits.py` | **Modify** | Add `entity_keys_from_edges` (connected-components entity keying); keep `split_of` |
-| `scripts/er_matcher/sources/leipzig.py` | **Modify** | Build gold edges, key records to entities, split on the entity key, generate negatives per-split |
+| `scripts/er_matcher/sources/leipzig.py` | **Modify** | Build gold edges, key records to entities, split on the entity key, generate negatives per-split, expose `record_pools()` |
+| `scripts/er_matcher/sources/base.py` | **Modify** | Add `record_pools()` to the source protocol/ABC |
+| `scripts/er_matcher/sources/febrl.py` | **Modify** | Expose `record_pools()` (group by `_entity_of`'s split); split logic unchanged |
 | `scripts/er_matcher/fs_enrich.py` | **Create** | Pure: `soft_confidence`, `select_hard_negatives`, `enrich` orchestration, cache key |
 | `scripts/er_matcher/build_corpus.py` | **Modify** | Build the real goldenmatch FS scorer/blocker closure; call `fs_enrich.enrich` |
 | `scripts/er_matcher/train.py` | **Modify** | Read per-row `confidence`; drop the fixed 0.9/0.1 default path |
@@ -41,10 +43,10 @@
 
 - [ ] **Step 1: Read the current split logic.** Read `sources/splits.py` (the `split_of` hash) and `sources/leipzig.py:30-100` (the record-level `split_of(eid_a)` call the design flags as leaky). Confirm the gold match mapping available in `leipzig.py` (the perfect-match pairs) so you know the edge source.
 
-- [ ] **Step 2: Write the failing test** for connected-components entity keying + the anti-leakage invariant. Header: `import os, sys; sys.path.insert(0, os.path.join(os.path.dirname(__file__), "sources")); sys.path.insert(0, os.path.dirname(__file__))`.
+- [ ] **Step 2: Write the failing test** for connected-components entity keying + the anti-leakage invariant. Match the existing `test_splits.py` import style (`from sources.splits import ...`) — do NOT add a second `sources`-on-path import that double-loads the module. NOTE the real `split_of` signature is `split_of(eid, *, seed, val_frac, test_frac, holdout_domain=None, domain=None)` — `seed`/`val_frac`/`test_frac` are REQUIRED keyword-only args; pass them.
 
 ```python
-from splits import entity_keys_from_edges, split_of
+from sources.splits import entity_keys_from_edges, split_of
 
 def test_connected_components_merges_transitively():
     # A1-B1 and B1-A2 gold edges => {A1,B1,A2} are ONE entity
@@ -66,9 +68,9 @@ def test_entity_split_has_no_leakage():
     ids = [f"A{i}" for i in range(50)] + [f"B{i}" for i in range(50)]
     edges = [(f"A{i}", f"B{i}") for i in range(50)]        # 50 two-record entities
     keys = entity_keys_from_edges(ids, edges)
-    split = {rid: split_of(keys[rid]) for rid in ids}
+    sp = {rid: split_of(keys[rid], seed=1, val_frac=0.15, test_frac=0.15) for rid in ids}
     for i in range(50):                                    # both records share a split
-        assert split[f"A{i}"] == split[f"B{i}"]
+        assert sp[f"A{i}"] == sp[f"B{i}"]
 ```
 
 - [ ] **Step 3: Run the test to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_splits.py -k "connected or singletons or leakage" -v`. Expected: FAIL (`entity_keys_from_edges` undefined).
@@ -118,11 +120,15 @@ def entity_keys_from_edges(
 
 - [ ] **Step 5: Run the test to verify it passes.** Run the same command. Expected: PASS.
 
-- [ ] **Step 6: Wire entity splits into `leipzig.py`.** Replace the record-level `split_of(eid_a)` with: build gold edges from the perfect-match pairs, compute `key_of = entity_keys_from_edges(all_record_ids, gold_edges)`, and assign each record's split via `split_of(key_of[record_id])`. Move negative generation to happen AFTER records are split, over each split's record pool only (per the leakage-free ordering). Keep the FEBRL loader unchanged (it already splits at entity level).
+- [ ] **Step 6: Wire entity splits into `leipzig.py`.** Replace the record-level `split_of(eid_a, ...)` with: build gold edges from `_read_gold_pairs` (the perfect-match mapping), compute `key_of = entity_keys_from_edges(all_record_ids, gold_edges)`, and assign each record's split via `split_of(key_of[record_id], seed=..., val_frac=..., test_frac=...)` (reuse the seed/fracs the loader already passes). Move negative generation to happen AFTER records are split, over each split's record pool only (per the leakage-free ordering). Keep the FEBRL loader's split logic unchanged (it already splits at entity level via `_entity_of`).
 
-- [ ] **Step 7: Run the full sources test suite.** Run: `uv run python -m pytest scripts/er_matcher/test_splits.py scripts/er_matcher/test_leipzig.py scripts/er_matcher/test_febrl.py -q`. Expected: PASS (fix any leipzig test that assumed record-level splits — update the assertion to the entity-level behavior, do not weaken the invariant).
+- [ ] **Step 6b: Expose per-split record pools (needed by Task 6 mining).** `PairSource.splits()` yields labeled *pairs* only; hard-negative mining needs the raw per-split *record pool* (including never-paired records). Add a method to the source protocol — `record_pools(self) -> dict[str, list[dict]]` returning `{split: [record dicts]}`, where each record is assigned to the split of its entity (the same `split_of(key_of[record_id], ...)` used in Step 6, so pools are leakage-consistent with the pairs). Implement it in `sources/base.py` (protocol/ABC), `sources/leipzig.py` (group `tableA`+`tableB` records by their entity's split), and `sources/febrl.py` (group records by `_entity_of`'s split). Sources with no meaningful record pool may return `{}`.
 
-- [ ] **Step 8: Commit.** `git add scripts/er_matcher/sources/splits.py scripts/er_matcher/sources/leipzig.py scripts/er_matcher/test_splits.py && git commit -m "feat(er-matcher): entity-level splits (connected components, no leakage)"`
+- [ ] **Step 6c: Test `record_pools` leakage-consistency.** Add a test asserting: (a) every record id in `record_pools()` appears in exactly one split, and (b) for a known gold-linked record pair, both records land in the same split as their pairs do. Run: `uv run python -m pytest scripts/er_matcher/test_leipzig.py scripts/er_matcher/test_febrl.py -k record_pool -v`. Expected: PASS.
+
+- [ ] **Step 7: Run the full sources test suite.** Run: `uv run python -m pytest scripts/er_matcher/test_splits.py scripts/er_matcher/test_leipzig.py scripts/er_matcher/test_febrl.py scripts/er_matcher/test_sources_base.py -q`. Expected: PASS (fix any leipzig test that assumed record-level splits — update the assertion to the entity-level behavior, do not weaken the invariant).
+
+- [ ] **Step 8: Commit.** `git add scripts/er_matcher/sources/ scripts/er_matcher/test_splits.py scripts/er_matcher/test_leipzig.py scripts/er_matcher/test_febrl.py && git commit -m "feat(er-matcher): entity-level splits + per-split record pools (no leakage)"`
 
 ---
 
@@ -350,27 +356,31 @@ def enrich(
 - Modify: `scripts/er_matcher/train.py`
 - Test: `scripts/er_matcher/test_train_helpers.py`
 
-- [ ] **Step 1: Read** `train.py` around the `render_target`/`DEFAULT_MATCH_CONF`/`DEFAULT_NOMATCH_CONF` usage (the fixed 0.9/0.1 path) and the function that turns a corpus row into an SFT example.
+- [ ] **Step 1: Read** `train.py` — the real helper is `example_to_messages(row: dict, cfg: TrainConfig) -> list[dict[str, str]]`, returning a 3-message chat list (`system`/`user`/`assistant`) where the **assistant** message's `content` holds the `render_target(...)` JSON. Confirm `DEFAULT_MATCH_CONF` (0.9) / `DEFAULT_NOMATCH_CONF` (0.1) and how `example_to_messages` currently chooses the confidence. Read `test_train_helpers.py`'s existing import header + how it builds a `TrainConfig` and a minimal row, and mirror that.
 
-- [ ] **Step 2: Write the failing test** asserting the per-row confidence is used when present, falling back to the constant only when absent.
+- [ ] **Step 2: Write the failing test** asserting the per-row confidence is used when present, falling back to the constant only when absent. Extract the assistant message content and assert on the compact JSON (`render_target` uses `separators=(",", ":")`, so it's `"confidence":0.62` with no space).
 
 ```python
-# in test_train_helpers.py, matching its existing import header
+def _assistant(msgs):
+    return next(m["content"] for m in msgs if m["role"] == "assistant")
+
 def test_row_confidence_overrides_constant():
-    row = {"a": {...}, "b": {...}, "label": "match", "confidence": 0.62}
-    ex = build_sft_example(row)            # the existing row->example helper
-    assert '"confidence":0.62' in ex["target"]   # compact JSON, per render_target
+    cfg = _make_cfg()                       # same TrainConfig the other tests build
+    row = {"a": _rec(), "b": _rec(), "label": "match", "confidence": 0.62}
+    msgs = example_to_messages(row, cfg)
+    assert '"confidence":0.62' in _assistant(msgs)
 
 def test_missing_confidence_falls_back_to_constant():
-    row = {"a": {...}, "b": {...}, "label": "match"}   # no confidence
-    ex = build_sft_example(row)
-    assert '"confidence":0.9' in ex["target"]     # DEFAULT_MATCH_CONF
+    cfg = _make_cfg()
+    row = {"a": _rec(), "b": _rec(), "label": "match"}    # no confidence
+    msgs = example_to_messages(row, cfg)
+    assert '"confidence":0.9' in _assistant(msgs)         # DEFAULT_MATCH_CONF
 ```
-(Adapt `build_sft_example`/field names to the actual helper in `train.py`; fill the `{...}` records with a minimal valid pair.)
+(`_make_cfg`/`_rec` = the minimal `TrainConfig` + record helpers already used in `test_train_helpers.py`; reuse them, don't invent new shapes.)
 
-- [ ] **Step 3: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_train_helpers.py -k confidence -v`. Expected: FAIL.
+- [ ] **Step 3: Run to verify it fails.** Run: `uv run python -m pytest scripts/er_matcher/test_train_helpers.py -k confidence -v`. Expected: FAIL (the current code ignores `row["confidence"]`).
 
-- [ ] **Step 4: Implement.** In the row->example helper, use `row.get("confidence", DEFAULT_MATCH_CONF if match else DEFAULT_NOMATCH_CONF)` as the confidence passed to `render_target`. Keep the constants as the fallback only.
+- [ ] **Step 4: Implement.** In `example_to_messages`, use `row.get("confidence", DEFAULT_MATCH_CONF if match else DEFAULT_NOMATCH_CONF)` as the confidence passed to `render_target`. Keep the constants as the fallback only.
 
 - [ ] **Step 5: Run to verify it passes**, then the train-helper suite: `uv run python -m pytest scripts/er_matcher/test_train_helpers.py -q`. Expected: PASS.
 
@@ -385,41 +395,51 @@ def test_missing_confidence_falls_back_to_constant():
 
 This task uses the heavy goldenmatch package, so it is verified by a real corpus build, not a box test. Keep the goldenmatch imports INSIDE the scorer-builder function (not at module top level) so the box suite stays clean.
 
-- [ ] **Step 1: Discovery — resolve the MatchkeyConfig -> MatchkeyField bridge.** `score_pair(a, b, fields: list[MatchkeyField])` (`goldenmatch/core/scorer.py:536`) wants runtime `MatchkeyField`s, but `auto_configure_df` returns a `GoldenMatchConfig` whose `.matchkeys` are `MatchkeyConfig` (schema). Grep for where the pipeline compiles config matchkeys into `MatchkeyField` (try: `grep -rn "MatchkeyField(" packages/python/goldenmatch/goldenmatch/core/ | head` and look in `scorer.py`/`pipeline.py` for a `build_fields`/`compile`/`to_field` helper). Record the exact call. If none exists as a public helper, construct `MatchkeyField` from each `MatchkeyConfig` following the pattern the pipeline uses.
+- [ ] **Step 1: Discovery — choose the scorer entry point (must return a P(match) in [0,1]).** The soft-confidence and band-selection math (Tasks 2-3) assume `score in [0,1]` centered on `tau`. `auto_configure_df` + `score_pair` (`scorer.py:536`) gives the *weighted heuristic* aggregator, whose output is NOT guaranteed to be a `[0,1]` probability — so **prefer the genuine FS posterior path**: `auto_configure_probabilistic_df` (`autoconfig.py:5220`) to fit an `EMResult`, then `score_pair_probabilistic` (`probabilistic.py:3925`), which returns the Fellegi-Sunter posterior P(match) in `[0,1]`. This also matches the design's "dogfood goldenmatch's own FS pipeline" framing. Discovery to record: (a) the exact args `auto_configure_probabilistic_df` needs and what it returns (config + `EMResult`?), (b) the exact signature of `score_pair_probabilistic` (does it take the `EMResult` + fields, or a bound scorer?), (c) how to get the runtime fields it wants from the returned config (grep `grep -rn "MatchkeyField(" packages/python/goldenmatch/goldenmatch/core/` and check `probabilistic.py`/`pipeline.py` for a compile/build-fields helper), (d) the FS decision threshold `tau` (from the config/EMResult; default 0.5 if absent). **Fallback:** if EM degenerates on a split's pool (see `feedback_fs_measure_degenerate_em_harness` — EM can degenerate on small/tiny data), fall back to the weighted `score_pair` normalized into `[0,1]` (e.g. min-max over the split's scored pairs) and log that the split used the fallback.
 
-- [ ] **Step 2: Write `_make_fs_scorer(records, domain)`** in `build_corpus.py`:
+- [ ] **Step 2: Write `_make_fs_scorer(records, domain)`** in `build_corpus.py` using the Step 1 posterior path. Heavy goldenmatch imports stay INSIDE the function (box-safety):
 
 ```python
 def _make_fs_scorer(records: list[dict], domain: str):
-    """Build (scorer, candidates_fn, scorer_cfg_str) from goldenmatch's FS pipeline for
-    a single split's record pool. Heavy imports stay local (box-safety)."""
+    """Build (scorer, candidates_fn, tau, scorer_cfg_str) from goldenmatch's FS
+    posterior for a single split's record pool. scorer(a,b) MUST return P(match) in
+    [0,1]. Heavy imports local."""
     import pyarrow as pa
-    from goldenmatch.core.autoconfig import auto_configure_df
-    from goldenmatch.core.scorer import score_pair
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
     from goldenmatch.core.blocker import build_blocks
-    # <MatchkeyConfig -> MatchkeyField> per Step 1 discovery
+    # + score_pair_probabilistic and the fields/EMResult per Step 1 discovery
 
     table = pa.Table.from_pylist(records)
-    cfg = auto_configure_df(table, confidence_required=False)   # tolerate a RED config here
-    fields = _fields_from_config(cfg)          # from Step 1
-    tau = _threshold_from_config(cfg)          # the FS decision threshold; default 0.5 if absent
+    cfg, em = _fit_fs_posterior(table)         # auto_configure_probabilistic_df (Step 1)
+    fields = _fields_from_config(cfg)          # runtime MatchkeyFields (Step 1)
+    tau = _threshold_from_config(cfg, em)      # FS threshold; 0.5 if absent
 
     def scorer(a: dict, b: dict) -> float:
-        return score_pair(a, b, fields)
+        p = _score_posterior(a, b, fields, em)  # score_pair_probabilistic (Step 1)
+        return min(max(float(p), 0.0), 1.0)     # guaranteed [0,1]
 
     def candidates_fn(recs: list[dict]) -> list[dict]:
         blocks = build_blocks(pa.Table.from_pylist(recs), cfg.blocking)
-        # expand each block into within-block pairs, tag gold_match from the known labels
-        return _pairs_from_blocks(blocks, recs)
+        return _pairs_from_blocks(blocks, recs)  # within-block pairs; gold_match from labels
 
-    scorer_cfg = cfg.model_dump_json()         # stable string for the cache key
+    scorer_cfg = cfg.model_dump_json()          # stable string for the cache key
     return scorer, candidates_fn, tau, scorer_cfg
 ```
-(Implement `_fields_from_config`, `_threshold_from_config`, `_pairs_from_blocks` per the Step 1 discovery + the `BlockResult` shape at `blocker.py:266`. `_pairs_from_blocks` sets `gold_match` from the source's gold mapping — a mined pair is a non-match iff the two records are not gold-linked.)
+(Implement `_fit_fs_posterior`, `_fields_from_config`, `_threshold_from_config`, `_score_posterior`, `_pairs_from_blocks` per Step 1 + the `BlockResult` shape at `blocker.py:266`. `_pairs_from_blocks` sets `gold_match` from the source's gold mapping — a mined pair is a non-match iff the two records are not gold-linked.)
 
-- [ ] **Step 2b: Verify the FS score distribution before trusting it** (spec risk: garbage-in). After building the scorer for one split, score ~200 known match and ~200 known non-match pairs and print `mean(score|match)` vs `mean(score|non-match)`. If they do not separate, STOP and surface — the matchkey config is wrong, and soft targets built on it would be garbage.
+- [ ] **Step 2b: Verify the score is in [0,1] AND separates** (spec risk: garbage-in). After building the scorer for one split, assert every score is within `[0,1]`, then score ~200 known-match and ~200 known-non-match pairs and print `mean(score|match)` vs `mean(score|non-match)`. If scores fall outside `[0,1]`, or the means don't separate, STOP and surface — the config/EM fit is wrong and soft targets built on it would be garbage (use the Step 1 fallback or fix the config before proceeding).
 
-- [ ] **Step 3: Call `fs_enrich.enrich` per split** in `build_corpus.py`, threading the cache. For each split's blended pairs + record pool: `enrich(pairs, records=split_records, scorer=scorer, candidates_fn=candidates_fn, tau=tau, delta=<cfg>, mine_cap=<cfg>)`. Cache the enriched output under `fs_enrich.cache_key(corpus_hash=..., scorer_cfg=scorer_cfg, tau=tau, delta=delta)` so rebuilds skip the FS pass. Write the enriched pairs (now carrying `confidence`) to the corpus JSONL.
+- [ ] **Step 3: Call `fs_enrich.enrich` per split** in `build_corpus.py`, threading the cache. Get the per-split record pool from the source's new `record_pools()` (Task 1 Step 6b): `pools = source.record_pools()`. For each split, build the scorer over that split's pool and enrich that split's pairs:
+
+```python
+pools = source.record_pools()
+for split, split_pairs in blended_by_split.items():
+    recs = pools.get(split, [])
+    scorer, candidates_fn, tau, scorer_cfg = _make_fs_scorer(recs, source.domain)
+    enriched = enrich(split_pairs, records=recs, scorer=scorer,
+                      candidates_fn=candidates_fn, tau=tau, delta=DELTA, mine_cap=MINE_CAP)
+```
+Cache the enriched output under `fs_enrich.cache_key(corpus_hash=..., scorer_cfg=scorer_cfg, tau=tau, delta=DELTA)` so rebuilds skip the FS pass. Write the enriched pairs (now carrying `confidence`) to the corpus JSONL. `DELTA`/`MINE_CAP` are module constants (start `DELTA=0.1`, `MINE_CAP` ~= the count of existing synthetic hard negatives per split so mined negatives augment rather than dominate).
 
 - [ ] **Step 4: Guard `eval_only` sources.** Confirm the enrichment loop only runs over `bundle`/`generate` sources; `magellan`/`ncvr` stay untouched (they never enter training). Re-run `test_build_corpus.py` to confirm the eval_only contribution invariant still holds.
 

--- a/docs/superpowers/specs/2026-07-28-er-matcher-honest-yardstick-design.md
+++ b/docs/superpowers/specs/2026-07-28-er-matcher-honest-yardstick-design.md
@@ -28,6 +28,8 @@ This is deliberately a data + measurement step. Model scaling (7B), hyperparamet
 
 New module **`scripts/er_matcher/fs_enrich.py`**, one focused unit. Its decision logic is pure and box-testable; the heavy goldenmatch FS matcher is **injected** as a `scorer(a, b) -> float` (match probability) callable so the box suite never imports it. `build_corpus.py` wires the real goldenmatch scorer; unit tests wire a stub.
 
+**Building the injected scorer/blocker (confirmed API, plan-level detail).** goldenmatch's real entry points are not zero-arg: `goldenmatch.core.scorer.score_pair(a, b, fields: list[MatchkeyField]) -> float` needs per-field weights/scorers, and `goldenmatch.core.blocker.build_blocks(lf: LazyFrame, config: BlockingConfig)` needs a Polars frame + blocking config. So `build_corpus.py` builds a **closure** that first resolves a matchkey + blocking config for each source — most likely via `auto_configure` keyed off the per-source `domain` field in `sources.yaml` — then adapts `score_pair`/`build_blocks` to the `scorer(a, b) -> float` and `candidates(records) -> pairs` interfaces `fs_enrich` consumes. The plan pins the exact config-resolution entry point; `fs_enrich` itself stays agnostic to how the scorer was built.
+
 ### Data flow
 
 ```
@@ -60,7 +62,7 @@ So a match the matcher was sure of -> ~0.95; a match it nearly missed -> ~0.6. T
 
 ### Core 2 — entity-level splits
 
-Derive a stable **entity key** per record from each benchmark's gold match mapping: records connected by a gold match edge form one entity (connected components over the match graph). Split on the entity key so every record of an entity lands in exactly one split. FEBRL already carries an entity id (the corruption anchor); this mainly changes `sources/leipzig.py` and `sources/splits.py`. The Leipzig gold mapping is bipartite (tableA<->tableB); connected components still yield correct transitive clusters.
+Derive a stable **entity key** per record from each benchmark's gold match mapping: records connected by a gold match edge form one entity (connected components over the match graph). Split on the entity key so every record of an entity lands in exactly one split. The connected-components entity-keying helper lives in **`sources/splits.py`** (shared, mirroring how `split_of` is already shared there) and is consumed by `sources/leipzig.py`. FEBRL already splits at entity level (`_entity_of` from `rec_id`, `split_of` called once per entity), so it is unchanged. The Leipzig gold mapping is bipartite (tableA<->tableB); connected components still yield correct transitive clusters.
 
 ### Core 3 — hard-negative mining
 

--- a/docs/superpowers/specs/2026-07-28-er-matcher-honest-yardstick-design.md
+++ b/docs/superpowers/specs/2026-07-28-er-matcher-honest-yardstick-design.md
@@ -1,0 +1,106 @@
+# ER-Matcher "Honest Yardstick" — Design (SP3.5)
+
+**Status:** approved design, pre-plan.
+**Worktree/branch:** `D:/ER/gm-yardstick` on `feat/er-matcher-honest-yardstick` (off `main` after SP3 / PR #2222 merged).
+
+## Problem
+
+SP2's headline in-distribution F1 (0.983) is inflated and cannot be trusted as a training signal:
+
+1. **Easy negatives.** Non-match pairs come from `sources/negatives.py::synth_negatives`: "hard" = two different entities sharing the lowercased **first whitespace token** of a block field, "easy" = random cross-block, `hard_frac=0.5`. These are deterministic synthetic near-misses, not calibrated hard negatives. The SP3 design already flags the resulting F1 as "almost certainly inflated."
+2. **Split leakage.** Leipzig sources split at **record/pair** level, not entity level (`sources/leipzig.py:30-40`), so the same real-world entity can appear in both train and test.
+3. **Broken calibration at the source.** Training uses **fixed** confidence targets (0.9 match / 0.1 no_match, `config.yaml:56-57`), which produced raw ECE ~0.46 — patched post-hoc by SP3 temperature scaling rather than fixed in training.
+
+The honest held-out numbers are SP3's zero-shot suite: Walmart-Amazon F1 0.640, Beer 0.897.
+
+## Goal
+
+Make the training signal and the metric honest, and confirm it with a retrain, before investing in the larger Phase 1b data-diversity build. Three coupled changes plus one retrain:
+
+1. **Entity-level splits** — kill the leakage.
+2. **FS-mined hard negatives** — mine near-threshold non-matches from goldenmatch's own Fellegi-Sunter (FS) pipeline (dogfooding).
+3. **FS-score-driven soft confidence targets** — replace fixed 0.9/0.1 with difficulty-aware targets derived from the same FS score, fixing calibration at the source.
+4. **Retrain + re-measure** on the frozen SP2 config (Qwen2.5-3B-Instruct, bf16 LoRA, 2 epochs) and report against the SP3 zero-shot suite + ECE.
+
+This is deliberately a data + measurement step. Model scaling (7B), hyperparameter sweeps, and the Rich Synthetic Generator (Phase 1b) are explicitly out of scope and follow later.
+
+## Architecture (Approach A: unified post-blend FS-enrichment stage, with caching)
+
+New module **`scripts/er_matcher/fs_enrich.py`**, one focused unit. Its decision logic is pure and box-testable; the heavy goldenmatch FS matcher is **injected** as a `scorer(a, b) -> float` (match probability) callable so the box suite never imports it. `build_corpus.py` wires the real goldenmatch scorer; unit tests wire a stub.
+
+### Data flow
+
+```
+sources.yaml -> loaders (febrl/leipzig) -> blended labeled pairs
+      |                                          |
+      |  records_by_source                       |  existing match / non-match pairs
+      v                                          v
+  fs_enrich.enrich(records, pairs, scorer, cfg):
+     1. soft targets : every pair -> confidence = f(FS score)          [calibration half]
+     2. mine hard neg: block record pool -> FS-score candidates ->
+                       keep near-threshold GROUND-TRUTH non-matches -> cap  [quality half]
+      v
+  entity-level split (fixed) -> corpus JSONL  (now carries per-row `confidence`)
+      v
+  train.py reads per-row confidence (no more constant 0.9/0.1) -> retrain
+      v
+  measure: in-distribution F1 + SP3 zero-shot suite + raw/calibrated ECE
+```
+
+Enrichment output is **cached**, keyed on a hash of (corpus content + scorer config), so rebuilds don't re-run the FS pass. Caching sits under Approach A as an optimization, not a separate source.
+
+### Core 1 — FS score -> soft confidence
+
+A monotonic map from the matcher's match-probability `s` to a target confidence, compressed toward 0.5 near the FS decision threshold `tau`, never 0/1:
+
+- **match** pair: `conf = clamp(0.5 + 0.45 * (s - tau) / (1 - tau), 0.55, 0.97)`
+- **non-match** pair: symmetric toward the low end, `conf in [0.03, 0.45]`.
+
+So a match the matcher was sure of -> ~0.95; a match it nearly missed -> ~0.6. The exact curve/clamps are finalized in the plan; the invariant under test is: **monotonic in `s`, compressed near `tau`, never 0 or 1.** `conf` is the target used to render the SFT verdict (`render_target`), replacing the fixed 0.9/0.1.
+
+### Core 2 — entity-level splits
+
+Derive a stable **entity key** per record from each benchmark's gold match mapping: records connected by a gold match edge form one entity (connected components over the match graph). Split on the entity key so every record of an entity lands in exactly one split. FEBRL already carries an entity id (the corruption anchor); this mainly changes `sources/leipzig.py` and `sources/splits.py`. The Leipzig gold mapping is bipartite (tableA<->tableB); connected components still yield correct transitive clusters.
+
+### Core 3 — hard-negative mining
+
+1. Block the record pool (reuse goldenmatch's candidate generation — proper dogfooding).
+2. FS-score the candidates.
+3. Keep pairs whose score is in a near-threshold band `[tau - delta, tau + delta]` **and** whose ground-truth label is **non-match** (label comes from the gold benchmark mapping, not from FS).
+4. Cap the mined count; blend alongside a reduced share of the old synthetic hard negatives (augment, not full replace — preserves a difficulty curriculum).
+
+Band width `delta`, cap, and mined/synthetic ratio are plan-level knobs.
+
+**FS is a hard-example selector, not the labeler.** It only chooses *which* ground-truth non-matches are hard; the label is always the gold benchmark label. This avoids training the LLM to merely mimic the FS decision boundary.
+
+## Testing
+
+Same box/GPU boundary as SP2/SP3.
+
+- **Box-safe unit tests** (injected fake scorer, no GPU, no goldenmatch import):
+  - `fs_enrich` soft-target map: monotonic in `s`, compressed near `tau`, clamped, never 0/1.
+  - `fs_enrich` mining: near-threshold band selection; ground-truth-label filter keeps only true non-matches; cap + mined/synthetic balance; cache-key stability.
+  - splits: connected-components entity keying correct + deterministic; **anti-leakage invariant as its own explicit test** (no entity id appears in two splits).
+  - `train.py`: reads per-row `confidence`, no constant.
+- **Retrain** validated by the real Modal run (GPU), not box-tested.
+
+## Measurement / success criteria
+
+- **In-distribution F1 should drop from 0.983** — that is the win; it means the metric stopped lying. No target number; the point is trustworthiness.
+- **SP3 zero-shot suite (Walmart-Amazon, Beer) should hold or improve** — harder negatives should sharpen real-world discrimination. This is the true, held-out quality signal.
+- **Raw ECE should improve sharply** (soft targets fix the source of the 0.46), ideally enough that post-hoc temperature scaling is unnecessary.
+- **Run watch-items:** mined negatives really are near-threshold (mean band score); the leakage invariant holds; the soft-target distribution is not collapsed.
+
+## Risks / mitigations
+
+- *"Are we just teaching the LLM to mimic the FS scorer?"* No — FS selects hard examples; the label stays the gold benchmark label.
+- *FS score miscalibration (garbage-in)* — sanity-check the score distribution before wiring; the `tau`-relative mapping tolerates absolute miscalibration.
+- *Mining candidate blowup* — cap candidates, bound the band, cache.
+- *Held-out integrity* — Walmart-Amazon/Beer stay `eval_only`; they never enter mining or training.
+- *Two variables move at once (data + soft targets)* — accepted: they move largely different metrics (data -> F1/generalization, soft targets -> ECE), and SP3 reports F1 and ECE separately, so each remains mostly attributable.
+
+## Out of scope (later tracks)
+
+- 7B base model / hyperparameter sweep (epochs, lr, LoRA rank).
+- Rich Synthetic Generator (Phase 1b data diversity) — the next step after this.
+- New sources (MusicBrainz-20K, NCVR real-person loader).

--- a/scripts/er_matcher/build_corpus.py
+++ b/scripts/er_matcher/build_corpus.py
@@ -147,6 +147,7 @@ def _fs_enrich_source(
             tau=tau,
             delta=delta,
             mine_cap=mine_cap,
+            domain=entry.domain,
         )
         mined = sum(1 for r in enriched if r.get("negative_kind") == "fs_mined")
         result[split] = _rebalance_negatives(enriched, mined)

--- a/scripts/er_matcher/build_corpus.py
+++ b/scripts/er_matcher/build_corpus.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import warnings
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +38,17 @@ _SPLITS = ("train", "val", "test")
 # somehow False, since their data is either cite-only/eval-only by design
 # or not locally materialized.
 _ROW_MECHANISMS = {"bundle", "generate"}
+
+# ── FS enrichment tunables (Task 6) ────────────────────────────────────────
+# The near-threshold hard-negative mining band half-width and per-split mining
+# cap threaded into `fs_enrich.enrich`. `DELTA` starts at 0.1 per the plan.
+DELTA = 0.1
+MINE_CAP = 200
+# A posterior scorer must beat the non-match mean by at least this margin on the
+# train split's labeled sample, else we fall back to the weighted scorer.
+_SEPARATION_MARGIN = 0.1
+# How many match / non-match pairs to draw for the separation self-check.
+_SEPARATION_SAMPLE = 200
 
 
 def _cap_preserving_balance(rows: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
@@ -59,8 +72,506 @@ def _cap_preserving_balance(rows: list[dict[str, Any]], cap: int) -> list[dict[s
     return interleaved[:cap]
 
 
+# ── Real goldenmatch FS scorer + blocker (Task 6) ──────────────────────────
+# Every function that imports goldenmatch keeps that import LOCAL so the pure
+# box suite (which never enables `--fs-enrich`) stays free of the heavy package.
+
+
+def _records_to_frame(records: list[dict], *, with_row_id: bool = True) -> Any:
+    """Build a polars DataFrame from a split's raw record pool. With
+    ``with_row_id`` (the EM/blocker path) it carries the stable ``__row_id__``
+    Int64 key goldenmatch's trainer + blocker expect (`pipeline._add_row_ids`
+    uses the same key). Auto-config PROFILES columns and adds its own row id, so
+    the profiling calls pass ``with_row_id=False`` -- else `auto_configure_df`'s
+    controller trips a duplicate-``__row_id__`` error."""
+    import polars as pl
+
+    cols = sorted({k for r in records for k in r})
+    data: dict[str, list] = {c: [r.get(c) for r in records] for c in cols}
+    df = pl.DataFrame(data)
+    if with_row_id:
+        df = df.with_columns(
+            pl.Series("__row_id__", list(range(len(records))), dtype=pl.Int64)
+        )
+    return df
+
+
+def _fields_from_config(mk: Any) -> list:
+    """The MatchkeyConfig -> runtime MatchkeyField bridge the weighted
+    ``score_pair`` wants. `MatchkeyConfig.fields` is ALREADY a
+    ``list[MatchkeyField]`` (see `config/schemas.py`; `match_one`/`db.sync` call
+    ``score_pair(a, b, mk.fields)`` directly), so the bridge is just the attr."""
+    return list(getattr(mk, "fields", []) or [])
+
+
+def _fit_fs_posterior(records: list[dict]) -> tuple[Any, Any, Any]:
+    """Fit the genuine Fellegi-Sunter POSTERIOR path on `records`:
+    `auto_configure_probabilistic_df` builds the probabilistic matchkey +
+    blocking; `train_em` fits the m/u weights. Returns ``(mk, em_result,
+    blocking)``. `score_pair_probabilistic(a, b, mk, em)` then yields P(match)
+    in [0,1] (a sigmoid posterior under the default 'posterior' calibration)."""
+    import os
+
+    os.environ.setdefault("GOLDENMATCH_FS_CALIBRATED", "posterior")
+
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms
+    from goldenmatch.core.probabilistic import train_em
+
+    config = auto_configure_probabilistic_df(_records_to_frame(records, with_row_id=False))
+    mk = config.matchkeys[0]
+    score_frame = precompute_matchkey_transforms(_records_to_frame(records), config.matchkeys)
+    # build_blocks' static primary builder consumes the ORIGINAL entry object and
+    # calls `.collect()` on it, so hand it a LazyFrame (not the eager frame the EM
+    # trainer wants).
+    blocks = build_blocks(score_frame.lazy(), config.blocking)
+    em = train_em(
+        score_frame,
+        mk,
+        blocks=blocks,
+        blocking_fields=collect_blocking_fields(config.blocking),
+    )
+    return mk, em, config.blocking
+
+
+def _threshold_from_config(mk: Any, em: Any) -> float:
+    """The FS decision threshold `tau` = the resolved link cutoff (which prefers
+    `EMResult.calibrated_link_threshold`); default 0.5 when unavailable."""
+    try:
+        from goldenmatch.core.probabilistic import resolve_thresholds
+
+        link, _review = resolve_thresholds(mk, em)
+        return 0.5 if link is None else float(link)
+    except Exception:
+        return 0.5
+
+
+def _score_posterior(mk: Any, em: Any) -> Callable[[dict, dict], float]:
+    """Wrap `score_pair_probabilistic` into a `scorer(a, b) -> float` clamped to
+    [0,1]. It applies each field's transforms internally (`comparison_vector`),
+    so it scores raw record dicts directly -- no precompute needed at score time."""
+    from goldenmatch.core.probabilistic import score_pair_probabilistic
+
+    def scorer(a: dict, b: dict) -> float:
+        s = float(score_pair_probabilistic(a, b, mk, em))
+        return min(1.0, max(0.0, s))
+
+    return scorer
+
+
+def _fit_weighted(records: list[dict]) -> tuple[Any, Any]:
+    """Weighted/iterative fallback config (`auto_configure_df`) -- the aggregator
+    whose `score_pair` output is NOT a [0,1] posterior (normalized separately).
+
+    `auto_configure_df` emits a MIX of exact + weighted matchkeys; `score_pair`
+    only works on a WEIGHTED (fuzzy-scorer) matchkey (an exact matchkey's fields
+    have `scorer=None` and raise on `.fuzzy_scorer`), so pick the first weighted
+    one, falling back to `matchkeys[0]` only if none exists."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    config = auto_configure_df(_records_to_frame(records, with_row_id=False))
+    weighted = [mk for mk in config.matchkeys if getattr(mk, "type", None) == "weighted"]
+    mk = weighted[0] if weighted else config.matchkeys[0]
+    return mk, config.blocking
+
+
+def _score_weighted(
+    mk: Any, sample_pairs: list[tuple[dict, dict, bool]]
+) -> Callable[[dict, dict], float]:
+    """Min-max-normalize the weighted `score_pair` aggregate into [0,1] using the
+    train sample's observed score range, then clamp (val/test can exceed the
+    train range). Falls back to a constant 0.5 when the range is degenerate."""
+    from goldenmatch.core.scorer import score_pair
+
+    fields = _fields_from_config(mk)
+    raw = [score_pair(a, b, fields) for a, b, _m in sample_pairs]
+    lo = min(raw) if raw else 0.0
+    hi = max(raw) if raw else 1.0
+    span = hi - lo
+
+    def scorer(a: dict, b: dict) -> float:
+        s = score_pair(a, b, fields)
+        norm = (s - lo) / span if span > 0 else 0.5
+        return min(1.0, max(0.0, norm))
+
+    return scorer
+
+
+def _scorer_cfg_signature(mk: Any, blocking: Any, mode: str) -> str:
+    """Stable digest input describing the fitted scorer, fed to
+    `fs_enrich.cache_key` so a rebuild with an unchanged config skips the FS
+    pass. Captures the calibration mode, matchkey name, scored fields, and
+    blocking fields (the levers that change scores)."""
+    try:
+        from goldenmatch.core.blocker import collect_blocking_fields
+
+        blk = sorted(collect_blocking_fields(blocking)) if blocking is not None else []
+    except Exception:
+        blk = []
+    fields = [getattr(f, "field", None) for f in getattr(mk, "fields", []) or []]
+    return json.dumps(
+        {
+            "mode": mode,
+            "matchkey": getattr(mk, "name", None),
+            "fields": fields,
+            "blocking": blk,
+        },
+        sort_keys=True,
+    )
+
+
+def _sample_labeled_pairs(
+    pairs: list[dict], k: int = _SEPARATION_SAMPLE
+) -> list[tuple[dict, dict, bool]]:
+    """Draw up to `k` match and `k` non-match labeled pairs (deterministic) for
+    the separation self-check. Returns ``(a, b, is_match)`` tuples."""
+    import random
+
+    rng = random.Random(0)
+    matches = [p for p in pairs if p.get("label") == "match"]
+    non = [p for p in pairs if p.get("label") != "match"]
+
+    def take(lst: list[dict]) -> list[dict]:
+        return list(lst) if len(lst) <= k else rng.sample(lst, k)
+
+    sel = take(matches) + take(non)
+    return [(p["a"], p["b"], p.get("label") == "match") for p in sel]
+
+
+def _check_separation(
+    scorer: Callable[[dict, dict], float], sample: list[tuple[dict, dict, bool]]
+) -> tuple[bool, float, float, bool]:
+    """Score the labeled sample once and report ``(ok, mean_match,
+    mean_nonmatch, all_in_range)``. `ok` requires every score in [0,1] AND
+    mean(match) to beat mean(non-match) by `_SEPARATION_MARGIN`."""
+    scored = [(scorer(a, b), is_m) for a, b, is_m in sample]
+    in_range = all(0.0 <= s <= 1.0 for s, _ in scored)
+    m = [s for s, is_m in scored if is_m]
+    n = [s for s, is_m in scored if not is_m]
+    mean_m = sum(m) / len(m) if m else 0.0
+    mean_n = sum(n) / len(n) if n else 0.0
+    ok = in_range and bool(m) and bool(n) and mean_m > mean_n + _SEPARATION_MARGIN
+    return ok, mean_m, mean_n, in_range
+
+
+def _make_fs_scorer(
+    train_records: list[dict],
+    domain: str,
+    *,
+    sample_pairs: list[tuple[dict, dict, bool]] | None = None,
+) -> tuple[Callable[[dict, dict], float], float, Any, str]:
+    """Fit ONCE on the TRAIN pool; return ``(scorer, tau, blocking_cfg,
+    scorer_cfg)``. Prefers the genuine FS posterior; if EM degenerates (the
+    posterior fails to separate the labeled sample, or the fit raises -- EM can
+    degenerate on tiny pools) it falls back to the weighted `score_pair`
+    min-max-normalized into [0,1], logging which path each split used. `scorer`
+    always clamps to [0,1]."""
+    if not train_records:
+        raise ValueError("FS scorer needs a non-empty train record pool")
+
+    # The probabilistic blocking (built without EM) is derived-column-free by
+    # design (auto_configure_probabilistic_df adds NO standardization), so it's
+    # the safe blocking to mine candidates with even when the SCORER falls back
+    # to weighted -- the weighted config's blocking can key on standardized
+    # columns (e.g. `__brand__`) the raw record pool doesn't carry.
+    posterior_blocking = None
+    try:
+        mk, em, posterior_blocking = _fit_fs_posterior(train_records)
+        scorer = _score_posterior(mk, em)
+        tau = _threshold_from_config(mk, em)
+        if not sample_pairs:
+            return scorer, tau, posterior_blocking, _scorer_cfg_signature(
+                mk, posterior_blocking, "posterior"
+            )
+        ok, mean_m, mean_n, in_range = _check_separation(scorer, sample_pairs)
+        if ok:
+            return scorer, tau, posterior_blocking, _scorer_cfg_signature(
+                mk, posterior_blocking, "posterior"
+            )
+        print(
+            f"[fs-enrich] posterior did not separate for domain={domain!r} "
+            f"(mean_match={mean_m:.3f} mean_nonmatch={mean_n:.3f} "
+            f"in_range={in_range}); falling back to weighted",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # EM degeneration / no matchkeys / etc.
+        print(
+            f"[fs-enrich] posterior fit failed for domain={domain!r}: {exc!r}; "
+            f"falling back to weighted",
+            file=sys.stderr,
+        )
+
+    wmk, wblocking = _fit_weighted(train_records)
+    scorer = _score_weighted(wmk, sample_pairs or [])
+    mining_blocking = posterior_blocking if posterior_blocking is not None else wblocking
+    return scorer, 0.5, mining_blocking, _scorer_cfg_signature(
+        wmk, mining_blocking, "weighted"
+    )
+
+
+def _record_signature(rec: dict) -> tuple:
+    """Hashable identity of a record from its field VALUES (record pools strip
+    the source id, so values are the only stable cross-reference between a
+    split's match rows and its record pool)."""
+    return tuple(sorted((str(k), str(v)) for k, v in rec.items()))
+
+
+def _gold_components(pairs: list[dict]) -> Callable[[dict, dict], bool]:
+    """Build a `gold_linked(rec_a, rec_b)` predicate from a split's MATCH rows
+    via connected components (union-find) over record signatures. Transitive
+    closure is load-bearing: FEBRL emits star-topology positives (anchor-vs-dup
+    only), so dup0-vs-dup1 is same-entity but never appears as a match row --
+    the component closure recovers it. Records absent from every match row are
+    non-matches (predicate returns False)."""
+    parent: dict[tuple, tuple] = {}
+
+    def find(x: tuple) -> tuple:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: tuple, b: tuple) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for p in pairs:
+        if p.get("label") == "match":
+            union(_record_signature(p["a"]), _record_signature(p["b"]))
+
+    def gold_linked(rec_a: dict, rec_b: dict) -> bool:
+        sa, sb = _record_signature(rec_a), _record_signature(rec_b)
+        if sa not in parent or sb not in parent:
+            return False
+        return find(sa) == find(sb)
+
+    return gold_linked
+
+
+def _pairs_from_blocks(
+    id_lists: list[list],
+    records_by_id: dict[Any, dict],
+    gold_linked: Callable[[dict, dict], bool],
+) -> list[dict]:
+    """PURE adapter (box-tested with fake blocks + fake gold): enumerate the
+    distinct within-block record pairs and tag each with `gold_match`. A mined
+    pair is a non-match iff its two records are NOT gold-linked. Deduped across
+    passes by the canonical (min, max) id so multi-pass blocking can't
+    double-count a pair."""
+    seen: set[tuple] = set()
+    out: list[dict] = []
+    for ids in id_lists:
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                id_a, id_b = ids[i], ids[j]
+                if id_a == id_b:
+                    continue
+                key = (id_a, id_b) if id_a <= id_b else (id_b, id_a)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rec_a, rec_b = records_by_id[id_a], records_by_id[id_b]
+                out.append(
+                    {
+                        "a": rec_a,
+                        "b": rec_b,
+                        "eid_a": id_a,
+                        "eid_b": id_b,
+                        "gold_match": bool(gold_linked(rec_a, rec_b)),
+                    }
+                )
+    return out
+
+
+def _make_candidates(
+    records: list[dict],
+    blocking_cfg: Any,
+    *,
+    gold_linked: Callable[[dict, dict], bool],
+    id_prefix: str = "",
+) -> list[dict]:
+    """Block WITHIN a single split's record pool with the fitted BlockingConfig
+    and return candidate pairs tagged with `gold_match`. Heavy import local."""
+    if not records or blocking_cfg is None:
+        return []
+
+    from goldenmatch.core.blocker import build_blocks
+
+    frame = _records_to_frame(records)
+    records_by_id = {f"{id_prefix}{i}": rec for i, rec in enumerate(records)}
+    id_lists: list[list] = []
+    try:
+        # `.lazy()`: build_blocks' static builder calls `.collect()` on the frame.
+        blocks = build_blocks(frame.lazy(), blocking_cfg)
+    except Exception as exc:
+        # Mining is best-effort: a blocking config that references a column the
+        # raw pool doesn't carry (e.g. a standardized `__brand__`) shouldn't sink
+        # the whole build -- just skip mined negatives for this split.
+        print(
+            f"[fs-enrich] blocking failed on pool ({id_prefix!r}): {exc!r}; "
+            f"skipping mined negatives for this split",
+            file=sys.stderr,
+        )
+        return []
+    for blk in blocks:
+        row_ids = _block_row_ids(blk)
+        id_lists.append([f"{id_prefix}{int(r)}" for r in row_ids])
+    return _pairs_from_blocks(id_lists, records_by_id, gold_linked)
+
+
+def _block_row_ids(blk: Any) -> list:
+    """Read a block's ``__row_id__`` members, robust to the BlockResult shape:
+    newer goldenmatch exposes ``.materialize().column(...)`` (seam Frame); older
+    builds carry a raw polars frame on ``.df``. Handles both so this wiring
+    survives goldenmatch version skew across the install/worktree."""
+    if hasattr(blk, "materialize"):
+        return blk.materialize().column("__row_id__").to_list()
+    df = getattr(blk, "df", None)
+    if df is None:
+        return []
+    if hasattr(df, "collect"):  # LazyFrame -> eager
+        df = df.collect()
+    return df["__row_id__"].to_list()
+
+
+def _rebalance_negatives(enriched: list[dict], mined_count: int) -> list[dict]:
+    """Honor "reduced share of synthetic negatives": for every mined hard
+    negative added, drop one ORIGINAL synthetic negative (a `no_match` row with
+    no `negative_kind`) so the total negative count stays balanced rather than
+    growing -- swapping easy synthetic negatives for hard mined ones.
+    Deterministic (drops in encounter order)."""
+    if mined_count <= 0:
+        return enriched
+    to_drop = mined_count
+    out: list[dict] = []
+    for row in enriched:
+        if (
+            to_drop > 0
+            and row.get("label") == "no_match"
+            and "negative_kind" not in row
+        ):
+            to_drop -= 1
+            continue
+        out.append(row)
+    return out
+
+
+def _pairs_hash(pairs: list[dict]) -> str:
+    """Deterministic digest of a source's pre-enrichment pairs -> the
+    `corpus_hash` fed to `fs_enrich.cache_key`."""
+    import hashlib
+
+    h = hashlib.sha256()
+    for p in pairs:
+        h.update(
+            json.dumps(
+                {k: p.get(k) for k in ("a", "b", "label", "eid_a", "eid_b")},
+                sort_keys=True,
+                default=str,
+            ).encode()
+        )
+    return h.hexdigest()
+
+
+def _fs_cache_path(out_dir: Path, key: str) -> Path:
+    return out_dir / ".fs_cache" / f"{key}.json"
+
+
+def _load_fs_cache(out_dir: Path, key: str) -> dict[str, list[dict]] | None:
+    path = _fs_cache_path(out_dir, key)
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return None
+
+
+def _save_fs_cache(out_dir: Path, key: str, result: dict[str, list[dict]]) -> None:
+    path = _fs_cache_path(out_dir, key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+
+
+def _fs_enrich_source(
+    src: Any,
+    entry: Any,
+    splits: dict[str, Any],
+    out_dir: Path,
+    *,
+    delta: float,
+    mine_cap: int,
+) -> dict[str, list[dict]]:
+    """Fit the FS scorer once on the source's TRAIN pool and enrich each split's
+    pairs (soft confidence + mined near-threshold gold non-matches), threading a
+    per-source disk cache keyed on `fs_enrich.cache_key`. Sources without a
+    `record_pools()` (or an empty train pool) are returned UNENRICHED -- the
+    trainer's per-row confidence has a constant fallback, so mixed rows are
+    safe."""
+    from fs_enrich import cache_key, enrich
+
+    materialized = {s: list(splits.get(s, [])) for s in _SPLITS}
+    pools = getattr(src, "record_pools", lambda: {})()
+    train_pool = pools.get("train", [])
+    if not train_pool:
+        print(
+            f"[fs-enrich] source {entry.name!r} has no train record pool; "
+            f"skipping FS enrichment (rows keep the training constant fallback)",
+            file=sys.stderr,
+        )
+        return materialized
+
+    sample_pairs = _sample_labeled_pairs(materialized["train"])
+    scorer, tau, blocking_cfg, scorer_cfg = _make_fs_scorer(
+        train_pool, entry.domain, sample_pairs=sample_pairs
+    )
+
+    corpus_hash = _pairs_hash([p for s in _SPLITS for p in materialized[s]])
+    key = cache_key(corpus_hash=corpus_hash, scorer_cfg=scorer_cfg, tau=tau, delta=delta)
+    cached = _load_fs_cache(out_dir, key)
+    if cached is not None:
+        print(f"[fs-enrich] cache hit for {entry.name!r} ({key[:12]})", file=sys.stderr)
+        return cached
+
+    result: dict[str, list[dict]] = {}
+    for split in _SPLITS:
+        rows = materialized[split]
+        recs = pools.get(split, [])
+        gold_linked = _gold_components(rows)
+        id_prefix = f"{entry.name}:{split}:"
+        if recs:
+            candidates_fn = (
+                lambda r, gl=gold_linked, pfx=id_prefix: _make_candidates(
+                    r, blocking_cfg, gold_linked=gl, id_prefix=pfx
+                )
+            )
+        else:
+            candidates_fn = lambda r: []  # noqa: E731 (defensive: no pool -> no mining)
+        enriched = enrich(
+            rows,
+            records=recs,
+            scorer=scorer,
+            candidates_fn=candidates_fn,
+            tau=tau,
+            delta=delta,
+            mine_cap=mine_cap,
+        )
+        mined = sum(1 for r in enriched if r.get("negative_kind") == "fs_mined")
+        result[split] = _rebalance_negatives(enriched, mined)
+
+    _save_fs_cache(out_dir, key, result)
+    return result
+
+
 def build_corpus(
-    sources_yaml: Path, out_dir: Path, *, seed: int, cap: int | None = None
+    sources_yaml: Path,
+    out_dir: Path,
+    *,
+    seed: int,
+    cap: int | None = None,
+    enrich_fs: bool = False,
+    delta: float = DELTA,
+    mine_cap: int = MINE_CAP,
 ) -> dict[str, Any]:
     """Blend every bundled/generated, non-eval-only source into
     `out_dir/{train,val,test}.jsonl` + `out_dir/manifest.json`. Returns the
@@ -71,6 +582,15 @@ def build_corpus(
     before truncating, see its docstring), so results stay reproducible AND
     class-balanced. This is the "cap oversized sources" lever; proportional
     weight-blending (`SourceEntry.weight`) is deferred to a later task.
+
+    `enrich_fs` (default OFF) folds the real goldenmatch Fellegi-Sunter scorer
+    into each contributing source: fit the FS posterior once on the source's
+    train pool, attach an FS-score-driven soft `confidence` to every pair, and
+    mine near-threshold gold non-matches (`negative_kind="fs_mined"`). OFF keeps
+    the output byte-identical to the pre-Task-6 blend (the pure box tests never
+    enable it and never import goldenmatch). `delta`/`mine_cap` thread the mining
+    band + per-split cap. eval-only/`fetch` sources are never enriched (they
+    never contribute rows).
     """
     entries = load_sources(sources_yaml)
 
@@ -94,8 +614,15 @@ def build_corpus(
 
         if contributes:
             splits = src.splits()
+            enriched_splits = (
+                _fs_enrich_source(
+                    src, entry, splits, out_dir, delta=delta, mine_cap=mine_cap
+                )
+                if enrich_fs
+                else {s: list(splits.get(s, [])) for s in _SPLITS}
+            )
             for split in _SPLITS:
-                rows = list(splits.get(split, []))
+                rows = enriched_splits.get(split, [])
                 if cap is not None:
                     rows = _cap_preserving_balance(rows, cap)
                 corpus[split].extend(rows)
@@ -167,9 +694,25 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--out-dir", type=Path, default=Path("data/er_matcher"))
     ap.add_argument("--seed", type=int, default=20260727)
     ap.add_argument("--cap", type=int, default=None)
+    ap.add_argument(
+        "--fs-enrich",
+        action="store_true",
+        help="Fold the real goldenmatch FS scorer in: soft confidence + mined "
+        "near-threshold gold negatives (needs the goldenmatch package + polars).",
+    )
+    ap.add_argument("--fs-delta", type=float, default=DELTA, help="FS mining band half-width.")
+    ap.add_argument("--fs-mine-cap", type=int, default=MINE_CAP, help="Max mined negatives/split.")
     args = ap.parse_args(argv)
 
-    manifest = build_corpus(args.sources, args.out_dir, seed=args.seed, cap=args.cap)
+    manifest = build_corpus(
+        args.sources,
+        args.out_dir,
+        seed=args.seed,
+        cap=args.cap,
+        enrich_fs=args.fs_enrich,
+        delta=args.fs_delta,
+        mine_cap=args.fs_mine_cap,
+    )
     print(json.dumps(manifest["totals"], indent=2, sort_keys=True))
     return 0
 

--- a/scripts/er_matcher/build_corpus.py
+++ b/scripts/er_matcher/build_corpus.py
@@ -14,8 +14,11 @@ Blend weights (`SourceEntry.weight`) are recorded in the manifest for the
 model card but ratio-blending by weight is DEFERRED -- this task only caps
 per-source row counts (the `cap` lever); it does not re-weight the mix.
 
-Box-safe: stdlib + `sources_config` (PyYAML) only. Never touches the
-network -- `fetch` sources contribute no rows here, so no download happens
+Box-safe: stdlib + `sources_config` (PyYAML) + `fs_scorer` only. `fs_scorer`
+keeps every goldenmatch/polars import function-local, so importing it here is
+free -- the heavy stack loads only under `--fs-enrich` (the opt-in FS
+enrichment layer; default off keeps the blend byte-identical). Never touches
+the network -- `fetch` sources contribute no rows here, so no download happens
 during a corpus build.
 """
 
@@ -25,10 +28,19 @@ import argparse
 import json
 import sys
 import warnings
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from fs_scorer import (
+    _gold_components,
+    _load_fs_cache,
+    _make_candidates,
+    _make_fs_scorer,
+    _pairs_hash,
+    _rebalance_negatives,
+    _sample_labeled_pairs,
+    _save_fs_cache,
+)
 from sources_config import build_source, load_sources
 
 _SPLITS = ("train", "val", "test")
@@ -41,14 +53,10 @@ _ROW_MECHANISMS = {"bundle", "generate"}
 
 # ── FS enrichment tunables (Task 6) ────────────────────────────────────────
 # The near-threshold hard-negative mining band half-width and per-split mining
-# cap threaded into `fs_enrich.enrich`. `DELTA` starts at 0.1 per the plan.
+# cap threaded into `fs_enrich.enrich`. `DELTA` starts at 0.1 per the plan. The
+# goldenmatch-coupled scorer/blocker layer lives in `fs_scorer`.
 DELTA = 0.1
 MINE_CAP = 200
-# A posterior scorer must beat the non-match mean by at least this margin on the
-# train split's labeled sample, else we fall back to the weighted scorer.
-_SEPARATION_MARGIN = 0.1
-# How many match / non-match pairs to draw for the separation self-check.
-_SEPARATION_SAMPLE = 200
 
 
 def _cap_preserving_balance(rows: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
@@ -72,425 +80,9 @@ def _cap_preserving_balance(rows: list[dict[str, Any]], cap: int) -> list[dict[s
     return interleaved[:cap]
 
 
-# ── Real goldenmatch FS scorer + blocker (Task 6) ──────────────────────────
-# Every function that imports goldenmatch keeps that import LOCAL so the pure
-# box suite (which never enables `--fs-enrich`) stays free of the heavy package.
-
-
-def _records_to_frame(records: list[dict], *, with_row_id: bool = True) -> Any:
-    """Build a polars DataFrame from a split's raw record pool. With
-    ``with_row_id`` (the EM/blocker path) it carries the stable ``__row_id__``
-    Int64 key goldenmatch's trainer + blocker expect (`pipeline._add_row_ids`
-    uses the same key). Auto-config PROFILES columns and adds its own row id, so
-    the profiling calls pass ``with_row_id=False`` -- else `auto_configure_df`'s
-    controller trips a duplicate-``__row_id__`` error."""
-    import polars as pl
-
-    cols = sorted({k for r in records for k in r})
-    data: dict[str, list] = {c: [r.get(c) for r in records] for c in cols}
-    df = pl.DataFrame(data)
-    if with_row_id:
-        df = df.with_columns(
-            pl.Series("__row_id__", list(range(len(records))), dtype=pl.Int64)
-        )
-    return df
-
-
-def _fields_from_config(mk: Any) -> list:
-    """The MatchkeyConfig -> runtime MatchkeyField bridge the weighted
-    ``score_pair`` wants. `MatchkeyConfig.fields` is ALREADY a
-    ``list[MatchkeyField]`` (see `config/schemas.py`; `match_one`/`db.sync` call
-    ``score_pair(a, b, mk.fields)`` directly), so the bridge is just the attr."""
-    return list(getattr(mk, "fields", []) or [])
-
-
-def _fit_fs_posterior(records: list[dict]) -> tuple[Any, Any, Any]:
-    """Fit the genuine Fellegi-Sunter POSTERIOR path on `records`:
-    `auto_configure_probabilistic_df` builds the probabilistic matchkey +
-    blocking; `train_em` fits the m/u weights. Returns ``(mk, em_result,
-    blocking)``. `score_pair_probabilistic(a, b, mk, em)` then yields P(match)
-    in [0,1] (a sigmoid posterior under the default 'posterior' calibration)."""
-    import os
-
-    os.environ.setdefault("GOLDENMATCH_FS_CALIBRATED", "posterior")
-
-    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
-    from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
-    from goldenmatch.core.matchkey import precompute_matchkey_transforms
-    from goldenmatch.core.probabilistic import train_em
-
-    config = auto_configure_probabilistic_df(_records_to_frame(records, with_row_id=False))
-    mk = config.matchkeys[0]
-    score_frame = precompute_matchkey_transforms(_records_to_frame(records), config.matchkeys)
-    # build_blocks' static primary builder consumes the ORIGINAL entry object and
-    # calls `.collect()` on it, so hand it a LazyFrame (not the eager frame the EM
-    # trainer wants).
-    blocks = build_blocks(score_frame.lazy(), config.blocking)
-    em = train_em(
-        score_frame,
-        mk,
-        blocks=blocks,
-        blocking_fields=collect_blocking_fields(config.blocking),
-    )
-    return mk, em, config.blocking
-
-
-def _threshold_from_config(mk: Any, em: Any) -> float:
-    """The FS decision threshold `tau` = the resolved link cutoff (which prefers
-    `EMResult.calibrated_link_threshold`); default 0.5 when unavailable."""
-    try:
-        from goldenmatch.core.probabilistic import resolve_thresholds
-
-        link, _review = resolve_thresholds(mk, em)
-        return 0.5 if link is None else float(link)
-    except Exception:
-        return 0.5
-
-
-def _score_posterior(mk: Any, em: Any) -> Callable[[dict, dict], float]:
-    """Wrap `score_pair_probabilistic` into a `scorer(a, b) -> float` clamped to
-    [0,1]. It applies each field's transforms internally (`comparison_vector`),
-    so it scores raw record dicts directly -- no precompute needed at score time."""
-    from goldenmatch.core.probabilistic import score_pair_probabilistic
-
-    def scorer(a: dict, b: dict) -> float:
-        s = float(score_pair_probabilistic(a, b, mk, em))
-        return min(1.0, max(0.0, s))
-
-    return scorer
-
-
-def _fit_weighted(records: list[dict]) -> tuple[Any, Any]:
-    """Weighted/iterative fallback config (`auto_configure_df`) -- the aggregator
-    whose `score_pair` output is NOT a [0,1] posterior (normalized separately).
-
-    `auto_configure_df` emits a MIX of exact + weighted matchkeys; `score_pair`
-    only works on a WEIGHTED (fuzzy-scorer) matchkey (an exact matchkey's fields
-    have `scorer=None` and raise on `.fuzzy_scorer`), so pick the first weighted
-    one, falling back to `matchkeys[0]` only if none exists."""
-    from goldenmatch.core.autoconfig import auto_configure_df
-
-    config = auto_configure_df(_records_to_frame(records, with_row_id=False))
-    weighted = [mk for mk in config.matchkeys if getattr(mk, "type", None) == "weighted"]
-    mk = weighted[0] if weighted else config.matchkeys[0]
-    return mk, config.blocking
-
-
-def _score_weighted(
-    mk: Any, sample_pairs: list[tuple[dict, dict, bool]]
-) -> Callable[[dict, dict], float]:
-    """Min-max-normalize the weighted `score_pair` aggregate into [0,1] using the
-    train sample's observed score range, then clamp (val/test can exceed the
-    train range). Falls back to a constant 0.5 when the range is degenerate."""
-    from goldenmatch.core.scorer import score_pair
-
-    fields = _fields_from_config(mk)
-    raw = [score_pair(a, b, fields) for a, b, _m in sample_pairs]
-    lo = min(raw) if raw else 0.0
-    hi = max(raw) if raw else 1.0
-    span = hi - lo
-
-    def scorer(a: dict, b: dict) -> float:
-        s = score_pair(a, b, fields)
-        norm = (s - lo) / span if span > 0 else 0.5
-        return min(1.0, max(0.0, norm))
-
-    return scorer
-
-
-def _scorer_cfg_signature(mk: Any, blocking: Any, mode: str) -> str:
-    """Stable digest input describing the fitted scorer, fed to
-    `fs_enrich.cache_key` so a rebuild with an unchanged config skips the FS
-    pass. Captures the calibration mode, matchkey name, scored fields, and
-    blocking fields (the levers that change scores)."""
-    try:
-        from goldenmatch.core.blocker import collect_blocking_fields
-
-        blk = sorted(collect_blocking_fields(blocking)) if blocking is not None else []
-    except Exception:
-        blk = []
-    fields = [getattr(f, "field", None) for f in getattr(mk, "fields", []) or []]
-    return json.dumps(
-        {
-            "mode": mode,
-            "matchkey": getattr(mk, "name", None),
-            "fields": fields,
-            "blocking": blk,
-        },
-        sort_keys=True,
-    )
-
-
-def _sample_labeled_pairs(
-    pairs: list[dict], k: int = _SEPARATION_SAMPLE
-) -> list[tuple[dict, dict, bool]]:
-    """Draw up to `k` match and `k` non-match labeled pairs (deterministic) for
-    the separation self-check. Returns ``(a, b, is_match)`` tuples."""
-    import random
-
-    rng = random.Random(0)
-    matches = [p for p in pairs if p.get("label") == "match"]
-    non = [p for p in pairs if p.get("label") != "match"]
-
-    def take(lst: list[dict]) -> list[dict]:
-        return list(lst) if len(lst) <= k else rng.sample(lst, k)
-
-    sel = take(matches) + take(non)
-    return [(p["a"], p["b"], p.get("label") == "match") for p in sel]
-
-
-def _check_separation(
-    scorer: Callable[[dict, dict], float], sample: list[tuple[dict, dict, bool]]
-) -> tuple[bool, float, float, bool]:
-    """Score the labeled sample once and report ``(ok, mean_match,
-    mean_nonmatch, all_in_range)``. `ok` requires every score in [0,1] AND
-    mean(match) to beat mean(non-match) by `_SEPARATION_MARGIN`."""
-    scored = [(scorer(a, b), is_m) for a, b, is_m in sample]
-    in_range = all(0.0 <= s <= 1.0 for s, _ in scored)
-    m = [s for s, is_m in scored if is_m]
-    n = [s for s, is_m in scored if not is_m]
-    mean_m = sum(m) / len(m) if m else 0.0
-    mean_n = sum(n) / len(n) if n else 0.0
-    ok = in_range and bool(m) and bool(n) and mean_m > mean_n + _SEPARATION_MARGIN
-    return ok, mean_m, mean_n, in_range
-
-
-def _make_fs_scorer(
-    train_records: list[dict],
-    domain: str,
-    *,
-    sample_pairs: list[tuple[dict, dict, bool]] | None = None,
-) -> tuple[Callable[[dict, dict], float], float, Any, str]:
-    """Fit ONCE on the TRAIN pool; return ``(scorer, tau, blocking_cfg,
-    scorer_cfg)``. Prefers the genuine FS posterior; if EM degenerates (the
-    posterior fails to separate the labeled sample, or the fit raises -- EM can
-    degenerate on tiny pools) it falls back to the weighted `score_pair`
-    min-max-normalized into [0,1], logging which path each split used. `scorer`
-    always clamps to [0,1]."""
-    if not train_records:
-        raise ValueError("FS scorer needs a non-empty train record pool")
-
-    # The probabilistic blocking (built without EM) is derived-column-free by
-    # design (auto_configure_probabilistic_df adds NO standardization), so it's
-    # the safe blocking to mine candidates with even when the SCORER falls back
-    # to weighted -- the weighted config's blocking can key on standardized
-    # columns (e.g. `__brand__`) the raw record pool doesn't carry.
-    posterior_blocking = None
-    try:
-        mk, em, posterior_blocking = _fit_fs_posterior(train_records)
-        scorer = _score_posterior(mk, em)
-        tau = _threshold_from_config(mk, em)
-        if not sample_pairs:
-            return scorer, tau, posterior_blocking, _scorer_cfg_signature(
-                mk, posterior_blocking, "posterior"
-            )
-        ok, mean_m, mean_n, in_range = _check_separation(scorer, sample_pairs)
-        if ok:
-            return scorer, tau, posterior_blocking, _scorer_cfg_signature(
-                mk, posterior_blocking, "posterior"
-            )
-        print(
-            f"[fs-enrich] posterior did not separate for domain={domain!r} "
-            f"(mean_match={mean_m:.3f} mean_nonmatch={mean_n:.3f} "
-            f"in_range={in_range}); falling back to weighted",
-            file=sys.stderr,
-        )
-    except Exception as exc:  # EM degeneration / no matchkeys / etc.
-        print(
-            f"[fs-enrich] posterior fit failed for domain={domain!r}: {exc!r}; "
-            f"falling back to weighted",
-            file=sys.stderr,
-        )
-
-    wmk, wblocking = _fit_weighted(train_records)
-    scorer = _score_weighted(wmk, sample_pairs or [])
-    mining_blocking = posterior_blocking if posterior_blocking is not None else wblocking
-    return scorer, 0.5, mining_blocking, _scorer_cfg_signature(
-        wmk, mining_blocking, "weighted"
-    )
-
-
-def _record_signature(rec: dict) -> tuple:
-    """Hashable identity of a record from its field VALUES (record pools strip
-    the source id, so values are the only stable cross-reference between a
-    split's match rows and its record pool)."""
-    return tuple(sorted((str(k), str(v)) for k, v in rec.items()))
-
-
-def _gold_components(pairs: list[dict]) -> Callable[[dict, dict], bool]:
-    """Build a `gold_linked(rec_a, rec_b)` predicate from a split's MATCH rows
-    via connected components (union-find) over record signatures. Transitive
-    closure is load-bearing: FEBRL emits star-topology positives (anchor-vs-dup
-    only), so dup0-vs-dup1 is same-entity but never appears as a match row --
-    the component closure recovers it. Records absent from every match row are
-    non-matches (predicate returns False)."""
-    parent: dict[tuple, tuple] = {}
-
-    def find(x: tuple) -> tuple:
-        parent.setdefault(x, x)
-        while parent[x] != x:
-            parent[x] = parent[parent[x]]
-            x = parent[x]
-        return x
-
-    def union(a: tuple, b: tuple) -> None:
-        ra, rb = find(a), find(b)
-        if ra != rb:
-            parent[ra] = rb
-
-    for p in pairs:
-        if p.get("label") == "match":
-            union(_record_signature(p["a"]), _record_signature(p["b"]))
-
-    def gold_linked(rec_a: dict, rec_b: dict) -> bool:
-        sa, sb = _record_signature(rec_a), _record_signature(rec_b)
-        if sa not in parent or sb not in parent:
-            return False
-        return find(sa) == find(sb)
-
-    return gold_linked
-
-
-def _pairs_from_blocks(
-    id_lists: list[list],
-    records_by_id: dict[Any, dict],
-    gold_linked: Callable[[dict, dict], bool],
-) -> list[dict]:
-    """PURE adapter (box-tested with fake blocks + fake gold): enumerate the
-    distinct within-block record pairs and tag each with `gold_match`. A mined
-    pair is a non-match iff its two records are NOT gold-linked. Deduped across
-    passes by the canonical (min, max) id so multi-pass blocking can't
-    double-count a pair."""
-    seen: set[tuple] = set()
-    out: list[dict] = []
-    for ids in id_lists:
-        for i in range(len(ids)):
-            for j in range(i + 1, len(ids)):
-                id_a, id_b = ids[i], ids[j]
-                if id_a == id_b:
-                    continue
-                key = (id_a, id_b) if id_a <= id_b else (id_b, id_a)
-                if key in seen:
-                    continue
-                seen.add(key)
-                rec_a, rec_b = records_by_id[id_a], records_by_id[id_b]
-                out.append(
-                    {
-                        "a": rec_a,
-                        "b": rec_b,
-                        "eid_a": id_a,
-                        "eid_b": id_b,
-                        "gold_match": bool(gold_linked(rec_a, rec_b)),
-                    }
-                )
-    return out
-
-
-def _make_candidates(
-    records: list[dict],
-    blocking_cfg: Any,
-    *,
-    gold_linked: Callable[[dict, dict], bool],
-    id_prefix: str = "",
-) -> list[dict]:
-    """Block WITHIN a single split's record pool with the fitted BlockingConfig
-    and return candidate pairs tagged with `gold_match`. Heavy import local."""
-    if not records or blocking_cfg is None:
-        return []
-
-    from goldenmatch.core.blocker import build_blocks
-
-    frame = _records_to_frame(records)
-    records_by_id = {f"{id_prefix}{i}": rec for i, rec in enumerate(records)}
-    id_lists: list[list] = []
-    try:
-        # `.lazy()`: build_blocks' static builder calls `.collect()` on the frame.
-        blocks = build_blocks(frame.lazy(), blocking_cfg)
-    except Exception as exc:
-        # Mining is best-effort: a blocking config that references a column the
-        # raw pool doesn't carry (e.g. a standardized `__brand__`) shouldn't sink
-        # the whole build -- just skip mined negatives for this split.
-        print(
-            f"[fs-enrich] blocking failed on pool ({id_prefix!r}): {exc!r}; "
-            f"skipping mined negatives for this split",
-            file=sys.stderr,
-        )
-        return []
-    for blk in blocks:
-        row_ids = _block_row_ids(blk)
-        id_lists.append([f"{id_prefix}{int(r)}" for r in row_ids])
-    return _pairs_from_blocks(id_lists, records_by_id, gold_linked)
-
-
-def _block_row_ids(blk: Any) -> list:
-    """Read a block's ``__row_id__`` members, robust to the BlockResult shape:
-    newer goldenmatch exposes ``.materialize().column(...)`` (seam Frame); older
-    builds carry a raw polars frame on ``.df``. Handles both so this wiring
-    survives goldenmatch version skew across the install/worktree."""
-    if hasattr(blk, "materialize"):
-        return blk.materialize().column("__row_id__").to_list()
-    df = getattr(blk, "df", None)
-    if df is None:
-        return []
-    if hasattr(df, "collect"):  # LazyFrame -> eager
-        df = df.collect()
-    return df["__row_id__"].to_list()
-
-
-def _rebalance_negatives(enriched: list[dict], mined_count: int) -> list[dict]:
-    """Honor "reduced share of synthetic negatives": for every mined hard
-    negative added, drop one ORIGINAL synthetic negative (a `no_match` row with
-    no `negative_kind`) so the total negative count stays balanced rather than
-    growing -- swapping easy synthetic negatives for hard mined ones.
-    Deterministic (drops in encounter order)."""
-    if mined_count <= 0:
-        return enriched
-    to_drop = mined_count
-    out: list[dict] = []
-    for row in enriched:
-        if (
-            to_drop > 0
-            and row.get("label") == "no_match"
-            and "negative_kind" not in row
-        ):
-            to_drop -= 1
-            continue
-        out.append(row)
-    return out
-
-
-def _pairs_hash(pairs: list[dict]) -> str:
-    """Deterministic digest of a source's pre-enrichment pairs -> the
-    `corpus_hash` fed to `fs_enrich.cache_key`."""
-    import hashlib
-
-    h = hashlib.sha256()
-    for p in pairs:
-        h.update(
-            json.dumps(
-                {k: p.get(k) for k in ("a", "b", "label", "eid_a", "eid_b")},
-                sort_keys=True,
-                default=str,
-            ).encode()
-        )
-    return h.hexdigest()
-
-
-def _fs_cache_path(out_dir: Path, key: str) -> Path:
-    return out_dir / ".fs_cache" / f"{key}.json"
-
-
-def _load_fs_cache(out_dir: Path, key: str) -> dict[str, list[dict]] | None:
-    path = _fs_cache_path(out_dir, key)
-    if path.exists():
-        return json.loads(path.read_text(encoding="utf-8"))
-    return None
-
-
-def _save_fs_cache(out_dir: Path, key: str, result: dict[str, list[dict]]) -> None:
-    path = _fs_cache_path(out_dir, key)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+# ── FS enrichment orchestrator (Task 6) ────────────────────────────────────
+# The goldenmatch-coupled scorer/blocker/cache layer lives in `fs_scorer`; this
+# orchestrator only sequences it (fit once per source, enrich each split, cache).
 
 
 def _fs_enrich_source(

--- a/scripts/er_matcher/fs_enrich.py
+++ b/scripts/er_matcher/fs_enrich.py
@@ -71,6 +71,7 @@ def enrich(
     tau: float = 0.5,
     delta: float = 0.1,
     mine_cap: int,
+    domain: str | None = None,
 ) -> list[dict]:
     """Attach FS-score-driven soft confidence to every pair, and append near-threshold
     gold non-matches mined from candidates_fn(records). Pure given injected scorer +
@@ -107,6 +108,7 @@ def enrich(
                 "label": "no_match",
                 "eid_a": c["eid_a"],
                 "eid_b": c["eid_b"],
+                "domain": domain,  # mined negs inherit the source domain (run_eval buckets by it)
                 "confidence": round(conf, 4),
                 "fs_score": round(c["score"], 4),
                 "negative_kind": "fs_mined",

--- a/scripts/er_matcher/fs_enrich.py
+++ b/scripts/er_matcher/fs_enrich.py
@@ -31,3 +31,22 @@ def soft_confidence(
         # (mid_lo - lo) subtraction, before the multiply ever runs.
         return mid_lo
     return lo + (mid_lo - lo) * frac
+
+
+def select_hard_negatives(
+    scored_candidates: list[dict],
+    *,
+    tau: float = 0.5,
+    delta: float = 0.1,
+    cap: int,
+) -> list[dict]:
+    """Keep candidates whose FS score is within [tau-delta, tau+delta] AND whose gold
+    label is non-match. Sort by closeness to tau (hardest first) for a deterministic
+    cap. Gold label is the truth; FS only selects difficulty."""
+    band = [
+        c
+        for c in scored_candidates
+        if not c["gold_match"] and abs(c["score"] - tau) <= delta
+    ]
+    band.sort(key=lambda c: (abs(c["score"] - tau), c["a_id"], c["b_id"]))
+    return band[:cap]

--- a/scripts/er_matcher/fs_enrich.py
+++ b/scripts/er_matcher/fs_enrich.py
@@ -19,9 +19,15 @@ def soft_confidence(
     if is_match:
         frac = max((s - tau) / (1.0 - tau), 0.0) if tau < 1.0 else 0.0
         if frac >= 1.0:
+            # Return the exact boundary constant: mid_hi + (hi-mid_hi)*1.0 usually
+            # rounds back to hi, but that's a coincidence of these literals, not a
+            # guarantee -- don't delete this in favor of the interpolation below.
             return hi
         return mid_hi + (hi - mid_hi) * frac
     frac = min(s / tau, 1.0) if tau > 0.0 else 0.0
     if frac >= 1.0:
+        # Return the exact boundary constant; lo + (mid_lo-lo)*1.0 overshoots to
+        # 0.45000000000000007 because the rounding error is baked into the
+        # (mid_lo - lo) subtraction, before the multiply ever runs.
         return mid_lo
     return lo + (mid_lo - lo) * frac

--- a/scripts/er_matcher/fs_enrich.py
+++ b/scripts/er_matcher/fs_enrich.py
@@ -1,0 +1,27 @@
+"""Post-blend FS enrichment: FS-score-driven soft confidence targets + hard-negative
+mining. Pure and box-testable; the FS matcher is injected as scorer(a,b)->float."""
+
+
+def soft_confidence(
+    score: float,
+    is_match: bool,
+    *,
+    tau: float = 0.5,
+    hi: float = 0.97,
+    lo: float = 0.03,
+    mid_hi: float = 0.55,
+    mid_lo: float = 0.45,
+) -> float:
+    """Map an FS match-probability to a P(match) training target, compressed toward
+    0.5 near the decision threshold tau. Gold label picks the direction; the score's
+    distance from tau picks how extreme. Never 0 or 1."""
+    s = min(max(score, 0.0), 1.0)
+    if is_match:
+        frac = max((s - tau) / (1.0 - tau), 0.0) if tau < 1.0 else 0.0
+        if frac >= 1.0:
+            return hi
+        return mid_hi + (hi - mid_hi) * frac
+    frac = min(s / tau, 1.0) if tau > 0.0 else 0.0
+    if frac >= 1.0:
+        return mid_lo
+    return lo + (mid_lo - lo) * frac

--- a/scripts/er_matcher/fs_enrich.py
+++ b/scripts/er_matcher/fs_enrich.py
@@ -2,6 +2,7 @@
 mining. Pure and box-testable; the FS matcher is injected as scorer(a,b)->float."""
 
 import hashlib
+from collections.abc import Callable
 
 
 def soft_confidence(
@@ -65,8 +66,8 @@ def enrich(
     pairs: list[dict],
     *,
     records: list[dict],
-    scorer,
-    candidates_fn,
+    scorer: Callable[[dict, dict], float],
+    candidates_fn: Callable[[list[dict]], list[dict]],
     tau: float = 0.5,
     delta: float = 0.1,
     mine_cap: int,
@@ -74,7 +75,12 @@ def enrich(
     """Attach FS-score-driven soft confidence to every pair, and append near-threshold
     gold non-matches mined from candidates_fn(records). Pure given injected scorer +
     candidates_fn. Records must already be within a single split (leakage-free
-    ordering)."""
+    ordering).
+
+    Output schema is asymmetric: original pairs keep all their input fields plus
+    `confidence`/`fs_score`, and have NO `negative_kind` key. Mined rows are rebuilt
+    from a fixed key set and DO carry `negative_kind="fs_mined"`. Downstream
+    consumers should use `.get("negative_kind")`, not assume the key is present."""
     enriched = []
     for p in pairs:
         s = scorer(p["a"], p["b"])
@@ -85,6 +91,8 @@ def enrich(
         {
             **c,
             "score": scorer(c["a"], c["b"]),
+            # select_hard_negatives expects a_id/b_id (Task 3 contract); candidates
+            # carry eid_a/eid_b -- bridge the two so the KeyError doesn't come back.
             "a_id": c["eid_a"],
             "b_id": c["eid_b"],
         }

--- a/scripts/er_matcher/fs_enrich.py
+++ b/scripts/er_matcher/fs_enrich.py
@@ -1,6 +1,8 @@
 """Post-blend FS enrichment: FS-score-driven soft confidence targets + hard-negative
 mining. Pure and box-testable; the FS matcher is injected as scorer(a,b)->float."""
 
+import hashlib
+
 
 def soft_confidence(
     score: float,
@@ -50,3 +52,56 @@ def select_hard_negatives(
     ]
     band.sort(key=lambda c: (abs(c["score"] - tau), c["a_id"], c["b_id"]))
     return band[:cap]
+
+
+def cache_key(*, corpus_hash: str, scorer_cfg: str, tau: float, delta: float) -> str:
+    """Stable digest of the enrichment inputs so a later build step can skip a
+    repeat FS pass when none of the corpus/scorer/threshold config changed."""
+    raw = f"{corpus_hash}|{scorer_cfg}|{tau:.4f}|{delta:.4f}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def enrich(
+    pairs: list[dict],
+    *,
+    records: list[dict],
+    scorer,
+    candidates_fn,
+    tau: float = 0.5,
+    delta: float = 0.1,
+    mine_cap: int,
+) -> list[dict]:
+    """Attach FS-score-driven soft confidence to every pair, and append near-threshold
+    gold non-matches mined from candidates_fn(records). Pure given injected scorer +
+    candidates_fn. Records must already be within a single split (leakage-free
+    ordering)."""
+    enriched = []
+    for p in pairs:
+        s = scorer(p["a"], p["b"])
+        conf = soft_confidence(s, p["label"] == "match", tau=tau)
+        enriched.append({**p, "confidence": round(conf, 4), "fs_score": round(s, 4)})
+
+    scored_cands = [
+        {
+            **c,
+            "score": scorer(c["a"], c["b"]),
+            "a_id": c["eid_a"],
+            "b_id": c["eid_b"],
+        }
+        for c in candidates_fn(records)
+    ]
+    for c in select_hard_negatives(scored_cands, tau=tau, delta=delta, cap=mine_cap):
+        conf = soft_confidence(c["score"], False, tau=tau)
+        enriched.append(
+            {
+                "a": c["a"],
+                "b": c["b"],
+                "label": "no_match",
+                "eid_a": c["eid_a"],
+                "eid_b": c["eid_b"],
+                "confidence": round(conf, 4),
+                "fs_score": round(c["score"], 4),
+                "negative_kind": "fs_mined",
+            }
+        )
+    return enriched

--- a/scripts/er_matcher/fs_scorer.py
+++ b/scripts/er_matcher/fs_scorer.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""goldenmatch Fellegi-Sunter scorer + blocker layer for corpus enrichment (Task 6).
+
+Everything goldenmatch/polars-coupled lives here so `build_corpus.py` stays a
+thin stdlib blender + orchestrator. The public surface `build_corpus`'s
+`_fs_enrich_source` uses:
+
+  - `_make_fs_scorer(train_records, domain, sample_pairs=) -> (scorer, tau,
+    blocking_cfg, scorer_cfg)` -- fit the FS posterior once (falling back to the
+    weighted scorer when EM degenerates),
+  - `_make_candidates(records, blocking_cfg, gold_linked=, id_prefix=)` -- block a
+    split's pool and tag candidate pairs with `gold_match`,
+  - `_gold_components(pairs)` -- match-row union-find -> `gold_linked` predicate,
+  - `_sample_labeled_pairs` / `_check_separation` -- the posterior-vs-weighted gate,
+  - the pure disk-cache helpers (`_pairs_hash`, `_load_fs_cache`, `_save_fs_cache`).
+
+BOX-SAFE AT IMPORT: every goldenmatch/polars import is function-local, so
+importing this module (e.g. to box-test the pure adapters) never pulls the heavy
+stack. Only `_fit_*`/`_score_*`/`_make_candidates`/`_records_to_frame` touch it,
+and only when actually called.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# The FS decision threshold used whenever a real calibrated cutoff isn't
+# available (weighted fallback, degenerate normalizer, resolve_thresholds break).
+_DEFAULT_TAU = 0.5
+# A posterior scorer must beat the non-match mean by at least this margin on the
+# train split's labeled sample, else we fall back to the weighted scorer.
+_SEPARATION_MARGIN = 0.1
+# How many match / non-match pairs to draw for the separation self-check.
+_SEPARATION_SAMPLE = 200
+
+# `_block_row_ids` logs the BlockResult shape it saw ONCE per shape (T7 uses it
+# to confirm which goldenmatch the run bound against).
+_LOGGED_BLOCK_SHAPES: set[str] = set()
+
+
+def _records_to_frame(records: list[dict], *, with_row_id: bool = True) -> Any:
+    """Build a polars DataFrame from a split's raw record pool. With
+    ``with_row_id`` (the EM/blocker path) it carries the stable ``__row_id__``
+    Int64 key goldenmatch's trainer + blocker expect (`pipeline._add_row_ids`
+    uses the same key). Auto-config PROFILES columns and adds its own row id, so
+    the profiling calls pass ``with_row_id=False`` -- else `auto_configure_df`'s
+    controller trips a duplicate-``__row_id__`` error."""
+    import polars as pl
+
+    cols = sorted({k for r in records for k in r})
+    data: dict[str, list] = {c: [r.get(c) for r in records] for c in cols}
+    df = pl.DataFrame(data)
+    if with_row_id:
+        df = df.with_columns(
+            pl.Series("__row_id__", list(range(len(records))), dtype=pl.Int64)
+        )
+    return df
+
+
+def _fields_from_config(mk: Any) -> list:
+    """The MatchkeyConfig -> runtime MatchkeyField bridge the weighted
+    ``score_pair`` wants. `MatchkeyConfig.fields` is ALREADY a
+    ``list[MatchkeyField]`` (see `config/schemas.py`; `match_one`/`db.sync` call
+    ``score_pair(a, b, mk.fields)`` directly), so the bridge is just the attr."""
+    return list(getattr(mk, "fields", []) or [])
+
+
+def _fit_fs_posterior(records: list[dict]) -> tuple[Any, Any, Any]:
+    """Fit the genuine Fellegi-Sunter POSTERIOR path on `records`:
+    `auto_configure_probabilistic_df` builds the probabilistic matchkey +
+    blocking; `train_em` fits the m/u weights. Returns ``(mk, em_result,
+    blocking)``. `score_pair_probabilistic(a, b, mk, em)` then yields P(match)
+    in [0,1] (a sigmoid posterior under the default 'posterior' calibration)."""
+    import os
+
+    os.environ.setdefault("GOLDENMATCH_FS_CALIBRATED", "posterior")
+
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms
+    from goldenmatch.core.probabilistic import train_em
+
+    config = auto_configure_probabilistic_df(_records_to_frame(records, with_row_id=False))
+    mk = config.matchkeys[0]
+    score_frame = precompute_matchkey_transforms(_records_to_frame(records), config.matchkeys)
+    # build_blocks' static primary builder consumes the ORIGINAL entry object and
+    # calls `.collect()` on it, so hand it a LazyFrame (not the eager frame the EM
+    # trainer wants).
+    blocks = build_blocks(score_frame.lazy(), config.blocking)
+    em = train_em(
+        score_frame,
+        mk,
+        blocks=blocks,
+        blocking_fields=collect_blocking_fields(config.blocking),
+    )
+    return mk, em, config.blocking
+
+
+def _threshold_from_config(mk: Any, em: Any) -> float:
+    """The FS decision threshold `tau` = the resolved link cutoff (which prefers
+    `EMResult.calibrated_link_threshold`); `_DEFAULT_TAU` when unavailable."""
+    try:
+        from goldenmatch.core.probabilistic import resolve_thresholds
+
+        link, _review = resolve_thresholds(mk, em)
+        return _DEFAULT_TAU if link is None else float(link)
+    except Exception as exc:
+        # Don't silently score against tau=0.5 if resolve_thresholds actually
+        # broke -- surface it so a real regression isn't masked.
+        print(
+            f"[fs-enrich] resolve_thresholds failed ({exc!r}); "
+            f"using default tau={_DEFAULT_TAU}",
+            file=sys.stderr,
+        )
+        return _DEFAULT_TAU
+
+
+def _score_posterior(mk: Any, em: Any) -> Callable[[dict, dict], float]:
+    """Wrap `score_pair_probabilistic` into a `scorer(a, b) -> float` clamped to
+    [0,1]. It applies each field's transforms internally (`comparison_vector`),
+    so it scores raw record dicts directly -- no precompute needed at score time."""
+    from goldenmatch.core.probabilistic import score_pair_probabilistic
+
+    def scorer(a: dict, b: dict) -> float:
+        s = float(score_pair_probabilistic(a, b, mk, em))
+        return min(1.0, max(0.0, s))
+
+    return scorer
+
+
+def _fit_weighted(records: list[dict]) -> tuple[Any, Any]:
+    """Weighted/iterative fallback config (`auto_configure_df`) -- the aggregator
+    whose `score_pair` output is NOT a [0,1] posterior (normalized separately).
+
+    `auto_configure_df` emits a MIX of exact + weighted matchkeys; `score_pair`
+    only works on a WEIGHTED (fuzzy-scorer) matchkey (an exact matchkey's fields
+    have `scorer=None` and raise on `.fuzzy_scorer`), so pick the first weighted
+    one, falling back to `matchkeys[0]` only if none exists."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    config = auto_configure_df(_records_to_frame(records, with_row_id=False))
+    weighted = [mk for mk in config.matchkeys if getattr(mk, "type", None) == "weighted"]
+    mk = weighted[0] if weighted else config.matchkeys[0]
+    return mk, config.blocking
+
+
+def _score_weighted(
+    mk: Any, sample_pairs: list[tuple[dict, dict, bool]]
+) -> Callable[[dict, dict], float]:
+    """Min-max-normalize the weighted `score_pair` aggregate into [0,1] using the
+    train sample's observed score range, then clamp (val/test can exceed the
+    train range). Falls back to a constant `_DEFAULT_TAU` when the range is
+    degenerate."""
+    from goldenmatch.core.scorer import score_pair
+
+    fields = _fields_from_config(mk)
+    raw = [score_pair(a, b, fields) for a, b, _m in sample_pairs]
+    lo = min(raw) if raw else 0.0
+    hi = max(raw) if raw else 1.0
+    span = hi - lo
+
+    def scorer(a: dict, b: dict) -> float:
+        s = score_pair(a, b, fields)
+        norm = (s - lo) / span if span > 0 else _DEFAULT_TAU
+        return min(1.0, max(0.0, norm))
+
+    return scorer
+
+
+def _scorer_cfg_signature(mk: Any, blocking: Any, mode: str) -> str:
+    """Stable digest input describing the fitted scorer, fed to
+    `fs_enrich.cache_key` so a rebuild with an unchanged config skips the FS
+    pass. Captures the calibration mode, matchkey name, scored fields, and
+    blocking fields (the levers that change scores)."""
+    try:
+        from goldenmatch.core.blocker import collect_blocking_fields
+
+        blk = sorted(collect_blocking_fields(blocking)) if blocking is not None else []
+    except Exception as exc:
+        print(
+            f"[fs-enrich] collect_blocking_fields failed ({exc!r}); "
+            f"cache key omits blocking fields",
+            file=sys.stderr,
+        )
+        blk = []
+    fields = [getattr(f, "field", None) for f in getattr(mk, "fields", []) or []]
+    return json.dumps(
+        {
+            "mode": mode,
+            "matchkey": getattr(mk, "name", None),
+            "fields": fields,
+            "blocking": blk,
+        },
+        sort_keys=True,
+    )
+
+
+def _sample_labeled_pairs(
+    pairs: list[dict], k: int = _SEPARATION_SAMPLE
+) -> list[tuple[dict, dict, bool]]:
+    """Draw up to `k` match and `k` non-match labeled pairs (deterministic) for
+    the separation self-check. Returns ``(a, b, is_match)`` tuples."""
+    rng = random.Random(0)
+    matches = [p for p in pairs if p.get("label") == "match"]
+    non = [p for p in pairs if p.get("label") != "match"]
+
+    def take(lst: list[dict]) -> list[dict]:
+        return list(lst) if len(lst) <= k else rng.sample(lst, k)
+
+    sel = take(matches) + take(non)
+    return [(p["a"], p["b"], p.get("label") == "match") for p in sel]
+
+
+def _check_separation(
+    scorer: Callable[[dict, dict], float], sample: list[tuple[dict, dict, bool]]
+) -> tuple[bool, float, float, bool]:
+    """Score the labeled sample once and report ``(ok, mean_match,
+    mean_nonmatch, all_in_range)``. `ok` requires every score in [0,1] AND
+    mean(match) to beat mean(non-match) by `_SEPARATION_MARGIN`. This is the gate
+    that decides posterior vs weighted -- a margin/in-range regression silently
+    flips every source to the weighted fallback, so it is box-tested directly."""
+    scored = [(scorer(a, b), is_m) for a, b, is_m in sample]
+    in_range = all(0.0 <= s <= 1.0 for s, _ in scored)
+    m = [s for s, is_m in scored if is_m]
+    n = [s for s, is_m in scored if not is_m]
+    mean_m = sum(m) / len(m) if m else 0.0
+    mean_n = sum(n) / len(n) if n else 0.0
+    ok = in_range and bool(m) and bool(n) and mean_m > mean_n + _SEPARATION_MARGIN
+    return ok, mean_m, mean_n, in_range
+
+
+def _make_fs_scorer(
+    train_records: list[dict],
+    domain: str,
+    *,
+    sample_pairs: list[tuple[dict, dict, bool]] | None = None,
+) -> tuple[Callable[[dict, dict], float], float, Any, str]:
+    """Fit ONCE on the TRAIN pool; return ``(scorer, tau, blocking_cfg,
+    scorer_cfg)``. Prefers the genuine FS posterior; if EM degenerates (the
+    posterior fails to separate the labeled sample, or the fit raises -- EM can
+    degenerate on tiny pools) it falls back to the weighted `score_pair`
+    min-max-normalized into [0,1], logging which path each split used. `scorer`
+    always clamps to [0,1]."""
+    if not train_records:
+        raise ValueError("FS scorer needs a non-empty train record pool")
+
+    # The probabilistic blocking (built without EM) is derived-column-free by
+    # design (auto_configure_probabilistic_df adds NO standardization), so it's
+    # the safe blocking to mine candidates with even when the SCORER falls back
+    # to weighted -- the weighted config's blocking can key on standardized
+    # columns (e.g. `__brand__`) the raw record pool doesn't carry.
+    posterior_blocking = None
+    try:
+        mk, em, posterior_blocking = _fit_fs_posterior(train_records)
+        scorer = _score_posterior(mk, em)
+        tau = _threshold_from_config(mk, em)
+        posterior_sig = _scorer_cfg_signature(mk, posterior_blocking, "posterior")
+        if not sample_pairs:
+            return scorer, tau, posterior_blocking, posterior_sig
+        ok, mean_m, mean_n, in_range = _check_separation(scorer, sample_pairs)
+        if ok:
+            return scorer, tau, posterior_blocking, posterior_sig
+        print(
+            f"[fs-enrich] posterior did not separate for domain={domain!r} "
+            f"(mean_match={mean_m:.3f} mean_nonmatch={mean_n:.3f} "
+            f"in_range={in_range}); falling back to weighted",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # EM degeneration / no matchkeys / etc.
+        print(
+            f"[fs-enrich] posterior fit failed for domain={domain!r}: {exc!r}; "
+            f"falling back to weighted",
+            file=sys.stderr,
+        )
+
+    wmk, wblocking = _fit_weighted(train_records)
+    scorer = _score_weighted(wmk, sample_pairs or [])
+    mining_blocking = posterior_blocking if posterior_blocking is not None else wblocking
+    return scorer, _DEFAULT_TAU, mining_blocking, _scorer_cfg_signature(
+        wmk, mining_blocking, "weighted"
+    )
+
+
+def _record_signature(rec: dict) -> tuple:
+    """Hashable identity of a record from its field VALUES (record pools strip
+    the source id, so values are the only stable cross-reference between a
+    split's match rows and its record pool)."""
+    return tuple(sorted((str(k), str(v)) for k, v in rec.items()))
+
+
+def _gold_components(pairs: list[dict]) -> Callable[[dict, dict], bool]:
+    """Build a `gold_linked(rec_a, rec_b)` predicate from a split's MATCH rows
+    via connected components (union-find) over record signatures. Transitive
+    closure is load-bearing: FEBRL emits star-topology positives (anchor-vs-dup
+    only), so dup0-vs-dup1 is same-entity but never appears as a match row --
+    the component closure recovers it. Records absent from every match row are
+    non-matches (predicate returns False)."""
+    parent: dict[tuple, tuple] = {}
+
+    def find(x: tuple) -> tuple:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: tuple, b: tuple) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for p in pairs:
+        if p.get("label") == "match":
+            union(_record_signature(p["a"]), _record_signature(p["b"]))
+
+    def gold_linked(rec_a: dict, rec_b: dict) -> bool:
+        sa, sb = _record_signature(rec_a), _record_signature(rec_b)
+        if sa not in parent or sb not in parent:
+            return False
+        return find(sa) == find(sb)
+
+    return gold_linked
+
+
+def _pairs_from_blocks(
+    id_lists: list[list],
+    records_by_id: dict[Any, dict],
+    gold_linked: Callable[[dict, dict], bool],
+) -> list[dict]:
+    """PURE adapter (box-tested with fake blocks + fake gold): enumerate the
+    distinct within-block record pairs and tag each with `gold_match`. A mined
+    pair is a non-match iff its two records are NOT gold-linked. Deduped across
+    passes by the canonical (min, max) id so multi-pass blocking can't
+    double-count a pair."""
+    seen: set[tuple] = set()
+    out: list[dict] = []
+    for ids in id_lists:
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                id_a, id_b = ids[i], ids[j]
+                if id_a == id_b:
+                    continue
+                key = (id_a, id_b) if id_a <= id_b else (id_b, id_a)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rec_a, rec_b = records_by_id[id_a], records_by_id[id_b]
+                out.append(
+                    {
+                        "a": rec_a,
+                        "b": rec_b,
+                        "eid_a": id_a,
+                        "eid_b": id_b,
+                        "gold_match": bool(gold_linked(rec_a, rec_b)),
+                    }
+                )
+    return out
+
+
+def _make_candidates(
+    records: list[dict],
+    blocking_cfg: Any,
+    *,
+    gold_linked: Callable[[dict, dict], bool],
+    id_prefix: str = "",
+) -> list[dict]:
+    """Block WITHIN a single split's record pool with the fitted BlockingConfig
+    and return candidate pairs tagged with `gold_match`. Heavy import local."""
+    if not records or blocking_cfg is None:
+        return []
+
+    from goldenmatch.core.blocker import build_blocks
+
+    frame = _records_to_frame(records)
+    records_by_id = {f"{id_prefix}{i}": rec for i, rec in enumerate(records)}
+    id_lists: list[list] = []
+    try:
+        # `.lazy()`: build_blocks' static builder calls `.collect()` on the frame.
+        blocks = build_blocks(frame.lazy(), blocking_cfg)
+    except Exception as exc:
+        # Mining is best-effort: a blocking config that references a column the
+        # raw pool doesn't carry (e.g. a standardized `__brand__`) shouldn't sink
+        # the whole build -- just skip mined negatives for this split.
+        print(
+            f"[fs-enrich] blocking failed on pool ({id_prefix!r}): {exc!r}; "
+            f"skipping mined negatives for this split",
+            file=sys.stderr,
+        )
+        return []
+    for blk in blocks:
+        row_ids = _block_row_ids(blk)
+        id_lists.append([f"{id_prefix}{int(r)}" for r in row_ids])
+    return _pairs_from_blocks(id_lists, records_by_id, gold_linked)
+
+
+def _block_row_ids(blk: Any) -> list:
+    """Read a block's ``__row_id__`` members, robust to the BlockResult shape:
+    newer goldenmatch exposes ``.materialize().column(...)`` (seam Frame); older
+    builds carry a raw polars frame on ``.df``. Handles both so this wiring
+    survives goldenmatch version skew across the install/worktree. Logs the shape
+    it saw ONCE (T7 uses it to confirm which goldenmatch bound at run time)."""
+    if hasattr(blk, "materialize"):
+        _log_block_shape("materialize")
+        return blk.materialize().column("__row_id__").to_list()
+    _log_block_shape("df")
+    df = getattr(blk, "df", None)
+    if df is None:
+        return []
+    if hasattr(df, "collect"):  # LazyFrame -> eager
+        df = df.collect()
+    return df["__row_id__"].to_list()
+
+
+def _log_block_shape(shape: str) -> None:
+    """Emit a one-time `[fs-enrich]` note naming which BlockResult shape fired."""
+    if shape in _LOGGED_BLOCK_SHAPES:
+        return
+    _LOGGED_BLOCK_SHAPES.add(shape)
+    detail = (
+        "newer goldenmatch (seam Frame)"
+        if shape == "materialize"
+        else "older goldenmatch (raw .df frame)"
+    )
+    print(
+        f"[fs-enrich] BlockResult shape: '{shape}' -- {detail}",
+        file=sys.stderr,
+    )
+
+
+def _rebalance_negatives(enriched: list[dict], mined_count: int) -> list[dict]:
+    """Honor "reduced share of synthetic negatives": for every mined hard
+    negative added, drop one ORIGINAL synthetic negative (a `no_match` row with
+    no `negative_kind`) so the total negative count stays balanced rather than
+    growing -- swapping easy synthetic negatives for hard mined ones.
+    Deterministic (drops in encounter order)."""
+    if mined_count <= 0:
+        return enriched
+    to_drop = mined_count
+    out: list[dict] = []
+    for row in enriched:
+        if (
+            to_drop > 0
+            and row.get("label") == "no_match"
+            and "negative_kind" not in row
+        ):
+            to_drop -= 1
+            continue
+        out.append(row)
+    return out
+
+
+def _pairs_hash(pairs: list[dict]) -> str:
+    """Deterministic digest of a source's pre-enrichment pairs -> the
+    `corpus_hash` fed to `fs_enrich.cache_key`."""
+    h = hashlib.sha256()
+    for p in pairs:
+        h.update(
+            json.dumps(
+                {k: p.get(k) for k in ("a", "b", "label", "eid_a", "eid_b")},
+                sort_keys=True,
+                default=str,
+            ).encode()
+        )
+    return h.hexdigest()
+
+
+def _fs_cache_path(out_dir: Path, key: str) -> Path:
+    return out_dir / ".fs_cache" / f"{key}.json"
+
+
+def _load_fs_cache(out_dir: Path, key: str) -> dict[str, list[dict]] | None:
+    path = _fs_cache_path(out_dir, key)
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return None
+
+
+def _save_fs_cache(out_dir: Path, key: str, result: dict[str, list[dict]]) -> None:
+    path = _fs_cache_path(out_dir, key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")

--- a/scripts/er_matcher/modal_train.py
+++ b/scripts/er_matcher/modal_train.py
@@ -199,7 +199,16 @@ def full(config_name: str = "bf16-lora", gpu: str = GPU_FULL) -> None:
     function argument.
     """
     qlora = config_name == "qlora-4bit"
-    train_full.with_options(gpu=gpu).remote(qlora=qlora)
+    fn = train_full
+    if gpu != GPU_FULL:
+        # runtime GPU retarget needs modal.Function.with_options (newer modal);
+        # fall back to the decorator's GPU_FULL when it's unavailable (modal 1.4.x).
+        if hasattr(fn, "with_options"):
+            fn = fn.with_options(gpu=gpu)
+        else:
+            print(f"[warn] runtime GPU override to {gpu!r} needs modal.with_options "
+                  f"(unavailable here); using decorator default {GPU_FULL!r}")
+    fn.remote(qlora=qlora)
     print("full run done -> `modal volume get er-matcher-out model/merged` "
           "(quantize + publish per plan §Phase 4)")
 

--- a/scripts/er_matcher/modal_train.py
+++ b/scripts/er_matcher/modal_train.py
@@ -282,6 +282,17 @@ def evaluate(limit: int = 0) -> None:
     print("eval done -> `modal volume get er-matcher-out eval_results.json`")
 
 
+@app.local_entrypoint()
+def evaluate_detached(limit: int = 0) -> None:
+    """Fire-and-forget in-distribution eval: spawn eval_model and return immediately.
+    Run with `modal run --detach ...::evaluate_detached` so the spawned call survives
+    the client exit (the generative scan of the full test split takes ~30-60 min).
+    Poll `modal volume get er-matcher-out eval_results.json` for the result."""
+    call = eval_model.spawn(limit=limit)
+    print(f"eval spawned (detached): {call.object_id} -> poll "
+          "`modal volume get er-matcher-out eval_results.json`")
+
+
 @app.function(
     image=_image,
     gpu=GPU_FULL,

--- a/scripts/er_matcher/modal_train.py
+++ b/scripts/er_matcher/modal_train.py
@@ -220,10 +220,14 @@ def full(config_name: str = "bf16-lora", gpu: str = GPU_FULL) -> None:
     volumes={"/out": _out_vol},
     secrets=[modal.Secret.from_name("er-matcher-hf")],
 )
-def eval_model(limit: int = 0) -> None:
-    """Load the merged model and score match-F1 on the held-out test split via
-    generative inference (build_chat -> generate -> parse_verdict), using
-    eval.run_eval for overall + per-domain P/R/F1 + calibration."""
+def eval_model(limit: int = 0, fast: bool = True) -> None:
+    """Load the merged model and score match-F1 on the held-out test split, using
+    eval.run_eval for overall + per-domain P/R/F1 + calibration.
+
+    fast=True (default): teacher-force the compact-JSON verdict prefix `{"match":`
+    and read the next-token logits over the `true`/`false` ids (one forward pass per
+    pair, ~15x faster than generation). fast=False: full generative inference
+    (build_chat -> generate -> parse_verdict) for exact production-decode fidelity."""
     import json
     import sys
 
@@ -248,27 +252,56 @@ def eval_model(limit: int = 0) -> None:
     )
 
     # run_eval scores each pair once for "overall" AND again per-domain -- memoize
-    # so a slow generative matcher only does one generation per pair.
+    # so the matcher only touches the model once per pair.
     cache: dict[tuple[int, int], dict | None] = {}
 
-    def matcher(a: dict, b: dict) -> dict | None:
-        key = (id(a), id(b))
-        if key in cache:
-            return cache[key]
-        text = tok.apply_chat_template(build_chat(a, b), tokenize=False, add_generation_prompt=True)
-        inputs = tok(text, return_tensors="pt").to(model.device)
-        with torch.no_grad():
-            out = model.generate(**inputs, max_new_tokens=64, do_sample=False,
-                                 pad_token_id=tok.eos_token_id)
-        gen = tok.decode(out[0][inputs["input_ids"].shape[1]:], skip_special_tokens=True)
-        v = parse_verdict(gen)
-        cache[key] = v
-        return v
+    if fast:
+        # compact JSON (render_target uses separators=(",",":")) -> the value token
+        # after `{"match":` is `true`/`false` with NO leading space.
+        _tid = tok.encode("true", add_special_tokens=False)
+        _fid = tok.encode("false", add_special_tokens=False)
+        if len(_tid) != 1 or len(_fid) != 1:
+            raise RuntimeError(f"true/false not single tokens: {_tid} {_fid}")
+        true_id, false_id = _tid[0], _fid[0]
+
+        def matcher(a: dict, b: dict) -> dict | None:
+            key = (id(a), id(b))
+            if key in cache:
+                return cache[key]
+            text = tok.apply_chat_template(
+                build_chat(a, b), tokenize=False, add_generation_prompt=True
+            ) + '{"match":'
+            inputs = tok(text, return_tensors="pt").to(model.device)
+            with torch.no_grad():
+                logits = model(**inputs).logits[0, -1, :]
+            pair = torch.softmax(torch.stack([logits[true_id], logits[false_id]]), dim=0)
+            p_match = float(pair[0])
+            match = p_match > 0.5
+            v = {"match": match, "confidence": p_match if match else 1.0 - p_match}
+            cache[key] = v
+            return v
+    else:
+        def matcher(a: dict, b: dict) -> dict | None:
+            key = (id(a), id(b))
+            if key in cache:
+                return cache[key]
+            text = tok.apply_chat_template(
+                build_chat(a, b), tokenize=False, add_generation_prompt=True
+            )
+            inputs = tok(text, return_tensors="pt").to(model.device)
+            with torch.no_grad():
+                out = model.generate(**inputs, max_new_tokens=64, do_sample=False,
+                                     pad_token_id=tok.eos_token_id)
+            gen = tok.decode(out[0][inputs["input_ids"].shape[1]:], skip_special_tokens=True)
+            v = parse_verdict(gen)
+            cache[key] = v
+            return v
 
     rows = [json.loads(ln) for ln in open("/root/data/er_matcher/test.jsonl") if ln.strip()]
     if limit:
         rows = rows[:limit]
-    print(f"[eval] scoring {len(rows)} test pairs (memoized generative matcher)...")
+    print(f"[eval] scoring {len(rows)} test pairs ({'fast logit' if fast else 'generative'} "
+          "matcher)...")
     scorecard = ev.run_eval({"test": rows}, matcher)
     with open("/out/eval_results.json", "w") as f:
         json.dump(scorecard, f, indent=2)

--- a/scripts/er_matcher/sources/febrl.py
+++ b/scripts/er_matcher/sources/febrl.py
@@ -163,3 +163,24 @@ class FebrlSource:
                 )
 
         return out
+
+    def record_pools(self) -> dict[str, list[dict]]:
+        """Per-split raw record pool (every record grouped by its entity's
+        split via `_entity_of`), leakage-consistent with `splits()` -- used
+        by a later task (hard-negative mining) that needs the full record
+        pool for a split, not just the sampled pairs."""
+        records = self._read_records()
+
+        entities: dict[str, list[str]] = {}
+        for rec_id in records:
+            entities.setdefault(_entity_of(rec_id), []).append(rec_id)
+
+        entity_split: dict[str, str] = {
+            eid: split_of(eid, seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac)
+            for eid in entities
+        }
+
+        pools: dict[str, list[dict]] = {"train": [], "val": [], "test": []}
+        for rec_id, fields in records.items():
+            pools[entity_split[_entity_of(rec_id)]].append(fields)
+        return pools

--- a/scripts/er_matcher/sources/febrl.py
+++ b/scripts/er_matcher/sources/febrl.py
@@ -41,12 +41,11 @@ def _is_org(rec_id: str) -> bool:
 class FebrlSource:
     """PairSource for FEBRL-style synthetic person data: a single record
     table where each entity contributes one "org" record plus zero or
-    more "dup" records. Splits are assigned at the ENTITY level (unlike
-    Leipzig's record/pair-level split) since every record belonging to a
-    FEBRL entity lives in the same source table -- clean entity-level
-    no-leak across train/val/test is both achievable and required here.
-    Positives and negatives are generated WITHIN each split so no
-    entity's records ever appear in more than one split.
+    more "dup" records. Splits are assigned at the ENTITY level: every
+    record belonging to a FEBRL entity lives in the same source table, so
+    clean entity-level no-leak across train/val/test is both achievable
+    and required here. Positives and negatives are generated WITHIN each
+    split so no entity's records ever appear in more than one split.
     """
 
     license = "MPL-1.1"
@@ -94,9 +93,12 @@ class FebrlSource:
             "eid_b": eid_b,
         }
 
-    def splits(self) -> dict[str, list[Row]]:
-        records = self._read_records()
-
+    def _entities_and_splits(
+        self, records: dict[str, dict]
+    ) -> tuple[dict[str, list[str]], dict[str, str]]:
+        """Group every record by its entity (`_entity_of`), then hash each
+        entity's split once. Shared by `splits()` and `record_pools()` so
+        the entity-grouping + split-hash logic lives in exactly one place."""
         entities: dict[str, list[str]] = {}
         for rec_id in records:
             entities.setdefault(_entity_of(rec_id), []).append(rec_id)
@@ -105,6 +107,11 @@ class FebrlSource:
             eid: split_of(eid, seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac)
             for eid in entities
         }
+        return entities, entity_split
+
+    def splits(self) -> dict[str, list[Row]]:
+        records = self._read_records()
+        entities, entity_split = self._entities_and_splits(records)
 
         out: dict[str, list[Row]] = {"train": [], "val": [], "test": []}
 
@@ -170,15 +177,7 @@ class FebrlSource:
         by a later task (hard-negative mining) that needs the full record
         pool for a split, not just the sampled pairs."""
         records = self._read_records()
-
-        entities: dict[str, list[str]] = {}
-        for rec_id in records:
-            entities.setdefault(_entity_of(rec_id), []).append(rec_id)
-
-        entity_split: dict[str, str] = {
-            eid: split_of(eid, seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac)
-            for eid in entities
-        }
+        _entities, entity_split = self._entities_and_splits(records)
 
         pools: dict[str, list[dict]] = {"train": [], "val": [], "test": []}
         for rec_id, fields in records.items():

--- a/scripts/er_matcher/sources/leipzig.py
+++ b/scripts/er_matcher/sources/leipzig.py
@@ -112,11 +112,14 @@ class LeipzigSource:
         # two records are always unioned into the same entity, so eid_a and
         # eid_b resolve to the same split -- no record/pair-level leakage.
         key_of = self._key_of(entities, gold_pairs)
+        # Precompute once (not per-split-per-entity) -- record_split maps
+        # every record id to its split via a single split_of hash each.
+        record_split: dict[str, str] = {rid: self._split_of_record(key_of, rid) for rid in entities}
 
         out: dict[str, list[Row]] = {"train": [], "val": [], "test": []}
 
         for eid_a, eid_b in gold_pairs:
-            split = self._split_of_record(key_of, eid_a)
+            split = record_split[eid_a]
             out[split].append(self._row(entities, eid_a, eid_b, "match"))
 
         # Negatives are synthesized PER SPLIT, over that split's record pool
@@ -127,7 +130,7 @@ class LeipzigSource:
             n_positives = len(split_rows)
             if n_positives == 0:
                 continue
-            split_rec_ids = [rid for rid in entities if self._split_of_record(key_of, rid) == split]
+            split_rec_ids = [rid for rid, rid_split in record_split.items() if rid_split == split]
             split_entities = {rid: entities[rid] for rid in split_rec_ids}
             oversample = max(
                 _MIN_NEGATIVE_OVERSAMPLE, round(n_positives * _NEGATIVE_OVERSAMPLE_FRAC)

--- a/scripts/er_matcher/sources/leipzig.py
+++ b/scripts/er_matcher/sources/leipzig.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from sources.base import Row
 from sources.csv_tables import read_id_table
 from sources.negatives import synth_negatives
-from sources.splits import split_of
+from sources.splits import entity_keys_from_edges, split_of
 
 # synth_negatives is asked for a few extra candidates beyond the positive
 # count so that dropping any that coincide with a gold match (see below)
@@ -32,11 +32,16 @@ class LeipzigSource:
     Abt-Buy, Amazon-GoogleProducts, DBLP-Scholar): two record tables plus a
     perfect-mapping gold file of matches.
 
-    Split assignment is done at the record/pair level (keyed by `eid_a` via
-    `split_of`), NOT at a true cross-table entity-identity level. Strict
-    entity-level no-leak across two *different* tables is a known hard
-    problem and is out of scope here -- record/pair-level splitting is the
-    pragmatic approach these benchmarks use elsewhere.
+    Split assignment is at the ENTITY level: the gold mapping's (idA, idB)
+    pairs are treated as edges over the combined tableA+tableB record ids,
+    connected components (`entity_keys_from_edges`) group every A-side and
+    B-side record that is transitively linked by a gold match into one
+    entity, and that entity's canonical key is hashed via `split_of`. This
+    means a record's split assignment no longer depends on which side of
+    the pair it happens to be (`eid_a` vs `eid_b`), and a record chain
+    linked through multiple gold matches lands in exactly one split.
+    Negative pairs are then synthesized PER SPLIT, over that split's record
+    pool only, so no negative can cross a split boundary.
     """
 
     license = "CC-BY"
@@ -82,56 +87,94 @@ class LeipzigSource:
             "eid_b": eid_b,
         }
 
-    def splits(self) -> dict[str, list[Row]]:
-        entities: dict[str, dict] = {
+    def _entities(self) -> dict[str, dict]:
+        return {
             **read_id_table(self.root, "tableA.csv", "A"),
             **read_id_table(self.root, "tableB.csv", "B"),
         }
+
+    def _key_of(self, entities: dict[str, dict], gold_pairs: list[tuple[str, str]]) -> dict[str, str]:
+        return entity_keys_from_edges(entities.keys(), gold_pairs)
+
+    def _split_of_record(self, key_of: dict[str, str], rid: str) -> str:
+        return split_of(
+            key_of[rid], seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac
+        )
+
+    def splits(self) -> dict[str, list[Row]]:
+        entities = self._entities()
         gold_pairs = self._read_gold_pairs()
         # Order-normalized so a sampled negative is caught regardless of
         # which side synth_negatives happened to put first.
         gold_set = {(a, b) for a, b in gold_pairs} | {(b, a) for a, b in gold_pairs}
+        # Connected components over the gold-match edges give every A-side
+        # and B-side record a stable ENTITY key (Task 1 fix). A gold pair's
+        # two records are always unioned into the same entity, so eid_a and
+        # eid_b resolve to the same split -- no record/pair-level leakage.
+        key_of = self._key_of(entities, gold_pairs)
 
         out: dict[str, list[Row]] = {"train": [], "val": [], "test": []}
 
-        def assign(row: Row) -> None:
-            split = split_of(
-                row["eid_a"], seed=self.seed, val_frac=self.val_frac, test_frac=self.test_frac
-            )
-            out[split].append(row)
-
         for eid_a, eid_b in gold_pairs:
-            assign(self._row(entities, eid_a, eid_b, "match"))
+            split = self._split_of_record(key_of, eid_a)
+            out[split].append(self._row(entities, eid_a, eid_b, "match"))
 
-        n_positives = len(gold_pairs)
-        oversample = max(_MIN_NEGATIVE_OVERSAMPLE, round(n_positives * _NEGATIVE_OVERSAMPLE_FRAC))
-        candidates = synth_negatives(
-            entities,
-            block_keys=self.block_fields,
-            hard_frac=self.hard_frac,
-            seed=self.seed,
-            n=n_positives + oversample,
-            # Namespace prefix ("A"/"B") is the partition -- negatives must
-            # be strictly cross-table, matching what the gold mapping pairs.
-            partition_of=lambda eid: eid[0],
-        )
-
-        kept = 0
-        for eid_a, eid_b, _tag in candidates:
-            if kept >= n_positives:
-                break
-            if (eid_a, eid_b) in gold_set:
-                # A sampled "negative" that is actually a true match --
-                # dropping it is correctness-critical, not cosmetic.
+        # Negatives are synthesized PER SPLIT, over that split's record pool
+        # only, so a negative pair can never straddle a split boundary.
+        total_kept = 0
+        total_positives = len(gold_pairs)
+        for split, split_rows in out.items():
+            n_positives = len(split_rows)
+            if n_positives == 0:
                 continue
-            assign(self._row(entities, eid_a, eid_b, "no_match"))
-            kept += 1
+            split_rec_ids = [rid for rid in entities if self._split_of_record(key_of, rid) == split]
+            split_entities = {rid: entities[rid] for rid in split_rec_ids}
+            oversample = max(
+                _MIN_NEGATIVE_OVERSAMPLE, round(n_positives * _NEGATIVE_OVERSAMPLE_FRAC)
+            )
+            candidates = synth_negatives(
+                split_entities,
+                block_keys=self.block_fields,
+                hard_frac=self.hard_frac,
+                seed=self.seed,
+                n=n_positives + oversample,
+                # Namespace prefix ("A"/"B") is the partition -- negatives
+                # must be strictly cross-table, matching the gold mapping.
+                partition_of=lambda eid: eid[0],
+            )
 
-        if kept < n_positives:
+            kept = 0
+            for eid_a, eid_b, _tag in candidates:
+                if kept >= n_positives:
+                    break
+                if (eid_a, eid_b) in gold_set:
+                    # A sampled "negative" that is actually a true match --
+                    # dropping it is correctness-critical, not cosmetic.
+                    continue
+                out[split].append(self._row(entities, eid_a, eid_b, "no_match"))
+                kept += 1
+            total_kept += kept
+
+        if total_kept < total_positives:
             warnings.warn(
-                f"leipzig[{self.name}]: only {kept}/{n_positives} negatives "
+                f"leipzig[{self.name}]: only {total_kept}/{total_positives} negatives "
                 "after gold-filter + cross-table constraint",
                 stacklevel=2,
             )
 
         return out
+
+    def record_pools(self) -> dict[str, list[dict]]:
+        """Per-split raw record pool (tableA + tableB records grouped by
+        their entity's split), leakage-consistent with `splits()` -- used
+        by a later task (hard-negative mining) that needs the full record
+        pool for a split, not just the sampled pairs."""
+        entities = self._entities()
+        gold_pairs = self._read_gold_pairs()
+        key_of = self._key_of(entities, gold_pairs)
+
+        pools: dict[str, list[dict]] = {"train": [], "val": [], "test": []}
+        for rid, fields in entities.items():
+            split = self._split_of_record(key_of, rid)
+            pools[split].append(fields)
+        return pools

--- a/scripts/er_matcher/sources/splits.py
+++ b/scripts/er_matcher/sources/splits.py
@@ -8,6 +8,45 @@ partitioning."""
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterable
+
+
+def entity_keys_from_edges(
+    record_ids: Iterable[str], edges: Iterable[tuple[str, str]]
+) -> dict[str, str]:
+    """Map each record id to a stable entity key via connected components over the
+    gold match edges. Records with no edges are their own singleton entity. The key
+    is the min member id, so it is deterministic regardless of union order."""
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        while parent[x] != root:  # path halving
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for rid in record_ids:
+        find(rid)
+    for a, b in edges:
+        union(a, b)
+
+    groups: dict[str, list[str]] = {}
+    for rid in list(parent):
+        groups.setdefault(find(rid), []).append(rid)
+    key_of: dict[str, str] = {}
+    for members in groups.values():
+        canonical = min(members)
+        for m in members:
+            key_of[m] = canonical
+    return key_of
 
 
 def split_of(eid: int | str, *, seed: int, val_frac: float, test_frac: float,

--- a/scripts/er_matcher/test_build_corpus_fs.py
+++ b/scripts/er_matcher/test_build_corpus_fs.py
@@ -1,0 +1,150 @@
+"""Box tests for the PURE adapters in `build_corpus`'s FS-enrichment path
+(honest-yardstick Task 6): `_pairs_from_blocks` (block-pair -> gold-tagged
+candidate), `_gold_components` (match-row union-find + transitive closure),
+`_rebalance_negatives` (swap easy synth negatives for hard mined ones), and
+`_sample_labeled_pairs`.
+
+Box-safe: these functions are stdlib-only, so importing `build_corpus` here
+touches NEITHER goldenmatch NOR polars NOR yaml (every heavy import in
+`build_corpus` is function-local). No `--fs-enrich` codepath runs -- the
+goldenmatch-backed halves (`_fit_fs_posterior`, `_make_candidates`, ...) are
+verified by a real corpus build, not here."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from build_corpus import (  # noqa: E402
+    _gold_components,
+    _pairs_from_blocks,
+    _rebalance_negatives,
+    _record_signature,
+    _sample_labeled_pairs,
+)
+
+
+def _rec(name: str, entity: str) -> dict:
+    return {"name": name, "eid": entity}
+
+
+# ── _pairs_from_blocks ──────────────────────────────────────────────────────
+
+
+def test_pairs_from_blocks_enumerates_within_block_pairs_and_tags_gold():
+    records_by_id = {
+        "0": _rec("alice", "e1"),
+        "1": _rec("alyce", "e1"),  # same entity as 0
+        "2": _rec("bob", "e2"),
+    }
+    # One block of all three ids; gold links 0<->1 only.
+    gold = {("0", "1")}
+    gold_linked = lambda a, b: (a["eid"], b["eid"]) == ("e1", "e1")  # noqa: E731
+
+    out = _pairs_from_blocks([["0", "1", "2"]], records_by_id, gold_linked)
+
+    pairs = {(c["eid_a"], c["eid_b"]): c["gold_match"] for c in out}
+    assert pairs == {("0", "1"): True, ("0", "2"): False, ("1", "2"): False}
+    # every candidate carries the actual record dicts for scoring
+    assert all("a" in c and "b" in c for c in out)
+    del gold
+
+
+def test_pairs_from_blocks_dedups_across_passes_canonical_order():
+    records_by_id = {"0": _rec("a", "e1"), "1": _rec("b", "e2")}
+    never_gold = lambda a, b: False  # noqa: E731
+    # Same pair appears in two blocks, one in reversed id order.
+    out = _pairs_from_blocks([["0", "1"], ["1", "0"]], records_by_id, never_gold)
+    assert len(out) == 1
+    assert (out[0]["eid_a"], out[0]["eid_b"]) == ("0", "1")
+
+
+def test_pairs_from_blocks_skips_self_pairs():
+    records_by_id = {"0": _rec("a", "e1")}
+    out = _pairs_from_blocks([["0", "0"]], records_by_id, lambda a, b: False)
+    assert out == []
+
+
+# ── _gold_components (transitive closure) ───────────────────────────────────
+
+
+def test_gold_components_recovers_star_topology_transitive_closure():
+    """FEBRL emits only anchor-vs-dup positives; dup0-vs-dup1 is same-entity but
+    never a match row. The component closure must still mark it gold-linked."""
+    anchor, dup0, dup1 = _rec("anchor", "e1"), _rec("dup0", "e1"), _rec("dup1", "e1")
+    other = _rec("other", "e2")
+    pairs = [
+        {"a": anchor, "b": dup0, "label": "match"},
+        {"a": anchor, "b": dup1, "label": "match"},
+        {"a": anchor, "b": other, "label": "no_match"},  # negatives are ignored
+    ]
+    gold_linked = _gold_components(pairs)
+
+    assert gold_linked(dup0, dup1) is True  # closed transitively via the anchor
+    assert gold_linked(anchor, dup1) is True
+    assert gold_linked(dup0, other) is False
+    # a record never seen in any match row links to nothing
+    assert gold_linked(other, _rec("stranger", "e3")) is False
+
+
+def test_gold_components_matches_by_value_not_identity():
+    a1 = _rec("alice", "e1")
+    a1_copy = dict(a1)  # different object, same values (record_pools strips ids)
+    b1 = _rec("bob", "e1")
+    gold_linked = _gold_components([{"a": a1, "b": b1, "label": "match"}])
+    assert gold_linked(a1_copy, b1) is True
+
+
+def test_record_signature_is_order_independent():
+    assert _record_signature({"x": "1", "y": "2"}) == _record_signature({"y": "2", "x": "1"})
+
+
+# ── _rebalance_negatives ────────────────────────────────────────────────────
+
+
+def test_rebalance_drops_one_synth_negative_per_mined_negative():
+    enriched = [
+        {"label": "match", "confidence": 0.9},
+        {"label": "no_match", "confidence": 0.1},  # original synth neg (droppable)
+        {"label": "no_match", "confidence": 0.1},  # original synth neg (droppable)
+        {"label": "no_match", "confidence": 0.4, "negative_kind": "fs_mined"},
+        {"label": "no_match", "confidence": 0.4, "negative_kind": "fs_mined"},
+    ]
+    out = _rebalance_negatives(enriched, mined_count=2)
+    # both original synth negatives dropped; positives + mined survive
+    assert [r["label"] for r in out] == ["match", "no_match", "no_match"]
+    assert all(r.get("negative_kind") == "fs_mined" for r in out if r["label"] == "no_match")
+
+
+def test_rebalance_noop_when_no_mined():
+    enriched = [{"label": "no_match", "confidence": 0.1}]
+    assert _rebalance_negatives(enriched, 0) == enriched
+
+
+def test_rebalance_never_drops_mined_or_positives_even_if_short_on_synth():
+    enriched = [
+        {"label": "match"},
+        {"label": "no_match", "confidence": 0.1},  # only ONE droppable synth neg
+        {"label": "no_match", "negative_kind": "fs_mined"},
+    ]
+    out = _rebalance_negatives(enriched, mined_count=5)  # asks for more than available
+    assert {r["label"] for r in out} == {"match", "no_match"}
+    assert any(r.get("negative_kind") == "fs_mined" for r in out)
+    assert sum(1 for r in out if r["label"] == "match") == 1
+
+
+# ── _sample_labeled_pairs ───────────────────────────────────────────────────
+
+
+def test_sample_labeled_pairs_balances_and_tags_match_flag():
+    pairs = (
+        [{"a": {"n": i}, "b": {"n": i}, "label": "match"} for i in range(5)]
+        + [{"a": {"n": i}, "b": {"n": -i}, "label": "no_match"} for i in range(3)]
+    )
+    sample = _sample_labeled_pairs(pairs, k=10)
+    is_match = [m for _a, _b, m in sample]
+    assert sum(is_match) == 5
+    assert sum(1 for m in is_match if not m) == 3
+    assert all(isinstance(a, dict) and isinstance(b, dict) for a, b, _m in sample)

--- a/scripts/er_matcher/test_build_corpus_fs.py
+++ b/scripts/er_matcher/test_build_corpus_fs.py
@@ -1,28 +1,33 @@
-"""Box tests for the PURE adapters in `build_corpus`'s FS-enrichment path
-(honest-yardstick Task 6): `_pairs_from_blocks` (block-pair -> gold-tagged
+"""Box tests for the PURE adapters in the FS-enrichment layer (`fs_scorer`,
+honest-yardstick Task 6): `_pairs_from_blocks` (block-pair -> gold-tagged
 candidate), `_gold_components` (match-row union-find + transitive closure),
-`_rebalance_negatives` (swap easy synth negatives for hard mined ones), and
-`_sample_labeled_pairs`.
+`_rebalance_negatives` (swap easy synth negatives for hard mined ones),
+`_sample_labeled_pairs`, `_check_separation` (the posterior-vs-weighted gate),
+and the disk-cache helpers (`_pairs_hash` / `_save_fs_cache` / `_load_fs_cache`).
 
-Box-safe: these functions are stdlib-only, so importing `build_corpus` here
-touches NEITHER goldenmatch NOR polars NOR yaml (every heavy import in
-`build_corpus` is function-local). No `--fs-enrich` codepath runs -- the
-goldenmatch-backed halves (`_fit_fs_posterior`, `_make_candidates`, ...) are
-verified by a real corpus build, not here."""
+Box-safe: `fs_scorer` keeps every goldenmatch/polars import function-local, so
+importing it here touches NEITHER goldenmatch NOR polars NOR yaml. No
+`--fs-enrich` codepath runs -- the goldenmatch-backed halves (`_fit_fs_posterior`,
+`_make_candidates`, ...) are verified by a real corpus build, not here."""
 
 from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from build_corpus import (  # noqa: E402
+from fs_scorer import (  # noqa: E402
+    _check_separation,
     _gold_components,
+    _load_fs_cache,
     _pairs_from_blocks,
+    _pairs_hash,
     _rebalance_negatives,
     _record_signature,
     _sample_labeled_pairs,
+    _save_fs_cache,
 )
 
 
@@ -40,7 +45,6 @@ def test_pairs_from_blocks_enumerates_within_block_pairs_and_tags_gold():
         "2": _rec("bob", "e2"),
     }
     # One block of all three ids; gold links 0<->1 only.
-    gold = {("0", "1")}
     gold_linked = lambda a, b: (a["eid"], b["eid"]) == ("e1", "e1")  # noqa: E731
 
     out = _pairs_from_blocks([["0", "1", "2"]], records_by_id, gold_linked)
@@ -49,7 +53,6 @@ def test_pairs_from_blocks_enumerates_within_block_pairs_and_tags_gold():
     assert pairs == {("0", "1"): True, ("0", "2"): False, ("1", "2"): False}
     # every candidate carries the actual record dicts for scoring
     assert all("a" in c and "b" in c for c in out)
-    del gold
 
 
 def test_pairs_from_blocks_dedups_across_passes_canonical_order():
@@ -148,3 +151,72 @@ def test_sample_labeled_pairs_balances_and_tags_match_flag():
     assert sum(is_match) == 5
     assert sum(1 for m in is_match if not m) == 3
     assert all(isinstance(a, dict) and isinstance(b, dict) for a, b, _m in sample)
+
+
+# ── _check_separation (the posterior-vs-weighted gate) ──────────────────────
+
+
+def _sample(scores):
+    """A labeled sample as (a, b, is_match) where scorer reads a['s'] as the
+    injected score -- lets these tests drive `_check_separation` with no
+    goldenmatch."""
+    return [({"s": s}, {"s": s}, is_m) for s, is_m in scores]
+
+
+def _fake_scorer(a, b):
+    return a["s"]
+
+
+def test_check_separation_passes_when_margin_cleared_and_in_range():
+    sample = _sample([(0.95, True), (0.9, True), (0.05, False), (0.1, False)])
+    ok, mean_m, mean_n, in_range = _check_separation(_fake_scorer, sample)
+    assert ok is True
+    assert in_range is True
+    assert mean_m > mean_n
+
+
+def test_check_separation_fails_when_out_of_unit_range():
+    # match mean beats non-match mean by a mile, but a score sits outside [0,1]
+    sample = _sample([(1.4, True), (0.9, True), (0.05, False)])
+    ok, _mean_m, _mean_n, in_range = _check_separation(_fake_scorer, sample)
+    assert in_range is False
+    assert ok is False
+
+
+def test_check_separation_fails_when_margin_not_met():
+    # both classes ~0.5: mean(match) does NOT beat mean(non-match) by the margin
+    sample = _sample([(0.52, True), (0.5, True), (0.5, False), (0.48, False)])
+    ok, mean_m, mean_n, in_range = _check_separation(_fake_scorer, sample)
+    assert in_range is True
+    assert mean_m - mean_n < 0.1  # below _SEPARATION_MARGIN
+    assert ok is False
+
+
+def test_check_separation_fails_when_a_class_is_empty():
+    # no non-match scores at all -> cannot verify separation -> not ok
+    sample = _sample([(0.9, True), (0.95, True)])
+    ok, _mean_m, _mean_n, _in_range = _check_separation(_fake_scorer, sample)
+    assert ok is False
+
+
+# ── pure disk-cache helpers (round-trip) ────────────────────────────────────
+
+
+def test_pairs_hash_deterministic_and_order_sensitive():
+    p1 = [{"a": {"n": "x"}, "b": {"n": "y"}, "label": "match", "eid_a": "0", "eid_b": "1"}]
+    p2 = [{"a": {"n": "x"}, "b": {"n": "z"}, "label": "match", "eid_a": "0", "eid_b": "1"}]
+    assert _pairs_hash(p1) == _pairs_hash(p1)  # stable
+    assert _pairs_hash(p1) != _pairs_hash(p2)  # content-sensitive
+
+
+def test_fs_cache_save_load_round_trip(tmp_path: Path):
+    key = "deadbeef"
+    payload = {
+        "train": [{"label": "match", "confidence": 0.97}],
+        "val": [],
+        "test": [{"label": "no_match", "confidence": 0.03, "negative_kind": "fs_mined"}],
+    }
+    assert _load_fs_cache(tmp_path, key) is None  # miss before write
+    _save_fs_cache(tmp_path, key, payload)
+    assert _load_fs_cache(tmp_path, key) == payload  # hit after write
+    assert (tmp_path / ".fs_cache" / f"{key}.json").exists()

--- a/scripts/er_matcher/test_febrl.py
+++ b/scripts/er_matcher/test_febrl.py
@@ -96,6 +96,41 @@ def test_shortfall_warning_fires_on_tiny_fixture():
         src.splits()
 
 
+def test_record_pool_every_record_in_exactly_one_split():
+    src = FebrlSource(FIX, seed=1)
+    pools = src.record_pools()
+    assert set(pools) == {"train", "val", "test"}
+    all_soc_sec_ids = [entry["soc_sec_id"] for split in pools.values() for entry in split]
+    with open(FIX / "febrl_sample.csv", newline="", encoding="utf-8") as f:
+        n_records = sum(1 for _ in f) - 1  # minus header
+    assert sum(len(v) for v in pools.values()) == n_records
+    # soc_sec_id isn't unique per record here (dup rows share their org's
+    # value), so just check no record was dropped -- length parity above
+    # plus every entry present is the leakage-relevant invariant.
+    assert len(all_soc_sec_ids) == n_records
+
+
+def test_record_pool_leakage_consistent_with_gold_pairs():
+    src = FebrlSource(FIX, seed=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        splits = src.splits()
+    pools = src.record_pools()
+    records = src._read_records()
+
+    def find_split(rid: str) -> str:
+        target = records[rid]
+        for split, entries in pools.items():
+            if target in entries:
+                return split
+        raise AssertionError(f"{rid} missing from record_pools()")
+
+    positives = [r for r in (row for rows in splits.values() for row in rows) if r["label"] == "match"]
+    assert positives  # sanity
+    for r in positives:
+        assert find_split(r["eid_a"]) == find_split(r["eid_b"])
+
+
 def test_anchor_fallback_when_no_org_record():
     # rec-6 has only rec-6-dup-0 / rec-6-dup-1, no rec-6-org. The anchor
     # falls back to the first record in sorted order, and that entity

--- a/scripts/er_matcher/test_fs_enrich.py
+++ b/scripts/er_matcher/test_fs_enrich.py
@@ -93,10 +93,13 @@ def test_enrich_attaches_soft_conf_and_appends_mined_negs():
         tau=0.5,
         delta=0.1,
         mine_cap=10,
+        domain="product",
     )
     assert all(0.0 < p["confidence"] < 1.0 for p in out)
     mined = [p for p in out if (p["eid_a"], p["eid_b"]) == ("e", "f")]
     assert len(mined) == 1 and mined[0]["label"] == "no_match"
+    # mined negs must carry the source domain so run_eval can bucket by it
+    assert mined[0]["domain"] == "product"
     assert mined[0]["negative_kind"] == "fs_mined"
 
 

--- a/scripts/er_matcher/test_fs_enrich.py
+++ b/scripts/er_matcher/test_fs_enrich.py
@@ -1,9 +1,16 @@
+"""Tests for FS-score-driven soft confidence targets (honest-yardstick Task 2).
+
+Covers monotonicity, clamping to the hi/lo/mid_hi/mid_lo boundary constants, and
+the never-0/1 invariant -- pure stdlib, box-safe (no torch/scipy/numpy/network)."""
+from __future__ import annotations
+
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from fs_enrich import soft_confidence
+
+from fs_enrich import soft_confidence  # noqa: E402
 
 
 def test_soft_confidence_monotonic_and_clamped():

--- a/scripts/er_matcher/test_fs_enrich.py
+++ b/scripts/er_matcher/test_fs_enrich.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fs_enrich import soft_confidence
+
+
+def test_soft_confidence_monotonic_and_clamped():
+    # match: higher FS score -> higher confidence, never > 0.97, floor 0.55 near/below tau
+    assert soft_confidence(1.0, True, tau=0.5) == 0.97
+    assert soft_confidence(0.5, True, tau=0.5) == 0.55  # at threshold -> uncertain
+    assert soft_confidence(0.1, True, tau=0.5) == 0.55  # matcher missed it -> floor, not 0
+    mid = soft_confidence(0.75, True, tau=0.5)
+    assert 0.55 < mid < 0.97
+    # non-match: lower FS score -> lower confidence, never < 0.03, ceiling 0.45 near/above tau
+    assert soft_confidence(0.0, False, tau=0.5) == 0.03
+    assert soft_confidence(0.5, False, tau=0.5) == 0.45  # at threshold -> uncertain
+    assert soft_confidence(0.9, False, tau=0.5) == 0.45  # matcher wrongly high -> ceiling
+    nm = soft_confidence(0.25, False, tau=0.5)
+    assert 0.03 < nm < 0.45
+
+
+def test_soft_confidence_never_hits_0_or_1():
+    for s in (0.0, 0.5, 1.0):
+        for m in (True, False):
+            c = soft_confidence(s, m, tau=0.5)
+            assert 0.0 < c < 1.0

--- a/scripts/er_matcher/test_fs_enrich.py
+++ b/scripts/er_matcher/test_fs_enrich.py
@@ -1,7 +1,9 @@
-"""Tests for FS-score-driven soft confidence targets (honest-yardstick Task 2).
+"""Tests for FS-score-driven soft confidence targets, hard-negative selection, and
+enrichment orchestration (honest-yardstick Tasks 2-4).
 
-Covers monotonicity, clamping to the hi/lo/mid_hi/mid_lo boundary constants, and
-the never-0/1 invariant -- pure stdlib, box-safe (no torch/scipy/numpy/network)."""
+Covers monotonicity, clamping to the hi/lo/mid_hi/mid_lo boundary constants, the
+never-0/1 invariant, hard-negative mining, and the `enrich`/`cache_key` orchestration
+-- pure stdlib, box-safe (no torch/scipy/numpy/network)."""
 from __future__ import annotations
 
 import os
@@ -11,10 +13,10 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 
 
-from fs_enrich import select_hard_negatives, soft_confidence  # noqa: E402
+from fs_enrich import cache_key, enrich, select_hard_negatives, soft_confidence  # noqa: E402
 
 
-def _cand(a, b, score, gold):  # helper: a scored candidate with its gold label
+def _cand(a: str, b: str, score: float, gold: bool) -> dict:  # helper: a scored candidate with its gold label
     return {"a_id": a, "b_id": b, "score": score, "gold_match": gold}
 
 
@@ -67,3 +69,41 @@ def test_soft_confidence_never_hits_0_or_1():
         for m in (True, False):
             c = soft_confidence(s, m, tau=0.5)
             assert 0.0 < c < 1.0
+
+
+def test_enrich_attaches_soft_conf_and_appends_mined_negs():
+    pairs = [
+        {"a": {"id": "a"}, "b": {"id": "b"}, "label": "match", "eid_a": "a", "eid_b": "b"},
+        {"a": {"id": "c"}, "b": {"id": "d"}, "label": "no_match", "eid_a": "c", "eid_b": "d"},
+    ]
+
+    def scorer(x, y):
+        return {("a", "b"): 0.9, ("c", "d"): 0.1, ("e", "f"): 0.5}[(x["id"], y["id"])]
+
+    def candidates(records):
+        return [
+            {"a": {"id": "e"}, "b": {"id": "f"}, "gold_match": False, "eid_a": "e", "eid_b": "f"}
+        ]
+
+    out = enrich(
+        pairs,
+        records=[{"id": "e"}, {"id": "f"}],
+        scorer=scorer,
+        candidates_fn=candidates,
+        tau=0.5,
+        delta=0.1,
+        mine_cap=10,
+    )
+    assert all(0.0 < p["confidence"] < 1.0 for p in out)
+    mined = [p for p in out if (p["eid_a"], p["eid_b"]) == ("e", "f")]
+    assert len(mined) == 1 and mined[0]["label"] == "no_match"
+    assert mined[0]["negative_kind"] == "fs_mined"
+
+
+def test_cache_key_stable_and_sensitive():
+    a = cache_key(corpus_hash="h1", scorer_cfg="c1", tau=0.5, delta=0.1)
+    assert a == cache_key(corpus_hash="h1", scorer_cfg="c1", tau=0.5, delta=0.1)
+    assert a != cache_key(corpus_hash="h2", scorer_cfg="c1", tau=0.5, delta=0.1)
+    assert a != cache_key(corpus_hash="h1", scorer_cfg="c2", tau=0.5, delta=0.1)
+    assert a != cache_key(corpus_hash="h1", scorer_cfg="c1", tau=0.6, delta=0.1)
+    assert a != cache_key(corpus_hash="h1", scorer_cfg="c1", tau=0.5, delta=0.2)

--- a/scripts/er_matcher/test_fs_enrich.py
+++ b/scripts/er_matcher/test_fs_enrich.py
@@ -5,6 +5,7 @@ the never-0/1 invariant -- pure stdlib, box-safe (no torch/scipy/numpy/network).
 from __future__ import annotations
 
 import os
+import random
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -23,6 +24,7 @@ def test_select_keeps_near_threshold_gold_nonmatches_only():
         _cand("c", "d", 0.99, True),  # gold MATCH -> reject (not a negative)
         _cand("e", "f", 0.05, False),  # far below band -> reject (easy)
         _cand("g", "h", 0.48, False),  # near tau, gold NON-match -> KEEP
+        _cand("i", "j", 0.51, True),  # near tau but gold MATCH -> reject (proves gold gate)
     ]
     out = select_hard_negatives(cands, tau=0.5, delta=0.1, cap=10)
     kept = {(c["a_id"], c["b_id"]) for c in out}
@@ -34,6 +36,15 @@ def test_select_caps_and_is_deterministic():
     out = select_hard_negatives(cands, tau=0.5, delta=0.1, cap=5)
     assert len(out) == 5
     assert out == select_hard_negatives(cands, tau=0.5, delta=0.1, cap=5)  # deterministic
+
+
+def test_select_is_order_independent():
+    cands = [_cand(f"a{i}", f"b{i}", 0.5, False) for i in range(20)]
+    shuffled = cands[:]
+    random.Random(0).shuffle(shuffled)
+    assert select_hard_negatives(shuffled, tau=0.5, delta=0.1, cap=5) == select_hard_negatives(
+        cands, tau=0.5, delta=0.1, cap=5
+    )
 
 
 def test_soft_confidence_monotonic_and_clamped():

--- a/scripts/er_matcher/test_fs_enrich.py
+++ b/scripts/er_matcher/test_fs_enrich.py
@@ -10,7 +10,30 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 
 
-from fs_enrich import soft_confidence  # noqa: E402
+from fs_enrich import select_hard_negatives, soft_confidence  # noqa: E402
+
+
+def _cand(a, b, score, gold):  # helper: a scored candidate with its gold label
+    return {"a_id": a, "b_id": b, "score": score, "gold_match": gold}
+
+
+def test_select_keeps_near_threshold_gold_nonmatches_only():
+    cands = [
+        _cand("a", "b", 0.52, False),  # near tau, gold NON-match -> KEEP (hard neg)
+        _cand("c", "d", 0.99, True),  # gold MATCH -> reject (not a negative)
+        _cand("e", "f", 0.05, False),  # far below band -> reject (easy)
+        _cand("g", "h", 0.48, False),  # near tau, gold NON-match -> KEEP
+    ]
+    out = select_hard_negatives(cands, tau=0.5, delta=0.1, cap=10)
+    kept = {(c["a_id"], c["b_id"]) for c in out}
+    assert kept == {("a", "b"), ("g", "h")}
+
+
+def test_select_caps_and_is_deterministic():
+    cands = [_cand(f"a{i}", f"b{i}", 0.5, False) for i in range(20)]
+    out = select_hard_negatives(cands, tau=0.5, delta=0.1, cap=5)
+    assert len(out) == 5
+    assert out == select_hard_negatives(cands, tau=0.5, delta=0.1, cap=5)  # deterministic
 
 
 def test_soft_confidence_monotonic_and_clamped():

--- a/scripts/er_matcher/test_leipzig.py
+++ b/scripts/er_matcher/test_leipzig.py
@@ -77,6 +77,43 @@ def test_negatives_are_strictly_cross_table():
     assert all(r["eid_a"][0] != r["eid_b"][0] for r in no_match)
 
 
+def test_record_pool_every_record_in_exactly_one_split():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    pools = src.record_pools()
+    assert set(pools) == {"train", "val", "test"}
+    all_ids = [
+        entry.get("id") or entry.get("title") for split in pools.values() for entry in split
+    ]
+    # 4 rows in tableA + 4 rows in tableB == 8 total records, none dropped
+    # and none duplicated across splits.
+    assert sum(len(v) for v in pools.values()) == 8
+    assert len(all_ids) == len(set(all_ids))
+
+
+def test_record_pool_leakage_consistent_with_gold_pairs():
+    src = LeipzigSource(name="abt_buy", root=FIX, domain="product", block_fields=["title"], seed=1)
+    pools = src.record_pools()
+    entities = src._entities()
+    gold_pairs = src._read_gold_pairs()
+    key_of = src._key_of(entities, gold_pairs)
+
+    # Build id -> split from the record pool by matching on the field
+    # payload (record_pools() returns bare field dicts, not namespaced ids).
+    def find_split(rid: str) -> str:
+        for split, records in pools.items():
+            if entities[rid] in records:
+                return split
+        raise AssertionError(f"{rid} missing from record_pools()")
+
+    rows = _all_rows(src)
+    positive_rows = [r for r in rows if r["label"] == "match"]
+    assert positive_rows  # sanity
+    for r in positive_rows:
+        expected_split = src._split_of_record(key_of, r["eid_a"])
+        assert find_split(r["eid_a"]) == expected_split
+        assert find_split(r["eid_b"]) == expected_split
+
+
 def test_no_shortfall_warning_on_fixture():
     import warnings
 

--- a/scripts/er_matcher/test_splits.py
+++ b/scripts/er_matcher/test_splits.py
@@ -7,7 +7,31 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from sources.splits import split_of  # noqa: E402
+from sources.splits import entity_keys_from_edges, split_of  # noqa: E402
+
+
+def test_connected_components_merges_transitively():
+    keys = entity_keys_from_edges(
+        ["A1", "A2", "B1", "B2"],
+        [("A1", "B1"), ("B1", "A2")],
+    )
+    assert keys["A1"] == keys["B1"] == keys["A2"]
+    assert keys["B2"] != keys["A1"]
+    assert keys["A1"] == "A1"
+
+
+def test_singletons_get_own_key():
+    keys = entity_keys_from_edges(["X", "Y"], [])
+    assert keys["X"] == "X" and keys["Y"] == "Y" and keys["X"] != keys["Y"]
+
+
+def test_entity_split_has_no_leakage():
+    ids = [f"A{i}" for i in range(50)] + [f"B{i}" for i in range(50)]
+    edges = [(f"A{i}", f"B{i}") for i in range(50)]
+    keys = entity_keys_from_edges(ids, edges)
+    sp = {rid: split_of(keys[rid], seed=1, val_frac=0.15, test_frac=0.15) for rid in ids}
+    for i in range(50):
+        assert sp[f"A{i}"] == sp[f"B{i}"]
 
 
 def test_str_and_int_eid_parity():

--- a/scripts/er_matcher/test_train_helpers.py
+++ b/scripts/er_matcher/test_train_helpers.py
@@ -92,6 +92,26 @@ def _row(match: bool) -> dict:
     }
 
 
+def _assistant(msgs: list[dict]) -> str:
+    return next(m["content"] for m in msgs if m["role"] == "assistant")
+
+
+def test_row_confidence_overrides_constant():
+    cfg = tr.TrainConfig()
+    row = _row(match=True)
+    row["confidence"] = 0.62
+    msgs = tr.example_to_messages(row, cfg)
+    assert '"confidence":0.62' in _assistant(msgs)
+
+
+def test_missing_confidence_falls_back_to_constant():
+    cfg = tr.TrainConfig()
+    row = _row(match=True)
+    row.pop("confidence", None)
+    msgs = tr.example_to_messages(row, cfg)
+    assert '"confidence":0.9' in _assistant(msgs)  # DEFAULT_MATCH_CONF
+
+
 def test_example_to_messages_shape_and_roundtrip():
     cfg = tr.TrainConfig()
     for match in (True, False):

--- a/scripts/er_matcher/train.py
+++ b/scripts/er_matcher/train.py
@@ -166,13 +166,17 @@ def example_to_messages(row: dict[str, Any], cfg: TrainConfig) -> list[dict[str,
     the shared system+user prompt (build_chat) + the assistant TARGET verdict.
 
     The target is the exact JSON the model must emit at inference (render_target),
-    so training and serving share one contract. ``reason`` is a compact,
-    deterministic agreement summary (never-black-box; not free-form so the model
-    can't learn to hallucinate prose). Round-trips through parse_verdict by
-    construction (asserted in tests)."""
+    so training and serving share one contract. Confidence prefers the row's own
+    ``confidence`` (the FS-score-driven soft target some corpora carry) and falls
+    back to ``cfg.match_confidence``/``cfg.nomatch_confidence`` only when the row
+    has none -- an honest-yardstick label beats the fixed 0.9/0.1 constant.
+    ``reason`` is a compact, deterministic agreement summary (never-black-box; not
+    free-form so the model can't learn to hallucinate prose). Round-trips through
+    parse_verdict by construction (asserted in tests)."""
     a, b, label = row["a"], row["b"], row["label"]
     match = label == "match"
-    conf = cfg.match_confidence if match else cfg.nomatch_confidence
+    default_conf = cfg.match_confidence if match else cfg.nomatch_confidence
+    conf = row.get("confidence", default_conf)
     reason = _auto_reason(a, b, match)
     return [*build_chat(a, b), {"role": "assistant", "content": render_target(match, conf, reason)}]
 


### PR DESCRIPTION
## What

Makes the ER-matcher's training signal and metric **honest**, then confirms with a retrain measured against the SP3 zero-shot held-out suite. Precursor to Phase 1b data diversity.

Three coupled changes + a retrain:
1. **Entity-level splits** (connected components over gold match edges) — kills the record-level train/test leakage that inflated SP2's metric.
2. **FS-mined hard negatives** — mine near-threshold non-matches from goldenmatch's own Fellegi-Sunter posterior (dogfooding), instead of easy synthetic near-misses.
3. **FS-score-driven soft confidence targets** — replace the fixed 0.9/0.1 SFT targets with difficulty-aware ones from the same FS score, fixing calibration at the source.

## Results (real Modal A100, Qwen2.5-3B bf16 LoRA, frozen SP2 config)

| Metric | SP2 | SP3.5 (honest) |
|---|---|---|
| In-distribution F1 | 0.983 (inflated) | **0.970** (trustworthy) |
| In-distribution ECE | — | **0.0105** |
| Zero-shot F1 — Walmart-Amazon | 0.640 | 0.645 |
| Zero-shot F1 — Beer | 0.897 | 0.897 |
| Zero-shot raw ECE — Beer | 0.043 | 0.029 |

*Zero-shot benchmarks are held-out (never trained on), the honest generalization signal.*

**Read:** the yardstick is now honest — in-distribution F1 drops 0.983 -> 0.970 as the leakage + easy-negative inflation is removed, and the model is well-calibrated in-distribution (ECE 0.01) thanks to the soft targets. Zero-shot generalization is **neutral** (harder training data neither hurt nor helped held-out F1). That's the signal that the next real gains come from Phase 1b data diversity or a bigger base — which is exactly why we built the honest measurement first.

**Corpus** (17,682 / 3,718 / 3,507): FS-driven confidence is genuinely varied (420 distinct values, ~0% at the old 0.9/0.1), 747 mined hard negatives, leakage-free entity splits. The product domain's EM posterior degenerated, so its separation gate correctly fell back to the weighted scorer.

## How

- `sources/{splits,leipzig,febrl}.py`: entity-level splits + per-split `record_pools()`.
- `fs_enrich.py` (new, pure): `soft_confidence`, `select_hard_negatives`, `enrich`, cache key. Injected scorer so the box suite never imports goldenmatch.
- `fs_scorer.py` (new): fits the FS posterior once on the train pool (`auto_configure_probabilistic_df` -> `score_pair_probabilistic`), blocks per-split, with a weighted-fallback + [0,1] separation gate.
- `build_corpus.py`: opt-in `--fs-enrich` wiring.
- `train.py`: reads per-row `confidence` (constant is fallback).
- `modal_train.py`: `eval_model` gains a `fast=True` logit path (~15x faster in-distribution eval); `evaluate_detached` spawn entrypoint; `full` tolerates missing `with_options` on modal 1.4.x.

## Test boundary

Pure logic (splits, fs_enrich, fs_scorer adapters, per-row confidence) is box-tested with no GPU/goldenmatch import. The FS wiring is verified by a real corpus build; the retrain + evals by the real Modal run above (same boundary as SP2/SP3).

## Notable fixes found during the run
- fs-mined negatives were created without a `domain` field, which crashed `run_eval`'s per-domain bucketing (`KeyError: 'domain'`). Fixed: mined rows inherit the source domain (with a test).
- The generative in-distribution eval was ~85 min; the new `fast` logit path is ~6 min.

## Out of scope (later)
- Rich Synthetic Generator (Phase 1b data diversity) - the next step.
- 7B base / hyperparameter sweep; new sources (MusicBrainz, NCVR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXyU2FtzzQ68AYMaNKTX81