### PR TITLE
feat(semantic): surface serving-cert + store-emit on MCP and CLI (C360 arc D)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -696,9 +696,24 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `identity 360` | `--no-relationships` | boolean | `False` | Skip the relationship neighborhood read. |
 | `identity 360` | `--timeline-limit` | integer | `None` | Cap the number of timeline events (most recent first). |
 | `identity 360` | `--json` | boolean | `False` | Emit the full 360 page as JSON. |
+| `identity certify-serving-joins` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity certify-serving-joins` | `--dataset` | text | `None` | Restrict to one identity-graph dataset. |
+| `identity certify-serving-joins` | `--status` | text | `'active'` | Entity status to include. |
+| `identity certify-serving-joins` | `--page-size` | integer | `500` | Entity-scan pagination size. |
+| `identity certify-serving-joins` | `--max-entities` | integer | `None` | Cap the scan at this many entities (cert covers a prefix). |
+| `identity certify-serving-joins` | `--json` | boolean | `False` | Emit the certificate as JSON. |
 | `identity conflicts` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
 | `identity conflicts` | `--dataset` | text | `None` | Filter to identities in this dataset. |
 | `identity conflicts` | `--json` | boolean | `False` | Emit results as JSON instead of a table. |
+| `identity emit-catalog` | `source_name` | text | **required** | Logical source name the records were ingested under. |
+| `identity emit-catalog` | `source_pk_column` | text | **required** | Column holding each record's source primary key. |
+| `identity emit-catalog` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
+| `identity emit-catalog` | `--dialect` | text | `'metricflow'` | metricflow \| cube \| osi. |
+| `identity emit-catalog` | `--dataset` | text | `None` | Identity-graph dataset scope. |
+| `identity emit-catalog` | `--source-target` | text | `None` | Source model/cube/dataset the join points at (defaults to source_name). |
+| `identity emit-catalog` | `--resolved-key` | text | `'resolved_entity_id'` | The conformed join column name. |
+| `identity emit-catalog` | `--out` | text | `None` | Write the emitted YAML to this catalog file. |
+| `identity emit-catalog` | `--overwrite` | boolean | `False` | Overwrite an existing catalog file at --out. |
 | `identity history` | `entity_id` | text | **required** | The entity_id of the identity to operate on. |
 | `identity history` | `--path` | text | `'.goldenmatch/identity.db'` | Path to the identity graph database. |
 | `identity history` | `--limit` | integer | `50` | Maximum number of events to return. |
@@ -918,7 +933,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 ## MCP tools
 
-92 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
+94 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
 
 | Tool | Description |
 |---|---|
@@ -936,6 +951,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `build_clusters` | Group records into clusters given a file and matchkey definition. |
 | `certify_recall` | Estimate match RECALL without ground truth (unsupervised). Treats each auto-configured matchkey/pass as a decorrelated system and uses capture-recapture over their overlaps to estimate how many true matches were missed. Returns a point estimate (a safe lower bound additionally needs a small labelled audit; see `goldenmatch evaluate --certify --audit-out`). Needs >=3 decorrelated systems. |
 | `certify_semantic_model` | Semantic-layer front door: certify every declared entity key in a dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. The dialect is auto-detected. Returns, per declared key, whether it is unique at grain and its measure fan-out -- the keys a metric silently joins on. Advisory; it never mutates a metric. |
+| `certify_serving_joins` | Certify that a Customer 360 serving layer's join keys can't double-count. A 360 view joins the golden record to its source records on the durable record_id (`&#123;source&#125;:&#123;source_pk&#125;`); if that key is duplicated, a fact rolled up through the 360 silently double-counts. This walks the store's entities, assembles the record_id join key, and returns a key-integrity certificate over it (&#123;trustworthy, n_entities, n_records, truncated, record_id: &#123;is_unique_at_grain, duplicate_key_groups, max_fan_out, estimate&#125;&#125;). |
 | `compare_clusters` | Compare two ER clustering outcomes on the same dataset without ground truth (CCMS): classifies each cluster as unchanged / merged / partitioned / overlapping and returns the Talburt-Wang Index. Both inputs are JSON cluster files (as written by export-style output). |
 | `config_weaknesses` | Diagnose weaknesses in the loaded run's auto-config: columns admitted that shouldn't be (source/provenance labels, per-row IDs), oversized or shared-value blocks, null sinks, low-signal matchkeys, and over-merging. Returns ranked findings, each with a plain-English explanation + a concrete fix, plus a one-paragraph summary. |
 | `controller_telemetry` | Return the AutoConfigController telemetry from the most recent `auto_configure` or `agent_deduplicate` call in this MCP session. Same JSON shape as the web /api/v1/controller/telemetry endpoint. |
