### PR TITLE
feat(semantic): live catalog write-back + JSON-Schema OSI validation (roadmap 6/6)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 437,
+      "module_count": 438,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7106,6 +7106,7 @@
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.blocking",
+            "goldenmatch.semantic.catalog",
             "goldenmatch.semantic.certify",
             "goldenmatch.semantic.crosswalk",
             "goldenmatch.semantic.cube",
@@ -7129,6 +7130,19 @@
             "goldenmatch.semantic.certify",
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.osi"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.catalog",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/catalog.py",
+          "purpose": "Live catalog write-back for the semantic-layer wedge (wedge B, persisted).",
+          "defines": [
+            "write_resolved_catalog"
+          ],
+          "imports": [
+            "goldenmatch.semantic.cube",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi"
           ]
@@ -7253,8 +7267,10 @@
             "emit_osi_relationship",
             "emit_osi_yaml",
             "osi_join_keys",
+            "osi_json_schema",
             "parse_osi_models",
-            "validate_osi"
+            "validate_osi",
+            "validate_osi_schema"
           ],
           "imports": [
             "goldenmatch.semantic.blocking",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Live catalog write-back + JSON-Schema OSI validation (semantic-layer wedge).**
+  `goldenmatch.semantic.write_resolved_catalog(crosswalk, path, *, dialect,
+  source_target, ...)` emits a `ResolvedCrosswalk`'s conformed entity declaration
+  (the `resolved_entity_id` join a metric groups by) for dbt/MetricFlow, Cube, or
+  OSI and **writes it to the catalog file** the semantic layer reads — the last
+  mile of "resolve once, every metric inherits correct joins". Refuses to clobber
+  an existing file unless `overwrite=True`, creates parent dirs, and forwards
+  emitter kwargs (`measures`/`grain`/`resolved_field`/...). Also adds a bundled
+  JSON Schema for OSI/Ossie 0.2.0.dev0 (`osi_json_schema()`) and a
+  `jsonschema`-backed validator: `validate_osi_schema(source)` and
+  `validate_osi(source, engine="structural"|"jsonschema"|"auto")`. `jsonschema` is
+  optional (the `"auto"` engine falls back to the dependency-free structural check
+  when it is absent); the default `engine="structural"` is byte-identical to prior
+  behavior.
 - **Metric-aware resolution for the semantic-layer wedge (the differentiated
   wedge).** New `goldenmatch.semantic.semantic_field_roles(source)` reads a
   semantic model's declared `{keys, dimensions, measures}` across all three

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -22,6 +22,7 @@ from goldenmatch.semantic.blocking import (
     metric_aware_attributes,
     semantic_field_roles,
 )
+from goldenmatch.semantic.catalog import write_resolved_catalog
 from goldenmatch.semantic.certify import (
     KeyCertification,
     SemanticCertification,
@@ -59,8 +60,10 @@ from goldenmatch.semantic.osi import (
     emit_osi_model,
     emit_osi_yaml,
     osi_join_keys,
+    osi_json_schema,
     parse_osi_models,
     validate_osi,
+    validate_osi_schema,
 )
 
 __all__ = [
@@ -84,6 +87,8 @@ __all__ = [
     "emit_semantic_model",
     "emit_metricflow_yaml",
     "emit_from_crosswalk",
+    # live catalog write-back — persist the conformed declaration to a catalog file
+    "write_resolved_catalog",
     # wedge C — OSI / Apache Ossie native provider (bidirectional)
     "parse_osi_models",
     "osi_join_keys",
@@ -92,6 +97,8 @@ __all__ = [
     "emit_osi_yaml",
     "emit_osi_from_crosswalk",
     "validate_osi",
+    "validate_osi_schema",
+    "osi_json_schema",
     "OsiModel",
     "OsiDataset",
     "OsiRelationship",

--- a/packages/python/goldenmatch/goldenmatch/semantic/catalog.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/catalog.py
@@ -1,0 +1,73 @@
+"""Live catalog write-back for the semantic-layer wedge (wedge B, persisted).
+
+The `emit_*_from_crosswalk` functions PRODUCE the conformed entity declaration
+(the `resolved_entity_id` join a semantic layer should group metrics by) as a YAML
+string. `write_resolved_catalog` is the last mile: it emits that declaration for a
+`ResolvedCrosswalk` and WRITES it to the catalog file the semantic layer reads —
+so "resolve once, every metric inherits correct joins" lands as a file in the
+dbt/MetricFlow, Cube, or OSI project, not just a returned string.
+
+It dispatches to the right dialect emitter, refuses to clobber an existing file
+unless `overwrite=True`, and returns the written YAML.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_DIALECTS = ("metricflow", "cube", "osi")
+
+
+def write_resolved_catalog(
+    crosswalk: Any,
+    path: str | Path,
+    *,
+    dialect: str,
+    source_target: str,
+    overwrite: bool = False,
+    **emit_kwargs: Any,
+) -> str:
+    """Emit a `ResolvedCrosswalk`'s conformed entity declaration and write it to `path`.
+
+    Args:
+        crosswalk: a `ResolvedCrosswalk` (from `build_resolved_crosswalk`).
+        path: the catalog file to write (e.g. `models/customer_crosswalk.yml`).
+        dialect: one of `"metricflow"`, `"cube"`, `"osi"` — selects the emitter.
+        source_target: the source model / cube / dataset whose join points at the
+            crosswalk (the `model` for MetricFlow, `source_cube` for Cube,
+            `source_dataset` for OSI).
+        overwrite: refuse to overwrite an existing file unless True.
+        **emit_kwargs: forwarded to the dialect's `emit_*_from_crosswalk`
+            (e.g. `measures=`, `grain=`, `resolved_field=`, `certificate=`).
+
+    Returns:
+        The YAML string that was written.
+    """
+    key = dialect.strip().lower()
+    if key not in _DIALECTS:
+        raise ValueError(
+            f"write_resolved_catalog: unknown dialect {dialect!r}; expected one of {_DIALECTS}"
+        )
+
+    out = Path(path)
+    if out.exists() and not overwrite:
+        raise FileExistsError(
+            f"write_resolved_catalog: {out} already exists; pass overwrite=True to replace it"
+        )
+
+    if key == "metricflow":
+        from goldenmatch.semantic.metricflow import emit_from_crosswalk
+
+        yaml_str = emit_from_crosswalk(crosswalk, source_target, **emit_kwargs)
+    elif key == "cube":
+        from goldenmatch.semantic.cube import emit_cube_from_crosswalk
+
+        yaml_str = emit_cube_from_crosswalk(crosswalk, source_cube=source_target, **emit_kwargs)
+    else:  # osi
+        from goldenmatch.semantic.osi import emit_osi_from_crosswalk
+
+        yaml_str = emit_osi_from_crosswalk(crosswalk, source_dataset=source_target, **emit_kwargs)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(yaml_str, encoding="utf-8")
+    return yaml_str

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi.py
@@ -389,17 +389,85 @@ def _expression_issues(expr: Any, loc: str) -> list[str]:
     return [f"{loc}: missing/invalid 'expression'"]
 
 
-def validate_osi(source: str | Any) -> list[str]:
+def osi_json_schema() -> dict[str, Any]:
+    """Load the bundled OSI/Ossie 0.2.0.dev0 JSON Schema.
+
+    The schema (`osi_schema.json`, shipped in this package) is the machine-readable
+    form of the same structural contract `validate_osi` enforces — required fields,
+    the datatype/dialect enums, the `expression` shape, and the forbidden
+    `foreign_key`/`cardinality`/`aggregation` keys. Useful for validating OSI docs
+    with any JSON-Schema tool, not just GoldenMatch.
+    """
+    import json
+    from pathlib import Path
+
+    schema_path = Path(__file__).with_name("osi_schema.json")
+    with open(schema_path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def validate_osi_schema(source: str | Any) -> list[str]:
+    """Validate an OSI document against the bundled JSON Schema via `jsonschema`.
+
+    Returns a list of human-readable issues (empty when valid), sorted by JSON
+    path. Requires the optional `jsonschema` dependency; raises `ImportError` if it
+    is not installed (use `validate_osi` for the dependency-free structural check,
+    or `validate_osi(..., engine="auto")` to prefer this when available).
+    """
+    try:
+        import jsonschema
+    except ImportError as exc:  # pragma: no cover - exercised by the engine="auto" fallback
+        raise ImportError(
+            "validate_osi_schema requires the optional `jsonschema` package "
+            "(pip install jsonschema); use validate_osi(...) for the dependency-free "
+            "structural check."
+        ) from exc
+
+    data = _load(source)
+    validator = jsonschema.Draft202012Validator(osi_json_schema())
+    issues: list[str] = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path)):
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        issues.append(f"{loc}: {err.message}")
+    return issues
+
+
+def validate_osi(source: str | Any, *, engine: str = "structural") -> list[str]:
     """Validate an OSI/Ossie document against the spec's structural constraints
     (`core-spec/osi-schema.json`, 0.2.0.dev0) — returns a list of human-readable
     issues, empty when valid. Faithful to the schema's `required` sets + enums,
     and flags the keys the schema does NOT define (cardinality / foreign_key /
     aggregation) so hand-written or third-party docs stay conformant.
 
+    Args:
+        source: a path, raw YAML string, or loaded dict for an OSI document.
+        engine: `"structural"` (default) runs the dependency-free structural
+            validator below. `"jsonschema"` validates against the bundled JSON
+            Schema via the optional `jsonschema` package (raises if absent).
+            `"auto"` uses `jsonschema` when it is importable and falls back to the
+            structural check otherwise. All engines return the same issue-list
+            shape; the default is byte-identical to the prior behavior.
+
     Structural (no `jsonschema` dependency): validates required fields, list shape,
     and enum membership — the checks that keep GoldenMatch-emitted OSI round-trippable
     and portable across Ossie consumers. `validate_osi(emit_osi_yaml(...)) == []`.
     """
+    engine = engine.strip().lower()
+    if engine == "jsonschema":
+        return validate_osi_schema(source)
+    if engine == "auto":
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            pass  # jsonschema absent → structural fallback below
+        else:
+            return validate_osi_schema(source)
+    elif engine != "structural":
+        raise ValueError(
+            f"validate_osi: unknown engine {engine!r}; expected 'structural', "
+            "'jsonschema', or 'auto'"
+        )
+
     data = _load(source)
     issues: list[str] = []
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi_schema.json
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi_schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://goldenmatch.dev/schemas/osi-0.2.0.dev0.json",
+  "title": "Open Semantic Interchange (Ossie) 0.2.0.dev0 — GoldenMatch structural schema",
+  "description": "Machine-readable JSON Schema for the OSI/Ossie 0.2.0.dev0 structural contract as GoldenMatch reads and emits it (core-spec/osi-schema.json). Authored by GoldenMatch to mirror goldenmatch.semantic.osi.validate_osi: required fields, the datatype/dialect enums, the expression shape, and the keys the spec does NOT define (foreign_key / cardinality / aggregation). It is the machine-readable form of the same contract the structural validator enforces, not a copy of the upstream incubating schema.",
+  "type": "object",
+  "required": ["version", "semantic_model"],
+  "properties": {
+    "version": {"type": "string"},
+    "semantic_model": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/model"}
+    }
+  },
+  "$defs": {
+    "expression": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "object",
+          "required": ["dialects"],
+          "properties": {
+            "dialects": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["dialect", "expression"],
+                "properties": {
+                  "dialect": {
+                    "type": "string",
+                    "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY"]
+                  },
+                  "expression": {"type": "string"}
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "field": {
+      "type": "object",
+      "required": ["name", "expression"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "expression": {"$ref": "#/$defs/expression"},
+        "datatype": {
+          "type": "string",
+          "enum": ["String", "Integer", "Decimal", "Float", "Boolean", "Date", "Time", "DateTime", "DateTimeTz", "Opaque"]
+        }
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "required": ["name"],
+      "not": {"required": ["foreign_key"]},
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "source": {"type": "string"},
+        "primary_key": {"type": "array", "items": {"type": "string"}},
+        "unique_keys": {"type": "array"},
+        "fields": {"type": "array", "items": {"$ref": "#/$defs/field"}}
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "required": ["name", "from", "to", "from_columns", "to_columns"],
+      "not": {"required": ["cardinality"]},
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "from": {"type": "string", "minLength": 1},
+        "to": {"type": "string", "minLength": 1},
+        "from_columns": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "to_columns": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+      }
+    },
+    "metric": {
+      "type": "object",
+      "required": ["name", "expression"],
+      "allOf": [
+        {"not": {"required": ["aggregation"]}},
+        {"not": {"required": ["agg"]}}
+      ],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "expression": {"$ref": "#/$defs/expression"}
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "datasets": {"type": "array", "items": {"$ref": "#/$defs/dataset"}},
+        "relationships": {"type": "array", "items": {"$ref": "#/$defs/relationship"}},
+        "metrics": {"type": "array", "items": {"$ref": "#/$defs/metric"}}
+      }
+    }
+  }
+}

--- a/packages/python/goldenmatch/tests/test_osi.py
+++ b/packages/python/goldenmatch/tests/test_osi.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 import pyarrow as pa
+import pytest
 from goldenmatch.semantic import (
     OsiModel,
     certify_osi_relationships,
     emit_osi_from_crosswalk,
     emit_osi_yaml,
     osi_join_keys,
+    osi_json_schema,
     parse_osi_models,
     validate_osi,
+    validate_osi_schema,
 )
 
 # A real-shaped Ossie document (TPC-DS): version + semantic_model list, datasets
@@ -208,3 +211,82 @@ def test_validate_osi_flags_unknown_dialect():
     }
     issues = validate_osi(doc)
     assert any("dialect 'PRESTO' not in the Ossie enum" in i for i in issues)
+
+
+# --- JSON-Schema-backed validation (bundled osi_schema.json) -------------------
+
+jsonschema = pytest.importorskip("jsonschema")
+
+
+class _CrosswalkStub:
+    source_pk_column = "customer_id"
+    resolved_key = "resolved_entity_id"
+    n_records = 12
+    n_entities = 11
+    reduction_ratio = 1 - 11 / 12
+
+
+def test_osi_json_schema_loads_and_is_a_draft():
+    schema = osi_json_schema()
+    assert schema["$schema"].endswith("2020-12/schema")
+    assert schema["required"] == ["version", "semantic_model"]
+
+
+def test_schema_engine_accepts_emitted_and_reference_docs():
+    # the bundled schema agrees with the structural validator on valid docs
+    assert validate_osi_schema(_DOC) == []
+    assert validate_osi(_DOC, engine="jsonschema") == []
+    m = parse_osi_models(_DOC)[0]
+    assert validate_osi_schema(emit_osi_yaml(m)) == []
+    assert validate_osi_schema(
+        emit_osi_from_crosswalk(_CrosswalkStub(), source_dataset="store_sales")
+    ) == []
+
+
+def test_schema_engine_flags_missing_required():
+    bad = {"version": "0.2.0.dev0", "semantic_model": [{"datasets": []}]}  # model missing name
+    issues = validate_osi_schema(bad)
+    assert issues and any("name" in i for i in issues)
+
+
+def test_schema_engine_flags_bad_datatype_enum():
+    doc = {
+        "version": "0.2.0.dev0",
+        "semantic_model": [{
+            "name": "m",
+            "datasets": [{"name": "d", "fields": [
+                {"name": "x", "expression": "x", "datatype": "NotAType"},
+            ]}],
+        }],
+    }
+    assert validate_osi_schema(doc)  # datatype enum violation
+
+
+def test_schema_engine_flags_non_ossie_forbidden_key():
+    # a relationship with a `cardinality` key is not Ossie — the schema forbids it
+    doc = {
+        "version": "0.2.0.dev0",
+        "semantic_model": [{
+            "name": "m",
+            "relationships": [{
+                "name": "r", "from": "a", "to": "b",
+                "from_columns": ["x"], "to_columns": ["y"], "cardinality": "many_to_one",
+            }],
+        }],
+    }
+    assert validate_osi_schema(doc)
+
+
+def test_engine_auto_uses_jsonschema_when_available():
+    # with jsonschema importable, auto routes to the schema engine
+    assert validate_osi(_DOC, engine="auto") == []
+
+
+def test_engine_unknown_raises():
+    with pytest.raises(ValueError, match="unknown engine"):
+        validate_osi(_DOC, engine="bogus")
+
+
+def test_default_engine_is_structural_unchanged():
+    # the default remains the dependency-free structural validator (byte-identical)
+    assert validate_osi(_DOC) == []

--- a/packages/python/goldenmatch/tests/test_semantic_catalog.py
+++ b/packages/python/goldenmatch/tests/test_semantic_catalog.py
@@ -1,0 +1,93 @@
+"""Tests for live catalog write-back (write_resolved_catalog)."""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.semantic import (
+    parse_cube_models,
+    parse_osi_models,
+    parse_semantic_models,
+    validate_osi,
+    write_resolved_catalog,
+)
+
+
+class _Crosswalk:
+    """Minimal ResolvedCrosswalk stand-in (the emitters duck-type these attrs)."""
+
+    source_pk_column = "customer_id"
+    resolved_key = "resolved_entity_id"
+    n_records = 12
+    n_entities = 11
+    reduction_ratio = 1 - 11 / 12
+
+
+def test_write_metricflow_catalog(tmp_path):
+    out = tmp_path / "customer_crosswalk.yml"
+    yaml_str = write_resolved_catalog(
+        _Crosswalk(), out, dialect="metricflow", source_target="orders",
+    )
+    assert out.exists()
+    written = out.read_text(encoding="utf-8")
+    assert written == yaml_str
+    # the persisted file parses back as a MetricFlow model declaring the resolved key
+    specs = parse_semantic_models(written)
+    assert specs and specs[0].key == ["resolved_entity_id"]
+
+
+def test_write_cube_catalog(tmp_path):
+    out = tmp_path / "crosswalk.cube.yml"
+    write_resolved_catalog(
+        _Crosswalk(), out, dialect="cube", source_target="orders",
+    )
+    cubes = parse_cube_models(out.read_text(encoding="utf-8"))
+    names = {c.name for c in cubes}
+    assert "crosswalk" in names and "orders" in names
+
+
+def test_write_osi_catalog_is_valid_osi(tmp_path):
+    out = tmp_path / "crosswalk.osi.yml"
+    write_resolved_catalog(
+        _Crosswalk(), out, dialect="osi", source_target="store_sales",
+    )
+    doc = out.read_text(encoding="utf-8")
+    assert validate_osi(doc) == []                 # written catalog is valid OSI
+    assert parse_osi_models(doc)                    # and round-trips
+
+
+def test_write_refuses_to_clobber_without_overwrite(tmp_path):
+    out = tmp_path / "c.yml"
+    out.write_text("existing", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        write_resolved_catalog(_Crosswalk(), out, dialect="osi", source_target="s")
+    assert out.read_text(encoding="utf-8") == "existing"   # untouched
+
+
+def test_write_overwrite_true_replaces(tmp_path):
+    out = tmp_path / "c.yml"
+    out.write_text("stale", encoding="utf-8")
+    write_resolved_catalog(
+        _Crosswalk(), out, dialect="osi", source_target="s", overwrite=True,
+    )
+    assert out.read_text(encoding="utf-8") != "stale"
+
+
+def test_write_creates_parent_dirs(tmp_path):
+    out = tmp_path / "models" / "sub" / "c.yml"
+    write_resolved_catalog(_Crosswalk(), out, dialect="metricflow", source_target="orders")
+    assert out.exists()
+
+
+def test_write_unknown_dialect_raises(tmp_path):
+    with pytest.raises(ValueError, match="unknown dialect"):
+        write_resolved_catalog(_Crosswalk(), tmp_path / "c.yml", dialect="looker", source_target="x")
+
+
+def test_write_forwards_emit_kwargs(tmp_path):
+    # metricflow emit accepts measures/grain — they must reach the emitter
+    out = tmp_path / "c.yml"
+    write_resolved_catalog(
+        _Crosswalk(), out, dialect="metricflow", source_target="orders",
+        measures=["revenue"], grain="order_date",
+    )
+    specs = parse_semantic_models(out.read_text(encoding="utf-8"))
+    assert specs[0].measures == ["revenue"]


### PR DESCRIPTION
## What and why

The final roadmap item (6/6) for the semantic-layer wedge — two closing features.

**Live catalog write-back.** The `emit_*_from_crosswalk` functions produce the
conformed entity declaration (the `resolved_entity_id` join a metric groups by) as
a YAML string; nothing persisted it. `write_resolved_catalog` is the last mile —
it writes that declaration to the catalog file the semantic layer reads, so
"resolve once, every metric inherits correct joins" lands as a file in the
dbt/MetricFlow, Cube, or OSI project.

**JSON-Schema OSI validation.** `validate_osi` was structural-only (a hand-rolled
walker). This adds a bundled JSON Schema formalizing the OSI/Ossie 0.2.0.dev0
contract and a `jsonschema`-backed validation path, without changing the default.

## Changes

- `goldenmatch/semantic/catalog.py` — `write_resolved_catalog(crosswalk, path, *,
  dialect, source_target, overwrite=False, **emit_kwargs)`: dispatches to the
  dialect emitter, refuses to clobber without `overwrite=True`, creates parent
  dirs, forwards emitter kwargs (`measures`/`grain`/`resolved_field`/...), returns
  the written YAML.
- `goldenmatch/semantic/osi_schema.json` — bundled draft-2020-12 schema encoding
  the OSI structural contract (required fields, datatype/dialect enums, expression
  shape, forbidden `foreign_key`/`cardinality`/`aggregation` keys), authored to
  mirror `validate_osi`.
- `osi.py`: `osi_json_schema()` loads the schema; `validate_osi_schema(source)`
  validates via the optional `jsonschema`; `validate_osi(source, engine=...)` gains
  `"structural"` (default, byte-identical), `"jsonschema"`, and `"auto"` (jsonschema
  when importable, else structural fallback). `jsonschema` stays optional.
- Public exports + CHANGELOG; regenerated the agent codemap for the new symbols.

## Testing

- `python -m pytest tests/test_semantic_catalog.py tests/test_osi.py` → 26 passed (write-back per dialect incl. valid-OSI round-trip, clobber guard, overwrite, parent-dir creation, kwarg forwarding; schema loads, agrees with structural on valid docs, flags missing-required / bad-enum / forbidden-key, engine routing + fallback).
- `python -m pytest tests/test_certify_semantic_model.py tests/test_metric_aware_resolution.py tests/test_resolved_crosswalk.py tests/test_key_integrity.py` → 39 passed (no regression).
- `scripts/agent_codemap.py --write` + `scripts/test_agent_codemap.py` → green. `ruff check` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] No new CLI/MCP/A2A surface (library functions only); codemap regenerated, MCP/CLI-keyed artifacts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_