### PR TITLE
fix(qis-gate): skip pair-explosion rungs non-gating (unblock chronic bench-quality-scale red)

### DIFF
--- a/scripts/qis_gate.py
+++ b/scripts/qis_gate.py
@@ -72,6 +72,20 @@ DEFAULT_DELTA_TOL = 0.02  # a rung may sit at most this far below its committed 
 DEFAULT_ABS_FLOOR = 0.80  # hard minimum pairwise F1 for zero-config at any gated scale
 METRIC = "pairwise"       # headline metric; b_cubed/cluster are recorded for context
 
+# A committed config whose ESTIMATED candidate-pair count exceeds this is
+# UNMEASURABLE-by-explosion: scoring it would run far longer than any CI window.
+# The corrupted-realistic shape commits a fuzzy-name-only RED config whose pairs
+# grow n^2 (~1.9B at 500K -- ~9 min -- vs ~7.7B at 1M, which outlives the runner),
+# so the 1M rung never finishes and the nightly reds for a RUNNER-preemption, not
+# a quality regression: smaller rungs measure the SAME config at high F1. Such a
+# rung is skipped proactively and flagged NON-GATING (the #1934 gym-gate
+# `skipped_degenerate_ceiling` precedent + the #1933 "measure, don't auto-fail on a
+# refusal" contract), while a rung unmeasurable for any OTHER reason (an actual
+# force-run error) stays a hard violation. Chosen above 500K's ~1.9B (kept
+# measurable) and below 1M's ~7.7B; ~3B is ~15 min of scoring, well under the
+# ~40-min runner-reclaim window this shape was hitting.
+MEASURE_MAX_PAIRS = 3_000_000_000
+
 
 @dataclass
 class Violation:
@@ -89,10 +103,25 @@ class Violation:
 
 
 @dataclass
+class Skip:
+    """A rung that could not be measured for a KNOWN-benign reason (currently a
+    pair-explosion on a degenerate committed config). Advisory / non-gating --
+    surfaced in the summary + logs, but NOT a violation. Mirrors the #1934
+    gym-gate `skipped_degenerate_ceiling` sentinel."""
+    rung: int
+    reason: str
+    detail: str
+
+    def line(self) -> str:
+        return f"[skipped:{self.reason}] n={self.rung}: {self.detail}"
+
+
+@dataclass
 class GateResult:
     rung_f1: dict[int, float]
     reference_n: int
     violations: list[Violation] = field(default_factory=list)
