### PR TITLE
feat(goldencheck): own chi-squared + Pearson stats (flip correlation + Benford off scipy)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7855,7 +7855,7 @@
     },
     "goldencheck": {
       "root": "packages/python/goldencheck/goldencheck",
-      "module_count": 114,
+      "module_count": 115,
       "modules": [
         {
           "module": "goldencheck",
@@ -8064,6 +8064,17 @@
           ]
         },
         {
+          "module": "goldencheck.baseline._owned_stats",
+          "file": "packages/python/goldencheck/goldencheck/baseline/_owned_stats.py",
+          "purpose": "Owned pure-Python statistics kernels -- goldencheck's scipy-free reference for",
+          "defines": [
+            "chi2_contingency_stat",
+            "chi2_gof",
+            "gamma_ur",
+            "pearson_r"
+          ]
+        },
+        {
           "module": "goldencheck.baseline.constraints",
           "file": "packages/python/goldencheck/goldencheck/baseline/constraints.py",
           "purpose": "Constraint mining: functional dependencies, candidate keys, temporal orders.",
@@ -8091,6 +8102,7 @@
           ],
           "imports": [
             "goldencheck._polars_lazy",
+            "goldencheck.baseline._owned_stats",
             "goldencheck.baseline.models",
             "goldencheck.core._native_loader"
           ]
@@ -8173,6 +8185,7 @@
           "imports": [
             "goldencheck._polars_lazy",
             "goldencheck.baseline._ks",
+            "goldencheck.baseline._owned_stats",
             "goldencheck.baseline.models",
             "goldencheck.core._native_loader"
           ]

--- a/packages/python/goldencheck/goldencheck/baseline/_owned_stats.py
+++ b/packages/python/goldencheck/goldencheck/baseline/_owned_stats.py
@@ -1,0 +1,149 @@
+"""Owned pure-Python statistics kernels -- goldencheck's scipy-free reference for
+the baseline correlation + Benford profilers.
+
+These mirror the ``goldencheck-core`` Rust kernels (``correlation::pearson_r`` /
+``correlation::chi2_contingency_stat`` / ``gof::chi2_gof``) byte-for-byte, so the
+baseline path is scipy-free whether or not the native extension is installed:
+correlation/Benford now dispatch native-if-available-else-these. They reproduce
+``scipy.stats.pearsonr`` / ``chi2_contingency`` / ``chisquare`` to float epsilon
+(the parity test asserts ~1e-12); scipy stays a test-only oracle.
+
+Owning them also unblocks cross-surface parity -- these are elementary + one
+special function (the regularized upper incomplete gamma for the chi-squared
+upper tail), all portable to TS/Rust, where a scipy dependency never could be.
+
+NOTE: the distribution-fit + KS-test (``kstest`` / ``dist.fit``) paths in
+``statistical.py`` and ``drift/detector.py`` still use scipy -- the exact
+two-sided Kolmogorov distribution and the lognormal MLE are a separate, harder
+tier (see the PR that introduced this module).
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def gamma_ur(a: float, x: float) -> float:
+    """Regularized upper incomplete gamma Q(a, x) = ``scipy.special.gammaincc``.
+
+    Series for the lower tail when ``x < a + 1`` (then ``Q = 1 - P``); a Lentz
+    continued fraction for ``Q`` directly otherwise -- the same split Numerical
+    Recipes / Cephes use, so the upper tail keeps full precision for large ``x``
+    (never the catastrophic ``1 - cdf`` cancellation). Mirrors the Rust kernel's
+    ``statrs::function::gamma::gamma_ur``.
+    """
+    if x < 0.0 or a <= 0.0:
+        return float("nan")
+    if x == 0.0:
+        return 1.0
+    if x < a + 1.0:
+        # Series for P(a, x); Q = 1 - P.
+        ap = a
+        term = 1.0 / a
+        total = term
+        for _ in range(1000):
+            ap += 1.0
+            term *= x / ap
+            total += term
+            if abs(term) < abs(total) * 1e-16:
+                break
+        p = total * math.exp(-x + a * math.log(x) - math.lgamma(a))
+        return 1.0 - p
+    # Lentz continued fraction for Q(a, x) directly.
+    tiny = 1e-300
+    b = x + 1.0 - a
+    c = 1.0 / tiny
+    d = 1.0 / b
+    h = d
+    for i in range(1, 1000):
+        an = -i * (i - a)
+        b += 2.0
+        d = an * d + b
+        if abs(d) < tiny:
+            d = tiny
+        c = b + an / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 1e-16:
+            break
+    return math.exp(-x + a * math.log(x) - math.lgamma(a)) * h
+
+
+def pearson_r(x: Sequence[float], y: Sequence[float]) -> float:
+    """Pearson correlation coefficient, matching ``scipy.stats.pearsonr(x, y)[0]``.
+
+    Clamped to ``[-1, 1]`` (scipy does the same, so perfectly-correlated data
+    returns exactly +/-1.0). Returns NaN for empty / length-mismatched input; the
+    caller pre-guards zero variance."""
+    n = len(x)
+    if n == 0 or n != len(y):
+        return float("nan")
+    mx = sum(x) / n
+    my = sum(y) / n
+    sxy = sxx = syy = 0.0
+    for xi, yi in zip(x, y):
+        dx = xi - mx
+        dy = yi - my
+        sxy += dx * dy
+        sxx += dx * dx
+        syy += dy * dy
+    r = sxy / math.sqrt(sxx * syy)
+    return max(-1.0, min(1.0, r))
+
+
+def chi2_contingency_stat(values: Sequence[float], nrows: int, ncols: int) -> float:
+    """Chi-squared statistic of a row-major contingency table, matching
+    ``scipy.stats.chi2_contingency(matrix)[0]`` (default ``correction=True``).
+
+    Expected counts are ``row_sum[i] * col_sum[j] / total``. For 2x2 tables ONLY,
+    Yates' continuity correction clips each residual at 0
+    (``max(|obs-exp| - 0.5, 0)``); other shapes use ``(obs-exp)^2 / exp``.
+    """
+    if nrows == 0 or ncols == 0 or len(values) != nrows * ncols:
+        return float("nan")
+    row_sums = [0.0] * nrows
+    col_sums = [0.0] * ncols
+    total = 0.0
+    for i in range(nrows):
+        for j in range(ncols):
+            v = values[i * ncols + j]
+            row_sums[i] += v
+            col_sums[j] += v
+            total += v
+    yates = nrows == 2 and ncols == 2
+    chi2 = 0.0
+    for i in range(nrows):
+        for j in range(ncols):
+            obs = values[i * ncols + j]
+            exp = row_sums[i] * col_sums[j] / total
+            diff = abs(obs - exp)
+            residual = max(diff - 0.5, 0.0) if yates else diff
+            chi2 += residual * residual / exp
+    return chi2
+
+
+def chi2_gof(
+    observed: Sequence[float], expected: Sequence[float]
+) -> tuple[float, float]:
+    """Chi-squared goodness-of-fit statistic + upper-tail p-value, matching
+    ``scipy.stats.chisquare(f_obs=observed, f_exp=expected)`` (``ddof=0``).
+
+    ``chi2 = Sum (obs-exp)^2 / exp`` and ``p = gammaincc((k-1)/2, chi2/2)`` (the
+    regularized upper incomplete gamma, NOT ``1 - cdf``). Perfect fit ->
+    ``(0.0, 1.0)``; ``df <= 0`` -> ``(chi2, NaN)``; empty / mismatched -> NaN.
+    """
+    n = len(observed)
+    if n == 0 or n != len(expected):
+        return (float("nan"), float("nan"))
+    chi2 = 0.0
+    for o, e in zip(observed, expected):
+        chi2 += (o - e) ** 2 / e
+    if chi2 == 0.0:
+        return (chi2, 1.0)
+    df = n - 1.0
+    if df <= 0.0:
+        return (chi2, float("nan"))
+    return (chi2, gamma_ur(df / 2.0, chi2 / 2.0))

--- a/packages/python/goldencheck/goldencheck/baseline/correlation.py
+++ b/packages/python/goldencheck/goldencheck/baseline/correlation.py
@@ -1,11 +1,12 @@
 """Correlation analyzer — Pearson (numeric-numeric) and Cramer's V (categorical-categorical).
 
 **Polars-accelerator-only (declined from the seam eviction, R4).** The core is a
-``group_by([a, b]).agg(pl.len()).pivot(on=b, index=a, values=...)`` plus a hard ``numpy``/``scipy``
-dependency (``pearsonr``, ``chi2_contingency``, ``.to_numpy()``) -- a ``group_by().agg()`` + real
+``group_by([a, b]).agg(pl.len()).pivot(on=b, index=a, values=...)`` plus a hard ``numpy``
+dependency (``.to_numpy()``; the Pearson r + chi-squared statistics are owned now,
+no scipy) -- a ``group_by().agg()`` + real
 ``.pivot()`` the ``Frame``/``Column`` seam does not model. It is NOT routed through the seam; it stays
 import-safe for the goldencheck import gate (lazy ``pl``; ``baseline`` is imported lazily) but requires
-Polars (and the ``[baseline]`` numpy/scipy extra) at runtime. See
+Polars (and the ``[baseline]`` numpy extra) at runtime. See
 ``docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r4-decline.md``.
 """
 from __future__ import annotations
@@ -16,14 +17,19 @@ from typing import TYPE_CHECKING
 
 try:
     import numpy as np
-    from scipy.stats import chi2_contingency, pearsonr
 except ImportError as _err:  # pragma: no cover
     raise ImportError(
-        "scipy and numpy are required for deep-profiling baseline. "
-        "Install them with: pip install 'goldencheck[baseline]'"
+        "numpy is required for deep-profiling baseline. "
+        "Install it with: pip install 'goldencheck[baseline]'"
     ) from _err
 
 from goldencheck._polars_lazy import pl
+from goldencheck.baseline._owned_stats import (
+    chi2_contingency_stat as _owned_chi2_contingency_stat,
+)
+from goldencheck.baseline._owned_stats import (
+    pearson_r as _owned_pearson_r,
+)
 from goldencheck.baseline.models import CorrelationEntry
 from goldencheck.core._native_loader import native_enabled, native_module
 
@@ -76,10 +82,10 @@ def _pearson_entry(df: pl.DataFrame, col_a: str, col_b: str) -> CorrelationEntry
     if np.std(a_vals) == 0.0 or np.std(b_vals) == 0.0:
         return None
 
-    corr, _ = pearsonr(a_vals, b_vals)
-    # Shadow (W4): also compute the native pearson_r kernel and discard it. The
-    # emitted CorrelationEntry stays scipy until the Flip; the guard + swallow
-    # ensure this shadow compute can never raise out or alter the finding.
+    # Owned Pearson r (W4 Flip): the native kernel when available, else the pure
+    # `_owned_stats` mirror -- no scipy. Both reproduce `scipy.stats.pearsonr[0]`
+    # to float epsilon (the emitted value is `round(corr, 6)`, so identical).
+    corr: float | None = None
     if native_enabled("pearson_r"):
         try:
             import pyarrow as pa
@@ -88,9 +94,15 @@ def _pearson_entry(df: pl.DataFrame, col_a: str, col_b: str) -> CorrelationEntry
             # columns may arrive as int dtype). Mirrors the benford kernel path.
             xa = pa.array(np.asarray(a_vals, dtype=np.float64))
             ya = pa.array(np.asarray(b_vals, dtype=np.float64))
-            native_module().pearson_r(xa, ya)
-        except BaseException:  # noqa: BLE001 - swallow even PyO3 PanicException
-            logger.debug("native pearson_r shadow failed", exc_info=True)
+            corr = float(native_module().pearson_r(xa, ya))
+        except BaseException:  # noqa: BLE001 - swallow even PyO3 PanicException, fall back to pure
+            logger.debug("native pearson_r failed; using owned pure", exc_info=True)
+            corr = None
+    if corr is None:
+        corr = _owned_pearson_r(
+            np.asarray(a_vals, dtype=np.float64).tolist(),
+            np.asarray(b_vals, dtype=np.float64).tolist(),
+        )
     if not np.isfinite(corr):
         return None
 
@@ -138,22 +150,23 @@ def _cramers_v(df: pl.DataFrame, col_a: str, col_b: str) -> CorrelationEntry | N
     if matrix.shape[0] < 2 or matrix.shape[1] < 2:
         return None
 
-    try:
-        chi2, _, _, _ = chi2_contingency(matrix)
-    except Exception as exc:
-        logger.debug("Chi2 contingency failed for (%s, %s): %s", col_a, col_b, exc)
-        return None
-
-    # Shadow (W4): also compute the native chi2_contingency_stat kernel and
-    # discard it. Only reached when scipy did not raise (so the matrix is
-    # well-formed); the guard + swallow keep the finding scipy-authoritative.
+    # Owned chi-squared statistic (W4 Flip): native kernel when available, else
+    # the pure `_owned_stats` mirror -- no scipy. Both reproduce
+    # `scipy.stats.chi2_contingency(matrix)[0]` (default Yates for 2x2) to float
+    # epsilon; only the statistic is used (Cramer's V), never scipy's p-value.
+    nrows_m, ncols_m = matrix.shape[0], matrix.shape[1]
+    flat = matrix.astype(np.float64).flatten().tolist()
+    chi2: float | None = None
     if native_enabled("chi2_contingency"):
         try:
-            native_module().chi2_contingency_stat(
-                matrix.flatten().tolist(), matrix.shape[0], matrix.shape[1]
-            )
-        except BaseException:  # noqa: BLE001 - swallow even PyO3 PanicException
-            logger.debug("native chi2_contingency shadow failed", exc_info=True)
+            chi2 = float(native_module().chi2_contingency_stat(flat, nrows_m, ncols_m))
+        except BaseException:  # noqa: BLE001 - swallow even PyO3 PanicException, fall back to pure
+            logger.debug("native chi2_contingency failed; using owned pure", exc_info=True)
+            chi2 = None
+    if chi2 is None:
+        chi2 = _owned_chi2_contingency_stat(flat, nrows_m, ncols_m)
+    if not np.isfinite(chi2):
+        return None
 
     n = int(matrix.sum())
     if n == 0:
@@ -194,8 +207,8 @@ def _cramers_v(df: pl.DataFrame, col_a: str, col_b: str) -> CorrelationEntry | N
 def analyze_correlations(df: pl.DataFrame) -> list[CorrelationEntry]:
     """Analyze pairwise correlations in *df* and return reportable entries.
 
-    - Numeric pairs: Pearson correlation via scipy.stats.pearsonr.
-    - Categorical pairs: Cramer's V via chi2_contingency.
+    - Numeric pairs: Pearson correlation via the owned `_owned_stats.pearson_r`.
+    - Categorical pairs: Cramer's V via the owned `_owned_stats.chi2_contingency_stat`.
     - Only moderate (>=0.4) or strong (>=0.7) correlations are reported.
     - At most _MAX_PAIRS column pairs are evaluated to prevent O(n²) blowup.
     - String columns must have n_unique < _MAX_CAT_UNIQUE to qualify as categorical.

--- a/packages/python/goldencheck/goldencheck/baseline/statistical.py
+++ b/packages/python/goldencheck/goldencheck/baseline/statistical.py
@@ -17,6 +17,7 @@ except ImportError as _err:  # pragma: no cover
 
 from goldencheck._polars_lazy import pl
 from goldencheck.baseline._ks import kstest as _owned_kstest
+from goldencheck.baseline._owned_stats import chi2_gof as _owned_chi2_gof
 from goldencheck.baseline.models import StatProfile
 from goldencheck.core._native_loader import native_enabled, native_module
 
@@ -325,18 +326,21 @@ def _compute_benford(values: np.ndarray) -> dict[str, float]:
         observed_props.append(obs_count)
         expected_vals.append(expected_props[d] * total)
 
-    # Chi-squared test
-    chi2, pvalue = _stats.chisquare(f_obs=observed_props, f_exp=expected_vals)
-    # Shadow (W4): also compute the native chi2_gof kernel (statistic + p-value)
-    # on the same inputs scipy got, and discard it. The emitted chi2_pvalue stays
-    # scipy until the Flip; the guard + swallow keep it output-invariant.
+    # Chi-squared goodness-of-fit p-value (W4 Flip): the native chi2_gof kernel
+    # when available, else the pure `_owned_stats` mirror -- no scipy. Both
+    # reproduce `scipy.stats.chisquare(f_obs, f_exp)[1]` to float epsilon (the
+    # emitted value is `round(pvalue, 6)`, so identical).
+    obs_f = [float(x) for x in observed_props]
+    exp_f = [float(x) for x in expected_vals]
+    pvalue: float | None = None
     if native_enabled("chi2_gof"):
         try:
-            native_module().chi2_gof(
-                [float(x) for x in observed_props], [float(x) for x in expected_vals]
-            )
-        except BaseException:  # noqa: BLE001 - swallow even PyO3 PanicException
-            logger.debug("native chi2_gof shadow failed", exc_info=True)
+            _chi2, pvalue = native_module().chi2_gof(obs_f, exp_f)
+        except BaseException:  # noqa: BLE001 - swallow even PyO3 PanicException, fall back to pure
+            logger.debug("native chi2_gof failed; using owned pure", exc_info=True)
+            pvalue = None
+    if pvalue is None:
+        _chi2, pvalue = _owned_chi2_gof(obs_f, exp_f)
     result["chi2_pvalue"] = round(float(pvalue), 6)
 
     return result

--- a/packages/python/goldencheck/tests/baseline/test_owned_stats_parity.py
+++ b/packages/python/goldencheck/tests/baseline/test_owned_stats_parity.py
@@ -1,0 +1,81 @@
+"""Byte-parity gate for the owned baseline stats kernels (``_owned_stats``).
+
+Asserts the pure-Python ``pearson_r`` / ``chi2_contingency_stat`` / ``chi2_gof``
+(and the underlying regularized upper incomplete gamma) reproduce
+``scipy.stats.pearsonr`` / ``chi2_contingency`` / ``chisquare`` (and
+``scipy.special.gammaincc``) to float epsilon. These back the W4 Flip that made
+``correlation.py`` + the Benford profiler scipy-free; scipy is a test-only oracle.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from goldencheck.baseline._owned_stats import (
+    chi2_contingency_stat,
+    chi2_gof,
+    gamma_ur,
+    pearson_r,
+)
+
+scipy_stats = pytest.importorskip("scipy.stats")
+scipy_special = pytest.importorskip("scipy.special")
+
+
+@pytest.mark.parametrize("seed", range(15))
+def test_gamma_ur_matches_scipy_gammaincc(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    for _ in range(200):
+        a = float(rng.uniform(0.5, 20.0))
+        x = float(rng.uniform(0.0, 60.0))
+        assert gamma_ur(a, x) == pytest.approx(float(scipy_special.gammaincc(a, x)), abs=1e-12)
+
+
+@pytest.mark.parametrize("seed", range(15))
+def test_pearson_r_matches_scipy(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    n = int(rng.integers(3, 300))
+    x = rng.normal(0, 1, n)
+    y = 0.4 * x + rng.normal(0, 1, n)
+    ref = float(scipy_stats.pearsonr(x, y)[0])
+    assert pearson_r(x.tolist(), y.tolist()) == pytest.approx(ref, abs=1e-12)
+
+
+def test_pearson_r_clamps_perfect_correlation() -> None:
+    x = [1.0, 2.0, 3.0, 4.0]
+    assert pearson_r(x, [2.0, 4.0, 6.0, 8.0]) == 1.0
+    assert pearson_r(x, [8.0, 6.0, 4.0, 2.0]) == -1.0
+    assert np.isnan(pearson_r([], []))
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_chi2_contingency_stat_matches_scipy(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    r = int(rng.integers(2, 5))
+    c = int(rng.integers(2, 5))
+    m = rng.integers(1, 50, (r, c)).astype(float)  # >=1 so no zero expecteds
+    ref = float(scipy_stats.chi2_contingency(m)[0])  # default correction=True
+    got = chi2_contingency_stat(m.flatten().tolist(), r, c)
+    assert got == pytest.approx(ref, rel=1e-10, abs=1e-12)
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_chi2_gof_matches_scipy(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    k = int(rng.integers(2, 12))
+    total = int(rng.integers(50, 500))
+    p = rng.dirichlet(np.ones(k))
+    expected = (p * total).tolist()
+    observed = rng.multinomial(total, p).astype(float).tolist()
+    ref_stat, ref_p = scipy_stats.chisquare(f_obs=observed, f_exp=expected)
+    stat, pval = chi2_gof(observed, expected)
+    assert stat == pytest.approx(float(ref_stat), rel=1e-10, abs=1e-12)
+    assert pval == pytest.approx(float(ref_p), abs=1e-12)
+
+
+def test_chi2_gof_edge_cases() -> None:
+    assert chi2_gof([10.0, 10.0], [10.0, 10.0]) == (0.0, 1.0)  # perfect fit
+    stat, pval = chi2_gof([5.0], [10.0])  # df=0
+    assert stat == pytest.approx(2.5)
+    assert np.isnan(pval)
+    s, p = chi2_gof([], [])
+    assert np.isnan(s) and np.isnan(p)


### PR DESCRIPTION
## What

Executes goldencheck's **planned W4 "Flip"** for the three stats kernels it already owns in `goldencheck-core` (Rust) — `pearson_r`, `chi2_contingency_stat`, and `chi2_gof` (with the regularized upper incomplete gamma for the chi-squared upper tail). Those kernels have been *shadow-computed and discarded* ("emitted stays scipy until the Flip"); this adds pure-Python mirrors and completes the flip so `correlation.py` + the Benford profiler are **scipy-free** whether or not the native extension is installed.

Continues "own it, don't clone it" — and unblocks cross-surface parity (these are elementary + one special function, all portable to TS/Rust where a scipy dependency never could be).

## How

- **`baseline/_owned_stats.py`** (new): pure-Python `gamma_ur` (regularized upper incomplete gamma — series + Lentz continued fraction, the Cephes/NR split that keeps the tail precise instead of `1 - cdf`), `pearson_r`, `chi2_contingency_stat` (Yates correction for 2×2), `chi2_gof`. They mirror the Rust kernels' **naive summation** (so native == pure) and reproduce scipy to **~1e-15**.
- **`correlation.py`**: Pearson + chi²-contingency flipped to native-if-available-else-owned-pure; the module-top `from scipy.stats import ...` is **gone** (numpy-only now). Verified `analyze_correlations` runs with scipy fully import-blocked.
- **`statistical.py`**: the Benford `chi2_pvalue` flipped to owned `chi2_gof`.

## Behavior-preserving

Owned == scipy to ~1e-15, and the emitted values are `round(_, 6)` → identical. Existing correlation + statistical tests green (25 passed); new parity test **72 passed** (gamma/pearson/chi²-contingency/chi²-gof vs scipy).

## Scoped — what's NOT in this PR

This does **not** remove scipy from the `[baseline]` extra. `statistical.py`'s `_fit_distribution` (`dist.fit` + `kstest`) and `drift/detector.py`'s `kstest` still use scipy. Owning those is a larger, selection-sensitive tier:
- scipy's one-sample `kstest` p-value is exactly `kstwo.sf(D, n)` (confirmed, not the asymptotic) — the **exact two-sided Kolmogorov distribution**, portable via Marsaglia-Tsang-Wang (prototyped to ~1e-6, needs precision hardening for round-6 safety).
- `lognorm.fit` is a numerical 3-param MLE whose fitted params feed distribution *selection* — the fragile part; needs a re-bless/selection-stability gate.

Those are worth their own focused PR; this one banks the exact, ready, zero-behavior-change tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)