### PR TITLE
Local-model integration: self-hosted LLM-scorer provider + closed-loop refit

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -770,6 +770,9 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `lineage` | `--run-name` | text | `'lineage'` | Run name for the lineage file |
 | `lineage` | `--max-pairs` | integer | `10000` | Cap on lineage records (0 = no cap) |
 | `lineage` | `--nl` | boolean | `False` | Include natural-language explanations |
+| `llm serve-local` | `--host` | text | `'127.0.0.1'` | Bind host (loopback by default). |
+| `llm serve-local` | `--port` | integer | `8081` | Bind port. |
+| `llm serve-local` | `--model-path` | text | `None` | Explicit GGUF path (else the pinned model is resolved / downloaded). |
 | `match` | `target` | text | **required** | Target file as path or path:source_name |
 | `match` | `--against` | text | **required** | Reference files as path or path:source_name |
 | `match` | `--config` | text | `None` | Path to YAML config file (optional - auto-detects if omitted) |
@@ -1152,7 +1155,7 @@ _`_PLANNING_EFFORTS` -- `planning_effort`._
 
 ## Environment variables (index)
 
-182 `GOLDENMATCH_*` runtime knob(s) read by the package, scanned from source so this is complete. Details in [Tuning & opt-ins](/goldenmatch/tuning). Grouped by area:
+185 `GOLDENMATCH_*` runtime knob(s) read by the package, scanned from source so this is complete. Details in [Tuning & opt-ins](/goldenmatch/tuning). Grouped by area:
 
 - **AGENT** (1): `GOLDENMATCH_AGENT_TOKEN`
 - **ALLOWED** (1): `GOLDENMATCH_ALLOWED_ROOT`
@@ -1191,6 +1194,7 @@ _`_PLANNING_EFFORTS` -- `planning_effort`._
 - **INHOUSE** (1): `GOLDENMATCH_INHOUSE_MODEL`
 - **LLAMA** (1): `GOLDENMATCH_LLAMA_GGUF`
 - **LLM** (2): `GOLDENMATCH_LLM_BASE_URL`, `GOLDENMATCH_LLM_MODEL`
