### PR TITLE
feat(semantic): metric-aware resolution - declared roles drive the ER (roadmap 5/6)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 436,
+      "module_count": 437,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7105,8 +7105,28 @@
           "purpose": "Semantic-layer interoperability (the MetricFlow / Cube / OSI wedge).",
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.certify",
             "goldenmatch.semantic.crosswalk",
+            "goldenmatch.semantic.cube",
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.osi"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.blocking",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/blocking.py",
+          "purpose": "Metric-aware attribute selection for the semantic-layer resolution tier.",
+          "defines": [
+            "SemanticFieldRoles",
+            "_dedup",
+            "_frame_columns",
+            "metric_aware_attributes",
+            "semantic_field_roles"
+          ],
+          "imports": [
+            "goldenmatch.semantic.certify",
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
@@ -7125,6 +7145,7 @@
           ],
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
@@ -7172,6 +7193,7 @@
             "parse_cube_models"
           ],
           "imports": [
+            "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow"
           ]
@@ -7235,6 +7257,7 @@
             "validate_osi"
           ],
           "imports": [
+            "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow"
           ]

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Metric-aware resolution for the semantic-layer wedge (the differentiated
+  wedge).** New `goldenmatch.semantic.semantic_field_roles(source)` reads a
+  semantic model's declared `{keys, dimensions, measures}` across all three
+  dialects (dbt/MetricFlow, Cube, OSI), and `metric_aware_attributes(roles,
+  columns)` turns them into the entity-resolution attribute allow-list — resolve
+  on the declared dimensions, never on a measure (a measure like `revenue` is an
+  aggregation target, not identity evidence). `certify_semantic_model` gained a
+  `metric_aware=True` toggle (threaded uniformly through the Cube/OSI bridges via
+  a new `roles=` argument) so the `resolve=True` tier drives its ER off the
+  model's own metadata instead of blindly profiling every column. A model that
+  declares no dimensions is byte-identical to the prior blind selection; the
+  toggle has no effect unless `resolve=True`.
 - **`grain_strict` on `certify_key_integrity` (semantic-layer wedge).** Opt-in
   argument (default `False` = byte-identical to prior behavior: grain stays advisory
   context and uniqueness is evaluated on the key alone). When `True` and a `grain` is

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -17,6 +17,11 @@ so ``import goldenmatch`` stays lightweight and polars-free; import it explicitl
 from __future__ import annotations
 
 from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.blocking import (
+    SemanticFieldRoles,
+    metric_aware_attributes,
+    semantic_field_roles,
+)
 from goldenmatch.semantic.certify import (
     KeyCertification,
     SemanticCertification,
@@ -69,6 +74,10 @@ __all__ = [
     "KeyIntegrityCertificate",
     "parse_semantic_models",
     "DeclaredKeySpec",
+    # metric-aware resolution — declared roles drive the ER attribute selection
+    "semantic_field_roles",
+    "metric_aware_attributes",
+    "SemanticFieldRoles",
     # wedge B — resolve once, emit the conformed entity declaration
     "build_resolved_crosswalk",
     "ResolvedCrosswalk",

--- a/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
@@ -1,0 +1,167 @@
+"""Metric-aware attribute selection for the semantic-layer resolution tier.
+
+A semantic model already declares which columns are entity **keys**, which are
+**measures** (numeric aggregation targets — NOT identity evidence), and which are
+**dimensions** (the identity-bearing attributes a metric groups by). GoldenMatch's
+resolution tier (`certify_key_integrity(resolve=True)`) runs entity resolution to
+detect key fragmentation; feeding that ER the model's own measure/dimension
+metadata — instead of blindly profiling every column — is the differentiated
+wedge. A measure like `revenue` must never be a blocking key or a match signal,
+and a declared dimension like `email` is exactly the attribute to resolve on. No
+pure-ER tool has this metadata; the semantic model does.
+
+`semantic_field_roles(source)` reads the declared roles from any of the three
+dialects (dbt/MetricFlow, Cube, OSI/Ossie). `metric_aware_attributes(roles,
+columns)` turns them into the ER attribute allow-list: the declared dimensions
+present in the frame (measures and keys always excluded), with a safe fallback to
+"every non-key, non-measure column" when a model declares no dimensions — so a
+model that declares dimensions gets the metric-aware selection and one that
+doesn't is byte-identical to the blind selection the resolution tier used before.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SemanticFieldRoles:
+    """The column roles a semantic model declares, unioned across all of its
+    models / cubes / datasets.
+
+    * `keys` — declared entity key columns (primary / natural / unique).
+    * `dimensions` — declared dimension columns (identity-bearing attributes).
+    * `measures` — declared measure columns (aggregation targets, never identity).
+    """
+
+    keys: list[str] = field(default_factory=list)
+    dimensions: list[str] = field(default_factory=list)
+    measures: list[str] = field(default_factory=list)
+
+
+def _dedup(seq: Sequence[str]) -> list[str]:
+    """Order-preserving de-duplication (a column may be declared more than once)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for c in seq:
+        if c and c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+
+
+def _frame_columns(df: Any) -> list[str]:
+    """Column names of a supported table type, without a full Arrow conversion
+    where the type already exposes them."""
+    cols = getattr(df, "column_names", None)  # pyarrow.Table
+    if cols is not None:
+        return list(cols)
+    cols = getattr(df, "columns", None)  # polars / pandas DataFrame
+    if cols is not None:
+        return list(cols)
+    if isinstance(df, dict):
+        return list(df.keys())
+    # Last resort: coerce via the key_integrity Arrow adapter.
+    from goldenmatch.semantic.key_integrity import _to_arrow
+
+    return list(_to_arrow(df).column_names)
+
+
+def semantic_field_roles(source: str | Any) -> SemanticFieldRoles:
+    """Read the declared `{keys, dimensions, measures}` roles from a semantic model.
+
+    Args:
+        source: a path, raw YAML string, or loaded dict for a dbt/MetricFlow,
+            Cube, or OSI/Ossie semantic model (the dialect is auto-detected).
+
+    Returns:
+        A `SemanticFieldRoles` with the roles unioned across every model / cube /
+        dataset the document declares.
+    """
+    # Imported lazily to keep this module free of import cycles (the dialect
+    # readers and the front-door detector don't import blocking).
+    from goldenmatch.semantic.certify import detect_dialect
+    from goldenmatch.semantic.metricflow import _load
+
+    data = _load(source)
+    dialect = detect_dialect(data)
+    keys: list[str] = []
+    dimensions: list[str] = []
+    measures: list[str] = []
+
+    if dialect == "metricflow":
+        from goldenmatch.semantic.metricflow import _entity_column, _measure_column
+
+        for sm in data.get("semantic_models") or []:
+            if not isinstance(sm, dict):
+                continue
+            for ent in sm.get("entities") or []:
+                if isinstance(ent, dict) and (col := _entity_column(ent)):
+                    keys.append(col)
+            for dim in sm.get("dimensions") or []:
+                if isinstance(dim, dict) and (col := _entity_column(dim)):
+                    # dimensions share the entity `expr`-or-`name` column shape
+                    dimensions.append(col)
+            for m in sm.get("measures") or []:
+                if isinstance(m, dict) and (col := _measure_column(m)):
+                    measures.append(col)
+    elif dialect == "cube":
+        from goldenmatch.semantic.cube import parse_cube_models
+
+        for cube in parse_cube_models(data):
+            for d in cube.dimensions:
+                (keys if d.primary_key else dimensions).append(d.name)
+            for m in cube.measures:
+                measures.append(m.name)
+    else:  # osi
+        from goldenmatch.semantic.osi import parse_osi_models
+
+        for model in parse_osi_models(data):
+            for ds in model.datasets:
+                keys.extend(ds.primary_key)
+                key_set = set(ds.primary_key)
+                for f in ds.fields:
+                    if f.name not in key_set:
+                        dimensions.append(f.name)
+            # OSI metrics are aggregation expressions (often derived names, not raw
+            # frame columns); record them so an incidental same-named column is
+            # still excluded from identity evidence.
+            for metric in model.metrics:
+                if metric.name:
+                    measures.append(metric.name)
+
+    return SemanticFieldRoles(
+        keys=_dedup(keys),
+        dimensions=_dedup(dimensions),
+        measures=_dedup(measures),
+    )
+
+
+def metric_aware_attributes(
+    roles: SemanticFieldRoles, columns: Sequence[str]
+) -> list[str]:
+    """The entity-resolution attribute allow-list for a frame, given declared roles.
+
+    Measures and keys are always excluded (a measure is an aggregation target, a
+    key is what resolution is checking — neither is identity evidence). When the
+    model declares dimensions, the result is exactly the declared dimensions that
+    are present in the frame; otherwise it falls back to every remaining column,
+    so a model that declares no dimensions is byte-identical to the blind
+    selection. The result preserves frame-column order for determinism.
+
+    Args:
+        roles: the declared roles (from `semantic_field_roles`).
+        columns: the frame's column names.
+
+    Returns:
+        The attribute columns to run ER on (never a key or a measure).
+    """
+    columns = list(columns)
+    excluded = set(roles.keys) | set(roles.measures)
+    declared_dims = [c for c in roles.dimensions if c in columns and c not in excluded]
+    if declared_dims:
+        keep = set(declared_dims)
+        return [c for c in columns if c in keep]
+    # No declared dimensions present → blind fallback (measures/keys still excluded).
+    return [c for c in columns if c not in excluded]

--- a/packages/python/goldenmatch/goldenmatch/semantic/certify.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/certify.py
@@ -83,6 +83,7 @@ def certify_semantic_model(
     frames: dict[str, Any],
     *,
     resolve: bool = False,
+    metric_aware: bool = True,
 ) -> SemanticCertification:
     """Certify every declared identity key in a semantic model.
 
@@ -94,14 +95,30 @@ def certify_semantic_model(
             is skipped and recorded in `skipped`.
         resolve: also run entity resolution to measure fragmentation / undercount.
             Applied uniformly across all three dialects.
+        metric_aware: when resolving, drive the ER off the model's own declared
+            roles — resolve on the declared **dimensions** and never on a
+            **measure** (the differentiated wedge). A model that declares no
+            dimensions is byte-identical to the blind selection. Set False to
+            resolve on every non-key, non-measure column (the prior behavior).
+            No effect unless `resolve=True`.
 
     Returns:
         A `SemanticCertification` with one `KeyCertification` per certified key.
     """
+    from goldenmatch.semantic.blocking import (
+        _frame_columns,
+        metric_aware_attributes,
+        semantic_field_roles,
+    )
+
     data = _load(source)
     dialect = detect_dialect(data)
     entries: list[KeyCertification] = []
     skipped: list[str] = []
+
+    # Read the model's declared roles once, so the resolution tier is metric-aware
+    # across every dialect (a measure is never identity evidence).
+    roles = semantic_field_roles(data) if (resolve and metric_aware) else None
 
     if dialect == "metricflow":
         for spec in parse_semantic_models(data):
@@ -109,20 +126,24 @@ def certify_semantic_model(
             if df is None:
                 skipped.append(spec.model)
                 continue
+            attributes = (
+                metric_aware_attributes(roles, _frame_columns(df))
+                if roles is not None else None
+            )
             cert = certify_key_integrity(
                 df, key=spec.key, measures=spec.measures, grain=spec.grain,
-                resolve=resolve,
+                resolve=resolve, attributes=attributes,
             )
             entries.append(KeyCertification(target=spec.model, key=list(spec.key), certificate=cert))
     elif dialect == "cube":
         # certify_cube_joins already certifies the one-side key of each join.
-        for rep in certify_cube_joins(data, frames, resolve=resolve):
+        for rep in certify_cube_joins(data, frames, resolve=resolve, roles=roles):
             entries.append(KeyCertification(
                 target=rep["to_cube"], key=list(rep["key"]), certificate=rep["certificate"],
                 context=f"join from {rep['from_cube']}",
             ))
     else:  # osi
-        for rep in certify_osi_relationships(data, frames, resolve=resolve):
+        for rep in certify_osi_relationships(data, frames, resolve=resolve, roles=roles):
             entries.append(KeyCertification(
                 target=rep["dataset"], key=list(rep["key"]), certificate=rep["certificate"],
                 context=f"relationship {rep['relationship']}",

--- a/packages/python/goldenmatch/goldenmatch/semantic/cube.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/cube.py
@@ -293,7 +293,8 @@ def emit_cube_from_crosswalk(
 
 
 def certify_cube_joins(
-    model: list[Cube] | str | Any, frames: dict[str, Any], *, resolve: bool = False
+    model: list[Cube] | str | Any, frames: dict[str, Any], *, resolve: bool = False,
+    roles: Any = None,
 ) -> list[dict[str, Any]]:
     """For each join in a Cube model, certify the ONE-side key it joins on (the
     referenced primary key) using wedge A — certifying exactly the identity the
@@ -303,10 +304,13 @@ def certify_cube_joins(
     must be unique (certifying the many-side FK would spuriously flag a fan-out).
     `frames` maps cube name -> table; a join whose one-side frame is absent or
     whose one-side columns can't be parsed is skipped. `resolve=True` also
-    measures entity fragmentation / undercount via ER (fail-open).
+    measures entity fragmentation / undercount via ER (fail-open); pass `roles`
+    (a `SemanticFieldRoles`) to make that ER metric-aware — it resolves on the
+    cube's declared dimensions and never on a measure.
 
     Returns `[{from_cube, to_cube, key, certificate}]`.
     """
+    from goldenmatch.semantic.blocking import _frame_columns, metric_aware_attributes
     from goldenmatch.semantic.key_integrity import certify_key_integrity
 
     cubes = model if isinstance(model, list) else parse_cube_models(model)
@@ -320,7 +324,13 @@ def certify_cube_joins(
             df = frames.get(one_cube)
             if df is None or not one_columns:
                 continue
-            cert = certify_key_integrity(df, key=one_columns, resolve=resolve)
+            attributes = (
+                metric_aware_attributes(roles, _frame_columns(df))
+                if (resolve and roles is not None) else None
+            )
+            cert = certify_key_integrity(
+                df, key=one_columns, resolve=resolve, attributes=attributes
+            )
             out.append({
                 "from_cube": jk["from_cube"],
                 "to_cube": jk["to_cube"],

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi.py
@@ -324,16 +324,20 @@ def emit_osi_from_crosswalk(
 
 
 def certify_osi_relationships(
-    model: OsiModel | str | Any, frames: dict[str, Any], *, resolve: bool = False
+    model: OsiModel | str | Any, frames: dict[str, Any], *, resolve: bool = False,
+    roles: Any = None,
 ) -> list[dict[str, Any]]:
     """For each relationship in an OSI model, certify the ONE-side key it joins on
     (the referenced PK) using wedge A — i.e. certify exactly the identity the
     metrics depend on. `frames` maps dataset name -> table; datasets without a
     supplied frame are skipped. `resolve=True` also measures entity
-    fragmentation / undercount via ER (fail-open).
+    fragmentation / undercount via ER (fail-open); pass `roles` (a
+    `SemanticFieldRoles`) to make that ER metric-aware — it resolves on the
+    dataset's declared dimension fields and never on a measure.
 
     Returns `[{relationship, dataset, key, certificate}]`.
     """
+    from goldenmatch.semantic.blocking import _frame_columns, metric_aware_attributes
     from goldenmatch.semantic.key_integrity import certify_key_integrity
 
     if not isinstance(model, OsiModel):
@@ -347,7 +351,13 @@ def certify_osi_relationships(
         df = frames.get(rel.to_dataset)
         if df is None or not rel.to_columns:
             continue
-        cert = certify_key_integrity(df, key=rel.to_columns, resolve=resolve)
+        attributes = (
+            metric_aware_attributes(roles, _frame_columns(df))
+            if (resolve and roles is not None) else None
+        )
+        cert = certify_key_integrity(
+            df, key=rel.to_columns, resolve=resolve, attributes=attributes
+        )
         out.append({
             "relationship": rel.name,
             "dataset": rel.to_dataset,

--- a/packages/python/goldenmatch/tests/test_metric_aware_resolution.py
+++ b/packages/python/goldenmatch/tests/test_metric_aware_resolution.py
@@ -1,0 +1,169 @@
+"""Tests for metric-aware resolution: semantic_field_roles + metric_aware_attributes.
+
+The differentiated wedge — a semantic model's own measure/dimension metadata
+drives the entity resolution that backs certification: resolve on the declared
+dimensions, never on a measure.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    SemanticFieldRoles,
+    certify_semantic_model,
+    metric_aware_attributes,
+    semantic_field_roles,
+)
+
+_METRICFLOW = """
+semantic_models:
+  - name: orders
+    entities:
+      - name: order
+        type: primary
+        expr: order_id
+    dimensions:
+      - name: email
+      - name: city
+        expr: city_name
+    measures:
+      - name: revenue
+        agg: sum
+        expr: amount
+"""
+
+_CUBE = """
+cubes:
+  - name: customers
+    sql_table: public.customers
+    dimensions:
+      - name: id
+        sql: id
+        primary_key: true
+      - name: email
+        sql: email
+      - name: city
+        sql: city
+    measures:
+      - name: total_spend
+        type: sum
+        sql: amount
+"""
+
+_OSI = """
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    datasets:
+      - name: customers
+        primary_key: [id]
+        fields:
+          - name: id
+            expression: id
+          - name: email
+            expression: email
+          - name: city
+            expression: city
+    metrics:
+      - name: revenue
+        expression: SUM(customers.amount)
+"""
+
+
+# --- semantic_field_roles ------------------------------------------------------
+
+
+def test_roles_metricflow():
+    roles = semantic_field_roles(_METRICFLOW)
+    assert isinstance(roles, SemanticFieldRoles)
+    assert roles.keys == ["order_id"]
+    assert roles.dimensions == ["email", "city_name"]   # `expr` wins over `name`
+    assert roles.measures == ["amount"]                 # measure column, not label
+
+
+def test_roles_cube():
+    roles = semantic_field_roles(_CUBE)
+    assert roles.keys == ["id"]                         # primary_key dimension
+    assert roles.dimensions == ["email", "city"]        # non-key dimensions
+    assert roles.measures == ["total_spend"]
+
+
+def test_roles_osi():
+    roles = semantic_field_roles(_OSI)
+    assert roles.keys == ["id"]
+    assert roles.dimensions == ["email", "city"]        # fields minus the key
+    assert roles.measures == ["revenue"]                # metric name
+
+
+# --- metric_aware_attributes ---------------------------------------------------
+
+
+def test_attributes_select_declared_dimensions():
+    roles = SemanticFieldRoles(keys=["id"], dimensions=["email", "city"], measures=["amount"])
+    cols = ["id", "email", "city", "amount", "notes"]
+    # declared dimensions present in the frame; key/measure/undeclared dropped
+    assert metric_aware_attributes(roles, cols) == ["email", "city"]
+
+
+def test_attributes_measure_never_selected_even_if_also_a_dimension():
+    # a measure column wins the exclusion over a dimension declaration
+    roles = SemanticFieldRoles(keys=["id"], dimensions=["email", "amount"], measures=["amount"])
+    assert metric_aware_attributes(roles, ["id", "email", "amount"]) == ["email"]
+
+
+def test_attributes_preserve_frame_order():
+    roles = SemanticFieldRoles(dimensions=["city", "email"])
+    # result follows FRAME order, not declaration order
+    assert metric_aware_attributes(roles, ["email", "city"]) == ["email", "city"]
+
+
+def test_attributes_fallback_when_no_dimensions_declared():
+    # no dimensions -> every non-key, non-measure column (byte-identical to the
+    # blind selection the resolution tier used before), measures still excluded
+    roles = SemanticFieldRoles(keys=["id"], dimensions=[], measures=["amount"])
+    cols = ["id", "email", "city", "amount"]
+    assert metric_aware_attributes(roles, cols) == ["email", "city"]
+
+
+def test_attributes_fallback_when_dimensions_absent_from_frame():
+    # declared dimensions none of which are present -> fallback, measures excluded
+    roles = SemanticFieldRoles(keys=["id"], dimensions=["ghost"], measures=["amount"])
+    assert metric_aware_attributes(roles, ["id", "email", "amount"]) == ["email"]
+
+
+# --- front door: metric-aware resolve tier -------------------------------------
+
+
+def test_front_door_metric_aware_excludes_measure_from_resolution():
+    # Two byte-identical people split across order_id 1/2; `amount` is a MEASURE
+    # that happens to differ. Metric-aware resolution must NOT resolve on amount.
+    frames = {"orders": pa.table({
+        "order_id": [1, 2, 3, 4],
+        "email": ["a@x.com", "a@x.com", "b@x.com", "c@x.com"],
+        "city_name": ["Boston", "Boston", "Denver", "Miami"],
+        "amount": [10.0, 999.0, 5.0, 7.0],   # measure — differs on the dup pair
+    })}
+    rep = certify_semantic_model(_METRICFLOW, frames, resolve=True, metric_aware=True)
+    assert rep.n_certified == 1
+    cert = rep.entries[0].certificate
+    # resolution ran on the declared dimensions (email/city), not the measure;
+    # it either detects the fragmentation or fail-opens, but never errors.
+    assert cert.resolved_entities is None or isinstance(cert.resolved_entities, int)
+    assert "amount" not in cert.note        # the measure was not an attribute
+
+
+def test_front_door_metric_aware_toggle_off_still_runs():
+    frames = {"orders": pa.table({
+        "order_id": [1, 2, 3],
+        "email": ["a@x.com", "b@x.com", "c@x.com"],
+        "city_name": ["Boston", "Denver", "Miami"],
+        "amount": [10.0, 5.0, 7.0],
+    })}
+    rep = certify_semantic_model(_METRICFLOW, frames, resolve=True, metric_aware=False)
+    assert rep.n_certified == 1
+
+
+def test_front_door_metric_aware_is_noop_without_resolve():
+    # metric_aware has no effect unless resolve=True
+    frames = {"orders": pa.table({"order_id": [1, 2], "email": ["a", "b"], "amount": [1.0, 2.0]})}
+    rep = certify_semantic_model(_METRICFLOW, frames, resolve=False, metric_aware=True)
+    assert rep.n_certified == 1


### PR DESCRIPTION
## What and why

Roadmap item 5/6 for the semantic-layer wedge — the differentiated one. A
semantic model already declares which columns are entity **keys**, which are
**measures** (aggregation targets — never identity evidence), and which are
**dimensions** (the identity-bearing attributes a metric groups by). The
`resolve=True` certification tier previously ran entity resolution by blindly
profiling every non-key/non-measure column. This feeds the model's own
measure/dimension metadata into that ER instead — a measure like `revenue` is
never a blocking key or a match signal, and a declared dimension like `email` is
exactly the attribute to resolve on. No pure-ER tool has this metadata; the
semantic model does.

## Changes

- New `goldenmatch/semantic/blocking.py`:
  - `semantic_field_roles(source)` → `SemanticFieldRoles{keys, dimensions, measures}`,
    read across all three dialects (dbt/MetricFlow, Cube, OSI/Ossie).
  - `metric_aware_attributes(roles, columns)` → the ER attribute allow-list:
    declared dimensions present in the frame, measures and keys always excluded,
    with a safe fallback to every non-key/non-measure column when a model
    declares no dimensions (byte-identical to the prior blind selection).
- `certify_semantic_model(..., metric_aware=True)`: threaded uniformly through the
  Cube/OSI certify bridges via a new `roles=` argument, so the resolve tier
  resolves on the declared dimensions and never on a measure. No effect unless
  `resolve=True`; a dimension-less model is byte-identical to before.
- Public exports + CHANGELOG.

## Testing

- `python -m pytest packages/python/goldenmatch/tests/test_metric_aware_resolution.py` → 11 passed (roles per dialect, attribute selection incl. measure-exclusion / order / fallbacks, front-door resolve tier with the toggle on/off/no-resolve).
- `python -m pytest .../test_certify_semantic_model.py .../test_key_integrity.py .../test_cli_certify_keys.py` → 25 passed (no regression).
- `ruff check` on the changed files → clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] No new CLI/MCP/A2A surface (new library functions + a kwarg), so the api_parity manifest and generated-artifact cascade are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_