### PR TITLE
chore(thesis): prune the conformance board to the live risk surface (retire 8 resolved)

### DIFF
--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -10,19 +10,19 @@ The [suite matrix](/suite-matrix) renders cross-language *surface* parity. This 
 
 ## Standing
 
-**10** open weakness(es) — 🟢 low 10. Undeclared (a real divergence with no conformance level / contract): **0**.
+**2** open weakness(es) — 🟢 low 2. **8** resolved (archived below). Undeclared (a real divergence with no conformance level / contract): **0**.
 
-A weakness is a place the codebase does not yet fully meet the frame; each maps to one of the five decision tests (tenets). *Declared* means the divergence has a conformance level and a test — an accepted, contained cost — not an accident. The `declared: false` class is the dangerous one and is flagged below.
+A weakness is a place the codebase does not yet fully meet the frame; each maps to one of the five decision tests (tenets). *Declared* means the divergence has a conformance level and a test — an accepted, contained cost — not an accident. The `declared: false` class is the dangerous one and is flagged below. Resolved items are archived off this live board (conformance v2 — the live list is the real risk surface, not a museum of closed wins) but kept for the record.
 
 ## The five tenets
 
 | Tenet | Decision test | Open |
 |---|---|---|
-| **T1** | One authoritative semantic owner per capability (no second source of truth). | 4 |
-| **T2** | Conformance defines correctness (every divergence has a declared level + a test). | 2 |
-| **T3** | Kernelize on measurement (deferrals classified; no silent regress to fallback). | 1 |
-| **T4** | Compute vs control stay architecturally distinct (explicit, versioned seam). | 3 |
-| **T5** | Arrow at bulk boundaries, not the universal calling convention. | 0 |
+| **T1** | One authoritative semantic owner per capability (no second source of truth). | 1 |
+| **T2** | Conformance defines correctness (every divergence has a declared level + a test). | 0 |
+| **T3** | Kernelize on measurement (deferrals classified; no silent regress to fallback). | 0 |
+| **T4** | Compute vs control stay architecturally distinct (explicit, versioned seam). | 1 |
+| **T5** | Arrow at bulk boundaries, not the universal calling convention. [DECLARED WON -- see header] | 0 |
 
 ## Weakness board
 
