### PR TITLE
feat(thesis): T1 default-routing auditor — verify the owner IS the default (fs-default gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3690,6 +3690,10 @@ jobs:
           uv run pytest scripts/test_suite_matrix.py -q
           uv run python scripts/gen_thesis_weaknesses.py --check
           uv run pytest scripts/test_thesis_weaknesses.py -q
+          # T1 default-routing auditor: HARD-fails on an owner-default kernel that
+          # regressed to opt-in (the fs-default class); advisory on the rest.
+          uv run python scripts/check_thesis_conformance.py --check
+          uv run pytest scripts/test_thesis_conformance.py -q
           uv run python scripts/gen_api_surface.py --check
         env:
           POLARS_SKIP_CPU_CHECK: "1"

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -38,6 +38,31 @@ tenets:
   T4: "Compute vs control stay architecturally distinct (explicit, versioned seam)."
   T5: "Arrow at bulk boundaries, not the universal calling convention. [DECLARED WON -- see header]"
 
+# Default-routing inventory (conformance v2, 0047 amendment -- T1). The refined T1
+# test is "one owner AND the DEFAULT caller path routes to it": a shared owner shipped
+# opt-in while a second impl is the default is a LATENT second source (the fs-default
+# class). `check_thesis_conformance.py::harvest_ts_default_routing` VERIFIES these
+# claims against the code -- for a TS batteries entry it reads which enable-* kernels
+# are auto-registered as an import-time side-effect (a bare top-level call, resolving
+# `import { X as Y }` aliases) -- so a regressed default can't sit behind a stale
+# annotation. `owner_default` symbols MUST be auto-registered (else a GATING failure);
+# `opt_in` kernels must NOT be (deliberate edge-bundle discipline; auto-registering one
+# is an advisory reclassify prompt). A new auto-registered kernel absent from the
+# inventory is an advisory "add it so its default is audited".
+default_routing:
+  ts_batteries:
+    entry: packages/typescript/goldenmatch/src/index.ts
+    owner_default:
+      - enableFsWasmScoring   # fs_core default-on: registerFsKernel() at import (was the fs-default gap)
+    opt_in:                   # edge-bundle discipline: reachable only via an explicit enable*() call
+      - enableAutoconfigWasm
+      - enableClusterWasm
+      - enableFingerprintWasm
+      - enableGraphWasm
+      - enablePerceptualWasm
+      - enableSketchWasm
+      - enableSuggestWasm
+
 # Severity: critical > high > medium > low
 weaknesses:
   - id: incremental-resolution-no-persisted-index

--- a/scripts/check_thesis_conformance.py
+++ b/scripts/check_thesis_conformance.py
@@ -26,12 +26,17 @@ This tool has two halves:
 
 Modes:
   (default)   Render the scorecard: live harvest + curated inventory by tenet/severity.
-  --check     Exit non-zero on a DRIFT invariant (advisory unless --strict):
+  --check     Exit non-zero on a DRIFT invariant. Most are advisory unless --strict:
                 - a scorer is UNCOVERED (not kernel-backed, not deferred);
                 - a package grew a NEW _FALLBACK_ONLY kernel with no inventory entry;
                 - a curated weakness marked declared-divergent that names a
                   parity_test file that does not exist on disk.
-  --strict    Make --check gating (exit 1 on any drift). Default is advisory (exit 0).
+              EXCEPT the T1 default-routing GATING check, which exits 1 regardless of
+              --strict: an `owner_default` kernel (parity/thesis_conformance.yaml
+              `default_routing`) no longer auto-registered at its batteries entry is the
+              fs-default class -- a shared owner shipped opt-in while a second impl is the
+              default -- and hard-fails so it can't sit behind a stale annotation.
+  --strict    Make the ADVISORY invariants gating too (exit 1 on any drift).
   --json      Emit the scorecard as JSON instead of text.
 
 Deliberately NOT wired into ci-required: this is a visibility/roadmap instrument,
@@ -43,6 +48,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -158,6 +164,86 @@ def harvest_fallback_only() -> dict:
     return out
 
 
+_TS_IMPORT_RE = re.compile(r"import\s*\{([^}]*)\}\s*from")
+_TS_TOP_CALL_RE = re.compile(r"^([A-Za-z_$][\w$]*)\(\s*\)\s*;?\s*$")
+
+
+def harvest_ts_default_routing(inv: dict) -> dict:
+    """For each declared TS batteries entry, the enable-* symbols it AUTO-REGISTERS as
+    an import-time side-effect -- the 'owner is the default' signal (conformance v2 T1).
+
+    An auto-registration is a bare top-level call in the entry (e.g. ``registerFsKernel();``),
+    resolved through single-line ``import { X as Y }`` aliases. Box-safe line parse (no
+    TS toolchain). LIMIT: single-line imports + column-0 bare calls (module top-level)
+    only; a multi-line aliased import is not resolved -- but that fails an
+    ``owner_default`` claim LOUD (symbol not found) rather than passing silently.
+    """
+    out = {}
+    for name, block in (inv.get("default_routing") or {}).items():
+        entry = REPO / (block.get("entry") or "")
+        auto: set[str] = set()
+        exists = entry.exists()
+        if exists:
+            alias: dict[str, str] = {}
+            calls: list[str] = []
+            for line in entry.read_text().splitlines():
+                m = _TS_IMPORT_RE.search(line)
+                if m:
+                    for item in m.group(1).split(","):
+                        item = item.strip()
+                        if not item:
+                            continue
+                        parts = [p.strip() for p in item.split(" as ")]
+                        alias[parts[-1]] = parts[0]  # local -> original export
+                    continue
+                c = _TS_TOP_CALL_RE.match(line)
+                if c:
+                    calls.append(c.group(1))
+            for callee in calls:
+                auto.add(alias.get(callee, callee))
+        out[name] = {"entry": block.get("entry", ""), "exists": exists,
+                     "auto_registered": sorted(auto)}
+    return out
+
+
+def check_default_routing(inv: dict, harvest: dict) -> tuple[list, list]:
+    """Reconcile the default_routing claims against the harvested reality (T1).
+
+    Returns ``(gating, advisory)``. GATING: an ``owner_default`` kernel NOT auto-registered
+    -- the owner exists but a second impl is the default (the fs-default class), a hard
+    regression. ADVISORY: an ``opt_in`` kernel that IS auto-registered (reclassify), or an
+    auto-registered kernel absent from the inventory (add it so its default is audited).
+    """
+    gating: list[str] = []
+    advisory: list[str] = []
+    for name, block in (inv.get("default_routing") or {}).items():
+        h = harvest.get(name, {})
+        if not h.get("exists"):
+            advisory.append(
+                f"default_routing '{name}': batteries entry not found ({block.get('entry')})")
+            continue
+        auto = set(h.get("auto_registered", []))
+        owner = list(block.get("owner_default") or [])
+        optin = set(block.get("opt_in") or [])
+        for sym in owner:
+            if sym not in auto:
+                gating.append(
+                    f"T1 default-routing REGRESSION ({name}): '{sym}' is declared owner-default "
+                    f"but is NOT auto-registered at the batteries entry -- the shared owner exists "
+                    f"yet a second impl is the default (the fs-default class). Restore the "
+                    f"import-time registration, or reclassify it opt_in if that is intended.")
+        for sym in sorted(auto):
+            if sym in optin:
+                advisory.append(
+                    f"default-routing ({name}): '{sym}' is classified opt_in but IS auto-registered "
+                    f"at the batteries entry -- reclassify owner_default or drop the registration.")
+            elif sym not in owner:
+                advisory.append(
+                    f"default-routing ({name}): '{sym}' is auto-registered but absent from the "
+                    f"default_routing inventory -- add it (owner_default) so its default is audited.")
+    return gating, advisory
+
+
 def load_inventory() -> dict:
     inv = _load_yaml(INVENTORY)
     if not inv:
@@ -180,12 +266,14 @@ def build_scorecard() -> dict:
     resolved = sorted((w for w in all_w if w.get("status") == "resolved"), key=_key)
     return {
         "tenets": inv.get("tenets", {}),
+        "inventory": inv,
         "weaknesses": weaknesses,
         "resolved": resolved,
         "live": {
             "surface_gaps": harvest_surface_gaps(),
             "scorer_coverage": harvest_scorer_coverage(),
             "fallback_only_kernels": harvest_fallback_only(),
+            "ts_default_routing": harvest_ts_default_routing(inv),
         },
     }
 
@@ -224,11 +312,21 @@ def run_check(card: dict, strict: bool) -> int:
                 f"LATENT second source: '{w['id']}' has a shared owner but the default "
                 f"path does not route to it (default_routed: false) -- conformance v2 T1")
 
