### PR TITLE
fix(er-matcher): review correctness + perf-gate fixes (+ eval-variant parameterization)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1531,11 +1531,15 @@
             "LocalModelSpec",
             "_local_llm_mode",
             "_model_cache_dir",
+            "_project",
             "_verify_sha256",
             "load_local_adapter",
             "parse_verdict",
             "resolve_model_path",
             "serialize_pair_v1"
+          ],
+          "imports": [
+            "goldenmatch.core.er_matcher.prompt"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_llm_loader.py
@@ -215,44 +215,44 @@ def load_local_adapter(
 # ── serializer + adapter (shared contract with Path A) ─────────────────────────
 
 
-def serialize_pair_v1(row_a: dict, row_b: dict, columns: list[str]) -> str:
-    """Render two records for the model — the pinned ``serialize_pair_v1``.
+def _project(row: dict, columns: list[str] | None) -> dict:
+    """Restrict a pipeline row to the caller's data columns (dropping ``__row_id__``
+    and other internals) before serialization — the model was trained on the record
+    fields only, so leaking internal columns into the prompt is out-of-distribution."""
+    if columns is None:
+        return row
+    return {c: row.get(c) for c in columns}
 
-    Deterministic field order (the caller's ``columns``), ``field: value`` lines.
-    The serializer version is part of the model card; changing it means a new
-    model revision (companion spec §8).
+
+def serialize_pair_v1(row_a: dict, row_b: dict, columns: list[str] | None = None) -> str:
+    """The pinned ``serialize_pair_v1`` — SINGLE-SOURCED from
+    ``core.er_matcher.prompt.serialize_pair_v1`` (the exact rendering the model was
+    fine-tuned on) so Path A (served) and Path B (in-process) are byte-identical.
+
+    ``columns`` selects which fields to render (the canonical serializer then orders
+    them by the sorted key union); pass ``None`` to render every key. Having ONE v1
+    rendering is what makes the registry serializer-version guard meaningful — a
+    second hand-rolled ``v1`` that disagreed would feed the model OOD prompts the
+    version-string check cannot catch.
     """
-    def _fmt(row: dict) -> str:
-        return "\n".join(f"{c}: {row.get(c, '')}" for c in columns)
+    from goldenmatch.core.er_matcher.prompt import serialize_pair_v1 as _canonical
 
-    return f"Record A:\n{_fmt(row_a)}\n\nRecord B:\n{_fmt(row_b)}"
-
-
-_SYSTEM_PROMPT = (
-    "You are an entity-resolution adjudicator. Decide whether Record A and "
-    "Record B describe the SAME real-world entity. Weigh agreements and "
-    "conflicts; a missing value is not a conflict. Reply with compact JSON only: "
-    '{"match": true|false, "confidence": 0.0-1.0}.'
-)
+    return _canonical(_project(row_a, columns), _project(row_b, columns))
 
 
 def parse_verdict(text: str) -> tuple[bool, float]:
     """Lenient parse of the model's JSON verdict -> ``(is_match, confidence)``.
 
-    A parse failure returns ``(False, 0.0)`` — abstain, never crash (mirrors the
-    hosted fallback contract). ``confidence`` is clamped to ``[0, 1]``.
+    Delegates to the canonical ``core.er_matcher.prompt.parse_verdict`` (one parser
+    contract). A parse failure returns ``(False, 0.0)`` — abstain, never crash
+    (mirrors the hosted fallback contract). ``confidence`` is clamped to ``[0, 1]``.
     """
-    import json
-    import re
+    from goldenmatch.core.er_matcher.prompt import parse_verdict as _canonical
 
-    try:
-        m = re.search(r"\{.*\}", text, re.DOTALL)
-        obj = json.loads(m.group(0) if m else text)
-        is_match = bool(obj.get("match", False))
-        conf = float(obj.get("confidence", 0.0))
-        return is_match, max(0.0, min(1.0, conf))
-    except Exception:  # noqa: BLE001 - any malformed output -> abstain
+    v = _canonical(text)
+    if v is None:
         return False, 0.0
+    return bool(v["match"]), max(0.0, min(1.0, float(v["confidence"])))
 
 
 class LocalLlamaAdapter:
@@ -265,13 +265,15 @@ class LocalLlamaAdapter:
     def score_pair(
         self, row_a: dict, row_b: dict, columns: list[str]
     ) -> tuple[bool, float]:
-        prompt = serialize_pair_v1(row_a, row_b, columns)
+        # build_chat single-sources BOTH the system rubric and the user-turn
+        # serialization from core.er_matcher.prompt — the same messages the model
+        # was fine-tuned on (project to the data columns first, see _project).
+        from goldenmatch.core.er_matcher.prompt import build_chat
+
+        messages = build_chat(_project(row_a, columns), _project(row_b, columns))
         try:
             resp = self._llm.create_chat_completion(
-                messages=[
-                    {"role": "system", "content": _SYSTEM_PROMPT},
-                    {"role": "user", "content": prompt},
-                ],
+                messages=messages,
                 max_tokens=64,
                 temperature=0.0,
             )

--- a/packages/python/goldenmatch/tests/test_local_llm.py
+++ b/packages/python/goldenmatch/tests/test_local_llm.py
@@ -36,8 +36,38 @@ def _df():
 
 class TestSerializerAndParse:
     def test_serialize_pair_v1_is_deterministic_field_order(self):
+        # Rendering is the canonical prompt.serialize_pair_v1 (2-space indent,
+        # sorted-union field order, single-newline record separator).
         s = L.serialize_pair_v1({"b": 2, "a": 1}, {"a": 9, "b": 8}, ["a", "b"])
-        assert s == "Record A:\na: 1\nb: 2\n\nRecord B:\na: 9\nb: 8"
+        assert s == "Record A:\n  a: 1\n  b: 2\nRecord B:\n  a: 9\n  b: 8"
+
+    def test_serialize_pair_v1_is_single_sourced_from_prompt(self):
+        # The model is fine-tuned on core.er_matcher.prompt.serialize_pair_v1;
+        # Path B MUST render byte-identically or it feeds the model OOD prompts
+        # the registry's version-string drift guard cannot catch.
+        from goldenmatch.core.er_matcher.prompt import (
+            SYSTEM_RUBRIC,
+            build_chat,
+        )
+        from goldenmatch.core.er_matcher.prompt import (
+            serialize_pair_v1 as canonical,
+        )
+
+        a = {"name": "Ann Lee", "city": "NYC", "email": None}
+        b = {"name": "ann lee", "email": "a@x.io"}
+        cols = sorted(set(a) | set(b))
+        assert L.serialize_pair_v1(a, b, cols) == canonical(a, b)
+        # and the adapter's messages carry the canonical system rubric + user turn
+        msgs = build_chat(a, b)
+        assert msgs[0] == {"role": "system", "content": SYSTEM_RUBRIC}
+        assert msgs[1]["content"] == canonical(a, b)
+
+    def test_serialize_pair_v1_projects_out_internal_columns(self):
+        # __row_id__ and other internals must not leak into the prompt.
+        a = {"__row_id__": 7, "name": "Ann"}
+        b = {"__row_id__": 9, "name": "Ann"}
+        s = L.serialize_pair_v1(a, b, ["name"])
+        assert "__row_id__" not in s and "7" not in s
 
     def test_parse_verdict_plain_json(self):
         assert L.parse_verdict('{"match": true, "confidence": 0.9}') == (True, 0.9)

--- a/scripts/er_matcher/_train_runtime.py
+++ b/scripts/er_matcher/_train_runtime.py
@@ -54,11 +54,18 @@ class _ThroughputCallback(TrainerCallback):
     def __init__(self, seq_len: int) -> None:
         self.seq_len = seq_len
         self.t0 = None
+        self.t1 = None
         self.steps = 0
         self.util_samples: list[float] = []
 
     def on_train_begin(self, args, state, control, **kw):  # noqa: ANN001
         self.t0 = time.perf_counter()
+
+    def on_train_end(self, args, state, control, **kw):  # noqa: ANN001
+        # Snapshot the end of the training loop so wall_s() excludes the trailing
+        # trainer.evaluate()/save that happen AFTER training (otherwise s_per_step
+        # is inflated and the gate over-estimates the full-run cost).
+        self.t1 = time.perf_counter()
 
     def on_step_end(self, args, state, control, **kw):  # noqa: ANN001
         self.steps += 1
@@ -77,10 +84,19 @@ class _ThroughputCallback(TrainerCallback):
                 return
 
     def wall_s(self) -> float:
-        return (time.perf_counter() - self.t0) if self.t0 else 0.0
+        if not self.t0:
+            return 0.0
+        end = self.t1 if self.t1 is not None else time.perf_counter()
+        return end - self.t0
 
-    def mean_util(self) -> float:
-        return sum(self.util_samples) / len(self.util_samples) if self.util_samples else 0.0
+    def mean_util(self) -> float | None:
+        # None (not 0.0) when NO samples were collected: that means telemetry was
+        # unavailable (pynvml absent), which perf_report reads as "unknown/advisory"
+        # rather than "0% util = data-bound". 0.0 is reserved for a genuinely
+        # measured all-idle run.
+        if not self.util_samples:
+            return None
+        return sum(self.util_samples) / len(self.util_samples)
 
 
 def _load_split(data_dir: Path, name: str) -> list[dict[str, Any]]:
@@ -123,12 +139,16 @@ def run_training(cfg: TrainConfig, args: Any) -> int:
     if not train_rows:
         raise SystemExit(f"no train.jsonl under {args.data_dir} (run gen_pairs.py first)")
 
-    if args.smoke:
-        train_rows = train_rows[: args.smoke_rows]
-        val_rows = val_rows[: max(1, args.smoke_rows // 10)]
+    # Measure seq_len + total_steps over the FULL corpus BEFORE any smoke slice.
+    # The gate extrapolates the FULL run's cost from the smoke, so total_steps must
+    # be the full-corpus step count -- measuring it over the smoke slice (4k rows)
+    # under-counts steps by the slice ratio and yields a falsely-cheap GO.
+    # Tokenize the CHAT-TEMPLATED messages (what SFTTrainer actually tokenizes),
+    # NOT a naive content join, so the P95 includes the per-turn special tokens.
+    def _tok_msgs(msgs: list[dict[str, str]]):
+        return tok.apply_chat_template(msgs, tokenize=True)
 
-    # measured max_seq_len over the REAL tokenizer (the top memory/speed lever)
-    lengths = serialized_token_lengths(train_rows, lambda t: tok(t)["input_ids"])
+    lengths = serialized_token_lengths(train_rows, _tok_msgs)
     seq_len = measured_max_seq_len(
         lengths, percentile=cfg.seq_len_percentile,
         cap=cfg.seq_len_cap, multiple_of=cfg.seq_len_multiple_of,
@@ -136,16 +156,22 @@ def run_training(cfg: TrainConfig, args: Any) -> int:
     print(f"[train] measured max_seq_len={seq_len} (P{cfg.seq_len_percentile} of "
           f"{len(lengths)} pairs, cap {cfg.seq_len_cap})")
 
-    # Measured (packing-aware) total-step estimate for cfg.epochs over THESE
-    # rows' token lengths -- NOT rows/batch (packing makes that wrong) and NOT
+    # Measured (packing-aware) total-step estimate for cfg.epochs over the FULL
+    # corpus' token lengths -- NOT rows/batch (packing makes that wrong) and NOT
     # len(trainer.get_train_dataloader()) (packing=True builds a lengthless
-    # IterableDataset -- that raises TypeError). In --smoke mode this reflects
-    # the smoke-sliced rows (a coarser calibration figure); the sweep's 100%
-    # slice (run_sweep) measures it over the full, unsliced corpus.
+    # IterableDataset -- that raises TypeError). Computed over the full corpus in
+    # both --smoke and full mode so the emitted total_steps drives a correct
+    # full-run cost extrapolation.
     total_steps = estimate_total_steps(
         lengths, seq_len=seq_len, per_device_batch=cfg.per_device_batch,
         grad_accum=cfg.grad_accum, epochs=cfg.epochs,
     )
+
+    # Now (after measuring the full corpus) slice to the smoke rows for a cheap
+    # calibration train -- the metrics above still describe the full run.
+    if args.smoke:
+        train_rows = train_rows[: args.smoke_rows]
+        val_rows = val_rows[: max(1, args.smoke_rows // 10)]
 
     def to_text(rows: list[dict[str, Any]]) -> Dataset:
         recs = [{"messages": example_to_messages(r, cfg)} for r in rows]
@@ -225,7 +251,10 @@ def _emit_smoke_metrics(cfg: TrainConfig, args: Any, cb: _ThroughputCallback,
                         seq_len: int, total_steps: int) -> None:
     wall = cb.wall_s()
     toks = cb.steps * cfg.per_device_batch * cfg.grad_accum * seq_len
-    peak_gb = (torch.cuda.max_memory_allocated() / 1e9) if torch.cuda.is_available() else None
+    # Report RESERVED (not just allocated) peak: the caching allocator's reserved
+    # pool is what actually presses against capacity, so the gate's memory check
+    # (which derates capacity by a headroom factor) reasons about the real ceiling.
+    peak_gb = (torch.cuda.max_memory_reserved() / 1e9) if torch.cuda.is_available() else None
     cap_gb = (torch.cuda.get_device_properties(0).total_memory / 1e9
               if torch.cuda.is_available() else None)
     metrics = {
@@ -288,7 +317,8 @@ def run_sweep(cfg: TrainConfig, args: Any) -> int:
         raise SystemExit("--sweep needs val.jsonl (per-slice eval_loss) -- "
                           "run gen_pairs.py's split first")
 
-    lengths = serialized_token_lengths(train_rows, lambda t: tok(t)["input_ids"])
+    lengths = serialized_token_lengths(
+        train_rows, lambda msgs: tok.apply_chat_template(msgs, tokenize=True))
     seq_len = measured_max_seq_len(
         lengths, percentile=cfg.seq_len_percentile,
         cap=cfg.seq_len_cap, multiple_of=cfg.seq_len_multiple_of,
@@ -385,7 +415,10 @@ def _emit_sweep_metrics(cfg: TrainConfig, args: Any, points: list[tuple[float, f
                         cb: _ThroughputCallback, seq_len: int, total_steps: int) -> None:
     wall = cb.wall_s()
     toks = cb.steps * cfg.per_device_batch * cfg.grad_accum * seq_len
-    peak_gb = (torch.cuda.max_memory_allocated() / 1e9) if torch.cuda.is_available() else None
+    # Report RESERVED (not just allocated) peak: the caching allocator's reserved
+    # pool is what actually presses against capacity, so the gate's memory check
+    # (which derates capacity by a headroom factor) reasons about the real ceiling.
+    peak_gb = (torch.cuda.max_memory_reserved() / 1e9) if torch.cuda.is_available() else None
     cap_gb = (torch.cuda.get_device_properties(0).total_memory / 1e9
               if torch.cuda.is_available() else None)
     metrics = {

--- a/scripts/er_matcher/modal_train.py
+++ b/scripts/er_matcher/modal_train.py
@@ -220,9 +220,14 @@ def full(config_name: str = "bf16-lora", gpu: str = GPU_FULL) -> None:
     volumes={"/out": _out_vol},
     secrets=[modal.Secret.from_name("er-matcher-hf")],
 )
-def eval_model(limit: int = 0, fast: bool = True) -> None:
+def eval_model(model_path: str = "/out/model/merged", out_name: str = "eval_results.json",
+               limit: int = 0, fast: bool = True) -> None:
     """Load the merged model and score match-F1 on the held-out test split, using
     eval.run_eval for overall + per-domain P/R/F1 + calibration.
+
+    model_path/out_name default to the 3B (/out/model/merged -> eval_results.json)
+    but are overridable to score a scale variant without clobbering the 3B's card,
+    e.g. --model-path /out/model_7b/merged --out-name eval_results_7b.json.
 
     fast=True (default): teacher-force the compact-JSON verdict prefix `{"match":`
     and read the next-token logits over the `true`/`false` ids (one forward pass per
@@ -239,7 +244,8 @@ def eval_model(limit: int = 0, fast: bool = True) -> None:
     import eval as ev  # the mounted scripts/er_matcher/eval.py (pure metrics module)
     from goldenmatch.core.er_matcher.prompt import build_chat, parse_verdict
 
-    mpath = "/out/model/merged"
+    mpath = model_path
+    print(f"[eval] model={mpath} -> /out/{out_name}")
     tok = AutoTokenizer.from_pretrained(mpath)
     if tok.pad_token is None:
         tok.pad_token = tok.eos_token
@@ -303,27 +309,29 @@ def eval_model(limit: int = 0, fast: bool = True) -> None:
     print(f"[eval] scoring {len(rows)} test pairs ({'fast logit' if fast else 'generative'} "
           "matcher)...")
     scorecard = ev.run_eval({"test": rows}, matcher)
-    with open("/out/eval_results.json", "w") as f:
+    with open(f"/out/{out_name}", "w") as f:
         json.dump(scorecard, f, indent=2)
     _out_vol.commit()
     print("[eval] overall:", json.dumps(scorecard["splits"]["test"]["overall"], indent=2))
 
 
 @app.local_entrypoint()
-def evaluate(limit: int = 0) -> None:
-    eval_model.remote(limit=limit)
-    print("eval done -> `modal volume get er-matcher-out eval_results.json`")
+def evaluate(limit: int = 0, model_path: str = "/out/model/merged",
+             out_name: str = "eval_results.json") -> None:
+    eval_model.remote(model_path=model_path, out_name=out_name, limit=limit)
+    print(f"eval done -> `modal volume get er-matcher-out {out_name}`")
 
 
 @app.local_entrypoint()
-def evaluate_detached(limit: int = 0) -> None:
+def evaluate_detached(limit: int = 0, model_path: str = "/out/model/merged",
+                      out_name: str = "eval_results.json") -> None:
     """Fire-and-forget in-distribution eval: spawn eval_model and return immediately.
     Run with `modal run --detach ...::evaluate_detached` so the spawned call survives
     the client exit (the generative scan of the full test split takes ~30-60 min).
-    Poll `modal volume get er-matcher-out eval_results.json` for the result."""
-    call = eval_model.spawn(limit=limit)
+    Poll `modal volume get er-matcher-out <out_name>` for the result."""
+    call = eval_model.spawn(model_path=model_path, out_name=out_name, limit=limit)
     print(f"eval spawned (detached): {call.object_id} -> poll "
-          "`modal volume get er-matcher-out eval_results.json`")
+          f"`modal volume get er-matcher-out {out_name}`")
 
 
 @app.function(
@@ -333,8 +341,14 @@ def evaluate_detached(limit: int = 0) -> None:
     volumes={"/out": _out_vol},
     secrets=[modal.Secret.from_name("er-matcher-hf")],
 )
-def zeroshot_eval(dataset: str = "walmart_amazon", allow_fetch: bool = True, limit: int = 0) -> None:
+def zeroshot_eval(dataset: str = "walmart_amazon", allow_fetch: bool = True, limit: int = 0,
+                  model_path: str = "/out/model/merged",
+                  out_name: str = "zeroshot_eval_results.json") -> None:
     """Zero-shot P(match) via teacher-forced next-token logits (SP3 Task 5).
+
+    model_path/out_name default to the 3B but are overridable to score a scale
+    variant on the same held-out benchmark without clobbering the 3B's card,
+    e.g. --model-path /out/model_7b/merged --out-name zeroshot_7b_walmart.json.
 
     Unlike `eval_model` (which generates full JSON and parses it), this scores
     each pair by teacher-forcing the exact JSON prefix the SFT target starts
@@ -358,7 +372,8 @@ def zeroshot_eval(dataset: str = "walmart_amazon", allow_fetch: bool = True, lim
     from goldenmatch.core.er_matcher.prompt import build_chat
     from sources.magellan import MagellanSource
 
-    mpath = "/out/model/merged"
+    mpath = model_path
+    print(f"[zeroshot_eval] model={mpath} dataset={dataset} -> /out/{out_name}")
     tok = AutoTokenizer.from_pretrained(mpath)
     if tok.pad_token is None:
         tok.pad_token = tok.eos_token
@@ -500,13 +515,15 @@ def zeroshot_eval(dataset: str = "walmart_amazon", allow_fetch: bool = True, lim
         "separation": {"mean_p_match_true": mean_true, "mean_p_match_non": mean_non},
         "scorecard": card_json,
     }
-    with open("/out/zeroshot_eval_results.json", "w") as f:
+    with open(f"/out/{out_name}", "w") as f:
         json.dump(results, f, indent=2)
     _out_vol.commit()
     print("[zeroshot_eval] scorecard:", json.dumps(card_json, indent=2))
 
 
 @app.local_entrypoint()
-def zeroshot(dataset: str = "walmart_amazon", limit: int = 0) -> None:
-    zeroshot_eval.remote(dataset=dataset, limit=limit)
-    print("zeroshot eval done -> `modal volume get er-matcher-out zeroshot_eval_results.json`")
+def zeroshot(dataset: str = "walmart_amazon", limit: int = 0,
+             model_path: str = "/out/model/merged",
+             out_name: str = "zeroshot_eval_results.json") -> None:
+    zeroshot_eval.remote(dataset=dataset, limit=limit, model_path=model_path, out_name=out_name)
+    print(f"zeroshot eval done -> `modal volume get er-matcher-out {out_name}`")

--- a/scripts/er_matcher/perf_report.py
+++ b/scripts/er_matcher/perf_report.py
@@ -180,6 +180,7 @@ def evaluate_perf_gate(
     total_steps: int | None = None,
     gpu_cost_per_hour_usd: float | None = None,
     gpu_capacity_gb: float | None = None,
+    mem_headroom: float = 0.9,
 ) -> PerfGateResult:
     """Decide GO / NO-GO for the full run from a smoke-run ``metrics`` dict.
 
@@ -192,13 +193,21 @@ def evaluate_perf_gate(
     Pure; unit-tested without a GPU."""
     res = PerfGateResult(go=True)
 
-    util = float(metrics.get("gpu_util", 0.0))
-    res.add(
-        "gpu_util",
-        util >= min_gpu_util,
-        f"GPU util {util:.2%} vs floor {min_gpu_util:.0%} "
-        f"({'GPU-bound' if util >= min_gpu_util else 'DATA-BOUND -- fix the pack/dataloader path'})",
-    )
+    # gpu_util: None means telemetry was unavailable (pynvml absent / zero samples)
+    # -- that is "unknown", NOT "0% = data-bound". Only gate on a measured value,
+    # so a missing NVML never NO-GOs a genuinely GPU-bound run.
+    util_raw = metrics.get("gpu_util")
+    if util_raw is None:
+        res.add("gpu_util", True,
+                "GPU util not measured (NVML/pynvml telemetry unavailable) -- advisory, not gating")
+    else:
+        util = float(util_raw)
+        res.add(
+            "gpu_util",
+            util >= min_gpu_util,
+            f"GPU util {util:.2%} vs floor {min_gpu_util:.0%} "
+            f"({'GPU-bound' if util >= min_gpu_util else 'DATA-BOUND -- fix the pack/dataloader path'})",
+        )
 
     steps = int(metrics.get("smoke_steps", 0))
     wall = float(metrics.get("smoke_wall_s", 0.0))
@@ -223,21 +232,36 @@ def evaluate_perf_gate(
     else:
         res.add("budget", False, "cannot extrapolate: need smoke_steps/total_steps/gpu_cost_per_hour_usd")
 
-    slope = learning_curve_slope(metrics.get("learning_curve", []))
-    res.add(
-        "learning_curve",
-        slope > min_curve_slope,
-        f"marginal eval-loss improvement {slope:+.4f} vs floor {min_curve_slope} "
-        f"({'still climbing' if slope > min_curve_slope else 'plateaued -- more data/epochs will not help'})",
-    )
+    # learning_curve: needs >=2 slice points (the 10/25/50/100% sweep) to compute a
+    # slope. A single --smoke run emits an empty curve -- that is "not measured",
+    # NOT "plateaued", so it must be advisory. Otherwise the documented smoke->gate
+    # flow could NEVER return GO (empty curve -> slope 0.0 -> fails slope > 0.0).
+    curve = metrics.get("learning_curve") or []
+    if len(curve) < 2:
+        res.add("learning_curve", True,
+                "learning curve not measured (a single --smoke run has no 10/25/50/100% "
+                "slice sweep; run modal_train.py::benchmark to populate) -- advisory, not gating")
+    else:
+        slope = learning_curve_slope(curve)
+        res.add(
+            "learning_curve",
+            slope > min_curve_slope,
+            f"marginal eval-loss improvement {slope:+.4f} vs floor {min_curve_slope} "
+            f"({'still climbing' if slope > min_curve_slope else 'plateaued -- more data/epochs will not help'})",
+        )
 
+    # memory: compare against a headroom-derated capacity (default 0.9), consistent
+    # with gpu_tiers.select_cheapest_tier -- the caching allocator's reserved pool
+    # runs above the reported peak, so a no-margin `peak <= cap` can pass then OOM.
     cap = gpu_capacity_gb if gpu_capacity_gb is not None else metrics.get("gpu_capacity_gb")
     peak = metrics.get("peak_mem_gb")
     if cap is not None and peak is not None:
+        usable = float(cap) * mem_headroom
         res.add(
             "memory",
-            float(peak) <= float(cap),
-            f"peak mem {float(peak):.1f} GB vs GPU capacity {float(cap):.1f} GB",
+            float(peak) <= usable,
+            f"peak mem {float(peak):.1f} GB vs {mem_headroom:.0%} of {float(cap):.1f} GB "
+            f"capacity ({usable:.1f} GB usable)",
         )
     # memory check is advisory when capacity/peak absent (smoke may not report cap)
     return res
@@ -254,6 +278,8 @@ def main(argv: Iterable[str] | None = None) -> int:
     ap.add_argument("--total-steps", type=int, default=None)
     ap.add_argument("--gpu-cost-per-hour-usd", type=float, default=None)
     ap.add_argument("--gpu-capacity-gb", type=float, default=None)
+    ap.add_argument("--mem-headroom", type=float, default=0.9,
+                    help="fraction of GPU capacity treated as usable (default 0.9)")
     args = ap.parse_args(list(argv) if argv is not None else None)
 
     metrics = json.loads(args.metrics.read_text())
@@ -265,6 +291,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         total_steps=args.total_steps,
         gpu_cost_per_hour_usd=args.gpu_cost_per_hour_usd,
         gpu_capacity_gb=args.gpu_capacity_gb,
+        mem_headroom=args.mem_headroom,
     )
     print(json.dumps({"go": gate.go, "checks": gate.checks,
                       "extrapolation": gate.extrapolation}, indent=2))

--- a/scripts/er_matcher/sources/leipzig.py
+++ b/scripts/er_matcher/sources/leipzig.py
@@ -104,9 +104,6 @@ class LeipzigSource:
     def splits(self) -> dict[str, list[Row]]:
         entities = self._entities()
         gold_pairs = self._read_gold_pairs()
-        # Order-normalized so a sampled negative is caught regardless of
-        # which side synth_negatives happened to put first.
-        gold_set = {(a, b) for a, b in gold_pairs} | {(b, a) for a, b in gold_pairs}
         # Connected components over the gold-match edges give every A-side
         # and B-side record a stable ENTITY key (Task 1 fix). A gold pair's
         # two records are always unioned into the same entity, so eid_a and
@@ -150,9 +147,15 @@ class LeipzigSource:
             for eid_a, eid_b, _tag in candidates:
                 if kept >= n_positives:
                     break
-                if (eid_a, eid_b) in gold_set:
+                if key_of.get(eid_a) == key_of.get(eid_b):
                     # A sampled "negative" that is actually a true match --
-                    # dropping it is correctness-critical, not cosmetic.
+                    # dropping it is correctness-critical, not cosmetic. We test
+                    # ENTITY-key equality (connected components over the gold edges),
+                    # NOT direct gold-pair membership: on many-to-many sources
+                    # (amazon_google, dblp_scholar) two records can belong to the
+                    # same entity without a DIRECT gold edge between them, and a
+                    # gold_set-membership check would emit that true match as a
+                    # `no_match` -- silent training-label corruption.
                     continue
                 out[split].append(self._row(entities, eid_a, eid_b, "no_match"))
                 kept += 1

--- a/scripts/er_matcher/test_leipzig.py
+++ b/scripts/er_matcher/test_leipzig.py
@@ -124,3 +124,48 @@ def test_no_shortfall_warning_on_fixture():
     shortfall_warnings = [w for w in caught if "negatives after gold-filter" in str(w.message)]
     assert not shortfall_warnings
     assert sum(r["label"] == "no_match" for r in rows) == 2
+
+
+FIX_MM = Path(__file__).parent / "tests" / "fixtures" / "leipzig_manytomany"
+
+
+def test_manytomany_negatives_never_same_entity():
+    """Regression for the negative-mining label flip: on a many-to-many source a
+    sampled cross-table pair can belong to the SAME entity (connected component)
+    without a DIRECT gold edge. Filtering negatives by gold-pair MEMBERSHIP (not
+    entity-key equality) would emit that true match as `no_match` -- silent
+    training-label corruption. Assert no emitted negative is same-entity.
+
+    Fixture: mapping a1-b1, a1-b2, a2-b2 => entity {a1,a2,b1,b2}; (a2,b1) is
+    same-entity but NOT a direct gold edge. a3-b3 is a distinct entity (so valid
+    cross-entity negatives still exist).
+    """
+    # Single split (val/test frac 0) co-locates both entities so cross-table
+    # negatives -- including the same-entity (a2,b1) -- are actually generated,
+    # making the invariant non-vacuous (it fails on the old gold_set check).
+    src = LeipzigSource(name="mm", root=FIX_MM, domain="product", block_fields=["title"],
+                        seed=1, val_frac=0.0, test_frac=0.0)
+    entities = src._entities()
+    gold = src._read_gold_pairs()
+    key_of = src._key_of(entities, gold)
+
+    negs = {(r["eid_a"], r["eid_b"]) for r in _all_rows(src) if r["label"] == "no_match"}
+    assert negs  # negatives were actually generated (else the test is vacuous)
+    for a, b in negs:
+        assert key_of[a] != key_of[b], f"same-entity pair {a},{b} mislabeled no_match"
+
+    # the specific transitive same-entity pair must never surface as a negative
+    both = negs | {(b, a) for a, b in negs}
+    assert ("A:a2", "B:b1") not in both
+
+
+def test_manytomany_still_emits_cross_entity_negatives():
+    """The fix must not over-prune: distinct entities (a3-b3 vs the {a1,a2,b1,b2}
+    component) still produce valid negatives, so the corpus keeps hard negatives."""
+    src = LeipzigSource(name="mm", root=FIX_MM, domain="product", block_fields=["title"],
+                        seed=1, val_frac=0.0, test_frac=0.0)
+    entities = src._entities()
+    key_of = src._key_of(entities, src._read_gold_pairs())
+    negs = {(r["eid_a"], r["eid_b"]) for r in _all_rows(src) if r["label"] == "no_match"}
+    # at least one negative spans the two distinct entities
+    assert any(key_of[a] != key_of[b] for a, b in negs)

--- a/scripts/er_matcher/test_perf_report.py
+++ b/scripts/er_matcher/test_perf_report.py
@@ -92,6 +92,39 @@ def test_gate_nogo_on_oom():
     assert any(c["check"] == "memory" and not c["passed"] for c in g.checks)
 
 
+def test_gate_advisory_on_empty_learning_curve():
+    # A single --smoke run emits no slice sweep -> empty learning_curve. That must
+    # be advisory (not measured), NOT a hard NO-GO; otherwise the documented
+    # smoke->gate flow could never return GO.
+    m = _good_metrics()
+    m["learning_curve"] = []
+    g = pr.evaluate_perf_gate(m)
+    assert g.go is True
+    lc = next(c for c in g.checks if c["check"] == "learning_curve")
+    assert lc["passed"] is True and "not measured" in lc["detail"]
+
+
+def test_gate_advisory_on_missing_gpu_util():
+    # gpu_util None means telemetry unavailable (pynvml absent), NOT 0% data-bound.
+    m = _good_metrics()
+    m["gpu_util"] = None
+    g = pr.evaluate_perf_gate(m)
+    assert g.go is True
+    gu = next(c for c in g.checks if c["check"] == "gpu_util")
+    assert gu["passed"] is True and "not measured" in gu["detail"]
+
+
+def test_gate_memory_applies_headroom():
+    # peak just under raw capacity but over the 90%-derated usable ceiling must fail.
+    m = _good_metrics()
+    m["peak_mem_gb"] = 23.0  # < 24 raw, but > 0.9*24 = 21.6 usable
+    g = pr.evaluate_perf_gate(m)
+    assert g.go is False
+    assert any(c["check"] == "memory" and not c["passed"] for c in g.checks)
+    # slacker headroom passes it
+    assert pr.evaluate_perf_gate(m, mem_headroom=1.0).go is True
+
+
 def test_extrapolate_on_tier_prices_at_tier_rate():
     tier = gpu_tiers.Tier("L4", 24.0, 0.80)
     ext = pr.extrapolate_on_tier(

--- a/scripts/er_matcher/test_train_helpers.py
+++ b/scripts/er_matcher/test_train_helpers.py
@@ -137,8 +137,11 @@ def test_auto_reason_lists_agreements_and_conflicts():
 
 def test_serialized_token_lengths_uses_injected_tokenizer():
     rows = [_row(True), _row(False)]
-    # stub tokenizer = whitespace split; lengths are positive + deterministic
-    lens = tr.serialized_token_lengths(rows, lambda t: t.split())
+    # stub tokenize_messages: chat-template stand-in = whitespace-split the joined
+    # message contents (mirrors apply_chat_template(msgs, tokenize=True)'s shape:
+    # messages in, token sequence out). Lengths are positive + deterministic.
+    stub = lambda msgs: " ".join(m["content"] for m in msgs).split()  # noqa: E731
+    lens = tr.serialized_token_lengths(rows, stub)
     assert len(lens) == 2 and all(n > 0 for n in lens)
 
 

--- a/scripts/er_matcher/tests/fixtures/leipzig_manytomany/mapping.csv
+++ b/scripts/er_matcher/tests/fixtures/leipzig_manytomany/mapping.csv
@@ -1,0 +1,5 @@
+idA,idB
+a1,b1
+a1,b2
+a2,b2
+a3,b3

--- a/scripts/er_matcher/tests/fixtures/leipzig_manytomany/tableA.csv
+++ b/scripts/er_matcher/tests/fixtures/leipzig_manytomany/tableA.csv
@@ -1,0 +1,4 @@
+id,title,manufacturer,price
+a1,Camera Alpha Model,Acme,10.00
+a2,Camera Alpha Model,Acme,10.00
+a3,Camera Beta Model,Beta,20.00

--- a/scripts/er_matcher/tests/fixtures/leipzig_manytomany/tableB.csv
+++ b/scripts/er_matcher/tests/fixtures/leipzig_manytomany/tableB.csv
@@ -1,0 +1,4 @@
+id,title,manufacturer,price
+b1,Camera Alpha Model,Acme,10.00
+b2,Camera Alpha Model,Acme,10.00
+b3,Camera Beta Model,Beta,20.00

--- a/scripts/er_matcher/train.py
+++ b/scripts/er_matcher/train.py
@@ -201,16 +201,17 @@ def _norm(v: Any) -> str:
     return "" if v is None else str(v).strip().lower()
 
 
-def serialized_token_lengths(rows: Iterable[dict[str, Any]], tokenizer: Any) -> list[int]:
-    """Token length of each serialized pair (system+user+target) under the real
-    tokenizer -- feeds measured_max_seq_len. Tokenizer is injected so this is
-    testable with a stub (len-of-split) without transformers."""
-    out = []
-    for row in rows:
-        msgs = example_to_messages(row, TrainConfig())
-        text = "\n".join(m["content"] for m in msgs)
-        out.append(len(tokenizer(text)))
-    return out
+def serialized_token_lengths(rows: Iterable[dict[str, Any]], tokenize_messages: Any) -> list[int]:
+    """Token length of each training example under the SAME tokenization the
+    trainer uses -- the chat-templated (system+user+target) message sequence.
+
+    ``tokenize_messages(messages) -> Sequence`` is injected: the GPU caller passes
+    ``lambda msgs: tokenizer.apply_chat_template(msgs, tokenize=True)`` so the
+    measured P95 includes the per-turn special tokens (``<|im_start|>`` etc.) --
+    a naive ``"\\n".join(content)`` omits them and under-measures max_seq_len,
+    making truncation more common than intended. Injecting the tokenizer keeps
+    this testable with a stub (no transformers)."""
+    return [len(tokenize_messages(example_to_messages(row, TrainConfig()))) for row in rows]
 
 
 # --- IO ----------------------------------------------------------------------


### PR DESCRIPTION
## What and why

A multi-agent review of the ER-matcher effort surfaced two correctness bugs and a cluster of P3a perf-gate reliability issues. This PR lands those fixes, plus the eval-entrypoint parameterization that enabled the model-scale comparison.

### #1 — Leipzig negative-mining label flip (CRITICAL)
`scripts/er_matcher/sources/leipzig.py` filtered sampled negatives by **direct gold-pair membership** (`gold_set`) while entity membership is the **connected-components** key (`key_of`). On many-to-many bundled **training** sources (`amazon_google`, `dblp_scholar`) two records can share an entity without a direct gold edge, so that true match was emitted as `no_match` — silent training-label corruption. Now filters by entity-key equality; dead `gold_set` removed. New `leipzig_manytomany` fixture + 2 tests (the 1:1 fixture couldn't see it).

### #2 — Two diverging `serialize_pair_v1`, both stamped `v1` (HIGH)
`core/_llm_loader.py` hand-rolled a **second** v1 serializer + system prompt that disagreed with `core/er_matcher/prompt.py` (field order, indent, missing-value sentinel, record separator, system text). The model is fine-tuned on `prompt.py`'s rendering, so Path B fed it out-of-distribution prompts — and the registry drift guard only compares the version **string**, so it couldn't catch it. Now single-sourced from `prompt.serialize_pair_v1` / `build_chat` / `parse_verdict` (projecting rows to the caller's data columns first so `__row_id__` never leaks). Serializer-parity test added.

### P3a perf-gate cluster (`perf_report.py` + `_train_runtime.py` + `train.py`)
- **Empty `learning_curve` is now advisory**, not a hard NO-GO — a single `--smoke` run has no slice sweep, so the documented smoke→gate flow could never return GO (`slope 0.0 > 0.0` is False). Guarded like the memory check.
- **`gpu_util` None** (telemetry unavailable) is advisory instead of read as `0% == DATA-BOUND`; `mean_util()` returns `None` (not `0.0`) on zero samples.
- **Memory check derates capacity** by a headroom factor (default 0.9, `--mem-headroom`), consistent with `gpu_tiers`; peak now reports `max_memory_reserved` (the pool that presses capacity), not allocated.
- **Smoke `total_steps` + `seq_len` measured over the FULL corpus before the smoke slice** (was measured on the 4k-row slice → under-counted the full-run cost extrapolation → falsely-cheap GO).
- **seq-len measured on the chat-templated messages** (`apply_chat_template`), not a naive content join that omits per-turn special tokens and under-measures P95.
- `_ThroughputCallback` snapshots wall at `on_train_end` so trailing `evaluate()`/save don't inflate `s_per_step`.

### Eval-variant parameterization
`eval_model` / `zeroshot_eval` gained backward-compatible `--model-path` / `--out-name` params so the trained scale variants (`model_7b` / `model_1p5b`) can be scored without clobbering the shipped 3B's card — which is how the model-scale decision (**3B confirmed as the sweet spot**) was measured.

## Testing
- `scripts/er_matcher` box-safe suite green (perf_report +3, leipzig +2, train-helpers updated); ruff clean.
- The `goldenmatch`-importing tests (`test_local_llm`, `test_train_helpers`) run in the `er_matcher`/goldenmatch CI lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8LFfCN5WULzTzKd8vaU6C)_