### PR TITLE
feat(goldenanalysis): port key.integrity analyzer to TS — parity shared (roadmap 2/6)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -58,7 +58,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenpipe` | a2a_skills | 4 | 0 | 0 |
 | `goldenanalysis` | mcp_tools | 4 | 0 | 0 |
 | `goldenanalysis` | cli_commands | 4 | 0 | 0 |
-| `goldenanalysis` | analyzers | 4 | 1 | 0 |
+| `goldenanalysis` | analyzers | 5 | 0 | 0 |
 | `infermap` | mcp_tools | 4 | 0 | 0 |
 | `infermap` | cli_commands | 5 | 0 | 0 |
 | `infermap` | scorers | 7 | 0 | 0 |
@@ -75,6 +75,5 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenflow` **cli_commands** — Python-only: `init`, `interactive`, `schedule`, `watch`.
 - `goldenflow` **transforms** — TS-only: `category_llm_correct`.
 - `goldenpipe` **cli_commands** — Python-only: `interactive`.
-- `goldenanalysis` **analyzers** — Python-only: `key.integrity`.
 
 {/* suite-matrix:generated:end */}

--- a/packages/typescript/goldenanalysis/src/core/analyzers/keyIntegrity.ts
+++ b/packages/typescript/goldenanalysis/src/core/analyzers/keyIntegrity.ts
@@ -1,0 +1,104 @@
+/**
+ * `key.integrity` — metric-aware key-integrity metrics from a certificate.
+ *
+ * Reads a `key_certificate` (a GoldenMatch KeyIntegrityCertificate, serialized to
+ * a plain object over the wire) from `AnalyzerInput.artifacts` and projects it
+ * into the suite's Metric / AnalysisTable reporting shape — the read-side sibling
+ * of `match.rates` (which consumes a recall certificate).
+ *
+ * The certificate answers "is the entity key a semantic model declares actually
+ * trustworthy?": unique-at-grain, per-measure fan-out, and (opt-in) entity
+ * fragmentation / undercount. This analyzer only *reports* it — the computation
+ * and the advisory contract live in goldenmatch.
+ *
+ * Parity with `packages/python/goldenanalysis/goldenanalysis/analyzers/key_integrity.py`.
+ */
+
+import type {
+  AnalysisTable,
+  Analyzer,
+  AnalyzerInfo,
+  AnalyzerInput,
+  AnalyzerResult,
+  Metric,
+} from "../types.js";
+
+const PRODUCES = [
+  "key.uniqueness",
+  "key.duplicate_groups",
+  "key.max_fan_out",
+  "key.undercount_estimate",
+  "key.fragmented_entities",
+];
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export class KeyIntegrityAnalyzer implements Analyzer {
+  readonly info: AnalyzerInfo = {
+    name: "key.integrity",
+    consumes: ["key_certificate"],
+    produces: PRODUCES,
+  };
+
+  run(input: AnalyzerInput): AnalyzerResult {
+    const metrics: Metric[] = [];
+    const tables: AnalysisTable[] = [];
+
+    const raw = input.artifacts["key_certificate"];
+    if (raw === null || raw === undefined || typeof raw !== "object") {
+      return { metrics, tables };
+    }
+    const cert = raw as Record<string, unknown>;
+
+    // `estimate` is a property on the dataclass; recompute for the dict path
+    // (the serialized certificate carries no `estimate` field).
+    let uniqueness = asNumber(cert["estimate"]);
+    if (uniqueness === null) {
+      const nGroups = asNumber(cert["n_key_groups"]) ?? 0;
+      const dupes = asNumber(cert["duplicate_key_groups"]) ?? 0;
+      uniqueness = nGroups ? 1.0 - dupes / nGroups : 1.0;
+    }
+    metrics.push({ key: "key.uniqueness", value: uniqueness, unit: "ratio", direction: "higher_better" });
+
+    metrics.push({
+      key: "key.duplicate_groups",
+      value: Math.trunc(asNumber(cert["duplicate_key_groups"]) ?? 0),
+      unit: "groups",
+      direction: "lower_better",
+    });
+    metrics.push({
+      key: "key.max_fan_out",
+      value: asNumber(cert["max_fan_out"]) ?? 1.0,
+      unit: "ratio",
+      direction: "lower_better",
+    });
+
+    const undercount = asNumber(cert["undercount_estimate"]);
+    if (undercount !== null) {
+      metrics.push({ key: "key.undercount_estimate", value: undercount, unit: "ratio", direction: "lower_better" });
+    }
+    const fragmented = asNumber(cert["fragmented_entities"]);
+    if (fragmented !== null) {
+      metrics.push({
+        key: "key.fragmented_entities",
+        value: Math.trunc(fragmented),
+        unit: "entities",
+        direction: "lower_better",
+      });
+    }
+
+    const fanOut = cert["measure_fan_out"];
+    if (fanOut !== null && typeof fanOut === "object") {
+      const rows: (string | number)[][] = Object.entries(fanOut as Record<string, unknown>).map(
+        ([measure, ratio]) => [measure, Number(ratio)],
+      );
+      if (rows.length > 0) {
+        tables.push({ name: "measure_fan_out", columns: ["measure", "fan_out_ratio"], rows });
+      }
+    }
+
+    return { metrics, tables };
+  }
+}

