### PR TITLE
feat(semantic): wedge B — resolve once, emit the conformed entity declaration for the semantic layer

### DIFF
--- a/context-network/decisions/0050-resolved-crosswalk-emit.md
+++ b/context-network/decisions/0050-resolved-crosswalk-emit.md
@@ -1,0 +1,55 @@
+# 0050 — Wedge B: resolve once, emit the conformed entity declaration
+
+**Status:** accepted (2026-07-30, Ben) • **Shipped:** `goldenmatch.semantic.build_resolved_crosswalk` + `emit_semantic_model` / `emit_metricflow_yaml` / `emit_from_crosswalk` • **Builds on:** [0049](0049-metric-aware-key-certification.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+Wedge A ([0049](0049-metric-aware-key-certification.md)) *certifies* the key a
+semantic model already declares. Wedge B is the other half of the planning doc:
+**produce the conformed key.** A semantic layer joins on entity-key equality but
+never resolves those keys; GoldenMatch does. B runs entity resolution once and
+hands back the resolved join key + the MetricFlow declaration that points every
+metric at it — "resolve once, every metric inherits correct joins."
+
+## Decision
+1. **The resolved key is the control plane's durable `entity_id` (UUIDv7), not a
+   run-local surrogate.** `build_resolved_crosswalk` runs the normal `dedupe_df`
+   pipeline with the identity graph enabled and reads the assigned ids back from
+   `source_records` by record id, returning a `{source, source_pk,
+   resolved_entity_id}` crosswalk. Reusing the identity graph is exactly "the
+   control plane owns stable IDs" (frame decision test) — inventing a
+   canonical-representative id would be a second identity scheme, which the
+   frame forbids. Pass `store_path` for ids durable across runs; omit for ephemeral.
+2. **Emit is the codegen inverse of A's reader.** `emit_semantic_model` /
+   `emit_metricflow_yaml` generate `semantic_models` YAML declaring the resolved
+   key as the PRIMARY entity and the original source key as a `unique` entity, so
+   `parse_semantic_models(emit_metricflow_yaml(...))` round-trips. House style:
+   `yaml.safe_dump(sort_keys=False, default_flow_style=False)`.
+3. **MetricFlow-first, library-only, advisory.** Same scope discipline as A: no
+   Cube/OSI emitter, no dbt/CLI/MCP surface, no key mutation in the warehouse — B
+   produces artifacts a user drops into their project. Parity-free (the module has
+   no MCP/CLI/A2A/TS entry; `semantic/` stays out of top-level `goldenmatch/__init__.py`
+   so `import goldenmatch` stays polars-free).
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — the resolved id comes from the Identity Control
+  Plane; B is a projection + codegen adapter, not a new id scheme.
+- **Compute vs control distinct** ✅ — resolution is the compute pipeline; the
+  durable ids + crosswalk are control-plane reads; the emitted YAML is metadata.
+- **Arrow at bulk boundaries** ✅ — the crosswalk is a pyarrow table; the YAML is
+  small metadata.
+- **Advanced, never black-box** ✅ — the crosswalk is inspectable; emit is a scaffold
+  the user reviews (measure aggregations are a stamped default, flagged as such).
+
+## Consequences / honest flags
+- **The crosswalk inherits ER behavior** — on tiny/degenerate frames zero-config ER
+  may not merge (documented toy-merge degeneracy); durability needs a stable
+  `store_path`. Ephemeral runs note their non-durability.
+- **Emitted measures carry a placeholder `agg`** (`sum`) — the entity/join
+  declaration is the deliverable; the user sets real per-measure aggregations.
+- **Follow-ons (not v1):** Cube/OSI emitters, a dbt materialization that builds the
+  crosswalk table in-warehouse (the existing `goldenmatch_dedupe` `clusters` shape
+  is run-local, not the durable entity crosswalk), a CLI/MCP front door, and wiring
+  the crosswalk emit into the `key.integrity` reporting surface.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-07-30

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -1,15 +1,19 @@
 # Semantic Layering (MetricFlow / Cube / OSI) — brainstorm / planning
 
-> **Status:** v1 (wedge A) SHIPPED — see decision
-> [../decisions/0049-metric-aware-key-certification.md](../decisions/0049-metric-aware-key-certification.md).
+> **Status:** wedges **A + B** SHIPPED — decisions
+> [0049](../decisions/0049-metric-aware-key-certification.md) (certify) +
+> [0050](../decisions/0050-resolved-crosswalk-emit.md) (resolve once + emit).
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**
-> (metric-aware key certification) is built: `goldenmatch.semantic.certify_key_integrity`
+> (metric-aware key certification): `goldenmatch.semantic.certify_key_integrity`
 > + a MetricFlow YAML reader + a `key.integrity` goldenanalysis analyzer + a
-> `goldenmatch_key_integrity` dbt test. **B** (emit the crosswalk) and **C** (OSI
-> provider) remain planned. Greenfield when written: no prior repo code, doc, or
-> decision referenced this ecosystem (grep, 2026-07-30).
+> `goldenmatch_key_integrity` dbt test. Problem **B** (emit the resolved crosswalk):
+> `build_resolved_crosswalk` (durable control-plane entity ids) +
+> `emit_semantic_model` / `emit_metricflow_yaml` (declare the conformed key as the
+> primary entity; round-trips through the A reader). **C** (OSI provider) remains
+> planned. Greenfield when written: no prior repo code, doc, or decision referenced
+> this ecosystem (grep, 2026-07-30).
 
 ## The premise
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 430,
+      "module_count": 431,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7045,8 +7045,25 @@
           "purpose": "Semantic-layer interoperability (the MetricFlow / Cube / OSI wedge).",
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.crosswalk",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.crosswalk",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py",
+          "purpose": "Resolve once, emit a durable entity crosswalk for the semantic layer (wedge B).",
+          "defines": [
+            "ResolvedCrosswalk",
+            "build_resolved_crosswalk"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.identity.store",
+            "goldenmatch.semantic.key_integrity"
           ]
         },
         {
@@ -7069,12 +7086,15 @@
         {
           "module": "goldenmatch.semantic.metricflow",
           "file": "packages/python/goldenmatch/goldenmatch/semantic/metricflow.py",
-          "purpose": "Read declared entity keys + measures from a dbt / MetricFlow semantic model.",
+          "purpose": "Read / emit dbt / MetricFlow semantic-model entity declarations.",
           "defines": [
             "DeclaredKeySpec",
             "_entity_column",
             "_load",
             "_measure_column",
+            "emit_from_crosswalk",
+            "emit_metricflow_yaml",
+            "emit_semantic_model",
             "parse_semantic_models"
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -17,12 +17,26 @@ so ``import goldenmatch`` stays lightweight and polars-free; import it explicitl
 from __future__ import annotations
 
 from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.crosswalk import ResolvedCrosswalk, build_resolved_crosswalk
 from goldenmatch.semantic.key_integrity import certify_key_integrity
-from goldenmatch.semantic.metricflow import DeclaredKeySpec, parse_semantic_models
+from goldenmatch.semantic.metricflow import (
+    DeclaredKeySpec,
+    emit_from_crosswalk,
+    emit_metricflow_yaml,
+    emit_semantic_model,
+    parse_semantic_models,
+)
 
 __all__ = [
+    # wedge A — certify a declared key
     "certify_key_integrity",
     "KeyIntegrityCertificate",
     "parse_semantic_models",
     "DeclaredKeySpec",
+    # wedge B — resolve once, emit the conformed entity declaration
+    "build_resolved_crosswalk",
+    "ResolvedCrosswalk",
+    "emit_semantic_model",
+    "emit_metricflow_yaml",
+    "emit_from_crosswalk",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
@@ -1,0 +1,143 @@
+"""Resolve once, emit a durable entity crosswalk for the semantic layer (wedge B).
+
+A semantic layer joins on entity-key equality but never resolves those keys.
+Wedge A *certifies* a declared key; wedge B *produces the conformed key*: run
+GoldenMatch entity resolution, then hand back a `{source, source_pk,
+resolved_entity_id}` crosswalk keyed on the control plane's **durable** stable
+`entity_id` (UUIDv7). Point the semantic layer's joins at `resolved_entity_id`
+and every metric inherits correct, conformed joins — "resolve once."
+
+The resolved key is the Identity Control Plane's stable id (owned there — this is
+not a second identity scheme). The builder runs the normal `dedupe_df` pipeline
+with the identity graph enabled and reads the assigned ids back from
+`source_records` by record id. Pass a `store_path` to make the ids durable across
+runs (the whole point of "resolve once"); omit it for an ephemeral run.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+import pyarrow as pa
+
+from goldenmatch.semantic.key_integrity import _to_arrow
+
+
+@dataclass
+class ResolvedCrosswalk:
+    """A `{source, source_pk, resolved_entity_id}` crosswalk over resolved identity.
+
+    `table` has one row per input record, in input order. `resolved_entity_id` is
+    the durable control-plane entity id; rows entity resolution could not place
+    (rare — e.g. a null source_pk) carry a null id and are counted in `unmapped`.
+    """
+
+    table: pa.Table
+    source: str
+    source_pk_column: str
+    resolved_key: str = "resolved_entity_id"
+    n_records: int = 0
+    n_entities: int = 0
+    unmapped: int = 0
+    store_path: str | None = None
+    note: str = ""
+
+    def to_arrow(self) -> pa.Table:
+        return self.table
+
+    @property
+    def reduction_ratio(self) -> float:
+        """1 - entities/records: how much the resolved key collapses the source
+        key space (0 = every source_pk is already its own entity)."""
+        if not self.n_records:
+            return 0.0
+        return 1.0 - (self.n_entities / self.n_records)
+
+
+def build_resolved_crosswalk(
+    df: Any,
+    *,
+    source_pk: str,
+    source_name: str = "dataframe",
+    dataset: str | None = None,
+    store_path: str | None = None,
+    config: Any = None,
+) -> ResolvedCrosswalk:
+    """Resolve `df` and return a durable `{source, source_pk, resolved_entity_id}` crosswalk.
+
+    Args:
+        df: the source table (pyarrow / polars / pandas / dict).
+        source_pk: the column holding each record's source primary key.
+        source_name: logical source name (the `{source}` half of the record id).
+        dataset: identity-graph dataset scope (defaults to `source_name`).
+        store_path: SQLite path for the identity graph. Pass a stable path to make
+            entity ids durable across runs ("resolve once"); omit for an ephemeral
+            temp store.
+        config: an explicit GoldenMatchConfig; zero-config auto-config otherwise.
+
+    Returns:
+        A `ResolvedCrosswalk`. The resolved key is the control plane's stable id.
+    """
+    from goldenmatch._api import dedupe_df
+    from goldenmatch.config.schemas import IdentityConfig
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.identity.store import IdentityStore
+
+    table = _to_arrow(df)
+    if source_pk not in set(table.column_names):
+        raise ValueError(f"build_resolved_crosswalk: source_pk column not in table: {source_pk!r}")
+
+    dataset = dataset or source_name
+    ephemeral = store_path is None
+    if ephemeral:
+        fd, store_path = tempfile.mkstemp(prefix="gm_crosswalk_", suffix=".db")
+        os.close(fd)
+
+    # Zero-config (or the caller's config), with the identity graph enabled so the
+    # pipeline assigns durable stable ids. Disable rerank so certification never
+    # blocks on a cross-encoder download (offline-safe, as in wedge A).
+    cfg = config if config is not None else auto_configure_df(df, confidence_required=False)
+    for mk in cfg.get_matchkeys():
+        if getattr(mk, "rerank", False):
+            mk.rerank = False
+    cfg.identity = IdentityConfig(
+        enabled=True,
+        backend="sqlite",
+        path=store_path,
+        source_pk_column=source_pk,
+        dataset=dataset,
+    )
+
+    dedupe_df(df, config=cfg, source_name=source_name, confidence_required=False)
+
+    store = IdentityStore(backend="sqlite", path=store_path)
+    pks = table.column(source_pk).to_pylist()
+    record_ids = [f"{source_name}:{pk}" for pk in pks]
+    mapping = store.lookup_entity_ids(record_ids)
+    resolved = [mapping.get(rid) for rid in record_ids]
+
+    out = pa.table({
+        "source": [source_name] * len(pks),
+        "source_pk": [None if pk is None else str(pk) for pk in pks],
+        "resolved_entity_id": resolved,
+    })
+    n_entities = len({r for r in resolved if r is not None})
+    unmapped = sum(1 for r in resolved if r is None)
+    note = ""
+    if unmapped:
+        note = f"{unmapped} record(s) unresolved (null/duplicate source_pk?)"
+    if ephemeral:
+        note = (note + "; " if note else "") + "ephemeral store — pass store_path for durable ids across runs"
+
+    return ResolvedCrosswalk(
+        table=out,
+        source=source_name,
+        source_pk_column=source_pk,
+        n_records=len(pks),
+        n_entities=n_entities,
+        unmapped=unmapped,
+        store_path=None if ephemeral else store_path,
+        note=note,
+    )

--- a/packages/python/goldenmatch/goldenmatch/semantic/metricflow.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/metricflow.py
@@ -1,13 +1,18 @@
-"""Read declared entity keys + measures from a dbt / MetricFlow semantic model.
+"""Read / emit dbt / MetricFlow semantic-model entity declarations.
 
 MetricFlow declares, per `semantic_models[]`: `entities` (with `type` one of
 primary/foreign/unique/natural), `measures`, and a default `agg_time_dimension`.
 Joins across semantic models happen implicitly on *shared entities* — so the
 primary entity's key is exactly what `certify_key_integrity` needs to check.
 
-`parse_semantic_models(source) -> list[DeclaredKeySpec]` extracts that surface so
-you can point the certifier at a real dbt project instead of hand-passing a key.
-This reads the *declaration* only; it does not touch a warehouse.
+- `parse_semantic_models(source) -> list[DeclaredKeySpec]` (wedge A) reads the
+  declared key so you can point the certifier at a real dbt project.
+- `emit_semantic_model` / `emit_metricflow_yaml` (wedge B) go the other way: given
+  a GoldenMatch-resolved key, generate the `semantic_models` YAML that declares
+  that conformed key as the PRIMARY entity — so every metric joins on resolved
+  identity. `parse_semantic_models(emit_metricflow_yaml(...))` round-trips.
+
+This reads/writes the *declaration* only; it does not touch a warehouse.
 """
 from __future__ import annotations
 
@@ -120,3 +125,92 @@ def parse_semantic_models(source: str | Path | dict[str, Any]) -> list[DeclaredK
         )
 
     return specs
+
+
+# --- emit (wedge B): resolved key -> MetricFlow semantic-model declaration ------
+
+
+def emit_semantic_model(
+    model: str,
+    *,
+    resolved_key: str,
+    entity_name: str | None = None,
+    source_key: str | None = None,
+    measures: list[str] | tuple[str, ...] = (),
+    grain: list[str] | str | None = None,
+    model_ref: str | None = None,
+    measure_agg: str = "sum",
+) -> dict[str, Any]:
+    """Build ONE MetricFlow `semantic_models[]` entry declaring `resolved_key` as
+    the PRIMARY entity — the GoldenMatch-conformed join key every metric inherits.
+
+    The original per-source key (`source_key`), if given, is declared as a
+    `unique` entity so it stays queryable but is no longer the join primary.
+
+    Args:
+        model: the semantic model / dbt model name.
+        resolved_key: the resolved-entity column (e.g. `resolved_entity_id`) to
+            declare as the primary entity's `expr`.
+        entity_name: the entity's logical name (defaults to `model`).
+        source_key: the original source primary key, declared `unique` if given.
+        measures: measure column names (emitted with `agg=measure_agg`, `expr=name`).
+        grain: the default agg time dimension (str or 1-list), if any.
+        model_ref: the `model:` ref expression (defaults to `ref('<model>')`).
+        measure_agg: the aggregation stamped on each measure (a scaffold default —
+            set the real aggregation per measure in your project).
+    """
+    entities: list[dict[str, Any]] = [
+        {"name": entity_name or model, "type": "primary", "expr": resolved_key},
+    ]
+    if source_key and source_key != resolved_key:
+        entities.append({"name": source_key, "type": "unique", "expr": source_key})
+
+    sm: dict[str, Any] = {
+        "name": model,
+        "model": model_ref or f"ref('{model}')",
+        "entities": entities,
+    }
+
+    grain_list = [grain] if isinstance(grain, str) else list(grain or [])
+    if grain_list:
+        sm["defaults"] = {"agg_time_dimension": grain_list[0]}
+
+    if measures:
+        sm["measures"] = [
+            {"name": m, "agg": measure_agg, "expr": m} for m in measures
+        ]
+    return sm
+
+
+def emit_metricflow_yaml(models: dict[str, Any] | list[dict[str, Any]]) -> str:
+    """Render one or more `emit_semantic_model` dicts as a `semantic_models` YAML
+    document (block style, key order preserved). Round-trips through
+    `parse_semantic_models`."""
+    if isinstance(models, dict):
+        models = [models]
+    payload = {"semantic_models": list(models)}
+    return yaml.safe_dump(payload, sort_keys=False, default_flow_style=False)
+
+
+def emit_from_crosswalk(
+    crosswalk: Any,
+    model: str,
+    *,
+    entity_name: str | None = None,
+    measures: list[str] | tuple[str, ...] = (),
+    grain: list[str] | str | None = None,
+    model_ref: str | None = None,
+) -> str:
+    """Emit the `semantic_models` YAML for a `ResolvedCrosswalk`: its
+    `resolved_key` becomes the primary entity, its `source_pk_column` the `unique`
+    source key. Convenience over `emit_semantic_model` + `emit_metricflow_yaml`."""
+    sm = emit_semantic_model(
+        model,
+        resolved_key=getattr(crosswalk, "resolved_key", "resolved_entity_id"),
+        entity_name=entity_name,
+        source_key=getattr(crosswalk, "source_pk_column", None),
+        measures=measures,
+        grain=grain,
+        model_ref=model_ref,
+    )
+    return emit_metricflow_yaml(sm)

--- a/packages/python/goldenmatch/tests/test_metricflow_emit.py
+++ b/packages/python/goldenmatch/tests/test_metricflow_emit.py
@@ -1,0 +1,71 @@
+"""Tests for the MetricFlow emitter (wedge B: emit the conformed entity declaration)."""
+from __future__ import annotations
+
+from goldenmatch.semantic import (
+    emit_from_crosswalk,
+    emit_metricflow_yaml,
+    emit_semantic_model,
+    parse_semantic_models,
+)
+
+
+def test_emit_declares_resolved_key_as_primary():
+    sm = emit_semantic_model(
+        "customers",
+        resolved_key="resolved_entity_id",
+        source_key="customer_id",
+        measures=["revenue"],
+        grain="order_date",
+    )
+    ents = {e["name"]: e for e in sm["entities"]}
+    assert ents["customers"]["type"] == "primary"
+    assert ents["customers"]["expr"] == "resolved_entity_id"
+    # the original source key stays declared, but as a non-primary unique entity
+    assert ents["customer_id"]["type"] == "unique"
+    assert sm["defaults"]["agg_time_dimension"] == "order_date"
+    assert sm["model"] == "ref('customers')"
+
+
+def test_round_trips_through_parse():
+    yaml_text = emit_metricflow_yaml(
+        emit_semantic_model(
+            "orders",
+            resolved_key="resolved_entity_id",
+            entity_name="customer",
+            source_key="customer_id",
+            measures=["amount", "order_count"],
+            grain="order_date",
+        )
+    )
+    spec = parse_semantic_models(yaml_text)[0]
+    assert spec.model == "orders"
+    assert spec.key == ["resolved_entity_id"]         # resolved key is the primary
+    assert spec.foreign_keys == ["customer_id"]       # source key -> unique/foreign
+    assert spec.measures == ["amount", "order_count"]
+    assert spec.grain == ["order_date"]
+
+
+def test_emit_multiple_models():
+    a = emit_semantic_model("a", resolved_key="rid_a")
+    b = emit_semantic_model("b", resolved_key="rid_b")
+    specs = parse_semantic_models(emit_metricflow_yaml([a, b]))
+    assert {s.model for s in specs} == {"a", "b"}
+
+
+def test_no_source_key_or_measures_is_minimal():
+    sm = emit_semantic_model("m", resolved_key="rid")
+    assert [e["name"] for e in sm["entities"]] == ["m"]   # only the primary
+    assert "measures" not in sm and "defaults" not in sm
+
+
+def test_emit_from_crosswalk_uses_its_keys():
+    class _XW:
+        resolved_key = "resolved_entity_id"
+        source_pk_column = "customer_id"
+
+    spec = parse_semantic_models(
+        emit_from_crosswalk(_XW(), "customers", measures=["revenue"])
+    )[0]
+    assert spec.key == ["resolved_entity_id"]
+    assert spec.foreign_keys == ["customer_id"]
+    assert spec.measures == ["revenue"]

--- a/packages/python/goldenmatch/tests/test_resolved_crosswalk.py
+++ b/packages/python/goldenmatch/tests/test_resolved_crosswalk.py
@@ -1,0 +1,71 @@
+"""Tests for goldenmatch.semantic.build_resolved_crosswalk (wedge B: resolve once)."""
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from goldenmatch.semantic import ResolvedCrosswalk, build_resolved_crosswalk
+
+# customer_id 100 and 101 are byte-identical people -> ER collapses them to one
+# durable entity; the rest are distinct.
+_NAMES = ["Robert Smith", "Robert Smith", "Jane Doe", "Alice Ray", "Tom Lee",
+          "Nina Fox", "Ed Poe", "Uma Roy", "Cy Vane", "Al Ives", "Bo Katz", "Di Nash"]
+_CITIES = ["Boston", "Boston", "Denver", "Miami", "Reno", "Akron",
+           "Provo", "Ames", "Waco", "Bend", "Ojai", "Enid"]
+_CIDS = [100, 101, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209]
+
+
+def _frame():
+    return pa.table({"customer_id": _CIDS, "name": _NAMES, "city": _CITIES})
+
+
+def test_crosswalk_collapses_duplicates_to_one_entity():
+    xw = build_resolved_crosswalk(_frame(), source_pk="customer_id", source_name="crm")
+    assert isinstance(xw, ResolvedCrosswalk)
+    assert xw.n_records == 12
+    assert xw.n_entities == 11          # 100 & 101 share one entity
+    assert xw.unmapped == 0
+    assert xw.reduction_ratio == pytest.approx(1 - 11 / 12)
+
+    d = xw.table.to_pydict()
+    by_pk = {pk: eid for pk, eid in zip(d["source_pk"], d["resolved_entity_id"])}
+    # the dirty duplicate keys map to the SAME durable entity id
+    assert by_pk["100"] == by_pk["101"]
+    # distinct people keep distinct ids
+    assert by_pk["200"] != by_pk["100"]
+    # every id is a durable (UUID-shaped) control-plane id, not a row index
+    assert all(eid and "-" in eid for eid in d["resolved_entity_id"])
+
+
+def test_crosswalk_columns_and_order():
+    xw = build_resolved_crosswalk(_frame(), source_pk="customer_id", source_name="crm")
+    assert xw.table.column_names == ["source", "source_pk", "resolved_entity_id"]
+    d = xw.table.to_pydict()
+    assert d["source_pk"] == [str(c) for c in _CIDS]   # input order preserved
+    assert set(d["source"]) == {"crm"}
+
+
+def test_durable_ids_stable_across_runs(tmp_path):
+    """The point of 'resolve once': re-running against the same store yields the
+    same entity ids for the same source keys."""
+    store = str(tmp_path / "identity.db")
+    a = build_resolved_crosswalk(_frame(), source_pk="customer_id",
+                                 source_name="crm", store_path=store)
+    b = build_resolved_crosswalk(_frame(), source_pk="customer_id",
+                                 source_name="crm", store_path=store)
+    ma = dict(zip(a.table.column("source_pk").to_pylist(),
+                  a.table.column("resolved_entity_id").to_pylist()))
+    mb = dict(zip(b.table.column("source_pk").to_pylist(),
+                  b.table.column("resolved_entity_id").to_pylist()))
+    assert ma == mb                     # stable across runs
+    assert a.store_path == store        # durable store echoed back
+
+
+def test_ephemeral_store_notes_non_durability():
+    xw = build_resolved_crosswalk(_frame(), source_pk="customer_id", source_name="crm")
+    assert xw.store_path is None
+    assert "ephemeral" in xw.note
+
+
+def test_missing_source_pk_raises():
+    with pytest.raises(ValueError):
+        build_resolved_crosswalk(_frame(), source_pk="nope")


### PR DESCRIPTION
## What and why

The follow-on to the merged wedge A (#2267, metric-aware key certification). A semantic layer joins on entity-key equality but never resolves those keys; **wedge B produces the conformed key** and the MetricFlow declaration that points every metric at it — "resolve once, every metric inherits correct joins."

The resolved join key is the Identity Control Plane's **durable** stable `entity_id` (UUIDv7), reused — not a second identity scheme (the frame's "control plane owns stable IDs" decision test).

## Changes

- `goldenmatch/semantic/crosswalk.py` — `build_resolved_crosswalk(df, source_pk=, source_name=, store_path=, ...)` -> `ResolvedCrosswalk`. Runs the normal `dedupe_df` pipeline with the identity graph enabled and reads the assigned `entity_id` back from `source_records` by record id, returning a `{source, source_pk, resolved_entity_id}` crosswalk in input order. Pass `store_path` to make ids durable across runs ("resolve once"); omit for ephemeral. Offline-safe (disables rerank, like wedge A's resolution tier).
- `goldenmatch/semantic/metricflow.py` — `emit_semantic_model` / `emit_metricflow_yaml` / `emit_from_crosswalk`: the codegen inverse of A's `parse_semantic_models`. Declares the resolved key as the PRIMARY entity and the original source key as a `unique` entity, so `parse_semantic_models(emit_metricflow_yaml(...))` round-trips. House-style `yaml.safe_dump(sort_keys=False, ...)`.
- `goldenmatch/semantic/__init__.py` — exports the new symbols (subpackage stays out of top-level `goldenmatch/__init__.py`, so `import goldenmatch` remains polars-free).
- ADR `context-network/decisions/0050-resolved-crosswalk-emit.md` + planning-doc status (wedges A + B shipped). Regenerated `docs/agent-codemap.json` (new source module).

Design discipline (same as A): library-only, MetricFlow-first, advisory; no Cube/OSI emitter, no dbt/CLI/MCP surface, no warehouse key mutation — B produces artifacts a user drops into their project. Parity-free (no MCP/CLI/A2A/TS entry).

## Testing

Run locally via the uv workspace (all green):
- `uv run --package goldenmatch python -m pytest packages/python/goldenmatch/tests/test_resolved_crosswalk.py packages/python/goldenmatch/tests/test_metricflow_emit.py` — 10 passed (duplicate-key collapse to one durable entity, cross-run id stability, emit round-trip through the A reader)
- Wedge A unchanged: `test_key_integrity.py` + `test_metricflow_parse.py` — 13 passed
- `import goldenmatch` verified polars-free (`semantic` lazy); `ruff check` clean on all new/changed files
- Proactively ran the doc/manifest gates: `agent_codemap.py --check`, `gen_config_matrix.py --manifest-check`, `gen_suite_matrix.py --check`, `gen_api_surface.py --check`, and `scripts/test_config_matrix.py` + `scripts/test_agent_codemap.py` (54 passed) — all green

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — ran `ruff check` on new files (clean); full pre-commit not run in sandbox
- [ ] Package `CHANGELOG.md` updated if behavior changed — additive new capability; CHANGELOG can follow before release
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated — new ADR 0050 + planning-doc status + regenerated agent-codemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_