### PR TITLE
feat(semantic): follow-ons — Cube (cube.dev) dialect + OSI conformance validation

### DIFF
--- a/context-network/decisions/0052-cube-dialect-and-osi-validation.md
+++ b/context-network/decisions/0052-cube-dialect-and-osi-validation.md
@@ -1,0 +1,86 @@
+# 0052 — Follow-ons: Cube (cube.dev) dialect + OSI conformance validation
+
+**Status:** accepted (2026-07-30, Ben) • **Shipped:** `goldenmatch.semantic.{parse_cube_models, cube_join_keys, certify_cube_joins, emit_cube_yaml, emit_cube_from_crosswalk}` + `Cube*` dataclasses, and `goldenmatch.semantic.validate_osi` • **Builds on:** [0049 (certify)](0049-metric-aware-key-certification.md) + [0050 (resolve+emit)](0050-resolved-crosswalk-emit.md) + [0051 (OSI)](0051-osi-ossie-native-provider.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+Wedges A + B + C landed the semantic-layer arc against dbt/MetricFlow and
+OSI/Apache Ossie. ADR 0051 named two follow-ons "not v1": a **Cube emitter** and
+**JSON-Schema validation**. This ADR ships both — the two that stay within the
+established discipline (library-only, advisory, parity-free) and need no new
+gated surface.
+
+- **Cube (cube.dev)** is the third major semantic layer, and it is the same shape
+  as the other two: a cube's identity is a **dimension marked `primary_key: true`**
+  and joins live in a `joins:` block whose `relationship` (`one_to_one` /
+  `one_to_many` / `many_to_one`) encodes cardinality from the declaring cube's
+  point of view — so the join key is, again, the identity the metrics silently
+  assume. Adding it completes the MetricFlow ✓ / OSI ✓ / Cube ✓ reader+emitter
+  symmetry: GoldenMatch reads any of the three and emits the conformed key back
+  into it.
+- **OSI validation** hardens wedge C. Emitting *valid* OSI is a claim; without a
+  check it can only be asserted. The Ossie 0.x schema is small enough to validate
+  structurally with no dependency, and the highest-value check is not generic
+  JSON-Schema conformance but flagging the **non-Ossie keys hand-written docs tend
+  to invent** — `cardinality`, `foreign_key`, `aggregation` — which are exactly
+  the ones 0051 was careful never to emit.
+
+## Decision
+1. **Cube dialect — schema-faithful to the current snake_case YAML data model,
+   invent nothing.** Top level is a `cubes:` list; a cube is `name` +
+   `sql_table`/`sql` + `dimensions` + `measures` + `joins`. Primary key = the
+   `primary_key: true` dimensions (composite = several). Joins are
+   `{name, relationship, sql}` with member refs in the **YAML** single-brace form
+   (`{CUBE}.fk = {other.pk}`, column outside the braces for self, inside for the
+   other cube — the `${...}` template form is JS-models only). **Legacy
+   relationship aliases** (`has_one`/`has_many`/`belongs_to` + camelCase) are read
+   and normalized to the modern enum on emit. `parse_cube_models(emit_cube_yaml(...))`
+   round-trips. `views:` are a consumption re-projection with no keys/joins of
+   their own and are intentionally not modeled.
+2. **Same bridges to A + B as OSI.** `cube_join_keys` surfaces "what to resolve"
+   (best-effort parsing FK/PK columns out of the join `sql`); `certify_cube_joins`
+   certifies the ONE-side key of each join via wedge A (metric-aware);
+   `emit_cube_from_crosswalk` turns a wedge-B `ResolvedCrosswalk` into a crosswalk
+   cube (keyed on the source PK) + a `many_to_one` join from the source cube — so
+   metrics group by the conformed `resolved_entity_id`. GoldenMatch provenance
+   rides in the crosswalk cube's `meta` (Cube's sanctioned free-form extension
+   point).
+3. **`validate_osi` is a dependency-free STRUCTURAL validator**, not a jsonschema
+   dependency: it checks the Ossie `0.2.0.dev0` required-field sets, list shape,
+   and enum membership (dialects + datatypes), and — the distinctive part — flags
+   the keys the schema does NOT define (`cardinality`/`foreign_key`/`aggregation`)
+   so both GoldenMatch-emitted and third-party docs stay portable across Ossie
+   consumers. `validate_osi(emit_osi_yaml(...)) == []` is the round-trip contract.
+4. **Library-only, advisory, parity-free** — same discipline as A/B/C; no
+   MCP/CLI/A2A/TS surface (so `api_parity` is untouched), and `semantic/` stays
+   out of top-level `goldenmatch/__init__.py` so `import goldenmatch` stays
+   polars-free.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — a second interchange adapter (Cube) over the
+  control plane's resolved ids + wedge A/B, plus a validator over C's own output;
+  no new identity or metric semantics.
+- **Conformance defines correctness** ✅ — `validate_osi` makes wedge C's "we emit
+  valid OSI" checkable rather than asserted; the Cube reader/emitter is pinned to
+  the documented snake_case data model and round-trip-tested.
+- **Arrow at bulk boundaries** ✅ — dialect docs are small metadata (YAML); the
+  frames `certify_cube_joins` certifies are Arrow.
+
+## Consequences / honest flags
+- **Cube join-column parsing is best-effort from the join `sql` string.** The
+  relationship + target cube are structured; the FK/PK columns are recovered by
+  parsing `{...}` member refs, which covers the standard equi-join form but not
+  arbitrary SQL. `certify_cube_joins` simply skips a join whose target columns
+  can't be parsed (never guesses).
+- **`validate_osi` is structural, not full JSON-Schema.** It deliberately does
+  NOT vendor `osi-schema.json` or pull a `jsonschema` dependency; it validates the
+  required-field/enum constraints that keep GoldenMatch-emitted OSI round-trippable
+  and portable. A vendored-schema validation mode remains a possible follow-on if
+  a consumer needs byte-level schema conformance.
+- **Targets Ossie `0.2.0.dev0` / Cube's current YAML model** — both incubating /
+  evolving; pin + revisit on a spec bump, as with 0051.
+- **Still-deferred follow-ons** (unchanged from 0051): a CLI/MCP front door (would
+  add an `api_parity`-gated surface), metric-aware *blocking*, dbt crosswalk
+  materialization, and writing back into a live catalog.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-07-30

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -1,9 +1,12 @@
 # Semantic Layering (MetricFlow / Cube / OSI) — brainstorm / planning
 