-    if problems:
+    # T1 default-routing, VERIFIED against code (not just the manual annotation): an
+    # owner_default kernel that is no longer auto-registered at its batteries entry is a
+    # HARD regression (the fs-default class) and GATES regardless of --strict; the
+    # softer reclassify/audit prompts join the advisory set.
+    gating, dr_advisory = check_default_routing(
+        card["inventory"], card["live"]["ts_default_routing"])
+    problems.extend(dr_advisory)
+
+    if gating or problems:
         print("THESIS-CONFORMANCE DRIFT:")
+        for p in gating:
+            print(f"  - [GATING] {p}")
         for p in problems:
             print(f"  - {p}")
-        return 1 if strict else 0
+        return 1 if (gating or strict) else 0
     print("thesis-conformance drift check: OK")
     return 0
 
@@ -285,6 +383,20 @@ def render(card: dict) -> None:
             for w in revalidate:
                 first = " ".join(str(w["un_defer"]).split())
                 print(f"    - {w['id']}: {first[:110]}{'...' if len(first) > 110 else ''}")
+        print()
+
+    dr = card["live"].get("ts_default_routing") or {}
+    inv_dr = card.get("inventory", {}).get("default_routing") or {}
+    if dr:
+        print("-" * 78)
+        print("DEFAULT-ROUTING (T1, VERIFIED against code: is the owner auto-registered?)")
+        print("-" * 78)
+        for name, h in dr.items():
+            auto = set(h.get("auto_registered", []))
+            owner = list((inv_dr.get(name) or {}).get("owner_default") or [])
+            miss = [s for s in owner if s not in auto]
+            status = "OK" if not miss else f"REGRESSION -- owner-default not auto-registered: {miss}"
+            print(f"    {name} ({h.get('entry')}): auto-registered={sorted(auto)}  [{status}]")
         print()
 
     print("-" * 78)

