### PR TITLE
perf(goldenphonetic): ASCII fast path — nysiis 6.8x, soundex 1.8x faster (byte-identical), v0.1.1

### DIFF
--- a/packages/rust/extensions/goldenphonetic-core/Cargo.toml
+++ b/packages/rust/extensions/goldenphonetic-core/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "goldenphonetic-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenphonetic-core/examples/bench_vs_jellyfish.rs
+++ b/packages/rust/extensions/goldenphonetic-core/examples/bench_vs_jellyfish.rs
@@ -1,0 +1,152 @@
+// Head-to-head: goldenphonetic-core (soundex / nysiis) vs the Python `jellyfish`
+// package, on an ASCII single-token name corpus (the overwhelming common case).
+//
+// Build+run:  cargo run --release --example bench_vs_jellyfish
+//
+// This example ONLY calls the public `soundex` / `nysiis`, so it compiles
+// unchanged against both the pre- and post-fast-path lib. To get the before/after
+// split with an identical harness:
+//   cargo run --release --example bench_vs_jellyfish            # AFTER (fast path)
+//   git stash && cargo run --release --example bench_vs_jellyfish && git stash pop  # BEFORE
+//
+// It also writes the exact corpus it timed to
+// `target/bench_ascii_names.txt` so `scripts/bench_jellyfish.py` can time the SAME
+// inputs with Python `jellyfish` and the ratios line up.
+use std::path::Path;
+use std::time::Instant;
+
+use goldenphonetic_core::{nysiis, soundex};
+
+fn next(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+// Real-ish given/surname fragments — same flavour as the parity corpus, all ASCII.
+const FRAGS: &[&str] = &[
+    "robert",
+    "rupert",
+    "ashcraft",
+    "ashcroft",
+    "tymczak",
+    "pfister",
+    "honeyman",
+    "catherine",
+    "kathryn",
+    "smith",
+    "smyth",
+    "jonathan",
+    "thompson",
+    "byrne",
+    "michael",
+    "michelle",
+    "gutierrez",
+    "vandeusen",
+    "vanderberg",
+    "mcdonald",
+    "macintosh",
+    "mackenzie",
+    "knight",
+    "wright",
+    "pneumonia",
+    "phillip",
+    "schwartz",
+    "schmidt",
+    "quentin",
+    "xavier",
+    "yolanda",
+    "zachary",
+    "elizabeth",
+    "william",
+    "andrew",
+    "matthew",
+    "christopher",
+    "kristopher",
+    "jennifer",
+    "wojcik",
+    "kowalski",
+    "schneider",
+    "fischer",
+    "hoffmann",
+    "richter",
+    "schroeder",
+    "neumann",
+    "gennifer",
+    "nathaniel",
+    "maryanne",
+];
+
+// Build `n` single-token ASCII names: a fragment, sometimes concatenated with a
+// second fragment (compound surname) to spread lengths realistically.
+fn corpus(n: usize) -> Vec<String> {
+    let mut rng: u64 = 0xC0FF_EE12_3456_789A;
+    (0..n)
+        .map(|_| {
+            let a = FRAGS[(next(&mut rng) as usize) % FRAGS.len()];
+            if next(&mut rng) & 3 == 0 {
+                let b = FRAGS[(next(&mut rng) as usize) % FRAGS.len()];
+                format!("{a}{b}")
+            } else {
+                a.to_string()
+            }
+        })
+        .collect()
+}
+
+// ns/call: run the encoder over every name in `corpus`, `reps` times.
+fn time<F: Fn(&str) -> String>(corpus: &[String], reps: usize, f: F) -> f64 {
+    let t = Instant::now();
+    let mut acc = 0usize;
+    for _ in 0..reps {
+        for s in corpus {
+            acc += f(s).len();
+        }
+    }
+    std::hint::black_box(acc);
+    let calls = (reps * corpus.len()) as f64;
+    t.elapsed().as_secs_f64() / calls * 1e9
+}
+
+fn main() {
+    let names = corpus(50_000);
+    let reps = 20; // 1,000,000 calls per encoder
+
+    // Persist the exact corpus for the Python jellyfish side.
+    let out = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("bench_ascii_names.txt");
+    if let Some(dir) = out.parent() {
+        std::fs::create_dir_all(dir).ok();
+    }
+    std::fs::write(&out, names.join("\n")).expect("write corpus");
+
+    // Warm up (fill caches / branch predictor) before timing.
+    let _ = time(&names, 1, soundex);
+    let _ = time(&names, 1, nysiis);
+
+    let sx = time(&names, reps, soundex);
+    let ny = time(&names, reps, nysiis);
+
+    let total_ms = |ns: f64| ns * names.len() as f64 / 1e6;
+
+    println!(
+        "goldenphonetic-core ASCII name corpus: {} names x {} reps = {} calls/encoder",
+        names.len(),
+        reps,
+        names.len() * reps
+    );
+    println!("corpus written to {}", out.display());
+    println!();
+    println!(
+        "{:<10} {:>12} {:>16}",
+        "encoder", "ns/call", "ms / corpus-pass"
+    );
+    println!("{}", "-".repeat(40));
+    println!("{:<10} {:>10.1}ns {:>13.1}ms", "soundex", sx, total_ms(sx));
+    println!("{:<10} {:>10.1}ns {:>13.1}ms", "nysiis", ny, total_ms(ny));
+    println!();
+    println!("ms / corpus-pass is directly comparable to scripts/bench_jellyfish.py");
+}

--- a/packages/rust/extensions/goldenphonetic-core/scripts/bench_jellyfish.py
+++ b/packages/rust/extensions/goldenphonetic-core/scripts/bench_jellyfish.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Time Python `jellyfish` soundex/nysiis on the SAME ASCII name corpus the Rust
+`bench_vs_jellyfish` example timed, so the goldenphonetic-vs-jellyfish ratios line
+up on identical inputs.
+
+Run:
+    cargo run --release --example bench_vs_jellyfish   # writes target/bench_ascii_names.txt
+    uv run --no-project --with jellyfish --python 3.12 python \
+        packages/rust/extensions/goldenphonetic-core/scripts/bench_jellyfish.py
+
+Reports ns/call and ms/corpus-pass for each encoder (ms/corpus-pass is directly
+comparable to the Rust example's output).
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import jellyfish
+
+
+def bench(fn, corpus, reps):
+    # warm up
+    for s in corpus:
+        fn(s)
+    t0 = time.perf_counter()
+    acc = 0
+    for _ in range(reps):
+        for s in corpus:
+            acc += len(fn(s))
+    dt = time.perf_counter() - t0
+    _ = acc
+    calls = reps * len(corpus)
+    return dt / calls * 1e9  # ns/call
+
+
+def main() -> int:
+    corpus_path = (
+        Path(__file__).resolve().parent.parent / "target" / "bench_ascii_names.txt"
+    )
+    if len(sys.argv) > 1:
+        corpus_path = Path(sys.argv[1])
+    if not corpus_path.exists():
+        print(f"corpus not found: {corpus_path}", file=sys.stderr)
+        print("run `cargo run --release --example bench_vs_jellyfish` first", file=sys.stderr)
+        return 1
+
+    corpus = corpus_path.read_text(encoding="utf-8").split("\n")
+    reps = 20
+
+    sx = bench(jellyfish.soundex, corpus, reps)
+    ny = bench(jellyfish.nysiis, corpus, reps)
+
+    def total_ms(ns):
+        return ns * len(corpus) / 1e6
+
+    print(f"jellyfish ASCII name corpus: {len(corpus)} names x {reps} reps")
+    print()
+    print(f"{'encoder':<10} {'ns/call':>12} {'ms / corpus-pass':>16}")
+    print("-" * 40)
+    print(f"{'soundex':<10} {sx:>10.1f}ns {total_ms(sx):>13.1f}ms")
+    print(f"{'nysiis':<10} {ny:>10.1f}ns {total_ms(ny):>13.1f}ms")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/rust/extensions/goldenphonetic-core/src/lib.rs
+++ b/packages/rust/extensions/goldenphonetic-core/src/lib.rs
@@ -42,13 +42,26 @@ use nfkd::nfkd_chars;
 /// `s.to_uppercase().nfkd()`, keep the first codepoint verbatim, then map
 /// consonants to Soundex digits (collapsing adjacent equal digits, `H`/`W`
 /// transparent), pad/truncate to length 4.
+///
+/// ## ASCII fast path
+/// For pure-ASCII input (the overwhelming common case for names) `to_uppercase`
+/// == `to_ascii_uppercase` char-for-char and NFKD is the identity, so we skip the
+/// vendored per-char NFKD table lookup ([`nfkd_chars`]) entirely and build the
+/// working `char` vector directly. The unicode path below is preserved verbatim as
+/// the byte-identical-to-jellyfish reference for accented / decomposed input. Both
+/// feed the same downstream `Vec<char>` loop — no algorithm duplication.
 pub fn soundex(s: &str) -> String {
     if s.is_empty() {
         return String::new();
     }
 
-    let upper: Vec<char> = s.to_uppercase().chars().collect();
-    let v = nfkd_chars(&upper);
+    let v: Vec<char> = if s.is_ascii() {
+        // ASCII: uppercase in place, NFKD is identity — skip the table lookup.
+        s.chars().map(|c| c.to_ascii_uppercase()).collect()
+    } else {
+        let upper: Vec<char> = s.to_uppercase().chars().collect();
+        nfkd_chars(&upper)
+    };
     if v.is_empty() {
         // to_uppercase()/nfkd() cannot empty a non-empty string in practice, but
         // guard the v[0] index defensively (jellyfish indexes v[0] unconditionally).
@@ -281,40 +294,87 @@ pub fn metaphone(s: &str) -> String {
 // precomposed, and their NFD forms — proven over the fuzz corpus in
 // `scripts/check_phonetic_parity.py`.
 
-#[inline]
-fn ny_isvowel(s: &str) -> bool {
-    matches!(s, "A" | "E" | "I" | "O" | "U")
+/// One unit of the NYSIIS working sequence. The unicode path uses grapheme
+/// clusters (`String`); the ASCII fast path uses bare `char`s. The core algorithm
+/// ([`nysiis_core`]) is written once over this trait so there is a single source of
+/// truth for the NYSIIS logic — only the unit representation differs.
+trait NyUnit: Clone + PartialEq {
+    /// Build a unit from a single ASCII letter (the algorithm only ever synthesizes
+    /// single-ASCII-letter units: `A`/`F`/`G`/`S`/`N`/`C`/`D`/`Y`).
+    fn from_ascii(c: u8) -> Self;
+    /// Does this unit equal the single ASCII letter `c`? (A multi-codepoint
+    /// grapheme is never equal to a one-byte ASCII letter.)
+    fn eq_ascii(&self, c: u8) -> bool;
+    /// Append this unit to the output key string.
+    fn push_key(&self, out: &mut String);
+    /// Is this unit one of the NYSIIS vowels `A`/`E`/`I`/`O`/`U`?
+    #[inline]
+    fn is_vowel(&self) -> bool {
+        self.eq_ascii(b'A')
+            || self.eq_ascii(b'E')
+            || self.eq_ascii(b'I')
+            || self.eq_ascii(b'O')
+            || self.eq_ascii(b'U')
+    }
 }
 
-/// NYSIIS phonetic encoding, byte-identical to `jellyfish.nysiis`.
-pub fn nysiis(s: &str) -> String {
-    if s.is_empty() {
-        return String::new();
+impl NyUnit for char {
+    #[inline]
+    fn from_ascii(c: u8) -> Self {
+        c as char
     }
+    #[inline]
+    fn eq_ascii(&self, c: u8) -> bool {
+        *self == c as char
+    }
+    #[inline]
+    fn push_key(&self, out: &mut String) {
+        out.push(*self);
+    }
+}
 
-    let upper = s.to_uppercase();
-    let mut v: Vec<String> = graphemes(&upper.chars().collect::<Vec<_>>());
+impl NyUnit for String {
+    #[inline]
+    fn from_ascii(c: u8) -> Self {
+        (c as char).to_string()
+    }
+    #[inline]
+    fn eq_ascii(&self, c: u8) -> bool {
+        // A grapheme equals an ASCII letter iff it is exactly that one byte.
+        self.len() == 1 && self.as_bytes()[0] == c
+    }
+    #[inline]
+    fn push_key(&self, out: &mut String) {
+        out.push_str(self);
+    }
+}
 
+/// The NYSIIS algorithm over an abstract unit sequence, byte-identical to
+/// `jellyfish.nysiis`. `v` is the (grapheme- or char-) segmented, uppercased input;
+/// `upper` is the uppercased string used only for the prefix/suffix `starts_with` /
+/// `ends_with` tests (identical between paths on ASCII, and the reference behaviour
+/// on unicode). See [`nysiis`] for the ASCII/unicode split that feeds this.
+fn nysiis_core<U: NyUnit>(mut v: Vec<U>, upper: &str) -> String {
     // step 1: prefixes
     if upper.starts_with("MAC") {
-        v[1] = "C".to_string(); // MAC -> MCC
+        v[1] = U::from_ascii(b'C'); // MAC -> MCC
     } else if upper.starts_with("KN") {
         v.remove(0); // strip leading K from KN
     } else if upper.starts_with('K') {
-        v[0] = "C".to_string(); // K -> C
+        v[0] = U::from_ascii(b'C'); // K -> C
     } else if upper.starts_with("PH") || upper.starts_with("PF") {
-        v[0] = "F".to_string();
-        v[1] = "F".to_string(); // -> FF
+        v[0] = U::from_ascii(b'F');
+        v[1] = U::from_ascii(b'F'); // -> FF
     } else if upper.starts_with("SCH") {
-        v[1] = "S".to_string();
-        v[2] = "S".to_string(); // SCH -> SSS
+        v[1] = U::from_ascii(b'S');
+        v[2] = U::from_ascii(b'S'); // SCH -> SSS
     }
 
     // step 2: suffixes
     if upper.ends_with("IE") || upper.ends_with("EE") {
         v.pop();
         v.pop();
-        v.push("Y".to_string());
+        v.push(U::from_ascii(b'Y'));
     } else if upper.ends_with("DT")
         || upper.ends_with("RT")
         || upper.ends_with("RD")
@@ -323,57 +383,79 @@ pub fn nysiis(s: &str) -> String {
     {
         v.pop();
         v.pop();
-        v.push("D".to_string());
+        v.push(U::from_ascii(b'D'));
     }
 
     // step 3: key starts with first character
-    let mut key: Vec<String> = Vec::new();
+    let mut key: Vec<U> = Vec::with_capacity(v.len());
     key.push(v[0].clone());
 
-    // step 4: translate remaining characters
+    // step 4: translate remaining characters.
+    //
+    // Each iteration produces a 1- or 2-unit replacement group. jellyfish builds a
+    // `Vec` per character; we hold the group in a stack pair `(u0, u1)` so the hot
+    // loop makes ZERO heap allocations per character. Every arm produces at least
+    // `u0` (the `vec` was never empty), so the old `!chars.is_empty()` guard drops.
     let mut i = 1;
     while i < v.len() {
-        let chars: Vec<String> = match v[i].as_str() {
-            "E" if i + 1 < v.len() && v[i + 1] == "V" => {
-                i += 1;
-                vec!["A".to_string(), "F".to_string()]
-            }
-            "A" | "E" | "I" | "O" | "U" => vec!["A".to_string()],
-            "Q" => vec!["G".to_string()],
-            "Z" => vec!["S".to_string()],
-            "M" => vec!["N".to_string()],
-            "K" => {
-                if i + 1 < v.len() && v[i + 1] == "N" {
-                    vec!["N".to_string()]
-                } else {
-                    vec!["C".to_string()]
-                }
-            }
-            "S" if i + 2 < v.len() && v[i + 1] == "C" && v[i + 2] == "H" => {
-                i += 2;
-                vec!["S".to_string(), "S".to_string()]
-            }
-            "P" if i + 1 < v.len() && v[i + 1] == "H" => {
-                i += 1;
-                vec!["F".to_string()]
-            }
-            "H" if !ny_isvowel(&v[i - 1])
-                || (i + 1 < v.len() && !ny_isvowel(&v[i + 1]))
-                || (i + 1 == v.len()) =>
-            {
-                if ny_isvowel(&v[i - 1]) {
-                    vec!["A".to_string()]
-                } else {
-                    vec![v[i - 1].clone()]
-                }
-            }
-            "W" if ny_isvowel(&v[i - 1]) => vec![v[i - 1].clone()],
-            _ => vec![v[i].clone()],
-        };
+        // Ordered exactly like jellyfish's `match v[i] { .. }` guard chain.
+        let u0: U;
+        let mut u1: Option<U> = None;
+        if v[i].eq_ascii(b'E') && i + 1 < v.len() && v[i + 1].eq_ascii(b'V') {
+            i += 1;
+            u0 = U::from_ascii(b'A');
+            u1 = Some(U::from_ascii(b'F'));
+        } else if v[i].is_vowel() {
+            u0 = U::from_ascii(b'A');
+        } else if v[i].eq_ascii(b'Q') {
+            u0 = U::from_ascii(b'G');
+        } else if v[i].eq_ascii(b'Z') {
+            u0 = U::from_ascii(b'S');
+        } else if v[i].eq_ascii(b'M') {
+            u0 = U::from_ascii(b'N');
+        } else if v[i].eq_ascii(b'K') {
+            u0 = if i + 1 < v.len() && v[i + 1].eq_ascii(b'N') {
+                U::from_ascii(b'N')
+            } else {
+                U::from_ascii(b'C')
+            };
+        } else if v[i].eq_ascii(b'S')
+            && i + 2 < v.len()
+            && v[i + 1].eq_ascii(b'C')
+            && v[i + 2].eq_ascii(b'H')
+        {
+            i += 2;
+            u0 = U::from_ascii(b'S');
+            u1 = Some(U::from_ascii(b'S'));
+        } else if v[i].eq_ascii(b'P') && i + 1 < v.len() && v[i + 1].eq_ascii(b'H') {
+            i += 1;
+            u0 = U::from_ascii(b'F');
+        } else if v[i].eq_ascii(b'H')
+            && (!v[i - 1].is_vowel()
+                || (i + 1 < v.len() && !v[i + 1].is_vowel())
+                || (i + 1 == v.len()))
+        {
+            u0 = if v[i - 1].is_vowel() {
+                U::from_ascii(b'A')
+            } else {
+                v[i - 1].clone()
+            };
+        } else if v[i].eq_ascii(b'W') && v[i - 1].is_vowel() {
+            u0 = v[i - 1].clone();
+        } else {
+            u0 = v[i].clone();
+        }
 
-        if !chars.is_empty() && chars[chars.len() - 1] != key[key.len() - 1] {
-            for c in chars {
-                key.push(c);
+        // Dedup on the group's LAST unit vs key's last; push the whole group if it
+        // differs (jellyfish: `if chars[-1] != key[-1]: key.extend(chars)`).
+        let differs = {
+            let last = u1.as_ref().unwrap_or(&u0);
+            *last != key[key.len() - 1]
+        };
+        if differs {
+            key.push(u0);
+            if let Some(u1) = u1 {
+                key.push(u1);
             }
         }
 
@@ -381,21 +463,50 @@ pub fn nysiis(s: &str) -> String {
     }
 
     // step 5: remove trailing S
-    if key[key.len() - 1] == "S" && key.len() > 1 {
+    if key[key.len() - 1].eq_ascii(b'S') && key.len() > 1 {
         key.pop();
     }
 
     // step 6: replace AY with Y
-    if key.len() >= 2 && key[key.len() - 2] == "A" && key[key.len() - 1] == "Y" {
+    if key.len() >= 2 && key[key.len() - 2].eq_ascii(b'A') && key[key.len() - 1].eq_ascii(b'Y') {
         key.remove(key.len() - 2);
     }
 
     // step 7: remove trailing A
-    if key[key.len() - 1] == "A" && key.len() > 1 {
+    if key[key.len() - 1].eq_ascii(b'A') && key.len() > 1 {
         key.pop();
     }
 
-    key.concat()
+    let mut out = String::with_capacity(key.len());
+    for u in &key {
+        u.push_key(&mut out);
+    }
+    out
+}
+
+/// NYSIIS phonetic encoding, byte-identical to `jellyfish.nysiis`.
+///
+/// ## ASCII fast path
+/// For pure-ASCII input each `char` is its own grapheme cluster, so we skip the
+/// UAX-29 grapheme segmentation ([`graphemes`]) and its per-unit `String`
+/// allocations — the working sequence is a `Vec<char>` fed to [`nysiis_core`]. The
+/// unicode path builds the grapheme `Vec<String>` exactly as jellyfish does and is
+/// the byte-identical reference for accented / combining-mark input. Both call the
+/// same generic core, so there is one NYSIIS implementation, not two.
+pub fn nysiis(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    if s.is_ascii() {
+        let upper = s.to_ascii_uppercase();
+        let v: Vec<char> = upper.chars().collect();
+        nysiis_core(v, &upper)
+    } else {
+        let upper = s.to_uppercase();
+        let v: Vec<String> = graphemes(&upper.chars().collect::<Vec<_>>());
+        nysiis_core(v, &upper)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/rust/extensions/goldenphonetic-py/Cargo.toml
+++ b/packages/rust/extensions/goldenphonetic-py/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "goldenphonetic-py"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenphonetic-py/pyproject.toml
+++ b/packages/rust/extensions/goldenphonetic-py/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenphonetic"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fast, byte-identical-to-jellyfish phonetic encoders (soundex / metaphone / nysiis / match_rating)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -531,6 +531,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "goldenfuzz-core"
+version = "0.1.1"
+
+[[package]]
 name = "goldenmatch-autoconfig-core"
 version = "0.1.0"
 dependencies = [
@@ -607,6 +611,7 @@ version = "0.1.0"
 name = "goldenmatch-score-core"
 version = "0.1.0"
 dependencies = [
+ "goldenfuzz-core",
  "regex",
  "rustc-hash",
  "unicode-normalization",


### PR DESCRIPTION
An ASCII fast path for `goldenphonetic-core`'s `soundex` + `nysiis`, byte-identical to jellyfish.

## Why
Measured the published 0.1.0 vs jellyfish (single-token name corpus): **nysiis 3.8× slower**, soundex 1.6× slower (metaphone was par; match_rating already 3.5× ahead). Root cause: both ran the full NFKD-table lookup (`soundex`) and UAX-29 grapheme clustering into `Vec<String>` (`nysiis`) on *every* input — but for pure-ASCII names (the overwhelming common case), NFKD is the identity and each char is its own grapheme, so it's all wasted work + allocations.

## What
- `s.is_ascii()` guard: uppercase via `to_ascii_uppercase`, operate on `char` units, skip `nfkd_chars` (soundex) and `graphemes` (nysiis) entirely. `nysiis` is single-sourced into a generic `nysiis_core<U: NyUnit>` fed `char` units (ASCII) or grapheme/`String` units (unicode) — no algorithm duplication — and the per-char heap `Vec` in the hot loop is gone (stack pair). The non-ASCII path is preserved verbatim as the byte-identical reference for accented/decomposed input.

## Results (pure-Rust core, ns/call)
| encoder | before | after | speedup |
|---|---|---|---|
| soundex | 637ns | 351ns | **1.8×** |
| nysiis | 2897ns | 427ns | **6.8×** |

Both now at/below jellyfish. (Honest caveat: the jellyfish comparison column is Python/pyo3-called so it slightly overstates jellyfish's true kernel cost; the before/after is the apples-to-apples win.)

## Verified (independently re-run in review)
- **Byte-identical preserved**: `check_phonetic_parity.py` — 26,602 comparisons, 0 mismatches, all encoders, incl. José/Müller/Ærø precomposed AND decomposed.
- `cargo test` 10/10, `cargo fmt --check` clean, bench confirms the numbers.
- clippy: the agent ran it clean; my box couldn't re-run it (persistent cargo loader failure under memory pressure). goldenphonetic-core's CI clippy/test lane is still deferred (see #2232) — flagged for the follow-up.

Bumps 0.1.0→0.1.1 (core Cargo + py pyproject + py Cargo, lockstep); release cut after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd