### PR TITLE
chore: evict faiss-cpu from the [embeddings] extra (own the flat index)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5011,7 +5011,7 @@
         {
           "module": "goldenmatch.db.ann_index",
           "file": "packages/python/goldenmatch/goldenmatch/db/ann_index.py",
-          "purpose": "Persistent FAISS ANN index manager for database integration.",
+          "purpose": "Persistent ANN index manager for database integration.",
           "defines": [
             "PersistentANNIndex"
           ],

--- a/packages/python/goldenmatch/goldenmatch/core/ann_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/ann_blocker.py
@@ -1,26 +1,25 @@
 """ANN (Approximate Nearest Neighbor) blocker for GoldenMatch.
 
-Three interchangeable backends behind one surface, resolved per ``build_index``:
+Two interchangeable backends behind one surface, resolved per ``build_index``:
 
 * **native HNSW** -- the ``goldenmatch-hnsw`` wheel (``goldenmatch_hnsw``), a
   pure-Rust ``IndexHNSWFlat`` with zero C dependencies. Sub-linear ANN queries
   for large corpora, installs everywhere the pure-Python package does.
-* **FAISS** -- ``IndexFlatIP`` (the ``goldenmatch[embeddings]`` extra). Exact
-  inner product, O(N) per probe.
-* **numpy** -- a pure-numpy all-pairs inner-product fallback, zero deps.
+* **numpy** -- an owned pure-numpy all-pairs (flat) inner-product index, zero
+  deps. Exact top-k by descending inner product (a BLAS-backed ``q @ corpus.T``
+  matmul + argpartition), the exact-search reference for medium-scale corpora.
 
-Scores are the raw inner product on the FAISS and HNSW paths (byte-identical
-between them) and the range-safe cosine on the numpy path; on the normal
-GoldenMatch path the embedder emits L2-normalized vectors, so the three agree.
+Scores are the raw inner product on the HNSW path and the range-safe cosine on
+the numpy path; on the normal GoldenMatch path the embedder emits L2-normalized
+vectors, so the two agree.
 
-Backend selection (``_resolve_backend``) prefers **native HNSW -> FAISS ->
-numpy**, but in ``auto`` mode HNSW is chosen only where it actually wins:
+Backend selection (``_resolve_backend``) prefers **native HNSW -> numpy exact**,
+but in ``auto`` mode HNSW is chosen only where it actually wins:
 ``n_vectors >= GOLDENMATCH_ANN_HNSW_MIN`` (default 4096) AND
 ``top_k <= GOLDENMATCH_ANN_HNSW_MAX_K`` (default 512). Below the size gate,
-brute force is both faster and exact, so small N keeps the exact path and the
-numpy-fallback parity contract holds unchanged. ``GOLDENMATCH_ANN_BACKEND`` in
-``{auto, hnsw, faiss, numpy}`` forces a specific backend (gates ignored for an
-explicit ``hnsw``).
+brute force is both faster and exact, so small N keeps the exact numpy path.
+``GOLDENMATCH_ANN_BACKEND`` in ``{auto, hnsw, numpy}`` forces a specific backend
+(gates ignored for an explicit ``hnsw``).
 """
 
 from __future__ import annotations
@@ -30,8 +29,7 @@ import os
 
 import numpy as np
 
-# Detected once at import; tests flip these to exercise a specific backend.
-_HAS_FAISS = importlib.util.find_spec("faiss") is not None
+# Detected once at import; tests flip this to exercise a specific backend.
 _HAS_HNSW = importlib.util.find_spec("goldenmatch_hnsw") is not None
 
 # auto-mode size gates (env-overridable) — HNSW only earns its keep when the
@@ -41,23 +39,20 @@ _HNSW_MAX_K_DEFAULT = 512
 
 
 def _resolve_backend(n_vectors: int, top_k: int) -> str:
-    """Pick ``"hnsw"`` / ``"faiss"`` / ``"numpy"`` for this corpus.
+    """Pick ``"hnsw"`` / ``"numpy"`` for this corpus.
 
     Honors ``GOLDENMATCH_ANN_BACKEND`` (forced), else auto-selects with the
     HNSW size gate. Always degrades to an available backend (never returns a
-    backend whose library is absent).
+    backend whose library is absent) -- the numpy exact index is always
+    available (numpy is a base dep).
     """
     forced = os.environ.get("GOLDENMATCH_ANN_BACKEND", "auto").strip().lower()
     if forced == "hnsw":
-        if _HAS_HNSW:
-            return "hnsw"
-        return "faiss" if _HAS_FAISS else "numpy"
-    if forced == "faiss":
-        return "faiss" if _HAS_FAISS else "numpy"
+        return "hnsw" if _HAS_HNSW else "numpy"
     if forced == "numpy":
         return "numpy"
     # auto: prefer HNSW only above the size gate (its win is asymptotic); exact
-    # below, which keeps small-N results identical to the brute-force paths.
+    # numpy below, which keeps small-N results identical to the brute-force path.
     if _HAS_HNSW:
         try:
             min_n = int(os.environ.get("GOLDENMATCH_ANN_HNSW_MIN", _HNSW_MIN_DEFAULT))
@@ -66,30 +61,28 @@ def _resolve_backend(n_vectors: int, top_k: int) -> str:
             min_n, max_k = _HNSW_MIN_DEFAULT, _HNSW_MAX_K_DEFAULT
         if n_vectors >= min_n and top_k <= max_k:
             return "hnsw"
-    if _HAS_FAISS:
-        return "faiss"
     return "numpy"
 
 
 class ANNBlocker:
     """Build an inner-product index and query for top-K neighbors.
 
