### PR TITLE
feat(er-matcher): distilled band-override scorer — spec, plan + Phase 0 harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3949,7 +3949,10 @@ jobs:
       - name: Sync workspace (goldenmatch importable + dev tools)
         run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: ER-matcher box-safe tests
-        run: uv run pytest scripts/er_matcher/ -q
+        # --with scikit-learn: the band_student harness (Phase 0 of the distilled
+        # band-override scorer) trains a GBDT; sklearn is an offline-only dep not in
+        # the workspace, added ephemerally here so its test RUNS (not skips).
+        run: uv run --with scikit-learn pytest scripts/er_matcher/ -q
         env:
           GOLDENMATCH_NATIVE: "0"
           POLARS_SKIP_CPU_CHECK: "1"

--- a/docs/superpowers/plans/2026-07-31-distilled-band-override-scorer-plan.md
+++ b/docs/superpowers/plans/2026-07-31-distilled-band-override-scorer-plan.md
@@ -1,0 +1,57 @@
+# Plan: distilled band-override scorer
+
+- **Spec:** `docs/superpowers/specs/2026-07-31-distilled-band-override-scorer-design.md`
+- **Date:** 2026-07-31
+- **Posture:** validation-first. Each phase is committable + reversible; the runtime
+  path stays behind an opt-in flag until the gates pass. We train + ship; users consume.
+
+## Phase 0 — offline harness (THIS phase; also the generalization-gate machinery)
+
+Turn the scratchpad probes into a real, tested in-repo harness under
+`scripts/er_matcher/band_student/`. This is what runs the gates AND the foundation
+the runtime kernel later consumes.
+
+- **`features.py`** — `band_features(row_a, row_b, fields, fs_score)`: generic
+  comparison-feature vector `[jaro_winkler, token_sort, exact, both_present]` per
+  field + the FS score. Order-invariant, domain-agnostic (the transfer thesis).
+- **`student.py`** — `BandStudent` wrapping a GBDT (`HistGradientBoostingClassifier`);
+  `fit` / `predict` / `save_json` / `load_json`. (Portable export = Phase 2.)
+- **`evaluate.py`** — `distillation_fidelity` (student-vs-teacher, student-vs-gold)
+  + `end_to_end_override` (best-threshold pair-F1 over a fixed candidate universe,
+  band pairs overridden). Reproduces historical_50k: ceiling 0.967 / distill 0.880 /
+  e2e +3.1–4.8.
+- **`test_band_student.py`** — self-contained SYNTHETIC test (no external dataset):
+  build a tiny separable band, assert train→predict→eval runs + the override never
+  regresses a confident-FS no-op case. Deterministic, CI-safe.
+- **TDD:** failing test (feature shape + override no-op) → impl → commit.
+
+## Phase 1 — runtime scorer (opt-in, Python v0)
+
+- `core/band_student.py` runtime loader + `score_buckets` hook: on band pairs
+  (adaptive window around the operating threshold), predict with the pinned student;
+  else FS. Env-gated `GOLDENMATCH_BAND_STUDENT=1`, default OFF, byte-identical when off.
+- Cluster-level F1 measured here (**gate #2**) — plug the override into the live
+  pipeline + re-cluster, not just candidate-set pair-F1.
+
+## Phase 2 — pinned distribution (we train, users consume)
+
+- Train centrally on a diverse corpus (synthetic + eval-only, the 1.5B posture);
+  serialize to a PORTABLE format; register + pin (url + sha256) like
+  `core/er_matcher/registry.py`. `resolve_band_student()` downloads + verifies.
+- Modal/CI training workflow (teacher = the 1.5B, offline).
+
+## Phase 3 — score-core kernel + parity (perf + closure)
+
+- Reimplement student inference in `score-core` (Rust) → native/WASM/TS parity
+  fixtures, quantized/deterministic — the "one kernel, all surfaces" thesis.
+- NNUE-style per-record accumulator (block-N² reuse + streaming edits).
+
+## Validation gates (spec §Open questions) — block default-on
+
+1. **Transfer** (load-bearing): diverse-train / held-out-hard eval + schema
+   normalization + CI transfer-panel. 2. Cluster-level F1. 3. Calibration.
+   4. Label-budget curve. 5. Explainability (feature attribution).
+
+## Non-goals
+
+Replacing zero-config FS (opt-in tier); any query-time model (offline teacher only).

--- a/docs/superpowers/specs/2026-07-31-distilled-band-override-scorer-design.md
+++ b/docs/superpowers/specs/2026-07-31-distilled-band-override-scorer-design.md
@@ -1,0 +1,132 @@
+# Design: distilled band-override scorer (local LLM → µs student)
+
+- **Date:** 2026-07-31
+- **Status:** DRAFT (design proposal from the FS + local-LLM investigation, 2026-07-30/31)
+- **Related:** `core/_llm_loader.py` (local ER-matcher, PR #2288 shipped the 1.5B),
+  `core/er_matcher/*`, `core/probabilistic.py` (`estimate_m_from_labels`),
+  `core/llm_scorer.py` (`provider="local"` boost), `score_buckets` / score-core kernels.
+
+## Problem
+
+Fellegi-Sunter resolves the bulk of ER **fully locally** — on `historical_50k`,
+**0.93 pair-F1 at recall 1.0**, CPU + native Rust kernels, no LLM/GPU/API. That
+is the product's moat. But FS is a **linear model with a conditional-independence
+assumption**, so on hard/corrupted data (no clean identifier) it leaves a residual
+**uncertain band** it cannot separate — measured on `historical_50k` at scores
+[0.55, 0.65], where FS's per-threshold accuracy is only ~0.64–0.71 and its
+false-positives cap precision.
+
+The shipped local-LLM boost (`provider="local"`, the 1.5B) *is* accurate on that
+band (measured **0.885**, 97% label-precision on its match calls) — but at
+**~3.9 s/pair on 4-core CPU**, and the band is ~67k pairs / ~42k distinct
+(only 1.6× compressible), a **live** per-pair LLM boost is **~70 hours**.
+Impractical. Latency micro-opts (grammar-constrained output, threads=physical,
+prefix cache) give ~3–5×; the workload needs ~10,000×.
+
+## What was ruled out (measured, 2026-07-30/31)
+
+1. **Global FS refit** (`estimate_m_from_labels` on band labels): **neutral-to-harmful.**
+   Even a *perfect oracle* labeler via iterative refit could not beat baseline
+   (0.927 → 0.913). Labeling only the band gives an **unrepresentative** sample —
+   hard positives bias `m` pessimistic, hard negatives bias `u` high (the pos+neg
+   variant collapsed recall 0.83 → 0.50). FS's model class can't absorb the band's
+   nonlinear field interactions by re-estimating m/u.
+2. **Live per-pair LLM at query time:** perf-impossible at scale (above).
+
+## Proposal: distill the LLM's band judgment into a µs CPU student
+
+**We train, users consume.** The teacher (LLM) and the distillation run **once, in
+OUR pipeline** — never at the user's end. We ship the trained student as a **pinned
+artifact** (weights + sha256, exactly like the 1.5B GGUF registry in
+`core/er_matcher/registry.py`). Users get a fast, accurate, fully-local band-override
+scorer **out of the box — no labeling, no training, no LLM dependency at all.** This
+is the same distribution model as the 1.5B itself (trained centrally on synthetic +
+eval-only data, pinned, consumed zero-config).
+
+**Teacher offline (ours), student online (theirs).** The LLM labels a band sample
+during our training; a **small quantized student** — a GBDT or NNUE-style pair-head
+over comparison features — reproduces those verdicts and serves the band **override**
+at query time in the score-core kernel, fully local.
+
+- **Override, not refit.** The student *replaces FS's decision on the band pairs
+  only*; non-band pairs keep FS. This sidesteps the unrepresentative-sample failure
+  (it's a local classifier, not a global re-estimate).
+- **Nonlinear.** A small tree/MLP expresses the field-interaction correlations FS's
+  linear/conditional-independence model can't — the actual headroom.
+
+### Measured evidence (`historical_50k`)
+
+- **Ceiling (features suffice):** GBDT on comparison features, gold labels, 5-fold CV
+  → **band accuracy 0.959 / F1 0.967** (vs LLM 0.885, FS 0.64–0.71), at **2.86 µs/pair**
+  (~1.4M× faster than the 1.5B).
+- **Distillation (deployable):** student trained on the **1.5B's 600 labels**
+  (not gold) → **0.880 vs ground truth ≈ matches the teacher (0.885)**.
+- **End-to-end dedupe F1 (fixed candidate universe):**
+  - baseline (FS): P 0.971 / R 0.834 / **F1 0.897**
+  - override, 1.5B-labeled student: P 0.971 / R 0.889 / **F1 0.928 (+0.031)**
+  - override, gold-ceiling student: P 0.973 / R 0.920 / **F1 0.945 (+0.048)**
+  The gain is recall: FS scored true matches in the band below its operating
+  threshold; the student promotes them, precision held.
+
+## Architecture
+
+1. **Feature extractor** (dataset-agnostic): per matchkey field, `[jaro_winkler,
+   token_sort, exact, both_present]` + the FS score. Same comparison primitives the
+   scorer already computes — reuse `core/scorer` / score-core, no new math.
+2. **Student model:** start with GBDT (portable, tiny, fast to train); NNUE-style
+   quantized pair-head is the follow-on for a pure-integer score-core kernel with an
+   **incrementally-updatable per-record accumulator** (embed each record once, reuse
+   across a block's N² pairs; O(changed-fields) update on streaming edits — maps onto
+   `match_one` / `add_to_cluster` / incremental identity #1109).
+3. **Training pipeline (OURS, offline):** teacher (the 1.5B or a bigger GPU teacher)
+   labels a band sample over a **diverse corpus** (synthetic + benchmark ER, the
+   1.5B's own training-data posture: fully synthetic + eval-only restricted sets) →
+   train student → serialize + pin (weights + sha256, registered like the GGUF). The
+   student learns a domain-agnostic *"how to combine comparison signals"* rule, not
+   entities — which is what lets a centrally-trained artifact transfer to users' data.
+   Runs in CI/Modal, never at the user's end.
+4. **Runtime (online):** `score_buckets` / FS path routes band pairs (score in an
+   adaptive window around the operating threshold) through the student kernel; else FS.
+   The student is a **score-core kernel** — single-sourced Rust → native/WASM/TS,
+   quantized/deterministic, with parity fixtures like every other scorer.
+
+## Integration & scope
+
+- **Shipped, pre-trained, zero-config — users do NOT train it.** We train the student
+  centrally and ship it pinned; users just consume it, fully local, no LLM/labels at
+  their end. It can be default-on once the generalization gate (below) passes, exactly
+  like the noise-aware scorer or FS-autoconfig-v2 defaults — not a "bring your labels"
+  tier.
+- **Additive / safe.** Where FS is already confident (clean identifiers → no band —
+  confirmed no-op on febrl3/synthetic), the override does nothing.
+- **Generalization is the load-bearing requirement,** not a caveat: a centrally-trained
+  student must transfer to unseen user data. This is tractable because the inputs are
+  **generic comparison features**, not raw entities — but it needs **schema
+  normalization** (map any dataset's fields into a fixed, order-invariant feature space)
+  and possibly a **small family of per-domain students** (person / product / biblio,
+  mirroring the domain packs).
+
+## Open questions / validation gates (before any default-on)
+
+1. **Generalization / transfer (THE gate — because we ship one trained artifact).**
+   A centrally-trained student must lift F1 on datasets it was NOT trained on. The
+   +3–5 is one dataset (`historical_50k`); febrl3/synthetic are *solved* (no band →
+   no-op, confirmed). Required: (a) **train on a diverse corpus, evaluate held-out** —
+   messy real data (NCVR, product ER with entity truth); (b) **schema normalization**
+   so any field layout maps into the student's fixed feature space; (c) full-candidate-set
+   extraction (pre-review-cut FS scores; the public `dedupe_df().scored_pairs` exposes
+   only emitted matches on cleanly-separated data). → CI transfer-panel gate before
+   default-on.
+2. **Cluster-level F1**, not just candidate-set pair-F1 (plug the student as a live
+   band override and re-cluster).
+3. **Calibration** of the student score to a threshold/posterior (Platt/temperature)
+   — FS gives a principled posterior; the student needs one.
+4. **Label budget vs gain:** deployable +3.1 vs ceiling +4.8 → more/better teacher
+   labels close some gap; quantify the curve.
+5. **Explainability:** FS has per-field lineage; the student needs a feature-attribution
+   surface to honor "never black-box" (NNUE accumulator contributions are inspectable).
+
+## Non-goals
+
+- Replacing zero-config FS (this is an opt-in tier).
+- Running any model at query time (the whole point is offline teacher → µs student).

--- a/scripts/er_matcher/band_student/__init__.py
+++ b/scripts/er_matcher/band_student/__init__.py
@@ -1,0 +1,25 @@
+"""Offline harness for the distilled band-override scorer (spec/plan 2026-07-31).
+
+We (goldenmatch) train the student centrally from an LLM teacher's band labels and
+ship it pinned; users consume it zero-config, fully local. This package is the
+OFFLINE training + gate-evaluation harness (not the shipped runtime).
+"""
+from .evaluate import (
+    FidelityResult,
+    OverrideResult,
+    distillation_fidelity,
+    end_to_end_override,
+)
+from .features import band_features, feature_names, field_features
+from .student import BandStudent
+
+__all__ = [
+    "band_features",
+    "feature_names",
+    "field_features",
+    "BandStudent",
+    "distillation_fidelity",
+    "end_to_end_override",
+    "FidelityResult",
+    "OverrideResult",
+]

--- a/scripts/er_matcher/band_student/evaluate.py
+++ b/scripts/er_matcher/band_student/evaluate.py
@@ -1,0 +1,86 @@
+"""Gate metrics for the band-override student.
+
+- ``distillation_fidelity``: student-vs-teacher agreement + student-vs-gold accuracy
+  (the deployable number; teacher-vs-gold is the ceiling context).
+- ``end_to_end_override``: best-threshold pair-F1 over a FIXED candidate universe,
+  with band pairs' FS decision replaced by the student's. Reproduces the
+  historical_50k +3.1/+4.8 result. FS everywhere else -> the delta isolates the
+  band override.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FidelityResult:
+    student_vs_gold: float
+    student_vs_teacher: float
+    teacher_vs_gold: float
+    n: int
+
+
+def distillation_fidelity(student_pred, teacher_labels, gold_labels) -> FidelityResult:
+    sp = np.asarray(student_pred)
+    tl = np.asarray(teacher_labels)
+    gl = np.asarray(gold_labels)
+    return FidelityResult(
+        student_vs_gold=float((sp == gl).mean()),
+        student_vs_teacher=float((sp == tl).mean()),
+        teacher_vs_gold=float((tl == gl).mean()),
+        n=int(sp.shape[0]),
+    )
+
+
+@dataclass(frozen=True)
+class OverrideResult:
+    threshold: float
+    precision: float
+    recall: float
+    f1: float
+
+
+def _best_f1(decision_for, universe_keys, gold, base_score, band_decision) -> OverrideResult:
+    """Sweep the non-band FS threshold; band keys take the student decision."""
+    P_total = int(sum(gold.values()))
+    best = OverrideResult(0.0, 0.0, 0.0, 0.0)
+    for ti in range(30, 96):
+        T = ti / 100.0
+        tp = fp = 0
+        for k in universe_keys:
+            if k in band_decision:
+                pred = band_decision[k]
+            else:
+                pred = 1 if base_score[k] >= T else 0
+            if pred:
+                if gold[k]:
+                    tp += 1
+                else:
+                    fp += 1
+        rec = tp / P_total if P_total else 0.0
+        prec = tp / (tp + fp) if (tp + fp) else 0.0
+        f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+        if f1 > best.f1:
+            best = OverrideResult(T, prec, rec, f1)
+    return best
+
+
+def end_to_end_override(
+    *,
+    gold: Mapping,
+    base_score: Mapping,
+    band_decision: Mapping,
+) -> tuple[OverrideResult, OverrideResult]:
+    """Return (baseline, override) best-F1 over the same fixed universe.
+
+    ``gold``/``base_score`` are keyed by canonical pair over the full candidate
+    universe; ``band_decision`` maps the band subset -> the student's 0/1 call.
+    Baseline = FS everywhere (empty band_decision); override = student on the band.
+    """
+    keys = list(gold)
+    baseline = _best_f1(None, keys, gold, base_score, {})
+    override = _best_f1(None, keys, gold, base_score, dict(band_decision))
+    return baseline, override

--- a/scripts/er_matcher/band_student/features.py
+++ b/scripts/er_matcher/band_student/features.py
@@ -1,0 +1,60 @@
+"""Generic comparison-feature extractor for the band-override student.
+
+Domain-agnostic by design (the transfer thesis): the student learns *how to
+combine similarity signals*, not entities. For each shared field we emit
+[jaro_winkler, token_sort, exact, both_present]; plus the FS score. This fixed,
+order-invariant vector is what lets a centrally-trained student transfer to
+unseen user data (spec 2026-07-31).
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from rapidfuzz.distance import JaroWinkler
+from rapidfuzz.fuzz import token_sort_ratio
+
+# Per-field feature names (documented so the vector layout is stable + inspectable).
+PER_FIELD = ("jw", "token_sort", "exact", "both_present")
+
+
+def field_features(a: str, b: str) -> list[float]:
+    """The 4 per-field comparison signals for two cell values."""
+    a = a or ""
+    b = b or ""
+    return [
+        JaroWinkler.normalized_similarity(a, b),
+        token_sort_ratio(a, b) / 100.0,
+        1.0 if a and b and a == b else 0.0,
+        1.0 if a and b else 0.0,
+    ]
+
+
+def band_features(
+    row_a: Mapping[str, Any],
+    row_b: Mapping[str, Any],
+    fields: Sequence[str],
+    fs_score: float,
+) -> list[float]:
+    """Full feature vector for a candidate pair: per-field signals + FS score.
+
+    ``fields`` fixes the layout; a missing key reads as empty (both_present=0),
+    so schema normalization = agreeing on ``fields`` across datasets.
+    """
+    vec: list[float] = []
+    for f in fields:
+        vec.extend(field_features(_cell(row_a, f), _cell(row_b, f)))
+    vec.append(float(fs_score))
+    return vec
+
+
+def feature_names(fields: Sequence[str]) -> list[str]:
+    """Human-readable name per feature dimension (for explainability / attribution)."""
+    names = [f"{f}.{p}" for f in fields for p in PER_FIELD]
+    names.append("fs_score")
+    return names
+
+
+def _cell(row: Mapping[str, Any], field: str) -> str:
+    v = row.get(field)
+    return "" if v is None else str(v)

--- a/scripts/er_matcher/band_student/student.py
+++ b/scripts/er_matcher/band_student/student.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import numpy as np
-from sklearn.ensemble import HistGradientBoostingClassifier
+
+if TYPE_CHECKING:
+    from sklearn.ensemble import HistGradientBoostingClassifier
 
 
 @dataclass
@@ -28,6 +31,10 @@ class BandStudent:
     _clf: HistGradientBoostingClassifier | None = field(default=None, repr=False)
 
     def fit(self, X: Sequence[Sequence[float]], y: Sequence[int]) -> BandStudent:
+        # Lazy import: the package must import without sklearn (offline dep) so
+        # pytest collection never hard-fails where the harness isn't exercised.
+        from sklearn.ensemble import HistGradientBoostingClassifier
+
         self._clf = HistGradientBoostingClassifier(
             max_iter=self.max_iter, max_depth=self.max_depth,
             learning_rate=self.learning_rate, l2_regularization=self.l2,

--- a/scripts/er_matcher/band_student/student.py
+++ b/scripts/er_matcher/band_student/student.py
@@ -1,0 +1,62 @@
+"""The band-override student: a small GBDT over comparison features.
+
+Trained OFFLINE (ours) on teacher (LLM) or gold labels; it OVERRIDES FS on the
+uncertain band only. Small + nonlinear — it expresses the field-interaction
+correlations FS's linear/conditional-independence model can't (spec 2026-07-31).
+Portable-format export for the shipped artifact is Phase 2; here we keep the
+sklearn estimator for the offline harness + gate runs.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingClassifier
+
+
+@dataclass
+class BandStudent:
+    """A trained band classifier. ``fields`` fixes the feature layout it expects."""
+
+    fields: list[str]
+    max_iter: int = 200
+    max_depth: int = 4
+    learning_rate: float = 0.1
+    l2: float = 1.0
+    seed: int = 0
+    _clf: HistGradientBoostingClassifier | None = field(default=None, repr=False)
+
+    def fit(self, X: Sequence[Sequence[float]], y: Sequence[int]) -> BandStudent:
+        self._clf = HistGradientBoostingClassifier(
+            max_iter=self.max_iter, max_depth=self.max_depth,
+            learning_rate=self.learning_rate, l2_regularization=self.l2,
+            random_state=self.seed,
+        )
+        self._clf.fit(np.asarray(X, dtype=np.float32), np.asarray(y))
+        return self
+
+    def predict(self, X: Sequence[Sequence[float]]) -> np.ndarray:
+        """Binary match decisions (1=match) for the given feature rows."""
+        return self._estimator().predict(np.asarray(X, dtype=np.float32))
+
+    def predict_proba(self, X: Sequence[Sequence[float]]) -> np.ndarray:
+        """P(match) — for calibration (gate #3) + threshold tuning."""
+        return self._estimator().predict_proba(np.asarray(X, dtype=np.float32))[:, 1]
+
+    def save(self, path: str) -> None:
+        import joblib
+        joblib.dump({"fields": self.fields, "clf": self._estimator()}, path)
+
+    @classmethod
+    def load(cls, path: str) -> BandStudent:
+        import joblib
+        blob = joblib.load(path)
+        s = cls(fields=list(blob["fields"]))
+        s._clf = blob["clf"]
+        return s
+
+    def _estimator(self) -> HistGradientBoostingClassifier:
+        if self._clf is None:
+            raise RuntimeError("BandStudent is not fitted; call fit() or load() first.")
+        return self._clf

--- a/scripts/er_matcher/band_student/test_band_student.py
+++ b/scripts/er_matcher/band_student/test_band_student.py
@@ -1,0 +1,95 @@
+"""Self-contained tests for the band-override harness (Phase 0).
+
+No external datasets — a tiny synthetic band the FS threshold provably CAN'T
+separate (constant FS score inside the band) but the student can. Locks the
+harness contract: feature layout, distillation, and that the override improves
+end-to-end F1 while being a strict no-op when the band decision is empty.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("sklearn")
+
+# scripts/er_matcher on the path so `import band_student` (the package) resolves,
+# mirroring test_train_helpers.py's self-managed sys.path.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from band_student import (  # noqa: E402
+    BandStudent,
+    band_features,
+    distillation_fidelity,
+    end_to_end_override,
+    feature_names,
+)
+
+FIELDS = ["name", "dob"]
+
+
+def _universe():
+    """Build rows + a candidate universe: 100 band pairs (constant FS 0.6, 60/40
+    true/false, separable on name) + confident matches (FS .95) + non-matches (.3)."""
+    rows, band, gold, base = {}, [], {}, {}
+    rid = 0
+
+    def add(name_a, dob_a, name_b, dob_b, is_match, fs, band_pair):
+        nonlocal rid
+        a, b = rid, rid + 1
+        rid += 2
+        rows[a] = {"name": name_a, "dob": dob_a}
+        rows[b] = {"name": name_b, "dob": dob_b}
+        key = (a, b)
+        gold[key] = 1 if is_match else 0
+        base[key] = fs
+        if band_pair:
+            band.append(key)
+        return key
+
+    for i in range(60):  # band, true: identical name+dob, but FS is uncertain (0.6)
+        add(f"person {i}", "1990-01-01", f"person {i}", "1990-01-01", True, 0.60, True)
+    for i in range(40):  # band, false: dissimilar name, FS still 0.6
+        add(f"aaaa {i}", "1990-01-01", f"zzzz {i}", "1975-12-31", False, 0.60, True)
+    for i in range(50):  # confident matches (not overridden)
+        add(f"m {i}", "2000-05-05", f"m {i}", "2000-05-05", True, 0.95, False)
+    for i in range(50):  # confident non-matches
+        add(f"p {i}", "1", f"q {i}", "2", False, 0.30, False)
+    return rows, band, gold, base
+
+
+def test_feature_layout():
+    v = band_features({"name": "a", "dob": "x"}, {"name": "a", "dob": "y"}, FIELDS, 0.6)
+    assert len(v) == len(FIELDS) * 4 + 1
+    assert v[-1] == pytest.approx(0.6)
+    assert feature_names(FIELDS)[-1] == "fs_score"
+    assert feature_names(FIELDS)[:4] == ["name.jw", "name.token_sort", "name.exact", "name.both_present"]
+
+
+def test_distillation_and_override():
+    rows, band, gold, base = _universe()
+    X = [band_features(rows[a], rows[b], FIELDS, base[(a, b)]) for a, b in band]
+    y_gold = [gold[k] for k in band]
+    # teacher labels: gold with a couple of flips (simulate an imperfect teacher)
+    y_teacher = list(y_gold)
+    y_teacher[0] = 1 - y_teacher[0]
+    y_teacher[-1] = 1 - y_teacher[-1]
+
+    student = BandStudent(fields=FIELDS).fit(X, y_teacher)
+    pred = student.predict(X)
+
+    fid = distillation_fidelity(pred, y_teacher, y_gold)
+    assert fid.n == len(band)
+    assert fid.student_vs_gold >= 0.9  # distilled student recovers the true separation
+
+    band_decision = {k: int(p) for k, p in zip(band, pred)}
+    baseline, override = end_to_end_override(gold=gold, base_score=base, band_decision=band_decision)
+    assert override.f1 > baseline.f1 + 0.05  # the band override lifts end-to-end F1
+    assert baseline.recall <= override.recall  # gain is recovered band matches
+
+
+def test_override_empty_is_noop():
+    _, _, gold, base = _universe()
+    baseline, override = end_to_end_override(gold=gold, base_score=base, band_decision={})
+    assert override.f1 == baseline.f1  # no band decision -> byte-identical to FS


### PR DESCRIPTION
## What and why

The FS + local-LLM investigation (2026-07-30/31) turned into a buildable feature: **spec + implementation plan + Phase 0 harness** (tested).

**Product model:** *we* run the teacher (LLM) + distillation centrally and ship the trained student **pinned** (like the 1.5B GGUF). Users consume it **zero-config, fully local — no LLM, no labels, no training at their end.**

## The investigation, in one line

FS resolves the bulk **fully locally** (~0.90–0.93 F1, recall 1.0). Its residual *uncertain band* is limited by **nonlinear field interactions** FS's linear/conditional-independence model can't express — which **global FS refit cannot fix** (measured neutral-to-harmful, even with a *perfect oracle* labeler; hard positives bias `m`, hard negatives bias `u`). The fix is a **per-pair override** by a small nonlinear student, **distilled** from the LLM offline so no model runs at query time.

## Measured (`historical_50k`)

| result | number |
|---|---|
| band-features ceiling (GBDT, gold, CV) | **0.967 F1 @ 2.86 µs/pair** (~1.4M× faster than the 1.5B) |
| distilled student (trained on 1.5B labels) | **0.880 ≈ teacher 0.885** |
| end-to-end dedupe F1 | baseline **0.897** → **+3.1 (deployable) / +4.8 (gold ceiling)** |

## Changes

- **Spec** `docs/superpowers/specs/2026-07-31-distilled-band-override-scorer-design.md`.
- **Plan** `docs/superpowers/plans/2026-07-31-distilled-band-override-scorer-plan.md` (Phase 0 harness → Phase 1 opt-in runtime + cluster-F1 gate → Phase 2 pinned distribution → Phase 3 score-core kernel + NNUE + TS/WASM parity; 5 validation gates).
- **Phase 0 harness** `scripts/er_matcher/band_student/` — `features` (generic, domain-agnostic comparison-feature vector), `student` (GBDT band classifier), `evaluate` (distillation fidelity + end-to-end override best-F1), and a self-contained synthetic test (feature layout, distillation, override lift, empty-band strict no-op).

## Testing

- `pytest scripts/er_matcher/band_student/` — 3 passed. The `er_matcher` CI lane runs it via `uv run --with scikit-learn` (sklearn is an offline-only dep, so the test **runs, not skips**). The package lazy-imports sklearn so collection never hard-fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)