### PR TITLE
feat(semantic): wedge C — OSI / Apache Ossie native identity provider (bidirectional)

### DIFF
--- a/context-network/decisions/0051-osi-ossie-native-provider.md
+++ b/context-network/decisions/0051-osi-ossie-native-provider.md
@@ -1,0 +1,66 @@
+# 0051 — Wedge C: OSI / Apache Ossie native identity provider (bidirectional)
+
+**Status:** accepted (2026-07-30, Ben) • **Shipped:** `goldenmatch.semantic.{parse_osi_models, osi_join_keys, certify_osi_relationships, emit_osi_model, emit_osi_yaml, emit_osi_from_crosswalk}` + `Osi*` dataclasses • **Builds on:** [0049 (certify)](0049-metric-aware-key-certification.md) + [0050 (resolve+emit)](0050-resolved-crosswalk-emit.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+Wedges A + B target dbt/MetricFlow. Wedge C is the planning doc's moonshot: make
+GoldenMatch a native provider for **Open Semantic Interchange (Apache Ossie)** —
+the vendor-neutral interchange spec onto which the whole ecosystem is converging.
+C closes the loop bidirectionally: **consume** an OSI model to learn which keys the
+metrics join on, and **emit** valid OSI declaring the GoldenMatch-resolved key as
+the conformed join. Resolve once against the interchange standard → every
+OSI-consuming tool (dbt SL, Polaris, Cube, …) inherits correct joins.
+
+The ADR-0049 caveat was "attach when the spec firms up." It has: the Ossie core
+(datasets / fields / relationships / metrics) ships a **published JSON Schema**
+(`core-spec/osi-schema.json`, spec `0.2.0.dev0`) that validates a real TPC-DS
+example — concrete enough to build a faithful reader/emitter today.
+
+## Decision
+1. **Schema-faithful to the real Ossie objects — invent nothing.** Top level is
+   `version` + a `semantic_model` LIST. Identity is `datasets` + `primary_key` /
+   `unique_keys` + `relationships` — there is **no `entity` object**. A
+   relationship's *direction* IS its cardinality (`from` = many, `to` = one), so
+   we emit **no `cardinality`, no `foreign_key`, no `aggregation` key** (FKs live
+   in the relationship's `from_columns`/`to_columns`; aggregation lives inside the
+   metric's SQL `expression`). Field/metric expressions are dialect-scoped
+   (`expression.dialects[].{dialect,expression}`). `parse_osi_models(emit_osi_yaml(...))`
+   round-trips.
+2. **GoldenMatch metadata rides in `custom_extensions`.** Provenance (n_entities,
+   reduction_ratio) and an optional key-integrity certificate go under
+   `custom_extensions.goldenmatch` — the schema-sanctioned extension point — so
+   emitted OSI stays valid against the incubating 0.x spec.
+3. **Bidirectional bridges to A + B.** `certify_osi_relationships(model, frames)`
+   certifies the ONE-side key of each relationship via wedge A — certifying
+   *exactly* the identity the metrics depend on (metric-aware). `emit_osi_from_crosswalk`
+   turns a wedge-B `ResolvedCrosswalk` into an OSI crosswalk dataset + conformed
+   relationship. `osi_join_keys` surfaces "what to resolve."
+4. **Library-only, advisory, parity-free** — same discipline as A + B; no
+   MCP/CLI/A2A/TS surface, `semantic/` stays out of top-level `goldenmatch/__init__.py`
+   so `import goldenmatch` stays polars-free.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — an interchange adapter over the control plane's
+  resolved ids + wedge A/B; no new identity or metric semantics.
+- **Conformance defines correctness** ✅ — this is the purest expression of the
+  frame's "conformance" test: GM emits/reads the Ossie JSON-Schema objects, and we
+  pinned to a spec version rather than guessing.
+- **Arrow at bulk boundaries** ✅ — OSI docs are small metadata (YAML); the frames
+  the bridge certifies are Arrow.
+
+## Consequences / honest flags
+- **Targets Ossie `0.2.0.dev0` (0.x / incubating).** Additive churn is expected
+  (the Metric Language WG may later add structured aggregation fields). We validate
+  round-trip internally against the documented objects; we do **not** run the
+  official reference converters (dbt/Polaris) in CI. Pin + revisit on a spec bump.
+- **`certify_osi_relationships` needs the data frames** (OSI references tables by
+  `source` name only); the caller supplies `{dataset: frame}`. Wiring OSI `source`
+  refs to a live warehouse is a follow-on.
+- **Follow-ons (not v1):** Cube emitter, JSON-Schema validation against a vendored
+  `osi-schema.json`, writing back into a live Ossie catalog, a CLI/MCP front door,
+  and metric-aware *blocking* (resolve the entities that drive metrics first).
+- **Numbering note:** a concurrent PR also used `0049` (`0049-customer-360-identity-store-spine.md`);
+  this collision predates and is unrelated to the semantic-layer arc (0049 A / 0050 B / 0051 C).
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-07-30

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -1,8 +1,9 @@
 # Semantic Layering (MetricFlow / Cube / OSI) — brainstorm / planning
 
-> **Status:** wedges **A + B** SHIPPED — decisions
+> **Status:** wedges **A + B + C** SHIPPED — decisions
 > [0049](../decisions/0049-metric-aware-key-certification.md) (certify) +
-> [0050](../decisions/0050-resolved-crosswalk-emit.md) (resolve once + emit).
+> [0050](../decisions/0050-resolved-crosswalk-emit.md) (resolve once + emit) +
+> [0051](../decisions/0051-osi-ossie-native-provider.md) (OSI/Ossie provider).
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**
@@ -11,9 +12,13 @@
 > `goldenmatch_key_integrity` dbt test. Problem **B** (emit the resolved crosswalk):
 > `build_resolved_crosswalk` (durable control-plane entity ids) +
 > `emit_semantic_model` / `emit_metricflow_yaml` (declare the conformed key as the
-> primary entity; round-trips through the A reader). **C** (OSI provider) remains
-> planned. Greenfield when written: no prior repo code, doc, or decision referenced
-> this ecosystem (grep, 2026-07-30).
+> primary entity; round-trips through the A reader). Problem **C** (OSI/Apache Ossie
+> native provider): `parse_osi_models` + `osi_join_keys` (consume — learn what to
+> resolve), `certify_osi_relationships` (bridge to A — certify the keys metrics
+> join on), `emit_osi_from_crosswalk` (bridge to B — emit the conformed join), all
+> schema-faithful to Ossie `0.2.0.dev0`. The arc is complete — the whole
+> crawl→walk→run is landed. Greenfield when written: no prior repo code, doc, or
+> decision referenced this ecosystem (grep, 2026-07-30).
 
 ## The premise
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 431,
+      "module_count": 432,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7057,7 +7057,8 @@
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.crosswalk",
             "goldenmatch.semantic.key_integrity",
-            "goldenmatch.semantic.metricflow"
+            "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.osi"
           ]
         },
         {
@@ -7106,6 +7107,35 @@
             "emit_metricflow_yaml",
             "emit_semantic_model",
             "parse_semantic_models"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.osi",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/osi.py",
+          "purpose": "Open Semantic Interchange / Apache Ossie reader + emitter (wedge C).",
+          "defines": [
+            "OsiDataset",
+            "OsiField",
+            "OsiMetric",
+            "OsiModel",
+            "OsiRelationship",
+            "_dialect_expression",
+            "_parse_dataset",
+            "_parse_relationship",
+            "_read_expression",
+            "certify_osi_relationships",
+            "emit_osi_dataset",
+            "emit_osi_field",
+            "emit_osi_from_crosswalk",
+            "emit_osi_model",
+            "emit_osi_relationship",
+            "emit_osi_yaml",
+            "osi_join_keys",
+            "parse_osi_models"
+          ],
+          "imports": [
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -26,6 +26,19 @@ from goldenmatch.semantic.metricflow import (
     emit_semantic_model,
     parse_semantic_models,
 )
+from goldenmatch.semantic.osi import (
+    OsiDataset,
+    OsiField,
+    OsiMetric,
+    OsiModel,
+    OsiRelationship,
+    certify_osi_relationships,
+    emit_osi_from_crosswalk,
+    emit_osi_model,
+    emit_osi_yaml,
+    osi_join_keys,
+    parse_osi_models,
+)
 
 __all__ = [
     # wedge A — certify a declared key
@@ -39,4 +52,16 @@ __all__ = [
     "emit_semantic_model",
     "emit_metricflow_yaml",
     "emit_from_crosswalk",
+    # wedge C — OSI / Apache Ossie native provider (bidirectional)
+    "parse_osi_models",
+    "osi_join_keys",
+    "certify_osi_relationships",
+    "emit_osi_model",
+    "emit_osi_yaml",
+    "emit_osi_from_crosswalk",
+    "OsiModel",
+    "OsiDataset",
+    "OsiRelationship",
+    "OsiField",
+    "OsiMetric",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi.py
@@ -1,0 +1,345 @@
+"""Open Semantic Interchange / Apache Ossie reader + emitter (wedge C).
+
+GoldenMatch as an OSI-native identity provider — the bidirectional close of the
+semantic-layer arc:
+
+- **consume** an OSI model to learn which keys the metrics join on (`parse_osi_models`,
+  `osi_join_keys`) and certify exactly those keys (`certify_osi_relationships`,
+  bridging wedge A) — "resolve the identity the metrics actually depend on";
+- **emit** valid OSI declaring the GoldenMatch-resolved key as the conformed join
+  (`emit_osi_from_crosswalk`, bridging wedge B), with certification/provenance in
+  `custom_extensions`.
+
+Targets the Ossie core objects (datasets / fields / relationships / metrics) as of
+spec `0.2.0.dev0` (JSON Schema `core-spec/osi-schema.json`). **Schema-faithful:**
+the top level is `version` + a `semantic_model` LIST; identity is datasets +
+`primary_key`/`unique_keys` + relationships (there is no `entity` object); a
+relationship's direction IS its cardinality (`from` = many, `to` = one), so we
+never invent `cardinality`, `foreign_key`, or `aggregation` keys — FKs live in the
+relationship, aggregation lives inside the metric's SQL expression. GoldenMatch
+metadata rides in `custom_extensions` to stay valid against an incubating 0.x spec.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+from goldenmatch.semantic.metricflow import _load
+
+OSI_VERSION = "0.2.0.dev0"
+DEFAULT_DIALECT = "ANSI_SQL"
+
+
+# --- model -------------------------------------------------------------------
+
+
+@dataclass
+class OsiField:
+    name: str
+    expression: str                      # the (ANSI_SQL) expression — usually the column
+    datatype: str | None = None
+    is_time: bool = False
+    label: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class OsiDataset:
+    name: str
+    source: str | None = None            # physical table ref
+    primary_key: list[str] = field(default_factory=list)
+    unique_keys: list[list[str]] = field(default_factory=list)
+    fields: list[OsiField] = field(default_factory=list)
+
+
+@dataclass
+class OsiRelationship:
+    name: str
+    from_dataset: str                    # MANY side (`from`)
+    to_dataset: str                      # ONE side (`to`)
+    from_columns: list[str] = field(default_factory=list)   # FK columns
+    to_columns: list[str] = field(default_factory=list)     # referenced PK/unique columns
+
+
+@dataclass
+class OsiMetric:
+    name: str
+    expression: str                      # aggregation SQL, dataset-qualified columns
+    datatype: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class OsiModel:
+    name: str
+    datasets: list[OsiDataset] = field(default_factory=list)
+    relationships: list[OsiRelationship] = field(default_factory=list)
+    metrics: list[OsiMetric] = field(default_factory=list)
+    description: str | None = None
+    version: str = OSI_VERSION
+    custom_extensions: dict[str, Any] | None = None
+
+
+# --- parse (consume) ---------------------------------------------------------
+
+
+def _read_expression(expr: Any) -> str:
+    """A field/metric `expression` is `{dialects: [{dialect, expression}]}` (or a
+    bare string in loose docs). Prefer ANSI_SQL, else the first dialect."""
+    if isinstance(expr, str):
+        return expr
+    if isinstance(expr, dict):
+        dialects = expr.get("dialects") or []
+        for d in dialects:
+            if isinstance(d, dict) and d.get("dialect") == DEFAULT_DIALECT:
+                return str(d.get("expression", ""))
+        if dialects and isinstance(dialects[0], dict):
+            return str(dialects[0].get("expression", ""))
+    return ""
+
+
+def _parse_dataset(d: dict[str, Any]) -> OsiDataset:
+    fields = []
+    for f in d.get("fields") or []:
+        if not isinstance(f, dict):
+            continue
+        dim = f.get("dimension") or {}
+        fields.append(OsiField(
+            name=str(f.get("name", "")),
+            expression=_read_expression(f.get("expression")),
+            datatype=f.get("datatype"),
+            is_time=bool(dim.get("is_time", False)) if isinstance(dim, dict) else False,
+            label=f.get("label"),
+            description=f.get("description"),
+        ))
+    pk = d.get("primary_key") or []
+    if isinstance(pk, str):
+        pk = [pk]
+    return OsiDataset(
+        name=str(d.get("name", "")),
+        source=d.get("source"),
+        primary_key=list(pk),
+        unique_keys=[list(k) for k in (d.get("unique_keys") or [])],
+        fields=fields,
+    )
+
+
+def _parse_relationship(r: dict[str, Any]) -> OsiRelationship:
+    def _cols(v: Any) -> list[str]:
+        if v is None:
+            return []
+        return [v] if isinstance(v, str) else list(v)
+
+    return OsiRelationship(
+        name=str(r.get("name", "")),
+        from_dataset=str(r.get("from", "")),
+        to_dataset=str(r.get("to", "")),
+        from_columns=_cols(r.get("from_columns")),
+        to_columns=_cols(r.get("to_columns")),
+    )
+
+
+def parse_osi_models(source: str | Any) -> list[OsiModel]:
+    """Parse an OSI/Ossie document (path, YAML string, or dict) into `OsiModel`s.
+
+    `semantic_model` is a list, so this returns one `OsiModel` per model.
+    """
+    data = _load(source)
+    version = str(data.get("version", OSI_VERSION))
+    out: list[OsiModel] = []
+    for sm in data.get("semantic_model") or []:
+        if not isinstance(sm, dict):
+            continue
+        out.append(OsiModel(
+            name=str(sm.get("name", "")),
+            datasets=[_parse_dataset(d) for d in (sm.get("datasets") or []) if isinstance(d, dict)],
+            relationships=[_parse_relationship(r) for r in (sm.get("relationships") or []) if isinstance(r, dict)],
+            metrics=[
+                OsiMetric(name=str(m.get("name", "")), expression=_read_expression(m.get("expression")),
+                          datatype=m.get("datatype"), description=m.get("description"))
+                for m in (sm.get("metrics") or []) if isinstance(m, dict)
+            ],
+            description=sm.get("description"),
+            version=version,
+            custom_extensions=sm.get("custom_extensions"),
+        ))
+    return out
+
+
+def osi_join_keys(model: OsiModel) -> list[dict[str, Any]]:
+    """The keys the model's relationships join on — i.e. the identity a metric
+    depends on. One entry per relationship end: `{dataset, columns, side}`. This
+    is what GoldenMatch should resolve/certify (metric-aware)."""
+    out: list[dict[str, Any]] = []
+    for r in model.relationships:
+        out.append({"dataset": r.to_dataset, "columns": r.to_columns, "side": "one", "relationship": r.name})
+        out.append({"dataset": r.from_dataset, "columns": r.from_columns, "side": "many", "relationship": r.name})
+    return out
+
+
+# --- emit (produce) ----------------------------------------------------------
+
+
+def _dialect_expression(expression: str, dialect: str = DEFAULT_DIALECT) -> dict[str, Any]:
+    return {"dialects": [{"dialect": dialect, "expression": expression}]}
+
+
+def emit_osi_field(f: OsiField) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": f.name, "expression": _dialect_expression(f.expression or f.name)}
+    if f.datatype:
+        out["datatype"] = f.datatype
+    out["dimension"] = {"is_time": f.is_time}
+    if f.label:
+        out["label"] = f.label
+    if f.description:
+        out["description"] = f.description
+    return out
+
+
+def emit_osi_dataset(ds: OsiDataset) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": ds.name}
+    if ds.source:
+        out["source"] = ds.source
+    if ds.primary_key:
+        out["primary_key"] = list(ds.primary_key)
+    if ds.unique_keys:
+        out["unique_keys"] = [list(k) for k in ds.unique_keys]
+    if ds.fields:
+        out["fields"] = [emit_osi_field(f) for f in ds.fields]
+    return out
+
+
+def emit_osi_relationship(r: OsiRelationship) -> dict[str, Any]:
+    # NOTE: no `cardinality` key — direction encodes it (from=many, to=one).
+    return {
+        "name": r.name,
+        "from": r.from_dataset,
+        "to": r.to_dataset,
+        "from_columns": list(r.from_columns),
+        "to_columns": list(r.to_columns),
+    }
+
+
+def emit_osi_model(model: OsiModel) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": model.name}
+    if model.description:
+        out["description"] = model.description
+    if model.datasets:
+        out["datasets"] = [emit_osi_dataset(d) for d in model.datasets]
+    if model.relationships:
+        out["relationships"] = [emit_osi_relationship(r) for r in model.relationships]
+    if model.metrics:
+        out["metrics"] = [
+            {"name": m.name, "expression": _dialect_expression(m.expression),
+             **({"datatype": m.datatype} if m.datatype else {})}
+            for m in model.metrics
+        ]
+    if model.custom_extensions:
+        out["custom_extensions"] = model.custom_extensions
+    return out
+
+
+def emit_osi_yaml(models: OsiModel | list[OsiModel], *, version: str = OSI_VERSION) -> str:
+    """Render `OsiModel`(s) as a valid OSI document — top-level `version` +
+    `semantic_model` list. Round-trips through `parse_osi_models`."""
+    if isinstance(models, OsiModel):
+        models = [models]
+    doc = {"version": version, "semantic_model": [emit_osi_model(m) for m in models]}
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+
+
+def emit_osi_from_crosswalk(
+    crosswalk: Any,
+    *,
+    source_dataset: str,
+    source_join_column: str | None = None,
+    crosswalk_dataset: str = "crosswalk",
+    crosswalk_source: str | None = None,
+    resolved_field: str | None = None,
+    certificate: Any = None,
+    model_name: str | None = None,
+) -> str:
+    """Emit valid OSI for a `ResolvedCrosswalk` (wedge B): a crosswalk dataset keyed
+    on `source_pk`, plus a relationship joining the source dataset (many) to it
+    (one) — so metrics group by the conformed `resolved_entity_id`. GoldenMatch
+    provenance (+ an optional key-integrity certificate) rides in `custom_extensions`.
+    """
+    src_pk = getattr(crosswalk, "source_pk_column", "source_pk")
+    resolved_field = resolved_field or getattr(crosswalk, "resolved_key", "resolved_entity_id")
+    join_col = source_join_column or src_pk
+
+    xw = OsiDataset(
+        name=crosswalk_dataset,
+        source=crosswalk_source,
+        primary_key=[src_pk],
+        fields=[
+            OsiField("source", "source", datatype="String"),
+            OsiField(src_pk, src_pk),
+            OsiField(resolved_field, resolved_field, datatype="String"),
+        ],
+    )
+    rel = OsiRelationship(
+        name=f"{source_dataset}_to_{crosswalk_dataset}",
+        from_dataset=source_dataset,
+        to_dataset=crosswalk_dataset,
+        from_columns=[join_col],
+        to_columns=[src_pk],
+    )
+
+    gm: dict[str, Any] = {
+        "generated_by": "goldenmatch.semantic",
+        "resolved_key": resolved_field,
+        "n_records": getattr(crosswalk, "n_records", None),
+        "n_entities": getattr(crosswalk, "n_entities", None),
+        "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
+    }
+    if certificate is not None:
+        gm["key_integrity"] = {
+            "uniqueness_estimate": getattr(certificate, "estimate", None),
+            "max_fan_out": getattr(certificate, "max_fan_out", None),
+            "undercount_estimate": getattr(certificate, "undercount_estimate", None),
+        }
+
+    model = OsiModel(
+        name=model_name or f"{source_dataset}_resolved",
+        datasets=[xw],
+        relationships=[rel],
+        custom_extensions={"goldenmatch": gm},
+    )
+    return emit_osi_yaml(model)
+
+
+# --- bridge: certify the keys an OSI model joins on (metric-aware, wedge A) ----
+
+
+def certify_osi_relationships(model: OsiModel | str | Any, frames: dict[str, Any]) -> list[dict[str, Any]]:
+    """For each relationship in an OSI model, certify the ONE-side key it joins on
+    (the referenced PK) using wedge A — i.e. certify exactly the identity the
+    metrics depend on. `frames` maps dataset name -> table; datasets without a
+    supplied frame are skipped.
+
+    Returns `[{relationship, dataset, key, certificate}]`.
+    """
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    if not isinstance(model, OsiModel):
+        models = parse_osi_models(model)
+        if not models:
+            return []
+        model = models[0]
+
+    out: list[dict[str, Any]] = []
+    for rel in model.relationships:
+        df = frames.get(rel.to_dataset)
+        if df is None or not rel.to_columns:
+            continue
+        cert = certify_key_integrity(df, key=rel.to_columns)
+        out.append({
+            "relationship": rel.name,
+            "dataset": rel.to_dataset,
+            "key": list(rel.to_columns),
+            "certificate": cert,
+        })
+    return out

--- a/packages/python/goldenmatch/tests/test_osi.py
+++ b/packages/python/goldenmatch/tests/test_osi.py
@@ -1,0 +1,123 @@
+"""Tests for the OSI / Apache Ossie reader + emitter (wedge C)."""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    OsiModel,
+    certify_osi_relationships,
+    emit_osi_from_crosswalk,
+    emit_osi_yaml,
+    osi_join_keys,
+    parse_osi_models,
+)
+
+# A real-shaped Ossie document (TPC-DS): version + semantic_model list, datasets
+# with primary_key + dialect-scoped field expressions, relationships from/to.
+_DOC = """
+version: "0.2.0.dev0"
+semantic_model:
+  - name: tpcds_retail_model
+    description: retail model
+    datasets:
+      - name: store_sales
+        source: tpcds.public.store_sales
+        primary_key: [ss_item_sk, ss_ticket_number]
+        fields:
+          - name: ss_customer_sk
+            expression: {dialects: [{dialect: ANSI_SQL, expression: ss_customer_sk}]}
+            datatype: Integer
+      - name: customer
+        source: tpcds.public.customer
+        primary_key: [c_customer_sk]
+        fields:
+          - name: c_customer_sk
+            expression: {dialects: [{dialect: ANSI_SQL, expression: c_customer_sk}]}
+            datatype: Integer
+    relationships:
+      - name: store_sales_to_customer
+        from: store_sales
+        to: customer
+        from_columns: [ss_customer_sk]
+        to_columns: [c_customer_sk]
+    metrics:
+      - name: total_sales
+        expression: {dialects: [{dialect: ANSI_SQL, expression: SUM(store_sales.ss_ext_sales_price)}]}
+        datatype: Decimal
+"""
+
+
+def test_parse_datasets_relationships_metrics():
+    m = parse_osi_models(_DOC)[0]
+    assert isinstance(m, OsiModel)
+    assert m.name == "tpcds_retail_model"
+    assert [d.name for d in m.datasets] == ["store_sales", "customer"]
+    customer = next(d for d in m.datasets if d.name == "customer")
+    assert customer.primary_key == ["c_customer_sk"]
+    assert customer.source == "tpcds.public.customer"
+    # composite primary key parsed
+    ss = next(d for d in m.datasets if d.name == "store_sales")
+    assert ss.primary_key == ["ss_item_sk", "ss_ticket_number"]
+    # dialect-scoped field expression unwrapped
+    assert ss.fields[0].name == "ss_customer_sk" and ss.fields[0].expression == "ss_customer_sk"
+    r = m.relationships[0]
+    assert (r.from_dataset, r.to_dataset) == ("store_sales", "customer")
+    assert r.from_columns == ["ss_customer_sk"] and r.to_columns == ["c_customer_sk"]
+    assert m.metrics[0].expression == "SUM(store_sales.ss_ext_sales_price)"
+
+
+def test_join_keys_are_what_to_resolve():
+    m = parse_osi_models(_DOC)[0]
+    keys = {(k["dataset"], tuple(k["columns"]), k["side"]) for k in osi_join_keys(m)}
+    assert ("customer", ("c_customer_sk",), "one") in keys
+    assert ("store_sales", ("ss_customer_sk",), "many") in keys
+
+
+def test_round_trips_through_parse():
+    m = parse_osi_models(_DOC)[0]
+    m2 = parse_osi_models(emit_osi_yaml(m))[0]
+    assert [d.name for d in m2.datasets] == [d.name for d in m.datasets]
+    assert next(d for d in m2.datasets if d.name == "customer").primary_key == ["c_customer_sk"]
+    r2 = m2.relationships[0]
+    assert (r2.from_dataset, r2.to_dataset, r2.from_columns, r2.to_columns) == \
+        ("store_sales", "customer", ["ss_customer_sk"], ["c_customer_sk"])
+    # schema-faithful: no invented cardinality key
+    assert "cardinality" not in emit_osi_yaml(m)
+
+
+def test_emit_from_crosswalk_declares_conformed_join():
+    class _XW:
+        source_pk_column = "customer_id"
+        resolved_key = "resolved_entity_id"
+        n_records = 12
+        n_entities = 11
+        reduction_ratio = 1 - 11 / 12
+
+    y = emit_osi_from_crosswalk(_XW(), source_dataset="store_sales",
+                                crosswalk_source="analytics.customer_crosswalk")
+    m = parse_osi_models(y)[0]
+    xw = next(d for d in m.datasets if d.name == "crosswalk")
+    assert xw.primary_key == ["customer_id"]
+    assert {f.name for f in xw.fields} == {"source", "customer_id", "resolved_entity_id"}
+    r = m.relationships[0]
+    assert (r.from_dataset, r.to_dataset) == ("store_sales", "crosswalk")
+    assert r.from_columns == ["customer_id"] and r.to_columns == ["customer_id"]
+    # GoldenMatch provenance rides in custom_extensions (schema-safe)
+    gm = m.custom_extensions["goldenmatch"]
+    assert gm["resolved_key"] == "resolved_entity_id" and gm["n_entities"] == 11
+
+
+def test_certify_osi_relationships_bridges_wedge_a():
+    m = parse_osi_models(_DOC)[0]
+    # customer.c_customer_sk has a duplicate -> the key metrics join on is unsafe
+    frames = {"customer": pa.table({"c_customer_sk": [1, 1, 2], "name": ["a", "a", "b"]})}
+    rep = certify_osi_relationships(m, frames)
+    assert len(rep) == 1
+    entry = rep[0]
+    assert entry["dataset"] == "customer" and entry["key"] == ["c_customer_sk"]
+    assert entry["certificate"].estimate == 0.5
+    assert entry["certificate"].max_fan_out == 2.0
+
+
+def test_certify_osi_relationships_accepts_source_and_skips_absent_frames():
+    # passing the raw doc (not a parsed model) + no frames -> nothing to certify
+    assert certify_osi_relationships(_DOC, frames={}) == []

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -493,18 +493,7 @@ _PEPY_RE = re.compile(r"pepy\.tech/projects\?q=(?P<q>[A-Za-z0-9+._-]+)")
 # like goldenmatch-pg it has a publish workflow but is excluded from the download
 # badge totals on purpose. (goldenmatch-hnsw published its first release 2026-07-29
 # and graduated into PYPI_PACKAGES + the README pepy list.)
-# goldengraph / goldenprofile-native gained publish workflows in #2273 but are not
-# yet graduated into the download-badge totals — same "publish-wired, not-yet-badged"
-# default as goldenmatch-hnsw before its first release. goldenprofile-native is a
-# native accelerator (mirrors infermap-native); goldengraph can be graduated into
-# PYPI_PACKAGES + the README pepy list when a badge is wanted.
-_PYPI_PUBLISH_BADGE_EXCEPTIONS = {
-    "goldenmatch-pg", "infermap-native", "er-matcher",
-    "goldengraph", "goldenprofile-native",
-}
-# npm equivalent: goldenmatch-wasm-runtime (#2273) is a shared internal WASM runtime,
-# not a user-facing package with its own download badge.
-_NPM_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-wasm-runtime"}
+_PYPI_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-pg", "infermap-native", "er-matcher"}
 
 
 def check_aggregate_badges(res: Result) -> None:
@@ -526,7 +515,7 @@ def check_aggregate_badges(res: Result) -> None:
         f"symmetric-diff (add to PYPI_PACKAGES, add a publish-*.yml, or to "
         f"EXCEPTIONS): {sorted(pypi_drift)}" if pypi_drift else "",
     )
-    npm_drift = (npm_pub - _NPM_PUBLISH_BADGE_EXCEPTIONS) ^ npm_set
+    npm_drift = npm_pub ^ npm_set
     res.record(
         "npm publishers <-> badge NPM_PACKAGES",
         not npm_drift,

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -493,7 +493,18 @@ _PEPY_RE = re.compile(r"pepy\.tech/projects\?q=(?P<q>[A-Za-z0-9+._-]+)")
 # like goldenmatch-pg it has a publish workflow but is excluded from the download
 # badge totals on purpose. (goldenmatch-hnsw published its first release 2026-07-29
 # and graduated into PYPI_PACKAGES + the README pepy list.)
-_PYPI_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-pg", "infermap-native", "er-matcher"}
+# goldengraph / goldenprofile-native gained publish workflows in #2273 but are not
+# yet graduated into the download-badge totals — same "publish-wired, not-yet-badged"
+# default as goldenmatch-hnsw before its first release. goldenprofile-native is a
+# native accelerator (mirrors infermap-native); goldengraph can be graduated into
+# PYPI_PACKAGES + the README pepy list when a badge is wanted.
+_PYPI_PUBLISH_BADGE_EXCEPTIONS = {
+    "goldenmatch-pg", "infermap-native", "er-matcher",
+    "goldengraph", "goldenprofile-native",
+}
+# npm equivalent: goldenmatch-wasm-runtime (#2273) is a shared internal WASM runtime,
+# not a user-facing package with its own download badge.
+_NPM_PUBLISH_BADGE_EXCEPTIONS = {"goldenmatch-wasm-runtime"}
 
 
 def check_aggregate_badges(res: Result) -> None:
@@ -515,7 +526,7 @@ def check_aggregate_badges(res: Result) -> None:
         f"symmetric-diff (add to PYPI_PACKAGES, add a publish-*.yml, or to "
         f"EXCEPTIONS): {sorted(pypi_drift)}" if pypi_drift else "",
     )
-    npm_drift = npm_pub ^ npm_set
+    npm_drift = (npm_pub - _NPM_PUBLISH_BADGE_EXCEPTIONS) ^ npm_set
     res.record(
         "npm publishers <-> badge NPM_PACKAGES",
         not npm_drift,


### PR DESCRIPTION
## What and why

The bidirectional close of the semantic-layer arc (after **A** certify #2267 and **B** resolve+emit #2274). GoldenMatch as a native provider for **Open Semantic Interchange (Apache Ossie)** — the vendor-neutral interchange spec the whole ecosystem (Snowflake, dbt Labs, Cube, Databricks, Salesforce, …) is converging on. Resolve once against the interchange standard → every OSI-consuming tool inherits correct joins.

C closes the loop both directions:
- **consume** an OSI model to learn which keys the metrics join on, and certify *exactly* those keys;
- **emit** valid OSI declaring the GoldenMatch-resolved key as the conformed join.

I researched the current spec first (this repo defines correctness by conformance, so I didn't guess a schema): Ossie ships a published JSON Schema (`core-spec/osi-schema.json`, spec `0.2.0.dev0`) that validates a real TPC-DS example — concrete enough to build a faithful reader/emitter today.

## Changes

- `goldenmatch/semantic/osi.py`:
  - **`parse_osi_models(source) -> [OsiModel]`** — reads Ossie YAML: top-level `version` + `semantic_model` list; datasets (`primary_key`/`unique_keys`/dialect-scoped `fields`); relationships (`from`/`to`/`from_columns`/`to_columns`); metrics. `osi_join_keys(model)` surfaces "what to resolve."
  - **`certify_osi_relationships(model, frames)`** — bridge to wedge A: certifies the ONE-side key of each relationship (the identity metrics join on) via `certify_key_integrity`.
  - **`emit_osi_from_crosswalk(crosswalk, ...)`** — bridge to wedge B: emits a valid OSI crosswalk dataset + conformed relationship from a `ResolvedCrosswalk`; GM provenance in `custom_extensions`.
  - `emit_osi_model` / `emit_osi_yaml` round-trip through `parse_osi_models`; `Osi{Model,Dataset,Relationship,Field,Metric}` dataclasses.
- ADR `context-network/decisions/0051-osi-ossie-native-provider.md` + planning-doc status (A+B+C shipped, arc complete). Regenerated `docs/agent-codemap.json`.

**Schema-faithful to Ossie `0.2.0.dev0`:** top-level `version` + `semantic_model` LIST; identity is datasets + `primary_key`/`unique_keys` + relationships (no `entity` object); relationship *direction* IS its cardinality — so **no invented `cardinality`, `foreign_key`, or `aggregation` keys** (FKs live in the relationship, aggregation lives in the metric SQL); field/metric expressions are dialect-scoped; GoldenMatch metadata is confined to `custom_extensions` to stay valid against the incubating 0.x spec.

Same discipline as A + B: library-only, advisory, parity-free (no MCP/CLI/A2A/TS surface); `import goldenmatch` stays polars-free (`semantic` lazy).

## Testing

Local (uv workspace), all green:
- `uv run --package goldenmatch python -m pytest packages/python/goldenmatch/tests/test_osi.py` — 6 passed (parse a real TPC-DS-shaped doc, `osi_join_keys`, emit round-trip incl. no-`cardinality` assertion, `emit_osi_from_crosswalk` round-trip + provenance, the `certify_osi_relationships` → wedge A bridge catching a duplicate join key)
- Wedges A + B unchanged: `test_key_integrity.py` + `test_metricflow_parse.py` + `test_metricflow_emit.py` + `test_resolved_crosswalk.py` — 23 passed
- `import goldenmatch` verified polars-free (`semantic` lazy); `ruff check` clean
- Proactively ran the doc/manifest gate battery (`agent_codemap`/`gen_config_matrix --manifest-check`/`gen_suite_matrix --check`/`gen_api_surface --check` + `scripts/test_config_matrix.py`/`test_agent_codemap.py`/`test_docs_sections.py`/`test_api_surface.py`, 64 passed) — all green

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — ran `ruff check` on new files (clean); full pre-commit not run in sandbox
- [ ] Package `CHANGELOG.md` updated if behavior changed — additive new capability; CHANGELOG can follow before release
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated — new ADR 0051 + planning-doc status + regenerated agent-codemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_