@@ -945,6 +961,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `dedupe` | Alias for `find_duplicates`. Find duplicate matches for a record. Provide field values to search against the loaded dataset. |
 | `documents_ingest` | Extract records from documents (PDF/image) against a target schema into rows ready for dedupe_df. Returns records + an ingest report. |
 | `documents_suggest_schema` | Propose a target extraction schema (JSON) from a sample document image/PDF. |
+| `emit_semantic_model_from_store` | Emit a conformed semantic-layer catalog (the `resolved_entity_id` join a MetricFlow / Cube / OSI model should group metrics by) directly from the durable identity store — 'keep the semantic layer's identity join live against the control plane'. Returns the emitted YAML; when `path` is set, also writes it to that catalog file (refuses to clobber unless overwrite=true). |
 | `evaluate` | Score the loaded run against ground-truth pairs. Loads a ground-truth CSV (id_a,id_b columns) and returns precision, recall, and F1 for the current clustering. |
 | `explain_cluster` | Alias for `agent_explain_cluster`. Explain why records are in the same cluster |
 | `explain_match` | Explain why two records match or don't match. Shows per-field score breakdown. |

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.26.0` | `goldenmatch` | 92 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.26.0` | `goldenmatch` | 94 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
@@ -59,7 +59,7 @@ neglect:
   (`read_file`, `write_csv`, `server_info`) were the last holdouts, and Python now
   exposes all eight.
 
-So GoldenMatch's **83 TS tools vs 92 Python** breaks down as 83 shared operations,
+So GoldenMatch's **83 TS tools vs 94 Python** breaks down as 83 shared operations,
 **zero TS-only**, and 9 Python-only tools (the VLM document-ingest pair, the
 distributed routing trio, `list_plugins`, `pprl_auto_config`,
 `certify_semantic_model`, and `customer_360`). The TS MCP surface
@@ -129,7 +129,7 @@ graph, privacy-preserving linkage. The flagship — a native wheel, SQL extensio
 
 **Servers** — REST (`goldenmatch serve`: `/match`, `/autoconfig`, `/clusters`,
 `/reviews`, `/controller/telemetry`, …) · A2A (`goldenmatch agent-serve`) · local
-web UI (`goldenmatch serve-ui`) · **92 MCP tools**.
+web UI (`goldenmatch serve-ui`) · **94 MCP tools**.
 
 **Native / SQL** — `goldenmatch-native` wheel, a Postgres extension (pgrx:
 `goldenmatch_dedupe`, `goldenmatch_autoconfig`, `goldenmatch_connected_components`, …),

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,13 +14,13 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 92 | 202 | 51 | 41 | Yes | Yes |
+| `goldenmatch` | 94 | 202 | 51 | 41 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
 | `goldenanalysis` | 4 | 8 | — | 4 | Yes | Yes |
 | `infermap` | 4 | 19 | — | 5 | Yes | Yes |
-| **suite** | **133** | | | | | |
+| **suite** | **135** | | | | | |
 
 ## Compute substrate — the Rust `-core` kernel is the reference
 
@@ -41,7 +41,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 83 | 9 | 0 |
+| `goldenmatch` | mcp_tools | 83 | 11 | 0 |
 | `goldenmatch` | cli_commands | 32 | 9 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 15 | 10 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
@@ -66,7 +66,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `customer_360`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
+- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `certify_serving_joins`, `customer_360`, `documents_ingest`, `documents_suggest_schema`, `emit_semantic_model_from_store`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
 - `goldenmatch` **cli_commands** — Python-only: `certify-keys`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_import`, `scan_quality`, `score`.

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -74,7 +74,7 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldenmatch` | a2a_skills | 15 | 10 |
 | `goldenmatch` | blocking_strategies | 1 | 0 |
 | `goldenmatch` | cli_commands | 9 | 0 |
