### PR TITLE
feat(semantic): grain-aware key-integrity - opt-in unique-at-grain (Python + dbt, roadmap 4/6)

### DIFF
--- a/packages/dbt/goldensuite/CHANGELOG.md
+++ b/packages/dbt/goldensuite/CHANGELOG.md
@@ -18,6 +18,13 @@ Suite monorepo and is consumed from there (not published to PyPI).
   (macros) and a `pip install "git+...#subdirectory=..."` for the Python helper.
 
 ### Added
+- **`grain_strict` on the `goldenmatch_key_integrity` test.** Opt-in argument
+  (default `false` = byte-identical to the prior key-only test). When `true` and a
+  `grain` is supplied, uniqueness / fan-out is evaluated on `key + grain` — true
+  "unique at grain", so a fact that legitimately repeats a key across grain buckets
+  (e.g. daily rows per customer) is certified instead of being reported as fan-out.
+  Mirrors the Python `certify_key_integrity(grain_strict=True)` in lockstep so the
+  SQL test and the capability stay semantically identical.
 - **`run_goldenmatch_crosswalk` Python helper (semantic-layer wedge B).** Resolves
   identity once and materializes the durable `{source, source_pk, resolved_entity_id}`
   crosswalk table in DuckDB — the conformed join key a semantic layer (dbt/MetricFlow,

--- a/packages/dbt/goldensuite/macros/test_key_integrity.sql
+++ b/packages/dbt/goldensuite/macros/test_key_integrity.sql
@@ -16,8 +16,14 @@
     model         relation under test.
     key           entity key column, or a list of columns (composite key).
     measures      numeric columns to check for fan-out (default: none).
-    grain         ADVISORY in v1 -- recorded, not folded into the uniqueness
-                  group, to stay identical to the Python capability's semantics.
+    grain         ADVISORY by default -- recorded, not folded into the uniqueness
+                  group, to stay identical to the Python capability's default
+                  semantics. When `grain_strict=true`, grain IS folded into the
+                  GROUP BY (see below).
+    grain_strict  opt-in. When true AND `grain` is supplied, evaluate uniqueness /
+                  fan-out on `key + grain` (true "unique at grain") -- mirrors the
+                  Python `certify_key_integrity(grain_strict=True)`. Default false
+                  keeps grain advisory (byte-identical to the key-only test).
     max_fan_out   fail if any key group has more rows than this, or any measure
                   SUM inflates beyond it (default 1.0 = a true, non-fanning key).
     min_uniqueness fail if the fraction of unique-at-grain key groups drops below
@@ -25,12 +31,19 @@
 #}
 
 {% macro goldenmatch_key_integrity_sql(model, key, measures=[], grain=none,
-        max_fan_out=1.0, min_uniqueness=1.0) %}
+        max_fan_out=1.0, min_uniqueness=1.0, grain_strict=false) %}
     {%- set keys = [key] if key is string else key -%}
     {%- if keys | length == 0 -%}
         {{ exceptions.raise_compiler_error("goldenmatch_key_integrity: `key` must name at least one column") }}
     {%- endif -%}