--- a/packages/typescript/goldenanalysis/src/core/index.ts
+++ b/packages/typescript/goldenanalysis/src/core/index.ts
@@ -8,6 +8,7 @@ export { FrameSummaryAnalyzer } from "./analyzers/frameSummary.js";
 export { MatchRatesAnalyzer } from "./analyzers/matchRates.js";
 export { ClusterDistributionAnalyzer } from "./analyzers/clusterDist.js";
 export { QualityRollupAnalyzer } from "./analyzers/qualityRollup.js";
+export { KeyIntegrityAnalyzer } from "./analyzers/keyIntegrity.js";
 export * as aggregate from "./aggregate.js";
 export { enableAnalysisWasm, disableAnalysisWasm } from "./wasm/index.js";
 export type { AnalysisBackend, EnableAnalysisWasmOptions } from "./wasm/index.js";

--- a/packages/typescript/goldenanalysis/src/core/registry.ts
+++ b/packages/typescript/goldenanalysis/src/core/registry.ts
@@ -3,6 +3,7 @@
 
 import { ClusterDistributionAnalyzer } from "./analyzers/clusterDist.js";
 import { FrameSummaryAnalyzer } from "./analyzers/frameSummary.js";
+import { KeyIntegrityAnalyzer } from "./analyzers/keyIntegrity.js";
 import { MatchRatesAnalyzer } from "./analyzers/matchRates.js";
 import { QualityRollupAnalyzer } from "./analyzers/qualityRollup.js";
 import type { Analyzer } from "./types.js";
@@ -12,6 +13,7 @@ const FACTORIES: Record<string, () => Analyzer> = {
   "match.rates": () => new MatchRatesAnalyzer(),
   "cluster.distribution": () => new ClusterDistributionAnalyzer(),
   "quality.rollup": () => new QualityRollupAnalyzer(),
+  "key.integrity": () => new KeyIntegrityAnalyzer(),
 };
 
 export function availableAnalyzers(): string[] {

--- a/packages/typescript/goldenanalysis/tests/keyIntegrity.test.ts
+++ b/packages/typescript/goldenanalysis/tests/keyIntegrity.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `key.integrity` analyzer — parity with the Python sibling.
+ *
+ * Mirrors `packages/python/goldenanalysis/tests/test_key_integrity_analyzer.py`
+ * case-for-case: the same certificate dict (as it crosses the JSON wire) must
+ * project to the same metrics + measure_fan_out table. The certificate carries no
+ * `estimate` field over the wire, so uniqueness is recomputed as 1 - dupes/groups.
+ */
+
+import { describe, expect, it } from "vitest";
+import { KeyIntegrityAnalyzer } from "../src/core/analyzers/keyIntegrity.js";
+import { availableAnalyzers, loadAnalyzer } from "../src/core/registry.js";
+import type { AnalyzerInput } from "../src/core/types.js";
+
+function cert(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    key_columns: ["customer_id"],
+    grain: null,
+    n_rows: 3,
+    n_key_groups: 2,
+    is_unique_at_grain: false,
+    duplicate_key_groups: 1,
+    max_fan_out: 2.0,
+    measure_fan_out: { revenue: 1.6667 },
+    resolved_entities: null,
+    fragmented_entities: null,
+    undercount_estimate: null,
+    estimable: true,
+    note: "",
+    ...overrides,
+  };
+}
+
+function run(artifacts: Record<string, unknown>) {
+  const input: AnalyzerInput = { dataset: "t", artifacts };
+  const res = new KeyIntegrityAnalyzer().run(input);
+  const byKey: Record<string, number | string> = {};
+  for (const m of res.metrics) byKey[m.key] = m.value;
+  return { metrics: res.metrics, byKey, tables: res.tables };
+}
+
+describe("key.integrity analyzer (parity with python)", () => {
+  it("is registered", () => {
+    expect(availableAnalyzers()).toContain("key.integrity");
+    expect(loadAnalyzer("key.integrity").info.name).toBe("key.integrity");
+  });
+
+  it("projects structural metrics from a certificate dict", () => {
+    const { byKey, tables } = run({ key_certificate: cert() });
+    expect(byKey["key.uniqueness"]).toBe(0.5); // 1 - 1/2 (no `estimate` on the wire)
+    expect(byKey["key.duplicate_groups"]).toBe(1);
+    expect(byKey["key.max_fan_out"]).toBe(2.0);
+    // undercount/fragmented omitted when resolution wasn't run
+    expect("key.undercount_estimate" in byKey).toBe(false);
+    expect("key.fragmented_entities" in byKey).toBe(false);
+    const fan = tables.find((t) => t.name === "measure_fan_out");
+    expect(fan?.rows).toEqual([["revenue", 1.6667]]);
+  });
+
+  it("emits undercount + fragmented when resolution ran", () => {
+    const { byKey } = run({
+      key_certificate: cert({ resolved_entities: 1, fragmented_entities: 1, undercount_estimate: 1.0 }),
+    });
+    expect(byKey["key.undercount_estimate"]).toBe(1.0);
+    expect(byKey["key.fragmented_entities"]).toBe(1);
+  });
+
+  it("prefers an explicit `estimate` when the wire carries one", () => {
+    const { byKey } = run({ key_certificate: cert({ estimate: 0.9 }) });
+    expect(byKey["key.uniqueness"]).toBe(0.9);
+  });
+
+  it("returns empty when no certificate is supplied", () => {
+    const { metrics, tables } = run({});
+    expect(metrics).toEqual([]);
+    expect(tables).toEqual([]);
+  });
+});