-> **Status:** wedges **A + B + C** SHIPPED — decisions
+> **Status:** wedges **A + B + C** SHIPPED + **follow-ons** (Cube dialect, OSI
+> conformance validation) — decisions
 > [0049](../decisions/0049-metric-aware-key-certification.md) (certify) +
 > [0050](../decisions/0050-resolved-crosswalk-emit.md) (resolve once + emit) +
-> [0051](../decisions/0051-osi-ossie-native-provider.md) (OSI/Ossie provider).
+> [0051](../decisions/0051-osi-ossie-native-provider.md) (OSI/Ossie provider) +
+> [0052](../decisions/0052-cube-dialect-and-osi-validation.md) (Cube dialect +
+> OSI validation).
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**
@@ -16,9 +19,16 @@
 > native provider): `parse_osi_models` + `osi_join_keys` (consume — learn what to
 > resolve), `certify_osi_relationships` (bridge to A — certify the keys metrics
 > join on), `emit_osi_from_crosswalk` (bridge to B — emit the conformed join), all
-> schema-faithful to Ossie `0.2.0.dev0`. The arc is complete — the whole
-> crawl→walk→run is landed. Greenfield when written: no prior repo code, doc, or
-> decision referenced this ecosystem (grep, 2026-07-30).
+> schema-faithful to Ossie `0.2.0.dev0`. **Follow-ons** (0052): a **Cube (cube.dev)
+> dialect** — `parse_cube_models` + `cube_join_keys` (consume), `certify_cube_joins`
+> (bridge to A), `emit_cube_from_crosswalk` (bridge to B), completing the
+> MetricFlow ✓ / OSI ✓ / Cube ✓ reader+emitter symmetry — and **OSI conformance
+> validation** (`validate_osi`): a dependency-free structural validator over the
+> Ossie `0.2.0.dev0` required-field + enum constraints that also flags the
+> non-Ossie keys (`cardinality`/`foreign_key`/`aggregation`) hand-written docs
+> tend to invent. The arc is complete — the whole crawl→walk→run is landed.
+> Greenfield when written: no prior repo code, doc, or decision referenced this
+> ecosystem (grep, 2026-07-30).
 
 ## The premise
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7150,7 +7150,7 @@
             "OsiModel",
             "OsiRelationship",
             "_dialect_expression",
-            "_expr_ok",
+            "_expression_issues",
             "_parse_dataset",
             "_parse_relationship",
             "_read_expression",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 432,
+      "module_count": 433,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7056,6 +7056,7 @@
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.crosswalk",
+            "goldenmatch.semantic.cube",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi"
@@ -7075,6 +7076,35 @@
             "goldenmatch.core.autoconfig",
             "goldenmatch.identity.store",
             "goldenmatch.semantic.key_integrity"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.cube",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/cube.py",