-    Backed by FAISS (`IndexFlatIP`) when available; otherwise a numpy all-pairs
-    inner-product fallback with byte-compatible top-K / self-exclusion /
-    canonicalization semantics.
+    Backed by native HNSW (`goldenmatch_hnsw`) at scale; otherwise an owned
+    numpy all-pairs (flat) inner-product index -- the exact-search reference,
+    with descending-inner-product top-K / self-exclusion / canonicalization
+    semantics.
     """
 
     def __init__(self, top_k: int = 20):
         self.top_k = top_k
-        self._index = None
-        # numpy-fallback corpus (stored on build_index so query_* can use it)
+        # numpy exact-index corpus (stored on build_index so query_* can use it)
         self._corpus: np.ndarray | None = None
         # native HNSW index (goldenmatch_hnsw.HnswIndex) when that backend wins.
         self._hnsw = None
         # Resolved on build_index; "numpy" until then.
         self._backend: str = "numpy"
 
-    # HNSW graph parameters (env-overridable). Defaults mirror FAISS
+    # HNSW graph parameters (env-overridable). Defaults mirror the common
     # IndexHNSWFlat(d, M=16) / hnswlib presets.
     @staticmethod
     def _hnsw_params() -> tuple[int, int, int]:
@@ -109,12 +102,11 @@ class ANNBlocker:
 
         The backend is resolved from the corpus size + ``top_k`` (see
         :func:`_resolve_backend`): native HNSW (``IndexHNSWFlat``) at scale,
-        FAISS ``IndexFlatIP`` for exact medium-scale, else the numpy all-pairs
-        fallback. All three share the ``_search`` result contract.
+        else the owned numpy all-pairs exact index. Both share the ``_search``
+        result contract.
         """
         corpus = np.ascontiguousarray(embeddings.astype(np.float32))
         self._corpus = corpus
-        self._index = None
         self._hnsw = None
         n = corpus.shape[0]
         self._backend = _resolve_backend(n, self.top_k)
@@ -131,17 +123,10 @@ class ANNBlocker:
             if n:
                 self._hnsw.add_batch(corpus.tobytes(), n)
             return
