### PR TITLE
feat(goldencheck): port the `refs` referential-integrity engine + CLI to TS

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -47,7 +47,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
-| `goldencheck` | cli_commands | 15 | 7 | 0 |
+| `goldencheck` | cli_commands | 16 | 6 | 0 |
 | `goldencheck` | a2a_skills | 9 | 0 | 0 |
 | `goldenflow` | mcp_tools | 10 | 0 | 0 |
 | `goldenflow` | cli_commands | 12 | 4 | 0 |
@@ -71,7 +71,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
-- `goldencheck` **cli_commands** — Python-only: `denial-constraints`, `init`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
+- `goldencheck` **cli_commands** — Python-only: `denial-constraints`, `init`, `review`, `scan-db`, `schedule`, `serve`.
 - `goldenflow` **cli_commands** — Python-only: `init`, `interactive`, `schedule`, `watch`.
 - `goldenflow` **transforms** — TS-only: `category_llm_correct`.
 - `goldenpipe` **cli_commands** — Python-only: `interactive`.

--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -5,13 +5,13 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Command } from "commander";
 import { readFile } from "./node/reader.js";
 import { scanData } from "./core/engine/scanner.js";
 import { applyConfidenceDowngrade } from "./core/engine/confidence.js";
-import { Severity, healthScore, type Finding } from "./core/types.js";
+import { Severity, severityLabel, healthScore, type Finding } from "./core/types.js";
 import { reportJson } from "./core/reporters/json.js";
 import { ciCheck } from "./core/reporters/ci.js";
 import { listAvailableDomains } from "./core/semantic/domains/index.js";
@@ -19,6 +19,7 @@ import { recordScan, loadHistory } from "./core/engine/history.js";
 import { evaluateScan, type ExpectedFinding } from "./core/engine/evaluate.js";
 import { maybeSample } from "./core/engine/sampler.js";
 import { generateRules, serializeRules } from "./core/llm/rule-generator.js";
+import { referentialIntegrity } from "./core/engine/referential.js";
 
 export const program = new Command();
 
@@ -166,6 +167,45 @@ program
     const newResult = scanData(newData);
     const report = diffData(oldData, newData, oldResult.findings, newResult.findings);
     console.log(formatDiffReport(report));
