### PR TITLE
feat(thesis): T2 default-routing REACHED gate — prove the batteries workload routes through the owner

### DIFF
--- a/packages/typescript/goldenmatch/tests/unit/fs-default-routing-reached.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/fs-default-routing-reached.test.ts
@@ -1,0 +1,122 @@
+/**
+ * fs-default-routing-reached.test.ts -- the T2 "workload reached" conformance
+ * check (conformance v2, 0047 amendment; the follow-on to the T1 default-routing
+ * auditor in scripts/check_thesis_conformance.py).
+ *
+ * T1 (the Python static gate) verifies the batteries entry (`src/index.ts`)
+ * AUTO-REGISTERS the fs-core kernel at import -- i.e. the default GATE exists.
+ * Its documented honest limit: it does NOT prove the default caller path actually
+ * ROUTES THROUGH the registered backend on a real workload. A deliberately (or
+ * accidentally) mis-wired pipeline -- one that registers the backend but never
+ * consults it -- would pass T1 and the flag test while silently running the
+ * pure-TS fallback, exactly the "owner shipped, default elsewhere" class T1 exists
+ * to kill, one layer down.
+ *
+ * This closes that limit BEHAVIORALLY: importing ONLY the batteries root (no
+ * manual `enableFsWasmScoring()` call), a default `runDedupePipeline` on a
+ * probabilistic-eligible workload must INVOKE the auto-registered FS backend --
+ * the pipeline reaches the owner, not just the flag. A negative control (backend
+ * cleared -> the same workload runs pure-TS and never touches the spy) proves the
+ * assertion is meaningful, not always-true.
+ *
+ * Runs in the existing `typescript` CI lane (a vitest unit test) -- no new lane,
+ * mirroring T1's "wire into the existing thesis step" discipline. Vitest isolates
+ * the module registry per file, so the batteries side-effect here does not leak
+ * into the core-only test files that expect the pure-TS default.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+// Import the BATTERIES ROOT for its import-time side-effect ONLY: this is the
+// single thing under test -- `src/index.ts` calling registerFsKernel() at import.
+// We never call enableFsWasmScoring() ourselves.
+import { runDedupePipeline, makeConfig, makeBlockingConfig } from "../../src/index.js";
+import type { MatchkeyConfig, Row } from "../../src/core/index.js";
+import {
+  getFsScoreBackend,
+  setFsScoreBackend,
+  disableFsWasmScoring,
+  isFsWasmScoringEnabled,
+} from "../../src/core/fsScoreBackend.js";
+import type { FsScoreBackend } from "../../src/core/fsScoreBackend.js";
+import { enableFsWasmScoring } from "../../src/core/fsScore.js";
+
+// A probabilistic, kernel-eligible workload: one jaro_winkler field (score_one id
+// 0, so `fsRerouteEligible` accepts it) blocked on a shared key so a >=2-row block
+// forms and `scoreProbabilisticBlocks` actually has a block to score.
+const rows: Row[] = [
+  { name: "John", zip: "x" },
+  { name: "Jon", zip: "x" },
+  { name: "John", zip: "x" },
+  { name: "Mary", zip: "y" },
+  { name: "Mary", zip: "y" },
+];
+const probabilisticMk: MatchkeyConfig = {
+  name: "fs",
+  type: "probabilistic",
+  fields: [
+    { field: "name", transforms: [], scorer: "jaro_winkler", weight: 1, levels: 3, partialThreshold: 0.8 },
+  ],
+  linkThreshold: 0.5,
+};
+const config = makeConfig({
+  matchkeys: [probabilisticMk],
+  blocking: makeBlockingConfig({ strategy: "static", keys: [{ fields: ["zip"], transforms: [] }] }),
+});
+
+/** Wrap the currently-registered backend in a call-counter, delegating both methods. */
+function spyOnRegisteredBackend(): { calls: () => number } {
+  const real = getFsScoreBackend();
+  if (real === null) throw new Error("expected a backend to be auto-registered by the batteries import");
+  let n = 0;
+  const spy: FsScoreBackend = {
+    eligible: (mk) => real.eligible(mk),
+    scoreBlock: (blockRows, mk, em, threshold) => {
+      n += 1;
+      return real.scoreBlock(blockRows, mk, em, threshold);
+    },
+  };
+  setFsScoreBackend(spy);
+  return { calls: () => n };
+}
+
+afterEach(() => {
+  // Restore the batteries default (the real kernel backend) so ordering between
+  // this file's own tests can't leave the registry cleared. The per-file module
+  // isolation keeps this out of other test files regardless.
+  enableFsWasmScoring();
+});
+
+describe("T2 default-routing REACHED (batteries workload actually invokes the owner)", () => {
+  it("registers the fs backend purely from the batteries import (no manual enable)", () => {
+    // Precondition for the whole check: T1's gate is about THIS being true; T2
+    // builds on it to prove the pipeline then consults what T1 registered.
+    expect(isFsWasmScoringEnabled()).toBe(true);
+    expect(getFsScoreBackend()).not.toBeNull();
+  });
+
+  it("a default dedupe workload routes probabilistic blocks THROUGH the registered kernel", async () => {
+    const spy = spyOnRegisteredBackend();
+    const result = await runDedupePipeline(rows, config);
+
+    // The owner was REACHED: the pipeline invoked the auto-registered backend at
+    // least once (the "x" block has 3 rows) -- the fallback path never runs while a
+    // backend is registered and the matchkey is eligible.
+    expect(spy.calls()).toBeGreaterThanOrEqual(1);
+    // And the workload really scored (guards against a vacuous pass where the block
+    // loop is skipped entirely).
+    expect(result.scoredPairs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("NEGATIVE CONTROL: with the backend cleared, the same workload never touches the spy", async () => {
+    // Register a spy, then clear the registry: the pipeline must fall back to
+    // pure-TS `scoreProbabilistic` and NOT call the (now-unregistered) spy -- so the
+    // positive test's counter tracks real routing, not an always-true assertion.
+    const spy = spyOnRegisteredBackend();
+    disableFsWasmScoring();
+    expect(getFsScoreBackend()).toBeNull();
+
+    const result = await runDedupePipeline(rows, config);
+    expect(spy.calls()).toBe(0);
+    // The fallback still produces a working result (pure-TS FS scoring).
+    expect(result.scoredPairs.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -52,6 +52,12 @@ tenets:
 default_routing:
   ts_batteries:
     entry: packages/typescript/goldenmatch/src/index.ts
+    # T2 (conformance v2 follow-on): the static T1 gate proves the owner is
+    # AUTO-REGISTERED here; this vitest gate proves a default workload actually
+    # ROUTES THROUGH it (the honest limit T1 documented). Existence is guarded in
+    # scripts/test_thesis_conformance.py so the runtime check can't be silently
+    # dropped while this inventory still claims the default is code-verified.
+    runtime_reached_test: packages/typescript/goldenmatch/tests/unit/fs-default-routing-reached.test.ts
     owner_default:
       - enableFsWasmScoring   # fs_core default-on: registerFsKernel() at import (was the fs-default gap)
     opt_in:                   # edge-bundle discipline: reachable only via an explicit enable*() call

--- a/scripts/test_thesis_conformance.py
+++ b/scripts/test_thesis_conformance.py
@@ -50,3 +50,22 @@ def test_unlisted_auto_registered_kernel_is_advisory():
     gating, advisory = c.check_default_routing(inv, harvest)
     assert gating == []
     assert any("absent from the" in a and "enableNewWasm" in a for a in advisory)
+
+
+def test_declared_runtime_reached_tests_exist_on_disk():
+    # T2 follow-on: a default_routing block MAY name a `runtime_reached_test` -- the
+    # behavioral gate proving the DEFAULT workload routes through the owner (T1's
+    # documented honest limit). If named, the file MUST exist, so the runtime check
+    # can't be deleted/renamed while the inventory still claims the default is
+    # code-verified. Mirrors the gate's own weakness `parity_test` existence check.
+    inv = c.load_inventory()
+    named = 0
+    for name, block in (inv.get("default_routing") or {}).items():
+        rt = block.get("runtime_reached_test")
+        if rt is None:
+            continue
+        named += 1
+        assert (c.REPO / rt).exists(), f"default_routing '{name}' runtime_reached_test missing: {rt}"
+    # The ts_batteries fs-default class is the one that shipped opt-in-while-default;
+    # it MUST carry the runtime gate (regression guard on the annotation itself).
+    assert named >= 1, "expected at least one default_routing runtime_reached_test to be declared"


### PR DESCRIPTION
## What and why

The **behavioral follow-on** to the T1 default-routing auditor (merged in #2311). T1 (a Python static gate) verifies the batteries entry `src/index.ts` AUTO-REGISTERS the fs-core kernel at import — the default *gate* exists. Its **documented honest limit**: it does not prove the default caller path actually ROUTES THROUGH the registered backend on a real workload. A pipeline that registers the backend but never consults it would pass T1 and the flag test while silently running the pure-TS fallback — the "owner shipped, default elsewhere" class T1 exists to kill, one layer down.

This closes that limit **behaviorally**. You confirmed the framing: WASM is the optimal TS path, so a default `dedupe()` must actually reach it.

## Changes

- **`packages/typescript/goldenmatch/tests/unit/fs-default-routing-reached.test.ts`** (new, 3 tests) — importing ONLY the batteries root (no manual `enableFsWasmScoring()` call), a default `runDedupePipeline` on a probabilistic-eligible workload must INVOKE the auto-registered FS backend: it spies the registered backend and asserts `scoreBlock` is called. A **negative control** (backend cleared → the same workload runs pure-TS, the spy is never touched) proves the assertion is meaningful, not always-true. Runs in the existing `typescript` CI lane — no new lane, mirroring T1's discipline.
- **`parity/thesis_conformance.yaml`** — annotate the `ts_batteries` `default_routing` block with `runtime_reached_test` pointing at the gate. Purely documentary: the T1 harvester reads only `entry`/`owner_default`/`opt_in`, so the new key is ignored by the static gate.
- **`scripts/test_thesis_conformance.py`** — guard that any declared `runtime_reached_test` exists on disk (mirrors the gate's own weakness `parity_test` existence check), so the runtime gate can't be silently dropped while the inventory still claims the default is code-verified.

## Honest limits (documented in code)

- Proves the default path reaches the owner for a probabilistic **kernel-eligible** matchkey via an explicit config (the deterministic exercise of the FS route); autoconfig's *choice* of a probabilistic matchkey is a separate concern.
- The #1854 operating-point divergence (kernel FIXED-range vs pure-TS shrinking-range) is already locked at the adapter + pipeline level in `fs-reroute.test.ts`; this gate is scoped to *reached*, not *re-proving divergence*.

## Testing

- `python3 scripts/check_thesis_conformance.py --check` → **OK** (owner auto-registered; scorecard default-routing section renders `[OK]`).
- `pytest scripts/test_thesis_conformance.py` → **6 pass** (5 prior + the new existence guard).
- `npx vitest run` on the three fs files together → **15 pass** (no registry cross-leak).
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / gate wired; honest limits documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_