### PR TITLE
feat(goldencheck): wire the `learn` CLI command in TS (close a parity gap)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -47,7 +47,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
-| `goldencheck` | cli_commands | 14 | 8 | 0 |
+| `goldencheck` | cli_commands | 15 | 7 | 0 |
 | `goldencheck` | a2a_skills | 9 | 0 | 0 |
 | `goldenflow` | mcp_tools | 10 | 0 | 0 |
 | `goldenflow` | cli_commands | 12 | 4 | 0 |
@@ -71,7 +71,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
-- `goldencheck` **cli_commands** — Python-only: `denial-constraints`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
+- `goldencheck` **cli_commands** — Python-only: `denial-constraints`, `init`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
 - `goldenflow` **cli_commands** — Python-only: `init`, `interactive`, `schedule`, `watch`.
 - `goldenflow` **transforms** — TS-only: `category_llm_correct`.
 - `goldenpipe` **cli_commands** — Python-only: `interactive`.

--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -4,7 +4,7 @@
  * Port of goldencheck/cli/main.py using Commander.js.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Command } from "commander";
@@ -17,6 +17,8 @@ import { ciCheck } from "./core/reporters/ci.js";
 import { listAvailableDomains } from "./core/semantic/domains/index.js";
 import { recordScan, loadHistory } from "./core/engine/history.js";
 import { evaluateScan, type ExpectedFinding } from "./core/engine/evaluate.js";
+import { maybeSample } from "./core/engine/sampler.js";
+import { generateRules, serializeRules } from "./core/llm/rule-generator.js";
 
 export const program = new Command();
 
@@ -341,6 +343,38 @@ program
     if (ev.f1 < minF1) {
       console.error(`\nF1 ${ev.f1.toFixed(4)} is below minimum ${minF1.toFixed(4)}`);
       process.exit(1);
+    }
+  });
+
+// Generate validation rules via LLM analysis of the data. Mirrors the Python
+// `learn` command (goldencheck/cli/main.py): sample -> scan -> generateRules ->
+// serialize to a rules file. The engine (generateRules/serializeRules) is already
+// edge-safe (fetch-based, no SDK); this wires the CLI command over it, closing the
+// goldencheck `learn` python_only parity gap.
+program
+  .command("learn <file>")
+  .description("Generate validation rules using LLM analysis of your data")
+  .option("-o, --output <path>", "Output path for rules", "goldencheck_rules.json")
+  .option("--llm-provider <provider>", "LLM provider: anthropic or openai", "anthropic")
+  .action(async (file: string, opts: Record<string, unknown>) => {
+    const data = readFile(file);
+    const sample = maybeSample(data, 100_000);
+    const { findings } = scanData(data);
+
+    console.log(`Analyzing ${data.rowCount.toLocaleString()} rows, ${data.columns.length} columns...`);
+    const rules = await generateRules(sample, findings, String(opts["llmProvider"] ?? "anthropic"));
+
+    if (rules.length === 0) {
+      console.error("No rules generated.");
+      process.exitCode = 1;
+      return;
+    }
+
+    const outPath = String(opts["output"] ?? "goldencheck_rules.json");
+    writeFileSync(outPath, serializeRules(rules));
+    console.log(`Generated ${rules.length} rules -> ${outPath}`);
+    for (const r of rules) {
+      console.log(`  [${r.ruleType}] ${r.column}: ${r.description}`);
     }
   });
 

--- a/packages/typescript/goldencheck/tests/unit/cli/commands.test.ts
+++ b/packages/typescript/goldencheck/tests/unit/cli/commands.test.ts
@@ -34,4 +34,19 @@ describe("goldencheck CLI command registration", () => {
     expect(history!.options.some((o) => o.long === "--last")).toBe(true);
     expect(history!.options.some((o) => o.long === "--json")).toBe(true);
   });
