### PR TITLE
feat(ts): port the Customer 360 serving view + customer_360 MCP tool (C360 arc F)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -59,10 +59,11 @@ neglect:
   (`read_file`, `write_csv`, `server_info`) were the last holdouts, and Python now
   exposes all eight.
 
-So GoldenMatch's **83 TS tools vs 94 Python** breaks down as 83 shared operations,
-**zero TS-only**, and 9 Python-only tools (the VLM document-ingest pair, the
-distributed routing trio, `list_plugins`, `pprl_auto_config`,
-`certify_semantic_model`, and `customer_360`). The TS MCP surface
+So GoldenMatch's **84 TS tools vs 94 Python** breaks down as 84 shared operations,
+**zero TS-only**, and 10 Python-only tools (the VLM document-ingest pair, the
+distributed routing trio, `list_plugins`, `pprl_auto_config`, and the
+semantic-layer wedge — `certify_semantic_model`, `certify_serving_joins`,
+`emit_semantic_model_from_store`). The TS MCP surface
 is now a strict subset of the Python one — every TS tool has a Python counterpart of
 the same name, and what remains Python-only is the set with no JS-ecosystem
 equivalent. On the shared core the **public function names match**, and that parity

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -41,9 +41,9 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 83 | 11 | 0 |
+| `goldenmatch` | mcp_tools | 84 | 10 | 0 |
 | `goldenmatch` | cli_commands | 32 | 9 | 0 |
-| `goldenmatch` | a2a_skills | 36 | 15 | 10 |
+| `goldenmatch` | a2a_skills | 36 | 15 | 11 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
@@ -66,10 +66,10 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `certify_serving_joins`, `customer_360`, `documents_ingest`, `documents_suggest_schema`, `emit_semantic_model_from_store`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
+- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `certify_serving_joins`, `documents_ingest`, `documents_suggest_schema`, `emit_semantic_model_from_store`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
 - `goldenmatch` **cli_commands** — Python-only: `certify-keys`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
