### PR TITLE
refit: close the loop from persisted verdicts (labels_from_corrections)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4204,13 +4204,17 @@
             "RefitNotApplicableError",
             "RefitResult",
             "_find_probabilistic_matchkey",
+            "labels_from_corrections",
             "labels_from_verdicts",
+            "refit_from_corrections",
             "refit_from_labels",
+            "refit_from_memory",
             "refit_from_verdicts"
           ],
           "imports": [
             "goldenmatch.config.schemas",
             "goldenmatch.core.blocker",
+            "goldenmatch.core.memory.store",
             "goldenmatch.core.probabilistic"
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/core/refit.py
+++ b/packages/python/goldenmatch/goldenmatch/core/refit.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from goldenmatch.config.schemas import GoldenMatchConfig, MatchkeyConfig
+    from goldenmatch.core.memory.store import Correction, MemoryStore
     from goldenmatch.core.probabilistic import EMResult
 
 # A verdict from the adjudicator: (id_a, id_b, is_match, confidence).
@@ -101,6 +102,84 @@ def labels_from_verdicts(
             seen.add(pair)
             labels.append(pair)
     return labels
+
+
+def labels_from_corrections(
+    corrections: Iterable[Correction],
+    *,
+    sources: Iterable[str] | None = None,
+) -> list[tuple[int, int]]:
+    """Extract confident-match labels from persisted ``Correction`` verdicts.
+
+    The LLM boost, the review-queue steward loop, and the boost tab all persist
+    their per-pair verdicts to a ``MemoryStore`` as ``approve``/``reject``
+    ``Correction`` rows. This turns the ``approve`` ones into labels — the honest
+    bridge from the real adjudication stream to the refit.
+
+    Only pair-level ``approve`` decisions are kept: ``reject`` is dropped (u stays
+    from random pairs), and ``field_correct`` / ``cluster_decision`` rows (whose
+    ``id_a``/``id_b`` mean cluster-id / unused, not a pair) are excluded by the
+    ``approve`` filter. Pairs are canonicalized ``(min, max)`` and deduped.
+
+    Args:
+        corrections: the persisted verdicts (e.g. ``store.get_corrections(dataset)``).
+        sources: if given, keep only corrections whose ``source`` is in this set
+            (e.g. ``{"llm"}`` to trust only the model's verdicts). None = all sources.
+    """
+    from goldenmatch.core.memory.store import Decision
+
+    allow = set(sources) if sources is not None else None
+    seen: set[tuple[int, int]] = set()
+    labels: list[tuple[int, int]] = []
+    for c in corrections:
+        if c.decision != Decision.APPROVE or c.id_a == c.id_b:
+            continue
+        if allow is not None and c.source not in allow:
+            continue
+        pair = (min(c.id_a, c.id_b), max(c.id_a, c.id_b))
+        if pair not in seen:
+            seen.add(pair)
+            labels.append(pair)
+    return labels
+
+
+def refit_from_corrections(
+    df,
+    config: GoldenMatchConfig,
+    corrections: Iterable[Correction],
+    *,
+    sources: Iterable[str] | None = None,
+    matchkey: MatchkeyConfig | None = None,
+) -> RefitResult:
+    """Refit the FS model from persisted ``Correction`` verdicts (suggest mode).
+
+    Equivalent to :func:`labels_from_corrections` followed by
+    :func:`refit_from_labels`. The ``(id_a, id_b)`` in the corrections must
+    reference ``df``'s ``__row_id__`` (true for a same-frame in-run refit; across
+    runs, re-anchor the corrections to the current frame first).
+    """
+    labels = labels_from_corrections(corrections, sources=sources)
+    return refit_from_labels(df, config, labels, matchkey=matchkey)
+
+
+def refit_from_memory(
+    df,
+    config: GoldenMatchConfig,
+    store: MemoryStore,
+    *,
+    dataset: str | None = None,
+    sources: Iterable[str] | None = None,
+    matchkey: MatchkeyConfig | None = None,
+) -> RefitResult:
+    """Refit the FS model from a ``MemoryStore``'s verdicts (suggest mode).
+
+    Reads ``store.get_corrections(dataset)`` and refits. The closed loop from the
+    persisted adjudication stream, end to end: the boost / review / LLM tier writes
+    ``approve``/``reject`` corrections during a run; this reads them back and
+    produces a refined, suggested config.
+    """
+    corrections = store.get_corrections(dataset)
+    return refit_from_corrections(df, config, corrections, sources=sources, matchkey=matchkey)
 
 
 def _find_probabilistic_matchkey(config: GoldenMatchConfig) -> MatchkeyConfig:

--- a/packages/python/goldenmatch/tests/test_refit.py
+++ b/packages/python/goldenmatch/tests/test_refit.py
@@ -73,6 +73,48 @@ class TestLabelsFromVerdicts:
         assert R.labels_from_verdicts(verdicts, confidence_threshold=0.95) == [(0, 1)]
 
 
+def _correction(id_a, id_b, decision, source="llm"):
+    from goldenmatch.core.memory.store import Correction
+    return Correction(
+        id=f"{id_a}-{id_b}-{decision}", id_a=id_a, id_b=id_b, decision=decision,
+        source=source, trust=0.5, field_hash="", record_hash="", original_score=0.8,
+    )
+
+
+class TestLabelsFromCorrections:
+    def test_keeps_approve_pairs_only(self):
+        corrections = [
+            _correction(0, 1, "approve"),          # -> label
+            _correction(2, 3, "reject"),           # dropped (u is from random pairs)
+            _correction(9, 0, "field_correct"),    # dropped (id_a is a cluster_id, not a pair)
+            _correction(4, 4, "approve"),          # dropped (degenerate self-pair)
+        ]
+        assert R.labels_from_corrections(corrections) == [(0, 1)]
+
+    def test_canonicalizes_and_dedupes(self):
+        corrections = [_correction(1, 0, "approve"), _correction(0, 1, "approve")]
+        assert R.labels_from_corrections(corrections) == [(0, 1)]
+
+    def test_source_filter(self):
+        corrections = [
+            _correction(0, 1, "approve", source="llm"),
+            _correction(2, 3, "approve", source="boost"),
+        ]
+        assert R.labels_from_corrections(corrections, sources={"llm"}) == [(0, 1)]
+
+    def test_refit_from_memory_reads_store(self, tmp_path):
+        from goldenmatch.core.memory.store import MemoryStore
+        store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+        for a, b in [(0, 1), (2, 3), (4, 5)]:
+            store.add_correction(_correction(a, b, "approve"))
+        store.add_correction(_correction(0, 2, "reject"))  # ignored by the refit
+
+        result = R.refit_from_memory(_supervised_df(), _config(), store)
+        assert result.n_labels == 3
+        assert result.matchkey_name == "fs"
+        assert result.em_result.iterations == 0
+
+
 class TestRefitFromLabels:
     def test_returns_refined_em_and_thresholds(self):
         df, config = _supervised_df(), _config()


### PR DESCRIPTION
## What and why

Follow-up to the merged local-model integration (#2260). It bridges the closed-loop refit (`core/refit.py`) to the **real adjudication stream**: the LLM boost, the review-queue steward loop, and the boost tab all persist their per-pair verdicts to a `MemoryStore` as `approve`/`reject` `Correction` rows. This turns the `approve` ones into confident-match labels for `estimate_m_from_labels`, so the refit consumes actual run verdicts rather than a hand-supplied label list.

Part of D2 P3 (the closed loop "from persisted verdicts") from `docs/superpowers/specs/2026-07-29-local-model-integration-design.md`.

## Changes

- `core/refit.py`:
  - `labels_from_corrections(corrections, *, sources=None)` — `approve`-only, pair-level (`field_correct`/`cluster_decision` rows are excluded by the `approve` filter since their `id_a`/`id_b` mean cluster-id/unused), canonicalized `(min, max)` + deduped. Optional `sources` filter (e.g. `{"llm"}` to trust only the model's verdicts).
  - `refit_from_corrections` — `labels_from_corrections` → `refit_from_labels`.
  - `refit_from_memory(df, config, store, *, dataset=None, ...)` — reads `store.get_corrections(dataset)` and refits: persisted verdicts → refined suggested config, end to end.

Suggest-mode, additive, no pipeline surgery — reuses `estimate_m_from_labels` verbatim (no second refit owner).

## Testing

`uv run python -m pytest packages/python/goldenmatch/tests/test_refit.py` — 13 passed (9 prior + 4 new), ruff clean. The new tests cover the `approve`-only filter, canonicalize/dedup, the `sources` filter, and a real SQLite-backed `MemoryStore` round-trip (`reject` rows are correctly ignored). No model / network needed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` — deferred (additive library surface, off any run path)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / spec already cover this (D2 P3)

## Follow-ups (not in this PR)

- Wire `auto_refit=True` into `dedupe_df` to apply the refit in-run (this bridge is the label source it will use).
- Multiprocessing throughput for the local provider (D3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z)_