### PR TITLE
perf(identity): collapse 14M relgraph resolve (relationship_groups seq-scan + has_run_event N+1)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -705,6 +705,20 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
         if preflight_existing else {}
     )
 
+    # Same anti-N+1 for the CREATED-event idempotency guard in the created-cluster
+    # branch below: it did one ``has_run_event`` SELECT per created cluster
+    # (millions), which under ``write_pipeline`` syncs per cluster AND seq-scans
+    # identity_events when the secondary indexes are deferred by the initial-load
+    # fast path -> O(n^2) (measured: ~3h at 14M). Preload the run's already-created
+    # entities ONCE; the guard becomes an in-memory set test. Empty (instant) on a
+    # from-empty build; kept exact as CREATED events are added in-loop. SQL backends
+    # only -- mongo / minimal fake stores fall back to ``has_run_event``.
+    _created_events: set[str] | None = (
+        store.run_event_entities(run_name, EventKind.CREATED.value)
+        if getattr(store, "_backend", None) in ("sqlite", "postgres")
+        and hasattr(store, "run_event_entities") else None
+    )
+
     # Fire-and-forget event/edge writes: the resolve path ignores the generated
     # id, and skipping the read-back is what lets ``write_pipeline`` actually
     # batch (an id read-back would sync the pipeline on every call). The store
@@ -985,7 +999,13 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                         created_at=now,
                         updated_at=now,
                     ))
-                    if not store.has_run_event(entity_id, run_name, EventKind.CREATED.value):
+                    _already_created = (
+                        entity_id in _created_events
+                        if _created_events is not None
+                        else store.has_run_event(
+                            entity_id, run_name, EventKind.CREATED.value)
+                    )
+                    if not _already_created:
                         _emit(IdentityEvent(
                             entity_id=entity_id,
                             kind=EventKind.CREATED.value,
@@ -998,6 +1018,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                             actor=actor, trust=_cluster_confidence(info),
                         ))
                         summary.events_emitted += 1
+                        if _created_events is not None:
+                            _created_events.add(entity_id)
                     summary.created += 1
                     structural_change = True
                     changed_records = set(record_ids)

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -2053,6 +2053,21 @@ class IdentityStore:
         )
         return row is not None
 
+    def run_event_entities(self, run_name: str, kind: str) -> set[str]:
+        """Batch form of ``has_run_event``: the set of entity_ids that already have
+        an event of (``run_name``, ``kind``). ``resolve_clusters`` preloads this
+        ONCE so the created-cluster idempotency guard is an in-memory membership
+        test instead of one ``has_run_event`` SELECT per cluster -- an N+1 that also
+        seq-scanned ``identity_events`` (O(n^2)) whenever the secondary indexes are
+        deferred by the initial-load fast path. SQL backends only; the caller
+        falls back to ``has_run_event`` for mongo/minimal stores."""
+        rows = self._fetchall(
+            "SELECT DISTINCT entity_id FROM identity_events "
+            "WHERE run_name = ? AND kind = ?",
+            (run_name, kind),
+        )
+        return {r["entity_id"] for r in rows}
+
     def add_alias(self, alias: IdentityAlias) -> None:
         if self._backend == "mongo":
             self._mongo.add_alias(alias)

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -1759,25 +1759,62 @@ class IdentityStore:
             raise NotImplementedError("relationship_groups: not supported on mongo")
         if not _SAFE_FIELD.fullmatch(field):
             raise ValueError(f"unsafe relationship field name: {field!r}")
+        # Perf (#2226-followup): the old shape extracted the payload field 3x per
+        # row, re-cast an already-``jsonb`` column, and ran ``COUNT(DISTINCT)`` +
+        # ``string_agg(DISTINCT)`` PER GROUP over every ``source_records`` row -- so
+        # a mega-shared value (a clinic switchboard phone held by 100k+ records) got
+        # its full distinct-aggregate computed only to be thrown away by the fanout
+        # cap. On 28M rows that seq-scanned + stalled for >1h. Rewrite: extract the
+        # field ONCE, dedup ``(value, entity_id)`` pairs, find the values whose
+        # distinct-entity count is in range, then ``string_agg`` ONLY those
+        # qualifying (small) groups -- never the mega-shared ones. A covering
+        # expression index makes the dedup an index scan instead of a heap seq scan.
+        self._ensure_relationship_index(field)
         if self._backend == "postgres":