-        if self._backend == "numpy":
-            # numpy fallback: keep the corpus; scoring happens at query time.
-            return
-        import faiss
-
-        dim = corpus.shape[1]
-        self._index = faiss.IndexFlatIP(dim)  # inner product = cosine on normalized vectors
-        self._index.add(corpus)
+        # numpy exact index: keep the corpus; scoring happens at query time.
 
     def _hnsw_search(self, query_embeddings: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """HNSW replacement for ``faiss.IndexFlatIP.search``.
+        """HNSW replacement for an exact ``IndexFlatIP.search``.
 
         Returns ``(scores, indices)`` of shape ``(n_query, k)`` where
         ``k = min(top_k, n_corpus)``. Scores are the raw inner product (FAISS
@@ -207,15 +192,11 @@ class ANNBlocker:
         """Dispatch to the resolved backend's search.
 
         Returns ``(scores, indices)`` of shape ``(n_query, k)`` with consistent
-        ranking semantics across all three backends.
+        ranking semantics across both backends.
         """
         if self._backend == "hnsw":
             return self._hnsw_search(query_embeddings)
-        if self._backend == "numpy":
-            return self._np_search(query_embeddings)
-        if self._index is None:
-            raise RuntimeError("Index not built. Call build_index first.")
-        return self._index.search(query_embeddings.astype(np.float32), self.top_k)
+        return self._np_search(query_embeddings)
 
     def query(self, query_embeddings: np.ndarray) -> list[tuple[int, int]]:
         """Find top-K neighbors for each query. Returns (query_idx, neighbor_idx) pairs."""
@@ -234,9 +215,7 @@ class ANNBlocker:
         """Number of vectors currently in the index."""
         if self._backend == "hnsw":
             return len(self._hnsw) if self._hnsw is not None else 0
-        if self._backend == "numpy":
-            return 0 if self._corpus is None else int(self._corpus.shape[0])
-        return self._index.ntotal if self._index is not None else 0
+        return 0 if self._corpus is None else int(self._corpus.shape[0])
 
     def add_to_index(self, embedding: np.ndarray) -> int:
         """Add a single embedding vector to the index (incremental).
@@ -259,16 +238,10 @@ class ANNBlocker:
             if self._corpus is not None:
                 self._corpus = np.vstack([self._corpus, vec]).astype(np.float32)
             return pos
-        if self._backend == "numpy":
-            if self._corpus is None:
-                raise RuntimeError("Index not built. Call build_index first.")
-            pos = int(self._corpus.shape[0])
-            self._corpus = np.vstack([self._corpus, vec]).astype(np.float32)
-            return pos
-        if self._index is None:
+        if self._corpus is None:
             raise RuntimeError("Index not built. Call build_index first.")
-        pos = self._index.ntotal
-        self._index.add(vec)
+        pos = int(self._corpus.shape[0])
+        self._corpus = np.vstack([self._corpus, vec]).astype(np.float32)
         return pos
 
     def query_one(self, embedding: np.ndarray) -> list[tuple[int, float]]:

--- a/packages/python/goldenmatch/goldenmatch/db/ann_index.py
+++ b/packages/python/goldenmatch/goldenmatch/db/ann_index.py
@@ -1,4 +1,11 @@
-"""Persistent FAISS ANN index manager for database integration."""
+"""Persistent ANN index manager for database integration.
+
+Owned pure-numpy flat (brute-force) inner-product index over the
+``gm_embeddings`` table -- exact top-K by descending inner product, the same
+semantics an exact ``IndexFlatIP`` provides. Vectors are persisted as an
+``index_vectors.npy`` matrix (alongside ``id_map.npy`` + ``index_meta.json``);
+no third-party ANN library is required (numpy is a base dependency).
+"""
 
 from __future__ import annotations
 
@@ -12,12 +19,17 @@ from goldenmatch.db.connector import DatabaseConnector
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INDEX_DIR = ".goldenmatch_faiss"
+DEFAULT_INDEX_DIR = ".goldenmatch_ann"
 DEFAULT_MIN_COVERAGE = 0.10  # 10% of records must be embedded for ANN to activate
 
 
 class PersistentANNIndex:
-    """Manages a persistent FAISS index backed by gm_embeddings table."""
+    """Manages a persistent flat inner-product index backed by gm_embeddings.
+
+    Backed by an in-memory ``np.ndarray`` of vectors; ``query`` does an exact
+    brute-force top-K inner-product search (``q @ vectors.T`` + argpartition),
+    returning raw inner-product scores in descending order.
+    """
 
     def __init__(
         self,
@@ -33,7 +45,7 @@ class PersistentANNIndex:
         self.model_name = model_name
         self.min_coverage = min_coverage
 
-        self._index = None
+        self._vectors: np.ndarray | None = None  # (n, dim) float32 corpus
         self._id_map: list[int] = []  # positional index → DB record ID
         self._id_to_pos: dict[int, int] = {}  # DB record ID → positional index
         self._dim: int = 0
@@ -42,7 +54,7 @@ class PersistentANNIndex:
     @property
     def is_available(self) -> bool:
         """True if index has enough embeddings for useful queries."""
-        if self._index is None or len(self._id_map) == 0:
+        if self._vectors is None or len(self._id_map) == 0:
             return False
         if self.connector is None:
             return len(self._id_map) > 0
@@ -63,12 +75,6 @@ class PersistentANNIndex:
 
     def load_or_build(self) -> None:
         """Load index from disk if fresh, rebuild from DB if stale."""
-        try:
-            import faiss  # noqa: F401  # availability check for optional dep
-        except ImportError:
-            logger.warning("faiss-cpu not installed. ANN index unavailable.")
-            return
-
         disk_count = self._load_from_disk()
         db_count = self._get_db_embedding_count()
 
@@ -97,21 +103,19 @@ class PersistentANNIndex:
         logger.info("No embeddings available yet. ANN index empty.")
 
     def _load_from_disk(self) -> int:
-        """Load FAISS index + id_map from disk. Returns record count or 0."""
-        index_path = self.index_dir / "index.faiss"
+        """Load vectors + id_map from disk. Returns record count or 0."""
+        vectors_path = self.index_dir / "index_vectors.npy"
         meta_path = self.index_dir / "index_meta.json"
         idmap_path = self.index_dir / "id_map.npy"
 
-        if not all(p.exists() for p in [index_path, meta_path, idmap_path]):
+        if not all(p.exists() for p in [vectors_path, meta_path, idmap_path]):
             return 0
 
         try:
-            import faiss
-
             with open(meta_path) as f:
                 meta = json.load(f)
 
-            self._index = faiss.read_index(str(index_path))
+            self._vectors = np.load(str(vectors_path)).astype(np.float32)
             self._id_map = np.load(str(idmap_path)).tolist()
             self._id_to_pos = {rid: i for i, rid in enumerate(self._id_map)}
             self._dim = meta.get("dim", 0)
@@ -158,9 +162,7 @@ class PersistentANNIndex:
             return None
 
     def _rebuild_from_db(self) -> None:
-        """Full rebuild of FAISS index from gm_embeddings."""
-        import faiss
-
+        """Full rebuild of the vector index from gm_embeddings."""
         logger.info("Rebuilding ANN index from gm_embeddings...")
 
         df = self.connector.read_query(
@@ -176,11 +178,10 @@ class PersistentANNIndex:
         ids = df["record_id"].to_list()
         embeddings = np.array([
             np.frombuffer(b, dtype=np.float32) for b in df["embedding"].to_list()
-        ])
+        ]).astype(np.float32)
 
         self._dim = embeddings.shape[1]
-        self._index = faiss.IndexFlatIP(self._dim)
-        self._index.add(embeddings)
+        self._vectors = embeddings
         self._id_map = ids
         self._id_to_pos = {rid: i for i, rid in enumerate(ids)}
 
@@ -189,20 +190,37 @@ class PersistentANNIndex:
     # ── Query ─────────────────────────────────────────────────────────
 
     def query(self, embeddings: np.ndarray, top_k: int = 20) -> list[tuple[int, int, float]]:
-        """Find top-K neighbors. Returns (query_idx, db_record_id, score)."""
-        if self._index is None or self._index.ntotal == 0:
+        """Find top-K neighbors. Returns (query_idx, db_record_id, score).
+
+        Exact brute-force inner-product search: top-K by descending raw inner
+        product against the stored vectors (identical neighbor set + raw-IP
+        scores to an exact ``IndexFlatIP.search``).
+        """
+        if self._vectors is None or self._vectors.shape[0] == 0:
             return []
 
-        k = min(top_k, self._index.ntotal)
-        scores, indices = self._index.search(embeddings.astype(np.float32), k)
+        ntotal = self._vectors.shape[0]
+        k = min(top_k, ntotal)
+        if k <= 0:
+            return []
+
+        q = embeddings.astype(np.float32)
+        ip = q @ self._vectors.T  # (n_query, ntotal) raw inner-product matrix
+        # Top-k per row by descending raw IP (argpartition for the cut, then
+        # sort the k survivors so order matches a sorted IndexFlatIP output).
+        part = np.argpartition(-ip, k - 1, axis=1)[:, :k]
+        part_ip = np.take_along_axis(ip, part, axis=1)
+        order = np.argsort(-part_ip, axis=1)
+        indices = np.take_along_axis(part, order, axis=1)
+        scores = np.take_along_axis(ip, indices, axis=1)
 
         results = []
         for query_idx in range(len(embeddings)):
             for j in range(k):
-                faiss_idx = int(indices[query_idx][j])
-                if faiss_idx < 0 or faiss_idx >= len(self._id_map):
+                pos = int(indices[query_idx][j])
+                if pos < 0 or pos >= len(self._id_map):
                     continue
-                db_id = self._id_map[faiss_idx]
+                db_id = self._id_map[pos]
                 score = float(scores[query_idx][j])
                 results.append((query_idx, db_id, score))
 
@@ -212,29 +230,32 @@ class PersistentANNIndex:
 
     def add(self, record_ids: list[int], embeddings: np.ndarray) -> None:
         """Add new embeddings to index and store in gm_embeddings."""
-        import faiss
-
         if len(record_ids) == 0:
             return
 
         emb = embeddings.astype(np.float32)
-
-        if self._index is None:
-            self._dim = emb.shape[1]
-            self._index = faiss.IndexFlatIP(self._dim)
-
-        # Add to FAISS
-        self._index.add(emb)
-
-        # Update id_map
-        for rid in record_ids:
-            pos = len(self._id_map)
-            self._id_map.append(rid)
-            self._id_to_pos[rid] = pos
+        self._add_to_index(record_ids, emb)
 
         # Store in DB
         if self.connector is not None:
             self._store_embeddings_in_db(record_ids, emb)
+
+    def _add_to_index(self, record_ids: list[int], embeddings: np.ndarray) -> None:
+        """Append vectors + extend id_map (in-memory only, no DB write)."""
+        if len(record_ids) == 0:
+            return
+
+        emb = embeddings.astype(np.float32)
+        if self._vectors is None:
+            self._vectors = emb
+        else:
+            self._vectors = np.vstack([self._vectors, emb])
+        self._dim = self._vectors.shape[1]
+
+        for rid in record_ids:
+            pos = len(self._id_map)
+            self._id_map.append(rid)
+            self._id_to_pos[rid] = pos
 
     def _store_embeddings_in_db(self, record_ids: list[int], embeddings: np.ndarray) -> None:
         """Batch insert embeddings into gm_embeddings."""
@@ -258,14 +279,12 @@ class PersistentANNIndex:
 
     def save(self) -> None:
         """Persist index to disk."""
-        if self._index is None or len(self._id_map) == 0:
+        if self._vectors is None or len(self._id_map) == 0:
             return
-
-        import faiss
 
         self.index_dir.mkdir(parents=True, exist_ok=True)
 
-        faiss.write_index(self._index, str(self.index_dir / "index.faiss"))
+        np.save(str(self.index_dir / "index_vectors.npy"), self._vectors)
         np.save(str(self.index_dir / "id_map.npy"), np.array(self._id_map))
 
         meta = {

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
 ]
 embeddings = [
     "sentence-transformers>=2.2",
-    "faiss-cpu>=1.7",
 ]
 # Decode adapters for the multimodal-ER crawl tier (ADR 0022). The perceptual
 # kernel itself is dependency-free (operates on decoded luma grids / PCM); these

--- a/packages/python/goldenmatch/tests/test_ann_blocker.py
+++ b/packages/python/goldenmatch/tests/test_ann_blocker.py
@@ -2,60 +2,43 @@
 
 from __future__ import annotations
 
-import pytest
+import numpy as np
+from goldenmatch.core.ann_blocker import ANNBlocker
 
 
 class TestANNBlocker:
     def test_build_and_query(self):
-        try:
-            import numpy as np
-            from goldenmatch.core.ann_blocker import ANNBlocker
+        # Create synthetic embeddings (10 records, 64 dims)
+        np.random.seed(42)
+        embeddings = np.random.randn(10, 64).astype(np.float32)
+        # Normalize
+        embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
 
-            # Create synthetic embeddings (10 records, 64 dims)
-            np.random.seed(42)
-            embeddings = np.random.randn(10, 64).astype(np.float32)
-            # Normalize
-            embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
-
-            blocker = ANNBlocker(top_k=3)
-            blocker.build_index(embeddings)
-            pairs = blocker.query(embeddings)
-            assert len(pairs) > 0
-            assert all(isinstance(p, tuple) and len(p) == 2 for p in pairs)
-        except ImportError:
-            pytest.skip("faiss-cpu not installed")
+        blocker = ANNBlocker(top_k=3)
+        blocker.build_index(embeddings)
+        pairs = blocker.query(embeddings)
+        assert len(pairs) > 0
+        assert all(isinstance(p, tuple) and len(p) == 2 for p in pairs)
 
     def test_pairs_are_ordered(self):
-        try:
-            import numpy as np
-            from goldenmatch.core.ann_blocker import ANNBlocker
+        np.random.seed(123)
+        embeddings = np.random.randn(5, 32).astype(np.float32)
+        embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
 
-            np.random.seed(123)
-            embeddings = np.random.randn(5, 32).astype(np.float32)
-            embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
-
-            blocker = ANNBlocker(top_k=2)
-            blocker.build_index(embeddings)
-            pairs = blocker.query(embeddings)
-            # All pairs should be (min, max) ordered
-            for a, b in pairs:
-                assert a < b
-        except ImportError:
-            pytest.skip("faiss-cpu not installed")
+        blocker = ANNBlocker(top_k=2)
+        blocker.build_index(embeddings)
+        pairs = blocker.query(embeddings)
+        # All pairs should be (min, max) ordered
+        for a, b in pairs:
+            assert a < b
 
     def test_no_self_pairs(self):
-        try:
-            import numpy as np
-            from goldenmatch.core.ann_blocker import ANNBlocker
+        np.random.seed(99)
+        embeddings = np.random.randn(8, 16).astype(np.float32)
+        embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
 
-            np.random.seed(99)
-            embeddings = np.random.randn(8, 16).astype(np.float32)
-            embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
-
-            blocker = ANNBlocker(top_k=4)
-            blocker.build_index(embeddings)
-            pairs = blocker.query(embeddings)
-            for a, b in pairs:
-                assert a != b
-        except ImportError:
-            pytest.skip("faiss-cpu not installed")
+        blocker = ANNBlocker(top_k=4)
+        blocker.build_index(embeddings)
+        pairs = blocker.query(embeddings)
+        for a, b in pairs:
+            assert a != b

--- a/packages/python/goldenmatch/tests/test_ann_fallback.py
+++ b/packages/python/goldenmatch/tests/test_ann_fallback.py
@@ -1,8 +1,10 @@
-"""Tests for the numpy all-pairs cosine fallback in the ANN blocker.
+"""Tests for the owned numpy all-pairs (flat) exact index in the ANN blocker.
 
-The fallback path runs when faiss is absent (or explicitly forced off via the
-module-level ``_HAS_FAISS`` flag). It must produce the SAME neighbor set as
-faiss for small N (parity) with zero new dependencies.
+The numpy path is the exact-search reference for medium-scale corpora (the tier
+that used to route to faiss ``IndexFlatIP``). It ranks top-k by descending raw
+inner product with the same neighbor set an exact ``IndexFlatIP`` returns; these
+tests pin that against an independent brute-force reference (and, when faiss
+happens to be installed, cross-check against faiss as an oracle).
 """
 
 from __future__ import annotations
@@ -16,32 +18,63 @@ def _vecs():
     return rng.standard_normal((20, 8)).astype(np.float32)
 
 
-def test_numpy_fallback_runs_without_faiss(monkeypatch):
-    monkeypatch.setattr("goldenmatch.core.ann_blocker._HAS_FAISS", False, raising=False)
+def _brute_force_topk_ids(corpus: np.ndarray, top_k: int) -> list[set[int]]:
+    """Reference top-k neighbor IDs per row by descending raw inner product.
+
+    Mirrors an exact ``IndexFlatIP.search`` (self NOT excluded, raw IP ranking).
+    """
+    ip = corpus @ corpus.T
+    k = min(top_k, corpus.shape[0])
+    return [set(np.argsort(-ip[i])[:k].tolist()) for i in range(corpus.shape[0])]
+
+
+def test_numpy_exact_index_runs(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
     b = ANNBlocker(top_k=5)
     b.build_index(_vecs())
+    assert b._backend == "numpy"
     pairs = b.query_with_scores(_vecs())
-    assert pairs, "fallback should produce candidate pairs"
+    assert pairs, "exact index should produce candidate pairs"
     assert all(a < c for a, c, _ in pairs)                 # canonical (a<b)
     assert all(-1.0001 <= s <= 1.0001 for *_, s in pairs)  # cosine range
 
 
-def test_fallback_parity_with_faiss_small_n():
+def test_owned_flat_search_matches_brute_force(monkeypatch):
+    """The owned flat search returns the exact brute-force top-k neighbor set."""
+    monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
+    v = _vecs()
+    top_k = 5
+    b = ANNBlocker(top_k=top_k)
+    b.build_index(v)
+    _scores, indices = b._search(v)
+
+    want = _brute_force_topk_ids(v, top_k)
+    for i in range(len(v)):
+        got = {int(j) for j in indices[i] if j >= 0}
+        assert got == want[i], f"row {i}: owned top-k {got} != brute-force {want[i]}"
+
+
+def test_owned_flat_search_matches_faiss_oracle():
+    """If faiss is installed, the owned flat search matches faiss IndexFlatIP."""
     import importlib.util
 
     import pytest
     if importlib.util.find_spec("faiss") is None:
         pytest.skip("faiss not installed")
+    import faiss  # noqa: WPS433
+
     v = _vecs()
-    faiss_b = ANNBlocker(top_k=5); faiss_b.build_index(v)
-    faiss_pairs = {(a, c) for a, c, _ in faiss_b.query_with_scores(v)}
-    # force numpy on a fresh blocker
-    import goldenmatch.core.ann_blocker as m
-    orig = m._HAS_FAISS
-    try:
-        m._HAS_FAISS = False
-        np_b = ANNBlocker(top_k=5); np_b.build_index(v)
-        np_pairs = {(a, c) for a, c, _ in np_b.query_with_scores(v)}
-    finally:
-        m._HAS_FAISS = orig
-    assert faiss_pairs == np_pairs                          # same neighbor SET
+    top_k = 5
+    index = faiss.IndexFlatIP(v.shape[1])
+    index.add(v)
+    _fscores, findices = index.search(v, top_k)
+
+    b = ANNBlocker(top_k=top_k)
+    b._backend = "numpy"
+    b._corpus = v
+    _scores, indices = b._np_search(v)
+
+    for i in range(len(v)):
+        want = set(findices[i].tolist())
+        got = {int(j) for j in indices[i] if j >= 0}
+        assert got == want, f"row {i}: owned {got} != faiss {want}"

--- a/packages/python/goldenmatch/tests/test_ann_hnsw.py
+++ b/packages/python/goldenmatch/tests/test_ann_hnsw.py
@@ -4,7 +4,7 @@ Two layers:
 
 * **Resolver logic** (no wheel needed) — monkeypatch the ``_HAS_*`` flags and
   assert :func:`_resolve_backend` honors the forced env var + the ``auto`` size
-  gate (native HNSW -> FAISS -> numpy).
+  gate (native HNSW -> numpy exact).
 * **Integration** (skipped unless ``goldenmatch-hnsw`` is installed) — build a
   corpus large enough to trip the size gate and assert the HNSW path returns
   high-recall, correctly-scored, incrementally-extensible results matching the
@@ -26,11 +26,8 @@ _HNSW_MIN = 4096  # keep in sync with _HNSW_MIN_DEFAULT
 
 def test_resolve_forced_backends(monkeypatch):
     monkeypatch.setattr(ab, "_HAS_HNSW", True)
-    monkeypatch.setattr(ab, "_HAS_FAISS", True)
     monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
     assert _resolve_backend(10_000, 20) == "numpy"
-    monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "faiss")
-    assert _resolve_backend(10, 5) == "faiss"
     monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "hnsw")
     # forced hnsw ignores the size gate
     assert _resolve_backend(1, 1) == "hnsw"
@@ -38,43 +35,36 @@ def test_resolve_forced_backends(monkeypatch):
 
 def test_resolve_forced_degrades_when_absent(monkeypatch):
     monkeypatch.setattr(ab, "_HAS_HNSW", False)
-    monkeypatch.setattr(ab, "_HAS_FAISS", False)
     monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "hnsw")
