### PR TITLE
perf(distributed): make record_store arrow-native (evict polars from the distributed store)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5423,7 +5423,6 @@
           "imports": [
             "goldenmatch",
             "goldenmatch._api",
-            "goldenmatch._polars_lazy",
             "goldenmatch.config.schemas",
             "goldenmatch.core.autoconfig",
             "goldenmatch.core.golden",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5438,7 +5438,10 @@
           "purpose": "DuckDB-backed prepared-record store.",
           "defines": [
             "PreparedRecordStore",
+            "_coerce_backend",
+            "_is_arrow_table",
             "_sanitize_signature",
+            "_write_frame_parquet",
             "iter_buckets",
             "load_bucket",
             "load_prepared_records",
@@ -5446,7 +5449,6 @@
             "materialize_prepared_records"
           ],
           "imports": [
-            "goldenmatch._polars_lazy",
             "goldenmatch.core._hashing",
             "goldenmatch.core.frame"
           ]

--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -166,17 +166,18 @@ def score_blocks_ray(
         each block, returns concatenated pairs."""
         from pathlib import Path as _Path
 
+        from goldenmatch.core.frame import to_frame
         from goldenmatch.core.scorer import _score_one_block
         from goldenmatch.distributed.record_store import load_bucket
 
-        bucket_df = load_bucket(_Path(bucket_path))
+        # load_bucket is arrow-native (pa.Table); partition per block_key via
+        # the core.frame seam (polars-free) rather than pl.partition_by.
+        bucket_tbl = load_bucket(_Path(bucket_path))
         all_pairs: list[tuple[int, int, float]] = []
-        for block_key, block_df in bucket_df.partition_by(
-            "__block_key__", as_dict=True,
-        ).items():
-            # block_key arrives as tuple under Polars >= 1.0 partition_by.
-            if isinstance(block_key, tuple):
-                block_key = block_key[0]
+        for block_key, block_frame in to_frame(bucket_tbl).group_partitions(
+            "__block_key__",
+        ):
+            block_df = block_frame.native
             shim = _KeyModeBlock(block_key=str(block_key), df=block_df)
             all_pairs.extend(
                 _score_one_block(

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3040,6 +3040,11 @@ def _run_dedupe_pipeline(
                 from goldenmatch.distributed.record_store import load_prepared_records
                 cached_disk = load_prepared_records(_prep_store, signature=disk_signature)
                 if cached_disk is not None:
+                    # record_store is arrow-native (returns a pa.Table); this
+                    # legacy prep-cache branch is polars-lazy, so coerce here.
+                    # (Migrating this whole branch onto the arrow lane is the
+                    # remaining prep-cache eviction step.)
+                    cached_disk = pl.from_arrow(cached_disk)
                     combined_lf = cached_disk.lazy()
                     # Seed in-memory cache so subsequent in-process iterations
                     # skip the disk read (RAM > DuckDB+Arrow latency).

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3043,8 +3043,9 @@ def _run_dedupe_pipeline(
                     # record_store is arrow-native (returns a pa.Table); this
                     # legacy prep-cache branch is polars-lazy, so coerce here.
                     # (Migrating this whole branch onto the arrow lane is the
-                    # remaining prep-cache eviction step.)
-                    cached_disk = pl.from_arrow(cached_disk)
+                    # remaining prep-cache eviction step.) pl.from_arrow on a
+                    # Table always yields a DataFrame -> narrow for pyright.
+                    cached_disk = cast("pl.DataFrame", pl.from_arrow(cached_disk))
                     combined_lf = cached_disk.lazy()
                     # Seed in-memory cache so subsequent in-process iterations
                     # skip the disk read (RAM > DuckDB+Arrow latency).

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -18,8 +18,6 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from goldenmatch._polars_lazy import pl
-
 if TYPE_CHECKING:
     from ray.data import Dataset
 
@@ -49,11 +47,15 @@ def run_dedupe_pipeline_distributed(ds: Dataset, **kwargs: Any):
 
 
 def _run_phase2_cheat_line(ds: Dataset, **kwargs: Any):
+    import pyarrow as pa
+
     from goldenmatch import dedupe_df
 
     rows = ds.take_all()
-    df = pl.from_dicts(list(rows))
-    return dedupe_df(df, **kwargs)
+    # dedupe_df is arrow-native; build a pa.Table from the Ray rows (dicts)
+    # instead of pl.from_dicts so this cheat-line imports no polars.
+    tbl = pa.Table.from_pylist(list(rows))
+    return dedupe_df(tbl, **kwargs)
 
 
 def _run_phase4_pipeline(ds: Dataset, **kwargs: Any):
@@ -64,11 +66,15 @@ def _run_phase4_pipeline(ds: Dataset, **kwargs: Any):
     callers to the distributed path. Phase 5 retires the take_all here
     by distributing the scoring stage end-to-end.
     """
+    import pyarrow as pa
+
     from goldenmatch import dedupe_df
 
     rows = ds.take_all()
-    df = pl.from_dicts(list(rows))
-    return dedupe_df(df, **kwargs)
+    # dedupe_df is arrow-native; build a pa.Table from the Ray rows (dicts)
+    # instead of pl.from_dicts so this cheat-line imports no polars.
+    tbl = pa.Table.from_pylist(list(rows))
+    return dedupe_df(tbl, **kwargs)
 
 
 def _phase5_cluster(raw_pairs_ds: Dataset, cfg: Any) -> Dataset:
@@ -333,25 +339,24 @@ def _join_assignments_distributed(
     """
     import os
 
-    import polars as pl
-
     if num_partitions is None:
         cpu = os.cpu_count() or 16
         num_partitions = min(256, max(4, cpu * 4))
 
     def _project_multi(batch: Any) -> Any:  # pa.Table -> pa.Table
-        df = pl.from_arrow(batch)
-        assert isinstance(df, pl.DataFrame)
-        if df.height == 0:
-            return pl.DataFrame(
-                schema={"member_id": pl.Int64, "__cluster_id__": pl.Int64},
-            ).to_arrow()
-        df = df.filter(pl.col("cluster_size") > 1)
-        out = df.select(
-            pl.col("member_id").cast(pl.Int64),
-            pl.col("cluster_id").cast(pl.Int64).alias("__cluster_id__"),
-        )
-        return out.to_arrow()
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        if batch.num_rows == 0:
+            return pa.table({
+                "member_id": pa.array([], pa.int64()),
+                "__cluster_id__": pa.array([], pa.int64()),
+            })
+        filtered = batch.filter(pc.greater(batch.column("cluster_size"), 1))
+        return pa.table({
+            "member_id": pc.cast(filtered.column("member_id"), pa.int64()),
+            "__cluster_id__": pc.cast(filtered.column("cluster_id"), pa.int64()),
+        })
 
     assign = assignments_ds.map_batches(_project_multi, batch_format="pyarrow")
 
@@ -364,10 +369,8 @@ def _join_assignments_distributed(
     )
 
     def _drop_member(batch: Any) -> Any:  # pa.Table -> pa.Table
-        df = pl.from_arrow(batch)
-        assert isinstance(df, pl.DataFrame)
-        if "member_id" in df.columns:
-            df = df.drop("member_id")
-        return df.to_arrow()
+        if "member_id" in batch.column_names:
+            return batch.drop_columns(["member_id"])
+        return batch
 
     return joined.map_batches(_drop_member, batch_format="pyarrow")

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -29,11 +29,9 @@ import shutil
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import duckdb
-
-from goldenmatch._polars_lazy import pl
 
 _TABLE_PREFIX = "prepared_"
 
@@ -153,21 +151,65 @@ class PreparedRecordStore:
         self.close()
 
 
+def _is_arrow_table(obj: Any) -> bool:
+    """True when ``obj`` is a PyArrow ``Table`` (arrow lane), False for a
+    Polars ``DataFrame``. Duck-typed on ``column_names`` (pa.Table has it,
+    pl.DataFrame exposes ``columns`` instead) so neither engine is imported
+    eagerly -- mirrors the ``core._hashing`` idiom."""
+    return hasattr(obj, "column_names")
+
+
+def _coerce_backend(frame: Any, backend: str) -> Any:
+    """Return ``frame`` (a ``core.frame`` Frame) on the requested backend.
+
+    record_store is arrow-native: the only conversion it performs is
+    polars->arrow (``.to_arrow()``, no Polars import), so a mixed
+    (polars-``df`` + arrow-assignments, or vice-versa) call still joins on
+    one lane. When ``backend="polars"`` the frame is returned as-is -- real
+    callers pass ``df`` and ``block_assignments`` on the same lane, and the
+    seam ``join_inner`` needs no coercion in that case."""
+    from goldenmatch.core.frame import to_frame
+
+    is_arrow = _is_arrow_table(frame.native)
+    if backend == "arrow" and not is_arrow:
+        return to_frame(frame.to_arrow())
+    return frame
+
+
+def _write_frame_parquet(frame: Any, path: Path) -> None:
+    """Write a ``core.frame`` Frame to ``path`` as snappy Parquet, per lane.
+    Polars frames use Polars' own writer (byte-identical to the pre-port
+    ``native.write_parquet``); arrow frames use ``pyarrow.parquet`` so the
+    arrow lane needs no Polars import."""
+    native = frame.native
+    if hasattr(native, "write_parquet"):  # polars DataFrame
+        native.write_parquet(path, compression="snappy")
+    else:  # pyarrow Table (arrow lane)
+        import pyarrow.parquet as papq
+
+        papq.write_table(native, str(path), compression="snappy")
+
+
 def materialize_prepared_records(
     store: PreparedRecordStore,
-    df: pl.DataFrame,
+    df: Any,
     *,
     signature: str,
 ) -> None:
     """Write ``df`` into the store under ``signature``.
 
-    Polars -> Arrow -> DuckDB via ``arrow_table`` view registration. Same
-    pattern as ``backends/score_duckdb.py`` (PR #235). Existing entries
-    at the same signature are replaced.
+    Arrow-native: ``df`` may be a PyArrow ``Table`` OR a Polars ``DataFrame``
+    -- both reach DuckDB as Arrow via the ``core.frame`` seam
+    (``to_frame(df).to_arrow()``), and record_store itself never imports
+    Polars. Same DuckDB ``arrow_table`` view registration pattern as
+    ``backends/score_duckdb.py`` (PR #235); existing entries at the same
+    signature are replaced.
     """
+    from goldenmatch.core.frame import to_frame
+
     table = _TABLE_PREFIX + _sanitize_signature(signature)
     con = store.connection
-    arrow_table = df.to_arrow()  # noqa: F841  -- DuckDB resolves by local name
+    arrow_table = to_frame(df).to_arrow()  # noqa: F841 -- DuckDB resolves by local name
     con.execute(f'DROP TABLE IF EXISTS "{table}"')
     con.execute(f'CREATE TABLE "{table}" AS SELECT * FROM arrow_table')
 
@@ -176,11 +218,13 @@ def load_prepared_records(
     store: PreparedRecordStore,
     *,
     signature: str,
-) -> pl.DataFrame | None:
-    """Read ``signature``'s entry back as a Polars DataFrame.
+) -> Any | None:
+    """Read ``signature``'s entry back as a PyArrow ``Table``.
 
     Returns None when the signature isn't present in the store (cache
-    miss; caller prepares + materializes).
+    miss; caller prepares + materializes). Arrow-native: the caller owns any
+    conversion to its own frame representation (record_store imports no
+    Polars).
     """
     table = _TABLE_PREFIX + _sanitize_signature(signature)
     con = store.connection
@@ -190,17 +234,21 @@ def load_prepared_records(
     ).fetchone()
     if exists is None:
         return None
-    arrow_table = con.execute(f'SELECT * FROM "{table}"').arrow()
-    # pl.from_arrow returns DataFrame | Series; an Arrow Table always
-    # produces a DataFrame, so narrow via cast for type-checkers.
-    return cast(pl.DataFrame, pl.from_arrow(arrow_table))
+    result = con.execute(f'SELECT * FROM "{table}"')
+    # Prefer the non-deprecated to_arrow_table(); fall back to .arrow() (a
+    # RecordBatchReader on newer DuckDB -> read_all() gives the Table).
+    to_arrow_table = getattr(result, "to_arrow_table", None)
+    if to_arrow_table is not None:
+        return to_arrow_table()
+    arrow_obj = result.arrow()
+    return arrow_obj.read_all() if hasattr(arrow_obj, "read_all") else arrow_obj
 
 
 def materialize_bucketed_blocks(
     store: PreparedRecordStore,
-    df: pl.DataFrame,
+    df: Any,
     *,
-    block_assignments: dict[int, str] | pl.DataFrame,
+    block_assignments: dict[int, str] | Any,
     n_buckets: int,
     signature: str,
 ) -> Path:
@@ -216,82 +264,101 @@ def materialize_bucketed_blocks(
       exists to avoid.
 
     Empty assignments yield a bucket_dir with no Parquet files
-    (Polars' partition_by skips empty groups).
+    (the group-partition step skips empty groups).
+
+    Arrow-native: ``df`` and ``block_assignments`` may be PyArrow ``Table``s
+    OR Polars ``DataFrame``s; every intermediate stays on ``df``'s backend
+    via the ``core.frame`` seam (record_store imports no Polars). Byte-
+    identical bucket layout on a Polars input (the seam's polars
+    ``with_bucket_column`` is this stage's old ``hash(seed) % n`` expr).
 
     Spec: docs/superpowers/specs/2026-05-17-...-v2-bucketed-storage-design.md
     §Components #1.
     """
+    from goldenmatch.core.frame import frame_from_column_data, to_frame
+
     sig_hash = _sanitize_signature(signature)
     bucket_dir = store.path.parent / f"buckets_{sig_hash}"
     # W4e FIX (latent stale-file bug): the signature is CONFIG-ONLY, so a
-    # persisted store re-materialized with different data (or, post-W5, a
-    # different backend hash) would leave stale bucket=K parquets that
-    # iter_buckets happily returns. Materialize is an authoritative rebuild:
-    # clear the dir first.
+    # persisted store re-materialized with different data (or a different
+    # backend hash) would leave stale bucket=K parquets that iter_buckets
+    # happily returns. Materialize is an authoritative rebuild: clear the
+    # dir first.
     if bucket_dir.exists():
         import shutil
 
         shutil.rmtree(bucket_dir)
     bucket_dir.mkdir(parents=True, exist_ok=True)
 
-    # Normalize to a Polars DataFrame.
+    # Build/keep every intermediate on the SAME backend as ``df`` so the seam
+    # join never mixes lanes and the arrow lane never imports Polars.
+    df_backend = "arrow" if _is_arrow_table(df) else "polars"
+
     if isinstance(block_assignments, dict):
         if not block_assignments:
             return bucket_dir
-        from goldenmatch.core.frame import frame_from_column_data
-
-        rid_to_block = frame_from_column_data(
+        assign_frame = frame_from_column_data(
             {
                 "__row_id__": list(block_assignments.keys()),
                 "__block_key__": list(block_assignments.values()),
             },
-            backend="polars",
-        ).native
+            backend=df_backend,
+        )
     else:
-        rid_to_block = block_assignments
-        if rid_to_block.height == 0:
+        assign_frame = to_frame(block_assignments)
+        if assign_frame.height == 0:
             return bucket_dir
         required = {"__row_id__", "__block_key__"}
-        if not required.issubset(set(rid_to_block.columns)):
+        if not required.issubset(set(assign_frame.columns)):
             raise ValueError(
                 f"block_assignments DataFrame must have columns "
-                f"{required}; got {set(rid_to_block.columns)}"
+                f"{required}; got {set(assign_frame.columns)}"
             )
+        assign_frame = _coerce_backend(assign_frame, df_backend)
 
     # Inner join attaches __block_key__. Rows in `df` without an
     # assignment drop out (matches v1: unassigned rows weren't scored).
-    from goldenmatch.core.frame import to_frame
+    keyed = to_frame(df).join_inner(assign_frame, on="__row_id__")
 
-    keyed = to_frame(df).join_inner(to_frame(rid_to_block), on="__row_id__")
-
-    # Bucket assignment via Polars xxHash with fixed seed. W5: bucket layout
-    # is per-backend shard-internal (never output-visible; the clear-on-
-    # materialize above makes cross-run reuse of a differently-hashed layout
-    # impossible) -- the arrow lane gets its own stable hash at the flip.
-    with_bucket = keyed.native.with_columns(
-        (pl.col("__block_key__").hash(seed=BUCKET_HASH_SEED) % n_buckets)
-        .alias("__bucket__"),
+    # Bucket assignment via the canonical `core.frame` seam -- the SAME
+    # `with_bucket_column(seed=BUCKET_HASH_SEED)` op the bucket scorer
+    # (`backends.score_buckets`) uses, so a block's bucket is consistent
+    # across the two surfaces by construction (test_cross_surface_consistency
+    # pins the shared seed). Polars lane is byte-identical to this stage's old
+    # `hash(seed) % n` expr; the arrow lane gets the seam's dictionary-code
+    # twin. Bucket layout is shard-internal (never output-visible; the
+    # clear-on-materialize above makes cross-run reuse of a differently-hashed
+    # layout impossible).
+    bucketed = keyed.with_bucket_column(
+        "__block_key__", "__bucket__", n_buckets, BUCKET_HASH_SEED,
     )
 
     # W4e: group_partitions == partition_by(as_dict) with unwrapped keys.
-    for bucket_id, bucket_frame in to_frame(with_bucket).group_partitions("__bucket__"):
+    for bucket_id, bucket_frame in bucketed.group_partitions("__bucket__"):
         bucket_path = bucket_dir / f"bucket={int(bucket_id)}" / "data.parquet"
         bucket_path.parent.mkdir(parents=True, exist_ok=True)
-        # W5: parquet shard IO goes through io_arrow twins at the flip.
-        bucket_frame.drop(["__bucket__"]).native.write_parquet(
-            bucket_path, compression="snappy",
-        )
+        _write_frame_parquet(bucket_frame.drop(["__bucket__"]), bucket_path)
 
     return bucket_dir
 
 
-def load_bucket(bucket_path: Path) -> pl.DataFrame:
-    """Read a bucket Parquet file as a Polars DataFrame.
+def load_bucket(bucket_path: Path) -> Any:
+    """Read a bucket Parquet file back as a PyArrow ``Table``.
+
+    Arrow-native (via ``pyarrow.parquet``): record_store imports no Polars.
+    The Ray worker consumer (``backends.ray_backend``) partitions the returned
+    table through the ``core.frame`` seam.
 
     Trivial wrapper, lifted to a function so future enhancements
     (streaming, column projection) have one site to change.
     """
-    return pl.read_parquet(bucket_path)
+    import pyarrow.parquet as papq
+
+    # Read ONLY this file. A dataset-style read (pq.read_table) would infer a
+    # Hive partition from the enclosing ``bucket=<id>`` directory and inject a
+    # spurious ``bucket`` column that the prior ``pl.read_parquet`` never
+    # produced -- ParquetFile.read() reads just the file's own schema.
+    return papq.ParquetFile(str(bucket_path)).read()
 
 
 def iter_buckets(bucket_dir: Path) -> Iterator[tuple[int, Path]]:

--- a/packages/python/goldenmatch/tests/nopolars/test_polars_absent.py
+++ b/packages/python/goldenmatch/tests/nopolars/test_polars_absent.py
@@ -148,6 +148,58 @@ def test_blocking_risk_arrow_is_polars_free() -> None:
     assert "polars" not in sys.modules
 
 
+def test_prepared_record_store_arrow_is_polars_free(tmp_path) -> None:
+    """The distributed prepared-record store (``distributed/record_store.py``)
+    round-trips a ``pa.Table`` with polars absent: ``materialize_prepared_records``
+    -> ``load_prepared_records`` returns a ``pa.Table``, and
+    ``materialize_bucketed_blocks`` -> ``iter_buckets``/``load_bucket`` stays arrow
+    end-to-end. record_store imports no polars (the distributed machinery is
+    arrow-native), and the bucket assignment co-locates same-block_key rows via
+    the shared ``core.frame`` ``with_bucket_column`` seam."""
+    pytest.importorskip("duckdb")
+    import pyarrow as pa
+    from goldenmatch.distributed.record_store import (
+        PreparedRecordStore,
+        iter_buckets,
+        load_bucket,
+        load_prepared_records,
+        materialize_bucketed_blocks,
+        materialize_prepared_records,
+    )
+
+    tbl = pa.table({"__row_id__": [0, 1, 2, 3], "name": ["a", "b", "c", "d"]})
+    with PreparedRecordStore(base_dir=str(tmp_path)) as store:
+        materialize_prepared_records(store, tbl, signature="sig")
+        loaded = load_prepared_records(store, signature="sig")
+        assert isinstance(loaded, pa.Table)
+        assert loaded.num_rows == 4
+
+        assignments = pa.table({
+            "__row_id__": [0, 1, 2, 3],
+            "__block_key__": ["k0", "k0", "k1", "k1"],
+        })
+        bucket_dir = materialize_bucketed_blocks(
+            store, tbl, block_assignments=assignments, n_buckets=4, signature="sig",
+        )
+        by_key: dict[str, set[int]] = {}
+        total = 0
+        for _bid, path in iter_buckets(bucket_dir):
+            bt = load_bucket(path)
+            assert isinstance(bt, pa.Table)
+            total += bt.num_rows
+            for rid, bk in zip(
+                bt.column("__row_id__").to_pylist(),
+                bt.column("__block_key__").to_pylist(),
+            ):
+                by_key.setdefault(bk, set()).add(rid)
+        assert total == 4
+        # co-location invariant: same block_key -> same bucket file.
+        assert by_key["k0"] == {0, 1}
+        assert by_key["k1"] == {2, 3}
+
+    assert "polars" not in sys.modules
+
+
 def test_guarded_matchkey_arrow_is_polars_free() -> None:
     """A guarded matchkey runs on a ``pa.Table`` polars-free. The pipeline's
     raw-value capture (for the guard's ``a_``/``b_`` predicate) reads through the

--- a/packages/python/goldenmatch/tests/test_bucketed_store.py
+++ b/packages/python/goldenmatch/tests/test_bucketed_store.py
@@ -52,9 +52,9 @@ def test_load_bucket_roundtrip(tmp_path: Path):
     p.parent.mkdir(parents=True)
     df = pl.DataFrame({"__row_id__": [0, 1], "__block_key__": ["k0", "k0"]})
     df.write_parquet(p)
-    loaded = load_bucket(p)
-    assert loaded.shape == df.shape
-    assert set(loaded.columns) == set(df.columns)
+    loaded = load_bucket(p)  # arrow-native: pa.Table
+    assert (loaded.num_rows, loaded.num_columns) == df.shape
+    assert set(loaded.column_names) == set(df.columns)
 
 
 def test_iter_buckets_yields_sorted(tmp_path: Path):
@@ -98,8 +98,8 @@ def test_hash_is_deterministic_across_calls(tmp_path: Path):
     def bucket_for_key(store_path, key):
         # Find which bucket file contains rows with this block_key.
         for bid, path in iter_buckets(store_path.parent / f"buckets_{_sanitize_signature('sig-v1')}"):
-            bucket_df = load_bucket(path)
-            if key in bucket_df["__block_key__"].to_list():
+            bucket_tbl = load_bucket(path)  # arrow-native: pa.Table
+            if key in bucket_tbl.column("__block_key__").to_pylist():
                 return bid
         raise AssertionError(f"key {key!r} not found in any bucket")
 
@@ -121,6 +121,38 @@ def test_hash_is_deterministic_across_calls(tmp_path: Path):
         b_second = {f"k{i}": bucket_for_key(s2.path, f"k{i}") for i in range(10)}
 
     assert b_first == b_second
+
+
+def test_materialize_bucketed_blocks_arrow_input(tmp_path: Path):
+    """Arrow lane: a ``pa.Table`` df + ``pa.Table`` assignments round-trip through
+    the bucketed store WITHOUT polars. Same ``__block_key__`` co-locates (the
+    invariant that matters -- exact bucket numbers are shard-internal and the
+    arrow lane's dictionary-code hash differs from polars' xxhash), all rows are
+    preserved, and ``load_bucket`` returns a ``pa.Table``."""
+    import pyarrow as pa
+
+    tbl = pa.table({"__row_id__": list(range(6)), "name": [f"n{i}" for i in range(6)]})
+    assignments = pa.table({
+        "__row_id__": list(range(6)),
+        "__block_key__": ["k0", "k0", "k1", "k1", "k2", "k2"],
+    })
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        bucket_dir = materialize_bucketed_blocks(
+            store, tbl, block_assignments=assignments, n_buckets=8, signature="sig-arrow",
+        )
+        by_key: dict[str, set[int]] = {}
+        total = 0
+        for _bid, path in iter_buckets(bucket_dir):
+            bt = load_bucket(path)
+            assert isinstance(bt, pa.Table)  # arrow-native return, not polars
+            total += bt.num_rows
+            for rid, bk in zip(
+                bt.column("__row_id__").to_pylist(),
+                bt.column("__block_key__").to_pylist(),
+            ):
+                by_key.setdefault(bk, set()).add(rid)
+    assert total == 6
+    assert by_key == {"k0": {0, 1}, "k1": {2, 3}, "k2": {4, 5}}
 
 
 def test_n_buckets_bounds_validated():
@@ -169,7 +201,7 @@ def test_hash_distribution_skew_bounded(tmp_path: Path):
         )
         sizes = []
         for _, path in iter_buckets(bucket_dir):
-            sizes.append(load_bucket(path).height)
+            sizes.append(load_bucket(path).num_rows)  # arrow-native: pa.Table
     assert min(sizes) > 0
     assert max(sizes) / min(sizes) <= 3.0
 

--- a/packages/python/goldenmatch/tests/test_prepared_record_store.py
+++ b/packages/python/goldenmatch/tests/test_prepared_record_store.py
@@ -48,6 +48,9 @@ def test_materialize_and_load_roundtrips_dataframe(tmp_path: Path):
         signature = "sig-v1"
         materialize_prepared_records(store, df, signature=signature)
         loaded = load_prepared_records(store, signature=signature)
+        # record_store is arrow-native (returns a pa.Table); polars is the
+        # test's comparison oracle here.
+        loaded = pl.from_arrow(loaded)
         # Order may differ post-DuckDB; compare as sets of row tuples.
         assert set(loaded.iter_rows()) == set(df.iter_rows())
         assert set(loaded.columns) == set(df.columns)
@@ -76,8 +79,9 @@ def test_signature_isolates_entries(tmp_path: Path):
         loaded_b = load_prepared_records(store, signature="sig-b")
         assert loaded_a is not None
         assert loaded_b is not None
-        assert set(loaded_a.columns) == {"__row_id__", "name", "email", "__mk_email_lower__"}
-        assert set(loaded_b.columns) == {"__row_id__", "x"}
+        # arrow-native return: column names live on .column_names.
+        assert set(loaded_a.column_names) == {"__row_id__", "name", "email", "__mk_email_lower__"}
+        assert set(loaded_b.column_names) == {"__row_id__", "x"}
     finally:
         store.close()
 
@@ -111,7 +115,7 @@ def test_close_preserves_file_when_cleanup_false(tmp_path: Path):
     try:
         loaded = load_prepared_records(store2, signature="sig-v1")
         assert loaded is not None
-        assert loaded.height == 4
+        assert loaded.num_rows == 4
     finally:
         store2.close()
 
@@ -136,7 +140,7 @@ def test_read_only_false_allows_write(tmp_path: Path):
         materialize_prepared_records(store, _sample_df(), signature="sig-ro")
         loaded = load_prepared_records(store, signature="sig-ro")
         assert loaded is not None
-        assert loaded.height == 4
+        assert loaded.num_rows == 4
     finally:
         store.close()
 
@@ -170,6 +174,6 @@ def test_read_only_true_allows_read(tmp_path: Path):
     try:
         loaded = load_prepared_records(store, signature="sig-ro-read")
         assert loaded is not None
-        assert set(loaded.iter_rows()) == set(_sample_df().iter_rows())
+        assert set(pl.from_arrow(loaded).iter_rows()) == set(_sample_df().iter_rows())
     finally:
         store.close()


### PR DESCRIPTION
## What and why

Continues the polars-eviction migration into the distributed machinery: `goldenmatch/distributed/record_store.py` (the DuckDB-backed prepared-record + hash-bucketed block store) no longer imports polars at all. It becomes lane-agnostic on input (pa.Table OR pl.DataFrame) and arrow-native on output, so the distributed store path runs with polars uninstalled. Byte-identical bucket layout on the polars lane.

## Changes

- **`distributed/record_store.py` is polars-free** (drops the `_polars_lazy` import):
  - `materialize_prepared_records` / `materialize_bucketed_blocks` accept a `pa.Table` OR `pl.DataFrame` via the `core.frame` seam (`to_frame(df).to_arrow()`); every intermediate stays on `df`'s backend.
  - `load_prepared_records` / `load_bucket` now return a `pa.Table` (were `pl.DataFrame`).
  - Bucket assignment now uses the canonical `Frame.with_bucket_column` seam -- the SAME op `backends.score_buckets` uses with `BUCKET_HASH_SEED` -- instead of a hand-rolled `pl.col().hash(seed) % n`. Polars lane is byte-identical to the old expr; the arrow lane gets the seam's dictionary-code twin. Cross-surface seed consistency is unchanged (still pinned by `test_cross_surface_consistency`). The co-location invariant (same `__block_key__` -> same bucket) holds on both lanes.
  - `load_bucket` reads the single file via `pyarrow.parquet.ParquetFile(...).read()` so the enclosing `bucket=<id>` directory is not inferred as a Hive partition column (a dataset-style read injects a spurious `bucket` column that `pl.read_parquet` never produced).
- **Consumers updated for the arrow return type:**
  - `backends/ray_backend.py` partitions the bucket table via the `core.frame` seam (`group_partitions`) instead of `pl.partition_by`.
  - `core/pipeline.py`'s legacy prepared-record-store prep-cache branch coerces the arrow result to polars locally. That branch is still polars-lazy; migrating it onto the arrow lane is the remaining prep-cache eviction step (called out in a code comment).

## Testing

Run against the workspace venv (`uv sync --package goldenmatch`, polars present as the dev/test oracle):

- `pytest tests/test_bucketed_store.py tests/test_prepared_record_store.py tests/test_prepared_record_store_controller.py tests/test_prepared_record_store_pipeline.py tests/test_cross_surface_consistency.py` -> green (polars lane byte-identical).
- Broad sweep `tests/test_distributed_scoring.py tests/test_distributed_pipeline*.py tests/test_bucket_*.py tests/test_score_buckets_arrow.py tests/test_partitioned_block_scoring_pipeline.py` -> green (the only failures were a pre-existing local `xfail(strict)` XPASS in `test_bucket_null_block_key.py`, unrelated: reproduces identically with these changes stashed).
- New `test_bucketed_store.py::test_materialize_bucketed_blocks_arrow_input` (arrow-input round-trip + co-location).
- New `tests/nopolars/test_polars_absent.py::test_prepared_record_store_arrow_is_polars_free` -- the durable guard for the `goldenmatch_nopolars` CI lane. Verified locally by hard-blocking the `polars` import: full materialize -> load -> bucket -> iter/load round-trip completes with polars absent, co-location holds, `polars` never enters `sys.modules`.
- `ruff check` clean on all changed files.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ran `ruff check` on changed files; full pre-commit not run in this env)
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal return-type change on an opt-in store; no public-API behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (no workflow/gotcha change; distributed store is now arrow-native)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1VZjzNuoMPhHbN3HuiGuA)_