### PR TITLE
feat(goldencheck): own the Kolmogorov-Smirnov test (flip KS call sites off scipy)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7855,7 +7855,7 @@
     },
     "goldencheck": {
       "root": "packages/python/goldencheck/goldencheck",
-      "module_count": 113,
+      "module_count": 114,
       "modules": [
         {
           "module": "goldencheck",
@@ -8049,6 +8049,21 @@
           ]
         },
         {
+          "module": "goldencheck.baseline._ks",
+          "file": "packages/python/goldencheck/goldencheck/baseline/_ks.py",
+          "purpose": "Owned one-sample Kolmogorov-Smirnov test -- goldencheck's scipy-free",
+          "defines": [
+            "_cdf_expon",
+            "_cdf_lognorm",
+            "_cdf_norm",
+            "_cdf_uniform",
+            "_ks_cdf",
+            "_mpower",
+            "kstest",
+            "kstwo_sf"
+          ]
+        },
+        {
           "module": "goldencheck.baseline.constraints",
           "file": "packages/python/goldencheck/goldencheck/baseline/constraints.py",
           "purpose": "Constraint mining: functional dependencies, candidate keys, temporal orders.",
@@ -8157,6 +8172,7 @@
           ],
           "imports": [
             "goldencheck._polars_lazy",
+            "goldencheck.baseline._ks",
             "goldencheck.baseline.models",
             "goldencheck.core._native_loader"
           ]
@@ -8562,6 +8578,7 @@
           ],
           "imports": [
             "goldencheck._polars_lazy",
+            "goldencheck.baseline._ks",
             "goldencheck.baseline.correlation",
             "goldencheck.baseline.models",
             "goldencheck.baseline.patterns",

--- a/packages/python/goldencheck/goldencheck/baseline/_ks.py
+++ b/packages/python/goldencheck/goldencheck/baseline/_ks.py
@@ -1,0 +1,145 @@
+"""Owned one-sample Kolmogorov-Smirnov test -- goldencheck's scipy-free
+``scipy.stats.kstest`` for the distribution-fit + drift profilers.
+
+Two pieces, both verified against scipy (``tests/baseline/test_ks_parity.py``):
+
+* ``kstwo_sf`` -- the exact two-sided Kolmogorov distribution survival function
+  (``scipy.stats.kstwo.sf``). Marsaglia, Tsang & Wang (2003) matrix method for
+  the body (matches scipy to float epsilon at small n) with their asymptotic tail
+  for large ``n * d^2`` (matches to ~1e-6 -- the p-value only gates threshold
+  decisions here, and the emitted value is ``round(p, 6)``; verified zero
+  threshold-decision disagreements vs scipy). No scipy dependency.
+* ``kstest`` -- the D+/D- statistic against a fully-specified ``norm`` /
+  ``lognorm`` / ``expon`` / ``uniform`` CDF (all elementary via ``math.erf``),
+  byte-identical D to scipy; returns ``(D, kstwo_sf(D, n))``.
+
+Owning it evicts scipy from the drift detector and unblocks a cross-surface KS
+test (a scipy dependency never could).
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+
+import numpy as np
+
+_SQRT2 = math.sqrt(2.0)
+
+
+def _ks_cdf(n: int, d: float) -> float:
+    """P(D_n < d) -- the two-sided Kolmogorov CDF (Marsaglia-Tsang-Wang)."""
+    if d <= 0.0:
+        return 0.0
+    if d >= 1.0:
+        return 1.0
+    s = d * d * n
+    # Asymptotic tail: the same switch + correction as Marsaglia's reference K().
+    if s > 7.24 or (s > 3.76 and n > 99):
+        return 1.0 - 2.0 * math.exp(-(2.000071 + 0.331 / math.sqrt(n) + 1.409 / n) * s)
+    k = int(n * d) + 1
+    m = 2 * k - 1
+    h = k - n * d
+    hh = np.zeros((m, m))
+    for i in range(m):
+        for j in range(m):
+            hh[i, j] = 0.0 if (i - j + 1 < 0) else 1.0
+    for i in range(m):
+        hh[i, 0] -= h ** (i + 1)
+        hh[m - 1, i] -= h ** (m - i)
+    if (2 * h - 1) > 0:
+        hh[m - 1, 0] += (2 * h - 1) ** m
+    for i in range(m):
+        for j in range(m):
+            if i - j + 1 > 0:
+                fac = 1.0
+                for g in range(1, i - j + 2):
+                    fac *= g
+                hh[i, j] /= fac
+    q, e_q = _mpower(hh, 0, n, m)
+    s2 = q[k - 1, k - 1]
+    for i in range(1, n + 1):
+        s2 = s2 * i / n
+        if s2 < 1e-140:
+            s2 *= 1e140
+            e_q -= 140
+    return s2 * (10.0 ** e_q)
+
+
+def _mpower(a: np.ndarray, e_a: int, n: int, m: int) -> tuple[np.ndarray, int]:
+    """``a**n`` with central-element exponent scaling (Marsaglia mPower)."""
+    if n == 1:
+        return a.copy(), e_a
+    v, e_v = _mpower(a, e_a, n // 2, m)
+    b = v @ v
+    e_b = 2 * e_v
+    if n % 2 == 0:
+        r, e_r = b, e_b
+    else:
+        r, e_r = a @ b, e_a + e_b
+    c = m // 2
+    if r[c, c] > 1e140:
+        r = r * 1e-140
+        e_r += 140
+    return r, e_r
+
+
+def kstwo_sf(d: float, n: int) -> float:
+    """Survival ``P(D_n >= d)`` = ``scipy.stats.kstwo.sf(d, n)``."""
+    return max(0.0, min(1.0, 1.0 - _ks_cdf(n, d)))
+
+
+def _cdf_norm(x: float, loc: float, scale: float) -> float:
+    return 0.5 * (1.0 + math.erf((x - loc) / (scale * _SQRT2)))
+
+
+def _cdf_expon(x: float, loc: float, scale: float) -> float:
+    z = (x - loc) / scale
+    return 0.0 if z < 0 else 1.0 - math.exp(-z)
+
+
+def _cdf_uniform(x: float, loc: float, scale: float) -> float:
+    z = (x - loc) / scale
+    return 0.0 if z < 0 else (1.0 if z > 1 else z)
+
+
+def _cdf_lognorm(x: float, s: float, loc: float, scale: float) -> float:
+    z = x - loc
+    if z <= 0:
+        return 0.0
+    return 0.5 * (1.0 + math.erf(math.log(z / scale) / (s * _SQRT2)))
+
+
+# Keyed by the scipy distribution name (what `dist.name` yields), so callers pass
+# the same identifier they gave scipy's kstest.
+_CDFS: dict[str, Callable[..., float]] = {
+    "norm": _cdf_norm,
+    "expon": _cdf_expon,
+    "uniform": _cdf_uniform,
+    "lognorm": _cdf_lognorm,
+}
+
+
+def kstest(
+    values: Sequence[float], dist_name: str, params: Sequence[float]
+) -> tuple[float, float]:
+    """One-sample two-sided KS test of ``values`` vs the fully-specified
+    distribution ``dist_name`` (scipy name) with ``params`` (scipy ``args``).
+
+    Returns ``(D, pvalue)`` matching
+    ``scipy.stats.kstest(values, dist_name, args=params)``: the D+/D- statistic is
+    byte-identical, the p-value is ``kstwo_sf(D, n)``. Raises ``KeyError`` for an
+    unsupported distribution.
+    """
+    cdf = _CDFS[dist_name]
+    xs = sorted(float(v) for v in values)
+    n = len(xs)
+    if n == 0:
+        return (float("nan"), float("nan"))
+    d_plus = 0.0
+    d_minus = 0.0
+    for i, x in enumerate(xs):
+        c = cdf(x, *params)
+        d_plus = max(d_plus, (i + 1) / n - c)
+        d_minus = max(d_minus, c - i / n)
+    d = max(d_plus, d_minus)
+    return (d, kstwo_sf(d, n))

--- a/packages/python/goldencheck/goldencheck/baseline/statistical.py
+++ b/packages/python/goldencheck/goldencheck/baseline/statistical.py
@@ -16,6 +16,7 @@ except ImportError as _err:  # pragma: no cover
     ) from _err
 
 from goldencheck._polars_lazy import pl
+from goldencheck.baseline._ks import kstest as _owned_kstest
 from goldencheck.baseline.models import StatProfile
 from goldencheck.core._native_loader import native_enabled, native_module
 
@@ -154,7 +155,9 @@ def _fit_distribution(values: np.ndarray) -> tuple[str | None, dict | None]:
 
         try:
             fit_params = dist.fit(values)  # type: ignore[attr-defined]
-            _stat, pvalue = _stats.kstest(values, dist.name, args=fit_params)  # type: ignore[attr-defined]
+            # Owned KS test (no scipy) -- byte-identical D, p = kstwo_sf(D, n).
+            # (scipy is still used for `dist.fit` above -- a separate follow-up.)
+            _stat, pvalue = _owned_kstest(values, dist.name, fit_params)  # type: ignore[attr-defined]
         except Exception as exc:
             logger.debug("Distribution fit failed for %s: %s", name, exc)
             continue

--- a/packages/python/goldencheck/goldencheck/drift/detector.py
+++ b/packages/python/goldencheck/goldencheck/drift/detector.py
@@ -15,6 +15,7 @@ except ImportError:
     _SCIPY_AVAILABLE = False
 
 from goldencheck._polars_lazy import pl
+from goldencheck.baseline._ks import kstest as _owned_kstest
 from goldencheck.baseline.correlation import _cramers_v
 from goldencheck.baseline.models import BaselineProfile
 from goldencheck.baseline.patterns import _induce_column_grammars
@@ -114,14 +115,16 @@ def _check_distribution_drift(col: str, series: pl.Series, sp: Any) -> list[Find
     if sp.distribution is None or sp.params is None:
         return []
 
-    dist_map = {
-        "normal": _stats.norm,
-        "log_normal": _stats.lognorm,
-        "exponential": _stats.expon,
-        "uniform": _stats.uniform,
+    # goldencheck's internal distribution name -> the scipy distribution name the
+    # owned KS test keys on (byte-identical to `scipy.stats.kstest(..., name)`).
+    dist_name_map = {
+        "normal": "norm",
+        "log_normal": "lognorm",
+        "exponential": "expon",
+        "uniform": "uniform",
     }
-    dist_obj = dist_map.get(sp.distribution)
-    if dist_obj is None:
+    dist_name = dist_name_map.get(sp.distribution)
+    if dist_name is None:
         return []
 
     values: np.ndarray = series.cast(pl.Float64).to_numpy()
@@ -143,8 +146,9 @@ def _check_distribution_drift(col: str, series: pl.Series, sp: Any) -> list[Find
     except (KeyError, TypeError):
         return []
 
+    # Owned KS test (no scipy) -- byte-identical D, p-value = kstwo_sf(D, n).
     try:
-        _stat, pvalue = _stats.kstest(values, dist_obj.name, args=fit_params)
+        _stat, pvalue = _owned_kstest(values, dist_name, fit_params)
     except Exception as exc:
         logger.debug("KS-test failed for %s: %s", col, exc)
         return []

--- a/packages/python/goldencheck/tests/baseline/test_ks_parity.py
+++ b/packages/python/goldencheck/tests/baseline/test_ks_parity.py
@@ -1,0 +1,70 @@
+"""Parity gate for the owned one-sample Kolmogorov-Smirnov test (``baseline._ks``).
+
+Asserts ``kstwo_sf`` reproduces ``scipy.stats.kstwo.sf`` and ``kstest`` reproduces
+``scipy.stats.kstest`` (statistic + p-value) across the four fitted distributions
+goldencheck uses. The KS statistic is byte-identical; the p-value matches to ~1e-6
+in the asymptotic tail (it only gates threshold decisions here, and the emitted
+value is ``round(p, 6)``) -- so this test ALSO asserts zero threshold-decision
+disagreement at the 0.01 / 0.05 gates. scipy is a test-only oracle.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from goldencheck.baseline._ks import kstest, kstwo_sf
+
+scipy_stats = pytest.importorskip("scipy.stats")
+
+
+@pytest.mark.parametrize("n", [10, 20, 50, 100, 500, 1000, 5000])
+def test_kstwo_sf_matches_scipy(n: int) -> None:
+    rng = np.random.default_rng(n)
+    for _ in range(40):
+        d = float(rng.uniform(0.005, 0.6))
+        assert kstwo_sf(d, n) == pytest.approx(float(scipy_stats.kstwo.sf(d, n)), abs=1e-5)
+
+
+def test_kstwo_sf_small_n_is_exact() -> None:
+    rng = np.random.default_rng(0)
+    for n in (5, 10, 15, 20):
+        for _ in range(20):
+            d = float(rng.uniform(0.05, 0.6))
+            assert kstwo_sf(d, n) == pytest.approx(float(scipy_stats.kstwo.sf(d, n)), abs=1e-12)
+
+
+_DISTS = ["norm", "expon", "uniform", "lognorm"]
+
+
+@pytest.mark.parametrize("seed", range(30))
+def test_kstest_matches_scipy_and_decisions(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    kind = _DISTS[seed % len(_DISTS)]
+    n = int(rng.integers(30, 2000))
+    if kind == "norm":
+        x = rng.normal(3.0, 2.0, n)
+        params = (3.0, 2.0)
+    elif kind == "expon":
+        x = rng.exponential(2.0, n) + 1.0
+        params = (1.0, 2.0)
+    elif kind == "uniform":
+        x = rng.uniform(5.0, 10.0, n)
+        params = (5.0, 5.0)
+    else:  # lognorm
+        x = scipy_stats.lognorm.rvs(0.7, loc=0.0, scale=2.0, size=n, random_state=rng)
+        params = (0.7, 0.0, 2.0)
+
+    d_s, p_s = scipy_stats.kstest(x, kind, args=params)
+    d_o, p_o = kstest(x.tolist(), kind, params)
+
+    assert d_o == pytest.approx(float(d_s), abs=1e-12)  # statistic is exact
+    assert p_o == pytest.approx(float(p_s), abs=1e-5)
+    # The gate decisions (0.01 / 0.05) must be identical.
+    for thr in (0.01, 0.05):
+        assert (p_o < thr) == (p_s < thr)
+
+
+def test_kstest_empty_and_unknown() -> None:
+    d, p = kstest([], "norm", (0.0, 1.0))
+    assert np.isnan(d) and np.isnan(p)
+    with pytest.raises(KeyError):
+        kstest([1.0, 2.0, 3.0], "weibull", (1.0,))


### PR DESCRIPTION
## What

Owns the **exact two-sided Kolmogorov distribution** + the one-sample KS test (`baseline/_ks.py`) — the last "special function" behind goldencheck's scipy use — and flips the two KS call sites (`drift._check_distribution_drift` + `statistical._fit_distribution`) off `scipy.stats.kstest`. Continues "own it, don't clone it."

## How

- **`_ks.py`**:
  - `kstwo_sf` — exact two-sided Kolmogorov survival function (`scipy.stats.kstwo.sf`). Marsaglia-Tsang-Wang matrix method for the body (matches scipy to **float epsilon** at small n) with their asymptotic tail for large `n·d²` (~1e-6).
  - `kstest` — the D+/D- statistic (**byte-identical** to scipy) against owned `norm` / `lognorm` / `expon` / `uniform` CDFs (all elementary via stdlib `math.erf`), returning `(D, kstwo_sf(D, n))`.
  - Pure Python + numpy, **no scipy**.
- `drift._check_distribution_drift` and `statistical._fit_distribution` now call the owned KS test.

## Behavior-preserving

The KS p-value only gates the 0.01 / 0.05 drift + fit-acceptance thresholds, and is emitted as `round(p, 6)`. The parity test asserts **zero threshold-decision disagreement** vs scipy across all four distributions (plus statistic byte-identical, p-value ~1e-6). Existing drift + statistical suites green (77 passed total).

Why not bit-for-bit on the p-value: scipy's `kstwo.sf` uses a multi-regime method (Simard-L'Ecuyer); matching the *value* to ~1e-15 everywhere isn't the goal — matching the *decision* is, and this does (0 mismatches). The KS statistic itself is exact.

## Scoped — what's NOT in this PR

This owns the KS piece; scipy is **still** a `[baseline]` dep for the remaining, harder tier:
- `statistical._fit_distribution` still calls `dist.fit()` — the closed-form norm/expon/uniform MLEs are easy, but **`lognorm.fit`** is a numerical 3-param MLE whose fitted params feed distribution *selection* (the fragile part; needs a selection-stability gate).
- `drift/detector.py` keeps two chi²/pearson **shadow** computes (the W4 pattern — the owned kernels for those land in #2255).

Those are the final follow-up to fully retire scipy from `[baseline]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)