### PR TITLE
docs: crates.io badge + realign llms.txt to the identity-platform framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Zero-config matching that **beats expert-tuned Splink head-to-head on messy cust
 <!-- Reach -->
 [![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenfuzz+goldenphonetic+goldenmatch-hnsw+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldengraph-native+goldenprofile-native+goldenmatch-embed+goldengraph+golden-suite)
 [![npm downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fnpm-downloads.json)](https://www.npmjs.com/~benzsevern)
+[![crates.io downloads](https://img.shields.io/crates/d/goldenfuzz-core?color=d4a017&label=crates.io%20dl&logo=rust&logoColor=white)](https://crates.io/crates/goldenfuzz-core)
 [![GitHub stars](https://img.shields.io/github/stars/benseverndev-oss/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benseverndev-oss/goldenmatch/stargazers)
 
 <!-- Ecosystem -->

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Golden Suite
 
-> A polyglot data-quality and entity-resolution toolkit: profile, standardize, deduplicate, and report on tabular data. Six composable packages on PyPI and npm, with SQL-native PostgreSQL/DuckDB extensions, MCP/REST/A2A servers, and edge-safe TypeScript ports (optional WebAssembly). Headline package: GoldenMatch.
+> Zero-config entity resolution that feeds a durable identity layer — resolve messy records from any source into stable golden entities (a Customer 360 / master-data-management spine) with whole-record provenance, merge/split, and a tamper-evident audit log. The Arrow-native, Rust-authoritative matching engine beats hand-tuned Splink out of the box and scales to a verified 100M-row dedupe in 9.2 min; the resolved identities live in a transaction-native control plane (SQLite/Postgres). Fuzzy + exact + probabilistic (Fellegi-Sunter) + LLM matching, privacy-preserving record linkage (PPRL), and GraphRAG / knowledge-graph integration. A polyglot suite of composable packages on PyPI and npm, SQL-native in PostgreSQL and DuckDB, MCP/REST/A2A servers, and edge-safe TypeScript ports (optional WebAssembly). Headline package: GoldenMatch.
 
 ## The pipeline
 GoldenCheck (profile + validate) → GoldenFlow (standardize) → GoldenMatch (dedupe + cluster + survivorship) → GoldenAnalysis (cross-cutting reporting), orchestrated by GoldenPipe, with InferMap for schema mapping.


### PR DESCRIPTION
## What and why

Final discovery-surface pass following the README repositioning (#2277), addressing four asks: North Star alignment, LLM **and** user discovery optimization, a crates.io download badge, and keeping the "quoted"/stat areas programmatic rather than hardcoded.

## Changes

- **crates.io downloads badge (README).** A live shields.io native badge for `goldenfuzz-core` (the flagship owned crate — our byte-identical `rapidfuzz` replacement). It queries crates.io on render, so it's **programmatically updated** like the existing PyPI/npm/stars/last-commit badges — no static number. Only `goldenfuzz-core` and `goldenphonetic-core` are actually on crates.io (the rest are internal path-deps), so one flagship badge is honest and zero-infra vs. a two-crate aggregate that would need the badges-branch pipeline.
- **`llms.txt` realigned (LLM discovery).** The lead blockquote still described a "polyglot data-quality and entity-resolution *toolkit*" (pre-repositioning). Rewrote it to the identity-platform framing — Customer 360 / MDM spine, golden entities, provenance, audit, transaction-native control plane, GraphRAG — keyword-rich so LLMs summarizing the repo get the current positioning. Only the lead prose changed; the gate-governed capability counts and benchmark citations are untouched.

## North Star & discovery

- **North Star** ("the default tool for entity resolution") is preserved: both surfaces still lead with *entity resolution* as the core, with the identity layer as the frame it feeds — an extension, not a replacement.
- **User discovery:** the crates.io badge + README keywords (Customer 360, MDM, golden records, identity resolution) strengthen GitHub/search surfacing. (Repo **topics** are the other lever — they can't be set through the agent proxy; command handed to the maintainer separately.)
- **LLM discovery:** `llms.txt` lead now carries the identity-platform vocabulary.
- **Programmatic/"quoted" areas:** every badge is a live shields endpoint (versions, downloads incl. crates.io, stars, last-commit); benchmark numbers are governed by `check_benchmark_claims`; release callouts auto-sync from the CHANGELOG. Nothing is a hand-maintained stat.

## Testing

Docs-only. Verified locally: `check_benchmark_claims`, `check_docs_consistency` (×4), `check_docs_links`, `check_llms_counts` **all exit 0** (llms_counts confirms 131 suite MCP tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSJNG3TjJL38C71MRB8Str)_