### PR TITLE
chore(goldencheck): retire scipy from [baseline] (final consolidation)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -8634,6 +8634,7 @@
           "imports": [
             "goldencheck._polars_lazy",
             "goldencheck.baseline._ks",
+            "goldencheck.baseline._owned_stats",
             "goldencheck.baseline.correlation",
             "goldencheck.baseline.models",
             "goldencheck.baseline.patterns",

--- a/packages/python/goldencheck/goldencheck/baseline/__init__.py
+++ b/packages/python/goldencheck/goldencheck/baseline/__init__.py
@@ -42,15 +42,16 @@ def create_baseline(
         A fully-populated baseline profile.
     """
     # ------------------------------------------------------------------
-    # Guard: scipy + numpy must be importable before any heavy work.
+    # Guard: numpy must be importable before any heavy work. (The baseline
+    # subsystem is scipy-free -- chi-squared / Pearson / KS / distribution MLEs
+    # are owned in `goldencheck.baseline`; only numpy + polars are needed.)
     # ------------------------------------------------------------------
     try:
         import numpy  # noqa: F401
-        import scipy  # noqa: F401
     except ImportError as exc:
         raise ImportError(
-            "scipy and numpy are required for deep-profiling baseline. "
-            "Install them with: pip install 'goldencheck[baseline]'"
+            "numpy is required for deep-profiling baseline. "
+            "Install it with: pip install 'goldencheck[baseline]'"
         ) from exc
 
     skip_set: set[str] = set(skip or [])

--- a/packages/python/goldencheck/goldencheck/drift/detector.py
+++ b/packages/python/goldencheck/goldencheck/drift/detector.py
@@ -9,13 +9,14 @@ from typing import Any
 
 try:
     import numpy as np
-    import scipy.stats as _stats
-    _SCIPY_AVAILABLE = True
+    _NUMPY_AVAILABLE = True
 except ImportError:
-    _SCIPY_AVAILABLE = False
+    _NUMPY_AVAILABLE = False
 
 from goldencheck._polars_lazy import pl
 from goldencheck.baseline._ks import kstest as _owned_kstest
+from goldencheck.baseline._owned_stats import chi2_gof as _owned_chi2_gof
+from goldencheck.baseline._owned_stats import pearson_r as _owned_pearson_r
 from goldencheck.baseline.correlation import _cramers_v
 from goldencheck.baseline.models import BaselineProfile
 from goldencheck.baseline.patterns import _induce_column_grammars
@@ -110,7 +111,7 @@ def _check_statistical(df: pl.DataFrame, baseline: BaselineProfile) -> list[Find
 
 def _check_distribution_drift(col: str, series: pl.Series, sp: Any) -> list[Finding]:
     """KS-test: compare current distribution against the saved fitted distribution."""
-    if not _SCIPY_AVAILABLE:
+    if not _NUMPY_AVAILABLE:
         return []
     if sp.distribution is None or sp.params is None:
         return []
@@ -206,7 +207,7 @@ def _entropy(values: list) -> float:
 
 
 def _check_entropy_drift_numeric(col: str, series: pl.Series, sp: Any) -> list[Finding]:
-    if not _SCIPY_AVAILABLE:
+    if not _NUMPY_AVAILABLE:
         return []
     values: np.ndarray = series.cast(pl.Float64).to_numpy()
     values = values[np.isfinite(values)]
@@ -257,7 +258,7 @@ def _check_entropy_drift_categorical(col: str, series: pl.Series, sp: Any) -> li
 
 
 def _check_bound_violation(col: str, series: pl.Series, sp: Any) -> list[Finding]:
-    if not _SCIPY_AVAILABLE:
+    if not _NUMPY_AVAILABLE:
         return []
     bounds = sp.bounds
     p01 = bounds.get("p01")
@@ -291,7 +292,7 @@ def _check_bound_violation(col: str, series: pl.Series, sp: Any) -> list[Finding
 
 def _check_benford_drift(col: str, series: pl.Series, sp: Any) -> list[Finding]:
     """Warn if Benford's conformance flips (baseline passed, current fails or vice versa)."""
-    if not _SCIPY_AVAILABLE:
+    if not _NUMPY_AVAILABLE:
         return []
     if sp.benford is None:
         return []
@@ -347,16 +348,19 @@ def _compute_benford_pvalue(values: np.ndarray) -> float | None:
         return None
     observed = [counts.get(d, 0) for d in range(1, 10)]
     expected = [math.log10(1 + 1 / d) * total for d in range(1, 10)]
+    obs_f = [float(x) for x in observed]
+    exp_f = [float(x) for x in expected]
     try:
-        _chi2, pvalue = _stats.chisquare(f_obs=observed, f_exp=expected)
-        # Shadow (W5 reuse): compute the W4 native chi2_gof kernel alongside the
-        # authoritative scipy value and discard it. `except BaseException` because
-        # a pyo3 PanicException is a BaseException and would escape `except Exception`.
+        # Owned chi2_gof (no scipy): native kernel when available, else the pure
+        # `_owned_stats` mirror. Both reproduce `scipy.stats.chisquare(...)[1]`.
+        pvalue: float | None = None
         if native_enabled("chi2_gof"):
             try:
-                native_module().chi2_gof(observed, expected)
-            except BaseException:  # noqa: BLE001 - shadow must never raise out
-                pass
+                _chi2, pvalue = native_module().chi2_gof(obs_f, exp_f)
+            except BaseException:  # noqa: BLE001 - fall back to pure on any native error
+                pvalue = None
+        if pvalue is None:
+            _chi2, pvalue = _owned_chi2_gof(obs_f, exp_f)
         return float(pvalue)
     except Exception as exc:
         logger.debug("Benford chi-square test failed: %s", exc)
@@ -697,7 +701,7 @@ def _compute_correlation(
     df: pl.DataFrame, col_a: str, col_b: str, measure: str
 ) -> float | None:
     """Compute the requested correlation measure between two columns."""
-    if not _SCIPY_AVAILABLE:
+    if not _NUMPY_AVAILABLE:
         return None
 
     if measure == "pearson":
@@ -709,21 +713,21 @@ def _compute_correlation(
             b_vals = sub[col_b].cast(pl.Float64).to_numpy()
             if np.std(a_vals) == 0.0 or np.std(b_vals) == 0.0:
                 return None
-            corr, _ = _stats.pearsonr(a_vals, b_vals)
-            # Shadow (W5 reuse): compute the W4 native pearson_r kernel alongside
-            # the authoritative scipy value and discard it. a_vals/b_vals are
-            # already Float64 (drift pre-casts). `except BaseException` because a
-            # pyo3 PanicException would escape `except Exception`.
+            # Owned Pearson r (no scipy): native kernel when available, else the
+            # pure `_owned_stats` mirror -- both reproduce `scipy.stats.pearsonr[0]`.
+            corr: float | None = None
             if native_enabled("pearson_r"):
                 try:
                     import pyarrow as pa
 
-                    native_module().pearson_r(
+                    corr = float(native_module().pearson_r(
                         pa.array(a_vals, type=pa.float64()),
                         pa.array(b_vals, type=pa.float64()),
-                    )
-                except BaseException:  # noqa: BLE001 - shadow must never raise out
-                    pass
+                    ))
+                except BaseException:  # noqa: BLE001 - fall back to pure on any native error
+                    corr = None
+            if corr is None:
+                corr = _owned_pearson_r(a_vals.tolist(), b_vals.tolist())
             return float(corr) if np.isfinite(corr) else None
         except Exception as exc:
             logger.debug("Pearson correlation failed for (%s, %s): %s", col_a, col_b, exc)

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -80,9 +80,10 @@ agent = [
 ]
 baseline = [
     # The baseline statistics + drift + correlation subsystems are opt-in and still
-    # run on Polars (group_by/pivot/join) + scipy. 3.0.0 gates them here rather than
-    # porting them off Polars -- installing [baseline] pulls the polars they need.
-    "scipy>=1.11",
+    # run on Polars (group_by/pivot/join). They are now scipy-FREE: chi-squared,
+    # Pearson, the Kolmogorov-Smirnov test, and the distribution MLEs are owned in
+    # `goldencheck.baseline` (`_owned_stats` / `_ks` / `_distributions`, byte-close
+    # to scipy). scipy stays a dev-only parity oracle in the workspace dev group.
     "numpy>=1.26",
     "polars>=1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -990,7 +990,6 @@ agent = [
 baseline = [
     { name = "numpy" },
     { name = "polars" },
-    { name = "scipy" },
 ]
 db = [
     { name = "connectorx" },
@@ -1044,7 +1043,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
-    { name = "scipy", marker = "extra == 'baseline'", specifier = ">=1.11" },
     { name = "sentence-transformers", marker = "extra == 'semantic'", specifier = ">=2.2" },
     { name = "textual", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },


### PR DESCRIPTION
## What

The **final consolidation** that fully removes scipy from goldencheck's `[baseline]` extra. With chi²/Pearson (#2255), the Kolmogorov-Smirnov test (#2256), and the distribution MLEs (#2257) all owned, this flips the two remaining `scipy.stats` call sites and drops the dependency.

## How

- **`drift/detector.py`**: `_compute_benford_pvalue` (chisquare) and `_compute_correlation` (pearsonr) now use the owned `_owned_stats` kernels (native-if-available-else-pure); removed `import scipy.stats`; the availability flag keys on numpy.
- **`baseline/statistical.py`**: dropped the now-dead `import scipy.stats` (Benford + KS + fit are all owned).
- **`baseline/__init__.py`**: the deep-profiling guard checks `numpy` (not scipy).
- **`pyproject.toml`**: `scipy>=1.11` removed from the `[baseline]` extra. scipy stays a dev-only parity oracle (workspace dev group). `uv.lock` regenerated (goldencheck's block no longer references scipy).

## Verified

- Full baseline + drift + correlation + **all four** owned-kernel parity suites green (**209 passed**).
- `profile_statistical` + `create_baseline` + `run_drift_checks` all run with **scipy IMPORT-BLOCKED** (0 scipy in `sys.modules`) — distributions still detected, baseline built, drift found. `pip install goldencheck[baseline]` no longer pulls scipy.

## Stacking

This is the tip of the goldencheck scipy-eviction stack: **#2255 + #2256 → #2257 → this**. To be self-contained and end-to-end verifiable, this branch **cherry-picks #2255** (chi²/Pearson) on top of #2257's branch, so its diff currently shows that too. Once #2255/#2256/#2257 land on main, I'll rebase this onto main and it collapses to just the cleanup diff. Not armed for auto-merge until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)