-- `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
+- `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `customer_360`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `init`, `review`, `scan-db`, `schedule`, `serve`.
 - `goldenflow` **cli_commands** — Python-only: `init`, `interactive`, `schedule`, `watch`.

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -57,10 +57,10 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldencheck` | mcp_tools | 1 | 0 |
 | `goldenflow` | cli_commands | 4 | 0 |
 | `goldenflow` | transforms | 0 | 1 |
-| `goldenmatch` | a2a_skills | 15 | 10 |
+| `goldenmatch` | a2a_skills | 15 | 11 |
 | `goldenmatch` | blocking_strategies | 1 | 0 |
 | `goldenmatch` | cli_commands | 9 | 0 |
-| `goldenmatch` | mcp_tools | 11 | 0 |
+| `goldenmatch` | mcp_tools | 10 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 
 ## Resolved (archived)

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [Unreleased]
+
+### Added
+- **Customer 360 serving view (`customer360Page`) + the `customer_360` MCP tool.**
+  Edge-safe port of Python `identity/profile.py::customer_360` — the unified
+  serving read of one entity composed from the durable store in one call: golden
+  record + per-field source provenance + every linked source record + the event
+  timeline + the relationship neighborhood. `customer360Page(store, entityId,
+  { includeRelationships, timelineLimit })` returns the same `as_dict()`-shaped
+  object every Python surface returns (shared-capabilities-conform), so a metric
+  grouped on the durable `entity_id` drills straight through to the customer. The
+  relationship overlay is a federated read the edge-safe store doesn't implement,
+  so it degrades to `[]` (mirroring Python's `AttributeError → []` fallback; a
+  store MAY provide an optional `getRelationships`). Surfaced as the TS MCP
+  `customer_360` tool (identity tools 15 → 16, total MCP 83 → 84), which flips
+  `customer_360` from `python_only` to `shared` under `mcp_tools`; because the TS
+  A2A card auto-exposes every identity tool, it becomes an `a2a_skills.ts_only`
+  skill (Python's A2A never advertised it).
+
 ## [1.26.0] - 2026-07-27
 
 ### Changed (default behavior — read before upgrading)

--- a/packages/typescript/goldenmatch/src/core/identity/profile.ts
+++ b/packages/typescript/goldenmatch/src/core/identity/profile.ts
@@ -8,7 +8,7 @@
  * Backs the `identity_profile` / `identity_stats` / `identity_worklist` MCP
  * tools. Each function returns the Python `as_dict()`-shaped object directly.
  */
-import type { IdentityStore, IdentityNode } from "./types.js";
+import type { IdentityStore, IdentityNode, SourceRecord, IdentityEvent } from "./types.js";
 import { pyIsoformat } from "./pyDatetime.js";
 
 const PAGE = 500;
@@ -156,6 +156,173 @@ export async function identitySummaryStats(
       entity_id,
       record_count,
     })),
+  };
+}
+
+// ── Customer 360 (unified serving read) ──────────────────────────────────────
+//
+// One read that composes the durable spine into the whole picture of a customer:
+// golden record + per-field source provenance + every linked source record + the
+// event timeline + the relationship overlay. Edge-safe port of Python
+// `identity/profile.py::customer_360` — the serving realization of decision 0049.
+// Backs the `customer_360` MCP tool and the REST `/identities/{id}/360` route.
+
+/** Normalize a payload/golden cell for provenance comparison: `null` stays
+ * `null`; everything else is string-cast + trimmed, so a golden `42` matches a
+ * source payload `"42"` without treating an empty string as a real value.
+ * (Float formatting differs Python↔JS — `String(5.0)` is `"5"` — the documented
+ * PPRL-class gap; irrelevant for the string payloads a 360 typically carries.) */
+function norm(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const s = String(value).trim();
+  return s || null;
+}
+
+interface FieldContribution {
+  source: string;
+  record_id: string;
+  source_pk: string;
+  value: unknown;
+  last_seen: string | null;
+}
+
+/** Attribute each golden field to the source records that carry its value.
+ * Winner = the contributing record with the most recent `lastSeenAt` (ties broken
+ * by `recordId` descending, matching Python). Mirrors `_field_provenance`. */
+function fieldProvenance(
+  goldenRecord: Record<string, unknown> | null,
+  records: readonly SourceRecord[],
+): Array<Record<string, unknown>> {
+  if (!goldenRecord) return [];
+  const out: Array<Record<string, unknown>> = [];
+  for (const [fname, gvalue] of Object.entries(goldenRecord)) {
+    const gnorm = norm(gvalue);
+    const contributors: Array<FieldContribution & { _ts: number }> = [];
+    const conflicts = new Map<string, Record<string, unknown>>();
+    for (const rec of records) {
+      const payload = rec.payload ?? {};
+      if (!(fname in payload)) continue;
+      const rnorm = norm(payload[fname]);
+      if (rnorm !== null && rnorm === gnorm) {
+        contributors.push({
+          source: rec.source,
+          record_id: rec.recordId,
+          source_pk: rec.sourcePk,
+          value: payload[fname],
+          last_seen: rec.lastSeenAt ? pyIsoformat(rec.lastSeenAt) : null,
+          _ts: rec.lastSeenAt ? rec.lastSeenAt.getTime() : -Infinity,
+        });
+      } else if (rnorm !== null && !conflicts.has(rnorm)) {
+        conflicts.set(rnorm, {
+          value: payload[fname],
+          source: rec.source,
+          record_id: rec.recordId,
+        });
+      }
+    }
+    // Most recent first; ties broken by record_id descending (Python reverse sort).
+    contributors.sort((a, b) => {
+      if (a._ts !== b._ts) return b._ts - a._ts;
+      return a.record_id < b.record_id ? 1 : a.record_id > b.record_id ? -1 : 0;
+    });
+    const winner = contributors[0];
+    out.push({
+      field: fname,
+      value: gvalue,
+      winning_source: winner ? winner.source : null,
+      winning_record_id: winner ? winner.record_id : null,
+      contributors: contributors.map(({ _ts, ...c }) => c),
+      conflicting_values: [...conflicts.values()].sort((a, b) =>
+        String(a.value) < String(b.value) ? -1 : String(a.value) > String(b.value) ? 1 : 0,
+      ),
+    });
+  }
+  return out;
+}
+
+function recordAsDict(rec: SourceRecord): Record<string, unknown> {
+  return {
+    record_id: rec.recordId,
+    source: rec.source,
+    source_pk: rec.sourcePk,
+    dataset: rec.dataset,
+    first_seen: rec.firstSeenAt ? pyIsoformat(rec.firstSeenAt) : null,
+    last_seen: rec.lastSeenAt ? pyIsoformat(rec.lastSeenAt) : null,
+    payload: rec.payload,
+  };
+}
+
+function eventAsDict(ev: IdentityEvent): Record<string, unknown> {
+  const reason =
+    ev.payload && typeof ev.payload === "object" ? (ev.payload as Record<string, unknown>).reason ?? null : null;
+  return {
+    event_id: ev.eventId,
+    kind: ev.kind,
+    actor: ev.actor ?? null,
+    trust: ev.trust ?? null,
+    run_name: ev.runName,
+    dataset: ev.dataset,
+    reason,
+    recorded_at: ev.recordedAt ? pyIsoformat(ev.recordedAt) : null,
+  };
+}
+
+/** The single Customer 360 serving read: everything known about one entity,
+ * composed from the durable store in one call. Returns `null` if the entity
+ * doesn't exist. JSON-ready (the `as_dict()`-shaped object Python returns), so
+ * every serving surface returns the same 360 shape. Mirrors Python
+ * `customer_360_page`.
+ *
+ * The relationship overlay (decision 0049) is a federated read the edge-safe
+ * store doesn't implement; like Python's `AttributeError → []` fallback, it
+ * degrades to an empty list here (a store MAY provide an optional
+ * `getRelationships(entityId)` and it will be used). */
+export async function customer360Page(
+  store: IdentityStore,
+  entityId: string,
+  opts: { includeRelationships?: boolean; timelineLimit?: number } = {},
+): Promise<Record<string, unknown> | null> {
+  const includeRelationships = opts.includeRelationships ?? true;
+
+  const profile = await entityProfile(store, entityId);
+  if (profile === null) return null;
+
+  const records = await store.getRecordsForEntity(entityId);
+  const goldenRecord = (profile.golden_record ?? null) as Record<string, unknown> | null;
+
+  let relationships: Array<Record<string, unknown>> = [];
+  if (includeRelationships) {
+    const getRel = (store as { getRelationships?: (id: string) => Promise<Array<Record<string, unknown>>> })
+      .getRelationships;
+    if (typeof getRel === "function") {
+      try {
+        relationships = await getRel.call(store, entityId);
+      } catch {
+        relationships = [];
+      }
+    }
+  }
+
+  const events = await store.history(entityId, opts.timelineLimit);
+
+  return {
+    entity_id: entityId,
+    status: profile.status,
+    merged_into: profile.merged_into,
+    dataset: profile.dataset,
+    confidence: profile.confidence,
+    version: profile.version,
+    record_count: profile.record_count,
+    sources: profile.sources,
+    source_counts: profile.source_counts,
+    conflict_count: profile.conflict_count,
+    first_seen: profile.first_seen,
+    last_seen: profile.last_seen,
+    golden_record: goldenRecord,
+    field_provenance: fieldProvenance(goldenRecord, records),
+    source_records: records.map(recordAsDict),
+    timeline: events.map(eventAsDict),
+    relationships,
   };
 }
 

--- a/packages/typescript/goldenmatch/src/node/mcp/identity-tools.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/identity-tools.ts
@@ -24,6 +24,7 @@ import {
 } from "../../core/identity/query.js";
 import { mediateConflict } from "../../core/identity/mediation.js";
 import {
+  customer360Page,
   entityProfile,
   identitySummaryStats,
   stewardWorklist,
@@ -307,6 +308,30 @@ export const IDENTITY_TOOLS: readonly Tool[] = [
         limit: { type: "integer", default: 50 },
         path: { type: "string", description: "Identity DB path" },
       },
+    },
+  },
+  {
+    name: "customer_360",
+    description:
+      "The unified Customer 360 serving view of one entity, composed from the " +
+      "durable store in one call: the golden record + per-field source " +
+      "provenance, every linked source record, the event timeline, and the " +
+      "relationship neighborhood. This is the same durable entity_id a resolved " +
+      "crosswalk (semantic-layer wedge) groups metrics by, so a metric row " +
+      "drills straight through to the customer. Returns {found: false} when no " +
+      "such entity exists.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entity_id: { type: "string" },
+        include_relationships: { type: "boolean", default: true },
+        timeline_limit: {
+          type: "integer",
+          description: "Cap the number of timeline events (most recent first).",
+        },
+        path: { type: "string", description: "Identity DB path" },
+      },
+      required: ["entity_id"],
     },
   },
 ];
@@ -657,6 +682,18 @@ async function dispatch(
         limit: intArg(args, "limit", 50),
       });
       return { items };
+    }
+
+    if (name === "customer_360") {
+      const entityId = strArg(args, "entity_id");
+      if (!entityId) return { error: "Missing required parameter: entity_id" };
+      const rawIncl = args["include_relationships"];
+      const rawLimit = args["timeline_limit"];
+      const page = await customer360Page(store, entityId, {
+        includeRelationships: typeof rawIncl === "boolean" ? rawIncl : true,
+        ...(typeof rawLimit === "number" ? { timelineLimit: rawLimit } : {}),
+      });
+      return page ?? { found: false };
     }
 
     return { error: `Unknown identity tool: ${name}` };

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -4,12 +4,13 @@
  *
  * Node-only: uses node:fs, node:path, node:readline. NOT edge-safe.
  *
- * Exposes 83 tools covering dedupe, match, scoring, explanation,
+ * Exposes 84 tools covering dedupe, match, scoring, explanation,
  * profiling, auto-config (shorthand), evaluation, listings, the Splink ->
  * GoldenMatch config converter (convert_splink_config), CCMS cluster
  * comparison (compare_clusters), Learning Memory (6 memory tools via
- * MEMORY_TOOLS, incl. memory_import), the Identity Graph (8 identity tools
- * via IDENTITY_TOOLS, incl. identity_claim + identity_resolve_conflict),
+ * MEMORY_TOOLS, incl. memory_import), the Identity Graph (9 identity tools
+ * via IDENTITY_TOOLS, incl. identity_claim + identity_resolve_conflict +
+ * customer_360),
  * the AgentSession skills (15 agent tools via AGENT_MCP_TOOLS, incl. the
  * healer's review_config), the stateful run tools (7 via RUN_TOOLS:
  * get_stats/list_clusters/get_cluster/get_golden_record/export_results/

--- a/packages/typescript/goldenmatch/tests/unit/mcp-identity-tools.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-identity-tools.test.ts
@@ -98,7 +98,7 @@ afterEach(() => {
 });
 
 describe("IDENTITY_TOOLS metadata", () => {
-  it("exports the 15 identity tools matching the Python sibling", () => {
+  it("exports the 16 identity tools matching the Python sibling", () => {
     expect(IDENTITY_TOOLS.map((t) => t.name)).toEqual([
       "identity_resolve",
       "identity_list",
@@ -115,8 +115,9 @@ describe("IDENTITY_TOOLS metadata", () => {
       "identity_profile",
       "identity_stats",
       "identity_worklist",
+      "customer_360",
     ]);
-    expect(IDENTITY_TOOL_NAMES.size).toBe(15);
+    expect(IDENTITY_TOOL_NAMES.size).toBe(16);
     for (const t of IDENTITY_TOOLS) {
       expect(t.description.length).toBeGreaterThan(0);
       expect(t.inputSchema).toBeTypeOf("object");
@@ -347,5 +348,56 @@ describe("identity read tools (show / profile / stats / worklist)", () => {
     expect(items.some((i) => i["entity_id"] === "E1")).toBe(true);
     const e1 = items.find((i) => i["entity_id"] === "E1")!;
     expect(e1["reasons"]).toContain("has_conflicts");
+  });
+
+  it("customer_360 composes the unified serving view", async () => {
+    const r = await call("customer_360", { entity_id: "E1" });
+    expect(r["entity_id"]).toBe("E1");
+    expect(r["record_count"]).toBe(1);
+    expect(r["golden_record"]).toEqual({ name: "E1" });
+    // every 360 section is present + JSON-ready
+    for (const key of [
+      "field_provenance",
+      "source_records",
+      "timeline",
+      "relationships",
+    ]) {
+      expect(Array.isArray(r[key])).toBe(true);
+    }
+    // per-field provenance: the golden `name` (E1) disagrees with src:1's
+    // payload (Alice), so it has no winning contributor and records the override
+    const prov = r["field_provenance"] as Record<string, unknown>[];
+    const nameProv = prov.find((p) => p["field"] === "name")!;
+    expect(nameProv["winning_record_id"]).toBeNull();
+    const conflicts = nameProv["conflicting_values"] as Record<string, unknown>[];
+    expect(conflicts.some((c) => c["value"] === "Alice")).toBe(true);
+    // the edge-safe store has no relationship overlay -> empty (Python's fallback)
+    expect(r["relationships"]).toEqual([]);
+  });
+
+  it("customer_360 attributes a golden field back to the source record that carries it", async () => {
+    // Re-stamp E1's golden so it agrees with src:1's payload (name: Alice).
+    await store.upsertIdentity({
+      entityId: "E1",
+      status: "active",
+      mergedInto: null,
+      goldenRecord: { name: "Alice" },
+      confidence: 0.9,
+      dataset: "d",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const r = await call("customer_360", { entity_id: "E1" });
+    const prov = r["field_provenance"] as Record<string, unknown>[];
+    const nameProv = prov.find((p) => p["field"] === "name")!;
+    expect(nameProv["winning_record_id"]).toBe("src:1");
+    expect(nameProv["winning_source"]).toBe("src");
+  });
+
+  it("customer_360 respects include_relationships=false and returns found:false for unknowns", async () => {
+    const r = await call("customer_360", { entity_id: "E1", include_relationships: false });
+    expect(r["relationships"]).toEqual([]);
+    const missing = await call("customer_360", { entity_id: "NOPE" });
+    expect(missing["found"]).toBe(false);
   });
 });

--- a/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
@@ -184,7 +184,7 @@ describe("MCP server — handleTool dispatcher", () => {
 
 describe("MCP server — agent tools wiring", () => {
   it("TOOLS exposes 80 tools (46 + 4 cross-language naming aliases, #1451; +convert_splink_config +compare_clusters +7 run tools (incl. lineage) +2 rollback tools +2 surgery tools +2 identity-conflict tools +memory_import +schema_match +config_weaknesses +analyze_blocking +certify_recall +incremental +sensitivity +retrieve_similar)", () => {
-    expect(TOOLS.length).toBe(83);
+    expect(TOOLS.length).toBe(84);
   });
 
   it("TOOLS includes the agent skill names", () => {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -71,6 +71,7 @@ mcp_tools:
   - controller_telemetry
   - convert_splink_config
   - create_domain
+  - customer_360
   - dedupe
   - evaluate
   - explain_cluster
@@ -139,7 +140,6 @@ mcp_tools:
   python_only:
   - certify_semantic_model
   - certify_serving_joins
-  - customer_360
   - documents_ingest
   - documents_suggest_schema
   - emit_semantic_model_from_store
@@ -256,6 +256,7 @@ a2a_skills:
   - agent_explain_pair
   - agent_match_sources
   - agent_review_queue
+  - customer_360
   - fix_quality
   - memory_import
   - scan_quality


### PR DESCRIPTION
## What and why

The final follow-on of the Customer 360 ↔ semantic-layer arc. The C360 serving view existed on the Python library, MCP, CLI, and REST — but not in the TypeScript port. This ports the drill-through view so the edge-safe TS surface conforms (shared-capabilities-conform), keyed on the same durable `entity_id` a resolved crosswalk groups metrics by.

## Changes

- **Core (`src/core/identity/profile.ts`):** `customer360Page(store, entityId, { includeRelationships, timelineLimit })` — edge-safe port of Python `identity/profile.py::customer_360`. Composes golden record + per-field source provenance (`fieldProvenance`, faithful winner/override logic) + linked source records + event timeline + relationship neighborhood, returning the same `as_dict()`-shaped object every Python surface returns. The relationship overlay is a federated read the edge-safe store doesn't implement, so it degrades to `[]` (mirroring Python's `AttributeError → []`; a store MAY provide an optional `getRelationships`).
- **MCP (`src/node/mcp/identity-tools.ts`):** new `customer_360` tool + dispatch (identity tools 15 → 16, total MCP 83 → 84).
- **Parity:** `customer_360` moves `python_only → shared` under `mcp_tools`. Because the TS A2A card auto-exposes every identity tool (`server.ts` builds it from `IDENTITY_TOOLS`), `customer_360` also becomes an `a2a_skills.ts_only` skill — Python's A2A never advertised it (the C360 arc put it on MCP+CLI only). Manifest-derived docs regenerated (suite-matrix, thesis-weaknesses, api-surface prose).

Note: the semantic-layer `ResolvedCrosswalk` (hence the Python `profile_from_crosswalk` drill-through) is intentionally Python-only, so the TS port is the store-keyed `customer360Page` view.

## Testing

- `npx tsc --noEmit` clean; `npm run build` succeeds.
- `npx vitest run` — **3533 passed** / 1 expected-fail / 158 skipped, including new `customer_360` cases (view shape, provenance winner + override paths, `include_relationships=false`, found:false).
- `python scripts/check_api_parity.py goldenmatch` — **parity OK** (manifest exactly partitions the real MCP + CLI surface, with the TS emitter now surfacing `customer_360`); suite-matrix / thesis-weaknesses / api-surface / api-parity / config-matrix gate tests all pass.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (parity manifest + manifest-derived pages + CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_