+          "purpose": "Cube (cube.dev) semantic-layer reader + emitter — the third dialect.",
+          "defines": [
+            "Cube",
+            "CubeDimension",
+            "CubeJoin",
+            "CubeMeasure",
+            "_member_refs",
+            "_normalize_relationship",
+            "_parse_dimension",
+            "_parse_join",
+            "_parse_measure",
+            "certify_cube_joins",
+            "cube_join_keys",
+            "emit_cube",
+            "emit_cube_dimension",
+            "emit_cube_from_crosswalk",
+            "emit_cube_join",
+            "emit_cube_measure",
+            "emit_cube_yaml",
+            "parse_cube_models"
+          ],
+          "imports": [
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow"
           ]
         },
         {
@@ -7120,6 +7150,7 @@
             "OsiModel",
             "OsiRelationship",
             "_dialect_expression",
+            "_expr_ok",
             "_parse_dataset",
             "_parse_relationship",
             "_read_expression",
@@ -7131,7 +7162,8 @@
             "emit_osi_relationship",
             "emit_osi_yaml",
             "osi_join_keys",
-            "parse_osi_models"
+            "parse_osi_models",
+            "validate_osi"
           ],
           "imports": [
             "goldenmatch.semantic.key_integrity",

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -18,6 +18,17 @@ from __future__ import annotations
 
 from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
 from goldenmatch.semantic.crosswalk import ResolvedCrosswalk, build_resolved_crosswalk
+from goldenmatch.semantic.cube import (
+    Cube,
+    CubeDimension,
+    CubeJoin,
+    CubeMeasure,
+    certify_cube_joins,
+    cube_join_keys,
+    emit_cube_from_crosswalk,
+    emit_cube_yaml,
+    parse_cube_models,
+)
 from goldenmatch.semantic.key_integrity import certify_key_integrity
 from goldenmatch.semantic.metricflow import (
     DeclaredKeySpec,
@@ -38,6 +49,7 @@ from goldenmatch.semantic.osi import (
     emit_osi_yaml,
     osi_join_keys,
     parse_osi_models,
+    validate_osi,
 )
 
 __all__ = [
@@ -59,9 +71,20 @@ __all__ = [
     "emit_osi_model",
     "emit_osi_yaml",
     "emit_osi_from_crosswalk",
+    "validate_osi",
     "OsiModel",
     "OsiDataset",
     "OsiRelationship",
     "OsiField",
     "OsiMetric",
+    # follow-on — Cube (cube.dev) dialect (reader + emitter + bridges)
+    "parse_cube_models",
+    "cube_join_keys",
+    "certify_cube_joins",
+    "emit_cube_yaml",
+    "emit_cube_from_crosswalk",
+    "Cube",
+    "CubeDimension",
+    "CubeMeasure",
+    "CubeJoin",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/cube.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/cube.py
@@ -1,0 +1,319 @@
+"""Cube (cube.dev) semantic-layer reader + emitter — the third dialect.
+
+Cube's YAML data model is a `cubes:` list (+ an optional `views:` list). A cube's
+identity is a **dimension marked `primary_key: true`** (composite = several so
+marked); joins live in the cube's `joins:` block, each `{name, relationship,
+sql}` where `relationship` is `one_to_one` / `one_to_many` / `many_to_one` and
+the direction is written from the declaring cube's point of view. So — exactly as
+with MetricFlow entities and OSI relationships — the join key is the identity the
+metrics silently assume.
+
+- **consume** a Cube model to learn the declared keys + joins (`parse_cube_models`,
+  `cube_join_keys`) — "what to resolve";
+- **emit** valid Cube YAML declaring the GoldenMatch-resolved key as a conformed
+  join: a crosswalk cube keyed on the source PK + a join from the source cube to
+  it (`emit_cube_from_crosswalk`, bridging wedge B), with provenance in `meta`.
+
+Schema-faithful to the current snake_case YAML data model (member refs use single
+braces `{CUBE}.fk = {other.pk}`; the `${...}` template form is JS-models only).
+Legacy relationship aliases (`has_one`/`has_many`/`belongs_to` and their camelCase
+spellings) are read and normalized to the modern enum on emit. `parse_cube_models(
+emit_cube_yaml(...))` round-trips. Library-only, advisory, parity-free.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+from goldenmatch.semantic.metricflow import _load
+
+# relationship enum + legacy aliases -> modern form (direction: declaring cube first)
+_RELATIONSHIPS = frozenset({"one_to_one", "one_to_many", "many_to_one"})
+_RELATIONSHIP_ALIASES = {
+    "has_one": "one_to_one", "hasone": "one_to_one",
+    "has_many": "one_to_many", "hasmany": "one_to_many",
+    "belongs_to": "many_to_one", "belongsto": "many_to_one",
+}
+# Member refs are asymmetric: `{CUBE}.col` (self, column OUTSIDE the braces) and
+# `{other_cube.member}` (column INSIDE). Capture the braced token + an optional
+# trailing `.column`.
+_MEMBER_REF = re.compile(r"\{([^}]+)\}(?:\.(\w+))?")
+
+
+# --- model -------------------------------------------------------------------
+
+
+@dataclass
+class CubeDimension:
+    name: str
+    sql: str                             # the SQL expression — usually the column
+    type: str = "string"                 # string / number / time / boolean / geo
+    primary_key: bool = False
+
+
+@dataclass
+class CubeMeasure:
+    name: str
+    type: str = "count"                  # count / sum / avg / count_distinct / ...
+    sql: str | None = None               # not required for `count`
+
+
+@dataclass
+class CubeJoin:
+    name: str                            # the joined cube's name
+    relationship: str                    # one_to_one / one_to_many / many_to_one
+    sql: str                             # the ON condition, e.g. "{CUBE}.fk = {other.id}"
+
+
+@dataclass
+class Cube:
+    name: str
+    sql_table: str | None = None
+    sql: str | None = None               # a SELECT used instead of a table
+    dimensions: list[CubeDimension] = field(default_factory=list)
+    measures: list[CubeMeasure] = field(default_factory=list)
+    joins: list[CubeJoin] = field(default_factory=list)
+    meta: dict[str, Any] | None = None
+
+    @property
+    def primary_key(self) -> list[str]:
+        """The cube's (possibly composite) primary key — the dimensions marked
+        `primary_key: true`, in declaration order."""
+        return [d.name for d in self.dimensions if d.primary_key]
+
+
+# --- parse (consume) ---------------------------------------------------------
+
+
+def _normalize_relationship(rel: Any) -> str:
+    r = str(rel or "").strip()
+    key = r.lower().replace("-", "_")
+    if key in _RELATIONSHIPS:
+        return key
+    return _RELATIONSHIP_ALIASES.get(key, r)
+
+
+def _parse_dimension(d: dict[str, Any]) -> CubeDimension:
+    return CubeDimension(
+        name=str(d.get("name", "")),
+        sql=str(d.get("sql", d.get("name", ""))),
+        type=str(d.get("type", "string")),
+        primary_key=bool(d.get("primary_key", False)),
+    )
+
+
+def _parse_measure(m: dict[str, Any]) -> CubeMeasure:
+    return CubeMeasure(
+        name=str(m.get("name", "")),
+        type=str(m.get("type", "count")),
+        sql=m.get("sql"),
+    )
+
+
+def _parse_join(j: dict[str, Any]) -> CubeJoin:
+    return CubeJoin(
+        name=str(j.get("name", "")),
+        relationship=_normalize_relationship(j.get("relationship")),
+        sql=str(j.get("sql", "")),
+    )
+
+
+def parse_cube_models(source: str | Any) -> list[Cube]:
+    """Parse a Cube data model (path, YAML string, or dict) into `Cube`s.
+
+    Reads the top-level `cubes:` list; `views:` are a consumption re-projection
+    (no keys/joins of their own) and are intentionally not modeled here.
+    """
+    data = _load(source)
+    out: list[Cube] = []
+    for c in data.get("cubes") or []:
+        if not isinstance(c, dict):
+            continue
+        out.append(Cube(
+            name=str(c.get("name", "")),
+            sql_table=c.get("sql_table"),
+            sql=c.get("sql"),
+            dimensions=[_parse_dimension(d) for d in (c.get("dimensions") or []) if isinstance(d, dict)],
+            measures=[_parse_measure(m) for m in (c.get("measures") or []) if isinstance(m, dict)],
+            joins=[_parse_join(j) for j in (c.get("joins") or []) if isinstance(j, dict)],
+            meta=c.get("meta"),
+        ))
+    return out
+
+
+def _member_refs(sql: str) -> list[tuple[str | None, str]]:
+    """Pull `{CUBE}.col` / `{other.col}` member refs out of a join `sql`, as
+    `(cube_or_None, column)` — `{CUBE}` (self) yields `(None, col)`."""
+    refs: list[tuple[str | None, str]] = []
+    for inside, after in _MEMBER_REF.findall(sql):
+        token = inside.strip()
+        if "." in token:                      # `{other_cube.member}` form
+            head, _, col = token.rpartition(".")
+            head = head.strip()
+            refs.append((None if head == "CUBE" else head, col.strip()))
+        elif after:                           # `{CUBE}.col` / `{cube}.col` form
+            refs.append((None if token == "CUBE" else token, after.strip()))
+    return refs
+
+
+def cube_join_keys(cube: Cube) -> list[dict[str, Any]]:
+    """The keys a cube's joins ride on — the identity its metrics depend on. One
+    entry per join: `{from_cube, to_cube, relationship, from_columns, to_columns,
+    sql}`. Columns are best-effort parsed from the join `sql` member refs — this
+    is what GoldenMatch should resolve/certify (metric-aware)."""
+    out: list[dict[str, Any]] = []
+    for j in cube.joins:
+        from_cols: list[str] = []
+        to_cols: list[str] = []
+        for ref_cube, col in _member_refs(j.sql):
+            if ref_cube is None or ref_cube == cube.name:
+                from_cols.append(col)
+            elif ref_cube == j.name:
+                to_cols.append(col)
+        out.append({
+            "from_cube": cube.name,
+            "to_cube": j.name,
+            "relationship": j.relationship,
+            "from_columns": from_cols,
+            "to_columns": to_cols,
+            "sql": j.sql,
+        })
+    return out
+
+
+# --- emit (produce) ----------------------------------------------------------
+
+
+def emit_cube_dimension(d: CubeDimension) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": d.name, "sql": d.sql, "type": d.type}
+    if d.primary_key:
+        out["primary_key"] = True
+    return out
+
+
+def emit_cube_measure(m: CubeMeasure) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": m.name, "type": m.type}
+    if m.sql is not None:
+        out["sql"] = m.sql
+    return out
+
+
+def emit_cube_join(j: CubeJoin) -> dict[str, Any]:
+    return {"name": j.name, "relationship": _normalize_relationship(j.relationship), "sql": j.sql}
+
+
+def emit_cube(cube: Cube) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": cube.name}
+    if cube.sql_table:
+        out["sql_table"] = cube.sql_table
+    elif cube.sql:
+        out["sql"] = cube.sql
+    if cube.joins:
+        out["joins"] = [emit_cube_join(j) for j in cube.joins]
+    if cube.dimensions:
+        out["dimensions"] = [emit_cube_dimension(d) for d in cube.dimensions]
+    if cube.measures:
+        out["measures"] = [emit_cube_measure(m) for m in cube.measures]
+    if cube.meta:
+        out["meta"] = cube.meta
+    return out
+
+
+def emit_cube_yaml(cubes: Cube | list[Cube]) -> str:
+    """Render `Cube`(s) as a valid Cube data model — a top-level `cubes:` list.
+    Round-trips through `parse_cube_models`."""
+    if isinstance(cubes, Cube):
+        cubes = [cubes]
+    doc = {"cubes": [emit_cube(c) for c in cubes]}
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+
+
+def emit_cube_from_crosswalk(
+    crosswalk: Any,
+    *,
+    source_cube: str,
+    source_join_column: str | None = None,
+    crosswalk_cube: str = "crosswalk",
+    crosswalk_sql_table: str | None = None,
+    resolved_field: str | None = None,
+    certificate: Any = None,
+) -> str:
+    """Emit valid Cube YAML for a `ResolvedCrosswalk` (wedge B): a crosswalk cube
+    keyed on `source_pk` (a `primary_key` dimension), plus a `many_to_one` join
+    from the source cube to it — so metrics group by the conformed
+    `resolved_entity_id`. GoldenMatch provenance (+ an optional key-integrity
+    certificate) rides in the crosswalk cube's `meta.goldenmatch`.
+    """
+    src_pk = getattr(crosswalk, "source_pk_column", "source_pk")
+    resolved_field = resolved_field or getattr(crosswalk, "resolved_key", "resolved_entity_id")
+    join_col = source_join_column or src_pk
+
+    xw = Cube(
+        name=crosswalk_cube,
+        sql_table=crosswalk_sql_table,
+        dimensions=[
+            CubeDimension(src_pk, src_pk, type="string", primary_key=True),
+            CubeDimension("source", "source", type="string"),
+            CubeDimension(resolved_field, resolved_field, type="string"),
+        ],
+    )
+
+    gm: dict[str, Any] = {
+        "generated_by": "goldenmatch.semantic",
+        "resolved_key": resolved_field,
+        "n_records": getattr(crosswalk, "n_records", None),
+        "n_entities": getattr(crosswalk, "n_entities", None),
+        "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
+    }
+    if certificate is not None:
+        gm["key_integrity"] = {
+            "uniqueness_estimate": getattr(certificate, "estimate", None),
+            "max_fan_out": getattr(certificate, "max_fan_out", None),
+            "undercount_estimate": getattr(certificate, "undercount_estimate", None),
+        }
+    xw.meta = {"goldenmatch": gm}
+
+    # The source cube declares the conformed join to the crosswalk (many source
+    # rows -> one crosswalk row on the source PK).
+    src = Cube(
+        name=source_cube,
+        joins=[CubeJoin(
+            name=crosswalk_cube,
+            relationship="many_to_one",
+            sql=f"{{CUBE}}.{join_col} = {{{crosswalk_cube}.{src_pk}}}",
+        )],
+    )
+    return emit_cube_yaml([src, xw])
+
+
+# --- bridge: certify the keys a Cube model joins on (metric-aware, wedge A) ----
+
+
+def certify_cube_joins(model: list[Cube] | str | Any, frames: dict[str, Any]) -> list[dict[str, Any]]:
+    """For each join in a Cube model, certify the ONE-side key it joins on (the
+    referenced primary key) using wedge A — certifying exactly the identity the
+    metrics depend on. `frames` maps cube name -> table; cubes without a supplied
+    frame (or a join whose target columns can't be parsed) are skipped.
+
+    Returns `[{from_cube, to_cube, key, certificate}]`.
+    """
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    cubes = model if isinstance(model, list) else parse_cube_models(model)
+    out: list[dict[str, Any]] = []
+    for cube in cubes:
+        for jk in cube_join_keys(cube):
+            df = frames.get(jk["to_cube"])
+            if df is None or not jk["to_columns"]:
+                continue
+            cert = certify_key_integrity(df, key=jk["to_columns"])
+            out.append({
+                "from_cube": jk["from_cube"],
+                "to_cube": jk["to_cube"],
+                "key": list(jk["to_columns"]),
+                "certificate": cert,
+            })
+    return out

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi.py
@@ -357,14 +357,23 @@ def certify_osi_relationships(model: OsiModel | str | Any, frames: dict[str, Any
 # --- conformance validation --------------------------------------------------
 
 
-def _expr_ok(expr: Any) -> bool:
-    """A valid Ossie expression is a str or a `{dialects: [{dialect, expression}]}`."""
+def _expression_issues(expr: Any, loc: str) -> list[str]:
+    """Validate an Ossie `expression` — a str or `{dialects: [{dialect, expression}]}`.
+    Returns issues for a missing/malformed expression AND for any dialect name
+    outside the Ossie enum (`_OSI_DIALECTS`)."""
     if isinstance(expr, str):
-        return True
+        return []
     if isinstance(expr, dict):
         dialects = expr.get("dialects")
-        return isinstance(dialects, list) and bool(dialects)
-    return False
+        if not isinstance(dialects, list) or not dialects:
+            return [f"{loc}: missing/invalid 'expression'"]
+        out: list[str] = []
+        for d in dialects:
+            dialect = d.get("dialect") if isinstance(d, dict) else None
+            if dialect is not None and dialect not in _OSI_DIALECTS:
+                out.append(f"{loc}: dialect {dialect!r} not in the Ossie enum")
+        return out
+    return [f"{loc}: missing/invalid 'expression'"]
 
 
 def validate_osi(source: str | Any) -> list[str]:
@@ -408,8 +417,7 @@ def validate_osi(source: str | Any) -> list[str]:
                 if not isinstance(f, dict) or not str(f.get("name", "")).strip():
                     issues.append(f"{floc}: missing 'name'")
                     continue
-                if not _expr_ok(f.get("expression")):
-                    issues.append(f"{floc}: missing/invalid 'expression'")
+                issues.extend(_expression_issues(f.get("expression"), floc))
                 dt = f.get("datatype")
                 if dt is not None and dt not in _OSI_DATATYPES:
                     issues.append(f"{floc}: datatype {dt!r} not in the Ossie enum")
@@ -430,8 +438,7 @@ def validate_osi(source: str | Any) -> list[str]:
             if not isinstance(mt, dict) or not str(mt.get("name", "")).strip():
                 issues.append(f"{mloc}: missing 'name'")
                 continue
-            if not _expr_ok(mt.get("expression")):
-                issues.append(f"{mloc}: missing/invalid 'expression'")
+            issues.extend(_expression_issues(mt.get("expression"), mloc))
             if "aggregation" in mt or "agg" in mt:
                 issues.append(f"{mloc}: aggregation belongs inside the metric SQL expression, not a key")
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi.py
@@ -31,6 +31,15 @@ from goldenmatch.semantic.metricflow import _load
 OSI_VERSION = "0.2.0.dev0"
 DEFAULT_DIALECT = "ANSI_SQL"
 
+# The Ossie 0.2.0.dev0 enums (core-spec/osi-schema.json). Used by validate_osi.
+_OSI_DIALECTS = frozenset(
+    {"ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY"}
+)
+_OSI_DATATYPES = frozenset({
+    "String", "Integer", "Decimal", "Float", "Boolean",
+    "Date", "Time", "DateTime", "DateTimeTz", "Opaque",
+})
+
 
 # --- model -------------------------------------------------------------------
 
@@ -343,3 +352,87 @@ def certify_osi_relationships(model: OsiModel | str | Any, frames: dict[str, Any
             "certificate": cert,
         })
     return out
+
+
+# --- conformance validation --------------------------------------------------
+
+
+def _expr_ok(expr: Any) -> bool:
+    """A valid Ossie expression is a str or a `{dialects: [{dialect, expression}]}`."""
+    if isinstance(expr, str):
+        return True
+    if isinstance(expr, dict):
+        dialects = expr.get("dialects")
+        return isinstance(dialects, list) and bool(dialects)
+    return False
+
+
+def validate_osi(source: str | Any) -> list[str]:
+    """Validate an OSI/Ossie document against the spec's structural constraints
+    (`core-spec/osi-schema.json`, 0.2.0.dev0) — returns a list of human-readable
+    issues, empty when valid. Faithful to the schema's `required` sets + enums,
+    and flags the keys the schema does NOT define (cardinality / foreign_key /
+    aggregation) so hand-written or third-party docs stay conformant.
+
+    Structural (no `jsonschema` dependency): validates required fields, list shape,
+    and enum membership — the checks that keep GoldenMatch-emitted OSI round-trippable
+    and portable across Ossie consumers. `validate_osi(emit_osi_yaml(...)) == []`.
+    """
+    data = _load(source)
+    issues: list[str] = []
+
+    if "version" not in data:
+        issues.append("missing top-level 'version'")
+    sm = data.get("semantic_model")
+    if not isinstance(sm, list):
+        issues.append("'semantic_model' must be a list of models")
+        return issues
+
+    for i, m in enumerate(sm):
+        loc = f"semantic_model[{i}]"
+        if not isinstance(m, dict):
+            issues.append(f"{loc}: must be a mapping")
+            continue
+        if not str(m.get("name", "")).strip():
+            issues.append(f"{loc}: missing 'name'")
+
+        for j, d in enumerate(m.get("datasets") or []):
+            dloc = f"{loc}.datasets[{j}]"
+            if not isinstance(d, dict) or not str(d.get("name", "")).strip():
+                issues.append(f"{dloc}: missing 'name'")
+                continue
+            if "foreign_key" in d:
+                issues.append(f"{dloc}: 'foreign_key' is not an Ossie key — declare FKs in relationships")
+            for k, f in enumerate(d.get("fields") or []):
+                floc = f"{dloc}.fields[{k}]"
+                if not isinstance(f, dict) or not str(f.get("name", "")).strip():
+                    issues.append(f"{floc}: missing 'name'")
+                    continue
+                if not _expr_ok(f.get("expression")):
+                    issues.append(f"{floc}: missing/invalid 'expression'")
+                dt = f.get("datatype")
+                if dt is not None and dt not in _OSI_DATATYPES:
+                    issues.append(f"{floc}: datatype {dt!r} not in the Ossie enum")
+
+        for j, r in enumerate(m.get("relationships") or []):
+            rloc = f"{loc}.relationships[{j}]"
+            if not isinstance(r, dict):
+                issues.append(f"{rloc}: must be a mapping")
+                continue
+            for req in ("name", "from", "to", "from_columns", "to_columns"):
+                if req not in r or r.get(req) in (None, "", []):
+                    issues.append(f"{rloc}: missing required '{req}'")
+            if "cardinality" in r:
+                issues.append(f"{rloc}: 'cardinality' is not an Ossie key — direction is from(many)->to(one)")
+
+        for j, mt in enumerate(m.get("metrics") or []):
+            mloc = f"{loc}.metrics[{j}]"
+            if not isinstance(mt, dict) or not str(mt.get("name", "")).strip():
+                issues.append(f"{mloc}: missing 'name'")
+                continue
+            if not _expr_ok(mt.get("expression")):
+                issues.append(f"{mloc}: missing/invalid 'expression'")
+            if "aggregation" in mt or "agg" in mt:
+                issues.append(f"{mloc}: aggregation belongs inside the metric SQL expression, not a key")
+
+    return issues

--- a/packages/python/goldenmatch/tests/test_cube.py
+++ b/packages/python/goldenmatch/tests/test_cube.py
@@ -1,0 +1,158 @@
+"""Tests for the Cube (cube.dev) reader + emitter (semantic-layer follow-on)."""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    Cube,
+    certify_cube_joins,
+    cube_join_keys,
+    emit_cube_from_crosswalk,
+    emit_cube_yaml,
+    parse_cube_models,
+)
+
+# A real-shaped Cube data model: cubes with a primary_key dimension + a join
+# whose relationship + sql (single-brace member refs) encode the FK->PK edge.
+_DOC = """
+cubes:
+  - name: orders
+    sql_table: public.orders
+    joins:
+      - name: customers
+        relationship: many_to_one
+        sql: "{CUBE}.customer_id = {customers.id}"
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: customer_id
+        sql: customer_id
+        type: number
+    measures:
+      - name: count
+        type: count
+      - name: total_amount
+        type: sum
+        sql: amount
+  - name: customers
+    sql_table: public.customers
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: name
+        sql: name
+        type: string
+"""
+
+
+def test_parse_cubes_dimensions_joins_measures():
+    cubes = parse_cube_models(_DOC)
+    assert [c.name for c in cubes] == ["orders", "customers"]
+    orders = cubes[0]
+    assert orders.sql_table == "public.orders"
+    assert orders.primary_key == ["id"]
+    # measure without sql (count) parses
+    assert {m.name for m in orders.measures} == {"count", "total_amount"}
+    j = orders.joins[0]
+    assert (j.name, j.relationship) == ("customers", "many_to_one")
+    assert cubes[1].primary_key == ["id"]
+
+
+def test_composite_primary_key():
+    doc = """
+cubes:
+  - name: order_lines
+    sql_table: public.order_lines
+    dimensions:
+      - name: order_id
+        sql: order_id
+        type: number
+        primary_key: true
+      - name: line_no
+        sql: line_no
+        type: number
+        primary_key: true
+"""
+    assert parse_cube_models(doc)[0].primary_key == ["order_id", "line_no"]
+
+
+def test_legacy_relationship_aliases_normalize():
+    doc = """
+cubes:
+  - name: orders
+    sql_table: public.orders
+    joins:
+      - name: customers
+        relationship: belongsTo
+        sql: "{CUBE}.customer_id = {customers.id}"
+"""
+    cube = parse_cube_models(doc)[0]
+    assert cube.joins[0].relationship == "many_to_one"
+    # ...and it emits the modern snake_case form
+    assert "many_to_one" in emit_cube_yaml(cube)
+
+
+def test_join_keys_are_what_to_resolve():
+    orders = parse_cube_models(_DOC)[0]
+    jk = cube_join_keys(orders)[0]
+    assert (jk["from_cube"], jk["to_cube"]) == ("orders", "customers")
+    assert jk["relationship"] == "many_to_one"
+    assert jk["from_columns"] == ["customer_id"] and jk["to_columns"] == ["id"]
+
+
+def test_round_trips_through_parse():
+    cubes = parse_cube_models(_DOC)
+    cubes2 = parse_cube_models(emit_cube_yaml(cubes))
+    assert [c.name for c in cubes2] == [c.name for c in cubes]
+    assert cubes2[0].primary_key == ["id"]
+    j = cubes2[0].joins[0]
+    assert (j.name, j.relationship, j.sql) == \
+        ("customers", "many_to_one", "{CUBE}.customer_id = {customers.id}")
+
+
+def test_emit_from_crosswalk_declares_conformed_join():
+    class _XW:
+        source_pk_column = "customer_id"
+        resolved_key = "resolved_entity_id"
+        n_records = 12
+        n_entities = 11
+        reduction_ratio = 1 - 11 / 12
+
+    y = emit_cube_from_crosswalk(_XW(), source_cube="orders",
+                                 crosswalk_sql_table="analytics.customer_crosswalk")
+    cubes = {c.name: c for c in parse_cube_models(y)}
+    xw = cubes["crosswalk"]
+    assert xw.primary_key == ["customer_id"]
+    assert {d.name for d in xw.dimensions} == {"source", "customer_id", "resolved_entity_id"}
+    assert xw.sql_table == "analytics.customer_crosswalk"
+    # source cube carries the many_to_one join onto the crosswalk PK
+    j = cubes["orders"].joins[0]
+    assert (j.name, j.relationship) == ("crosswalk", "many_to_one")
+    assert j.sql == "{CUBE}.customer_id = {crosswalk.customer_id}"
+    # provenance rides in meta (Cube's sanctioned free-form extension point)
+    gm = xw.meta["goldenmatch"]
+    assert gm["resolved_key"] == "resolved_entity_id" and gm["n_entities"] == 11
+
+
+def test_certify_cube_joins_bridges_wedge_a():
+    cubes = parse_cube_models(_DOC)
+    # customers.id has a duplicate -> the key the metrics join on is unsafe
+    frames = {"customers": pa.table({"id": [1, 1, 2], "name": ["a", "a", "b"]})}
+    rep = certify_cube_joins(cubes, frames)
+    assert len(rep) == 1
+    entry = rep[0]
+    assert entry["to_cube"] == "customers" and entry["key"] == ["id"]
+    assert entry["certificate"].estimate == 0.5
+    assert entry["certificate"].max_fan_out == 2.0
+
+
+def test_certify_cube_joins_accepts_source_and_skips_absent_frames():
+    assert certify_cube_joins(_DOC, frames={}) == []
+
+
+def test_cube_dataclass_primary_key_property():
+    c = Cube(name="x")
+    assert c.primary_key == []

--- a/packages/python/goldenmatch/tests/test_osi.py
+++ b/packages/python/goldenmatch/tests/test_osi.py
@@ -190,3 +190,21 @@ def test_validate_osi_rejects_non_list_semantic_model():
     assert validate_osi({"version": "0.2.0.dev0", "semantic_model": {}}) == [
         "'semantic_model' must be a list of models"
     ]
+
+
+def test_validate_osi_flags_unknown_dialect():
+    doc = {
+        "version": "0.2.0.dev0",
+        "semantic_model": [{
+            "name": "m",
+            "datasets": [{
+                "name": "d",
+                "fields": [{
+                    "name": "x",
+                    "expression": {"dialects": [{"dialect": "PRESTO", "expression": "x"}]},
+                }],
+            }],
+        }],
+    }
+    issues = validate_osi(doc)
+    assert any("dialect 'PRESTO' not in the Ossie enum" in i for i in issues)

--- a/packages/python/goldenmatch/tests/test_osi.py
+++ b/packages/python/goldenmatch/tests/test_osi.py
@@ -9,6 +9,7 @@ from goldenmatch.semantic import (
     emit_osi_yaml,
     osi_join_keys,
     parse_osi_models,
+    validate_osi,
 )
 
 # A real-shaped Ossie document (TPC-DS): version + semantic_model list, datasets
@@ -121,3 +122,71 @@ def test_certify_osi_relationships_bridges_wedge_a():
 def test_certify_osi_relationships_accepts_source_and_skips_absent_frames():
     # passing the raw doc (not a parsed model) + no frames -> nothing to certify
     assert certify_osi_relationships(_DOC, frames={}) == []
+
+
+# --- conformance validation --------------------------------------------------
+
+
+def test_validate_osi_accepts_emitted_and_reference_docs():
+    # our own emit is valid, and the reference TPC-DS doc is valid
+    assert validate_osi(_DOC) == []
+    m = parse_osi_models(_DOC)[0]
+    assert validate_osi(emit_osi_yaml(m)) == []
+
+    class _XW:
+        source_pk_column = "customer_id"
+        resolved_key = "resolved_entity_id"
+        n_records = 12
+        n_entities = 11
+        reduction_ratio = 1 - 11 / 12
+
+    assert validate_osi(emit_osi_from_crosswalk(_XW(), source_dataset="store_sales")) == []
+
+
+def test_validate_osi_flags_the_non_ossie_keys_and_missing_requireds():
+    # A doc that violates several spec constraints at once, incl. the keys the
+    # schema does NOT define (cardinality / foreign_key / aggregation).
+    bad = {
+        "semantic_model": [  # note: no top-level 'version'
+            {
+                # no 'name'
+                "datasets": [
+                    {
+                        "name": "orders",
+                        "foreign_key": ["customer_id"],  # not an Ossie key
+                        "fields": [
+                            {"name": "amount"},  # missing expression
+                            {
+                                "name": "status",
+                                "expression": "status",
+                                "datatype": "Enum",  # not in the datatype enum
+                            },
+                        ],
+                    },
+                    {"source": "x"},  # missing dataset name
+                ],
+                "relationships": [
+                    {"name": "r", "from": "orders", "cardinality": "many_to_one"},  # missing to/cols + cardinality
+                ],
+                "metrics": [
+                    {"name": "total", "expression": "SUM(amount)", "agg": "sum"},  # agg is not a key
+                ],
+            }
+        ]
+    }
+    issues = validate_osi(bad)
+    joined = " | ".join(issues)
+    assert any("missing top-level 'version'" in i for i in issues)
+    assert any("missing 'name'" in i for i in issues)             # model + dataset
+    assert "foreign_key" in joined and "cardinality" in joined
+    assert any("datatype" in i for i in issues)
+    assert any("missing/invalid 'expression'" in i for i in issues)
+    assert any("aggregation belongs inside" in i for i in issues)
+    # relationship missing required to/from_columns/to_columns
+    assert any("missing required 'to'" in i for i in issues)
+
+
+def test_validate_osi_rejects_non_list_semantic_model():
+    assert validate_osi({"version": "0.2.0.dev0", "semantic_model": {}}) == [
+        "'semantic_model' must be a list of models"
+    ]


### PR DESCRIPTION
## What and why

Ships the two follow-ons noted in ADR 0051 that stay within the established
semantic-layer discipline (library-only, advisory, parity-free): a **Cube
(cube.dev) dialect** — completing the MetricFlow / OSI / Cube reader+emitter
symmetry — and **OSI conformance validation**, which hardens wedge C by making
"we emit valid OSI" checkable rather than asserted. Decision:
[ADR 0052](``https://github.com/benseverndev-oss/goldenmatch/blob/claude/semantic-layering-exploration-52p6rd/context-network/decisions/0052-cube-dialect-and-osi-validation.md).``

## Changes

- **Cube dialect** (`goldenmatch/semantic/cube.py`) — schema-faithful to the
  current snake_case YAML data model (single-brace member refs; legacy
  `has_one`/`has_many`/`belongs_to` relationship aliases normalized to the modern
  enum on emit):
  - `parse_cube_models` + `cube_join_keys` (consume — a cube's `primary_key: true`
    dimension is the identity; joins carry the `relationship` cardinality)
  - `certify_cube_joins` (bridge to wedge A — certify the ONE-side join key,
    metric-aware)
  - `emit_cube_from_crosswalk` (bridge to wedge B — a crosswalk cube keyed on the
    source PK + a `many_to_one` join declaring the conformed `resolved_entity_id`;
    GoldenMatch provenance rides in the cube's `meta`)
  - `emit_cube_yaml` round-trips through `parse_cube_models`
- **OSI validation** (`validate_osi` in `goldenmatch/semantic/osi.py`) — a
  dependency-free structural validator over the Ossie `0.2.0.dev0` required-field
  + enum constraints that also flags the non-Ossie keys hand-written docs tend to
  invent (`cardinality` / `foreign_key` / `aggregation`).
  `validate_osi(emit_osi_yaml(...)) == []`.
- Exports wired in `semantic/__init__.py`; ADR 0052 + planning-doc status update;
  `docs/agent-codemap.json` regenerated.

Library-only, advisory, parity-free: no MCP/CLI/A2A/TS surface (so `api_parity`
is untouched), and `semantic/` stays out of top-level `goldenmatch/__init__.py`
so `import goldenmatch` remains polars-free.

## Testing

- `uv run --package goldenmatch pytest tests/test_cube.py tests/test_osi.py tests/test_metricflow_parse.py tests/test_metricflow_emit.py tests/test_key_integrity.py tests/test_resolved_crosswalk.py` → **41 passed**
- `uv run ruff check packages/python/goldenmatch/goldenmatch/semantic/` → clean
- `python3 scripts/check_docs_consistency.py` → all PASS
- `scripts/gen_config_matrix.py --check` / `gen_suite_matrix.py --check` → OK (unaffected)
- `pytest scripts/test_agent_codemap.py` → 4 passed (codemap regenerated)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed (N/A — additive advisory library surface, semantic/ not re-exported from top-level)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / decision records updated (ADR 0052 + planning-doc status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_