### PR TITLE
feat(semantic): certify_serving_joins - a Customer 360 view can't double-count (C360 arc C)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7289,11 +7289,14 @@
           "file": "packages/python/goldenmatch/goldenmatch/semantic/serving.py",
           "purpose": "Semantic-layer ↔ Customer 360 drill-through.",
           "defines": [
+            "ServingJoinCertificate",
+            "certify_serving_joins",
             "entity_360",
             "profile_from_crosswalk"
           ],
           "imports": [
-            "goldenmatch.identity"
+            "goldenmatch.identity",
+            "goldenmatch.semantic.key_integrity"
           ]
         },
         {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -70,6 +70,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   the strict path. The `goldenmatch_key_integrity` dbt test gained a matching
   `grain_strict` argument in lockstep so the SQL test and this capability stay
   semantically identical.
+- **Certify the keys a Customer 360 serving layer joins on.**
+  `goldenmatch.semantic.certify_serving_joins(store, *, dataset=None, ...)` walks
+  the durable Identity Store and runs `certify_key_integrity` over the
+  source-record join key (`record_id` = `{source}:{source_pk}`) a Customer 360 view
+  rolls metrics up on — turning the serving layer's implicit join-key trust into an
+  advisory `KeyIntegrityCertificate`, so a metric joined through the 360 provably
+  can't double-count. Returns a `ServingJoinCertificate` (record certificate +
+  entity/record counts + `truncated` when a `max_entities` cap applies).
 
 ### Changed
 - **FS dedupe: Arrow-native columnar-cluster path (B2c), default-on (#1811/#2006).**

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -68,7 +68,12 @@ from goldenmatch.semantic.osi import (
     validate_osi,
     validate_osi_schema,
 )
-from goldenmatch.semantic.serving import entity_360, profile_from_crosswalk
+from goldenmatch.semantic.serving import (
+    ServingJoinCertificate,
+    certify_serving_joins,
+    entity_360,
+    profile_from_crosswalk,
+)
 
 __all__ = [
     # zero-config front door — certify a whole semantic model (any dialect)
@@ -98,6 +103,9 @@ __all__ = [
     # Customer 360 drill-through — resolved key -> the whole customer view
     "profile_from_crosswalk",
     "entity_360",
+    # certify the keys a Customer 360 serving layer joins on
+    "certify_serving_joins",
+    "ServingJoinCertificate",
     # wedge C — OSI / Apache Ossie native provider (bidirectional)
     "parse_osi_models",
     "osi_join_keys",

--- a/packages/python/goldenmatch/goldenmatch/semantic/serving.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/serving.py
@@ -9,10 +9,39 @@ timeline + relationship neighborhood) with zero key translation.
 
 `entity_360(store_path, entity_id)` is the direct read; `profile_from_crosswalk`
 is the drill-through: a source primary key → its resolved entity → the 360 page.
+
+`certify_serving_joins(store)` closes the loop the other way: a Customer 360
+serving view is itself a join surface (golden record ⋈ source records ⋈ events ⋈
+relationships, all on the durable `entity_id` / `record_id`), so it carries the
+same fan-out / double-count risk `certify_key_integrity` was built to catch. It
+certifies that the serving layer's source-record join key is unique — so a metric
+joined through the 360 provably can't double-count.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
+
+
+@dataclass
+class ServingJoinCertificate:
+    """Certifies the join keys a Customer 360 serving layer rolls metrics up on.
+
+    `record_certificate` is a `KeyIntegrityCertificate` over the source-record
+    join key (`record_id` = `{source}:{source_pk}`): unique means a fact joined to
+    source records and rolled up to the entity can't double-count. `n_entities` /
+    `n_records` are the population it was computed over; `truncated` is True when a
+    `max_entities` cap stopped the scan short (so the cert covers a prefix).
+    """
+
+    record_certificate: Any            # KeyIntegrityCertificate
+    n_entities: int
+    n_records: int
+    truncated: bool = False
+
+    @property
+    def is_trustworthy(self) -> bool:
+        return bool(self.record_certificate.is_trustworthy())
 
 
 def entity_360(
@@ -92,4 +121,74 @@ def profile_from_crosswalk(
         entity_id,
         include_relationships=include_relationships,
         timeline_limit=timeline_limit,
+    )
+
+
+def certify_serving_joins(
+    store: Any,
+    *,
+    dataset: str | None = None,
+    status: str | None = "active",
+    page_size: int = 500,
+    max_entities: int | None = None,
+) -> ServingJoinCertificate:
+    """Certify that a Customer 360 serving layer's join keys don't double-count.
+
+    A C360 view joins the golden record to its source records (and events /
+    relationships) on the durable `entity_id`, and a dashboard typically joins a
+    fact table to those source records on `record_id` (`{source}:{source_pk}`)
+    before rolling up to the entity. If a `record_id` is duplicated, that roll-up
+    silently double-counts. This walks the store's active entities, assembles the
+    `record_id` join key across their source records, and runs
+    `certify_key_integrity` over it — turning the serving layer's implicit
+    join-key trust into an advisory `KeyIntegrityCertificate`.
+
+    Args:
+        store: an open `IdentityStore`.
+        dataset: restrict to one identity-graph dataset (default: all).
+        status: entity status to include (default `"active"`; None = all).
+        page_size: pagination size for the entity scan.
+        max_entities: cap the scan at this many entities (the cert then covers a
+            prefix and sets `truncated=True`); None scans every entity.
+
+    Returns:
+        A `ServingJoinCertificate` whose `record_certificate.is_trustworthy()` is
+        True when every source record has a unique join key.
+    """
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    record_ids: list[str] = []
+    entity_ids: list[str] = []
+    offset = 0
+    truncated = False
+    while True:
+        limit = page_size
+        if max_entities is not None:
+            remaining = max_entities - len(entity_ids)
+            if remaining <= 0:
+                truncated = True
+                break
+            limit = min(page_size, remaining)
+        nodes = store.list_identities(
+            dataset=dataset, status=status, limit=limit, offset=offset
+        )
+        if not nodes:
+            break
+        for node in nodes:
+            entity_ids.append(node.entity_id)
+            for rec in store.get_records_for_entity(node.entity_id):
+                record_ids.append(rec.record_id)
+        offset += len(nodes)
+        if len(nodes) < limit:
+            break
+
+    # certify_key_integrity needs at least one row; an empty store is trivially
+    # trustworthy (no records means nothing can double-count).
+    table = {"record_id": record_ids or [None]}
+    cert = certify_key_integrity(table, key="record_id")
+    return ServingJoinCertificate(
+        record_certificate=cert,
+        n_entities=len(entity_ids),
+        n_records=len(record_ids),
+        truncated=truncated,
     )

--- a/packages/python/goldenmatch/tests/test_semantic_serving.py
+++ b/packages/python/goldenmatch/tests/test_semantic_serving.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 from goldenmatch.identity import IdentityNode, IdentityStore, SourceRecord, new_entity_id
-from goldenmatch.semantic import entity_360, profile_from_crosswalk
+from goldenmatch.semantic import (
+    ServingJoinCertificate,
+    certify_serving_joins,
+    entity_360,
+    profile_from_crosswalk,
+)
 from goldenmatch.semantic.crosswalk import ResolvedCrosswalk
 
 
@@ -72,3 +77,46 @@ def test_profile_from_crosswalk_requires_a_store(seeded):
     # ...but an explicit store_path override works
     page = profile_from_crosswalk(ephemeral, "1", store_path=xw.store_path)
     assert page is not None and page["entity_id"] == eid
+
+
+# --- certify_serving_joins (PR-C) ---------------------------------------------
+
+
+def test_certify_serving_joins_clean(tmp_path):
+    # 3 distinct source records across 2 entities -> unique record_id -> trustworthy
+    path = str(tmp_path / "id.db")
+    e1, e2 = new_entity_id(), new_entity_id()
+    with IdentityStore(path=path) as s:
+        s.upsert_identity(IdentityNode(entity_id=e1, dataset="crm", confidence=0.9))
+        s.upsert_identity(IdentityNode(entity_id=e2, dataset="crm", confidence=0.9))
+        s.upsert_record(SourceRecord("crm:1", "crm", "1", "h1", entity_id=e1, dataset="crm"))
+        s.upsert_record(SourceRecord("crm:2", "crm", "2", "h2", entity_id=e1, dataset="crm"))
+        s.upsert_record(SourceRecord("crm:3", "crm", "3", "h3", entity_id=e2, dataset="crm"))
+        cert = certify_serving_joins(s, dataset="crm")
+    assert isinstance(cert, ServingJoinCertificate)
+    assert cert.n_entities == 2
+    assert cert.n_records == 3
+    assert cert.is_trustworthy is True
+    assert cert.record_certificate.duplicate_key_groups == 0
+
+
+def test_certify_serving_joins_empty_store_is_trustworthy(tmp_path):
+    path = str(tmp_path / "id.db")
+    with IdentityStore(path=path) as s:
+        cert = certify_serving_joins(s)
+    assert cert.n_entities == 0
+    assert cert.n_records == 0
+    assert cert.is_trustworthy is True
+
+
+def test_certify_serving_joins_respects_max_entities(tmp_path):
+    path = str(tmp_path / "id.db")
+    with IdentityStore(path=path) as s:
+        for i in range(5):
+            eid = new_entity_id()
+            s.upsert_identity(IdentityNode(entity_id=eid, dataset="crm", confidence=0.9))
+            s.upsert_record(SourceRecord(f"crm:{i}", "crm", str(i), f"h{i}",
+                                         entity_id=eid, dataset="crm"))
+        cert = certify_serving_joins(s, dataset="crm", page_size=2, max_entities=3)
+    assert cert.n_entities == 3          # capped
+    assert cert.truncated is True


### PR DESCRIPTION
## What and why

Final item of the Customer 360 integration arc. A Customer 360 serving view is
itself a join surface — the golden record joins source records / events /
relationships on the durable `entity_id`, and a dashboard joins a fact table to
those source records on `record_id` (`{source}:{source_pk}`) before rolling up to
the entity. That carries the exact fan-out / double-count risk
`certify_key_integrity` was built to catch, but nothing certified it. This closes
the loop.

## Changes

- `goldenmatch.semantic.certify_serving_joins(store, *, dataset=None, status="active",
  page_size=500, max_entities=None)`: walks the durable Identity Store, assembles
  the source-record join key (`record_id`) across entities, and runs
  `certify_key_integrity` over it — turning the serving layer's implicit join-key
  trust into an advisory `KeyIntegrityCertificate`. A duplicate `record_id` means a
  metric joined through the 360 would double-count.
- `ServingJoinCertificate` dataclass: the record certificate + `n_entities` /
  `n_records` population + `truncated` (set when a `max_entities` cap covers only a
  prefix) + an `is_trustworthy` passthrough.
- Backend-agnostic (uses the public `list_identities` + `get_records_for_entity`,
  so it works on SQLite / Postgres / Mongo). Library function only; codemap
  regenerated.

## Testing

- `python -m pytest tests/test_semantic_serving.py` → 8 passed (clean store → trustworthy + zero duplicate key groups; empty store trivially trustworthy; `max_entities` cap → `truncated`).
- `scripts/test_agent_codemap.py` → green. `ruff check` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated (entry at the bottom of `Added` to avoid merge-queue top-insert contention)
- [x] No secrets, tokens, or `.env` files committed
- [x] No new CLI/MCP/A2A surface (library function only); codemap regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_