### PR TITLE
feat(identity): REST GET /api/v1/identities/{id}/360 (C360 arc E)

### DIFF
--- a/docs-site/goldenmatch/identity-graph.mdx
+++ b/docs-site/goldenmatch/identity-graph.mdx
@@ -127,6 +127,7 @@ goldenmatch identity split <entity_id> crm:42 crm:43 --reason "wrong merge"
 GET    /api/v1/identities                            # list (paginated)
 GET    /api/v1/identities/stats                      # totals
 GET    /api/v1/identities/{entity_id}                # full view
+GET    /api/v1/identities/{entity_id}/360            # Customer 360 serving view
 GET    /api/v1/identities/{entity_id}/history        # event log
 GET    /api/v1/identities/{entity_id}/evidence       # edges
 GET    /api/v1/identities/by-record/{record_id}      # resolve

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7912,6 +7912,7 @@
             "_store_for",
             "by_record_endpoint",
             "conflicts_endpoint",
+            "customer_360_endpoint",
             "evidence_endpoint",
             "get_endpoint",
             "history_endpoint",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -84,6 +84,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   (`certify-serving-joins`, `emit-catalog`) expose the Customer 360 serving-join
   certificate and the live-from-store semantic-catalog emit to agents and the
   shell — previously library-only. MCP tool count 92 → 94.
+- **REST `GET /api/v1/identities/{entity_id}/360`.** The Customer 360 serving
+  view (golden record + per-field provenance + linked source records + event
+  timeline + relationship neighborhood) is now reachable over the identity REST
+  surface, mirroring the `customer_360` MCP tool and the `identity 360` CLI
+  command. Query params `include_relationships` (default true) and
+  `timeline_limit`; 404 when the entity does not exist.
 
 ### Changed
 - **FS dedupe: Arrow-native columnar-cluster path (B2c), default-on (#1811/#2006).**

--- a/packages/python/goldenmatch/goldenmatch/web/routers/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/identity.py
@@ -3,6 +3,7 @@
 GET    /api/v1/identities                            -> list (paginated)
 GET    /api/v1/identities/stats                      -> counts
 GET    /api/v1/identities/{eid}                      -> full view
+GET    /api/v1/identities/{eid}/360                  -> Customer 360 serving view
 GET    /api/v1/identities/{eid}/history              -> events
 GET    /api/v1/identities/{eid}/evidence             -> edges
 GET    /api/v1/identities/by-record/{record_id}      -> view via record id
@@ -20,6 +21,7 @@ from pydantic import BaseModel
 
 from goldenmatch.identity import (
     IdentityStore,
+    customer_360_page,
     find_by_record,
     find_conflicts,
     get_entity,
@@ -101,6 +103,29 @@ def get_endpoint(entity_id: str, request: Request) -> dict[str, Any]:
     if view is None:
         raise HTTPException(status_code=404, detail=f"Identity {entity_id} not found")
     return view.to_dict()
+
+
+@router.get("/{entity_id}/360")
+def customer_360_endpoint(
+    entity_id: str,
+    request: Request,
+    include_relationships: bool = Query(True),
+    timeline_limit: int | None = Query(None, ge=1),
+) -> dict[str, Any]:
+    """The unified Customer 360 serving view of one entity: golden record +
+    per-field provenance + linked source records + event timeline + relationship
+    neighborhood, composed from the durable store in one call. This is the same
+    durable entity_id a resolved crosswalk (semantic-layer wedge) groups metrics
+    by, so a metric row drills straight through to the customer."""
+    with _store_for(request) as s:
+        page = customer_360_page(
+            s, entity_id,
+            include_relationships=include_relationships,
+            timeline_limit=timeline_limit,
+        )
+    if page is None:
+        raise HTTPException(status_code=404, detail=f"Identity {entity_id} not found")
+    return page
 
 
 @router.get("/{entity_id}/history")

--- a/packages/python/goldenmatch/tests/web/test_router_identity.py
+++ b/packages/python/goldenmatch/tests/web/test_router_identity.py
@@ -62,6 +62,33 @@ def test_identity_get_unknown(client, sample_project: Path):
     assert r.status_code == 404
 
 
+def test_identity_360_endpoint(client, sample_project: Path):
+    seeded = _seed_identity_db(sample_project)
+    r = client.get(f"/api/v1/identities/{seeded['eid1']}/360")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["entity_id"] == seeded["eid1"]
+    assert body["record_count"] == 2
+    for key in ("golden_record", "field_provenance", "source_records", "timeline", "relationships"):
+        assert key in body
+
+
+def test_identity_360_no_relationships(client, sample_project: Path):
+    seeded = _seed_identity_db(sample_project)
+    r = client.get(
+        f"/api/v1/identities/{seeded['eid1']}/360",
+        params={"include_relationships": "false"},
+    )
+    assert r.status_code == 200
+    assert r.json()["relationships"] == []
+
+
+def test_identity_360_unknown(client, sample_project: Path):
+    _seed_identity_db(sample_project)
+    r = client.get("/api/v1/identities/does-not-exist/360")
+    assert r.status_code == 404
+
+
 def test_identity_by_record(client, sample_project: Path):
     seeded = _seed_identity_db(sample_project)
     r = client.get("/api/v1/identities/by-record/src:1")


### PR DESCRIPTION
## What and why

The Customer 360 serving view is reachable over the library (`customer_360_page`), MCP (`customer_360`), and CLI (`identity 360`) — but not REST. This adds the endpoint so a dashboard or 360 UI can fetch the unified serving view of one entity over HTTP, keyed on the same durable `entity_id` a resolved crosswalk (semantic-layer wedge) groups metrics by.

## Changes

- **`GET /api/v1/identities/{entity_id}/360`** in `web/routers/identity.py` — reuses `customer_360_page` (golden record + per-field provenance + linked source records + event timeline + relationship neighborhood). Query params `include_relationships` (default `true`) and `timeline_limit` (≥1, optional); `404` when the entity doesn't exist. Route is a distinct path segment, so it doesn't shadow (or get shadowed by) the existing `/{entity_id}` view.
- Docs: added the route to the identity-graph REST endpoint list (`docs-site/goldenmatch/identity-graph.mdx`).

## Testing

- `pytest tests/web/` (excl. the pre-existing PIL-optional `test_documents_router*`) — 137 passed, including 3 new cases: the 360 view shape, `include_relationships=false` returning `[]`, and the 404 path.
- `ruff check` clean on the changed files.

Note: REST is a boolean present/absent surface in the parity/suite matrices (not per-endpoint), so no generated-artifact or tool-count cascade.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (identity-graph REST list + CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_