-    {%- set keyexpr = keys | join(", ") -%}
+    {#- Grouping columns: the key alone by default; key + grain when grain_strict,
+        so a fact legitimately repeating a key across grain buckets is certified
+        unique *at grain* rather than reported as fan-out. Mirrors the Python
+        capability's `grain_strict` path. Grain cols already in the key aren't
+        repeated. -#}
+    {%- set grain_cols = ([grain] if grain is string else grain) if grain is not none else [] -%}
+    {%- set group_cols = keys + (grain_cols | reject("in", keys) | list) if grain_strict else keys -%}
+    {%- set keyexpr = group_cols | join(", ") -%}
 
     {%- set rep_cols = [] -%}      {# MAX(measure) per group = de-duplicated representative #}
     {%- set dedup_sums = [] -%}    {# SUM of per-group representatives #}
@@ -79,6 +92,6 @@ SELECT * FROM scored WHERE " ~ (conds | join(" OR "))) }}
 {% endmacro %}
 
 {% test goldenmatch_key_integrity(model, key, measures=[], grain=none,
-        max_fan_out=1.0, min_uniqueness=1.0) %}
-{{ dbt_goldensuite.goldenmatch_key_integrity_sql(model, key, measures, grain, max_fan_out, min_uniqueness) }}
+        max_fan_out=1.0, min_uniqueness=1.0, grain_strict=false) %}
+{{ dbt_goldensuite.goldenmatch_key_integrity_sql(model, key, measures, grain, max_fan_out, min_uniqueness, grain_strict) }}
 {% endtest %}

--- a/packages/dbt/goldensuite/tests/test_key_integrity_macro.py
+++ b/packages/dbt/goldensuite/tests/test_key_integrity_macro.py
@@ -76,6 +76,31 @@ def test_empty_key_errors():
         h.goldenmatch_key_integrity_sql(model="m", key=[])
 
 
+def test_grain_advisory_by_default():
+    # grain is recorded but NOT folded into the group -> key-only GROUP BY.
+    h = _load_macros()
+    sql = h.goldenmatch_key_integrity_sql(model="m", key="customer_id", grain=["date"])
+    assert "GROUP BY customer_id" in sql
+    assert "GROUP BY customer_id, date" not in sql
+
+
+def test_grain_strict_folds_grain_into_group():
+    h = _load_macros()
+    sql = h.goldenmatch_key_integrity_sql(
+        model="m", key="customer_id", grain=["date"], grain_strict=True
+    )
+    assert "GROUP BY customer_id, date" in sql
+
+
+def test_grain_strict_dedupes_grain_already_in_key():
+    h = _load_macros()
+    sql = h.goldenmatch_key_integrity_sql(
+        model="m", key="customer_id", grain=["customer_id"], grain_strict=True
+    )
+    assert "GROUP BY customer_id\n" in sql or "GROUP BY customer_id " in sql
+    assert "customer_id, customer_id" not in sql
+
+
 # --- DuckDB execution ----------------------------------------------------------
 
 duckdb = pytest.importorskip("duckdb")
@@ -117,6 +142,49 @@ def test_tolerant_thresholds_pass_dup():
     sql = h.goldenmatch_key_integrity_sql(model="t", key="customer_id",
         measures=["revenue"], max_fan_out=2.0, min_uniqueness=0.5)
     assert len(con.sql(sql).fetchall()) == 0
+
+
+def _make_daily_con():
+    con = duckdb.connect()
+    # customer 1 repeats across two DATES (legit at daily grain); 2 is single.
+    con.execute(
+        "CREATE TABLE daily AS SELECT * FROM (VALUES "
+        "(1,'2026-01-01',10),(1,'2026-01-02',20),(2,'2026-01-01',5)"
+        ") v(customer_id, date, revenue)"
+    )
+    return con
+
+
+def test_grain_strict_certifies_daily_fact():
+    h = _load_macros()
+    con = _make_daily_con()
+    # key-only: customer 1 fans out 2x -> FAILS.
+    key_only = h.goldenmatch_key_integrity_sql(
+        model="daily", key="customer_id", measures=["revenue"], grain=["date"]
+    )
+    assert len(con.sql(key_only).fetchall()) == 1
+    # grain_strict: (customer_id, date) is unique -> PASSES.
+    strict = h.goldenmatch_key_integrity_sql(
+        model="daily", key="customer_id", measures=["revenue"],
+        grain=["date"], grain_strict=True,
+    )
+    assert len(con.sql(strict).fetchall()) == 0
+
+
+def test_grain_strict_still_flags_true_duplicate_at_grain():
+    h = _load_macros()
+    con = duckdb.connect()
+    # (customer_id, date) genuinely repeated -> grain can't excuse it.
+    con.execute(
+        "CREATE TABLE dup AS SELECT * FROM (VALUES "
+        "(1,'2026-01-01',10),(1,'2026-01-01',10),(2,'2026-01-01',5)"
+        ") v(customer_id, date, revenue)"
+    )
+    strict = h.goldenmatch_key_integrity_sql(
+        model="dup", key="customer_id", measures=["revenue"],
+        grain=["date"], grain_strict=True,
+    )
+    assert len(con.sql(strict).fetchall()) == 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+- **`grain_strict` on `certify_key_integrity` (semantic-layer wedge).** Opt-in
+  argument (default `False` = byte-identical to prior behavior: grain stays advisory
+  context and uniqueness is evaluated on the key alone). When `True` and a `grain` is
+  supplied, uniqueness and per-measure fan-out are evaluated on `key + grain` — true
+  "unique at grain", so a fact that legitimately repeats a key across grain buckets
+  (e.g. daily rows per customer) is certified rather than reported as fan-out; a real
+  duplicate *within* a grain bucket is still flagged. Grain columns are validated on
+  the strict path. The `goldenmatch_key_integrity` dbt test gained a matching
+  `grain_strict` argument in lockstep so the SQL test and this capability stay
+  semantically identical.
+
 ### Changed
 - **FS dedupe: Arrow-native columnar-cluster path (B2c), default-on (#1811/#2006).**
   A measure-first 5M profile pinned the FS scale wall at **clustering** (`cluster`

--- a/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
@@ -68,6 +68,7 @@ def certify_key_integrity(
     grain: Sequence[str] | None = None,
     attributes: Sequence[str] | None = None,
     resolve: bool = False,
+    grain_strict: bool = False,
 ) -> KeyIntegrityCertificate:
     """Certify a declared entity key for metric use.
 
@@ -77,11 +78,20 @@ def certify_key_integrity(
             `primary_key`, OSI dataset key).
         measures: numeric columns aggregated against this entity — fan-out is
             quantified per measure.
-        grain: the model's aggregation grain (recorded as advisory context in v1;
-            uniqueness is evaluated on the entity `key`).
+        grain: the model's aggregation grain. Advisory context by default
+            (uniqueness is evaluated on the entity `key` alone); when
+            `grain_strict=True` it is folded into the grouping so uniqueness /
+            fan-out is evaluated on `key + grain` (true "unique at grain").
         attributes: columns to run entity resolution on when `resolve=True`
             (default: every column that isn't a key or a measure).
         resolve: also measure entity fragmentation / undercount via GoldenMatch ER.
+        grain_strict: opt-in. When True *and* `grain` is supplied, evaluate
+            uniqueness and fan-out on `key + grain` rather than the key alone —
+            i.e. certify the key is unique *within each grain bucket* (a fact at
+            `(customer_id, date)` grain legitimately repeats a customer across
+            days, so the default key-only pass over-reports fan-out for it). The
+            default (False) is byte-identical to prior behavior: grain stays
+            advisory context and uniqueness is evaluated on the key.
 
     Returns:
         A `KeyIntegrityCertificate`. Advisory only — it never mutates the data.
@@ -100,6 +110,14 @@ def certify_key_integrity(
     missing_measures = [c for c in measure_cols if c not in present]
     if missing_measures:
         raise ValueError(f"certify_key_integrity: measure column(s) not in table: {missing_measures}")
+    # grain is validated only on the strict path (the default path treats grain
+    # as free-text advisory context, so a bogus grain there stays back-compat).
+    if grain_strict and grain_cols:
+        missing_grain = [c for c in grain_cols if c not in present]
+        if missing_grain:
+            raise ValueError(
+                f"certify_key_integrity: grain column(s) not in table: {missing_grain}"
+            )
 
     n_rows = table.num_rows
     notes: list[str] = []
@@ -114,10 +132,19 @@ def certify_key_integrity(
     if skipped:
         notes.append(f"non-numeric measures skipped for fan-out: {skipped}")
 
+    # Uniqueness/fan-out grouping. Default: the declared key alone. Strict:
+    # key + grain, so a fact legitimately repeating a key across grain buckets
+    # (e.g. daily rows per customer) is certified unique *at grain* rather than
+    # reported as fan-out. Grain cols already in the key aren't repeated.
+    if grain_strict and grain_cols:
+        group_columns = key_columns + [g for g in grain_cols if g not in key_columns]
+    else:
+        group_columns = key_columns
+
     aggs: list = [([], "count_all")]
     for m in numeric_measures:
         aggs.append((m, "max"))
-    grouped = table.group_by(key_columns).aggregate(aggs)
+    grouped = table.group_by(group_columns).aggregate(aggs)
 
     n_key_groups = grouped.num_rows
     counts = grouped.column("count_all")
@@ -138,7 +165,10 @@ def certify_key_integrity(
             measure_fan_out[m] = 1.0
 
     if grain_cols:
-        notes.append(f"grain {grain_cols} recorded as context; uniqueness evaluated on key")
+        if grain_strict:
+            notes.append(f"uniqueness evaluated at grain: key + {grain_cols}")
+        else:
+            notes.append(f"grain {grain_cols} recorded as context; uniqueness evaluated on key")
 
     cert = KeyIntegrityCertificate(
         key_columns=key_columns,

--- a/packages/python/goldenmatch/tests/test_key_integrity.py
+++ b/packages/python/goldenmatch/tests/test_key_integrity.py
@@ -40,6 +40,75 @@ def test_composite_key():
     assert c.max_fan_out == 2.0
 
 
+def test_grain_advisory_by_default():
+    # A daily fact: customer 1 legitimately repeats across dates. The default
+    # (key-only) pass reports fan-out even though the key is unique AT grain.
+    t = pa.table({
+        "customer_id": [1, 1, 2],
+        "date": ["2026-01-01", "2026-01-02", "2026-01-01"],
+        "revenue": [10, 20, 5],
+    })
+    c = certify_key_integrity(t, key="customer_id", grain=["date"], measures=["revenue"])
+    assert c.is_unique_at_grain is False       # key 1 appears twice
+    assert c.max_fan_out == 2.0
+    # naive SUM=35, key-deduped SUM (max per key)=20+5=25 -> 1.4x
+    assert c.measure_fan_out["revenue"] == pytest.approx(35.0 / 25.0)
+    assert "recorded as context" in c.note
+
+
+def test_grain_strict_certifies_unique_at_grain():
+    # Same daily fact, but grain_strict folds `date` into the group: each
+    # (customer_id, date) is unique, so the key IS trustworthy at grain.
+    t = pa.table({
+        "customer_id": [1, 1, 2],
+        "date": ["2026-01-01", "2026-01-02", "2026-01-01"],
+        "revenue": [10, 20, 5],
+    })
+    c = certify_key_integrity(
+        t, key="customer_id", grain=["date"], measures=["revenue"], grain_strict=True
+    )
+    assert c.is_unique_at_grain is True
+    assert c.duplicate_key_groups == 0
+    assert c.max_fan_out == 1.0
+    assert c.measure_fan_out == {"revenue": 1.0}
+    assert c.is_trustworthy() is True
+    assert "at grain: key + ['date']" in c.note
+
+
+def test_grain_strict_still_catches_true_duplicates():
+    # (customer_id, date) repeated -> a real duplicate the grain can't excuse.
+    t = pa.table({
+        "customer_id": [1, 1, 2],
+        "date": ["2026-01-01", "2026-01-01", "2026-01-01"],
+        "revenue": [10, 10, 5],
+    })
+    c = certify_key_integrity(
+        t, key="customer_id", grain=["date"], measures=["revenue"], grain_strict=True
+    )
+    assert c.is_unique_at_grain is False
+    assert c.duplicate_key_groups == 1
+    assert c.max_fan_out == 2.0
+
+
+def test_grain_strict_missing_grain_column_raises():
+    t = pa.table({"customer_id": [1, 2], "revenue": [1, 2]})
+    with pytest.raises(ValueError, match="grain column"):
+        certify_key_integrity(t, key="customer_id", grain=["nope"], grain_strict=True)
+    # ...but a bogus grain on the default (advisory) path stays back-compat.
+    c = certify_key_integrity(t, key="customer_id", grain=["nope"])
+    assert c.is_unique_at_grain is True
+
+
+def test_grain_strict_ignores_grain_already_in_key():
+    # grain col == key col: no duplicate group column, behaves like key-only.
+    t = pa.table({"customer_id": [1, 2, 3], "revenue": [1, 2, 3]})
+    c = certify_key_integrity(
+        t, key="customer_id", grain=["customer_id"], measures=["revenue"], grain_strict=True
+    )
+    assert c.is_unique_at_grain is True
+    assert c.max_fan_out == 1.0
+
+
 def test_non_numeric_measure_skipped_with_note():
     t = pa.table({"customer_id": [1, 2], "label": ["x", "y"]})
     c = certify_key_integrity(t, key="customer_id", measures=["label"])


### PR DESCRIPTION
## What and why

Roadmap item 4/6 for the semantic-layer wedge. The key-integrity certificate
evaluated uniqueness/fan-out on the declared key alone, so a fact table whose key
legitimately repeats across its grain (daily rows per customer) looked non-unique
and over-reported fan-out. This adds an opt-in `grain_strict` that evaluates
uniqueness at `key + grain` (true "unique at grain") on both the Python capability
and the dbt SQL test, in lockstep.

## Changes

- `certify_key_integrity(..., grain_strict=False)`: when `True` and a `grain` is
  supplied, the pyarrow group-by folds grain into the grouping so uniqueness /
  per-measure fan-out is evaluated on `key + grain`. Grain columns are validated on
  the strict path; grain cols already in the key are not repeated. Default `False`
  is byte-identical to prior behavior (grain advisory, uniqueness on the key alone).
- `goldenmatch_key_integrity` dbt test / `goldenmatch_key_integrity_sql` macro:
  matching `grain_strict=false` argument that folds grain into the `GROUP BY` exactly
  as the capability folds it into the group-by, keeping Python <-> dbt semantically
  identical.
- Tests: Python (advisory-by-default, strict certifies daily fact, strict still
  catches a true duplicate at grain, missing-grain validation, grain-already-in-key
  dedupe) and dbt macro (render shape + DuckDB execution proving the verdict flips).
- CHANGELOGs for both packages.

## Testing

- `python -m pytest packages/python/goldenmatch/tests/test_key_integrity.py packages/python/goldenmatch/tests/test_certify_semantic_model.py packages/python/goldenmatch/tests/test_cli_certify_keys.py packages/dbt/goldensuite/tests/test_key_integrity_macro.py` -> 36 passed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] No new CLI/MCP/A2A surface (a new kwarg only), so the api_parity manifest and generated-artifact cascade are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_