--- a/parity/goldenanalysis.yaml
+++ b/parity/goldenanalysis.yaml
@@ -29,20 +29,24 @@ cli_commands:
 # from goldenanalysis.registry.available_analyzers (Python) <-> core/registry.ts
 # availableAnalyzers() (TS). This is the cross-language `analyzers` parity surface
 # -- a partition (no kernel floor; the analysis-core kernel-backing of individual
-# analyzers is guarded separately by native/wasm parity fixtures). All 4 analyzers
+# analyzers is guarded separately by native/wasm parity fixtures). All 5 analyzers
 # are shared 1:1 across Python + TS.
+#
+# key.integrity: metric-aware key-integrity certification (semantic-layer wedge,
+# ADR 0049). A pure-TS certificate-PROJECTION analyzer (like match.rates): it reads
+# a serialized goldenmatch KeyIntegrityCertificate from artifacts and projects it
+# into metrics + a measure_fan_out table. No YAML dialect parsing, no group-by
+# kernel, no ER tier on the TS side -- those stay Python-only, upstream in
+# goldenmatch, feeding the certificate over the wire. Ported in
+# core/analyzers/keyIntegrity.ts, so it is now shared.
 analyzers:
   shared:
   - cluster.distribution
   - frame.summary
+  - key.integrity
   - match.rates
   - quality.rollup
-  # key.integrity: metric-aware key-integrity certification (semantic-layer wedge,
-  # ADR 0049). Python-only in v1 — reports a goldenmatch KeyIntegrityCertificate
-  # whose resolution tier runs the goldenmatch ER pipeline; a TS/WASM port is a
-  # deliberate follow-on. Declared python_only so the analyzers parity gate passes.
-  python_only:
-  - key.integrity
+  python_only: []
   ts_only: []
 # Frame-kernel cross-language boundary (distinct_count / null_ratio /
 # duplicate_row_ratio). Same classification-map idiom as goldenmatch's


### PR DESCRIPTION
## What and why

Roadmap 2/6. Ports the last `python_only` analyzer in the semantic-layer subsystem to the edge-safe TypeScript core, flipping `key.integrity` `python_only` → `shared` in `parity/goldenanalysis.yaml`.

**Scope narrowed from the original "TS/WASM certify port" after scouting.** A full `certify_semantic_model` TS port is **not** edge-viable: the edge bundle has no YAML parser and forcing `yaml` into `core` breaks the lean-bundle discipline the package is built around, plus it would need the group-by kernel + the ER resolve tier. But `key.integrity` is a pure-TS **certificate-projection** analyzer (structurally identical to the shipped `match.rates`): it reads a serialized `KeyIntegrityCertificate` from `artifacts` and projects metrics + a `measure_fan_out` table. No YAML, no WASM, no ER — those stay Python-only upstream in goldenmatch and feed the certificate over the wire.

## Changes

- **`core/analyzers/keyIntegrity.ts`** — faithful port of `key_integrity.py`: dict duck-typing, the uniqueness `estimate` fallback (`1 - dupes/n_groups`, since the serialized cert carries no `estimate`), undercount/fragmented emitted only when the resolution tier ran, the `measure_fan_out` table. Edge-safe (`import type` only).
- Registered in `registry.ts` `FACTORIES` + exported from `core/index.ts`, so `availableAnalyzers()` returns it and the `emit_ts_surface` gate sees it in `dist/`.
- **`parity/goldenanalysis.yaml`** — `key.integrity` moved `python_only` → `shared` (the mutually-locked partition: TS impl + registration + manifest flip land together, else the gate reddens either way).
- **`tests/keyIntegrity.test.ts`** — mirrors `test_key_integrity_analyzer.py` case-for-case.
- Regenerated `suite-matrix.mdx` (goldenanalysis now 5 shared analyzers).

The dialect readers + `certify_semantic_model` intentionally stay Python-only (a TS certificate *producer* would be a separate node-only PR behind the `yaml` peer dep).

## Testing

TS: `key.integrity` 5/5 + full goldenanalysis suite **97 passed**; typecheck clean. Python: analyzer test **5/5** (unchanged). `check_api_parity.py goldenanalysis` passes (TS `dist/` has `key.integrity`, manifest lists it `shared` — both consistent). All doc gates green (`gen_suite_matrix --check`, `gen_api_surface --check`, `check_llms_counts`).

## Checklist

- [x] Tests added/updated and passing (TS + Python)
- [x] Typecheck clean; api_parity + doc gates green
- [x] parity manifest flipped + suite-matrix regenerated
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_