### PR TITLE
fix(bench-er): measure F1 through a RED refusal in the cost-aware OFF-vs-ON lane

### DIFF
--- a/.github/workflows/bench-er-headtohead.yml
+++ b/.github/workflows/bench-er-headtohead.yml
@@ -276,6 +276,7 @@ jobs:
                 scripts/bench_er_headtohead/run_goldenmatch.py \
                 --input "ca_out/${SHAPE}.parquet" --rows "$COST_AWARE_SCALE" \
                 --mode zeroconfig --shape "$SHAPE" --allow-pure-python \
+                --measure-refused \
                 --out "ca_out/${SHAPE}_flag${FLAG}.json" \
                 --pred-out "ca_out/${SHAPE}_flag${FLAG}_pred.parquet"
               uv run python scripts/bench_er_headtohead/evaluate.py \

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -88,6 +88,15 @@ def main() -> None:
                     help="probabilistic mode only: rewrite any FS field scorer NOT in "
                          "the native FS kernel set to jaro_winkler, so both FS lanes "
                          "engage the Rust kernel and match Splink's JaroWinkler model")
+    ap.add_argument("--measure-refused", action="store_true", default=False,
+                    help="zeroconfig mode only: when the controller REFUSES a RED "
+                         "config (>=100K identifier-poor input), MEASURE the committed "
+                         "config's F1 by force-running it with allow_red_config=True "
+                         "(the QIS-gate idiom) and flag refused=true, instead of "
+                         "recording status=refused with no prediction. Required by the "
+                         "cost-aware OFF-vs-ON gate, whose person shape refuses by "
+                         "design (the #2021 case). Default OFF preserves the head-to-"
+                         "head matrix's refuse-and-record semantics.")
     args = ap.parse_args()
 
     os.environ["GOLDENMATCH_NATIVE"] = "1" if args.require_native else "auto"
@@ -178,18 +187,41 @@ def main() -> None:
             try:
                 with bench_capture() as bench:
                     ded = dedupe_df(df)
+                result["refused"] = False
             except ControllerNotConfidentError as e:
-                dedupe_wall = time.perf_counter() - t0
-                result.update(status="refused", error=str(e),
-                              dedupe_wall_seconds=round(dedupe_wall, 2))
-                result["total_wall_seconds"] = round(time.perf_counter() - t_start, 2)
-                result["peak_rss_mb"] = _peak_rss_mb()
-                _atomic_write(args.out, result)
+                if not args.measure_refused:
+                    dedupe_wall = time.perf_counter() - t0
+                    result.update(status="refused", error=str(e),
+                                  dedupe_wall_seconds=round(dedupe_wall, 2))
+                    result["total_wall_seconds"] = round(time.perf_counter() - t_start, 2)
+                    result["peak_rss_mb"] = _peak_rss_mb()
+                    _atomic_write(args.out, result)
+                    print(
+                        f"[goldenmatch] rows={args.rows:,} mode={args.mode} "
+                        f"status=refused error={e}"
+                    )
+                    return
+                # --measure-refused: a RED refusal is EXPECTED on identifier-poor
+                # inputs (the #2021 person case the cost-aware flag targets), and the
+                # OFF-vs-ON gate needs the committed config's ACTUAL F1 to compare.
+                # Re-config + force-run the SAME committed config with
+                # allow_red_config=True (+ _skip_finalize=True to skip the full-df
+                # verification profile) -- the QIS-gate measure_rungs idiom -- and
+                # flag refused=true for context. Pass/fail stays on the measured F1,
+                # not the refuse verdict (RED is a confidence flag, not a wrong
+                # answer). The force-run's bench_capture is what the pred-out +
+                # metrics below use, so they reflect the config actually scored.
+                from goldenmatch import auto_configure_df
+                result["refused"] = True
+                cfg = auto_configure_df(
+                    df, confidence_required=False, allow_red_config=True,
+                    _skip_finalize=True)
+                with bench_capture() as bench:
+                    ded = dedupe_df(df, config=cfg)
                 print(
                     f"[goldenmatch] rows={args.rows:,} mode={args.mode} "
-                    f"status=refused error={e}"
+                    f"status=refused-measured (allow_red_config force-run) error={e}"
                 )
-                return
             dedupe_wall = time.perf_counter() - t0
         else:  # probabilistic
             from goldenmatch.core.autoconfig import auto_configure_probabilistic_df


### PR DESCRIPTION
## What and why

Follow-up **stacked on #2278** (base = its `claude/product-blocking-config-34eio3` branch, so this diff is just the fix — merging it lands the fix on #2278).

The `cost-aware-offvson` gate job that #2278 adds — the lane meant to prove the `GOLDENMATCH_BLOCKING_COST_AWARE` default flip — **crashed on its very first datapoint** ([run 30578449096](https://github.com/benseverndev-oss/goldenmatch/actions/runs/30578449096)). On the **person** shape at 200K, `run_goldenmatch.py --mode zeroconfig` **refuses**: the controller commits a RED config (blocking sub-profile, `stop_reason: BUDGET_TIME`) on identifier-poor person data — *exactly the #2021 case the flag targets* — so it wrote `status=refused` with **no prediction parquet**, and the downstream `evaluate.py` died with `IO Error: No files found that match "ca_out/person_flag0_pred.parquet"`.

A refusal here is **expected, not a bench failure**, and the whole point of the gate is to compare the committed config's **actual F1** OFF vs ON — which a bare refusal can't provide.

## Changes

- **`scripts/bench_er_headtohead/run_goldenmatch.py`** — new `--measure-refused` flag (default OFF). When set and the zeroconfig controller raises `ControllerNotConfidentError`, re-config + force-run the **same committed config** with `allow_red_config=True` (+ `_skip_finalize=True`) so a prediction IS produced and F1 is measurable, flagging `refused=true` for context. This mirrors the QIS-gate `measure_rungs` idiom already documented in `CLAUDE.md`. Pass/fail stays on the **measured F1**, not the refuse verdict (RED is a confidence flag, not a wrong answer).
- **`.github/workflows/bench-er-headtohead.yml`** — the `cost-aware-offvson` step passes `--measure-refused`.
- Default OFF keeps the main head-to-head matrix's `gm_zeroconfig` lane refuse-and-record semantics **untouched** — only the cost-aware step opts in.

## Testing

- `python -m py_compile scripts/bench_er_headtohead/run_goldenmatch.py` — clean; workflow YAML parses.
- The refuse path only triggers at ≥100K rows (a ~5-min controller run each), so it's validated by re-dispatching the `cost-aware-offvson` lane itself rather than locally. Re-run pending.

## Checklist

- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` gotcha already documents the force-measure idiom (QIS-gate `measure_rungs`)
- [ ] Bench lane re-run green (pending 64 GB dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_