### PR TITLE
feat(local-llm): pin the published er-matcher-3b-v1.0.0 GGUF (sha256)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
@@ -73,7 +73,7 @@ PINNED_MODEL = LocalModelSpec(
         "er-matcher-3b-v1.0.0/goldenmatch-er-matcher-3b-q4_k_m.gguf"
     ),
     filename="goldenmatch-er-matcher-3b-q4_k_m.gguf",
-    sha256=None,
+    sha256="b6637fd9892b21b565098524501083edb91199b0bfffc267edf48885ce9c1d3b",
 )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/er_matcher/registry.py
+++ b/packages/python/goldenmatch/goldenmatch/core/er_matcher/registry.py
@@ -42,8 +42,11 @@ MODELS: dict[str, ModelSpec] = {
     "3b": ModelSpec(
         tier="3b",
         filename="goldenmatch-er-matcher-3b-q4_k_m.gguf",
-        url=None,
-        sha256=None,
+        url=(
+            "https://github.com/benseverndev-oss/goldenmatch/releases/download/"
+            "er-matcher-3b-v1.0.0/goldenmatch-er-matcher-3b-q4_k_m.gguf"
+        ),
+        sha256="b6637fd9892b21b565098524501083edb91199b0bfffc267edf48885ce9c1d3b",
         base_model="Qwen/Qwen2.5-3B-Instruct",
         serializer_version="v1",
     ),

--- a/packages/python/goldenmatch/tests/test_er_matcher_client.py
+++ b/packages/python/goldenmatch/tests/test_er_matcher_client.py
@@ -59,15 +59,18 @@ def test_score_pairs_batch():
 
 
 # --- registry ---------------------------------------------------------------
-def test_registry_specs_pending_until_published():
-    # Weights ship only after the eval gate; pins are PENDING for now.
-    for tier in ("3b", "7b"):
-        assert registry.MODELS[tier].published is False
+def test_registry_3b_published_7b_pending():
+    # 3b is published (er-matcher-3b-v1.0.0 GitHub Release, pinned url+sha256);
+    # 7b weights still ship only after its eval gate, so it stays PENDING.
+    assert registry.MODELS["3b"].published is True
+    assert registry.MODELS["7b"].published is False
 
 
 def test_resolve_refuses_unpublished():
+    # 7b is still PENDING (no url/sha256) -> resolve refuses (can't verify what
+    # isn't pinned). 3b is published now, so use 7b for the refusal check.
     with pytest.raises(ValueError, match="not published"):
-        registry.resolve_model("3b")
+        registry.resolve_model("7b")
 
 
 def test_resolve_unknown_tier():

--- a/packages/python/goldenmatch/tests/test_local_llm.py
+++ b/packages/python/goldenmatch/tests/test_local_llm.py
@@ -65,10 +65,13 @@ class TestLoader:
         assert L.resolve_model_path() is None
 
     def test_override_path_present_no_sha_returns_it(self, monkeypatch, tmp_path):
+        # A spec with no sha256 -> the override path is returned unverified.
+        # (Uses an explicit spec since PINNED_MODEL now carries a real sha256.)
         p = tmp_path / "model.gguf"
         p.write_bytes(b"gguf-bytes")
         monkeypatch.setenv("GOLDENMATCH_LOCAL_LLM_PATH", str(p))
-        assert L.resolve_model_path() == str(p)
+        spec = L.LocalModelSpec(url="https://example.test/m.gguf", filename="m.gguf", sha256=None)
+        assert L.resolve_model_path(spec) == str(p)
 
     def test_override_path_sha_mismatch_raises(self, monkeypatch, tmp_path):
         p = tmp_path / "model.gguf"


### PR DESCRIPTION
## What and why

The `publish-er-matcher` workflow succeeded — the trained ER-matcher model is now live as a GitHub Release asset. This pins its **sha256** into the loader so `goldenmatch[local-llm]` downloads → verifies → loads it from GitHub end-to-end. **This closes the local-model integration loop.**

- **Release:** https://github.com/benseverndev-oss/goldenmatch/releases/tag/er-matcher-3b-v1.0.0
- **Asset:** `goldenmatch-er-matcher-3b-q4_k_m.gguf`
- **sha256:** `b6637fd9892b21b565098524501083edb91199b0bfffc267edf48885ce9c1d3b`

## Changes

- `_llm_loader.py` `PINNED_MODEL.sha256` set to the published digest (URL was already `er-matcher-3b-v1.0.0` from #2281). With a real sha256, the loader now *verifies* the downloaded bytes (never-black-box).
- `er_matcher/registry.py` `MODELS['3b']` — `url` + `sha256` filled (published); `7b` stays PENDING until its eval gate.
- Updated the registry "pending" tests to reflect **3b published / 7b pending**, and the loader no-sha test to use an explicit no-sha spec (since `PINNED_MODEL` now carries a digest).

## Testing

- `test_local_llm.py` + `test_er_matcher_client.py` — 29 passed; ruff clean.
- The end-to-end publish pipeline (build → Modal download → convert+quantize → Release) was proven green by the workflow run itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgzBUa3Hi6mn2qdjx85x1z)_