### PR TITLE
ci: add publish workflows for the three unwired suite packages

### DIFF
--- a/.github/workflows/publish-goldengraph.yml
+++ b/.github/workflows/publish-goldengraph.yml
@@ -1,0 +1,38 @@
+name: Publish goldengraph to PyPI
+
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
+# goldengraph is a pure-Python package (hatchling); its compiled store ships
+# separately as goldengraph-native (see publish-goldengraph-native.yml) and its
+# runtime deps (goldenmatch, goldengraph-native) resolve from PyPI. It was the
+# one standalone suite package with no PyPI publisher wired -- this closes that
+# gap. goldengraph is EXCLUDED from the uv workspace, but `python -m build` runs
+# from its own pyproject standalone, so the reusable template works unchanged.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for goldengraph-v* tags (kept distinct from goldengraph-js-v* and
+    # goldengraph-native-v* so the publishers never cross-trigger).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldengraph-v')
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: goldengraph
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenmatch-wasm-runtime-js.yml
+++ b/.github/workflows/publish-goldenmatch-wasm-runtime-js.yml
@@ -1,0 +1,37 @@
+name: Publish goldenmatch-wasm-runtime to npm
+
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
+# goldenmatch-wasm-runtime is the shared WASM scorer-backend runtime the other TS
+# packages (goldenmatch, goldenanalysis, goldenflow, goldenpipe, infermap) consume
+# as a `workspace:^` devDependency and bundle into their own dist. It had no npm
+# publisher of its own; this closes that gap so the runtime is installable
+# standalone. It is a leaf package (no workspace deps, pure-TS tsup build), so
+# build_deps=false and no WASM build step is needed here.
+on:
+  push:
+    tags:
+      - "goldenmatch-wasm-runtime-js-v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Pack and validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldenmatch-wasm-runtime
+      build_deps: false
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenprofile-native.yml
+++ b/.github/workflows/publish-goldenprofile-native.yml
@@ -1,0 +1,142 @@
+name: Publish goldenprofile-native to PyPI
+
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI. goldenprofile-native is the optional Semantic-Signature
+# resolution engine; goldengraph gates on it (`import goldenprofile_native`) and
+# turns its anti-shatter matcher ON when the wheel is importable, else falls back.
+# Mirrors publish-infermap-native.yml / publish-goldenanalysis-native.yml exactly.
+#
+# Fires on a release tagged `goldenprofile-native-v*` (kept distinct from every
+# other Python/TS/native tag so the publishers never cross-trigger).
+# workflow_dispatch with a `ref` allows a manual/retro build; leave `publish`
+# unchecked for a build-matrix dry run.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      publish:
+        description: "Upload to PyPI (uncheck for a build-matrix dry run)"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
+  MANIFEST: packages/rust/extensions/goldenprofile-native/Cargo.toml
+
+jobs:
+  linux:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheels (maturin, abi3, manylinux)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: "2_28"
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: x64
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  macos:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
+    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile.
+    # macos-13 (Intel) runners queue indefinitely in this org, so we don't use them.
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          command: sdist
+          args: --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    needs: [linux, windows, macos, sdist]
+    # Release events always publish; a workflow_dispatch publishes only when the
+    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
+    if: github.event_name != 'workflow_dispatch' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          # Merge every wheels-* artifact into a single dist/ for upload.
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## What and why

A publish audit of the monorepo found the registry gaps between the repo and PyPI/npm. Most (18+) packages are in sync. The genuinely unpublished ones split into two kinds:

1. **Had a workflow, just never run / version bumped** — handled out-of-band via `workflow_dispatch` (not in this PR): `goldenmatch-duckdb 0.7.0` → PyPI (published), `infermap-native` → PyPI, `goldenprofile` → npm.
2. **Never published because there was no publish workflow at all** — this PR authors those three.

Each new workflow is a faithful mirror of an existing sibling, so it inherits the repo's established publish conventions (reusable `_publish-*.yml` templates, tag-prefix filter, `workflow_dispatch` with dry-run, pinned action SHAs).

## Changes

- **`publish-goldengraph.yml`** → PyPI, pure-Python. Mirrors `publish-goldenpipe.yml` (delegates to `_publish-pypi.yml`). `goldengraph` was the one standalone suite package with no PyPI publisher; it's `hatchling`-built and its runtime deps (`goldenmatch>=2.0`, `goldengraph-native>=0.1.0`) already resolve from PyPI. Tag prefix `goldengraph-v*`.
- **`publish-goldenprofile-native.yml`** → PyPI, maturin/abi3 cross-platform matrix. Mirrors `publish-infermap-native.yml`. `goldenprofile-native` is an **optional** accelerator with a real consumer: `goldengraph` gates its Semantic-Signature anti-shatter matcher on `import goldenprofile_native` (auto-on when the wheel is present, graceful fallback otherwise). Tag prefix `goldenprofile-native-v*`; `publish` toggle for a build-matrix dry run.
- **`publish-goldenmatch-wasm-runtime-js.yml`** → npm. Mirrors `publish-goldenprofile-js.yml` (delegates to `_publish-js.yml`). `goldenmatch-wasm-runtime` is the shared WASM scorer runtime the other TS packages consume as a `workspace:^` devDependency (they bundle it, so their installs don't break) — it simply had no standalone npm publisher. Leaf package, `build_deps: false`. Tag prefix `goldenmatch-wasm-runtime-js-v*`.

## How to publish after merge

Once on `main`, each is dispatchable: `Actions → <workflow> → Run workflow` (or push the tag). I'd dry-run the two first-time releases before the real upload.

## Not included (intentional)

- **`goldenmatch-kg`** stays unpublished by design — CLAUDE.md documents it as "NOT a roster/published-suite package (no `publish-goldenmatch-kg.yml`)" due to its heavy, conflicting framework extras.

## Testing

Workflow-only change. Each YAML was parse-validated locally; all three mirror already-working siblings byte-for-byte in structure (only `package` / `MANIFEST` / tag-prefix differ). They cannot run until merged to the default branch (GitHub `workflow_dispatch` requirement), so no dispatch is possible from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSJNG3TjJL38C71MRB8Str)_