+  });
+
+// --- refs (cross-file referential integrity / foreign-key validation) ---
+// Mirrors the Python `refs` command: read child + parent, check that the child's
+// FK values all exist in the parent's key, report orphans / rate / cardinality.
+// The engine (core/engine/referential.ts) is pure/edge-safe; file I/O lives here.
+program
+  .command("refs <child> <parent>")
+  .description("Check referential integrity (foreign keys) between two files")
+  .option(
+    "--on <mapping>",
+    "FK mapping 'child_col=parent_col' (repeatable); omit to auto-detect",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option("--json", "Output results as JSON")
+  .option("--fail-on <severity>", "CI exit threshold: error/warning/info", "error")
+  .action((child: string, parent: string, opts: Record<string, unknown>) => {
+    const childData = readFile(child);
+    const parentData = readFile(parent);
+    const on = opts["on"] as string[];
+    const findings = referentialIntegrity(childData, parentData, on.length > 0 ? on : undefined, {
+      childName: basename(child),
+      parentName: basename(parent),
+    });
+
+    if (opts["json"]) {
+      console.log(JSON.stringify(findings, null, 2));
+    } else {
+      const ordered = [...findings].sort((a, b) => b.severity - a.severity);
+      for (const f of ordered) {
+        console.log(`${severityLabel(f.severity)} ${f.column}: ${f.message}`);
+        if (f.sampleValues.length > 0) {
+          console.log(`  e.g. ${f.sampleValues.join(", ")}`);
+        }
+      }
+    }
+
+    process.exitCode = ciCheck(findings, String(opts["failOn"] ?? "error"));
   });
 
 // --- watch ---

--- a/packages/typescript/goldencheck/src/core/engine/referential.ts
+++ b/packages/typescript/goldencheck/src/core/engine/referential.ts
@@ -1,0 +1,184 @@
+/**
+ * Referential-integrity checks across TWO tables (foreign-key validation).
+ *
+ * GoldenCheck's scan path is single-file; this fills the common cross-table gap:
+ * do a child table's foreign-key values all exist in the parent's key? E.g.
+ * `orders.customer_id` must be a subset of `customers.id`. Reports orphan rows
+ * (FK values with no parent match), the orphan rate, and the join cardinality.
+ *
+ * Edge-safe / pure: operates on already-read `TabularData` (set membership over the
+ * parent key set + a few counts — no native kernel, no `node:fs`). File reading is
+ * the CLI action's job, mirroring how `diff` reads both files in the node layer.
+ *
+ * Parity with `packages/python/goldencheck/goldencheck/engine/referential.py`.
+ */
+
+import type { TabularData, ColumnValue } from "../data.js";
+import { type Finding, makeFinding, Severity } from "../types.js";
+
+// Orphan rate above this => ERROR; any orphans below it => WARNING.
+const ERROR_ORPHAN_RATE = 0.01;
+const MAX_SAMPLE = 5;
+
+/** A column usable as a parent key: present, non-null, and fully unique. */
+function isKey(data: TabularData, col: string): boolean {
+  if (!data.columns.includes(col)) return false;
+  const values = data.column(col);
+  const n = values.length;
+  if (n === 0) return false;
+  const nulls = values.reduce<number>((acc, v) => acc + (v === null ? 1 : 0), 0);
+  return nulls === 0 && data.nUnique(col) === n;
+}
+
+/** Same-named columns that are a unique+non-null key on the parent side. */
+export function autoDetectMappings(child: TabularData, parent: TabularData): Array<[string, string]> {
+  const mappings: Array<[string, string]> = [];
+  for (const col of child.columns) {
+    if (parent.columns.includes(col) && isKey(parent, col)) {
+      mappings.push([col, col]);
+    }
+  }
+  return mappings;
+}
+
+/** Parse `--on` specs: 'child=parent' or 'col' (same name both sides). */
+export function parseOn(spec: readonly string[]): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  for (const s of spec) {
+    const eq = s.indexOf("=");
+    if (eq >= 0) {
+      out.push([s.slice(0, eq).trim(), s.slice(eq + 1).trim()]);
+    } else {
+      out.push([s.trim(), s.trim()]);
+    }
+  }
+  return out;
+}
+
+export interface ReferentialOptions {
+  readonly childName?: string;
+  readonly parentName?: string;
+}
+
+/** For each (child_fk, parent_key) mapping, find orphan FK values. */
+export function checkReferentialIntegrity(
+  child: TabularData,
+  parent: TabularData,
+  mappings: ReadonlyArray<readonly [string, string]>,
+  opts: ReferentialOptions = {},
+): Finding[] {
+  const childName = opts.childName ?? "child";
+  const parentName = opts.parentName ?? "parent";
+  const findings: Finding[] = [];
+
+  for (const [childCol, parentCol] of mappings) {
+    if (!child.columns.includes(childCol) || !parent.columns.includes(parentCol)) {
+      findings.push(makeFinding({
+        severity: Severity.WARNING,
+        column: childCol,
+        check: "referential_integrity",
+        message: `Cannot check '${childName}.${childCol}' -> '${parentName}.${parentCol}': column not found.`,
+        confidence: 0.9,
+        metadata: { technique: "referential_integrity" },
+      }));
+      continue;
+    }
+
+    const childFk = child.column(childCol);
+    const nonNull = childFk.filter((v): v is Exclude<ColumnValue, null> => v !== null);
+    const considered = nonNull.length;
+    if (considered === 0) continue;
+
+    const parentKeys = new Set<ColumnValue>(parent.column(parentCol).filter((v) => v !== null));
+    const orphans = nonNull.filter((v) => !parentKeys.has(v));
+    const orphanRows = orphans.length;
+
+    // Join cardinality (informational): is each side unique on the key?
+    const childUnique = child.nUnique(childCol) === childFk.length;
+    const parentUnique = isKey(parent, parentCol);
+    const cardinality = `${childUnique ? "1" : "N"}:${parentUnique ? "1" : "N"}`;
+
+    if (orphanRows === 0) {
+      findings.push(makeFinding({
+        severity: Severity.INFO,
+        column: childCol,
+        check: "referential_integrity",
+        message: `'${childName}.${childCol}' fully references '${parentName}.${parentCol}' (${considered} rows, ${cardinality}).`,
+        affectedRows: 0,
+        confidence: 0.9,
+        metadata: {
+          technique: "referential_integrity",
+          child_column: childCol,
+          parent_column: parentCol,
+          cardinality,
+          orphan_rows: 0,
+        },
+      }));
+      continue;
+    }
+
+    const distinctOrphanValues = [...new Set(orphans)];
+    const distinctOrphans = distinctOrphanValues.length;
+    const rate = orphanRows / considered;
+    const severity = rate > ERROR_ORPHAN_RATE ? Severity.ERROR : Severity.WARNING;
+    const samples = distinctOrphanValues.slice(0, MAX_SAMPLE).map((v) => String(v));
+
+    findings.push(makeFinding({
+      severity,
+      column: childCol,
+      check: "referential_integrity",
+      message:
+        `${orphanRows} row(s) (${distinctOrphans} distinct value(s), ${formatPct(rate)}) in ` +
+        `'${childName}.${childCol}' have no match in '${parentName}.${parentCol}' — orphaned foreign keys.`,
+      affectedRows: orphanRows,
+      sampleValues: samples,
+      suggestion:
+        `Backfill the missing '${parentName}.${parentCol}' rows, or treat these ` +
+        `orphaned '${childCol}' values as invalid.`,
+      confidence: 0.85,
+      metadata: {
+        technique: "referential_integrity",
+        child_column: childCol,
+        parent_column: parentCol,
+        cardinality,
+        orphan_rows: orphanRows,
+        distinct_orphans: distinctOrphans,
+        orphan_rate: Number(rate.toFixed(6)),
+      },
+    }));
+  }
+
+  return findings;
+}
+
+/**
+ * Orchestrator: check referential integrity between two already-read tables.
+ * When `on` is omitted, auto-detect FK mappings from same-named parent-key columns;
+ * emit a guidance INFO finding when nothing can be inferred.
+ */
+export function referentialIntegrity(
+  child: TabularData,
+  parent: TabularData,
+  on: readonly string[] | undefined,
+  opts: ReferentialOptions = {},
+): Finding[] {
+  const mappings = on && on.length > 0 ? parseOn(on) : autoDetectMappings(child, parent);
+  if (mappings.length === 0) {
+    return [makeFinding({
+      severity: Severity.INFO,
+      column: "__dataset__",
+      check: "referential_integrity",
+      message:
+        "No foreign-key relationship detected (no shared unique-key column). " +
+        "Pass --on child_col=parent_col to check explicitly.",
+      confidence: 0.5,
+      metadata: { technique: "referential_integrity" },
+    })];
+  }
+  return checkReferentialIntegrity(child, parent, mappings, opts);
+}
+
+/** Mirror Python's `{rate:.1%}` formatting (one decimal, e.g. 5.0%). */
+function formatPct(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
+}