-    assert _resolve_backend(10_000, 20) == "numpy"  # no hnsw, no faiss
-    monkeypatch.setattr(ab, "_HAS_FAISS", True)
-    assert _resolve_backend(10_000, 20) == "faiss"  # hnsw absent -> faiss
+    assert _resolve_backend(10_000, 20) == "numpy"  # no hnsw -> numpy exact
 
 
 def test_resolve_auto_size_gate(monkeypatch):
     monkeypatch.delenv("GOLDENMATCH_ANN_BACKEND", raising=False)
     monkeypatch.setattr(ab, "_HAS_HNSW", True)
-    monkeypatch.setattr(ab, "_HAS_FAISS", True)
-    # below the row floor -> exact (faiss)
-    assert _resolve_backend(_HNSW_MIN - 1, 20) == "faiss"
+    # below the row floor -> exact (numpy)
+    assert _resolve_backend(_HNSW_MIN - 1, 20) == "numpy"
     # at/above the floor with a small top_k -> hnsw
     assert _resolve_backend(_HNSW_MIN, 20) == "hnsw"
     # large top_k (retrieve-nearly-all) is HNSW's bad case -> exact
-    assert _resolve_backend(100_000, 100_000) == "faiss"
+    assert _resolve_backend(100_000, 100_000) == "numpy"
 
 
-def test_resolve_auto_prefers_hnsw_over_faiss(monkeypatch):
+def test_resolve_auto_prefers_hnsw_over_numpy(monkeypatch):
     monkeypatch.delenv("GOLDENMATCH_ANN_BACKEND", raising=False)
     monkeypatch.setattr(ab, "_HAS_HNSW", True)
-    monkeypatch.setattr(ab, "_HAS_FAISS", True)
-    assert _resolve_backend(10_000, 20) == "hnsw"  # HNSW wins when both present
+    assert _resolve_backend(10_000, 20) == "hnsw"  # HNSW wins above the gate
 
 
 def test_resolve_auto_falls_back_to_numpy(monkeypatch):
     monkeypatch.delenv("GOLDENMATCH_ANN_BACKEND", raising=False)
     monkeypatch.setattr(ab, "_HAS_HNSW", False)
-    monkeypatch.setattr(ab, "_HAS_FAISS", False)
     assert _resolve_backend(10_000, 20) == "numpy"
 
 
 def test_env_min_override(monkeypatch):
     monkeypatch.delenv("GOLDENMATCH_ANN_BACKEND", raising=False)
     monkeypatch.setattr(ab, "_HAS_HNSW", True)
-    monkeypatch.setattr(ab, "_HAS_FAISS", False)
     monkeypatch.setenv("GOLDENMATCH_ANN_HNSW_MIN", "100")
     assert _resolve_backend(150, 20) == "hnsw"
     assert _resolve_backend(50, 20) == "numpy"

--- a/packages/python/goldenmatch/tests/test_ann_pairs.py
+++ b/packages/python/goldenmatch/tests/test_ann_pairs.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
-import pytest
 from goldenmatch.config.schemas import (
     BlockingConfig,
     BlockingKeyConfig,
@@ -12,14 +11,7 @@ from goldenmatch.config.schemas import (
     MatchkeyField,
 )
 
-try:
-    import faiss  # noqa: F401  # availability check for optional dep
-    HAS_FAISS = True
-except ImportError:
-    HAS_FAISS = False
 
-
-@pytest.mark.skipif(not HAS_FAISS, reason="faiss-cpu not installed")
 class TestQueryWithScores:
     def test_returns_scores(self):
         from goldenmatch.core.ann_blocker import ANNBlocker
@@ -66,7 +58,6 @@ class TestQueryWithScores:
             assert a != b
 
 
-@pytest.mark.skipif(not HAS_FAISS, reason="faiss-cpu not installed")
 class TestAnnPairsBlocking:
     def _make_fake_embedder(self):
         from goldenmatch.core.embedder import Embedder

--- a/packages/python/goldenmatch/tests/test_incremental.py
+++ b/packages/python/goldenmatch/tests/test_incremental.py
@@ -5,18 +5,9 @@ from __future__ import annotations
 import json
 
 import numpy as np
-import pytest
-
-try:
-    import faiss  # noqa: F401  # availability check for optional dep
-    HAS_FAISS = True
-except ImportError:
-    HAS_FAISS = False
-
 
 # ── Persistent ANN Index Tests ────────────────────────────────────────────
 
-@pytest.mark.skipif(not HAS_FAISS, reason="faiss-cpu not installed")
 class TestPersistentANNIndex:
     def test_build_and_query(self, tmp_path):
         from goldenmatch.db.ann_index import PersistentANNIndex
@@ -53,7 +44,7 @@ class TestPersistentANNIndex:
         index.add(ids, embeddings)
         index.save()
 
-        assert (index_dir / "index.faiss").exists()
+        assert (index_dir / "index_vectors.npy").exists()
         assert (index_dir / "id_map.npy").exists()
         assert (index_dir / "index_meta.json").exists()
 
@@ -143,7 +134,6 @@ class TestHybridBlockingUnit:
 
 # ── Progressive Embedding Tests ───────────────────────────────────────────
 
-@pytest.mark.skipif(not HAS_FAISS, reason="faiss-cpu not installed")
 class TestProgressiveEmbedding:
     def test_index_grows_across_adds(self, tmp_path):
         """Simulate progressive embedding across multiple runs."""

--- a/packages/python/goldenmatch/tests/test_retrieval.py
+++ b/packages/python/goldenmatch/tests/test_retrieval.py
@@ -80,9 +80,9 @@ def test_missing_column_raises():
 
 
 def test_numpy_fallback_matches(monkeypatch):
-    # Force the no-FAISS path; the exact-text query must still rank its row first.
+    # Force the exact numpy path; the exact-text query must still rank its row first.
     monkeypatch.setattr(
-        "goldenmatch.core.ann_blocker._HAS_FAISS", False, raising=False,
+        "goldenmatch.core.ann_blocker._HAS_HNSW", False,
     )
     res = retrieve_similar_records(_corpus(), "red apple pie recipe", "title", k=3)
     assert res[0].row_id == 10

--- a/packages/python/goldenmatch/tests/test_vector_index.py
+++ b/packages/python/goldenmatch/tests/test_vector_index.py
@@ -187,7 +187,7 @@ def test_reload_repopulates_cache_so_add_skips_known_text(tmp_path):
 
 
 def test_numpy_fallback_path(tmp_path, monkeypatch):
-    monkeypatch.setattr(ann_blocker, "_HAS_FAISS", False)
+    monkeypatch.setattr(ann_blocker, "_HAS_HNSW", False)
     idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
     hits = idx.query("acme corporation", k=1)
     assert hits and hits[0].record["name"] == "acme corporation"

--- a/uv.lock
+++ b/uv.lock
@@ -779,29 +779,6 @@ wheels = [
 ]
 
 [[package]]
-name = "faiss-cpu"
-version = "1.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/4a/97150aa1582fb9c2bca95bd8fc37f27d3b470acec6f0a6833844b21e4b40/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_x86_64.whl", hash = "sha256:c8d097884521e1ecaea6467aeebbf1aa56ee4a36350b48b2ca6b39366565c317", size = 7896434, upload-time = "2025-12-24T10:27:03.592Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/d0/0940575f059591ca31b63a881058adb16a387020af1709dcb7669460115c/faiss_cpu-1.13.2-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ee330a284042c2480f2e90450a10378fd95655d62220159b1408f59ee83ebf1", size = 11485825, upload-time = "2025-12-24T10:27:05.681Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/e1/a5acac02aa593809f0123539afe7b4aff61d1db149e7093239888c9053e1/faiss_cpu-1.13.2-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ab88ee287c25a119213153d033f7dd64c3ccec466ace267395872f554b648cd7", size = 23845772, upload-time = "2025-12-24T10:27:08.194Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/7b/49dcaf354834ec457e85ca769d50bc9b5f3003fab7c94a9dcf08cf742793/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:85511129b34f890d19c98b82a0cd5ffb27d89d1cec2ee41d2621ee9f9ef8cf3f", size = 13477567, upload-time = "2025-12-24T10:27:10.822Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/6b/12bb4037921c38bb2c0b4cfc213ca7e04bbbebbfea89b0b5746248ce446e/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b32eb4065bac352b52a9f5ae07223567fab0a976c7d05017c01c45a1c24264f", size = 25102239, upload-time = "2025-12-24T10:27:13.476Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6d/40439a05e4e60a0e889aa68b08ec70f5c8e32901f75f2be25c593a2e050e/faiss_cpu-1.13.2-cp311-cp311-win_amd64.whl", hash = "sha256:7c5944d7807d58fe7244b6aba06be710ee7ed99343365ed92699349efe979f51", size = 18879906, upload-time = "2025-12-24T10:27:19.041Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f9/b97eadbdd9e00f945d1566c7101382344f504596bfb19219465b0fc61e6e/faiss_cpu-1.13.2-cp311-cp311-win_arm64.whl", hash = "sha256:19508a1badfb36e456c1c8664eeb948349f604db5c7545f277a0126b4a84b080", size = 8548280, upload-time = "2025-12-24T10:27:22.114Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ff/35ed875423200c17bdd594ce921abfc1812ddd21e09355290b9a94e170ab/faiss_cpu-1.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:b82c01d30430dd7b1fa442001b9099735d1a82f6bb72033acdc9206d5ac66a64", size = 18890300, upload-time = "2025-12-24T10:27:24.194Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3a/bbdf5deaf6feb34b46b469c0a0acd40216c3d3c6ecf5aeb71d56b8a650e3/faiss_cpu-1.13.2-cp312-cp312-win_arm64.whl", hash = "sha256:2c4f696ae76e7c97cbc12311db83aaf1e7f4f7be06a3ffea7e5b0e8ec1fd805b", size = 8553157, upload-time = "2025-12-24T10:27:26.38Z" },
-    { url = "https://files.pythonhosted.org/packages/60/4b/903d85bf3a8264d49964ec799e45c7ffc91098606b8bc9ef2c904c1a56cb/faiss_cpu-1.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:cb4b5ee184816a4b099162ac93c0d7f0033d81a88e7c1291d0a9cc41ec348984", size = 18891330, upload-time = "2025-12-24T10:27:28.806Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/52/5d10642da628f63544aab27e48416be4a7ea25c6b81d8bd65016d8538b00/faiss_cpu-1.13.2-cp313-cp313-win_arm64.whl", hash = "sha256:1243967eeb2298791ff7f3683a4abd2100d7e6ec7542ca05c3b75d47a7f621e5", size = 8553088, upload-time = "2025-12-24T10:27:31.325Z" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1258,7 +1235,6 @@ agent = [
 all = [
     { name = "alembic" },
     { name = "anthropic" },
-    { name = "faiss-cpu" },
     { name = "fastapi" },
     { name = "goldencheck", extra = ["polars"] },
     { name = "goldenflow" },
@@ -1310,7 +1286,6 @@ duckdb = [
     { name = "duckdb" },
 ]
 embeddings = [
-    { name = "faiss-cpu" },
     { name = "sentence-transformers" },
 ]
 gcs = [
@@ -1403,7 +1378,6 @@ requires-dist = [
     { name = "duckdb", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'bench'", specifier = ">=0.10" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
-    { name = "faiss-cpu", marker = "extra == 'embeddings'", specifier = ">=1.7" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "goldencheck", extras = ["polars"], marker = "extra == 'quality'", editable = "packages/python/goldencheck" },
     { name = "goldenflow", marker = "extra == 'transform'", editable = "packages/python/goldenflow" },


### PR DESCRIPTION
Removes `faiss-cpu` from goldenmatch's optional `[embeddings]` extra. FAISS was used only for `IndexFlatIP` (exact brute-force inner product) + its on-disk index format — both trivially ownable. The HNSW graph is already owned (`goldenmatch-hnsw`); this closes the last FAISS usage.

## Changes
- **`core/ann_blocker.py`**: deleted the faiss branch — `_resolve_backend` now yields only `hnsw` (at scale) / `numpy`. The existing `_np_search` already replicated `IndexFlatIP.search` exactly (top-k by descending raw IP, same neighbor set), so numpy is the exact reference; `q @ corpus.T` is BLAS-backed.
- **`db/ann_index.py`**: the durable persisted index replaces the faiss object with a stored `np.ndarray` + brute-force top-k `query` (raw-IP scores, identical `(query_idx, db_record_id, score)` shape/semantics). Persistence is now `index_vectors.npy` (np.save/load) alongside the existing `id_map.npy` + `index_meta.json`.
- **`pyproject`**: `faiss-cpu>=1.7` removed from `[embeddings]` (kept `sentence-transformers`). uv.lock regenerated (faiss-cpu dropped).
- 7 test files repointed at the owned path; `test_ann_fallback` asserts the owned flat search == exact brute-force top-k, with a faiss-oracle cross-check when faiss *is* installed.

## Verified
Independently re-ran the ann tests with **faiss not importable**: `test_ann_fallback` + `test_ann_blocker` 5 passed, 1 skipped (the faiss-oracle test skips when faiss absent); the agent's full run was 57 passed / 5 skipped. ruff clean. Behavior is identical to `IndexFlatIP`.

## Caveats (honest)
- **On-disk format changed** (unavoidable — faiss's format is gone): persisted indexes now use `index_vectors.npy` and `DEFAULT_INDEX_DIR` `.goldenmatch_faiss` → `.goldenmatch_ann`. A pre-existing faiss index on disk is ignored and **rebuilt from the `gm_embeddings` DB table** (the source of truth) — a one-time rebuild, no data loss.
- **Latent bug fixed along the way**: `load_or_build`'s delta path called `self._add_to_index(...)`, which was referenced but never defined (would `AttributeError`); it's now defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoH3e9acqEL4xp1tkcfAXd