### PR TITLE
feat(semantic): key-certification front door across surfaces + review fixes

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -611,6 +611,10 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `autoconfig` | `--show-controller` | boolean | `True` | Render the controller telemetry panel on stderr. |
 | `autoconfig` | `--verbose` | boolean | `False` | Include indicator priors + decision trace in the panel. |
 | `autoconfig` | `--quiet` | boolean | `False` | Suppress all stderr output (panel + status messages). |
+| `certify-keys` | `model` | text | **required** | Semantic-model file (dbt/MetricFlow, Cube, or OSI YAML) |
+| `certify-keys` | `--data` | text | **required** | Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv |
+| `certify-keys` | `--resolve` | boolean | `False` | Also measure entity fragmentation / undercount via ER (MetricFlow dialect only). |
+| `certify-keys` | `--fail-untrustworthy` | boolean | `False` | Exit non-zero if any declared key is not unique at grain (CI gate). |
 | `compare-clusters` | `file_a` | text | **required** | First cluster JSON file (baseline / ER1) |
 | `compare-clusters` | `file_b` | text | **required** | Second cluster JSON file (comparison / ER2) |
 | `compare-clusters` | `--details` | boolean | `False` | Show per-cluster transformation details |
@@ -908,7 +912,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 ## MCP tools
 
-90 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
+91 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
 
 | Tool | Description |
 |---|---|
@@ -925,6 +929,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `auto_configure` | Run AutoConfigController on a CSV; return the committed GoldenMatchConfig (incl. negative_evidence / Path Y when chosen) plus telemetry — stop_reason, health, decision trace, indicator column priors. Programmatic equivalent of `goldenmatch autoconfig`. |
 | `build_clusters` | Group records into clusters given a file and matchkey definition. |
 | `certify_recall` | Estimate match RECALL without ground truth (unsupervised). Treats each auto-configured matchkey/pass as a decorrelated system and uses capture-recapture over their overlaps to estimate how many true matches were missed. Returns a point estimate (a safe lower bound additionally needs a small labelled audit; see `goldenmatch evaluate --certify --audit-out`). Needs >=3 decorrelated systems. |
+| `certify_semantic_model` | Semantic-layer front door: certify every declared entity key in a dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. The dialect is auto-detected. Returns, per declared key, whether it is unique at grain and its measure fan-out -- the keys a metric silently joins on. Advisory; it never mutates a metric. |
 | `compare_clusters` | Compare two ER clustering outcomes on the same dataset without ground truth (CCMS): classifies each cluster as unchanged / merged / partitioned / overlapping and returns the Talburt-Wang Index. Both inputs are JSON cluster files (as written by export-style output). |
 | `config_weaknesses` | Diagnose weaknesses in the loaded run's auto-config: columns admitted that shouldn't be (source/provenance labels, per-row IDs), oversized or shared-value blocks, null sinks, low-signal matchkeys, and over-merging. Returns ranked findings, each with a plain-English explanation + a concrete fix, plus a one-paragraph summary. |
 | `controller_telemetry` | Return the AutoConfigController telemetry from the most recent `auto_configure` or `agent_deduplicate` call in this MCP session. Same JSON shape as the web /api/v1/controller/telemetry endpoint. |

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.26.0` | `goldenmatch` | 90 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.26.0` | `goldenmatch` | 91 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
@@ -59,9 +59,10 @@ neglect:
   (`read_file`, `write_csv`, `server_info`) were the last holdouts, and Python now
   exposes all eight.
 
-So GoldenMatch's **83 TS tools vs 90 Python** breaks down as 83 shared operations,
-**zero TS-only**, and 7 Python-only tools (the VLM document-ingest pair, the
-distributed routing trio, `list_plugins`, and `pprl_auto_config`). The TS MCP surface
+So GoldenMatch's **83 TS tools vs 91 Python** breaks down as 83 shared operations,
+**zero TS-only**, and 8 Python-only tools (the VLM document-ingest pair, the
+distributed routing trio, `list_plugins`, `pprl_auto_config`, and
+`certify_semantic_model`). The TS MCP surface
 is now a strict subset of the Python one — every TS tool has a Python counterpart of
 the same name, and what remains Python-only is the set with no JS-ecosystem
 equivalent. On the shared core the **public function names match**, and that parity
@@ -128,7 +129,7 @@ graph, privacy-preserving linkage. The flagship — a native wheel, SQL extensio
 
 **Servers** — REST (`goldenmatch serve`: `/match`, `/autoconfig`, `/clusters`,
 `/reviews`, `/controller/telemetry`, …) · A2A (`goldenmatch agent-serve`) · local
-web UI (`goldenmatch serve-ui`) · **90 MCP tools**.
+web UI (`goldenmatch serve-ui`) · **91 MCP tools**.
 
 **Native / SQL** — `goldenmatch-native` wheel, a Postgres extension (pgrx:
 `goldenmatch_dedupe`, `goldenmatch_autoconfig`, `goldenmatch_connected_components`, …),

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,13 +14,13 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 90 | 202 | 50 | 40 | Yes | Yes |
+| `goldenmatch` | 91 | 202 | 50 | 41 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
 | `goldenanalysis` | 4 | 8 | — | 4 | Yes | Yes |
 | `infermap` | 4 | 19 | — | 5 | Yes | Yes |
-| **suite** | **131** | | | | | |
+| **suite** | **132** | | | | | |
 
 ## Compute substrate — the Rust `-core` kernel is the reference
 