--- a/packages/typescript/goldencheck/src/core/index.ts
+++ b/packages/typescript/goldencheck/src/core/index.ts
@@ -56,6 +56,7 @@ export { maybeSample } from "./engine/sampler.js";
 export { applyCorroborationBoost, applyConfidenceDowngrade } from "./engine/confidence.js";
 export { applyFixes, type FixEntry, type FixReport } from "./engine/fixer.js";
 export { diffData, formatDiffReport, type DiffReport, type SchemaChange, type FindingChange, type StatChange } from "./engine/differ.js";
+export { referentialIntegrity, checkReferentialIntegrity, autoDetectMappings, parseOn, type ReferentialOptions } from "./engine/referential.js";
 export { autoTriage, type TriageResult } from "./engine/triage.js";
 export {
   evaluateScan,

--- a/packages/typescript/goldencheck/tests/unit/cli/commands.test.ts
+++ b/packages/typescript/goldencheck/tests/unit/cli/commands.test.ts
@@ -35,6 +35,19 @@ describe("goldencheck CLI command registration", () => {
     expect(history!.options.some((o) => o.long === "--json")).toBe(true);
   });
 
+  it("registers the refs command (cross-file referential integrity)", () => {
+    expect(names).toContain("refs");
+    const refs = program.commands.find((c) => c.name() === "refs");
+    expect(refs).toBeDefined();
+    // Two positional args: <child> <parent>.
+    expect(refs!.registeredArguments.map((a) => a.name())).toEqual(["child", "parent"]);
+    // Repeatable --on mapping, --json, and --fail-on (default error).
+    expect(refs!.options.some((o) => o.long === "--on")).toBe(true);
+    const failOn = refs!.options.find((o) => o.long === "--fail-on");
+    expect(failOn).toBeDefined();
+    expect(failOn!.defaultValue).toBe("error");
+  });
+
   it("registers the learn command (TS parity with Python's LLM rule generator)", () => {
     expect(names).toContain("learn");
     const learn = program.commands.find((c) => c.name() === "learn");

--- a/packages/typescript/goldencheck/tests/unit/referential.test.ts
+++ b/packages/typescript/goldencheck/tests/unit/referential.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { TabularData } from "../../src/core/data.js";
+import {
+  autoDetectMappings,
+  checkReferentialIntegrity,
+  parseOn,
+  referentialIntegrity,
+} from "../../src/core/engine/referential.js";
+import { Severity } from "../../src/core/types.js";
+
+// Parity with packages/python/goldencheck/tests (engine/referential.py behavior).
+
+function td(rows: Array<Record<string, unknown>>): TabularData {
+  return new TabularData(rows);
+}
+
+describe("referential integrity", () => {
+  it("parseOn handles 'child=parent' and bare 'col'", () => {
+    expect(parseOn(["customer_id=id", "sku"])).toEqual([
+      ["customer_id", "id"],
+      ["sku", "sku"],
+    ]);
+  });
+
+  it("auto-detects same-named unique+non-null parent keys", () => {
+    const child = td([{ id: 1, ref: "a" }, { id: 2, ref: "b" }]);
+    const parent = td([{ ref: "a" }, { ref: "b" }, { ref: "c" }]); // unique, non-null key
+    // `id` on parent is absent; only `ref` is a shared parent key.
+    expect(autoDetectMappings(child, parent)).toEqual([["ref", "ref"]]);
+  });
+
+  it("does NOT auto-detect a non-unique parent column as a key", () => {
+    const child = td([{ ref: "a" }]);
+    const parent = td([{ ref: "a" }, { ref: "a" }]); // duplicated -> not a key
+    expect(autoDetectMappings(child, parent)).toEqual([]);
+  });
+
+  it("clean references -> INFO with cardinality", () => {
+    const child = td([{ cust: 1 }, { cust: 2 }, { cust: 1 }]); // N side
+    const parent = td([{ id: 1 }, { id: 2 }]); // unique key -> 1
+    const f = checkReferentialIntegrity(child, parent, [["cust", "id"]]);
+    expect(f).toHaveLength(1);
+    expect(f[0]!.severity).toBe(Severity.INFO);
+    expect(f[0]!.metadata["cardinality"]).toBe("N:1");
+    expect(f[0]!.metadata["orphan_rows"]).toBe(0);
+  });
+
+  it("orphans above 1% -> ERROR with rate, distinct count, and samples", () => {
+    // 4 rows, 2 orphaned (values 9, 8) -> 50% > 1% -> ERROR.
+    const child = td([{ cust: 1 }, { cust: 2 }, { cust: 9 }, { cust: 8 }]);
+    const parent = td([{ id: 1 }, { id: 2 }]);
+    const f = checkReferentialIntegrity(child, parent, [["cust", "id"]]);
+    expect(f).toHaveLength(1);
+    expect(f[0]!.severity).toBe(Severity.ERROR);
+    expect(f[0]!.affectedRows).toBe(2);
+    expect(f[0]!.metadata["distinct_orphans"]).toBe(2);
+    expect(f[0]!.metadata["orphan_rate"]).toBe(0.5);
+    expect(f[0]!.sampleValues).toEqual(["9", "8"]);
+  });
+
+  it("a single orphan under 1% -> WARNING", () => {
+    // 200 rows, 1 orphan -> 0.5% <= 1% -> WARNING.
+    const childRows = Array.from({ length: 199 }, () => ({ cust: 1 }));
+    childRows.push({ cust: 999 });
+    const parent = td([{ id: 1 }]);
+    const f = checkReferentialIntegrity(td(childRows), parent, [["cust", "id"]]);
+    expect(f[0]!.severity).toBe(Severity.WARNING);
+  });
+
+  it("nulls in the FK are ignored (not counted as orphans)", () => {
+    const child = td([{ cust: 1 }, { cust: null }, { cust: 2 }]);
+    const parent = td([{ id: 1 }, { id: 2 }]);
+    const f = checkReferentialIntegrity(child, parent, [["cust", "id"]]);
+    expect(f[0]!.severity).toBe(Severity.INFO); // only non-null FKs considered
+  });
+
+  it("orchestrator emits a guidance INFO when no mapping can be inferred", () => {
+    const child = td([{ a: 1 }]);
+    const parent = td([{ b: 1 }]);
+    const f = referentialIntegrity(child, parent, undefined);
+    expect(f).toHaveLength(1);
+    expect(f[0]!.severity).toBe(Severity.INFO);
+    expect(f[0]!.column).toBe("__dataset__");
+  });
+
+  it("missing column -> WARNING (cannot check)", () => {
+    const child = td([{ cust: 1 }]);
+    const parent = td([{ id: 1 }]);
+    const f = checkReferentialIntegrity(child, parent, [["nope", "id"]]);
+    expect(f[0]!.severity).toBe(Severity.WARNING);
+    expect(f[0]!.message).toContain("column not found");
+  });
+});

--- a/parity/goldencheck.yaml
+++ b/parity/goldencheck.yaml
@@ -7,10 +7,13 @@
 #   core exposes a read-only domain registry (listAvailableDomains / getDomainTypes /
 #   DOMAIN_REGISTRY, src/core/index.ts) with no install path, so there is no TS operation
 #   to reconcile). CLI: Python still ships more commands, but they are servers/daemons/
-#   interactive (agent-serve/serve/schedule/scan-db/init/review) or unported engines
-#   (denial-constraints/refs). `learn` is now SHARED — the TS core already carried the
-#   engine (core/llm/rule-generator.ts: generateRules/serializeRules, edge-safe over
-#   fetch()), so the CLI command was wired over it (cli.ts), same as history/evaluate.
+#   interactive (agent-serve/serve/schedule/scan-db/init/review) or the unported
+#   engine (denial-constraints). `refs` is now SHARED — the referential-integrity
+#   engine was ported to core/engine/referential.ts (pure/edge-safe set-membership
+#   over the parent key set, file I/O in the CLI action like `diff`). `learn` is now
+#   SHARED — the TS core already carried the engine (core/llm/rule-generator.ts:
+#   generateRules/serializeRules, edge-safe over fetch()), so the CLI command was
+#   wired over it (cli.ts), same as history/evaluate.
 #   `history` + `evaluate` are now SHARED — the TS port
 #   already carries the engines (core/engine/history.ts + evaluateScan), so the CLI
 #   commands were wired over them. `health-score` / `list-domains` / `profile` are now
@@ -57,13 +60,13 @@ cli_commands:
   - list-domains
   - mcp-serve
   - profile
+  - refs
   - scan
   - validate
   - watch
   python_only:
   - denial-constraints
   - init
-  - refs
   - review
   - scan-db
   - schedule


### PR DESCRIPTION
## What and why

Second goldencheck "unported engine" gap closed. `refs` (cross-file foreign-key / referential-integrity validation) was `python_only`. Unlike `learn`, the engine didn't exist in TS yet — but it's **pure set-membership** over the parent key set (no native kernel, no polars-specific operator), so it ports cleanly into an edge-safe core module, with file I/O in the CLI action (the `diff` pattern).

## Changes

- **`core/engine/referential.ts`** (NEW) — faithful port of `engine/referential.py`:
  - `autoDetectMappings` (same-named unique+non-null parent keys), `parseOn` (`child=parent` / bare `col`).
  - `checkReferentialIntegrity` — orphan rows/rate/distinct + join cardinality; **ERROR** when orphan rate > 1%, else **WARNING**; **INFO** when clean; **WARNING** on a missing column.
  - `referentialIntegrity` orchestrator — auto-detect + a guidance INFO when no mapping can be inferred. Metadata keys mirror the Python snake_case wire shape.
- **`cli.ts`** — `refs <child> <parent>` with repeatable `--on child=parent`, `--json`, `--fail-on` (default `error`), exiting via `ciCheck`. Mirrors `cli/main.py::refs`.
- **`core/index.ts`** — exports the engine.
- **`parity/goldencheck.yaml`** — `refs` `python_only` → `shared`; header updated (only `denial-constraints` remains an unported engine).
- **`docs-site/suite-matrix.mdx`** — regenerated (goldencheck `cli_commands` `15|7|0` → `16|6|0`).
- **Tests** — `referential.test.ts` (9 engine cases: parse, auto-detect incl. non-unique rejection, clean/ERROR/WARNING thresholds, null handling, missing column, no-mapping) + a `refs` CLI registration test.

## Testing

- `uv run python scripts/check_api_parity.py goldencheck` → **OK**.
- `pnpm exec vitest run` (goldencheck) → **277 passed**; new engine + CLI tests included.
- `pnpm typecheck` / `tsc --noEmit` → clean; `gen_suite_matrix.py --write` regenerated.

## Remaining

Only **`denial-constraints`** left of the goldencheck engine gaps (L effort: ~1277 LOC + a `u64`→`BigInt` bitmask rework) — a separate follow-up.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (parity manifest + suite-matrix regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_