### PR TITLE
feat(publish-er-matcher): pull the merged model straight from a Modal volume

### DIFF
--- a/.github/workflows/publish-er-matcher.yml
+++ b/.github/workflows/publish-er-matcher.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       model_source:
-        description: "https URL of a tarball/zip of the merged fp16 model dir (from the Modal full run)"
+        description: "Merged fp16 model: an https URL of a tarball/zip, OR modal://<volume>/<remote-path> to pull straight from a Modal volume"
         required: true
       tier:
         description: "Model tier (fills the GGUF filename + which registry pin to print)"
@@ -57,19 +57,41 @@ jobs:
           cmake --build build --config Release -j --target llama-quantize
 
       - name: Download merged model
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           set -euo pipefail
           mkdir -p model
           src="${{ inputs.model_source }}"
-          # a tarball/zip URL of the merged fp16 dir (e.g. served from the Modal run)
-          curl -fSL "$src" -o model_src.archive
-          if [[ "$src" == *.zip ]]; then unzip -q model_src.archive -d model; else tar -xf model_src.archive -C model; fi
-          # normalize: if the archive nested a single dir, hoist it
-          if [ ! -f model/config.json ]; then
-            inner=$(find model -maxdepth 2 -name config.json -printf '%h\n' | head -1)
-            [ -n "$inner" ] && model="$inner" && echo "MODEL_DIR=$inner" >> "$GITHUB_ENV"
+          if [[ "$src" == modal://* ]]; then
+            # modal://<volume>/<remote-path> -> pull the merged fp16 dir straight from
+            # a Modal volume on this runner (GitHub runners have direct network to Modal).
+            if [ -z "${MODAL_TOKEN_ID:-}" ] || [ -z "${MODAL_TOKEN_SECRET:-}" ]; then
+              echo "::error::model_source is modal:// but MODAL_TOKEN_ID / MODAL_TOKEN_SECRET repo secrets are not set."
+              exit 1
+            fi
+            pip install --upgrade modal
+            rest="${src#modal://}"
+            vol="${rest%%/*}"
+            path="${rest#*/}"
+            if [ -z "$vol" ] || [ "$path" = "$rest" ] || [ -z "$path" ]; then
+              echo "::error::modal source must be modal://<volume>/<remote-path>"; exit 1
+            fi
+            modal volume get "$vol" "$path" model/
+          else
+            # an https URL of a tarball/zip of the merged fp16 dir
+            curl -fSL "$src" -o model_src.archive
+            if [[ "$src" == *.zip ]]; then unzip -q model_src.archive -d model; else tar -xf model_src.archive -C model; fi
           fi
-          echo "MODEL_DIR=${MODEL_DIR:-model}" >> "$GITHUB_ENV"
+          # normalize: point MODEL_DIR at wherever config.json actually landed
+          if [ -f model/config.json ]; then
+            model_dir="model"
+          else
+            model_dir="$(find model -maxdepth 3 -name config.json -printf '%h\n' | head -1)"
+          fi
+          test -n "$model_dir" || { echo "::error::no HF model dir (config.json) found in the downloaded source"; exit 1; }
+          echo "MODEL_DIR=$model_dir" >> "$GITHUB_ENV"
 
       - name: Convert to GGUF + quantize + sha256
         run: |


### PR DESCRIPTION
## What and why

`publish-er-matcher.yml` publishes the trained ER-matcher GGUF to a GitHub Release, but its `model_source` was an https URL only — so a model sitting on a **Modal volume** had to be moved by hand first. This adds a `modal://` source so the workflow pulls the merged fp16 dir straight from the volume on a GitHub runner (which has direct network to Modal), using the `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` secrets already configured.

## Changes

- **`model_source` accepts `modal://<volume>/<remote-path>`** in addition to an https URL. On a `modal://` source the workflow: verifies the Modal secrets are present, `pip install modal`, parses volume + path, and `modal volume get <volume> <remote-path> model/`. https URLs behave exactly as before.
- Made the `MODEL_DIR` normalize step deterministic — find `config.json` (depth ≤3), write once, and error clearly if the source has no HF model dir (the old version wrote `MODEL_DIR` twice and the second write always won).

## How to publish now

1. Dispatch **publish-er-matcher** (Actions tab) with:
   - `model_source` = `modal://<your-volume>/<path-to-merged-fp16-dir>`
   - `tier` = `3b`, `release_tag` = `er-matcher-3b-v1`, `quant` = `q4_k_m q8_0`
2. It converts → quantizes → uploads the GGUF to the `er-matcher-3b-v1` Release and prints the `(url, filename, sha256)` pin.
3. Paste the `q4_k_m` pin into `core/_llm_loader.py` `PINNED_MODEL` (and, if you use the tiered subsystem, `core/er_matcher/registry.py MODELS['3b']`).

## Testing

- Workflow YAML validated; `modal://` parsing unit-checked (volume/path split, malformed-source rejection, https passthrough).
- `check_docs_consistency.py` — PASS (no new publish stem; still one publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z)_