@@ -41,8 +41,8 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 83 | 7 | 0 |
-| `goldenmatch` | cli_commands | 32 | 8 | 0 |
+| `goldenmatch` | mcp_tools | 83 | 8 | 0 |
+| `goldenmatch` | cli_commands | 32 | 9 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 14 | 10 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -66,8 +66,8 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
+- `goldenmatch` **cli_commands** — Python-only: `certify-keys`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 433,
+      "module_count": 435,
       "modules": [
         {
           "module": "goldenmatch",
@@ -481,6 +481,18 @@
           ]
         },
         {
+          "module": "goldenmatch.cli.certify_keys",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/certify_keys.py",
+          "purpose": "CLI `certify-keys` command -- the semantic-layer front door.",
+          "defines": [
+            "certify_keys_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core.io_arrow",
+            "goldenmatch.semantic"
+          ]
+        },
+        {
           "module": "goldenmatch.cli.compare",
           "file": "packages/python/goldenmatch/goldenmatch/cli/compare.py",
           "purpose": "CLI compare-clusters command for GoldenMatch.",
@@ -728,6 +740,7 @@
             "goldenmatch.cli.agent_serve",
             "goldenmatch.cli.anomalies",
             "goldenmatch.cli.autoconfig",
+            "goldenmatch.cli.certify_keys",
             "goldenmatch.cli.compare",
             "goldenmatch.cli.dedupe",
             "goldenmatch.cli.demo",
@@ -6473,6 +6486,7 @@
             "_safe_path_or_error",
             "_tool_analyze_blocking",
             "_tool_build_clusters",
+            "_tool_certify_semantic_model",
             "_tool_compare_clusters",
             "_tool_config_weaknesses",
             "_tool_convert_splink_config",
@@ -6533,6 +6547,7 @@
             "goldenmatch.core.evaluate",
             "goldenmatch.core.explainer",
             "goldenmatch.core.ingest",
+            "goldenmatch.core.io_arrow",
             "goldenmatch.core.lineage",
             "goldenmatch.core.match_one",
             "goldenmatch.core.matchkey",
@@ -6551,6 +6566,7 @@
             "goldenmatch.mcp.routing_tools",
             "goldenmatch.pprl.autoconfig",
             "goldenmatch.pprl.protocol",
+            "goldenmatch.semantic",
             "goldenmatch.tui.engine"
           ]
         },
@@ -7055,7 +7071,26 @@
           "purpose": "Semantic-layer interoperability (the MetricFlow / Cube / OSI wedge).",
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.certify",
             "goldenmatch.semantic.crosswalk",