+    skipped: list[Skip] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -104,6 +133,7 @@ def evaluate_gate(
     baseline: Optional[dict[str, float]],
     *,
     rung_refused: Optional[dict[int, bool]] = None,
+    rung_unmeasurable_reason: Optional[dict[int, Optional[str]]] = None,
     scale_tol: float = DEFAULT_SCALE_TOL,
     delta_tol: float = DEFAULT_DELTA_TOL,
     abs_floor: float = DEFAULT_ABS_FLOOR,
@@ -137,6 +167,7 @@ def evaluate_gate(
     if not rung_f1:
         raise ValueError("evaluate_gate: no rung measurements supplied")
     refused = rung_refused or {}
+    unmeasurable_reason = rung_unmeasurable_reason or {}
 
     reference_n = min(rung_f1)
     reference_f1 = rung_f1[reference_n]
@@ -155,8 +186,24 @@ def evaluate_gate(
         # explosion). A refused rung whose F1 WAS recovered does NOT land here --
         # it flows through the floor/scale checks below, RED being context only.
         if f1 is None:
+            reason = unmeasurable_reason.get(n)
             qualifier = "REFUSED (RED config) and F1 could not be measured" if was_refused \
                 else "F1 could not be measured"
+            # A pair-explosion unmeasurable rung ABOVE a measured reference is a
+            # KNOWN degenerate-config COST, not a regression (the same config
+            # measures at high F1 on the smaller rungs) -- skip it, non-gating, the
+            # #1934 precedent. At the reference scale there is no smaller rung to
+            # establish that, so even a pair-explosion there is a hard flag. Any
+            # OTHER unmeasurable reason (a real force-run error) stays a violation.
+            if reason == "pair_explosion" and n != reference_n and not reference_unmeasured:
+                res.skipped.append(
+                    Skip(n, "pair_explosion",
+                         f"zero-config committed a degenerate RED config whose estimated "
+                         f"candidate pairs exceed the {MEASURE_MAX_PAIRS/1e6:.0f}M measure "
+                         f"ceiling; F1 measured fine at the n={reference_n} reference "
+                         f"(f1={reference_f1:.4f}) -- non-gating (cost, not a regression)")
+                )
+                continue
             if n == reference_n:
                 res.violations.append(
                     Violation(n, "scale_invariance", 0.0, abs_floor,
@@ -207,6 +254,38 @@ def evaluate_gate(
 # --------------------------------------------------------------------------- IO
 
 
+def _estimate_candidate_pairs(cfg, df) -> float:
+    """Estimate a committed config's candidate-pair count on ``df``, mirroring the
+    ``config_lint`` ``blocking.pair_explosion`` rule EXACTLY: per blocking key/pass,
+    the most-selective field bounds the block size, so pairs ~= n^2 / (2 * n_distinct),
+    summed across keys (a union adds pairs). Best-effort -- any failure returns 0.0
+    (measure as before; the guard never makes a measurable rung skip). Reuses the
+    lint rule's own ``_blocking_keys`` extractor so the estimate can't drift from the
+    warning the pipeline already prints."""
+    try:
+        from goldenmatch.core.config_lint.rules import _blocking_keys
+        keys = _blocking_keys(cfg)
+        n = df.height if hasattr(df, "height") else len(df)
+        if not keys or n <= 1:
+            return 0.0
+        est = 0.0
+        for key in keys:
+            ratios = []
+            for c in key:
+                cols = getattr(df, "columns", [])
+                if c in cols:
+                    nd = int(df[c].n_unique())
+                    if nd > 0:
+                        ratios.append(nd / n)
+            if not ratios:
+                continue
+            n_distinct = max(1.0, max(ratios) * n)
+            est += (n * n) / (2.0 * n_distinct)
+        return est
+    except Exception:  # noqa: BLE001 -- best-effort guard; fall back to measuring
+        return 0.0
+
+
 def load_baseline(path: Path) -> Optional[dict]:
     if not path.exists():
         return None
@@ -254,10 +333,15 @@ def measure_rungs(rungs: list[int], *, seed: int, shape: str, corruption: str) -
                 predicted[int(cid)] = list(members)
         return qis.score_quality(predicted, gt)
 
-    def _measure_red(df) -> Optional[dict]:
+    def _measure_red(df) -> tuple[Optional[dict], Optional[str]]:
         """Score the committed RED config via the allow_red_config force-run.
-        Returns the metrics dict, or None if the config could not be measured
-        (force-run errored / OOM-risk) -- an honest UNMEASURABLE, not a 0.0."""
+        Returns ``(metrics, None)`` when measured, ``(None, "pair_explosion")`` when
+        the committed config's ESTIMATED candidate pairs exceed ``MEASURE_MAX_PAIRS``
+        (skip the infeasible force-run BEFORE it grinds for 30+ min and the runner is
+        reclaimed -- the chronic-nightly-red root cause), or ``(None, "error")`` on a
+        genuine force-run failure. An UNMEASURABLE rung is an honest None, never a
+        fabricated 0.0; the reason decides gating (``pair_explosion`` is non-gating,
+        ``error`` still flags)."""
         try:
             cfg = goldenmatch.auto_configure_df(
                 df, confidence_required=False, allow_red_config=True, _skip_finalize=True)
@@ -266,11 +350,18 @@ def measure_rungs(rungs: list[int], *, seed: int, shape: str, corruption: str) -
                     mk.rerank = False
                 if getattr(mk, "type", None) == "exact" and getattr(mk, "negative_evidence", None):
                     mk.negative_evidence = []
-            return _score(goldenmatch.dedupe_df(df, config=cfg))
+            est = _estimate_candidate_pairs(cfg, df)
+            if est > MEASURE_MAX_PAIRS:
+                print(f"[qis-gate] n={n}: committed config estimated ~{est/1e6:.0f}M candidate "
+                      f"pairs (> {MEASURE_MAX_PAIRS/1e6:.0f}M) -- UNMEASURABLE (pair explosion), "
+                      f"skipping the force-run (non-gating: degenerate cost, not a regression)",
+                      file=sys.stderr, flush=True)
+                return None, "pair_explosion"
+            return _score(goldenmatch.dedupe_df(df, config=cfg)), None
         except Exception as exc:  # noqa: BLE001  -- OOM/degenerate config: report, don't crash
             print(f"[qis-gate] n={n}: RED force-run unmeasurable ({type(exc).__name__}: "
                   f"{str(exc)[:120]})", file=sys.stderr, flush=True)
-            return None
+            return None, "error"
 
     _NONE = {"f1": None, "p": None, "r": None}
     out: dict[int, dict] = {}
@@ -281,12 +372,14 @@ def measure_rungs(rungs: list[int], *, seed: int, shape: str, corruption: str) -
         except ControllerNotConfidentError:
             # RED config on a >=100K input. Measure the committed config's actual
             # F1 (allow_red_config) rather than treating the refusal as a failure.
-            rec = _measure_red(df)
+            rec, reason = _measure_red(df)
             if rec is None:
                 out[n] = {"refused": True, "pairwise": dict(_NONE),
-                          "b_cubed": dict(_NONE), "cluster": dict(_NONE)}
+                          "b_cubed": dict(_NONE), "cluster": dict(_NONE),
+                          "unmeasurable_reason": reason}
             else:
                 rec["refused"] = True
+                rec["unmeasurable_reason"] = None
                 out[n] = rec
             continue
         predicted: dict[int, list[int]] = {}
@@ -296,6 +389,7 @@ def measure_rungs(rungs: list[int], *, seed: int, shape: str, corruption: str) -
                 predicted[int(cid)] = list(members)
         rec = qis.score_quality(predicted, gt)
         rec["refused"] = False
+        rec["unmeasurable_reason"] = None
         out[n] = rec
     return out
 
@@ -349,17 +443,24 @@ def write_step_summary(result: GateResult, records: dict[int, dict]) -> None:
 
     for n in sorted(records):
         r = records[n]
+        reason = r.get("unmeasurable_reason")
         if not r.get("refused"):
             verdict = "🟢 confident"
         elif r["pairwise"]["f1"] is not None:
             verdict = "🟡 RED (refused) — F1 measured via allow_red_config"
+        elif reason == "pair_explosion":
+            verdict = "⚪ RED (refused) — F1 unmeasurable (pair explosion, non-gating)"
         else:
             verdict = "🔴 RED (refused) — F1 unmeasurable"
         lines.append(f"| {n:,} | {_f(r['pairwise']['f1'])} | "
                      f"{_f(r['b_cubed']['f1'])} | {_f(r['cluster']['f1'])} | {verdict} |")
     lines.append("")
+    if result.skipped:
+        lines.append(f"⚪ **{len(result.skipped)} rung(s) skipped (non-gating):**")
+        for s in result.skipped:
+            lines.append(f"- {s.line()}")
     if result.ok:
-        lines.append(f"🟢 all rungs within tolerance (reference n={result.reference_n:,}).")
+        lines.append(f"🟢 all measurable rungs within tolerance (reference n={result.reference_n:,}).")
     else:
         lines.append(f"🔴 **{len(result.violations)} violation(s):**")
         for v in result.violations:
@@ -391,9 +492,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     records = measure_rungs(rungs, seed=args.seed, shape=args.shape, corruption=args.corruption)
     rung_f1 = {n: records[n][METRIC]["f1"] for n in records}
     rung_refused = {n: bool(records[n].get("refused")) for n in records}
+    rung_reason = {n: records[n].get("unmeasurable_reason") for n in records}
     for n in sorted(rung_f1):
-        f1, refused = rung_f1[n], rung_refused[n]
-        shown = "REFUSED (RED)" if refused else f"{METRIC}_f1={f1:.4f}"
+        f1, refused, reason = rung_f1[n], rung_refused[n], rung_reason[n]
+        if f1 is None:
+            shown = f"UNMEASURABLE ({reason or 'unknown'})"
+        elif refused:
+            shown = f"REFUSED (RED) {METRIC}_f1={f1:.4f}"
+        else:
+            shown = f"{METRIC}_f1={f1:.4f}"
         print(f"  n={n:>9,}  {shown}")
 
     if args.out_json:
@@ -411,13 +518,20 @@ def main(argv: Optional[list[str]] = None) -> int:
     baseline = load_baseline(args.baseline)
     base_f1 = (baseline or {}).get("f1") if baseline else None
     result = evaluate_gate(rung_f1, base_f1, rung_refused=rung_refused,
+                           rung_unmeasurable_reason=rung_reason,
                            scale_tol=args.scale_tol, delta_tol=args.delta_tol,
                            abs_floor=args.abs_floor)
     write_step_summary(result, records)
 
+    for s in result.skipped:
+        print(f"::notice::qis-gate {s.line()}")
+
     if result.ok:
-        print(f"OK: all {len(rung_f1)} rungs within tolerance "
-              f"(reference n={result.reference_n:,}, f1={rung_f1[result.reference_n]:.4f})")
+        ref_f1 = rung_f1[result.reference_n]
+        ref_shown = f"f1={ref_f1:.4f}" if ref_f1 is not None else "UNMEASURABLE"
+        skip_note = f" ({len(result.skipped)} rung(s) skipped, non-gating)" if result.skipped else ""
+        print(f"OK: all measurable rungs within tolerance{skip_note} "
+              f"(reference n={result.reference_n:,}, {ref_shown})")
         return 0
     print(f"::error::qis-gate FAILED with {len(result.violations)} violation(s):", file=sys.stderr)
     for v in result.violations:

--- a/scripts/test_qis_gate.py
+++ b/scripts/test_qis_gate.py
@@ -137,6 +137,64 @@ def test_confident_rungs_still_scored_when_a_later_rung_unmeasurable():
     assert (100_000, "scale_invariance") in checks     # unmeasurable vs GREEN reference
 
 
+def test_pair_explosion_unmeasurable_rung_is_non_gating():
+    # THE #2021 fix: the 1M rung's committed RED config explodes to billions of
+    # candidate pairs (unmeasurable in any CI window), while 50K-500K measure the
+    # SAME config at high F1. A pair-explosion unmeasurable rung ABOVE a measured
+    # reference is a COST property, not a regression -> non-gating SKIP, not a
+    # violation (the #1934 gym-gate skipped_degenerate_ceiling precedent).
+    rung_f1 = {50_000: 0.998, 100_000: 0.99, 500_000: 0.985, 1_000_000: None}
+    refused = {50_000: False, 100_000: True, 500_000: True, 1_000_000: True}
+    reasons = {50_000: None, 100_000: None, 500_000: None, 1_000_000: "pair_explosion"}
+    r = mod.evaluate_gate(rung_f1, None, rung_refused=refused,
+                          rung_unmeasurable_reason=reasons)
+    assert r.ok, [v.line() for v in r.violations]
+    assert {s.rung for s in r.skipped} == {1_000_000}
+    assert r.skipped[0].reason == "pair_explosion"
+    assert not any(v.rung == 1_000_000 for v in r.violations)
+
+
+def test_pair_explosion_at_reference_is_still_a_violation():
+    # No smaller rung to establish the config measures fine -> even a pair-explosion
+    # at the reference scale is a hard flag (can't wave through the ONLY evidence).
+    r = mod.evaluate_gate({1_000_000: None}, None,
+                          rung_refused={1_000_000: True},
+                          rung_unmeasurable_reason={1_000_000: "pair_explosion"})
+    checks = {(v.rung, v.check) for v in r.violations}
+    assert (1_000_000, "scale_invariance") in checks
+    assert not r.ok
+    assert not r.skipped
+
+
+def test_error_unmeasurable_still_gates_not_skipped():
+    # An unmeasurable rung whose reason is NOT pair_explosion (a genuine force-run
+    # ERROR) must STILL be a violation -- only the known-benign pair explosion is
+    # non-gating. Guards against the fix silently swallowing real breakage.
+    rung_f1 = {50_000: 0.99, 500_000: None}
+    reasons = {50_000: None, 500_000: "error"}
+    r = mod.evaluate_gate(rung_f1, None, rung_refused={50_000: False, 500_000: True},
+                          rung_unmeasurable_reason=reasons)
+    checks = {(v.rung, v.check) for v in r.violations}
+    assert (500_000, "scale_invariance") in checks
+    assert not r.ok
+    assert not r.skipped
+
+
+def test_pair_explosion_skip_does_not_mask_a_real_regression():
+    # A measured rung that craters is STILL caught even when a higher rung is a
+    # non-gating pair-explosion skip -- the skip only excuses the exploded rung.
+    rung_f1 = {50_000: 0.99, 100_000: 0.55, 500_000: None}
+    refused = {50_000: False, 100_000: False, 500_000: True}
+    reasons = {50_000: None, 100_000: None, 500_000: "pair_explosion"}
+    r = mod.evaluate_gate(rung_f1, None, rung_refused=refused,
+                          rung_unmeasurable_reason=reasons)
+    checks = {(v.rung, v.check) for v in r.violations}
+    assert (100_000, "absolute_floor") in checks       # 0.55 < 0.80 floor -> real fail
+    assert (100_000, "scale_invariance") in checks       # 0.55 << 0.99 reference
+    assert {s.rung for s in r.skipped} == {500_000}      # explosion still skipped
+    assert not r.ok                                       # the real regression fails the gate
+
+
 def test_empty_measurements_raises():
     try:
         mod.evaluate_gate({}, None)


### PR DESCRIPTION
## What and why

Fixes #2021. `bench-quality-scale` has failed **every nightly since ~2026-07-18** — ~12 consecutive runs. It's **not a quality regression, it's a runner preemption**.

The ci-tier measures zero-config F1 at 50K/100K/500K/1M on the corrupted-realistic shape. That shape commits a fuzzy-name-only **RED** config whose candidate pairs grow `n²`:

| rung | estimated candidate pairs | outcome |
|---|---|---|
| 500K | ~1.9B | measures in ~9 min |
| **1M** | **~7.7B** | force-run grinds **30+ min** → runner reclaimed at ~40 min → `runner has received a shutdown signal` |

`_measure_red` force-runs the committed RED config to measure its F1 (the #1933 "measure, don't auto-fail on a refusal" contract). At 1M that force-run is infeasible in any CI window, so the job dies mid-run. And even if it finished, `evaluate_gate` treated an unmeasurable non-reference rung as a **hard violation** — so it would fail regardless.

This is the documented false-positive class: **a known-degenerate config that's too costly to *measure* at scale is not an F1 regression** — the same config measures at high F1 on the smaller rungs. The fix mirrors the **#1934 gym-gate `skipped_degenerate_ceiling`** precedent.

## Changes (`scripts/qis_gate.py` + `scripts/test_qis_gate.py`)

- **Proactive skip:** `_measure_red` estimates the committed config's candidate pairs **before** the force-run (reusing config-lint's own `blocking.pair_explosion` formula + `_blocking_keys` extractor, so the estimate can't drift from the warning the pipeline already prints). If it exceeds `MEASURE_MAX_PAIRS` (3B — above 500K's ~1.9B, below 1M's ~7.7B), it skips the infeasible run and records the rung UNMEASURABLE with reason `pair_explosion` — a 30-min hang becomes an instant honest skip. Any other unmeasurable reason stays `error`.
- **Non-gating classification:** `evaluate_gate` treats a `pair_explosion` rung **above a measured reference** as a non-gating `Skip` (advisory — surfaced in the step summary + a `::notice::`), while a `pair_explosion` at the reference, or **any** `error` unmeasurable, stays a hard violation. A real F1 regression on a *measurable* rung is still caught — the skip only excuses the exploded rung.
- The estimator is best-effort (returns 0.0 on any failure → measures as before, never a spurious skip).

## Testing

- **17 pure-gate unit tests pass** (`scripts/test_qis_gate.py`, no goldenmatch needed), including 4 new: pair-explosion non-gating; pair-explosion-at-reference still fails; `error` still gates; a skip doesn't mask a real regression on a measurable rung.
- Estimator validated against config-lint's own formula (byte-exact) and its `n²` scaling: 20K→67M (measure), 200K→6.7B (skip), 1M→167B (skip); no-blocking-keys → 0.0 guard.
- End-to-end `measure_rungs([1500])` confirms the happy path threads `unmeasurable_reason=None` on measured rungs.

Note: scripts/ isn't ruff-gated in CI (`ci.yml` lints `packages/python/*` only); the code matches the file's existing `Optional[...]` style.

## Checklist

- [x] Tests added/updated and passing locally
- [x] No secrets or credentials committed
- [x] Root-cause fix (skip the infeasible measurement + honest non-gating classification), not a loosened assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_