+
+  it("registers the learn command (TS parity with Python's LLM rule generator)", () => {
+    expect(names).toContain("learn");
+    const learn = program.commands.find((c) => c.name() === "learn");
+    expect(learn).toBeDefined();
+    // -o/--output with the same default filename as the Python command.
+    const output = learn!.options.find((o) => o.long === "--output");
+    expect(output).toBeDefined();
+    expect(output!.short).toBe("-o");
+    expect(output!.defaultValue).toBe("goldencheck_rules.json");
+    // --llm-provider defaults to anthropic (mirrors goldencheck/cli/main.py).
+    const provider = learn!.options.find((o) => o.long === "--llm-provider");
+    expect(provider).toBeDefined();
+    expect(provider!.defaultValue).toBe("anthropic");
+  });
 });

--- a/parity/goldencheck.yaml
+++ b/parity/goldencheck.yaml
@@ -8,7 +8,10 @@
 #   DOMAIN_REGISTRY, src/core/index.ts) with no install path, so there is no TS operation
 #   to reconcile). CLI: Python still ships more commands, but they are servers/daemons/
 #   interactive (agent-serve/serve/schedule/scan-db/init/review) or unported engines
-#   (denial-constraints/refs/learn). `history` + `evaluate` are now SHARED — the TS port
+#   (denial-constraints/refs). `learn` is now SHARED — the TS core already carried the
+#   engine (core/llm/rule-generator.ts: generateRules/serializeRules, edge-safe over
+#   fetch()), so the CLI command was wired over it (cli.ts), same as history/evaluate.
+#   `history` + `evaluate` are now SHARED — the TS port
 #   already carries the engines (core/engine/history.ts + evaluateScan), so the CLI
 #   commands were wired over them. `health-score` / `list-domains` / `profile` are now
 #   SHARED too — the Python CLI wraps the existing scan/profile/domain engines (the same
@@ -50,6 +53,7 @@ cli_commands:
   - fix
   - health-score
   - history
+  - learn
   - list-domains
   - mcp-serve
   - profile
@@ -59,7 +63,6 @@ cli_commands:
   python_only:
   - denial-constraints
   - init
-  - learn
   - refs
   - review
   - scan-db


### PR DESCRIPTION
## What and why

First of the goldencheck "unported engine" parity gaps. `learn` (LLM-driven validation-rule generation) was declared `python_only` — but the **engine was already ported**: `core/llm/rule-generator.ts` ships `generateRules`/`serializeRules` (edge-safe over `fetch()`, no SDK), already exported from `core/index.ts`. Only the **CLI command** was missing. This wires it, exactly the pattern the manifest cites for `history`/`evaluate` (engine in `core/`, add CLI glue), closing the gap with the smallest possible diff.

## Changes

- **`cli.ts`** — `learn <file>` command: `readFile` → `maybeSample(100k)` → `scanData` → `await generateRules(...)` → `serializeRules` to `--output` (default `goldencheck_rules.json`); `--llm-provider` defaults to `anthropic`. Mirrors `goldencheck/cli/main.py::learn` (args, defaults, and output summary).
- **`parity/goldencheck.yaml`** — `learn` `python_only` → `shared`; header note updated (`denial-constraints`/`refs` remain the unported engines).
- **`docs-site/suite-matrix.mdx`** — regenerated (goldencheck `cli_commands` `14|8|0` → `15|7|0`; `learn` dropped from the gap list).
- **`tests/unit/cli/commands.test.ts`** — asserts `learn` is registered with `-o/--output` (default `goldencheck_rules.json`) and `--llm-provider` (default `anthropic`).

## Testing

- `uv run python scripts/check_api_parity.py goldencheck` → **OK** (manifest exactly partitions both surfaces; the emitter reads `learn` from the built `program.commands`).
- `pnpm exec vitest run` (goldencheck) → **267 passed**; new command test 5/5.
- `pnpm typecheck` / `tsc --noEmit` → clean; `gen_suite_matrix.py --write` regenerated.

## Follow-ups (the other two goldencheck engines)

Scoped but not in this PR: **`refs`** (referential-integrity, ~175 LOC pure-Polars → a new `core/engine/referential.ts`, effort M) and **`denial-constraints`** (~1277 LOC + a `u64`→`BigInt` bitmask rework, effort L). Both are genuine clean ports (no solver/LLM/refdata blocker), just larger.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (parity manifest + suite-matrix regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_