### PR TITLE
fix(publish-er-matcher): use prebuilt llama-quantize instead of compiling (OOM fix)

### DIFF
--- a/.github/workflows/publish-er-matcher.yml
+++ b/.github/workflows/publish-er-matcher.yml
@@ -47,14 +47,43 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Build llama.cpp (convert + quantize)
+      - name: Fetch llama.cpp (Python converter + quantize binary)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git clone --depth 1 https://github.com/ggerganov/llama.cpp
-          cd llama.cpp
-          pip install -r requirements.txt
-          cmake -B build -DGGML_NATIVE=OFF
-          cmake --build build --config Release -j --target llama-quantize
+          # Pin the Python converter and the quantize binary to the SAME llama.cpp
+          # release (GGUF format match), and PREFER the prebuilt ubuntu binary so
+          # the runner never OOMs compiling libllama's hundreds of per-architecture
+          # model .cpp files (the exit-143 shutdown). Fall back to a throttled
+          # source build (-j2, quantize target only) if the prebuilt can't run here.
+          LCPP_TAG="$(gh release view --repo ggml-org/llama.cpp --json tagName -q .tagName)"
+          echo "llama.cpp release: $LCPP_TAG"
+          git clone --depth 1 --branch "$LCPP_TAG" https://github.com/ggml-org/llama.cpp
+          pip install -r llama.cpp/requirements.txt
+          mkdir -p bin
+          asset="$(gh release view "$LCPP_TAG" --repo ggml-org/llama.cpp --json assets \
+            -q '.assets[].name | select(test("ubuntu-x64\\.zip$"))' | head -1 || true)"
+          ok=0
+          if [ -n "$asset" ]; then
+            echo "prebuilt asset: $asset"
+            gh release download "$LCPP_TAG" --repo ggml-org/llama.cpp --pattern "$asset" --output lcpp.zip
+            unzip -o lcpp.zip -d lcpp
+            find lcpp -type f \( -name 'llama-quantize' -o -name '*.so*' \) -exec cp {} bin/ \;
+            chmod +x bin/llama-quantize 2>/dev/null || true
+            if [ -x bin/llama-quantize ] && LD_LIBRARY_PATH="$PWD/bin" ./bin/llama-quantize --help >/dev/null 2>&1; then
+              ok=1; echo "using prebuilt llama-quantize"
+            fi
+          fi
+          if [ "$ok" != "1" ]; then
+            echo "::warning::prebuilt llama-quantize unavailable/unusable; building from source (throttled -j2)."
+            cmake -S llama.cpp -B llama.cpp/build -DGGML_NATIVE=OFF \
+              -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF
+            cmake --build llama.cpp/build --config Release -j 2 --target llama-quantize
+            cp llama.cpp/build/bin/llama-quantize bin/
+          fi
+          echo "QUANTIZE=$PWD/bin/llama-quantize" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD/bin" >> "$GITHUB_ENV"
 
       - name: Download merged model
         env:
@@ -101,7 +130,7 @@ jobs:
           mkdir -p dist
           for q in ${{ inputs.quant }}; do
             out="dist/goldenmatch-er-matcher-${{ inputs.tier }}-${q}.gguf"
-            ./llama.cpp/build/bin/llama-quantize base-f16.gguf "$out" "$q"
+            "$QUANTIZE" base-f16.gguf "$out" "$q"
           done
           cd dist && sha256sum *.gguf | tee SHA256SUMS.txt
 


### PR DESCRIPTION
## What and why

The first real dispatch of `publish-er-matcher` failed with **exit 143 (runner OOM-killed)** ~2.5 min into `cmake --build -j` — modern llama.cpp compiles *hundreds* of per-architecture model `.cpp` files into `libllama`, and unbounded parallel g++ blows the standard runner's RAM. The build never reached the model download.

## Fix

Stop compiling llama.cpp from source. The build step now:
- resolves the latest llama.cpp release tag, clones **that tag** (for the Python `convert_hf_to_gguf.py` — pure Python, no build) and installs its `requirements.txt`;
- downloads the **prebuilt `ubuntu-x64` `llama-quantize` binary** for the same tag (version-matched → GGUF format consistent), so there's no compile and no OOM;
- falls back to a **throttled source build** (`-j2`, `--target llama-quantize`, tests/examples/server off) only if the prebuilt binary is unavailable or won't run;
- exposes the binary via `$QUANTIZE` + `LD_LIBRARY_PATH`; the convert/quantize step uses `$QUANTIZE`.

## Testing

- Workflow YAML validated. **Re-dispatched the fixed workflow from this branch** to confirm the build fix end-to-end (`model_source=modal://er-matcher-out/model/merged`, `tier=3b`, `release_tag=er-matcher-3b-v1`) — I'll report the result and finish the `PINNED_MODEL` sha256 pin.
- Only touches `.github/workflows/publish-er-matcher.yml`; the `docs`/CI lanes are path-filtered out, so this is a fast, low-risk merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z)_