-            vexpr = f"((sr.payload)::jsonb ->> '{field}')"
-            agg = "string_agg(DISTINCT sr.entity_id, ',')"
+            vexpr = f"payload ->> '{field}'"        # payload is already jsonb
+            agg = "string_agg(p.entity_id, ',')"    # pairs are DISTINCT -> no DISTINCT
         else:
-            vexpr = f"json_extract(sr.payload, '$.{field}')"
-            agg = "group_concat(DISTINCT sr.entity_id)"
-        ds = "" if dataset is None else " AND sr.dataset = ?"
+            vexpr = f"json_extract(payload, '$.{field}')"
+            agg = "group_concat(p.entity_id)"
+        ds = "" if dataset is None else " AND dataset = ?"
         params: tuple = () if dataset is None else (dataset,)
         sql = (
-            f"SELECT {vexpr} AS v, {agg} AS eids "
-            "FROM source_records sr "
-            f"WHERE sr.entity_id IS NOT NULL AND {vexpr} IS NOT NULL "
-            f"AND {vexpr} != ''{ds} "
-            f"GROUP BY {vexpr} "
-            "HAVING COUNT(DISTINCT sr.entity_id) >= ? "
-            "AND COUNT(DISTINCT sr.entity_id) <= ?"
+            "WITH ex AS ("
+            f" SELECT {vexpr} AS v, entity_id FROM source_records"
+            f" WHERE entity_id IS NOT NULL{ds}"
+            "), pairs AS ("
+            " SELECT DISTINCT v, entity_id FROM ex WHERE v IS NOT NULL AND v <> ''"
+            "), qual AS ("
+            " SELECT v FROM pairs GROUP BY v HAVING COUNT(*) >= ? AND COUNT(*) <= ?"
+            ") "
+            f"SELECT p.v AS v, {agg} AS eids "
+            "FROM pairs p JOIN qual q ON p.v = q.v GROUP BY p.v"
         )
         rows = self._fetchall(sql, params + (min_entities, max_entities))
         return [(r["v"], str(r["eids"]).split(",")) for r in rows]
+
+    def _ensure_relationship_index(self, field: str) -> None:
+        """Best-effort covering expression index ``(payload->>field, entity_id)`` so
+        ``relationship_groups`` reads an index-ordered stream instead of seq-scanning
+        + re-parsing jsonb across the whole ``source_records`` heap. Idempotent
+        (``IF NOT EXISTS``) and fail-soft: the query is correct without it, and a
+        build failure (e.g. read-only role) must never break a resolve."""
+        if not _SAFE_FIELD.fullmatch(field):
+            return
+        idx = f"idx_sr_rel_{field}"[:60]
+        try:
+            if self._backend == "postgres":
+                self._conn.execute(
+                    f"CREATE INDEX IF NOT EXISTS {idx} ON source_records "
+                    f"((payload ->> '{field}'), entity_id) WHERE entity_id IS NOT NULL"
+                )
+            elif self._backend == "sqlite":
+                self._conn.execute(
+                    f"CREATE INDEX IF NOT EXISTS {idx} ON source_records "
+                    f"(json_extract(payload, '$.{field}'), entity_id)"
+                )
+        except Exception:  # noqa: BLE001 -- the index is an optimization, never fatal
+            pass
 
     def add_relationships(self, rows: list[tuple]) -> int:
         """Insert ``(entity_a, entity_b, kind, field, shared_value, dataset)``


### PR DESCRIPTION
Two perf fixes that take the full 14M-row identity+relationship-graph resolve from **~3 hours to (expected) minutes**, verified by faulthandler profiling. Folds in #2235.

**1. relationship_groups seq-scan** (commit 1): extracted the payload field 3x/row, re-cast an already-jsonb column, and ran per-group DISTINCT aggregates over all 28M source_records incl. mega-shared values the fanout cap discards. Rewrite: extract once, drop cast, two-phase CTE (only aggregate qualifying groups), + covering expression index.

**2. has_run_event N+1** (commit 2): `apply_batch` ran one `has_run_event` SELECT per created cluster (~735k serial round-trips at 14M rows), O(n^2) when the identity_events index is deferred by the initial-load fast path -> **95% of a 3h resolve** per faulthandler. Fix: preload the run's created-event entity set ONCE beside `preflight_nodes`; the guard is an in-memory membership test. From-empty => empty at preload => instant.

Both byte-identical in output; existing test_relationships / identity suites cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)