### PR TITLE
ci: re-add goldenphonetic-core test lane + self-diagnosing renorm flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1664,6 +1664,7 @@ jobs:
             packages/rust/extensions
             packages/rust/extensions/graph-core
             packages/rust/extensions/goldenfuzz-core
+            packages/rust/extensions/goldenphonetic-core
             packages/rust/extensions/score-core
             packages/rust/extensions/sketch-core
             packages/rust/extensions/perceptual-core
@@ -1708,6 +1709,12 @@ jobs:
       # only run when tested explicitly.
       - run: cargo test --manifest-path goldenfuzz-core/Cargo.toml
       - run: cargo clippy --manifest-path goldenfuzz-core/Cargo.toml --all-targets -- -D warnings
+      # goldenphonetic-core: byte-identical-to-jellyfish phonetic encoders
+      # (soundex / metaphone / nysiis / match_rating), its own [workspace] like
+      # goldenfuzz-core. The `goldenphonetic` product's kernel; run its unit
+      # tests + the jellyfish parity oracle explicitly.
+      - run: cargo test --manifest-path goldenphonetic-core/Cargo.toml
+      - run: cargo clippy --manifest-path goldenphonetic-core/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path score-core/Cargo.toml
       - run: cargo clippy --manifest-path score-core/Cargo.toml -- -D warnings
       # fs-core (2026-07-17) is the pyo3-free single source of truth for the

--- a/packages/python/goldenmatch/tests/test_weighted_null_renormalization.py
+++ b/packages/python/goldenmatch/tests/test_weighted_null_renormalization.py
@@ -109,9 +109,22 @@ class TestLiveWeightedPathMatchesScorePair:
         a = {"record_id": 0, "first_name": "john", "surname": "smith", "dob": "1980-01-01"}
         b = {"record_id": 1, "first_name": "zachary", "surname": "smith", "dob": None}
         df = pl.DataFrame([a, b])
-        assert (0, 1) not in self._cluster_pairs(df, backend), (
-            f"{backend}: renormalization must not make DISAGREEMENT free"
-        )
+        pairs = self._cluster_pairs(df, backend)
+        if (0, 1) in pairs:
+            # This has flaked ONCE in CI (native full-matrix) and does not reproduce
+            # against a correctly-built kernel -- the leading theory is an xdist
+            # worker state-leak, NOT a scoring bug. Dump the smoking gun so the NEXT
+            # occurrence is diagnosable: score_pair is the correct weighted score
+            # (~0.77 < 0.85 here) -- if it's below threshold yet the pair clustered,
+            # the merge did NOT come from this matchkey (suspect a leaked
+            # matchkey/config/registration from another test in the worker).
+            sp = score_pair(a, b, _mk().fields)
+            raise AssertionError(
+                f"{backend}: renormalization must not make DISAGREEMENT free. "
+                f"clustered={sorted(pairs)}; score_pair(a,b)={sp:.4f} "
+                f"threshold={_mk().threshold}. If score_pair < threshold, the clustering "
+                f"did NOT come from the weighted matchkey -> state-leak flake, not scoring."
+            )
 
 
 class TestAllNullColumnDoesNotZeroEveryPair:


### PR DESCRIPTION
Re-adds the goldenphonetic-core CI test+clippy lane deferred in #2232, and makes the flaky renorm test diagnosable — both coupled to the flake, so bundled.

## What
- **goldenphonetic-core lane**: restore `cargo test` + `cargo clippy --all-targets -D warnings` for goldenphonetic-core in the standalone-cores (rust) lane + its rust-cache workspace entry. The crate (jellyfish-parity encoders) now gets real CI coverage instead of resting on local verification.
- **Self-diagnosing flake**: `test_genuine_disagreement_still_does_not_match` now, on failure, dumps the clustered pairs + `score_pair(a,b)` vs threshold. The flake (a genuinely-disagreeing pair clustering) failed once, doesn't reproduce against a correctly-built kernel, and the theory is an xdist worker state-leak. This makes the next occurrence actionable: `score_pair < threshold` yet clustered ⇒ the merge didn't come from this matchkey ⇒ state-leak, not scoring. Assertion semantics unchanged.

## Note on the full matrix
This ci.yml edit forces the full merge-queue matrix, which runs the flaky `python_goldenmatch` native renorm shard. It's rare (one occurrence), so it'll most likely pass — but if it ejects, that's the natural recurrence we've been waiting for, now with the diagnostic dump to root-cause it live.

Verified: renorm test 2 passed, ruff clean, ci.yml parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd