### PR TITLE
feat(goldenmatch): own connected-components (drop undeclared scipy from distributed clustering)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 421,
+      "module_count": 422,
       "modules": [
         {
           "module": "goldenmatch",
@@ -5262,6 +5262,14 @@
           ]
         },
         {
+          "module": "goldenmatch.distributed._connected_components",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/_connected_components.py",
+          "purpose": "Owned weakly-connected-components over an undirected edge list.",
+          "defines": [
+            "connected_components_undirected"
+          ]
+        },
+        {
           "module": "goldenmatch.distributed._utils",
           "file": "packages/python/goldenmatch/goldenmatch/distributed/_utils.py",
           "purpose": "Tiny helpers shared across distributed submodules.",
@@ -5278,7 +5286,7 @@
             "_annotate_cluster_sizes",
             "_assert_scratch_shared_if_multinode",
             "_attach_quality_metadata",
-            "_build_clusters_scipy_fallback",
+            "_build_clusters_cc_fallback",
             "_derive_touched_ids",
             "_emit_boundary_pairs",
             "_phase_a_local_cc",
@@ -5312,7 +5320,8 @@
           ],
           "imports": [
             "goldenmatch.core.cluster",
-            "goldenmatch.core.frame"
+            "goldenmatch.core.frame",
+            "goldenmatch.distributed._connected_components"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/distributed/_connected_components.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/_connected_components.py
@@ -1,0 +1,57 @@
+"""Owned weakly-connected-components over an undirected edge list.
+
+GoldenMatch's distributed clustering fallback (``clustering.py``) used
+``scipy.sparse.csgraph.connected_components`` to label components on the driver.
+scipy was NOT a declared goldenmatch dependency, so that path was a latent
+``ImportError`` for anyone without scipy installed. This owns the one graph
+primitive it needed -- "own it, don't clone it" -- so the fallback is scipy-free
+and self-contained.
+
+``connected_components_undirected`` is byte-identical to
+``connected_components(graph, directed=False)`` (same ``(n_components, labels)``,
+labels numbered 0..k-1 by ascending minimum node index -- scipy's convention),
+verified against scipy in ``tests/test_connected_components_parity.py``. It is
+vectorized (min-label propagation with pointer jumping, Awerbuch-Shiloach), a
+handful of numpy passes rather than a per-edge Python union-find, to preserve the
+vectorized wall the scipy path was chosen for.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def connected_components_undirected(
+    row: np.ndarray, col: np.ndarray, n: int
+) -> tuple[int, np.ndarray]:
+    """Weakly-connected components of the undirected graph on ``n`` nodes with
+    edges ``(row[i], col[i])``.
+
+    Returns ``(n_components, labels)`` where ``labels`` is an ``int64`` array of
+    length ``n`` and ``labels[i]`` is node ``i``'s component id in ``0..k-1``,
+    numbered by ascending minimum node index (identical to
+    ``scipy.sparse.csgraph.connected_components(..., directed=False)``). Self-loops
+    and duplicate edges are ignored; isolated nodes are their own component.
+    """
+    n = int(n)
+    row = np.asarray(row, dtype=np.int64)
+    col = np.asarray(col, dtype=np.int64)
+    # Each node starts as its own label; propagation drives every node's label to
+    # the minimum node index reachable from it (its canonical component root).
+    labels = np.arange(n, dtype=np.int64)
+    if row.size:
+        # Symmetrize (undirected): an edge constrains both endpoints.
+        u = np.concatenate([row, col])
+        v = np.concatenate([col, row])
+        while True:
+            m = np.minimum(labels[u], labels[v])
+            new = labels.copy()
+            np.minimum.at(new, u, m)
+            np.minimum.at(new, v, m)
+            new = new[new]  # pointer jumping: collapse chains toward the root
+            if np.array_equal(new, labels):
+                break
+            labels = new
+    # Each distinct surviving label is a component's min node index. Densify to
+    # 0..k-1 in ascending order == scipy's numbering.
+    uniq, inv = np.unique(labels, return_inverse=True)
+    return int(uniq.size), inv.astype(np.int64).reshape(-1)

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -148,15 +148,16 @@ def _wcc_algorithm() -> str:
     return os.environ.get("GOLDENMATCH_DISTRIBUTED_WCC", "two_phase").lower()
 
 
-# Peak driver bytes per scored pair on the in-memory scipy route: ~24 B for the
+# Peak driver bytes per scored pair on the in-memory connected-components route: ~24 B for the
 # (id_a, id_b, score) = (int64, int64, f64) triple, times ~4 because the arrow
-# table, the numpy id arrays, the CSR matrix, and the labels array are all live
-# at once. Deliberately conservative -- routing in-memory must not OOM the driver.
+# table, the numpy id arrays, the symmetrized edge arrays, and the labels array
+# are all live at once. Deliberately conservative -- routing in-memory must not
+# OOM the driver.
 _PAIR_PEAK_BYTES = 96
 
 
 def _route_distributed(pair_count: int) -> bool:
-    """Decide the clustering route: True => distributed WCC, False => in-memory scipy.
+    """Decide the clustering route: True => distributed WCC, False => in-memory connected-components.
 
     The scored pair set fits one node far more often than the legacy fixed 50M
     threshold assumed (110M pairs ~= 1.76 GB raw), so the slow distributed WCC
@@ -190,7 +191,7 @@ def _route_distributed(pair_count: int) -> bool:
         pair_count,
         est_peak / (1024 ** 3),
         available / (1024 ** 3),
-        "distributed WCC" if distribute else "in-memory scipy",
+        "distributed WCC" if distribute else "in-memory connected-components",
     )
     return distribute
 
@@ -205,7 +206,7 @@ def _resolve_use_label_prop(
 
     An explicit planner strategy ("in_memory" / "distributed_wcc") wins;
     otherwise fall back to the memory-aware route decision (#956): in-memory
-    scipy whenever the scored pair set fits driver RAM, distributed WCC when it
+    in-memory connected-components whenever the scored pair set fits driver RAM, distributed WCC when it
     doesn't (or an explicit CLUSTERING_THRESHOLD says so).
     """
     if force_label_propagation:
@@ -220,7 +221,7 @@ def _resolve_use_label_prop(
 def _derive_touched_ids(pairs_ds: Dataset) -> list[int]:
     """Distinct ids appearing in any pair (id_a or id_b), sorted.
 
-    Driver-side collect of the distinct SET -- used ONLY on the scipy and
+    Driver-side collect of the distinct SET -- used ONLY on the connected-components and
     label-propagation routes, which are gated below the 50M-pair threshold,
     so the set is bounded. The two_phase_wcc route never calls this (it takes
     all_ids=None and derives touched members distributively in Phase A).
@@ -248,12 +249,12 @@ def build_clusters_distributed(
     Row shape: {member_id, cluster_id, cluster_size, oversized}.
 
     Routing (Splink-Spark style), memory-aware by default (#956):
-      - Pair set fits available driver RAM: driver-side scipy.csgraph. The
+      - Pair set fits available driver RAM: driver-side connected-components. The
         in-memory connected-components pass is seconds where the distributed
         WCC is a multi-hour tail, so it is the default whenever the pairs fit.
       - Pair set does NOT fit driver RAM, OR force_label_propagation=True:
         distributed WCC / label propagation on Ray Datasets. Falls back to
-        scipy on non-convergence.
+        the CC fallback on non-convergence.
 
     Setting GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD overrides the
     memory-aware default with an explicit pair-count threshold (see
@@ -262,12 +263,12 @@ def build_clusters_distributed(
     ``algorithm`` (keyword-only) overrides the GOLDENMATCH_DISTRIBUTED_WCC env
     selector for this call (e.g. "randomized_contraction"); None = env default.
     Only affects the at/above-threshold WCC path; below the threshold the route
-    is scipy regardless.
+    is the in-memory CC route regardless.
 
     ``all_ids`` is the full id universe (incl. isolated singletons). Pass
     ``None`` (default) for the golden scale path: only multi-member clusters
     are needed, so the two_phase route derives touched members distributively
-    and never builds an O(N) driver id list. The scipy / label-propagation
+    and never builds an O(N) driver id list. The connected-components / label-propagation
     routes (small scale) derive the touched set on demand when all_ids is None.
 
     cluster_id is the minimum member_id in the connected component.
@@ -281,13 +282,13 @@ def build_clusters_distributed(
 
     if not use_label_prop:
         logger.info(
-            "build_clusters_distributed: %d pairs route to scipy.csgraph "
+            "build_clusters_distributed: %d pairs route to driver-side connected-components "
             "(driver-side, fits memory -- faster at this scale).",
             pair_count,
         )
         ids = all_ids if all_ids is not None else _derive_touched_ids(pairs_ds)
         return _annotate_cluster_sizes(
-            _build_clusters_scipy_fallback(pairs_ds, ids, max_cluster_size),
+            _build_clusters_cc_fallback(pairs_ds, ids, max_cluster_size),
             max_cluster_size,
             already_sized=True,
         )
@@ -312,11 +313,11 @@ def build_clusters_distributed(
             )
         except ConvergenceError as e:
             logger.warning(
-                "label propagation did not converge; scipy.csgraph fallback on driver. %s",
+                "label propagation did not converge; connected-components fallback on driver. %s",
                 e,
             )
             return _annotate_cluster_sizes(
-                _build_clusters_scipy_fallback(pairs_ds, ids, max_cluster_size),
+                _build_clusters_cc_fallback(pairs_ds, ids, max_cluster_size),
                 max_cluster_size,
                 already_sized=True,
             )
@@ -373,7 +374,7 @@ def _annotate_cluster_sizes(
     Same co-location trick build_golden_records_distributed uses. Bounded
     per-partition memory, no driver-side O(clusters) structure.
 
-    ``already_sized=True`` short-circuits for the scipy fallback, which
+    ``already_sized=True`` short-circuits for the CC fallback, which
     already emits {member_id, cluster_id, cluster_size, oversized}.
     """
     import os
@@ -424,19 +425,19 @@ def _annotate_cluster_sizes(
     return colocated.map_batches(_emit, batch_format="pyarrow")
 
 
-def _build_clusters_scipy_fallback(
+def _build_clusters_cc_fallback(
     pairs_ds: Dataset,
     all_ids: list[int],
     max_cluster_size: int,
 ) -> Dataset:
-    """Driver-side scipy.csgraph fallback.
+    """Driver-side connected-components fallback (owned; scipy-free).
 
     Used for two paths in build_clusters_distributed:
       - default route below the 50M-pair threshold (Splink-DuckDB analog)
       - convergence-failure escape hatch when label propagation can't finish
 
     Vectorized end-to-end: pair rows -> Arrow columns -> numpy index lookup
-    -> scipy connected_components -> Arrow output -> ray.data.from_arrow.
+    -> owned connected_components_undirected -> Arrow output -> ray.data.from_arrow.
     Run 26122054424 had this at 67s on 8.3M pairs / 16.6M members; the
     naive Python-loop path drove that wall. Vectorized path targets <30s.
     """
@@ -444,8 +445,10 @@ def _build_clusters_scipy_fallback(
     import polars as pl
     import pyarrow as pa
     import ray
-    from scipy.sparse import csr_matrix
-    from scipy.sparse.csgraph import connected_components
+
+    from goldenmatch.distributed._connected_components import (
+        connected_components_undirected,
+    )
 
     # Pull pairs in pyarrow batches and concatenate (vectorized; the prior
     # take_all + per-row dict comprehension was the 67s bottleneck on
@@ -467,9 +470,7 @@ def _build_clusters_scipy_fallback(
     row_idx = np.searchsorted(sorted_ids, id_a_arr)
     col_idx = np.searchsorted(sorted_ids, id_b_arr)
 
-    data = np.ones(row_idx.shape[0], dtype=np.int8)
-    graph = csr_matrix((data, (row_idx, col_idx)), shape=(n, n))
-    _n_components, labels = connected_components(graph, directed=False)
+    _n_components, labels = connected_components_undirected(row_idx, col_idx, n)
 
     # Compute per-cluster size via bincount; broadcast back to per-member.
     sizes_per_label = np.bincount(labels, minlength=int(labels.max()) + 1 if labels.size else 1)
@@ -1245,7 +1246,7 @@ def _rc_union_isolated(labels_ds: Any, all_ids: list[int], pairs_ds: Any) -> Any
 
     Only reached when a caller passes a concrete ``all_ids`` (the full-universe,
     smaller-scale regime), so the driver-side touched-set derive is acceptable --
-    the same posture the scipy / label_propagation routes already take.
+    the same posture the connected-components / label_propagation routes already take.
     """
     import ray
     touched = set(_derive_touched_ids(pairs_ds))

--- a/packages/python/goldenmatch/tests/test_connected_components_parity.py
+++ b/packages/python/goldenmatch/tests/test_connected_components_parity.py
@@ -1,0 +1,66 @@
+"""Byte-parity gate for the owned connected-components kernel.
+
+Asserts ``goldenmatch.distributed._connected_components.connected_components_undirected``
+returns EXACTLY the same ``(n_components, labels)`` as
+``scipy.sparse.csgraph.connected_components(..., directed=False)`` across random +
+structured graphs (self-loops, duplicate edges, chains, stars, isolated nodes).
+The distributed clustering fallback consumes the label integers directly as
+cluster ids, so the labeling convention (0..k-1 by ascending min node index) must
+match. scipy is a test-only oracle; the runtime is scipy-free.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from goldenmatch.distributed._connected_components import connected_components_undirected
+
+csgraph = pytest.importorskip("scipy.sparse.csgraph")
+sparse = pytest.importorskip("scipy.sparse")
+
+
+def _scipy_labels(row: np.ndarray, col: np.ndarray, n: int) -> tuple[int, np.ndarray]:
+    data = np.ones(np.asarray(row).shape[0], dtype=np.int8)
+    graph = sparse.csr_matrix((data, (row, col)), shape=(n, n))
+    return csgraph.connected_components(graph, directed=False)
+
+
+def _assert_match(row, col, n) -> None:
+    row = np.asarray(row, dtype=np.int64)
+    col = np.asarray(col, dtype=np.int64)
+    nc_s, lab_s = _scipy_labels(row, col, n)
+    nc_o, lab_o = connected_components_undirected(row, col, n)
+    assert nc_o == nc_s
+    assert np.array_equal(lab_o, lab_s)
+
+
+@pytest.mark.parametrize("seed", range(50))
+def test_random_graphs_match_scipy(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    n = int(rng.integers(1, 80))
+    e = int(rng.integers(0, n * 2 + 1))
+    if e and n > 1:
+        row = rng.integers(0, n, e)
+        col = rng.integers(0, n, e)
+    else:
+        row = np.array([], dtype=np.int64)
+        col = np.array([], dtype=np.int64)
+    _assert_match(row, col, n)
+
+
+def test_structured_graphs_match_scipy() -> None:
+    _assert_match([], [], 10)              # all isolated
+    _assert_match([], [], 1)               # single node
+    _assert_match([0], [0], 1)             # self-loop only
+    _assert_match([0, 1, 2, 2], [0, 1, 2, 3], 5)   # self-loops + one edge
+    _assert_match([0, 0, 0, 1], [1, 1, 1, 2], 4)   # duplicate edges
+    _assert_match(list(range(199)), list(range(1, 200)), 200)  # chain
+    _assert_match([0] * 99, list(range(1, 100)), 100)          # star
+
+
+def test_two_components_labels_by_min_index() -> None:
+    # Nodes {0,2} and {1,3} -> component of node 0 is label 0, node 1 is label 1.
+    nc, labels = connected_components_undirected(
+        np.array([0, 1]), np.array([2, 3]), 4
+    )
+    assert nc == 2
+    assert labels.tolist() == [0, 1, 0, 1]

--- a/packages/python/goldenmatch/tests/test_distributed_clustering.py
+++ b/packages/python/goldenmatch/tests/test_distributed_clustering.py
@@ -155,8 +155,9 @@ def test_build_clusters_distributed_falls_back_on_non_convergence(caplog):
     assert any("fallback" in r.message.lower() for r in caplog.records)
 
 
-def test_build_clusters_distributed_routes_to_scipy_below_threshold(caplog):
-    """Default routing: small pair lists go straight to scipy.csgraph."""
+def test_build_clusters_distributed_routes_to_cc_below_threshold(caplog):
+    """Default routing: small pair lists go straight to the driver-side owned
+    connected-components fallback."""
     import logging
 
     from goldenmatch.distributed.clustering import (
@@ -174,9 +175,9 @@ def test_build_clusters_distributed_routes_to_scipy_below_threshold(caplog):
 
     rows = clusters_ds.take_all()
     assert len(rows) == 5
-    # Routing log must mention scipy.csgraph; label-prop log must NOT fire.
+    # Routing log must mention the connected-components route; label-prop must NOT fire.
     routing_msgs = [r.message.lower() for r in caplog.records]
-    assert any("scipy" in m for m in routing_msgs), routing_msgs
+    assert any("connected-components" in m for m in routing_msgs), routing_msgs
     assert not any("distributed label propagation" in m for m in routing_msgs)
 
 


### PR DESCRIPTION
## What

goldenmatch's distributed clustering driver-side fallback used `scipy.sparse.csgraph.connected_components` — but **scipy was never a declared goldenmatch dependency**. That path is the **default** route below 50M pairs (plus the label-propagation non-convergence escape hatch), so it was a **latent `ImportError`** for anyone without scipy installed. This owns the one graph primitive it needed and makes the fallback self-contained. Continues "own it, don't clone it."

## How

- **`distributed/_connected_components.py`** — `connected_components_undirected`: a vectorized weakly-connected-components (min-label propagation + pointer jumping, Awerbuch-Shiloach). A handful of numpy passes, **not** a per-edge Python union-find, so the vectorized wall the scipy path was chosen for is preserved.
- **Byte-identical to scipy**: same `(n_components, labels)`, labels numbered `0..k-1` by ascending minimum node index (scipy's `directed=False` convention). This matters because the fallback consumes the label integers **directly as cluster ids** — the grouping *and* the numbering must match.
- **`clustering.py`**: the fallback calls the owned kernel (no scipy import; dropped the `csr_matrix` build). Renamed `_build_clusters_scipy_fallback` → `_build_clusters_cc_fallback` and swept the stale "scipy" route vocabulary in comments/logs.

## Verification

`test_connected_components_parity.py` asserts owned == scipy **exactly** across 50 random graphs + structured cases (self-loops, duplicate edges, chains — the worst case for propagation — stars, isolated nodes): **52 passed**. Confirmed clustering imports + the kernel run with scipy **fully import-blocked**.

goldenmatch never declared scipy, so there's **no dep/lock change**. scipy stays a dev-only oracle and remains used independently by `goldencheck[baseline]`.

Note: this is the optional Ray/distributed tier. Correctness is locked here (byte-vs-scipy); wall-perf at 16M-node scale is exercised by the distributed lane in CI (the box can't scale-bench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)