+- **LOCAL** (3): `GOLDENMATCH_LOCAL_LLM`, `GOLDENMATCH_LOCAL_LLM_GPU_LAYERS`, `GOLDENMATCH_LOCAL_LLM_PATH`
 - **MATCH** (2): `GOLDENMATCH_MATCH_FUSED`, `GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS`
 - **MCP** (6): `GOLDENMATCH_MCP_ALLOW_PUBLIC`, `GOLDENMATCH_MCP_MAX_UPLOAD_BYTES`, `GOLDENMATCH_MCP_SESSION_MAX`, `GOLDENMATCH_MCP_SESSION_TTL`, `GOLDENMATCH_MCP_TOKEN`, `GOLDENMATCH_MCP_UPLOAD_TTL`
 - **MULTISOURCE** (1): `GOLDENMATCH_MULTISOURCE_AUTOCONFIG`

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -700,6 +700,9 @@ Within whichever path is chosen, the per-block math runs on the native Rust FS k
 | `GOLDENMATCH_GPU_MODE` / `_GPU_ENDPOINT` / `_GPU_API_KEY` | auto | GPU embedding mode / remote endpoint / key. |
 | `GOLDENMATCH_LLAMA_GGUF` | unset | Path to a local GGUF embedding model for the `model="llama"` / `"llama:/path.gguf"` backend — offline embeddings, no cloud/torch (`pip install goldenmatch[llama]`). Benchmarks: `scripts/bench_llama_embedder.py`, `scripts/bench_llama_product_matching.py`. |
 | `GOLDENMATCH_LLM_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible base URL for the LLM scorer — point at a local llama.cpp / llamafile server for offline, free LLM judging (also honors `OPENAI_BASE_URL`). |
+| `GOLDENMATCH_LOCAL_LLM` | `auto` | Gate for the in-process self-hosted LLM adapter (`provider="local"`, `pip install goldenmatch[local-llm]`). `auto` loads the pinned model when reachable, else abstains (candidates keep fuzzy scores); `1` requires it (raises if unavailable); `0` forces abstain. |
+| `GOLDENMATCH_LOCAL_LLM_PATH` | unset | Explicit path to a local GGUF for `provider="local"`, bypassing the pinned-model download. |
+| `GOLDENMATCH_LOCAL_LLM_GPU_LAYERS` | `0` | Layers to offload to GPU for the in-process local model (`0` = CPU-only). |
 | `GOLDENMATCH_WEAKNESS_LLM` | `0` (off) | Opt-in: let the `config_weaknesses` tool phrase its one-paragraph `summary_plain` with an LLM (needs `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`). Only a compact structured digest of the findings (ids/severities/short labels) is sent — never raw rows or data. The structured findings themselves are always deterministic and never depend on the LLM; off = deterministic template summary. |
 | `GOLDENMATCH_WEAKNESS_LLM_MODEL` | `gpt-4o-mini` (OpenAI) / `claude-3-5-haiku-latest` (Anthropic) | Model id for the `GOLDENMATCH_WEAKNESS_LLM` summary, per detected provider. |
 | `GOLDENMATCH_UDF_IMPORTS` | unset | Snowflake UDF import asset directory. |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 90 | 202 | 50 | 39 | Yes | Yes |
+| `goldenmatch` | 90 | 202 | 50 | 40 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 83 | 7 | 0 |
-| `goldenmatch` | cli_commands | 32 | 7 | 0 |
+| `goldenmatch` | cli_commands | 32 | 8 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 14 | 10 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -67,7 +67,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `import-dbt`, `ingest-docs`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 422,
+      "module_count": 425,
       "modules": [
         {
           "module": "goldenmatch",
@@ -685,6 +685,19 @@
           ]
         },
         {
+          "module": "goldenmatch.cli.llm",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/llm.py",
+          "purpose": "``goldenmatch llm`` — local-model convenience commands (D1 Path A).",
+          "defines": [
+            "_launch_server",
+            "_llama_server_available",
+            "serve_local_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core._llm_loader"
+          ]
+        },
+        {
           "module": "goldenmatch.cli.main",
           "file": "packages/python/goldenmatch/goldenmatch/cli/main.py",
           "purpose": "GoldenMatch CLI application.",
@@ -721,6 +734,7 @@
             "goldenmatch.cli.ingest_docs",
             "goldenmatch.cli.label",
             "goldenmatch.cli.lineage",
+            "goldenmatch.cli.llm",
             "goldenmatch.cli.match",
             "goldenmatch.cli.mcp_serve",
             "goldenmatch.cli.memory",
@@ -1490,6 +1504,23 @@
           ],
           "imports": [
             "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.core._llm_loader",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_llm_loader.py",
+          "purpose": "Loader + gate for the optional self-hosted local LLM adapter (D1 Path B).",
+          "defines": [
+            "LocalLLMAdapter",
+            "LocalLLMUnavailableError",
+            "LocalLlamaAdapter",
+            "LocalModelSpec",
+            "_local_llm_mode",
+            "_verify_sha256",
+            "load_local_adapter",
+            "parse_verdict",
+            "resolve_model_path",
+            "serialize_pair_v1"
           ]
         },
         {
@@ -3531,6 +3562,7 @@
             "_detect_provider",
             "_focused_sample",
             "_iterative_calibrate",
+            "_local_score_pairs",
             "_openai_base_url",
             "_record_llm_corrections",
             "_stratified_sample",
@@ -3539,6 +3571,7 @@
           ],
           "imports": [
             "goldenmatch._polars_lazy",
+            "goldenmatch.core._llm_loader",
             "goldenmatch.core.frame",
             "goldenmatch.core.llm_budget",
             "goldenmatch.core.memory.corrections",
@@ -4152,6 +4185,24 @@
           "imports": [
             "goldenmatch._api",
             "goldenmatch.core.autoconfig"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.refit",
+          "file": "packages/python/goldenmatch/goldenmatch/core/refit.py",
+          "purpose": "Closed-loop refit — turn adjudication verdicts into supervised FS labels (D2).",
+          "defines": [
+            "RefitNotApplicableError",
+            "RefitResult",
+            "_find_probabilistic_matchkey",
+            "labels_from_verdicts",
+            "refit_from_labels",
+            "refit_from_verdicts"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.probabilistic"
           ]
         },
         {

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -3580,6 +3580,32 @@
           ]
         },
         {
+          "command": "llm serve-local",
+          "options": [
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'127.0.0.1'",
+              "help": "Bind host (loopback by default)."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8081",
+              "help": "Bind port."
+            },
+            {
+              "name": "--model-path",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Explicit GGUF path (else the pinned model is resolved / downloaded)."
+            }
+          ]
+        },
+        {
           "command": "match",
           "options": [
             {
@@ -5667,6 +5693,11 @@
         "LLM": [
           "GOLDENMATCH_LLM_BASE_URL",
           "GOLDENMATCH_LLM_MODEL"
+        ],
+        "LOCAL": [
+          "GOLDENMATCH_LOCAL_LLM",
+          "GOLDENMATCH_LOCAL_LLM_GPU_LAYERS",
+          "GOLDENMATCH_LOCAL_LLM_PATH"
         ],
         "MATCH": [
           "GOLDENMATCH_MATCH_FUSED",

--- a/docs/superpowers/specs/2026-07-29-local-model-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-local-model-integration-design.md
@@ -1,0 +1,260 @@
+# Design Spec: Local-model integration — self-hosted boost + closed-loop refit
+
+- **Date:** 2026-07-29
+- **Status:** DRAFT (design only)
+- **Author:** Claude (with benzsevern)
+- **Companion spec:** `2026-07-26-oss-er-matcher-llm-boost-design.md` (the *model* — training, sizing, distribution, eval gates). This spec is the *integration* half: how a self-hosted model plugs into GoldenMatch's existing seams and how its verdicts feed back into the config. Read them together.
+- **Touches:** `goldenmatch/core/llm_scorer.py`, `goldenmatch/core/pipeline.py`, `goldenmatch/config/schemas.py` (`LLMScorerConfig`), `goldenmatch/core/review_queue.py`, `goldenmatch/core/probabilistic.py` (`estimate_m_from_labels`/`EMResult`), `goldenmatch/core/memory/store.py` (`Correction`).
+
+## 1. Summary
+
+Wire a **self-hosted local model** into GoldenMatch as a first-class option for the
+borderline-band adjudication tier, and **close the loop** so the tier's verdicts
+recalibrate the config instead of being thrown away after a single run.
+
+The headline finding from mapping the codebase: **this is wiring, not a new
+subsystem.** GoldenMatch already has all three seams:
+
+1. **A borderline-band → adjudicator tier already exists.** The optional
+   LLM-scorer stage (`LLMScorerConfig.enabled`, default off) already carves the
+   uncertain band (score in `[candidate_lo=0.75, candidate_hi=0.95]` → send to the
+   adjudicator; `> auto_threshold=0.95` → auto-accept) and already fans out with
+   `batch_size`/`max_workers`. Today it is backed by hosted API providers
+   (`openai`/`anthropic`). A self-hosted model is a **new provider for the
+   existing tier**, not a new stage.
+2. **The review queue already exists.** `review_queue.gate_pairs(...)` uses the
+   same 0.75–0.95 band and there is a `ReviewQueue` (memory / SQLite) whose
+   verdicts flow to a `MemoryStore` (SQLite / Postgres) via the `Correction`
+   sink. Opt-in human triage is wiring, not new infra.
+3. **The refit primitive already exists.** `estimate_m_from_labels(df, mk, labels)
+   → EMResult`, then `compute_thresholds()` for the recalibrated boundary.
+   `EMResult` is exactly the "suggested refined config" object to hand back
+   (persist via `EMResult.save_json`, reuse via `MatchkeyConfig.model_path`).
+
+So the feature collapses to three concrete deliverables:
+
+- **(D1) A self-hosted provider** for the existing `llm_scorer` tier, packaged as
+  an optional extra, with an `_llm_loader.py` mirroring the `_native_loader.py`
+  pattern (download-on-first-use + local-path override + pinned/verified artifact).
+- **(D2) Close the loop:** route the tier's verdicts into `estimate_m_from_labels`
+  → return a refined `EMResult`/`GoldenMatchConfig` as the **suggested** config
+  (default), with `auto_refit=True` to apply it in-run.
+- **(D3) Internal parallelism** for local throughput — extend the existing
+  `max_workers` fan-out to a multiprocessing path for the self-hosted model (the
+  hosted path is network-bound and stays threaded).
+
+**Default posture: full-auto.** The boost runs and auto-applies its verdicts by
+default (D1). The review queue (D2's human variant) and closed-loop *auto*-refit
+are both **opt-in** — full-auto returns the refined config as a *suggestion*
+without mutating the live run unless asked.
+
+## 2. On-mission check (North Star + architecture frame)
+
+- **zero-config:** a self-hosted boost that needs no API key and no network makes
+  the one remaining paid-dependency capability work out of the box.
+- **never-black-box:** the loop is inspectable — the model's verdicts become
+  labels, the labels become an `EMResult` you can print, diff, and persist.
+- **approach-the-expert:** the closed loop is the mechanism by which zero-config
+  *improves itself* on a dataset instead of running one static config forever.
+- **One authoritative semantic owner per capability:** we are **not** adding a
+  second adjudication tier or a second refit path. D1 adds a provider under the
+  existing `llm_scorer` owner; D2 reuses `estimate_m_from_labels` (the existing
+  supervised-m owner) verbatim. No new source of truth.
+- **Arrow at bulk boundaries, not the universal calling convention:** the
+  adjudicator sees a small `list` of borderline pairs (a fraction of candidates),
+  not an Arrow batch — the existing pair-list contract is correct; do not
+  Arrow-ify it.
+- **Compute vs. control stay distinct:** the boost is compute; the *refit
+  decision* (suggest vs. apply, and persisting a corrected `EMResult`) is control
+  and rides the existing memory/`Correction` + `model_path` machinery.
+
+## 3. The three seams (verified against source)
+
+### 3.1 The tier — `LLMScorerConfig` + the pipeline stage
+
+`config/schemas.py::LLMScorerConfig` (verified): `enabled: bool=False`,
+`provider: str|None=None` (currently `openai`/`anthropic`, auto-detected),
+`model`, `auto_threshold=0.95`, `candidate_lo=0.75`, `candidate_hi=0.95`,
+`batch_size=75`, `max_workers=5`, plus a `budget` and `mode` (`pairwise`/`cluster`).
+
+`core/pipeline.py` (verified): every backend gates the stage on
+`config.llm_scorer and config.llm_scorer.enabled and all_pairs` and calls
+`llm_score_pairs(all_pairs, df, config=config.llm_scorer, ...)`.
+
+`core/llm_scorer.py` (verified): `_openai_base_url()` already reads
+`GOLDENMATCH_LLM_BASE_URL` / `OPENAI_BASE_URL`, and `_detect_provider()` already
+returns `("openai", "sk-local")` when a base URL is set with no key — i.e. the
+**local OpenAI-compatible-server path (companion spec "Path A") is already wired**
+and needs only docs + a convenience launcher.
+
+### 3.2 The review queue — `review_queue.gate_pairs` + `Correction`
+
+`core/review_queue.py::gate_pairs(pairs, merge_threshold=0.95,
+review_threshold=0.75, ...)` (verified): splits scored pairs into
+`(auto_merged, review, auto_rejected)` on the same band; `ReviewQueue`
+(`backend="memory"` or `"sqlite"` only — verified; it raises on anything else)
+holds `ReviewItem`s; verdicts flow to `MemoryStore` (SQLite / Postgres — the
+durable backend lives here, **not** on `ReviewQueue`) via `Correction` /
+`add_correction`.
+
+### 3.3 The refit primitive — `estimate_m_from_labels` → `EMResult`
+
+`core/probabilistic.py::estimate_m_from_labels(df, mk, labels, *,
+n_sample_pairs=10000, blocking_fields=None, ...) → EMResult` (verified): the
+supervised analogue of `train_em` — given known true-match pairs, m is the
+observed comparison-level frequency (no EM iteration, no convergence risk). Its
+docstring already states the persistence contract: "Persist it with
+`EMResult.save_json` and reuse via `MatchkeyConfig.model_path`." `compute_thresholds()`
+turns the recalibrated weights into the operating boundary.
+
+## 4. Deliverable D1 — self-hosted provider + `_llm_loader.py`
+
+Two wiring paths, same prompt/IO contract as the companion spec (§8 there).
+
+- **Path A (ships first, ~0 core code):** a self-hosted OpenAI-compatible server
+  (llama.cpp / Ollama / vLLM). Set `provider="openai"` +
+  `GOLDENMATCH_LLM_BASE_URL=http://localhost:...`; the existing `_detect_provider`
+  supplies the stub key. **Repo work: docs + a `goldenmatch llm serve-local`
+  convenience command** that launches the pinned model. No scorer changes.
+- **Path B (in-process, no server):** a new optional extra
+  `goldenmatch[local-llm]` (`llama-cpp-python` + `huggingface_hub`) and a new
+  `provider="local"` branch. A `LocalLlamaAdapter` implements the same
+  prompt→`{match, confidence, reason}` contract in-process.
+
+**`_llm_loader.py` mirrors `core/_native_loader.py`:**
+
+| `_native_loader.py` idiom | `_llm_loader.py` analogue |
+|---|---|
+| `GOLDENMATCH_NATIVE=auto/0/1` gate | `GOLDENMATCH_LOCAL_LLM=auto/0/1` gate |
+| discover order: in-tree → wheel → pure-Python fallback | discover order: local path override → HF cache → download-on-first-use → abstain |
+| pinned + verified (companion spec: sha256 after download) | same pin `(repo_id, revision, filename, sha256)`, verified post-download |
+| graceful degradation (fallback path) | **graceful abstain** — a load/parse failure contributes nothing to the boost, never crashes the pipeline (mirrors the current hosted fallback: no key → unscored) |
+
+Provider validation: `provider` is a free `str` today (runtime-dispatched, not a
+Pydantic enum), so adding `"local"` is a new dispatch branch in `llm_scorer.py`,
+not a schema migration. Keep the openai/anthropic branches untouched (byte-identical when `provider != "local"`).
+
+## 5. Deliverable D2 — close the loop (the genuinely new piece)
+
+This is the part the companion spec does **not** cover. Today the tier's verdicts
+adjudicate the current run's borderline pairs and are then discarded. Closing the
+loop turns those verdicts into **labels** that recalibrate the config.
+
+**Not to be confused with the controller `RefitPolicy` family.** The auto-config
+controller already has a `RefitPolicy` line (`HeuristicRefitPolicy`,
+`LLMRefitPolicy`, … in `core/autoconfig_policy.py`) that *refits the config* by
+re-proposing rules from complexity signals during auto-config iteration — a
+signal-driven, label-free mechanism. D2 is a distinct thing: a **label-driven m
+re-estimation** that reuses `estimate_m_from_labels` (the supervised-m owner)
+with verdicts as labels. It does not add a new refit *owner* — it feeds the
+existing supervised primitive. Keep the two vocabularies separate in code (e.g.
+name D2's surface `refit_from_labels` / `auto_refit`, never `RefitPolicy`).
+
+**Flow:**
+
+1. The boost adjudicates the borderline band → per-pair `{match: bool,
+   confidence}` verdicts (D1). Confident matches (and, symmetrically, confident
+   non-matches) are the label set.
+2. Feed the confident-match pairs to `estimate_m_from_labels(df, mk, labels)` →
+   a refined `EMResult` (supervised m, no EM convergence risk).
+3. `compute_thresholds()` on the refined result → the recalibrated operating
+   boundary.
+4. Package the refined `EMResult` (+ threshold) as the **suggested**
+   `GoldenMatchConfig`, returned to the caller (surfaced on the result object).
+
+**Default = suggest, not apply.** Full-auto returns the refined config as a
+suggestion; the live run is unchanged. `auto_refit=True` (new kwarg /
+`GOLDENMATCH_AUTO_REFIT=1` / config field) re-runs the affected stage with the
+refined `EMResult` in the **same** call and applies it.
+
+**Reuse, don't reinvent:**
+- Confidence gate on which verdicts become labels: reuse the tier's
+  `auto_threshold` semantics (a verdict is a label only when the model is
+  confident), so the label set is precision-first — a wrong label poisons m.
+- Persistence: the refined `EMResult` persists via `EMResult.save_json` and is
+  reused across runs via `MatchkeyConfig.model_path` (the existing contract), and
+  the underlying verdicts can also flow to `MemoryStore` as `Correction`s
+  (`source` = the boost) so the learning-memory layer sees them like any other
+  correction.
+- **Label hygiene (the correctness gate):** only *confident* verdicts become
+  labels; `estimate_m_from_labels` already Laplace-smooths (`smoothing=1.0`) so a
+  level unseen among few labels can't force `m=0` (an infinite weight). Blocking
+  fields stay excluded from m-estimation (`blocking_fields=`), matching `train_em`.
+
+**Human variant (opt-in):** instead of the model's verdicts, route the borderline
+band through `gate_pairs` → `ReviewQueue`; steward verdicts become the label set
+for the same `estimate_m_from_labels` refit. Same loop, human-in-the-middle. The
+review queue and the model boost are two sources of the *same* label stream, not
+two loops.
+
+## 6. Deliverable D3 — internal parallelism
+
+The hosted path is network-bound; `max_workers` threads already give real
+concurrency (I/O wait). A self-hosted CPU model is **compute**-bound, so threads
+contend on the GIL / a single llama.cpp context. Extend the existing `max_workers`
+fan-out with a **multiprocessing** path selected when `provider="local"` (a pool
+of worker processes each holding a model context, or a batched server with
+`n_threads`). The hosted path stays threaded (byte-identical). This is a boost on
+a *fraction* of pairs (the borderline band), not every pair — so throughput needs
+to be adequate, not maximal; measure the whole-path wall (companion spec §10
+latency floor), not a per-call microbench.
+
+## 7. Rollout phases
+
+- **P0 (this spec).** Design + defaults for review.
+- **P1.** D1 Path A: docs + `goldenmatch llm serve-local`; confirm the existing
+  `GOLDENMATCH_LLM_BASE_URL` path end-to-end against a local server. Zero core risk.
+- **P2.** D2 the closed loop in **suggest** mode (return refined `EMResult` as a
+  suggestion). No behavior change to a run; purely additive on the result object.
+- **P3.** D2 `auto_refit=True` (apply in-run) + persistence via `model_path` /
+  `Correction`.
+- **P4.** D1 Path B: `goldenmatch[local-llm]` in-process `LocalLlamaAdapter` +
+  `_llm_loader.py`, skip-guarded test (mock the adapter or a tiny fixture model).
+- **P5.** D3 multiprocessing for the local provider.
+- **P6 (opt-in surface).** Wire the human-review variant of the loop (gate_pairs →
+  ReviewQueue → refit) as an explicit mode.
+
+Each phase is independently shippable and off-by-default until enabled.
+
+## 8. Defaults for review (open decisions)
+
+Local Claude's proposed defaults, called out for sign-off — these are the choices
+that shape the implementation:
+
+1. **Full-auto by default; review queue + auto-refit opt-in.** The boost runs and
+   auto-applies verdicts; the closed loop *suggests* a refined config without
+   mutating the run unless `auto_refit=True`. Confirm.
+2. **`auto_refit` default = off (suggest).** A refit silently mutating the
+   operating point on every run is surprising; suggest-by-default keeps the run
+   reproducible and lets the caller opt into applying it. Confirm.
+3. **Label set = confident verdicts only** (gated on `auto_threshold`), and both
+   confident-match and confident-non-match verdicts feed m-estimation (not just
+   matches). Confirm — or restrict to confident matches only for v1.
+4. **Base model / artifact:** inherited from the companion spec (lean
+   Qwen2.5-3B, Apache-2.0). No new decision here.
+5. **Cross-repo boundary:** the model artifact lives in the ER worktree /
+   HF Hub (companion spec §5); this repo holds only the loader, prompt template,
+   pinned `(repo_id, revision, filename, sha256)`, and the wiring. Confirm the
+   split.
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A wrong model verdict poisons the refit (bad m) | Label hygiene: only confident verdicts become labels; Laplace smoothing guards unseen levels; suggest-by-default keeps a bad refit out of the live run until reviewed |
+| `auto_refit` makes runs non-reproducible | Default off; when on, the refined `EMResult` is persisted (`save_json`) + pinned via `model_path` so a run is replayable |
+| Local CPU model too slow | It's a boost on the borderline band (a fraction of pairs), batched; D3 multiprocessing; companion spec latency floor gates "too slow to be default" |
+| Second adjudication/refit path drifts from the owner | No new owner: D1 is a provider under `llm_scorer`; D2 reuses `estimate_m_from_labels` verbatim |
+| Adding `provider="local"` breaks openai/anthropic | New dispatch branch only; `provider != "local"` is byte-identical; guarded by tests |
+| Loader/model download failure crashes a run | Graceful abstain (mirrors the no-key hosted fallback): the boost contributes nothing, never raises |
+
+## 10. Open questions
+
+1. Sign-off on the §8 defaults (esp. #1–#3).
+2. Should the refined `EMResult` from D2 auto-persist to `model_path` in
+   *suggest* mode, or only when `auto_refit=True`? (Lean: persist only on apply,
+   to keep suggest side-effect-free.)
+3. Does the human-review variant (P6) share one `auto_refit` switch with the model
+   loop, or get its own explicit "refit from steward labels" command?
+4. D3: worker-process pool vs. a single batched local server — pick after the D1
+   throughput measurement, not before.

--- a/packages/python/goldenmatch/goldenmatch/cli/llm.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/llm.py
@@ -1,0 +1,84 @@
+"""``goldenmatch llm`` — local-model convenience commands (D1 Path A).
+
+``serve-local`` launches a llama.cpp OpenAI-compatible server on the pinned
+self-hosted model, then prints the two env vars that point the existing LLM
+scorer at it (``provider="openai"`` + ``GOLDENMATCH_LLM_BASE_URL``). This is the
+zero-core-code path: the scorer's ``_openai_base_url()`` / ``_detect_provider()``
+already accept a local base URL with a stub key, so no scoring change is needed —
+just a launcher + the model resolution shared with the in-process adapter
+(``core/_llm_loader.py``).
+
+Spec: docs/superpowers/specs/2026-07-29-local-model-integration-design.md
+"""
+
+from __future__ import annotations
+
+import typer
+
+llm_app = typer.Typer(help="Local-model helpers for the LLM-scorer tier.")
+
+
+def _llama_server_available() -> bool:
+    """Whether llama-cpp-python (the OpenAI-compatible server) is importable.
+    Uses find_spec so the check itself never imports the heavy module."""
+    import importlib.util
+
+    return importlib.util.find_spec("llama_cpp") is not None
+
+
+def _launch_server(model_path: str, host: str, port: int) -> None:  # pragma: no cover - execs a server
+    """Run llama.cpp's OpenAI-compatible server (blocking). Separated so the
+    command's resolve/guard logic is testable without launching anything."""
+    import uvicorn
+    from llama_cpp.server.app import create_app  # pyright: ignore[reportMissingImports]
+    from llama_cpp.server.settings import ModelSettings, ServerSettings
+
+    server_settings = ServerSettings(host=host, port=port)
+    model_settings = [ModelSettings(model=model_path)]
+    app = create_app(server_settings=server_settings, model_settings=model_settings)
+    uvicorn.run(app, host=host, port=port)
+
+
+@llm_app.command("serve-local", help="Serve the pinned local ER-matcher over an OpenAI-compatible endpoint.")
+def serve_local_cmd(
+    host: str = typer.Option("127.0.0.1", help="Bind host (loopback by default)."),
+    port: int = typer.Option(8081, help="Bind port."),
+    model_path: str | None = typer.Option(
+        None, "--model-path",
+        help="Explicit GGUF path (else the pinned model is resolved / downloaded).",
+    ),
+) -> None:
+    from goldenmatch.core._llm_loader import resolve_model_path
+
+    if model_path is None:
+        import os
+
+        if model_path is None:
+            # Honor the explicit-override env the loader also reads.
+            model_path = os.environ.get("GOLDENMATCH_LOCAL_LLM_PATH")
+        if model_path is None:
+            model_path = resolve_model_path()
+
+    if not model_path:
+        typer.echo(
+            "No local model could be resolved. Install the extra "
+            "(pip install goldenmatch[local-llm]) so the pinned model can be "
+            "downloaded, or pass --model-path /path/to/model.gguf.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if not _llama_server_available():
+        typer.echo(
+            "llama-cpp-python is not installed. "
+            "Install it: pip install goldenmatch[local-llm].",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    base_url = f"http://{host}:{port}/v1"
+    typer.echo(f"Serving {model_path} at {base_url}")
+    typer.echo("Point the LLM scorer at it:")
+    typer.echo(f"  export GOLDENMATCH_LLM_BASE_URL={base_url}")
+    typer.echo("  # then set the scorer provider to 'openai' (a stub key is auto-supplied)")
+    _launch_server(model_path, host, port)

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -26,6 +26,7 @@ from goldenmatch.cli.incremental import incremental_cmd
 from goldenmatch.cli.ingest_docs import ingest_docs_app
 from goldenmatch.cli.label import label_cmd
 from goldenmatch.cli.lineage import lineage_cmd
+from goldenmatch.cli.llm import llm_app
 from goldenmatch.cli.match import match_cmd
 from goldenmatch.cli.mcp_serve import mcp_serve_cmd
 from goldenmatch.cli.memory import memory_app
@@ -129,6 +130,7 @@ app.command("evaluate", help="Evaluate matching quality against ground truth pai
 app.command("import-dbt", help="Distill a hand-rolled dbt project's ER logic (manifest.json) into a GoldenMatch config.")(import_dbt_cmd)
 app.command("import-splink", help="Convert a Splink settings or trained-model JSON to a GoldenMatch config.")(import_splink_cmd)
 app.command("migrate-splink", help="One-shot Splink migration: convert a model, verify it against Splink, and run the dedupe.")(migrate_splink_cmd)
+app.add_typer(llm_app, name="llm")
 app.add_typer(pprl_app, name="pprl")
 app.add_typer(memory_app, name="memory")
 app.add_typer(identity_app, name="identity")

--- a/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
@@ -77,7 +77,8 @@ class LocalLLMAdapter(Protocol):
 
     def score_pair(
         self, row_a: dict, row_b: dict, columns: list[str]
-    ) -> tuple[bool, float]: ...
+    ) -> tuple[bool, float]:
+        """Return ``(is_match, confidence)`` for the two records."""
 
 
 def _local_llm_mode() -> str:

--- a/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
@@ -1,0 +1,248 @@
+"""Loader + gate for the optional self-hosted local LLM adapter (D1 Path B).
+
+Mirrors ``core/_native_loader.py``: one env gate, a discover order, an artifact
+pin + verify, and **graceful abstain** — a missing extra / model returns ``None``
+rather than raising into a pipeline run (the same contract as the LLM scorer's
+"no API key -> unscored" fallback).
+
+``GOLDENMATCH_LOCAL_LLM`` env:
+- ``"0"``             -> force off; ``load_local_adapter`` returns ``None`` (abstain).
+- ``"1"``             -> require; raise ``LocalLLMUnavailableError`` if it can't load.
+- ``"auto"`` / unset  -> load if resolvable (extra installed + model reachable),
+  else abstain.
+
+Discover order for the GGUF model file (first hit wins):
+1. ``GOLDENMATCH_LOCAL_LLM_PATH`` — an explicit local path override.
+2. the Hugging Face cache (already downloaded).
+3. download-on-first-use via ``huggingface_hub`` from the pinned
+   ``(repo_id, revision, filename)``.
+4. abstain (``None``).
+
+Pin + verify: when :data:`PINNED_MODEL` carries a ``sha256`` the resolved file is
+checksum-verified (never-black-box — the exact bytes are pinned). The model
+artifact itself is NOT in the git tree; it lives on the Hugging Face Hub (see the
+companion spec ``2026-07-26-oss-er-matcher-llm-boost-design.md`` §5).
+
+The in-process adapter and its prompt/serializer are the same contract Path A's
+local OpenAI-compatible server uses, so the model artifact is identical across
+both paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+class LocalLLMUnavailableError(RuntimeError):
+    """Raised only under ``GOLDENMATCH_LOCAL_LLM=1`` when the adapter can't load."""
+
+
+@dataclass(frozen=True)
+class LocalModelSpec:
+    """A pinned local model artifact (never-black-box: exact bytes are pinned)."""
+
+    repo_id: str
+    revision: str
+    filename: str
+    sha256: str | None = None  # None -> not yet pinned; verification skipped.
+
+
+# The default self-hosted ER-matcher (companion spec §4: Qwen2.5-3B, Apache-2.0,
+# 4-bit GGUF). Placeholder coordinates until the trained model is published to the
+# Hub (companion spec P3); `sha256=None` skips verification until the real bytes
+# are pinned. The LOADER LOGIC below is complete and tested regardless of whether
+# this artifact exists yet — a missing repo simply abstains.
+PINNED_MODEL = LocalModelSpec(
+    repo_id="benseverndev-oss/goldenmatch-er-matcher-3b",
+    revision="main",
+    filename="goldenmatch-er-matcher-3b.q4_k_m.gguf",
+    sha256=None,
+)
+
+
+@runtime_checkable
+class LocalLLMAdapter(Protocol):
+    """The in-process pairwise-adjudication contract.
+
+    ``score_pair`` returns ``(is_match, confidence)`` for two records. Mirrors the
+    hosted tier's per-pair yes/no + confidence, so the closed-loop refit (D2) and
+    the review queue consume it identically.
+    """
+
+    def score_pair(
+        self, row_a: dict, row_b: dict, columns: list[str]
+    ) -> tuple[bool, float]: ...
+
+
+def _local_llm_mode() -> str:
+    return os.environ.get("GOLDENMATCH_LOCAL_LLM", "auto").strip().lower()
+
+
+def _verify_sha256(path: str, expected: str) -> None:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    actual = h.hexdigest()
+    if actual != expected:
+        raise LocalLLMUnavailableError(
+            f"local model checksum mismatch for {path}: expected {expected}, got {actual}"
+        )
+
+
+def resolve_model_path(spec: LocalModelSpec = PINNED_MODEL) -> str | None:
+    """Resolve the GGUF path via the discover order, or ``None`` to abstain.
+
+    Never raises for a plain "not reachable" (missing extra, offline, unknown
+    repo) — those all abstain. Only a genuine integrity failure (checksum
+    mismatch) raises, because a corrupt pinned artifact is an anomaly, not an
+    absence.
+    """
+    # 1. Explicit local override.
+    override = os.environ.get("GOLDENMATCH_LOCAL_LLM_PATH")
+    if override:
+        if os.path.exists(override):
+            if spec.sha256:
+                _verify_sha256(override, spec.sha256)
+            return override
+        logger.warning("GOLDENMATCH_LOCAL_LLM_PATH=%s does not exist; abstaining.", override)
+        return None
+
+    # 2/3. HF cache hit, else download-on-first-use. Both go through
+    # huggingface_hub.hf_hub_download, which returns a cached path when present
+    # and downloads otherwise. Absence of the extra / network -> abstain.
+    try:
+        from huggingface_hub import hf_hub_download  # pyright: ignore[reportMissingImports]
+    except Exception:  # noqa: BLE001 - extra not installed -> abstain
+        logger.info(
+            "huggingface_hub not installed; local LLM abstains "
+            "(pip install goldenmatch[local-llm])."
+        )
+        return None
+
+    try:
+        path = hf_hub_download(
+            repo_id=spec.repo_id, revision=spec.revision, filename=spec.filename
+        )
+    except Exception as e:  # noqa: BLE001 - unreachable repo / offline -> abstain
+        logger.info("local model not reachable (%s); abstaining.", e)
+        return None
+
+    if spec.sha256:
+        _verify_sha256(path, spec.sha256)
+    return path
+
+
+def load_local_adapter(
+    spec: LocalModelSpec = PINNED_MODEL,
+) -> LocalLLMAdapter | None:
+    """Load the in-process local adapter, honoring ``GOLDENMATCH_LOCAL_LLM``.
+
+    Returns an adapter, or ``None`` to abstain (mode ``0``, or ``auto`` with the
+    model/extra unavailable). Raises :class:`LocalLLMUnavailableError` only under
+    mode ``1`` when it cannot load.
+    """
+    mode = _local_llm_mode()
+    if mode == "0":
+        return None
+
+    path = resolve_model_path(spec)
+    if path is None:
+        if mode == "1":
+            raise LocalLLMUnavailableError(
+                "GOLDENMATCH_LOCAL_LLM=1 but no local model could be resolved "
+                "(install goldenmatch[local-llm] and ensure the pinned model is "
+                "reachable, or set GOLDENMATCH_LOCAL_LLM_PATH)."
+            )
+        return None
+
+    try:
+        from llama_cpp import Llama  # pyright: ignore[reportMissingImports]
+    except Exception as e:  # noqa: BLE001 - extra not installed
+        if mode == "1":
+            raise LocalLLMUnavailableError(
+                "GOLDENMATCH_LOCAL_LLM=1 but llama-cpp-python is not installed "
+                "(pip install goldenmatch[local-llm])."
+            ) from e
+        logger.info("llama-cpp-python not installed; local LLM abstains.")
+        return None
+
+    n_gpu_layers = int(os.environ.get("GOLDENMATCH_LOCAL_LLM_GPU_LAYERS", "0"))
+    llm = Llama(model_path=path, n_gpu_layers=n_gpu_layers, verbose=False)
+    return LocalLlamaAdapter(llm)
+
+
+# ── serializer + adapter (shared contract with Path A) ─────────────────────────
+
+
+def serialize_pair_v1(row_a: dict, row_b: dict, columns: list[str]) -> str:
+    """Render two records for the model — the pinned ``serialize_pair_v1``.
+
+    Deterministic field order (the caller's ``columns``), ``field: value`` lines.
+    The serializer version is part of the model card; changing it means a new
+    model revision (companion spec §8).
+    """
+    def _fmt(row: dict) -> str:
+        return "\n".join(f"{c}: {row.get(c, '')}" for c in columns)
+
+    return f"Record A:\n{_fmt(row_a)}\n\nRecord B:\n{_fmt(row_b)}"
+
+
+_SYSTEM_PROMPT = (
+    "You are an entity-resolution adjudicator. Decide whether Record A and "
+    "Record B describe the SAME real-world entity. Weigh agreements and "
+    "conflicts; a missing value is not a conflict. Reply with compact JSON only: "
+    '{"match": true|false, "confidence": 0.0-1.0}.'
+)
+
+
+def parse_verdict(text: str) -> tuple[bool, float]:
+    """Lenient parse of the model's JSON verdict -> ``(is_match, confidence)``.
+
+    A parse failure returns ``(False, 0.0)`` — abstain, never crash (mirrors the
+    hosted fallback contract). ``confidence`` is clamped to ``[0, 1]``.
+    """
+    import json
+    import re
+
+    try:
+        m = re.search(r"\{.*\}", text, re.DOTALL)
+        obj = json.loads(m.group(0) if m else text)
+        is_match = bool(obj.get("match", False))
+        conf = float(obj.get("confidence", 0.0))
+        return is_match, max(0.0, min(1.0, conf))
+    except Exception:  # noqa: BLE001 - any malformed output -> abstain
+        return False, 0.0
+
+
+class LocalLlamaAdapter:
+    """In-process adapter over a llama.cpp GGUF model (lazy — only built when a
+    model actually loads). Implements :class:`LocalLLMAdapter`."""
+
+    def __init__(self, llm) -> None:  # llm: llama_cpp.Llama (untyped — optional dep)
+        self._llm = llm
+
+    def score_pair(
+        self, row_a: dict, row_b: dict, columns: list[str]
+    ) -> tuple[bool, float]:
+        prompt = serialize_pair_v1(row_a, row_b, columns)
+        try:
+            resp = self._llm.create_chat_completion(
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=64,
+                temperature=0.0,
+            )
+            text = resp["choices"][0]["message"]["content"]
+        except Exception as e:  # noqa: BLE001 - inference failure -> abstain
+            logger.warning("local LLM inference failed: %s", e)
+            return False, 0.0
+        return parse_verdict(text)

--- a/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
+    from goldenmatch.core._llm_loader import LocalLLMAdapter
     from goldenmatch.core.memory.store import MemoryStore
 
 logger = logging.getLogger(__name__)
@@ -110,6 +111,7 @@ def llm_score_pairs(
     matchkey_fields: list[str] | None = None,
     matchkey_name: str | None = None,
     dataset: str | None = None,
+    local_adapter: LocalLLMAdapter | None = None,  # noqa: F821  # forward ref, resolved lazily
 ) -> list[tuple[int, int, float]] | tuple[list[tuple[int, int, float]], dict | None]:
     """Score borderline pairs with an LLM.
 
@@ -169,6 +171,32 @@ def llm_score_pairs(
 
     if not pairs:
         return _return(pairs)
+
+    # Self-hosted local model (D1 Path B). A distinct provider from openai/
+    # anthropic: scored in-process by a LocalLLMAdapter, no API key, no network.
+    # Resolve an injected adapter first (tests / callers), else the pinned model
+    # via _llm_loader. Graceful abstain: no adapter -> pairs returned unchanged
+    # (mirrors the no-key fallback), never a crash.
+    if provider == "local":
+        adapter = local_adapter
+        if adapter is None:
+            from goldenmatch.core._llm_loader import load_local_adapter
+            adapter = load_local_adapter()
+        if adapter is None:
+            logger.warning(
+                "provider='local' but no local model is available; candidates keep "
+                "fuzzy scores. Install goldenmatch[local-llm] or set "
+                "GOLDENMATCH_LOCAL_LLM_PATH."
+            )
+            return _return(pairs)
+        return _return(
+            _local_score_pairs(
+                pairs, df, adapter,
+                auto_threshold=auto_threshold,
+                candidate_lo=candidate_lo,
+                display_columns=display_columns,
+            )
+        )
 
     # Auto-detect provider
     if not provider or not api_key:
@@ -310,6 +338,51 @@ def llm_score_pairs(
         )
 
     return _return(result)
+
+
+def _local_score_pairs(
+    pairs: list[tuple[int, int, float]],
+    df: pl.DataFrame,
+    adapter: LocalLLMAdapter,
+    *,
+    auto_threshold: float = 0.95,
+    candidate_lo: float = 0.75,
+    display_columns: list[str] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Score the borderline band in-process with a self-hosted local model.
+
+    Same three-tier contract as the hosted path: ``>= auto_threshold`` auto-accept
+    (score 1.0); ``[candidate_lo, auto_threshold)`` sent to the adapter, promoted
+    to 1.0 on a match, else the original fuzzy score is kept (never demoted);
+    ``< candidate_lo`` untouched.
+
+    Scored sequentially against one model context (a single llama.cpp context is
+    not thread-safe). Multiprocessing for local throughput — a pool of worker
+    processes each holding a context — is the D3 follow-up; the hosted path stays
+    threaded (network-bound).
+    """
+    from goldenmatch.core.frame import to_frame as _tf_local
+
+    frame = _tf_local(df)
+    cols = display_columns or [c for c in frame.columns if not c.startswith("__")]
+    row_lookup: dict[int, dict] = {}
+    for row in frame.select_dicts(["__row_id__"] + cols):
+        row_lookup[row["__row_id__"]] = row
+
+    result = list(pairs)
+    for i, (a, b, s) in enumerate(pairs):
+        if s >= auto_threshold:
+            result[i] = (a, b, 1.0)
+        elif s >= candidate_lo:
+            row_a, row_b = row_lookup.get(a), row_lookup.get(b)
+            if row_a is None or row_b is None:
+                continue  # id not in frame -> keep original score
+            is_match, _conf = adapter.score_pair(row_a, row_b, cols)
+            if is_match:
+                result[i] = (a, b, 1.0)
+            # else: keep original fuzzy score (never demote), mirroring the hosted path
+        # below candidate_lo: untouched
+    return result
 
 
 def llm_explain_pair(

--- a/packages/python/goldenmatch/goldenmatch/core/refit.py
+++ b/packages/python/goldenmatch/goldenmatch/core/refit.py
@@ -1,0 +1,185 @@
+"""Closed-loop refit — turn adjudication verdicts into supervised FS labels (D2).
+
+The borderline-band adjudicator (the optional LLM boost, or the human review
+queue) produces per-pair verdicts. Today those verdicts adjudicate the current
+run's borderline pairs and are then discarded. This module *closes the loop*:
+confident verdicts become **labels**, the labels feed the EXISTING supervised
+primitive :func:`goldenmatch.core.probabilistic.estimate_m_from_labels`, and the
+refined :class:`EMResult` is returned as the **suggested** config. The caller
+decides whether to apply it (:meth:`RefitResult.persist`).
+
+Design notes (see ``docs/superpowers/specs/2026-07-29-local-model-integration-design.md``):
+
+- **One authoritative owner.** This adds no second refit path — it feeds the
+  existing supervised-m primitive. It is NOT the auto-config controller's
+  ``RefitPolicy`` family (signal-driven config re-proposal); this is
+  label-driven m re-estimation over the Fellegi-Sunter comparison model.
+- **Suggest by default.** :func:`refit_from_labels` never mutates the config or
+  touches disk — it returns a :class:`RefitResult` carrying the refined model.
+  :meth:`RefitResult.persist` is the explicit apply step (used by ``auto_refit``).
+- **Labels are confident MATCHES only.** ``estimate_m_from_labels`` estimates m
+  from known true-match pairs (u stays from random pairs), so confident
+  non-match verdicts have nowhere to feed and are dropped. A wrong label poisons
+  m, so the confidence gate is precision-first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from goldenmatch.config.schemas import GoldenMatchConfig, MatchkeyConfig
+    from goldenmatch.core.probabilistic import EMResult
+
+# A verdict from the adjudicator: (id_a, id_b, is_match, confidence).
+Verdict = tuple[int, int, bool, float]
+
+
+class RefitNotApplicableError(Exception):
+    """Raised when a refit cannot be performed.
+
+    Two causes: the config carries no ``probabilistic`` matchkey to refine, or
+    no verdict cleared the confidence gate (nothing to learn from).
+    """
+
+
+@dataclass
+class RefitResult:
+    """The outcome of a closed-loop refit (a suggestion until applied).
+
+    Attributes:
+        em_result: the refined Fellegi-Sunter model (supervised m; ``iterations=0``).
+        link_threshold: recalibrated match cutoff (:func:`compute_thresholds`).
+        review_threshold: recalibrated review-band lower bound.
+        n_labels: number of confident-match labels the estimate used.
+        matchkey_name: the probabilistic matchkey that was refined.
+    """
+
+    em_result: EMResult
+    link_threshold: float
+    review_threshold: float
+    n_labels: int
+    matchkey_name: str
+
+    def persist(self, config: GoldenMatchConfig, path: str) -> GoldenMatchConfig:
+        """Apply the refit: save the model to ``path`` and return a config copy
+        whose refined matchkey reuses it via ``model_path`` (skips EM next run).
+
+        The original ``config`` is left untouched — this returns a deep copy, so
+        applying a refit is an explicit, inspectable step, never a hidden
+        mutation of the caller's config.
+        """
+        self.em_result.save_json(path)
+        suggested = config.model_copy(deep=True)
+        for mk in suggested.get_matchkeys():
+            if mk.name == self.matchkey_name:
+                mk.model_path = path
+                break
+        return suggested
+
+
+def labels_from_verdicts(
+    verdicts: Iterable[Verdict],
+    confidence_threshold: float = 0.95,
+) -> list[tuple[int, int]]:
+    """Extract confident-match labels from adjudicator verdicts.
+
+    A verdict becomes a label only when it is a match AND its confidence is at or
+    above ``confidence_threshold`` (mirroring the LLM-scorer tier's
+    ``auto_threshold`` semantics). Pairs are canonicalized ``(min, max)`` and
+    deduplicated, matching the project-wide pair invariant.
+    """
+    seen: set[tuple[int, int]] = set()
+    labels: list[tuple[int, int]] = []
+    for id_a, id_b, is_match, confidence in verdicts:
+        if not is_match or confidence < confidence_threshold or id_a == id_b:
+            continue
+        pair = (min(id_a, id_b), max(id_a, id_b))
+        if pair not in seen:
+            seen.add(pair)
+            labels.append(pair)
+    return labels
+
+
+def _find_probabilistic_matchkey(config: GoldenMatchConfig) -> MatchkeyConfig:
+    for mk in config.get_matchkeys():
+        if getattr(mk, "type", None) == "probabilistic":
+            return mk
+    raise RefitNotApplicableError(
+        "closed-loop refit needs a probabilistic (Fellegi-Sunter) matchkey to "
+        "refine; this config has none. The refit recalibrates FS m-probabilities "
+        "from confident labels — a weighted/exact config has no EM model to refine."
+    )
+
+
+def refit_from_labels(
+    df,
+    config: GoldenMatchConfig,
+    labels: list[tuple[int, int]],
+    *,
+    matchkey: MatchkeyConfig | None = None,
+) -> RefitResult:
+    """Re-estimate the FS model from labeled match pairs (suggest mode).
+
+    Reuses :func:`estimate_m_from_labels` verbatim. Does NOT mutate ``config`` or
+    write to disk — returns a :class:`RefitResult`. Use :meth:`RefitResult.persist`
+    to apply it.
+
+    Args:
+        df: the prepared frame; MUST carry a ``__row_id__`` column (the pipeline's
+            internal id that ``labels`` reference). Arrow or polars.
+        config: the run config; its ``probabilistic`` matchkey is refined.
+        labels: confident ``(id_a, id_b)`` true-match pairs.
+        matchkey: refine this matchkey instead of auto-selecting the first
+            probabilistic one (must be ``type="probabilistic"``).
+    """
+    from goldenmatch.core.blocker import collect_blocking_fields
+    from goldenmatch.core.probabilistic import compute_thresholds, estimate_m_from_labels
+
+    if not labels:
+        raise RefitNotApplicableError(
+            "no confident-match labels to refit from (raise the adjudicator "
+            "confidence or gather more verdicts)."
+        )
+
+    mk = matchkey if matchkey is not None else _find_probabilistic_matchkey(config)
+    if getattr(mk, "type", None) != "probabilistic":
+        raise RefitNotApplicableError(
+            f"matchkey {mk.name!r} is {mk.type!r}, not 'probabilistic'; only an FS "
+            "matchkey can be refit from labels."
+        )
+
+    blocking_fields: list[str] = []
+    if getattr(config, "blocking", None) is not None:
+        try:
+            blocking_fields = collect_blocking_fields(config.blocking)
+        except Exception:  # pragma: no cover - defensive; refit stays best-effort
+            blocking_fields = []
+
+    em = estimate_m_from_labels(df, mk, labels, blocking_fields=blocking_fields)
+    link, review = compute_thresholds(em)
+    return RefitResult(
+        em_result=em,
+        link_threshold=link,
+        review_threshold=review,
+        n_labels=len(labels),
+        matchkey_name=mk.name,
+    )
+
+
+def refit_from_verdicts(
+    df,
+    config: GoldenMatchConfig,
+    verdicts: Iterable[Verdict],
+    *,
+    confidence_threshold: float = 0.95,
+    matchkey: MatchkeyConfig | None = None,
+) -> RefitResult:
+    """Convenience: extract confident-match labels from ``verdicts`` then refit.
+
+    Equivalent to :func:`labels_from_verdicts` followed by :func:`refit_from_labels`.
+    """
+    labels = labels_from_verdicts(verdicts, confidence_threshold=confidence_threshold)
+    return refit_from_labels(df, config, labels, matchkey=matchkey)

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -221,6 +221,15 @@ lance = [
 llama = [
     "llama-cpp-python>=0.3",
 ]
+# Self-hosted local ER-matcher for the LLM-scorer tier (D1 Path B): the
+# in-process LocalLlamaAdapter (goldenmatch/core/_llm_loader.py). llama-cpp-python
+# runs the pinned GGUF offline; huggingface_hub does download-on-first-use into
+# the HF cache. Both lazy-imported; absent them, provider='local' abstains.
+# Spec: docs/superpowers/specs/2026-07-29-local-model-integration-design.md
+local-llm = [
+    "llama-cpp-python>=0.3",
+    "huggingface_hub>=0.24",
+]
 web = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",

--- a/packages/python/goldenmatch/tests/test_cli_llm.py
+++ b/packages/python/goldenmatch/tests/test_cli_llm.py
@@ -1,0 +1,42 @@
+"""Tests for `goldenmatch llm serve-local` (D1 Path A).
+
+The server launch is monkeypatched out; only the resolve/guard logic and the
+env-var hint output are exercised.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.cli import llm as llm_mod
+from goldenmatch.cli.main import app
+from goldenmatch.core import _llm_loader
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_unresolvable_model_exits_with_hint(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_LOCAL_LLM_PATH", raising=False)
+    # The command does a function-local `from _llm_loader import resolve_model_path`,
+    # so patch the loader module's attribute.
+    monkeypatch.setattr(_llm_loader, "resolve_model_path", lambda *a, **k: None)
+    result = runner.invoke(app, ["llm", "serve-local"])
+    assert result.exit_code == 1
+    assert "No local model could be resolved" in result.output
+
+
+def test_launches_and_prints_base_url_hint(monkeypatch, tmp_path):
+    model = tmp_path / "m.gguf"
+    model.write_bytes(b"gguf")
+    launched: dict = {}
+    monkeypatch.setattr(llm_mod, "_llama_server_available", lambda: True)
+    monkeypatch.setattr(
+        llm_mod, "_launch_server",
+        lambda path, host, port: launched.update(path=path, host=host, port=port),
+    )
+    result = runner.invoke(
+        app,
+        ["llm", "serve-local", "--model-path", str(model), "--port", "9099"],
+    )
+    assert result.exit_code == 0, result.output
+    assert launched == {"path": str(model), "host": "127.0.0.1", "port": 9099}
+    assert "GOLDENMATCH_LLM_BASE_URL=http://127.0.0.1:9099/v1" in result.output

--- a/packages/python/goldenmatch/tests/test_local_llm.py
+++ b/packages/python/goldenmatch/tests/test_local_llm.py
@@ -1,0 +1,122 @@
+"""Tests for the self-hosted local LLM adapter + loader (D1 Path B).
+
+No model or network: the loader's gate/discover/verify logic is exercised with a
+fake path + monkeypatched download, and the ``provider="local"`` scoring path is
+driven by an injected stub adapter.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core import _llm_loader as L
+from goldenmatch.core.llm_scorer import llm_score_pairs
+
+
+class _StubAdapter:
+    """Deterministic in-process adapter: matches when both names are equal."""
+
+    def __init__(self):
+        self.calls: list[tuple[int, int]] = []
+
+    def score_pair(self, row_a, row_b, columns):
+        self.calls.append((row_a["__row_id__"], row_b["__row_id__"]))
+        return (row_a["name"] == row_b["name"], 0.99)
+
+
+def _df():
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": ["Ann", "Ann", "Bob", "Zed"],
+    })
+
+
+# ── serializer + verdict parsing ───────────────────────────────────────────────
+
+
+class TestSerializerAndParse:
+    def test_serialize_pair_v1_is_deterministic_field_order(self):
+        s = L.serialize_pair_v1({"b": 2, "a": 1}, {"a": 9, "b": 8}, ["a", "b"])
+        assert s == "Record A:\na: 1\nb: 2\n\nRecord B:\na: 9\nb: 8"
+
+    def test_parse_verdict_plain_json(self):
+        assert L.parse_verdict('{"match": true, "confidence": 0.9}') == (True, 0.9)
+
+    def test_parse_verdict_embedded_json(self):
+        assert L.parse_verdict('Sure! {"match": false, "confidence": 0.2} done') == (False, 0.2)
+
+    def test_parse_verdict_clamps_confidence(self):
+        assert L.parse_verdict('{"match": true, "confidence": 5}') == (True, 1.0)
+
+    def test_parse_verdict_garbage_abstains(self):
+        assert L.parse_verdict("not json at all") == (False, 0.0)
+
+
+# ── loader gate + discover order ───────────────────────────────────────────────
+
+
+class TestLoader:
+    def test_mode_0_abstains(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM", "0")
+        assert L.load_local_adapter() is None
+
+    def test_override_path_missing_abstains(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM_PATH", "/no/such/model.gguf")
+        assert L.resolve_model_path() is None
+
+    def test_override_path_present_no_sha_returns_it(self, monkeypatch, tmp_path):
+        p = tmp_path / "model.gguf"
+        p.write_bytes(b"gguf-bytes")
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM_PATH", str(p))
+        assert L.resolve_model_path() == str(p)
+
+    def test_override_path_sha_mismatch_raises(self, monkeypatch, tmp_path):
+        p = tmp_path / "model.gguf"
+        p.write_bytes(b"gguf-bytes")
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM_PATH", str(p))
+        spec = L.LocalModelSpec(repo_id="x", revision="main", filename="m.gguf", sha256="deadbeef")
+        with pytest.raises(L.LocalLLMUnavailableError):
+            L.resolve_model_path(spec)
+
+    def test_override_path_sha_match_returns_it(self, monkeypatch, tmp_path):
+        import hashlib
+        p = tmp_path / "model.gguf"
+        p.write_bytes(b"gguf-bytes")
+        digest = hashlib.sha256(b"gguf-bytes").hexdigest()
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM_PATH", str(p))
+        spec = L.LocalModelSpec(repo_id="x", revision="main", filename="m.gguf", sha256=digest)
+        assert L.resolve_model_path(spec) == str(p)
+
+    def test_mode_1_raises_when_unresolvable(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM", "1")
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM_PATH", "/no/such/model.gguf")
+        with pytest.raises(L.LocalLLMUnavailableError):
+            L.load_local_adapter()
+
+
+# ── provider="local" scoring path ──────────────────────────────────────────────
+
+
+class TestLocalScoringPath:
+    def test_injected_adapter_scores_the_band(self):
+        stub = _StubAdapter()
+        pairs = [
+            (0, 1, 0.80),  # in band, same name -> promoted to 1.0
+            (2, 3, 0.80),  # in band, different name -> keeps 0.80
+            (0, 2, 0.99),  # auto-accept -> 1.0 (no adapter call)
+            (1, 3, 0.50),  # below band -> untouched
+        ]
+        out = llm_score_pairs(pairs, _df(), provider="local", local_adapter=stub)
+        assert out[0] == (0, 1, 1.0)
+        assert out[1] == (2, 3, 0.80)
+        assert out[2] == (0, 2, 1.0)
+        assert out[3] == (1, 3, 0.50)
+        # Only the two in-band pairs hit the adapter; auto-accept/below did not.
+        assert set(stub.calls) == {(0, 1), (2, 3)}
+
+    def test_no_adapter_abstains_gracefully(self, monkeypatch):
+        # Force the loader off so provider='local' finds no adapter.
+        monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM", "0")
+        pairs = [(0, 1, 0.80), (0, 2, 0.99)]
+        out = llm_score_pairs(pairs, _df(), provider="local")
+        assert out == pairs  # unchanged, no crash

--- a/packages/python/goldenmatch/tests/test_refit.py
+++ b/packages/python/goldenmatch/tests/test_refit.py
@@ -1,0 +1,129 @@
+"""Tests for the closed-loop refit (D2, suggest mode).
+
+The borderline-band adjudicator (LLM boost or human review) produces per-pair
+verdicts; this loop turns the CONFIDENT ones into labels and feeds the existing
+supervised primitive ``estimate_m_from_labels`` to produce a refined ``EMResult``
+returned as a suggestion. No model / network needed — labels are supplied
+directly here.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core import refit as R
+
+
+def _make_probabilistic_mk(**kwargs):
+    defaults = dict(
+        name="fs",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3, partial_threshold=0.8),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2, partial_threshold=0.85),
+            MatchkeyField(field="zip", scorer="exact", levels=2),
+        ],
+    )
+    defaults.update(kwargs)
+    return MatchkeyConfig(**defaults)
+
+
+def _supervised_df():
+    # 3 true-match pairs (0-1, 2-3, 4-5) sharing zip blocks.
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "first_name": ["John", "Jon", "Jane", "Jane", "Bob", "Bob"],
+        "last_name": ["Smith", "Smith", "Doe", "Doe", "Lee", "Lee"],
+        "zip": ["111", "111", "222", "222", "333", "333"],
+    })
+
+
+def _blocking():
+    return BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])])
+
+
+def _config():
+    return GoldenMatchConfig(matchkeys=[_make_probabilistic_mk()], blocking=_blocking())
+
+
+class TestLabelsFromVerdicts:
+    def test_keeps_confident_matches_only(self):
+        verdicts = [
+            (0, 1, True, 0.99),   # confident match -> label
+            (2, 3, True, 0.80),   # match but below threshold -> dropped
+            (4, 5, False, 0.99),  # confident NON-match -> dropped (u is from random pairs)
+        ]
+        labels = R.labels_from_verdicts(verdicts, confidence_threshold=0.95)
+        assert labels == [(0, 1)]
+
+    def test_canonicalizes_and_dedupes(self):
+        verdicts = [(1, 0, True, 0.99), (0, 1, True, 0.97)]
+        labels = R.labels_from_verdicts(verdicts, confidence_threshold=0.95)
+        assert labels == [(0, 1)]
+
+    def test_threshold_boundary_is_inclusive(self):
+        verdicts = [(0, 1, True, 0.95)]
+        assert R.labels_from_verdicts(verdicts, confidence_threshold=0.95) == [(0, 1)]
+
+
+class TestRefitFromLabels:
+    def test_returns_refined_em_and_thresholds(self):
+        df, config = _supervised_df(), _config()
+        result = R.refit_from_labels(df, config, [(0, 1), (2, 3), (4, 5)])
+        assert result.n_labels == 3
+        assert result.matchkey_name == "fs"
+        assert result.em_result.iterations == 0            # supervised, no EM
+        assert result.em_result.converged is True
+        assert 0.0 <= result.review_threshold <= result.link_threshold <= 1.0
+
+    def test_suggest_mode_does_not_mutate_config(self):
+        df, config = _supervised_df(), _config()
+        R.refit_from_labels(df, config, [(0, 1), (2, 3), (4, 5)])
+        assert config.get_matchkeys()[0].model_path is None  # suggestion, side-effect-free
+
+    def test_refit_from_verdicts_convenience(self):
+        df, config = _supervised_df(), _config()
+        verdicts = [(0, 1, True, 0.99), (2, 3, True, 0.99), (4, 5, True, 0.99)]
+        result = R.refit_from_verdicts(df, config, verdicts, confidence_threshold=0.95)
+        assert result.n_labels == 3
+
+    def test_no_probabilistic_matchkey_raises(self):
+        df = _supervised_df()
+        weighted = MatchkeyConfig(
+            name="w", type="weighted",
+            fields=[MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0, threshold=0.8)],
+            threshold=0.8,
+        )
+        config = GoldenMatchConfig(matchkeys=[weighted], blocking=_blocking())
+        with pytest.raises(R.RefitNotApplicableError):
+            R.refit_from_labels(df, config, [(0, 1)])
+
+    def test_no_confident_labels_raises(self):
+        df, config = _supervised_df(), _config()
+        with pytest.raises(R.RefitNotApplicableError):
+            R.refit_from_verdicts(df, config, [(0, 1, True, 0.5)], confidence_threshold=0.95)
+
+
+class TestApply:
+    def test_persist_writes_model_and_points_matchkey(self, tmp_path):
+        df, config = _supervised_df(), _config()
+        result = R.refit_from_labels(df, config, [(0, 1), (2, 3), (4, 5)])
+        path = str(tmp_path / "refined.json")
+
+        suggested = result.persist(config, path)
+
+        # The refined model is on disk and reloadable...
+        from goldenmatch.core.probabilistic import EMResult
+        reloaded = EMResult.load_json(path)
+        assert reloaded.match_weights.keys() == result.em_result.match_weights.keys()
+        # ...the suggested config points at it...
+        assert suggested.get_matchkeys()[0].model_path == path
+        # ...and the ORIGINAL config is untouched (apply returns a copy).
+        assert config.get_matchkeys()[0].model_path is None

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -3580,6 +3580,32 @@
           ]
         },
         {
+          "command": "llm serve-local",
+          "options": [
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'127.0.0.1'",
+              "help": "Bind host (loopback by default)."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8081",
+              "help": "Bind port."
+            },
+            {
+              "name": "--model-path",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Explicit GGUF path (else the pinned model is resolved / downloaded)."
+            }
+          ]
+        },
+        {
           "command": "match",
           "options": [
             {
@@ -5667,6 +5693,11 @@
         "LLM": [
           "GOLDENMATCH_LLM_BASE_URL",
           "GOLDENMATCH_LLM_MODEL"
+        ],
+        "LOCAL": [
+          "GOLDENMATCH_LOCAL_LLM",
+          "GOLDENMATCH_LOCAL_LLM_GPU_LAYERS",
+          "GOLDENMATCH_LOCAL_LLM_PATH"
         ],
         "MATCH": [
           "GOLDENMATCH_MATCH_FUSED",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -182,6 +182,7 @@ cli_commands:
   python_only:
   - import-dbt
   - ingest-docs
+  - llm
   - migrate-splink
   - serve-ui
   - setup


### PR DESCRIPTION
## What and why

Wires a **self-hosted local model** into GoldenMatch's existing borderline-band LLM-scorer tier, and **closes the loop** so the tier's verdicts recalibrate the config. Every piece hangs off a seam that already exists — this is wiring, not a new subsystem. Design: `docs/superpowers/specs/2026-07-29-local-model-integration-design.md` (companion to the model/training spec `2026-07-26-oss-er-matcher-llm-boost-design.md`).

## Changes

- **Spec** — `docs/superpowers/specs/2026-07-29-local-model-integration-design.md` (reviewer-verified against source).
- **D2 — closed-loop refit** (`core/refit.py`, `test_refit.py`): confident adjudicator verdicts → labels → `estimate_m_from_labels` (reused verbatim) → refined `EMResult` returned as a **suggestion** (default, no mutation). `RefitResult.persist()` is the explicit apply step (saves the model, points `mk.model_path` at it via the existing train-once reuse seam). Raises `RefitNotApplicableError` when there's no probabilistic matchkey / no confident label.
- **D1 Path B — self-hosted provider** (`core/_llm_loader.py`, `llm_scorer.py`, `test_local_llm.py`): `provider="local"` — an in-process, no-key, no-network adjudicator. `_llm_loader` mirrors `_native_loader` (gate `GOLDENMATCH_LOCAL_LLM=auto/0/1`, discover order, pinned+sha256 verify, graceful abstain). `llm_score_pairs` gains a single early `provider=="local"` branch (byte-identical for every other provider) + an injectable `local_adapter` seam. New `[local-llm]` extra.
- **D1 Path A — `goldenmatch llm serve-local`** (`cli/llm.py`, `test_cli_llm.py`): launches the pinned GGUF over a llama.cpp OpenAI-compatible endpoint and prints the env vars that wire the existing scorer to it (the `GOLDENMATCH_LLM_BASE_URL` seam is already in place).

Default posture is full-auto; the closed loop suggests (never mutates) unless applied. The pinned model coordinates are a placeholder until the trained artifact ships (companion spec); all loader/adapter/refit logic is complete and tested regardless.

## Testing

`uv run python -m pytest` on the new suites — all green:
- `test_refit.py` — 9 passed
- `test_local_llm.py` — 13 passed
- `test_cli_llm.py` — 2 passed

No model, GPU, or network is needed: the refit is driven by supplied labels, the local provider by a stub adapter, and the loader by a fake path + sha256. Existing hosted-path LLM tests (`test_llm_calibration`, `test_llm_cost_surface`) still pass; the `provider="local"` branch is a single early return that leaves openai/anthropic byte-identical. Ruff clean (incl. import-sort).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` — deferred until the feature-set is finalized (behavior is additive + off-by-default)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / spec updated

## Follow-ups (not in this PR)

- Wire `auto_refit=True` into the pipeline/`dedupe_df` to apply the refit in-run (D2 P3; the library surface — `RefitResult.persist` — already exists and is tested).
- Multiprocessing throughput for the local provider (D3): a worker-process pool, each with its own model context. v1 scores sequentially against one context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z