-| `goldenmatch` | mcp_tools | 9 | 0 |
+| `goldenmatch` | mcp_tools | 11 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 
 {/* thesis-weaknesses:generated:end */}

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -616,8 +616,10 @@
           "purpose": "CLI: ``goldenmatch identity ...`` -- inspect and manage the Identity Graph.",
           "defines": [
             "_open",
+            "certify_serving_joins_cmd",
             "conflicts_cmd",
             "customer_360_cmd",
+            "emit_catalog_cmd",
             "history_cmd",
             "list_cmd",
             "merge_cmd",
@@ -628,7 +630,8 @@
             "split_cmd"
           ],
           "imports": [
-            "goldenmatch.identity"
+            "goldenmatch.identity",
+            "goldenmatch.semantic"
           ]
         },
         {
@@ -6461,11 +6464,13 @@
             "_actor_trust",
             "_dispatch",
             "_open",
+            "_serving_certificate_dict",
             "handle_identity_tool"
           ],
           "imports": [
             "goldenmatch.core.memory.store",
-            "goldenmatch.identity"
+            "goldenmatch.identity",
+            "goldenmatch.semantic"
           ]
         },
         {

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2998,6 +2998,53 @@
           ]
         },
         {
+          "command": "identity certify-serving-joins",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Restrict to one identity-graph dataset."
+            },
+            {
+              "name": "--status",
+              "type": "text",
+              "required": false,
+              "default": "'active'",
+              "help": "Entity status to include."
+            },
+            {
+              "name": "--page-size",
+              "type": "integer",
+              "required": false,
+              "default": "500",
+              "help": "Entity-scan pagination size."
+            },
+            {
+              "name": "--max-entities",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Cap the scan at this many entities (cert covers a prefix)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the certificate as JSON."
+            }
+          ]
+        },
+        {
           "command": "identity conflicts",
           "options": [
             {
@@ -3020,6 +3067,72 @@
               "required": false,
               "default": "False",
               "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity emit-catalog",
+          "options": [
+            {
+              "name": "source_name",
+              "type": "text",
+              "required": true,
+              "help": "Logical source name the records were ingested under."
+            },
+            {
+              "name": "source_pk_column",
+              "type": "text",
+              "required": true,
+              "help": "Column holding each record's source primary key."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dialect",
+              "type": "text",
+              "required": false,
+              "default": "'metricflow'",
+              "help": "metricflow | cube | osi."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Identity-graph dataset scope."
+            },
+            {
+              "name": "--source-target",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Source model/cube/dataset the join points at (defaults to source_name)."
+            },
+            {
+              "name": "--resolved-key",
+              "type": "text",
+              "required": false,
+              "default": "'resolved_entity_id'",
+              "help": "The conformed join column name."
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the emitted YAML to this catalog file."
+            },
+            {
+              "name": "--overwrite",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Overwrite an existing catalog file at --out."
             }
           ]
         },
@@ -4761,6 +4874,10 @@
           "description": "Semantic-layer front door: certify every declared entity key in a dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. The dialect is auto-detected. Returns, per declared key, whether it is unique at grain and its measure fan-out -- the keys a metric silently joins on. Advisory; it never mutates a metric."
         },
         {
+          "name": "certify_serving_joins",
+          "description": "Certify that a Customer 360 serving layer's join keys can't double-count. A 360 view joins the golden record to its source records on the durable record_id (`{source}:{source_pk}`); if that key is duplicated, a fact rolled up through the 360 silently double-counts. This walks the store's entities, assembles the record_id join key, and returns a key-integrity certificate over it ({trustworthy, n_entities, n_records, truncated, record_id: {is_unique_at_grain, duplicate_key_groups, max_fan_out, estimate}})."
+        },
+        {
           "name": "compare_clusters",
           "description": "Compare two ER clustering outcomes on the same dataset without ground truth (CCMS): classifies each cluster as unchanged / merged / partitioned / overlapping and returns the Talburt-Wang Index. Both inputs are JSON cluster files (as written by export-style output)."
         },
@@ -4795,6 +4912,10 @@
         {
           "name": "documents_suggest_schema",
           "description": "Propose a target extraction schema (JSON) from a sample document image/PDF."
+        },
+        {
+          "name": "emit_semantic_model_from_store",
+          "description": "Emit a conformed semantic-layer catalog (the `resolved_entity_id` join a MetricFlow / Cube / OSI model should group metrics by) directly from the durable identity store — 'keep the semantic layer's identity join live against the control plane'. Returns the emitted YAML; when `path` is set, also writes it to that catalog file (refuses to clobber unless overwrite=true)."
         },
         {
           "name": "evaluate",

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - DQbench composite 91.04; PPRL 92.4% F1 on FEBRL4; a durable Identity Graph (stable entity_ids that survive across runs)
 
 ## AI-native surface
-- Every package ships an MCP server (133 tools across the suite), a REST API, and most an A2A agent surface
+- Every package ships an MCP server (135 tools across the suite), a REST API, and most an A2A agent surface
 - One aggregator container exposes the whole suite: `docker run ghcr.io/benseverndev-oss/goldensuite-mcp:latest`
 - Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benseverndev-oss/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -78,6 +78,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   advisory `KeyIntegrityCertificate`, so a metric joined through the 360 provably
   can't double-count. Returns a `ServingJoinCertificate` (record certificate +
   entity/record counts + `truncated` when a `max_entities` cap applies).
+- **Surface the serving-layer certificate + store-emit on MCP and the CLI.** Two
+  new `identity_*` MCP tools (`certify_serving_joins`,
+  `emit_semantic_model_from_store`) and two `goldenmatch identity` subcommands
+  (`certify-serving-joins`, `emit-catalog`) expose the Customer 360 serving-join
+  certificate and the live-from-store semantic-catalog emit to agents and the
+  shell — previously library-only. MCP tool count 92 → 94.
 
 ### Changed
 - **FS dedupe: Arrow-native columnar-cluster path (B2c), default-on (#1811/#2006).**

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -106,7 +106,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 91.04 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **92 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **94 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### Run on unstructured input (document ingest)
@@ -217,7 +217,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 - **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
-- **REST API + MCP Server** — 92 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
+- **REST API + MCP Server** — 94 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
 - **A2A Agent** — 51 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
@@ -731,7 +731,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (92 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (94 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |
@@ -1294,7 +1294,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-92 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+94 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
 
 ### Local files with the remote server
 

--- a/packages/python/goldenmatch/goldenmatch/cli/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/identity.py
@@ -147,6 +147,98 @@ def customer_360_cmd(
     )
 
 
+@identity_app.command("certify-serving-joins")
+def certify_serving_joins_cmd(
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Path to the identity graph database."),
+    dataset: str | None = typer.Option(None, "--dataset", help="Restrict to one identity-graph dataset."),
+    status: str = typer.Option("active", "--status", help="Entity status to include."),
+    page_size: int = typer.Option(500, "--page-size", help="Entity-scan pagination size."),
+    max_entities: int | None = typer.Option(
+        None, "--max-entities", help="Cap the scan at this many entities (cert covers a prefix)."
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit the certificate as JSON."),
+) -> None:
+    """Certify that a Customer 360 serving layer's source-record join key is
+    unique — so a metric joined through the 360 provably can't double-count."""
+    from goldenmatch.semantic import certify_serving_joins
+
+    with _open(path) as s:
+        cert = certify_serving_joins(
+            s, dataset=dataset, status=status, page_size=page_size, max_entities=max_entities
+        )
+    rc = cert.record_certificate
+    payload = {
+        "trustworthy": cert.is_trustworthy,
+        "n_entities": cert.n_entities,
+        "n_records": cert.n_records,
+        "truncated": cert.truncated,
+        "record_id": {
+            "is_unique_at_grain": rc.is_unique_at_grain,
+            "duplicate_key_groups": rc.duplicate_key_groups,
+            "max_fan_out": rc.max_fan_out,
+            "estimate": rc.estimate,
+        },
+    }
+    if json_out:
+        console.print_json(json.dumps(payload))
+        return
+    verdict = "[green]TRUSTWORTHY[/green]" if cert.is_trustworthy else "[red]NOT trustworthy[/red]"
+    console.print(f"Serving-join certificate: {verdict}")
+    console.print(
+        f"  entities: {cert.n_entities}   records: {cert.n_records}"
+        f"   truncated: {cert.truncated}"
+    )
+    console.print(
+        f"  record_id unique-at-grain: {rc.is_unique_at_grain}   "
+        f"duplicate key groups: {rc.duplicate_key_groups}   "
+        f"max fan-out: {rc.max_fan_out}   estimate: {rc.estimate:.4f}"
+    )
+
+
+@identity_app.command("emit-catalog")
+def emit_catalog_cmd(
+    source_name: str = typer.Argument(..., help="Logical source name the records were ingested under."),
+    source_pk_column: str = typer.Argument(..., help="Column holding each record's source primary key."),
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Path to the identity graph database."),
+    dialect: str = typer.Option("metricflow", "--dialect", help="metricflow | cube | osi."),
+    dataset: str | None = typer.Option(None, "--dataset", help="Identity-graph dataset scope."),
+    source_target: str | None = typer.Option(
+        None, "--source-target", help="Source model/cube/dataset the join points at (defaults to source_name)."
+    ),
+    resolved_key: str = typer.Option(
+        "resolved_entity_id", "--resolved-key", help="The conformed join column name."
+    ),
+    out_path: str | None = typer.Option(
+        None, "--out", help="Write the emitted YAML to this catalog file."
+    ),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Overwrite an existing catalog file at --out."),
+) -> None:
+    """Emit a conformed semantic-layer catalog (the ``resolved_entity_id`` join)
+    directly from the durable identity store."""
+    from goldenmatch.semantic import emit_semantic_model_from_store
+
+    emit_kwargs: dict = {}
+    if dataset is not None:
+        emit_kwargs["dataset"] = dataset
+    if source_target is not None:
+        emit_kwargs["source_target"] = source_target
+    with _open(path) as s:
+        yaml_str = emit_semantic_model_from_store(
+            s,
+            source_name=source_name,
+            source_pk_column=source_pk_column,
+            dialect=dialect,
+            resolved_key=resolved_key,
+            path=out_path,
+            overwrite=overwrite,
+            **emit_kwargs,
+        )
+    if out_path:
+        console.print(f"[green]Wrote[/green] {dialect} catalog to {out_path}")
+    else:
+        console.print(yaml_str)
+
+
 @identity_app.command("resolve")
 def resolve_cmd(
     record_id: str = typer.Argument(..., help="`{source}:{pk}` to look up"),

--- a/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
@@ -17,6 +17,10 @@
 - ``identity_worklist``  -> prioritized steward worklist
 - ``customer_360``       -> the unified serving view of one entity (golden record +
                             provenance + linked records + timeline + relationships)
+- ``certify_serving_joins`` -> certify that a Customer 360 serving layer's
+                            source-record join key is unique (can't double-count)
+- ``emit_semantic_model_from_store`` -> emit a conformed semantic-layer catalog
+                            (the ``resolved_entity_id`` join) directly from the store
 """
 from __future__ import annotations
 
@@ -381,6 +385,86 @@ IDENTITY_TOOLS: list[Tool] = [
             "required": ["entity_id"],
         },
     ),
+    Tool(
+        name="certify_serving_joins",
+        description=(
+            "Certify that a Customer 360 serving layer's join keys can't "
+            "double-count. A 360 view joins the golden record to its source "
+            "records on the durable record_id (`{source}:{source_pk}`); if that "
+            "key is duplicated, a fact rolled up through the 360 silently "
+            "double-counts. This walks the store's entities, assembles the "
+            "record_id join key, and returns a key-integrity certificate over it "
+            "({trustworthy, n_entities, n_records, truncated, record_id: "
+            "{is_unique_at_grain, duplicate_key_groups, max_fan_out, estimate}})."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "dataset": {"type": "string", "description": "Restrict to one identity-graph dataset."},
+                "status": {
+                    "type": "string",
+                    "default": "active",
+                    "description": "Entity status to include (default 'active').",
+                },
+                "page_size": {"type": "integer", "default": 500, "description": "Entity-scan pagination size."},
+                "max_entities": {
+                    "type": "integer",
+                    "description": "Cap the scan at this many entities (cert then covers a prefix, truncated=true).",
+                },
+                "path": {"type": "string", "description": "Identity DB path"},
+            },
+        },
+    ),
+    Tool(
+        name="emit_semantic_model_from_store",
+        description=(
+            "Emit a conformed semantic-layer catalog (the `resolved_entity_id` "
+            "join a MetricFlow / Cube / OSI model should group metrics by) "
+            "directly from the durable identity store — 'keep the semantic "
+            "layer's identity join live against the control plane'. Returns the "
+            "emitted YAML; when `path` is set, also writes it to that catalog "
+            "file (refuses to clobber unless overwrite=true)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source_name": {
+                    "type": "string",
+                    "description": "Logical source name the records were ingested under.",
+                },
+                "source_pk_column": {
+                    "type": "string",
+                    "description": "Column holding each record's source primary key (the join column).",
+                },
+                "dialect": {
+                    "type": "string",
+                    "enum": ["metricflow", "cube", "osi"],
+                    "default": "metricflow",
+                },
+                "dataset": {"type": "string", "description": "Identity-graph dataset scope (defaults to all)."},
+                "source_target": {
+                    "type": "string",
+                    "description": "Source model / cube / dataset the join points at (defaults to source_name).",
+                },
+                "resolved_key": {
+                    "type": "string",
+                    "default": "resolved_entity_id",
+                    "description": "The conformed join column name (the control-plane id).",
+                },
+                "out_path": {
+                    "type": "string",
+                    "description": "Optional catalog file to write the emitted YAML to.",
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Overwrite an existing catalog file at `out_path`.",
+                },
+                "path": {"type": "string", "description": "Identity DB path"},
+            },
+            "required": ["source_name", "source_pk_column"],
+        },
+    ),
 ]
 
 
@@ -407,6 +491,24 @@ def _actor_trust(args: dict) -> tuple[str, float | None]:
         except Exception:
             trust = None
     return actor, (float(trust) if trust is not None else None)
+
+
+def _serving_certificate_dict(cert: Any) -> dict[str, Any]:
+    """Serialize a `ServingJoinCertificate` (from `certify_serving_joins`) to a
+    JSON-safe dict, projecting the inner `KeyIntegrityCertificate`."""
+    rc = cert.record_certificate
+    return {
+        "trustworthy": cert.is_trustworthy,
+        "n_entities": cert.n_entities,
+        "n_records": cert.n_records,
+        "truncated": cert.truncated,
+        "record_id": {
+            "is_unique_at_grain": rc.is_unique_at_grain,
+            "duplicate_key_groups": rc.duplicate_key_groups,
+            "max_fan_out": rc.max_fan_out,
+            "estimate": rc.estimate,
+        },
+    }
 
 
 def _dispatch(name: str, args: dict) -> dict[str, Any]:
@@ -541,6 +643,39 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
                 timeline_limit=int(tl) if tl is not None else None,
             )
         return page if page is not None else {"found": False}
+
+    if name == "certify_serving_joins":
+        from goldenmatch.semantic import certify_serving_joins
+        me = args.get("max_entities")
+        with _open(args) as s:
+            cert = certify_serving_joins(
+                s,
+                dataset=args.get("dataset"),
+                status=args.get("status", "active"),
+                page_size=int(args.get("page_size", 500)),
+                max_entities=int(me) if me is not None else None,
+            )
+        return _serving_certificate_dict(cert)
+
+    if name == "emit_semantic_model_from_store":
+        from goldenmatch.semantic import emit_semantic_model_from_store
+        emit_kwargs = {
+            k: args[k]
+            for k in ("dataset", "source_target")
+            if args.get(k) is not None
+        }
+        with _open(args) as s:
+            yaml_str = emit_semantic_model_from_store(
+                s,
+                source_name=args["source_name"],
+                source_pk_column=args["source_pk_column"],
+                dialect=args.get("dialect", "metricflow"),
+                resolved_key=args.get("resolved_key", "resolved_entity_id"),
+                path=args.get("out_path"),
+                overwrite=bool(args.get("overwrite", False)),
+                **emit_kwargs,
+            )
+        return {"yaml": yaml_str, "written_to": args.get("out_path")}
 
     raise ValueError(f"unknown identity tool: {name}")
 

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -6,8 +6,8 @@
 Zero-config gets good results and returns the config it chose; the healer (`review_config`) reviews the results and suggests ranked, self-verified tweaks; apply them, results improve, repeat — closing the gap to expert-tuned without you being the expert. Wired into the default pipeline: `dedupe_df` attaches candidate suggestions to `result.suggestions` when a free signal fires (`dedupe_df(suggest=True)` verified, `heal=True` full loop; disable with `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`). Needs `goldenmatch[native]`; degrades gracefully without it. Docs: https://docs.bensevern.dev/goldenmatch/config-suggestions
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (92 tools across data, agent, identity, memory, routing, and document groups)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (92 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- MCP Server: `goldenmatch mcp-serve` (94 tools across data, agent, identity, memory, routing, and document groups)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (94 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (51 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~202 exports

--- a/packages/python/goldenmatch/tests/identity/test_serving_cli.py
+++ b/packages/python/goldenmatch/tests/identity/test_serving_cli.py
@@ -1,0 +1,69 @@
+"""CLI: `goldenmatch identity certify-serving-joins` + `identity emit-catalog`
+(the semantic-layer <-> Customer 360 serving surfaces, PR-D)."""
+from __future__ import annotations
+
+import json
+
+from goldenmatch.cli.identity import identity_app
+from goldenmatch.identity import IdentityNode, IdentityStore, SourceRecord, new_entity_id
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _seed(db) -> tuple[str, str]:
+    e1, e2 = new_entity_id(), new_entity_id()
+    with IdentityStore(path=str(db)) as s:
+        s.upsert_identity(IdentityNode(entity_id=e1, dataset="crm", confidence=0.9))
+        s.upsert_identity(IdentityNode(entity_id=e2, dataset="crm", confidence=0.9))
+        s.upsert_record(SourceRecord("crm:1", "crm", "1", "h1", entity_id=e1, dataset="crm"))
+        s.upsert_record(SourceRecord("crm:2", "crm", "2", "h2", entity_id=e1, dataset="crm"))
+        s.upsert_record(SourceRecord("crm:3", "crm", "3", "h3", entity_id=e2, dataset="crm"))
+    return e1, e2
+
+
+def test_certify_serving_joins_json(tmp_path):
+    db = tmp_path / "id.db"
+    _seed(db)
+    res = runner.invoke(
+        identity_app, ["certify-serving-joins", "--path", str(db), "--dataset", "crm", "--json"]
+    )
+    assert res.exit_code == 0
+    cert = json.loads(res.stdout)
+    assert cert["trustworthy"] is True
+    assert cert["n_entities"] == 2
+    assert cert["n_records"] == 3
+    assert cert["record_id"]["duplicate_key_groups"] == 0
+
+
+def test_certify_serving_joins_table(tmp_path):
+    db = tmp_path / "id.db"
+    _seed(db)
+    res = runner.invoke(identity_app, ["certify-serving-joins", "--path", str(db), "--dataset", "crm"])
+    assert res.exit_code == 0
+    assert "TRUSTWORTHY" in res.stdout
+
+
+def test_emit_catalog_stdout(tmp_path):
+    db = tmp_path / "id.db"
+    _seed(db)
+    res = runner.invoke(
+        identity_app,
+        ["emit-catalog", "crm", "customer_id", "--path", str(db), "--dataset", "crm"],
+    )
+    assert res.exit_code == 0
+    assert "resolved_entity_id" in res.stdout
+
+
+def test_emit_catalog_writes_file(tmp_path):
+    db = tmp_path / "id.db"
+    _seed(db)
+    out_file = tmp_path / "catalog.yml"
+    res = runner.invoke(
+        identity_app,
+        ["emit-catalog", "crm", "customer_id", "--path", str(db), "--dataset", "crm",
+         "--out", str(out_file)],
+    )
+    assert res.exit_code == 0
+    assert out_file.exists()
+    assert "resolved_entity_id" in out_file.read_text()

--- a/packages/python/goldenmatch/tests/test_mcp_identity_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_identity_tools.py
@@ -19,7 +19,7 @@ from goldenmatch.mcp.identity_tools import (
 
 
 def test_identity_tool_count_and_names():
-    assert len(IDENTITY_TOOLS) == 16
+    assert len(IDENTITY_TOOLS) == 18
     assert IDENTITY_TOOL_NAMES == {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
@@ -32,6 +32,8 @@ def test_identity_tool_count_and_names():
         "identity_audit_seal", "identity_audit_verify",
         # Customer 360 serving view (D1b)
         "customer_360",
+        # Semantic-layer <-> Customer 360 serving surfaces (D)
+        "certify_serving_joins", "emit_semantic_model_from_store",
     }
 
 
@@ -90,6 +92,45 @@ def test_customer_360_via_mcp(seeded_db):
         assert key in out
     missing = _dispatch("customer_360", {"entity_id": "nope", "path": path})
     assert missing == {"found": False}
+
+
+def test_certify_serving_joins_via_mcp(seeded_db):
+    path, ids = seeded_db
+    out = _dispatch("certify_serving_joins", {"dataset": "d", "path": path})
+    # 3 distinct source records across 2 entities -> unique record_id -> trustworthy
+    assert out["trustworthy"] is True
+    assert out["n_entities"] == 2
+    assert out["n_records"] == 3
+    assert out["truncated"] is False
+    assert out["record_id"]["is_unique_at_grain"] is True
+    assert out["record_id"]["duplicate_key_groups"] == 0
+
+
+def test_emit_semantic_model_from_store_via_mcp(seeded_db):
+    path, ids = seeded_db
+    out = _dispatch("emit_semantic_model_from_store", {
+        "source_name": "src",
+        "source_pk_column": "customer_id",
+        "dataset": "d",
+        "path": path,
+    })
+    assert out["written_to"] is None
+    # the emitted MetricFlow catalog groups metrics on the resolved key
+    assert "resolved_entity_id" in out["yaml"]
+
+
+def test_emit_semantic_model_from_store_writes_file_via_mcp(seeded_db, tmp_path):
+    path, ids = seeded_db
+    out_file = str(tmp_path / "catalog.yml")
+    out = _dispatch("emit_semantic_model_from_store", {
+        "source_name": "src",
+        "source_pk_column": "customer_id",
+        "dataset": "d",
+        "out_path": out_file,
+        "path": path,
+    })
+    assert out["written_to"] == out_file
+    assert Path(out_file).read_text() == out["yaml"]
 
 
 def test_identity_merge_via_mcp(seeded_db):

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,7 +16,7 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_92():
+def test_total_tool_count_is_94():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
@@ -25,10 +25,10 @@ def test_total_tool_count_is_92():
 
     assert len(AGENT_TOOLS) == 19   # +1 retrieve_similar (#1089) +1 upload_dataset
     assert len(MEMORY_TOOLS) == 7
-    assert len(IDENTITY_TOOLS) == 16  # +3 MDM ops (#1114) +5 agent-memory ops +1 customer_360 (D1b)
+    assert len(IDENTITY_TOOLS) == 18  # +1 customer_360 (D1b) +2 serving surfaces (D)
     assert len(_BASE_TOOLS) == 45   # +5 core primitives +3 host helpers +1 certify_semantic_model
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 92   # +1 customer_360 (Customer 360 serving view, python_only)
+    assert len(TOOLS) == 94   # +2 serving surfaces (certify_serving_joins, emit_semantic_model_from_store)
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2998,6 +2998,53 @@
           ]
         },
         {
+          "command": "identity certify-serving-joins",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Restrict to one identity-graph dataset."
+            },
+            {
+              "name": "--status",
+              "type": "text",
+              "required": false,
+              "default": "'active'",
+              "help": "Entity status to include."
+            },
+            {
+              "name": "--page-size",
+              "type": "integer",
+              "required": false,
+              "default": "500",
+              "help": "Entity-scan pagination size."
+            },
+            {
+              "name": "--max-entities",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Cap the scan at this many entities (cert covers a prefix)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the certificate as JSON."
+            }
+          ]
+        },
+        {
           "command": "identity conflicts",
           "options": [
             {
@@ -3020,6 +3067,72 @@
               "required": false,
               "default": "False",
               "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity emit-catalog",
+          "options": [
+            {
+              "name": "source_name",
+              "type": "text",
+              "required": true,
+              "help": "Logical source name the records were ingested under."
+            },
+            {
+              "name": "source_pk_column",
+              "type": "text",
+              "required": true,
+              "help": "Column holding each record's source primary key."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dialect",
+              "type": "text",
+              "required": false,
+              "default": "'metricflow'",
+              "help": "metricflow | cube | osi."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Identity-graph dataset scope."
+            },
+            {
+              "name": "--source-target",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Source model/cube/dataset the join points at (defaults to source_name)."
+            },
+            {
+              "name": "--resolved-key",
+              "type": "text",
+              "required": false,
+              "default": "'resolved_entity_id'",
+              "help": "The conformed join column name."
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the emitted YAML to this catalog file."
+            },
+            {
+              "name": "--overwrite",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Overwrite an existing catalog file at --out."
             }
           ]
         },
@@ -4761,6 +4874,10 @@
           "description": "Semantic-layer front door: certify every declared entity key in a dbt/MetricFlow, Cube, or OSI/Ossie semantic model against its data. The dialect is auto-detected. Returns, per declared key, whether it is unique at grain and its measure fan-out -- the keys a metric silently joins on. Advisory; it never mutates a metric."
         },
         {
+          "name": "certify_serving_joins",
+          "description": "Certify that a Customer 360 serving layer's join keys can't double-count. A 360 view joins the golden record to its source records on the durable record_id (`{source}:{source_pk}`); if that key is duplicated, a fact rolled up through the 360 silently double-counts. This walks the store's entities, assembles the record_id join key, and returns a key-integrity certificate over it ({trustworthy, n_entities, n_records, truncated, record_id: {is_unique_at_grain, duplicate_key_groups, max_fan_out, estimate}})."
+        },
+        {
           "name": "compare_clusters",
           "description": "Compare two ER clustering outcomes on the same dataset without ground truth (CCMS): classifies each cluster as unchanged / merged / partitioned / overlapping and returns the Talburt-Wang Index. Both inputs are JSON cluster files (as written by export-style output)."
         },
@@ -4795,6 +4912,10 @@
         {
           "name": "documents_suggest_schema",
           "description": "Propose a target extraction schema (JSON) from a sample document image/PDF."
+        },
+        {
+          "name": "emit_semantic_model_from_store",
+          "description": "Emit a conformed semantic-layer catalog (the `resolved_entity_id` join a MetricFlow / Cube / OSI model should group metrics by) directly from the durable identity store — 'keep the semantic layer's identity join live against the control plane'. Returns the emitted YAML; when `path` is set, also writes it to that catalog file (refuses to clobber unless overwrite=true)."
         },
         {
           "name": "evaluate",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -138,9 +138,11 @@ mcp_tools:
   - write_csv
   python_only:
   - certify_semantic_model
+  - certify_serving_joins
   - customer_360
   - documents_ingest
   - documents_suggest_schema
+  - emit_semantic_model_from_store
   - explain_routing
   - lint_routing
   - list_plugins


### PR DESCRIPTION
## What and why

The Customer 360 serving-join certificate (`certify_serving_joins`) and the live-from-store semantic-catalog emit (`emit_semantic_model_from_store`) landed as library-only functions in the C360 arc (#2301, #2305). This surfaces both to agents (MCP) and the shell (CLI) so the "certify the 360 can't double-count" and "keep the semantic-layer join live against the control plane" capabilities are reachable without writing Python.

## Changes

- **MCP:** two new `identity_*` tools in `mcp/identity_tools.py` — `certify_serving_joins` and `emit_semantic_model_from_store` — dispatched via the existing `IDENTITY_TOOL_NAMES` path (`_open(args)` store helper, lazy `goldenmatch.semantic` import). The `ServingJoinCertificate` is projected to a JSON-safe dict (`trustworthy`, `n_entities`, `n_records`, `truncated`, `record_id: {is_unique_at_grain, duplicate_key_groups, max_fan_out, estimate}`).
- **CLI:** two new `goldenmatch identity` subcommands — `certify-serving-joins` and `emit-catalog` — placed under the `identity` group so top-level `cli_commands` parity is unchanged. `emit-catalog` uses `--out` for the catalog file (identity DB stays on `--path`, matching every other subcommand).
- **api_parity:** `parity/goldenmatch.yaml` gains the two tools in `mcp_tools.python_only` (surface 92 -> 94).
- **Generated-artifact cascade regenerated:** codemap, agent-manifest (+ bundled `goldensuite-mcp` copy), `config-matrix.mdx`, `api-surface.mdx` (table + the two inline MCP-tool figures), `suite-matrix.mdx`, `llms.txt` / `README.md` tool counts.
- Tool-count assertions bumped 92 -> 94 (`IDENTITY_TOOLS` 16 -> 18, `TOOLS` 92 -> 94).

## Testing

- `pytest tests/test_mcp_identity_tools.py tests/test_mcp_new_tools.py tests/identity/ tests/test_semantic_serving.py` — 394 passed, 7 skipped (new MCP + CLI dispatch tests for both tools, incl. write-to-file paths).
- `pytest scripts/test_api_surface.py scripts/test_suite_matrix.py scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_api_parity.py` — all pass (generated artifacts + parity manifest gates).
- `ruff check` clean on the changed files. (`check_api_parity.py` full run needs the TS `dist/` build — CI-only; the Python surface emits 94 including both new tools.)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (generated cascade + CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_