+            "goldenmatch.semantic.cube",
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.osi"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.certify",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/certify.py",
+          "purpose": "Zero-config front door: certify every declared key in a semantic model.",
+          "defines": [
+            "KeyCertification",
+            "SemanticCertification",
+            "certify_semantic_model",
+            "detect_dialect"
+          ],
+          "imports": [
+            "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2359,6 +2359,37 @@
           ]
         },
         {
+          "command": "certify-keys",
+          "options": [
+            {
+              "name": "model",
+              "type": "text",
+              "required": true,
+              "help": "Semantic-model file (dbt/MetricFlow, Cube, or OSI YAML)"
+            },
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv"
+            },
+            {
+              "name": "--resolve",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Also measure entity fragmentation / undercount via ER (MetricFlow dialect only)."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any declared key is not unique at grain (CI gate)."
+            }
+          ]
+        },
+        {
           "command": "compare-clusters",
           "options": [
             {
@@ -4678,6 +4709,10 @@
         {
           "name": "certify_recall",
           "description": "Estimate match RECALL without ground truth (unsupervised). Treats each auto-configured matchkey/pass as a decorrelated system and uses capture-recapture over their overlaps to estimate how many true matches were missed. Returns a point estimate (a safe lower bound additionally needs a small labelled audit; see `goldenmatch evaluate --certify --audit-out`). Needs >=3 decorrelated systems."
+        },
+        {
+          "name": "certify_semantic_model",
+          "description": "Semantic-layer front door: certify every declared entity key in a dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. The dialect is auto-detected. Returns, per declared key, whether it is unique at grain and its measure fan-out -- the keys a metric silently joins on. Advisory; it never mutates a metric."
         },
         {
           "name": "compare_clusters",

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - DQbench composite 91.04; PPRL 92.4% F1 on FEBRL4; a durable Identity Graph (stable entity_ids that survive across runs)
 
 ## AI-native surface
-- Every package ships an MCP server (131 tools across the suite), a REST API, and most an A2A agent surface
+- Every package ships an MCP server (132 tools across the suite), a REST API, and most an A2A agent surface
 - One aggregator container exposes the whole suite: `docker run ghcr.io/benseverndev-oss/goldensuite-mcp:latest`
 - Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benseverndev-oss/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -106,7 +106,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 91.04 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **90 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **91 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### Run on unstructured input (document ingest)
@@ -217,7 +217,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 - **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
-- **REST API + MCP Server** — 90 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
+- **REST API + MCP Server** — 91 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
 - **A2A Agent** — 50 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
@@ -731,7 +731,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (90 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (91 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |
@@ -1294,7 +1294,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-90 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+91 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
 
 ### Local files with the remote server
 

--- a/packages/python/goldenmatch/goldenmatch/cli/certify_keys.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/certify_keys.py
@@ -1,0 +1,75 @@
+"""CLI `certify-keys` command -- the semantic-layer front door.
+
+Surfaces ``goldenmatch.semantic.certify_semantic_model``: point it at a
+dbt/MetricFlow, Cube, or OSI/Ossie semantic model plus the data behind each
+model and get an advisory key-integrity certificate (uniqueness at grain +
+measure fan-out) for every declared entity key -- the keys a metric silently
+joins on. Advisory only; it never mutates a metric.
+"""
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def certify_keys_cmd(
+    model: str = typer.Argument(..., help="Semantic-model file (dbt/MetricFlow, Cube, or OSI YAML)"),
+    data: list[str] = typer.Option(
+        ..., "--data", "-d",
+        help="Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv",
+    ),
+    resolve: bool = typer.Option(
+        False, "--resolve",
+        help="Also measure entity fragmentation / undercount via ER (MetricFlow dialect only).",
+    ),
+    fail_untrustworthy: bool = typer.Option(
+        False, "--fail-untrustworthy",
+        help="Exit non-zero if any declared key is not unique at grain (CI gate).",
+    ),
+) -> None:
+    """Certify every declared key in a semantic model against its data."""
+    from goldenmatch.core.io_arrow import read_table_arrow
+    from goldenmatch.semantic import certify_semantic_model
+
+    frames: dict[str, object] = {}
+    for spec in data:
+        if "=" not in spec:
+            console.print(f"[red]--data must be name=path, got {spec!r}[/red]")
+            raise typer.Exit(code=2)
+        name, path = spec.split("=", 1)
+        frames[name.strip()] = read_table_arrow(path.strip())
+
+    report = certify_semantic_model(model, frames, resolve=resolve)
+
+    console.print(f"[bold]Dialect:[/bold] {report.dialect}   "
+                  f"[bold]certified:[/bold] {report.n_certified}   "
+                  f"[bold]untrustworthy:[/bold] {len(report.untrustworthy)}")
+    if report.skipped:
+        console.print(f"[dim]skipped (no frame supplied): {', '.join(report.skipped)}[/dim]")
+    if report.note:
+        console.print(f"[dim]{report.note}[/dim]")
+
+    if report.entries:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("target")
+        table.add_column("key")
+        table.add_column("unique@grain")
+        table.add_column("max_fan_out", justify="right")
+        table.add_column("context", style="dim")
+        for e in report.entries:
+            ok = e.certificate.is_unique_at_grain
+            table.add_row(
+                e.target,
+                ", ".join(e.key),
+                "[#2ecc71]yes[/]" if ok else "[red]NO[/]",
+                f"{e.certificate.max_fan_out:g}",
+                e.context,
+            )
+        console.print(table)
+
+    if fail_untrustworthy and report.untrustworthy:
+        console.print(f"[red]{len(report.untrustworthy)} declared key(s) are not unique at grain.[/red]")
+        raise typer.Exit(code=1)

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -14,6 +14,7 @@ from goldenmatch import __version__
 from goldenmatch.cli.agent_serve import agent_serve_cmd
 from goldenmatch.cli.anomalies import anomalies_cmd
 from goldenmatch.cli.autoconfig import autoconfig_cmd
+from goldenmatch.cli.certify_keys import certify_keys_cmd
 from goldenmatch.cli.compare import compare_clusters_cmd
 from goldenmatch.cli.dedupe import dedupe_cmd
 from goldenmatch.cli.demo import demo_cmd
@@ -144,6 +145,7 @@ app.command("agent-serve", help="Start the A2A agent server for AI-to-AI discove
 app.command("incremental", help="Match new records against an existing base dataset.")(incremental_cmd)
 app.command("compare-clusters", help="Compare two ER clustering outcomes (CCMS).")(compare_clusters_cmd)
 app.command("sensitivity", help="Analyze parameter sensitivity using CCMS comparison.")(sensitivity_cmd)
+app.command("certify-keys", help="Certify the entity keys a semantic model (MetricFlow/Cube/OSI) declares.")(certify_keys_cmd)
 
 
 @app.command("analyze-blocking")

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -781,6 +781,38 @@ _BASE_TOOLS = [
             },
         },
     ),
+    Tool(
+        name="certify_semantic_model",
+        description=(
+            "Semantic-layer front door: certify every declared entity key in a "
+            "dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. "
+            "The dialect is auto-detected. Returns, per declared key, whether it is "
+            "unique at grain and its measure fan-out -- the keys a metric silently "
+            "joins on. Advisory; it never mutates a metric."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "model_path": {
+                    "type": "string",
+                    "description": "Path to the semantic-model YAML (MetricFlow / Cube / OSI).",
+                },
+                "frames": {
+                    "type": "object",
+                    "description": (
+                        "Map of model/dataset/cube name -> data file path, e.g. "
+                        "{\"orders\": \"orders.csv\"}. A target with no frame is skipped."
+                    ),
+                },
+                "resolve": {
+                    "type": "boolean",
+                    "description": "Also measure fragmentation/undercount via ER (MetricFlow only).",
+                    "default": False,
+                },
+            },
+            "required": ["model_path", "frames"],
+        },
+    ),
 ]
 
 # --- Cross-language naming aliases (Python<->TS MCP parity) -----------------
@@ -1319,8 +1351,63 @@ def _handle_tool(name: str, args: dict) -> dict:
         return _tool_config_weaknesses(
             args.get("max_findings", 6), args.get("phrasing", "plain")
         )
+    elif name == "certify_semantic_model":
+        return _tool_certify_semantic_model(
+            args.get("model_path", ""), args.get("frames", {}), args.get("resolve", False)
+        )
     else:
         return {"error": f"Unknown tool: {name}"}
+
+
+def _tool_certify_semantic_model(model_path: str, frames: dict, resolve: bool) -> dict:
+    """Certify every declared key in a semantic model against its data files.
+
+    ``frames`` maps model/dataset/cube name -> data file path; each is loaded
+    into a pyarrow Table. Returns a JSON-serializable per-key report.
+    """
+    if not model_path:
+        return {"error": "model_path is required (path to a MetricFlow/Cube/OSI YAML)."}
+    if not isinstance(frames, dict) or not frames:
+        return {"error": "frames must map a model/dataset/cube name to a data file path."}
+
+    from goldenmatch.core.io_arrow import read_table_arrow
+    from goldenmatch.semantic import certify_semantic_model
+
+    loaded: dict[str, object] = {}
+    for target, path in frames.items():
+        try:
+            loaded[str(target)] = read_table_arrow(str(path))
+        except FileNotFoundError:
+            return {"error": f"data file not found for {target!r}: {path}"}
+        except Exception as exc:  # noqa: BLE001 - surface a clean tool error
+            return {"error": f"could not read data for {target!r} ({path}): {exc}"}
+
+    try:
+        report = certify_semantic_model(model_path, loaded, resolve=bool(resolve))
+    except FileNotFoundError:
+        return {"error": f"semantic-model file not found: {model_path}"}
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return {
+        "dialect": report.dialect,
+        "n_certified": report.n_certified,
+        "all_trustworthy": report.all_trustworthy,
+        "skipped": report.skipped,
+        "note": report.note,
+        "keys": [
+            {
+                "target": e.target,
+                "key": e.key,
+                "context": e.context,
+                "is_unique_at_grain": e.certificate.is_unique_at_grain,
+                "max_fan_out": e.certificate.max_fan_out,
+                "estimate": e.certificate.estimate,
+                "measure_fan_out": e.certificate.measure_fan_out,
+            }
+            for e in report.entries
+        ],
+    }
 
 
 def _tool_get_stats() -> dict:

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -17,6 +17,12 @@ so ``import goldenmatch`` stays lightweight and polars-free; import it explicitl
 from __future__ import annotations
 
 from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.certify import (
+    KeyCertification,
+    SemanticCertification,
+    certify_semantic_model,
+    detect_dialect,
+)
 from goldenmatch.semantic.crosswalk import ResolvedCrosswalk, build_resolved_crosswalk
 from goldenmatch.semantic.cube import (
     Cube,
@@ -53,6 +59,11 @@ from goldenmatch.semantic.osi import (
 )
 
 __all__ = [
+    # zero-config front door — certify a whole semantic model (any dialect)
+    "certify_semantic_model",
+    "SemanticCertification",
+    "KeyCertification",
+    "detect_dialect",
     # wedge A — certify a declared key
     "certify_key_integrity",
     "KeyIntegrityCertificate",

--- a/packages/python/goldenmatch/goldenmatch/semantic/certify.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/certify.py
@@ -1,0 +1,134 @@
+"""Zero-config front door: certify every declared key in a semantic model.
+
+`certify_semantic_model(source, frames)` auto-detects the dialect
+(dbt/MetricFlow, Cube, or OSI/Ossie), reads every declared identity key, and
+certifies each against the supplied data frames via wedge A
+(`certify_key_integrity`). One call, any of the three semantic layers, an
+advisory certificate per key — "point it at the semantic model you already have
+and get a fan-out / undercount report on the first run."
+
+This is the surface-agnostic core the `goldenmatch certify-keys` CLI command and
+the `certify_semantic_model` MCP tool both delegate to (shared-capabilities
+conform across surfaces). Advisory only — it never mutates a metric or a key.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.cube import certify_cube_joins
+from goldenmatch.semantic.key_integrity import certify_key_integrity
+from goldenmatch.semantic.metricflow import _load, parse_semantic_models
+from goldenmatch.semantic.osi import certify_osi_relationships
+
+
+@dataclass
+class KeyCertification:
+    """One certified declared key: which model/dataset/cube declared it, the key
+    column(s), and the advisory `KeyIntegrityCertificate`."""
+
+    target: str                          # the model / dataset / cube name
+    key: list[str]
+    certificate: KeyIntegrityCertificate
+    context: str = ""                    # e.g. the relationship / join it feeds
+
+
+@dataclass
+class SemanticCertification:
+    """The result of certifying a whole semantic model: the detected dialect and
+    one `KeyCertification` per declared key that had a supplied frame."""
+
+    dialect: str                         # "metricflow" | "cube" | "osi"
+    entries: list[KeyCertification] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)  # targets with no frame
+    note: str = ""
+
+    @property
+    def n_certified(self) -> int:
+        return len(self.entries)
+
+    @property
+    def untrustworthy(self) -> list[KeyCertification]:
+        """Entries whose declared key is NOT unique at grain (or fans out) — the
+        keys a metric silently depends on that will miscount."""
+        return [e for e in self.entries if not e.certificate.is_trustworthy()]
+
+    @property
+    def all_trustworthy(self) -> bool:
+        return not self.untrustworthy
+
+
+def detect_dialect(data: dict[str, Any]) -> str:
+    """Detect the semantic-layer dialect from a loaded document's top-level shape.
+
+    Cube uses a `cubes:` list, MetricFlow a `semantic_models:` list, OSI/Ossie a
+    `semantic_model` list (singular) + `version`. Raises if none match.
+    """
+    if "cubes" in data:
+        return "cube"
+    if "semantic_models" in data:
+        return "metricflow"
+    if "semantic_model" in data:
+        return "osi"
+    raise ValueError(
+        "certify_semantic_model: could not detect a semantic-layer dialect; "
+        "expected a top-level 'cubes' (Cube), 'semantic_models' (dbt/MetricFlow), "
+        "or 'semantic_model' (OSI/Ossie) key"
+    )
+
+
+def certify_semantic_model(
+    source: str | Any,
+    frames: dict[str, Any],
+    *,
+    resolve: bool = False,
+) -> SemanticCertification:
+    """Certify every declared identity key in a semantic model.
+
+    Args:
+        source: a path, raw YAML string, or loaded dict for a dbt/MetricFlow,
+            Cube, or OSI/Ossie semantic model (the dialect is auto-detected).
+        frames: maps each model/dataset/cube name to the table backing it
+            (pyarrow / polars / pandas / dict). A target with no supplied frame
+            is skipped and recorded in `skipped`.
+        resolve: also run entity resolution to measure fragmentation / undercount
+            (MetricFlow dialect only in v1; Cube/OSI certify structurally).
+
+    Returns:
+        A `SemanticCertification` with one `KeyCertification` per certified key.
+    """
+    data = _load(source)
+    dialect = detect_dialect(data)
+    entries: list[KeyCertification] = []
+    skipped: list[str] = []
+
+    if dialect == "metricflow":
+        for spec in parse_semantic_models(data):
+            df = frames.get(spec.model)
+            if df is None:
+                skipped.append(spec.model)
+                continue
+            cert = certify_key_integrity(
+                df, key=spec.key, measures=spec.measures, grain=spec.grain,
+                resolve=resolve,
+            )
+            entries.append(KeyCertification(target=spec.model, key=list(spec.key), certificate=cert))
+    elif dialect == "cube":
+        # certify_cube_joins already certifies the one-side key of each join.
+        for rep in certify_cube_joins(data, frames):
+            entries.append(KeyCertification(
+                target=rep["to_cube"], key=list(rep["key"]), certificate=rep["certificate"],
+                context=f"join from {rep['from_cube']}",
+            ))
+    else:  # osi
+        for rep in certify_osi_relationships(data, frames):
+            entries.append(KeyCertification(
+                target=rep["dataset"], key=list(rep["key"]), certificate=rep["certificate"],
+                context=f"relationship {rep['relationship']}",
+            ))
+
+    note = ""
+    if resolve and dialect != "metricflow":
+        note = f"resolution tier not applied for the {dialect} dialect (structural certification only)"
+    return SemanticCertification(dialect=dialect, entries=entries, skipped=skipped, note=note)

--- a/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
@@ -110,13 +110,23 @@ def build_resolved_crosswalk(
         dataset=dataset,
     )
 
-    dedupe_df(df, config=cfg, source_name=source_name, confidence_required=False)
+    try:
+        dedupe_df(df, config=cfg, source_name=source_name, confidence_required=False)
 
-    store = IdentityStore(backend="sqlite", path=store_path)
-    pks = table.column(source_pk).to_pylist()
-    record_ids = [f"{source_name}:{pk}" for pk in pks]
-    mapping = store.lookup_entity_ids(record_ids)
-    resolved = [mapping.get(rid) for rid in record_ids]
+        store = IdentityStore(backend="sqlite", path=store_path)
+        pks = table.column(source_pk).to_pylist()
+        record_ids = [f"{source_name}:{pk}" for pk in pks]
+        mapping = store.lookup_entity_ids(record_ids)
+        resolved = [mapping.get(rid) for rid in record_ids]
+    finally:
+        if ephemeral:
+            # The ephemeral store is a throwaway temp DB — remove it (and any
+            # SQLite -wal/-shm sidecars) so repeated ephemeral runs don't leak files.
+            for suffix in ("", "-wal", "-shm"):
+                try:
+                    os.unlink(store_path + suffix)
+                except OSError:
+                    pass
 
     out = pa.table({
         "source": [source_name] * len(pks),

--- a/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
@@ -126,6 +126,8 @@ def build_resolved_crosswalk(
                 try:
                     os.unlink(store_path + suffix)
                 except OSError:
+                    # Best-effort cleanup: the sidecar may not exist, and a
+                    # unlink failure must not mask an otherwise-successful result.
                     pass
 
     out = pa.table({

--- a/packages/python/goldenmatch/goldenmatch/semantic/cube.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/cube.py
@@ -295,8 +295,12 @@ def emit_cube_from_crosswalk(
 def certify_cube_joins(model: list[Cube] | str | Any, frames: dict[str, Any]) -> list[dict[str, Any]]:
     """For each join in a Cube model, certify the ONE-side key it joins on (the
     referenced primary key) using wedge A — certifying exactly the identity the
-    metrics depend on. `frames` maps cube name -> table; cubes without a supplied
-    frame (or a join whose target columns can't be parsed) are skipped.
+    metrics depend on. The one-side depends on the join's direction: for
+    `many_to_one` / `one_to_one` it is the joined (`to`) cube, but for
+    `one_to_many` the declaring (`from`) cube is the one-side, so its key is what
+    must be unique (certifying the many-side FK would spuriously flag a fan-out).
+    `frames` maps cube name -> table; a join whose one-side frame is absent or
+    whose one-side columns can't be parsed is skipped.
 
     Returns `[{from_cube, to_cube, key, certificate}]`.
     """
@@ -306,14 +310,18 @@ def certify_cube_joins(model: list[Cube] | str | Any, frames: dict[str, Any]) ->
     out: list[dict[str, Any]] = []
     for cube in cubes:
         for jk in cube_join_keys(cube):
-            df = frames.get(jk["to_cube"])
-            if df is None or not jk["to_columns"]:
+            if jk["relationship"] == "one_to_many":
+                one_cube, one_columns = jk["from_cube"], jk["from_columns"]
+            else:  # many_to_one / one_to_one → the joined (to) cube is the one-side
+                one_cube, one_columns = jk["to_cube"], jk["to_columns"]
+            df = frames.get(one_cube)
+            if df is None or not one_columns:
                 continue
-            cert = certify_key_integrity(df, key=jk["to_columns"])
+            cert = certify_key_integrity(df, key=one_columns)
             out.append({
                 "from_cube": jk["from_cube"],
                 "to_cube": jk["to_cube"],
-                "key": list(jk["to_columns"]),
+                "key": list(one_columns),
                 "certificate": cert,
             })
     return out

--- a/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
@@ -186,11 +186,15 @@ def _add_resolution(
         sub = table.select(attrs)
         # Build config zero-config, then disable rerank/cross-encoder so the
         # certification path never blocks on a model download (offline-safe).
-        cfg = auto_configure_df(sub, confidence_required=False)
+        cfg = auto_configure_df(sub, confidence_required=False, allow_red_config=True)
         for mk in cfg.get_matchkeys():
             if getattr(mk, "rerank", False):
                 mk.rerank = False
-        res = dedupe_df(sub, config=cfg, confidence_required=False)
+        # allow_red_config so a large table (>= the controller's REFUSE_AT_N) still
+        # MEASURES fragmentation rather than raising ControllerNotConfidentError and
+        # falling through to the "resolution unavailable" note (the #715 contract:
+        # confidence_required=False no longer bypasses the RED-refuse).
+        res = dedupe_df(sub, config=cfg, confidence_required=False, allow_red_config=True)
         clusters = getattr(res, "clusters", None) or {}
 
         keyvals = _row_key_values(table, key_columns)

--- a/packages/python/goldenmatch/goldenmatch/semantic/metricflow.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/metricflow.py
@@ -84,6 +84,7 @@ def parse_semantic_models(source: str | Path | dict[str, Any]) -> list[DeclaredK
 
         primary_key: list[str] = []
         foreign_keys: list[str] = []
+        unique_keys: list[str] = []
         for ent in entities:
             if not isinstance(ent, dict):
                 continue
@@ -96,13 +97,20 @@ def parse_semantic_models(source: str | Path | dict[str, Any]) -> list[DeclaredK
             elif etype == "foreign":
                 foreign_keys.append(col)
             elif etype == "unique":
-                # a unique (non-primary) key is still a valid identity to check;
-                # only promote it when no primary/natural entity was declared.
+                unique_keys.append(col)
+                # A unique (non-primary) entity is a join edge when a primary key
+                # is present (preserving the emit round-trip: a source key emitted
+                # as `unique`); it is promoted to the key only when no primary is.
                 foreign_keys.append(col)
 
-        if not primary_key:
-            # No primary/natural entity → nothing to certify for this model.
+        key = primary_key or unique_keys
+        if not key:
+            # No primary/natural/unique entity → nothing to certify for this model.
             continue
+        if not primary_key:
+            # Promoted a unique key to the primary role — it is the identity, not
+            # a foreign join edge, so drop it from foreign_keys.
+            foreign_keys = [c for c in foreign_keys if c not in unique_keys]
 
         measures = [
             c for m in (sm.get("measures") or [])
@@ -117,7 +125,7 @@ def parse_semantic_models(source: str | Path | dict[str, Any]) -> list[DeclaredK
         specs.append(
             DeclaredKeySpec(
                 model=name,
-                key=primary_key,
+                key=key,
                 measures=measures,
                 grain=grain,
                 foreign_keys=foreign_keys,

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -6,8 +6,8 @@
 Zero-config gets good results and returns the config it chose; the healer (`review_config`) reviews the results and suggests ranked, self-verified tweaks; apply them, results improve, repeat — closing the gap to expert-tuned without you being the expert. Wired into the default pipeline: `dedupe_df` attaches candidate suggestions to `result.suggestions` when a free signal fires (`dedupe_df(suggest=True)` verified, `heal=True` full loop; disable with `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`). Needs `goldenmatch[native]`; degrades gracefully without it. Docs: https://docs.bensevern.dev/goldenmatch/config-suggestions
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (90 tools across data, agent, identity, memory, routing, and document groups)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (90 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- MCP Server: `goldenmatch mcp-serve` (91 tools across data, agent, identity, memory, routing, and document groups)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (91 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (50 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~202 exports

--- a/packages/python/goldenmatch/tests/test_certify_semantic_model.py
+++ b/packages/python/goldenmatch/tests/test_certify_semantic_model.py
@@ -1,0 +1,130 @@
+"""Tests for the zero-config front door: certify_semantic_model (all dialects)."""
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from goldenmatch.semantic import (
+    KeyCertification,
+    SemanticCertification,
+    certify_semantic_model,
+    detect_dialect,
+)
+
+_METRICFLOW = """
+semantic_models:
+  - name: orders
+    model: ref('orders')
+    entities:
+      - name: order
+        type: primary
+        expr: order_id
+    measures:
+      - name: revenue
+        agg: sum
+        expr: amount
+"""
+
+_CUBE = """
+cubes:
+  - name: orders
+    sql_table: public.orders
+    joins:
+      - name: customers
+        relationship: many_to_one
+        sql: "{CUBE}.customer_id = {customers.id}"
+  - name: customers
+    sql_table: public.customers
+    dimensions:
+      - name: id
+        sql: id
+        primary_key: true
+"""
+
+_OSI = """
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    datasets:
+      - name: customers
+        primary_key: [id]
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [id]
+"""
+
+
+def test_detect_dialect():
+    assert detect_dialect({"cubes": []}) == "cube"
+    assert detect_dialect({"semantic_models": []}) == "metricflow"
+    assert detect_dialect({"semantic_model": []}) == "osi"
+    with pytest.raises(ValueError):
+        detect_dialect({"version": 2})
+
+
+def test_metricflow_front_door_certifies_and_flags_fanout():
+    # order_id has a duplicate -> the key a metric joins on is unsafe
+    frames = {"orders": pa.table({"order_id": [1, 1, 2], "amount": [10.0, 10.0, 5.0]})}
+    rep = certify_semantic_model(_METRICFLOW, frames)
+    assert isinstance(rep, SemanticCertification)
+    assert rep.dialect == "metricflow"
+    assert rep.n_certified == 1
+    entry = rep.entries[0]
+    assert isinstance(entry, KeyCertification)
+    assert entry.target == "orders" and entry.key == ["order_id"]
+    assert entry.certificate.max_fan_out == 2.0
+    # revenue SUM double-counts across the duplicate key
+    assert entry.certificate.measure_fan_out["amount"] > 1.0
+    assert rep.untrustworthy == [entry]
+    assert rep.all_trustworthy is False
+
+
+def test_clean_key_is_trustworthy():
+    frames = {"orders": pa.table({"order_id": [1, 2, 3], "amount": [1.0, 2.0, 3.0]})}
+    rep = certify_semantic_model(_METRICFLOW, frames)
+    assert rep.all_trustworthy is True
+    assert rep.untrustworthy == []
+
+
+def test_missing_frame_is_skipped_not_errored():
+    rep = certify_semantic_model(_METRICFLOW, frames={})
+    assert rep.n_certified == 0
+    assert rep.skipped == ["orders"]
+
+
+def test_cube_dialect_front_door():
+    frames = {"customers": pa.table({"id": [1, 1, 2]})}
+    rep = certify_semantic_model(_CUBE, frames)
+    assert rep.dialect == "cube"
+    assert rep.n_certified == 1
+    entry = rep.entries[0]
+    assert entry.target == "customers" and entry.key == ["id"]
+    assert entry.certificate.estimate == 0.5      # duplicate id
+    assert "join from orders" in entry.context
+
+
+def test_osi_dialect_front_door():
+    frames = {"customers": pa.table({"id": [1, 2, 3]})}
+    rep = certify_semantic_model(_OSI, frames)
+    assert rep.dialect == "osi"
+    assert rep.n_certified == 1
+    entry = rep.entries[0]
+    assert entry.target == "customers" and entry.key == ["id"]
+    assert entry.certificate.is_unique_at_grain is True
+    assert "relationship orders_to_customers" in entry.context
+
+
+def test_resolve_note_for_non_metricflow():
+    frames = {"customers": pa.table({"id": [1, 2, 3]})}
+    rep = certify_semantic_model(_OSI, frames, resolve=True)
+    assert "structural certification only" in rep.note
+
+
+def test_accepts_path(tmp_path):
+    p = tmp_path / "sm.yml"
+    p.write_text(_METRICFLOW, encoding="utf-8")
+    frames = {"orders": pa.table({"order_id": [1, 2], "amount": [1.0, 2.0]})}
+    rep = certify_semantic_model(str(p), frames)
+    assert rep.dialect == "metricflow" and rep.n_certified == 1

--- a/packages/python/goldenmatch/tests/test_cli_certify_keys.py
+++ b/packages/python/goldenmatch/tests/test_cli_certify_keys.py
@@ -1,0 +1,55 @@
+"""Test the `goldenmatch certify-keys` CLI command (semantic-layer front door)."""
+from __future__ import annotations
+
+from goldenmatch.cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+_METRICFLOW = """
+semantic_models:
+  - name: orders
+    model: ref('orders')
+    entities:
+      - name: order
+        type: primary
+        expr: order_id
+"""
+
+
+def test_certify_keys_reports_and_gates(tmp_path):
+    model = tmp_path / "sm.yml"
+    model.write_text(_METRICFLOW, encoding="utf-8")
+    # order_id has a duplicate -> not unique at grain
+    data = tmp_path / "orders.csv"
+    data.write_text("order_id\n1\n1\n2\n", encoding="utf-8")
+
+    # default: reports, exit 0
+    res = runner.invoke(app, ["certify-keys", str(model), "-d", f"orders={data}"])
+    assert res.exit_code == 0, res.output
+    assert "metricflow" in res.output
+    assert "order_id" in res.output
+
+    # --fail-untrustworthy: the duplicate key trips the gate (exit 1)
+    res2 = runner.invoke(
+        app, ["certify-keys", str(model), "-d", f"orders={data}", "--fail-untrustworthy"]
+    )
+    assert res2.exit_code == 1, res2.output
+
+
+def test_certify_keys_clean_key_passes_gate(tmp_path):
+    model = tmp_path / "sm.yml"
+    model.write_text(_METRICFLOW, encoding="utf-8")
+    data = tmp_path / "orders.csv"
+    data.write_text("order_id\n1\n2\n3\n", encoding="utf-8")
+    res = runner.invoke(
+        app, ["certify-keys", str(model), "-d", f"orders={data}", "--fail-untrustworthy"]
+    )
+    assert res.exit_code == 0, res.output
+
+
+def test_certify_keys_bad_data_spec(tmp_path):
+    model = tmp_path / "sm.yml"
+    model.write_text(_METRICFLOW, encoding="utf-8")
+    res = runner.invoke(app, ["certify-keys", str(model), "-d", "no-equals-sign"])
+    assert res.exit_code == 2, res.output

--- a/packages/python/goldenmatch/tests/test_cube.py
+++ b/packages/python/goldenmatch/tests/test_cube.py
@@ -156,3 +156,36 @@ def test_certify_cube_joins_accepts_source_and_skips_absent_frames():
 def test_cube_dataclass_primary_key_property():
     c = Cube(name="x")
     assert c.primary_key == []
+
+
+def test_certify_cube_joins_one_to_many_certifies_the_one_side():
+    """For a one_to_many join the DECLARING cube is the one-side, so its key (not
+    the many-side FK) must be certified for uniqueness."""
+    doc = """
+cubes:
+  - name: customers
+    sql_table: public.customers
+    joins:
+      - name: orders
+        relationship: one_to_many
+        sql: "{CUBE}.id = {orders.customer_id}"
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+"""
+    # customers.id is a clean unique key; orders.customer_id (the many-side FK)
+    # fans out by design. The one_to_many one-side is `customers`.
+    frames = {
+        "customers": pa.table({"id": [1, 2, 3]}),
+        "orders": pa.table({"customer_id": [1, 1, 2, 3, 3]}),
+    }
+    rep = certify_cube_joins(parse_cube_models(doc), frames)
+    assert len(rep) == 1
+    entry = rep[0]
+    # certified the declaring (one) side, not the many-side FK
+    assert entry["from_cube"] == "customers" and entry["to_cube"] == "orders"
+    assert entry["key"] == ["id"]
+    assert entry["certificate"].is_unique_at_grain is True
+    assert entry["certificate"].max_fan_out == 1.0

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,7 +16,7 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_90():
+def test_total_tool_count_is_91():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
@@ -26,9 +26,9 @@ def test_total_tool_count_is_90():
     assert len(AGENT_TOOLS) == 19   # +1 retrieve_similar (#1089) +1 upload_dataset
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 15  # +3 MDM ops (#1114) +5 agent-memory ops (#1075/#1078)
-    assert len(_BASE_TOOLS) == 44   # +5 core primitives +3 host helpers (TS reverse-parity)
+    assert len(_BASE_TOOLS) == 45   # +5 core primitives +3 host helpers +1 certify_semantic_model
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 90   # 82 + 5 core primitives + 3 host helpers (TS reverse-parity; ts_only now EMPTY)
+    assert len(TOOLS) == 91   # +1 certify_semantic_model (semantic-layer front door, python_only)
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_metricflow_parse.py
+++ b/packages/python/goldenmatch/tests/test_metricflow_parse.py
@@ -70,3 +70,47 @@ def test_accepts_dict_and_path(tmp_path):
 def test_empty_or_missing_semantic_models():
     assert parse_semantic_models("version: 2") == []
     assert parse_semantic_models({}) == []
+
+
+def test_unique_entity_promoted_when_no_primary():
+    """A semantic model whose identity is a `unique` (not `primary`/`natural`)
+    entity is still certifiable — the unique key is promoted to the key."""
+    yaml = """
+semantic_models:
+  - name: sessions
+    model: ref('sessions')
+    entities:
+      - name: session
+        type: unique
+        expr: session_id
+      - name: user
+        type: foreign
+        expr: user_id
+    measures:
+      - name: session_count
+        agg: count
+"""
+    specs = parse_semantic_models(yaml)
+    assert [s.model for s in specs] == ["sessions"]
+    spec = specs[0]
+    assert spec.key == ["session_id"]          # unique promoted to the key
+    assert spec.foreign_keys == ["user_id"]
+
+
+def test_primary_wins_over_unique():
+    """When both a primary and a unique entity are declared, the primary is the
+    key and the unique is not promoted."""
+    yaml = """
+semantic_models:
+  - name: orders
+    model: ref('orders')
+    entities:
+      - name: order
+        type: primary
+        expr: order_id
+      - name: order_ref
+        type: unique
+        expr: external_ref
+"""
+    spec = parse_semantic_models(yaml)[0]
+    assert spec.key == ["order_id"]

--- a/packages/python/goldenmatch/tests/test_resolved_crosswalk.py
+++ b/packages/python/goldenmatch/tests/test_resolved_crosswalk.py
@@ -1,6 +1,8 @@
 """Tests for goldenmatch.semantic.build_resolved_crosswalk (wedge B: resolve once)."""
 from __future__ import annotations
 
+import os
+
 import pyarrow as pa
 import pytest
 from goldenmatch.semantic import ResolvedCrosswalk, build_resolved_crosswalk
@@ -69,3 +71,16 @@ def test_ephemeral_store_notes_non_durability():
 def test_missing_source_pk_raises():
     with pytest.raises(ValueError):
         build_resolved_crosswalk(_frame(), source_pk="nope")
+
+
+def test_ephemeral_store_leaves_no_temp_files():
+    """The throwaway ephemeral store (and any SQLite sidecars) is removed after
+    the run — repeated ephemeral calls must not leak temp DB files."""
+    import glob
+    import tempfile
+
+    pattern = os.path.join(tempfile.gettempdir(), "gm_crosswalk_*")
+    before = set(glob.glob(pattern))
+    build_resolved_crosswalk(_frame(), source_pk="customer_id", source_name="crm")
+    after = set(glob.glob(pattern))
+    assert after <= before          # no new gm_crosswalk_* files remain

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2359,6 +2359,37 @@
           ]
         },
         {
+          "command": "certify-keys",
+          "options": [
+            {
+              "name": "model",
+              "type": "text",
+              "required": true,
+              "help": "Semantic-model file (dbt/MetricFlow, Cube, or OSI YAML)"
+            },
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv"
+            },
+            {
+              "name": "--resolve",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Also measure entity fragmentation / undercount via ER (MetricFlow dialect only)."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any declared key is not unique at grain (CI gate)."
+            }
+          ]
+        },
+        {
           "command": "compare-clusters",
           "options": [
             {
@@ -4678,6 +4709,10 @@
         {
           "name": "certify_recall",
           "description": "Estimate match RECALL without ground truth (unsupervised). Treats each auto-configured matchkey/pass as a decorrelated system and uses capture-recapture over their overlaps to estimate how many true matches were missed. Returns a point estimate (a safe lower bound additionally needs a small labelled audit; see `goldenmatch evaluate --certify --audit-out`). Needs >=3 decorrelated systems."
+        },
+        {
+          "name": "certify_semantic_model",
+          "description": "Semantic-layer front door: certify every declared entity key in a dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. The dialect is auto-detected. Returns, per declared key, whether it is unique at grain and its measure fan-out -- the keys a metric silently joins on. Advisory; it never mutates a metric."
         },
         {
           "name": "compare_clusters",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -137,6 +137,7 @@ mcp_tools:
   - upload_dataset
   - write_csv
   python_only:
+  - certify_semantic_model
   - documents_ingest
   - documents_suggest_schema
   - explain_routing
@@ -180,6 +181,7 @@ cli_commands:
   - tui
   - unmerge
   python_only:
+  - certify-keys
   - import-dbt
   - ingest-docs
   - llm


### PR DESCRIPTION
## What and why

Grew out of a review of the recently-landed semantic-layer subsystem (MetricFlow / Cube / OSI wedge, ADRs 0049-0052). Two parts:

1. **Front door + surface conformance (the headline).** The semantic-layer capability was library-only, which left it out of conformance with the two-engines frame's shared-capabilities commitment (every other GoldenMatch capability is reachable across surfaces). This adds a zero-config `certify_semantic_model(source, frames)` core that auto-detects the dialect (dbt/MetricFlow, Cube, OSI/Ossie) and certifies every declared entity key, then exposes it as a `goldenmatch certify-keys` CLI command and a `certify_semantic_model` MCP tool.
2. **Review fixes.** Contained correctness/robustness refinements surfaced during the review.

## Changes

**Front door (core):**
- `semantic/certify.py` — `certify_semantic_model` + `SemanticCertification` / `KeyCertification`, dialect auto-detection, `untrustworthy()` / `all_trustworthy` views. Reuses the existing `certify_key_integrity` / `certify_cube_joins` / `certify_osi_relationships` bridges.

**Front door (surfaces):**
- `cli/certify_keys.py` + registration — `goldenmatch certify-keys MODEL -d name=path [--resolve] [--fail-untrustworthy]`; the gate flag makes it CI-usable.
- `mcp/server.py` — `certify_semantic_model` tool (Tool + dispatch + `_tool_` helper loading frames via `read_table_arrow`, JSON-serializable report).
- `parity/goldenmatch.yaml` — both declared `python_only` (no TS counterpart yet) so `api_parity` passes; MCP tool count 90→91.
- Regenerated `docs/agent-codemap.json` + `docs/agent-manifest.json` (+ bundled `goldensuite_mcp` copy).

**Review fixes:**
- `metricflow.parse_semantic_models` — promote a `unique` entity to the certified key when no `primary`/`natural` is declared (the promotion the comment described but never did); keep it a foreign edge when a primary is present (preserves the emit round-trip).
- `certify_cube_joins` — certify the actual one-side of a join (declaring cube for `one_to_many`, target otherwise) instead of always the target, which spuriously flagged many-side FKs as fanning out.
- `build_resolved_crosswalk` — remove the ephemeral temp SQLite store (+ `-wal`/`-shm`) in a `finally` block; no more leaked files.
- `certify_key_integrity` resolution tier — pass `allow_red_config=True` so a large table still MEASURES fragmentation instead of degrading to a "resolution unavailable" note (the #715 contract).
- Explanatory comment on the ephemeral-cleanup `except OSError` (review nit).

## Testing

`uv run --package goldenmatch pytest` over the semantic + CLI + MCP-count/host-helper slice → **93 passed** (front-door dialects, CLI report + gate, MCP count/derivation, all three review fixes). `ruff check` clean on every changed source + test file. Regenerated-artifact guards (`test_agent_codemap`, `test_agent_manifest_current`) pass. Python `api_parity` emitter confirms `certify-keys` / `certify_semantic_model` are surfaced and declared (full gate runs the TS emitter in CI).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files (no secrets)
- [ ] Package `CHANGELOG.md` updated — advisory additions to an unreleased subsystem; no user-facing release yet
- [x] No secrets, tokens, or `.env` files committed
- [x] Regenerated generated artifacts (codemap + agent-manifest) for the new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)