@@ -30,22 +30,8 @@ Ranked by severity. *Routing* applies the conformance-v2 default-routing test (0
 
 | Severity | Tenet | Declared | Routing | Weakness |
 |---|---|---|---|---|
-| 🟢 low | T1 | yes | — | goldenmatch a2a_skills two-sided gap is now all intentional divergence (MDM trio reconciled) |
-| 🟢 low | T3 | yes | — | Kernel deferrals state a reason but not measured wall-clock provenance |
 | 🟢 low | T4 | yes | — | Compute/control shared frame-residency budget: now a contract field (was env-only) |
-| 🟢 low | T1 | yes | owner is default | TS Fellegi-Sunter scoring runs the shared fs-core kernel by default (batteries entry); pure-TS is the classified fallback |
-| 🟢 low | T4 | yes | — | Incremental resolution against a persisted identity index (C2/C4 landed) |
-| 🟢 low | T4 | yes | — | Compute->control handoff is a versioned ResolutionBatch consumed by apply_batch(store, batch) |
 | 🟢 low | T1 | yes | opt-in (fallback default) | Clustering + goldenanalysis frame kernels: both families now share a kernel (cluster-wasm + analysis-wasm) |
-| 🟢 low | T2 | yes | — | Standardize divergence now has a runnable characterization test (was prose-only) |
-| 🟢 low | T1 | yes | — | Golden-record rollup single-sourced through core.golden (was a 2nd hand-rolled rule in resolve.py) |
-| 🟢 low | T2 | yes | — | Cross-surface scorer/package divergences are now declared in the 0046 verdict table |
-
-## Re-validate (deferral triggers)
-
-Each deferral names the explicit condition that would *un-defer* it (conformance-v2 test T3). A deferral whose premise has already lifted is an OPEN divergence, not a settled low — these are re-checked each audit.
-
-- **deferrals-lack-measurement-provenance** — RE-VALIDATE (conformance v2, 0047 amendment): re-fires the moment a scorer/blocking deferral is added whose reason is PERF/SHAPE rather than model-backed -- that entry then owes a MEASURED wall-clock (kernelize on measurement). Currently vacuous: every deferral (embedding / record_embedding / simhash) is model-backed. Re-check on any new scorer_kernels_deferred / blocking_kernels_deferred entry.
 
 ## Live harvest (auto-detected)
 
@@ -76,5 +62,20 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldenmatch` | cli_commands | 9 | 0 |
 | `goldenmatch` | mcp_tools | 9 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
+
+## Resolved (archived)
+
+Weaknesses verified resolved-and-stable and moved off the live risk board (conformance v2, 0047 amendment #4). Kept for the record — the evidence + reasoning live in `parity/thesis_conformance.yaml`; a rotted premise un-archives.
+
+| Tenet | Weakness |
+|---|---|
+| T1 | goldenmatch a2a_skills two-sided gap is now all intentional divergence (MDM trio reconciled) |
+| T3 | Kernel deferrals state a reason but not measured wall-clock provenance |
+| T1 | TS Fellegi-Sunter scoring runs the shared fs-core kernel by default (batteries entry); pure-TS is the classified fallback |
+| T4 | Incremental resolution against a persisted identity index (C2/C4 landed) |
+| T4 | Compute->control handoff is a versioned ResolutionBatch consumed by apply_batch(store, batch) |
+| T2 | Standardize divergence now has a runnable characterization test (was prose-only) |
+| T1 | Golden-record rollup single-sourced through core.golden (was a 2nd hand-rolled rule in resolve.py) |
+| T2 | Cross-surface scorer/package divergences are now declared in the 0046 verdict table |
 
 {/* thesis-weaknesses:generated:end */}

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -15,17 +15,35 @@
 # weakness is closed or a new one is found; the script's --check mode fails when a
 # live signal (a new _FALLBACK_ONLY kernel, an uncovered scorer, a declared-divergent
 # boundary with no parity test) has no matching inventory entry.
+#
+# `status: resolved` ARCHIVES an entry off the LIVE risk board (conformance v2, 0047
+# amendment process #4: "retire resolved-and-stable / vacuous items so the live list
+# is the actual risk surface, not a museum of closed wins"). The entry + its evidence
+# stay for the record; build_scorecard splits open (no status) from resolved, and the
+# gate only checks the open ones. Un-archive by removing the marker if a premise rots.
 
+# Housekeeping (conformance v2, 0047 amendment #5):
+# - T5 (Arrow-at-bulk-boundaries) is DECLARED WON: it has never recorded a weakness, and
+#   the smallest-stable-primitive discipline is enforced live (several kernels take plain
+#   list[str]/two-string args, not Arrow). A future Arrow-forced-into-a-scalar-call
+#   regression re-opens it -- until then it is a solved tenet, not a silent measurement gap.
+# - INTENTIONAL ASYMMETRY is a first-class principle, not a weakness: the edge-safe TS
+#   subset deliberately omits heavy Python surfaces (distributed / Ray / GPU / full
+#   REST+web UI, opt-in-default WASM for bundle size). Those surface gaps are
+#   declared-by-design and are NOT re-litigated each audit.
 tenets:
   T1: "One authoritative semantic owner per capability (no second source of truth)."
   T2: "Conformance defines correctness (every divergence has a declared level + a test)."
   T3: "Kernelize on measurement (deferrals classified; no silent regress to fallback)."
   T4: "Compute vs control stay architecturally distinct (explicit, versioned seam)."
-  T5: "Arrow at bulk boundaries, not the universal calling convention."
+  T5: "Arrow at bulk boundaries, not the universal calling convention. [DECLARED WON -- see header]"
 
 # Severity: critical > high > medium > low
 weaknesses:
   - id: incremental-resolution-no-persisted-index
+    status: resolved   # C2 index + C4 bounded-work + no-PK content-hash landed & tested;
+                       # only residual is an OPTIONAL large-corpus RSS bench -> that is a
+                       # measurement-frontier item (needs scale infra), not a correctness gap.
     tenet: T4
     severity: low   # RESOLVED: C2 (persisted index + bidirectional query) + C4
                     # (bounded-work scale proof) landed; only broader-corpus RSS
@@ -67,6 +85,8 @@ weaknesses:
     owner_next: "context-network/architecture/identity-control-plane-manifesto.md (§4 (ii) delivered; C2 + C4 + no-PK ids landed; optional: large-corpus RSS bench)"
 
   - id: no-versioned-resolution-batch-contract
+    status: resolved   # Wave B/C/C1 landed; apply_batch==adapter + with_data locks pass;
+                       # "No open follow-on" -- the whole handoff is one versioned object.
     tenet: T4
     severity: low   # RESOLVED -- Wave B fixed the acute bug; Wave C/C1 landed the
                     # versioned contract; the C1 data-array fold + apply_batch now done
@@ -95,6 +115,8 @@ weaknesses:
       - packages/python/goldenmatch/tests/identity/test_postgres_bulk_payload_parity.py
 
   - id: fs-default-ts-path-unwired-second-source
+    status: resolved   # default_routed:true -- batteries index.ts auto-registers the kernel;
+                       # owner is the default; F1-neutral gate passes; no open follow-up.
     tenet: T1
     severity: low   # was medium; RESOLVED-as-wired AND default-on -- the batteries
                     # `goldenmatch` root entry auto-enables the kernel; goldenmatch/core
@@ -148,6 +170,8 @@ weaknesses:
       - context-network/decisions/0046-cross-language-phase-handoff-conformance.md
 
   - id: standardize-dates-no-conformance-test
+    status: resolved   # dual Python+TS characterization tests present & green; the
+                       # None-vs-"" divergence declared. Runnable, no longer prose-only.
     tenet: T2
     severity: low   # was high; CLOSED -- now has a runnable dual-pinned characterization
     declared: true
@@ -167,6 +191,8 @@ weaknesses:
     parity_test: packages/typescript/goldenmatch/tests/parity/standardizer-conformance.parity.test.ts
 
   - id: undeclared-cross-surface-divergences
+    status: resolved   # the 0046 amendment enumerates radial/ensemble ~4dp, PPRL float-CLK,
+                       # array_intersect:overlap; goldenanalysis frame-kernel now shared.
     tenet: T2
     severity: low   # was high (undeclared); DECLARED now in 0046 amendment + docs-site
     declared: true   # Wave A (2026-07-26)
@@ -196,6 +222,8 @@ weaknesses:
       - docs/superpowers/specs/2026-07-06-goldenanalysis-wave1b-deferred.md
 
   - id: three-golden-record-implementations
+    status: resolved   # single-sourced through core.golden (_survivor_value -> merge_field /
+                       # most_complete_value); config-aware done; ONE owner, tested green.
     tenet: T1
     severity: low   # was medium + declared:false (the dangerous class); RESOLVED --
                     # single authoritative owner, only doc-follow-on (identity golden
@@ -276,6 +304,9 @@ weaknesses:
 
   - id: a2a-skills-bidirectional-fracture
     tenet: T1
+    status: resolved   # 2026-07-31: the MDM trio reconciled; every remaining delta is
+                       # verified-intentional divergence (commitment 3 ALLOWS it), so this
+                       # is no longer a conform gap -- archived off the live risk board.
     severity: low   # was medium; the one genuine surface INCONSISTENCY (the MDM
                     # trio, shared on MCP but ts_only on A2A) is now reconciled;
                     # the remaining two-sided gap is ALL verified-intentional
@@ -289,10 +320,12 @@ weaknesses:
       identity_worklist, which is SHARED on the MCP surface but was ts_only on the A2A card
       -- is fixed by advertising it on Python's A2A card too (the capability already existed
       via entity_profile/identity_summary_stats/steward_worklist + the MCP tools). Gap is now
-      14 python_only vs 10 ts_only, and every remaining divergence is VERIFIED-DIFFERENT, NOT
-      drift: PY's richer file-lifecycle/routing skills (configure/list_runs/rollback/review/
-      incremental/sensitivity/schema_match/compare_clusters/analyze_blocking/retrieve_similar/
-      documents_*) which the edge-safe TS surface intentionally omits; PY `quality` vs TS
+      15 python_only vs 10 ts_only, and every remaining divergence is VERIFIED-DIFFERENT, NOT
+      drift: PY's richer file-lifecycle/routing/semantic skills (configure/list_runs/rollback/
+      review/incremental/sensitivity/schema_match/compare_clusters/analyze_blocking/
+      retrieve_similar/documents_*/certify_semantic_model -- the last is the semantic-model
+      certification surface, a Python-only stateful/semantic capability the edge TS omits)
+      which the edge-safe TS surface intentionally omits; PY `quality` vs TS
       `scan_quality`+`fix_quality` (1:2 granularity); PY `pprl` RUNS linkage vs TS `suggest_pprl`
       SUGGESTS params; and TS's edge agent_* variants + score/memory_import primitives. Two
       surfaces exposing genuinely different capabilities is what commitment 3 ALLOWS -- the
@@ -326,6 +359,10 @@ weaknesses:
       - packages/python/goldenmatch/goldenmatch/identity/resolve.py:453
 
   - id: deferrals-lack-measurement-provenance
+    status: resolved   # VACUOUS: all 3 deferrals (embedding/record_embedding/simhash) are
+                       # model-backed, none perf/shape, so nothing owes a wall-clock. The
+                       # un_defer tripwire (a future perf/shape deferral re-fires it) is
+                       # preserved in the 0047 amendment; archived here, not deleted.
     tenet: T3
     severity: low
     declared: true

--- a/scripts/check_thesis_conformance.py
+++ b/scripts/check_thesis_conformance.py
@@ -168,11 +168,20 @@ def load_inventory() -> dict:
 
 def build_scorecard() -> dict:
     inv = load_inventory()
-    weaknesses = sorted(inv.get("weaknesses", []),
-                        key=lambda w: (SEV_ORDER.get(w.get("severity"), 9), w.get("id", "")))
+    all_w = inv.get("weaknesses", [])
+
+    def _key(w):
+        return (SEV_ORDER.get(w.get("severity"), 9), w.get("id", ""))
+
+    # `status: resolved` archives an entry OFF the live risk board (conformance v2,
+    # 0047 amendment #4): the record stays, but only OPEN entries are the risk
+    # surface the gate checks + the scorecard ranks.
+    weaknesses = sorted((w for w in all_w if w.get("status") != "resolved"), key=_key)
+    resolved = sorted((w for w in all_w if w.get("status") == "resolved"), key=_key)
     return {
         "tenets": inv.get("tenets", {}),
         "weaknesses": weaknesses,
+        "resolved": resolved,
         "live": {
             "surface_gaps": harvest_surface_gaps(),
             "scorer_coverage": harvest_scorer_coverage(),
@@ -237,8 +246,9 @@ def render(card: dict) -> None:
     print("  frame: context-network/architecture/one-product-two-engines.md (0047)")
     print("=" * 78)
     print()
-    print("Weaknesses by severity: " + ", ".join(
-        f"{n} {s}" for s, n in sorted(counts.items(), key=lambda kv: SEV_ORDER[kv[0]])))
+    print("Open weaknesses by severity: " + (", ".join(
+        f"{n} {s}" for s, n in sorted(counts.items(), key=lambda kv: SEV_ORDER[kv[0]])) or "none"))
+    print(f"Resolved (archived off the live board): {len(card.get('resolved', []))}")
     print(f"Undeclared/under-declared (divergence with no conformance level): {len(undeclared)}"
           + (" -> " + ", ".join(w["id"] for w in undeclared) if undeclared else ""))
     print()

--- a/scripts/gen_thesis_weaknesses.py
+++ b/scripts/gen_thesis_weaknesses.py
@@ -66,6 +66,7 @@ def render_block() -> str:
     card = t.build_scorecard()
     tenets: dict = card["tenets"]
     weaknesses: list = card["weaknesses"]  # already sorted (severity, id) by build_scorecard
+    resolved: list = card.get("resolved", [])  # archived off the live risk board
     live: dict = card["live"]
 
     sev_counts: dict[str, int] = {}
@@ -89,6 +90,7 @@ def render_block() -> str:
         "",
         (
             f"**{len(weaknesses)}** open weakness(es) — {sev_line}. "
+            f"**{len(resolved)}** resolved (archived below). "
             f"Undeclared (a real divergence with no conformance level / contract): "
             f"**{len(undeclared)}**."
         ),
@@ -97,7 +99,9 @@ def render_block() -> str:
             "A weakness is a place the codebase does not yet fully meet the frame; each maps "
             "to one of the five decision tests (tenets). *Declared* means the divergence has a "
             "conformance level and a test — an accepted, contained cost — not an accident. The "
-            "`declared: false` class is the dangerous one and is flagged below."
+            "`declared: false` class is the dangerous one and is flagged below. Resolved items "
+            "are archived off this live board (conformance v2 — the live list is the real risk "
+            "surface, not a museum of closed wins) but kept for the record."
         ),
         "",
     ]
@@ -213,6 +217,24 @@ def render_block() -> str:
             if po or to:
                 L.append(f"| `{pkg}` | {surface} | {po} | {to} |")
     L.append("")
+
+    # -- Resolved (archived) --------------------------------------------------
+    if resolved:
+        L += [
+            "## Resolved (archived)",
+            "",
+            (
+                "Weaknesses verified resolved-and-stable and moved off the live risk board "
+                "(conformance v2, 0047 amendment #4). Kept for the record — the evidence + "
+                "reasoning live in `parity/thesis_conformance.yaml`; a rotted premise un-archives."
+            ),
+            "",
+            "| Tenet | Weakness |",
+            "|---|---|",
+        ]
+        for w in resolved:
+            L.append(f"| {w['tenet']} | {_cell(w.get('title', w.get('id', '')))} |")
+        L.append("")
 
     L += [MARKER_END]
     return "\n".join(L)


### PR DESCRIPTION
## What and why

The thesis-conformance board was **10 weaknesses, all `low`, all self-reporting RESOLVED** — the "museum of closed wins" the conformance-v2 amendment (0047, process #4) explicitly says to retire *"so the live list is the actual risk surface, not a museum of closed wins."* This is the first pass of taking on the 10: I independently verified each (evidence files exist; key identity + TS-parity tests run green) and **archived the 8 that are genuinely resolved-and-stable**, leaving the 2 with real open work.

## Approach (conservative — archive, don't delete)

A `status: resolved` marker moves an entry **off the live board** but keeps the record + evidence (a rotted premise un-archives). `build_scorecard` now splits **open vs resolved** as the single source both the gate and the docs page read — so the gate checks only open entries and the scorecard/page rank only open ones. The gate has no hardcoded ids, so this is safe; the mdx is regenerated in lockstep.

## Changes

- **Archived (8):** `no-versioned-resolution-batch-contract`, `fs-default-ts-path`, `standardize-dates`, `undeclared-cross-surface-divergences`, `three-golden-record`, `deferrals-lack-measurement-provenance` (verified **vacuous** — all deferrals model-backed, none perf/shape), `incremental-resolution` (residual is an *optional* large-corpus RSS bench → measurement frontier, not the low board), and `a2a-skills` (prose refreshed `14→15` python_only + `certify_semantic_model` credited as intentional; now all verified-intentional divergence).
- **Still OPEN (2):** `frame-residency-coupling` (prep-floor magnitude isn't yet a computed contract field — real S/M residual, its own follow-up PR) and `standalone-ts-algorithms` (opt-in-default WASM — the one conformance-v2 T1 opt-in edge, pending a standing 0047 ratification).
- **Housekeeping (amendment #5):** T5 (Arrow-at-bulk) **declared WON** (never recorded a weakness; smallest-primitive discipline enforced live); intentional TS-edge **asymmetry promoted to a first-class principle**, not a weakness. Both documented in the yaml header.
- **Regenerated `docs-site/thesis-weaknesses.mdx`** — now **2 open / 8 archived**, with a new "Resolved (archived)" section; the re-validate section correctly disappears (no open deferral).

## Testing

- `uv run python scripts/check_thesis_conformance.py --check` → **OK** (Open: 2 low; Resolved: 8; Undeclared: 0).
- `gen_thesis_weaknesses.py --write` then `--check` → idempotent; `scripts/test_thesis_weaknesses.py` → passes.
- `parity/thesis_conformance.yaml` valid YAML; evidence claims independently verified (tests green) before archiving.

## Follow-ups (the 2 still-open)

1. `frame-residency`: add the computed prep-floor estimate field to `resolution_batch.py` + wire in `resolve.py`, then archive.
2. `standalone-ts`: ratify the opt-in-default WASM as a standing 0047 decision (edge-bundle discipline), then archive.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs regenerated + gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_