--- a/scripts/test_thesis_conformance.py
+++ b/scripts/test_thesis_conformance.py
@@ -1,0 +1,52 @@
+"""Gate tests for the thesis-conformance T1 default-routing auditor (conformance v2,
+0047 amendment). Verifies the harvester reads the real batteries-entry registration
+and that the reconcile GATES the fs-default class (owner shipped opt-in while a second
+impl is the default). Run: `python scripts/check_thesis_conformance.py --check`.
+"""
+from __future__ import annotations
+
+import check_thesis_conformance as c
+
+
+def test_real_repo_default_routing_ok():
+    # The live goldenmatch batteries entry auto-registers the fs kernel, so the real
+    # inventory reconciles clean and --check exits 0.
+    card = c.build_scorecard()
+    gating, _advisory = c.check_default_routing(card["inventory"], card["live"]["ts_default_routing"])
+    assert gating == [], gating
+    assert c.run_check(card, strict=False) == 0
+
+
+def test_harvest_resolves_import_alias():
+    # `import { enableFsWasmScoring as registerFsKernel }` + top-level `registerFsKernel()`
+    # must resolve back to the exported symbol.
+    harvest = c.harvest_ts_default_routing(c.load_inventory())
+    ts = harvest["ts_batteries"]
+    assert ts["exists"] is True
+    assert "enableFsWasmScoring" in ts["auto_registered"]
+
+
+def test_owner_default_not_registered_is_gating():
+    # The fs-default class: a declared owner-default kernel that is NOT auto-registered
+    # at the entry must HARD-fail (gating), independent of --strict.
+    inv = {"default_routing": {"x": {"entry": "e", "owner_default": ["enableFooKernel"], "opt_in": []}}}
+    harvest = {"x": {"entry": "e", "exists": True, "auto_registered": []}}  # not registered
+    gating, advisory = c.check_default_routing(inv, harvest)
+    assert any("REGRESSION" in g and "enableFooKernel" in g for g in gating)
+    assert advisory == []
+
+
+def test_optin_kernel_auto_registered_is_advisory():
+    inv = {"default_routing": {"x": {"entry": "e", "owner_default": [], "opt_in": ["enableBarWasm"]}}}
+    harvest = {"x": {"entry": "e", "exists": True, "auto_registered": ["enableBarWasm"]}}
+    gating, advisory = c.check_default_routing(inv, harvest)
+    assert gating == []
+    assert any("opt_in" in a and "enableBarWasm" in a for a in advisory)
+
+
+def test_unlisted_auto_registered_kernel_is_advisory():
+    inv = {"default_routing": {"x": {"entry": "e", "owner_default": [], "opt_in": []}}}
+    harvest = {"x": {"entry": "e", "exists": True, "auto_registered": ["enableNewWasm"]}}
+    gating, advisory = c.check_default_routing(inv, harvest)
+    assert gating == []
+    assert any("absent from the" in a and "enableNewWasm" in a for a in advisory)


