### PR TITLE
fix(publish-er-matcher): attach assets at draft creation (immutable-release fix)

### DIFF
--- a/.github/workflows/publish-er-matcher.yml
+++ b/.github/workflows/publish-er-matcher.yml
@@ -30,9 +30,9 @@ on:
         description: "Release tag to create (fresh tag; e.g. er-matcher-3b-v1.0.0 — a burned immutable tag can't be reused)"
         required: true
       quant:
-        description: "Quantization types to build (space-separated llama.cpp quant names)"
+        description: "Quantization types to build (space-separated). Each asset must be < 2 GiB (GitHub release cap) — q8_0/f16 exceed it for a 3B+ model."
         required: false
-        default: "q4_k_m q8_0"
+        default: "q4_k_m"
 
 permissions:
   contents: write   # create the Release + upload assets
@@ -131,6 +131,18 @@ jobs:
           for q in ${{ inputs.quant }}; do
             out="dist/goldenmatch-er-matcher-${{ inputs.tier }}-${q}.gguf"
             "$QUANTIZE" base-f16.gguf "$out" "$q"
+          done
+          # GitHub caps a release asset at 2 GiB. Fail HERE (before touching the
+          # release) with a clear message rather than mid-upload — a too-big quant
+          # (q8_0/f16 on a 3B+) should be dropped or split, not silently skipped.
+          CAP=$((2 * 1024 * 1024 * 1024))
+          for f in dist/*.gguf; do
+            sz=$(stat -c%s "$f")
+            echo "$(numfmt --to=iec "$sz")  $f"
+            if [ "$sz" -ge "$CAP" ]; then
+              echo "::error::$f is $(numfmt --to=iec "$sz") >= 2 GiB (GitHub release-asset cap). Drop this quant from the 'quant' input or split it."
+              exit 1
+            fi
           done
           cd dist && sha256sum *.gguf | tee SHA256SUMS.txt
 

--- a/.github/workflows/publish-er-matcher.yml
+++ b/.github/workflows/publish-er-matcher.yml
@@ -27,7 +27,7 @@ on:
         type: choice
         options: ["3b", "7b"]
       release_tag:
-        description: "Release tag to create/update (e.g. er-matcher-3b-v1)"
+        description: "Release tag to create (fresh tag; e.g. er-matcher-3b-v1.0.0 — a burned immutable tag can't be reused)"
         required: true
       quant:
         description: "Quantization types to build (space-separated llama.cpp quant names)"
@@ -140,10 +140,16 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ inputs.release_tag }}"
-          gh release view "$tag" >/dev/null 2>&1 \
-            || gh release create "$tag" --title "ER-matcher ${{ inputs.tier }}" \
-                 --notes "OSS ER-matcher GGUF (${{ inputs.tier }}). Base: Qwen2.5-${{ inputs.tier }}-Instruct (Apache-2.0). See docs/superpowers/plans/2026-07-26-oss-er-matcher-llm-boost-plan.md."
-          gh release upload "$tag" dist/*.gguf dist/SHA256SUMS.txt --clobber
+          # Immutable releases are ON in this repo: a PUBLISHED release is sealed and
+          # rejects later asset uploads (HTTP 422). So attach every asset AT creation
+          # via a DRAFT (drafts aren't sealed), then publish with `edit --draft=false`,
+          # which seals it WITH the assets. Remove any prior/failed release for this
+          # tag first (best-effort; a burned immutable tag needs a fresh tag instead).
+          gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$tag" dist/*.gguf dist/SHA256SUMS.txt \
+            --draft --title "ER-matcher ${{ inputs.tier }}" \
+            --notes "OSS ER-matcher GGUF (${{ inputs.tier }}). Base: Qwen2.5-${{ inputs.tier }}-Instruct (Apache-2.0). See docs/superpowers/plans/2026-07-26-oss-er-matcher-llm-boost-plan.md."
+          gh release edit "$tag" --draft=false
 
       - name: Print the pin to paste into the runtime loader
         run: |

--- a/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
@@ -70,7 +70,7 @@ class LocalModelSpec:
 PINNED_MODEL = LocalModelSpec(
     url=(
         "https://github.com/benseverndev-oss/goldenmatch/releases/download/"
-        "er-matcher-3b-v1/goldenmatch-er-matcher-3b-q4_k_m.gguf"
+        "er-matcher-3b-v1.0.0/goldenmatch-er-matcher-3b-q4_k_m.gguf"
     ),
     filename="goldenmatch-er-matcher-3b-q4_k_m.gguf",
     sha256=None,


### PR DESCRIPTION
## What and why

With the OOM fix (#2280) in place, the publish run got all the way through **build ✅ → Modal download ✅ (so `model/merged` is on the volume — the training run is done) → convert+quantize ✅** and failed only at the last step:

```
HTTP 422: Cannot upload assets to an immutable release.
```

This repo has immutable releases ON, so `gh release create` seals the release at creation and the separate `gh release upload` is rejected. It also **burned the `er-matcher-3b-v1` tag** (deleting an immutable release doesn't free the name).

## Fix

- **Attach every asset at creation via a draft, then publish** — `gh release create <tag> dist/*.gguf SHA256SUMS.txt --draft …` then `gh release edit <tag> --draft=false`. Drafts aren't sealed, so publishing seals the release *with* its assets (the documented immutable-release pattern). Best-effort pre-delete of a stale release for the tag.
- **Fresh tag `er-matcher-3b-v1.0.0`** (v1 is burned); `_llm_loader.PINNED_MODEL` URL updated to match.

## Testing

- Workflow YAML validated; `test_local_llm.py` green; ruff clean.
- **Re-dispatched from this branch** with `release_tag=er-matcher-3b-v1.0.0` — I'll confirm the Release publishes with assets and then land the `sha256` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z)_