### PR DESCRIPTION
## What and why

The first **behavioral-frontier** conformance check (conformance v2, 0047 amendment) — the deliverable from the "what's the next real investment" thread. Until now `default_routed:` was a **hand-set annotation nothing verified**, which is exactly how the fs-default kernel shipped opt-in while pure-TS was the default and the gate stayed green. This turns the refined T1 test — *"one owner **and** the default caller path routes to it"* — into a **deterministic, code-verified gate**.

I picked this over an F1-neutrality (T2) check deliberately: routing is the one frontier piece you can make a *hard* gate rather than an advisory measurement, and it catches the demonstrated failure.

## Changes

- **`parity/thesis_conformance.yaml`** — a data-driven `default_routing` inventory. For the TS batteries entry, which `enable-*` kernels are `owner_default` (must be auto-registered at import) vs `opt_in` (edge-bundle discipline; must not be). Populated from the real `index.ts`: `enableFsWasmScoring` is owner-default (`registerFsKernel()` at import); the other 7 wasm kernels are opt-in.
- **`check_thesis_conformance.py`** — `harvest_ts_default_routing` statically reads which kernels the batteries entry auto-registers (a bare top-level call, resolving `import { X as Y }` aliases; box-safe, no TS toolchain), and `check_default_routing` reconciles vs the inventory:
  - an `owner_default` kernel **not** auto-registered → **HARD GATING** failure (exits 1 regardless of `--strict`) — the fs-default class;
  - an `opt_in` kernel that **is** auto-registered, or a **new** auto-registered kernel absent from the inventory → advisory.
  - Rendered in the scorecard's conformance-v2 section.
- **`scripts/test_thesis_conformance.py`** (5) — real-repo OK, alias resolution, the gating fs-default regression, and the two advisory prompts.
- **`ci.yml`** — runs `check_thesis_conformance.py --check` + the test in the **existing** thesis step (no new lane), so a regressed default-on kernel now blocks a PR.

## Honest limits (documented in code)

- Verifies the default **gate**, not that it's reached on every call site — a deliberately mis-wired downstream call could still evade it (that's the T2 workload check, the natural follow-on).
- Single-line imports + column-0 top-level calls; a multi-line aliased import fails an `owner_default` claim **loud** (symbol not found), never silently.

## Testing

- `check_thesis_conformance.py --check` → **OK** (fs genuinely auto-registered); `scripts/test_thesis_conformance.py` → **5 pass**, incl. the gating regression case.
- Thesis-weaknesses page + its gate unaffected (the new yaml key is ignored by the weakness split); `ci.yml` valid.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / gate wired; honest limits documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_