### PR TITLE
feat(ts): port certify_serving_joins + the key-integrity certifier (semantic wedge)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -59,11 +59,11 @@ neglect:
   (`read_file`, `write_csv`, `server_info`) were the last holdouts, and Python now
   exposes all eight.
 
-So GoldenMatch's **84 TS tools vs 94 Python** breaks down as 84 shared operations,
-**zero TS-only**, and 10 Python-only tools (the VLM document-ingest pair, the
+So GoldenMatch's **85 TS tools vs 94 Python** breaks down as 85 shared operations,
+**zero TS-only**, and 9 Python-only tools (the VLM document-ingest pair, the
 distributed routing trio, `list_plugins`, `pprl_auto_config`, and the
-semantic-layer wedge — `certify_semantic_model`, `certify_serving_joins`,
-`emit_semantic_model_from_store`). The TS MCP surface
+semantic-layer catalog front doors — `certify_semantic_model` and
+`emit_semantic_model_from_store` (the dialect emitters are Python-only)). The TS MCP surface
 is now a strict subset of the Python one — every TS tool has a Python counterpart of
 the same name, and what remains Python-only is the set with no JS-ecosystem
 equivalent. On the shared core the **public function names match**, and that parity

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -41,9 +41,9 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 84 | 10 | 0 |
+| `goldenmatch` | mcp_tools | 85 | 9 | 0 |
 | `goldenmatch` | cli_commands | 32 | 9 | 0 |
-| `goldenmatch` | a2a_skills | 36 | 15 | 11 |
+| `goldenmatch` | a2a_skills | 36 | 15 | 12 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
@@ -66,10 +66,10 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `certify_serving_joins`, `documents_ingest`, `documents_suggest_schema`, `emit_semantic_model_from_store`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
+- `goldenmatch` **mcp_tools** — Python-only: `certify_semantic_model`, `documents_ingest`, `documents_suggest_schema`, `emit_semantic_model_from_store`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
 - `goldenmatch` **cli_commands** — Python-only: `certify-keys`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
-- `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `customer_360`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
+- `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `certify_serving_joins`, `customer_360`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `init`, `review`, `scan-db`, `schedule`, `serve`.
 - `goldenflow` **cli_commands** — Python-only: `init`, `interactive`, `schedule`, `watch`.

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -57,10 +57,10 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldencheck` | mcp_tools | 1 | 0 |
 | `goldenflow` | cli_commands | 4 | 0 |
 | `goldenflow` | transforms | 0 | 1 |
-| `goldenmatch` | a2a_skills | 15 | 11 |
+| `goldenmatch` | a2a_skills | 15 | 12 |
 | `goldenmatch` | blocking_strategies | 1 | 0 |
 | `goldenmatch` | cli_commands | 9 | 0 |
-| `goldenmatch` | mcp_tools | 10 | 0 |
+| `goldenmatch` | mcp_tools | 9 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 
 ## Resolved (archived)

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Serving-join certification (`certifyServingJoins`) + the `certify_serving_joins`
+  MCP tool + a net-new key-integrity certifier (`certifyKeyIntegrity` /
+  `KeyIntegrityCertificate`).** Edge-safe port of Python
+  `semantic/serving.py::certify_serving_joins` and the structural tier of
+  `semantic/key_integrity.py`. A Customer 360 view joins the golden record to its
+  source records on the durable `recordId` (`{source}:{sourcePk}`); a duplicated
+  `recordId` makes a fact rolled up through the 360 silently double-count.
+  `certifyServingJoins(store, opts)` walks the store's entities, assembles the
+  `recordId` join key, and runs `certifyKeyIntegrity` over it — returning a
+  `ServingJoinCertificate` (`{ recordCertificate, nEntities, nRecords, truncated }`,
+  `isTrustworthy` getter). `certifyKeyIntegrity(table, { key, measures?, grain? })`
+  is the new structural key-integrity primitive (uniqueness at grain + per-measure
+  SUM fan-out); its `resolve=true` fragmentation/undercount tier is NOT ported.
+  Exposed as the TS MCP `certify_serving_joins` tool (identity tools 16 → 17, total
+  MCP 84 → 85), flipping `certify_serving_joins` from `python_only` to `shared`
+  under `mcp_tools`; like the other identity tools it is auto-advertised on the TS
+  A2A card, so it is declared `a2a_skills.ts_only`. New surface exports from
+  `goldenmatch/core` via `core/semantic`. NOTE: `emit_semantic_model_from_store`
+  stays Python-only — it depends on the entire Python-only semantic-layer emitter
+  subsystem (`ResolvedCrosswalk` + the MetricFlow/Cube/OSI YAML emitters), which is
+  a dedicated port, not part of this change.
 - **Customer 360 serving view (`customer360Page`) + the `customer_360` MCP tool.**
   Edge-safe port of Python `identity/profile.py::customer_360` — the unified
   serving read of one entity composed from the durable store in one call: golden

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -510,6 +510,7 @@ export { simhashSignature, simhashBandHashes } from "./simhash.js";
 
 export * from "./memory/index.js";
 export * from "./identity/index.js";
+export * from "./semantic/index.js";
 
 // ---------------------------------------------------------------------------
 // Agent decision core (AgentSession + strategy + skill registry)

--- a/packages/typescript/goldenmatch/src/core/semantic/index.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Semantic-layer interoperability (edge-safe subset).
+ *
+ * GoldenMatch produces the resolved, conformed entity keys a semantic layer's
+ * joins and measures silently assume. Today the TS port ships the key-integrity
+ * certifier + the Customer 360 serving-join certificate; the dialect catalog
+ * emitters (MetricFlow / Cube / OSI) remain Python-only.
+ */
+export {
+  KeyIntegrityCertificate,
+  certifyKeyIntegrity,
+  type KeyIntegrityCertificateInit,
+} from "./keyIntegrity.js";
+export { ServingJoinCertificate, certifyServingJoins } from "./serving.js";

--- a/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
@@ -1,0 +1,200 @@
+/**
+ * keyIntegrity.ts — the semantic-layer key-integrity certificate (edge-safe).
+ *
+ * Edge-safe port of the structural tier of Python
+ * `semantic/key_integrity.py::certify_key_integrity` +
+ * `core/key_integrity_certificate.py::KeyIntegrityCertificate`.
+ *
+ * A semantic layer (dbt/MetricFlow, Cube, OSI) is a join graph, and every join
+ * runs on entity-key equality. A metric is only correct if the declared key
+ * genuinely, uniquely identifies one real entity. `certifyKeyIntegrity` is the
+ * advisory answer to "is that declared key trustworthy?": is it unique at grain,
+ * and how much would a duplicated key inflate a `SUM`/`COUNT(DISTINCT)` (fan-out)?
+ * It never mutates a number; it reports and quantifies.
+ *
+ * SCOPE: the **structural** tier only (uniqueness + fan-out), which is all the
+ * serving-join certificate needs. The Python `resolve=true` fragmentation/
+ * undercount tier (which runs entity resolution on the record's attributes) is
+ * NOT ported here.
+ */
+
+export interface KeyIntegrityCertificateInit {
+  keyColumns: string[];
+  grain: string[] | null;
+  nRows: number;
+  nKeyGroups: number;
+  isUniqueAtGrain: boolean;
+  duplicateKeyGroups: number;
+  maxFanOut: number;
+  measureFanOut?: Record<string, number>;
+  note?: string;
+}
+
+/** Advisory certificate for a declared entity key (structural tier). */
+export class KeyIntegrityCertificate {
+  readonly keyColumns: string[];
+  readonly grain: string[] | null;
+  readonly nRows: number;
+  readonly nKeyGroups: number; // distinct key(-at-grain) tuples
+  readonly isUniqueAtGrain: boolean; // nKeyGroups === nRows
+  readonly duplicateKeyGroups: number; // key groups with >1 row
+  readonly maxFanOut: number; // worst-case row multiplicity for a key group
+  readonly measureFanOut: Record<string, number>; // per-measure SUM inflation ratio
+  note: string;
+
+  constructor(init: KeyIntegrityCertificateInit) {
+    this.keyColumns = init.keyColumns;
+    this.grain = init.grain;
+    this.nRows = init.nRows;
+    this.nKeyGroups = init.nKeyGroups;
+    this.isUniqueAtGrain = init.isUniqueAtGrain;
+    this.duplicateKeyGroups = init.duplicateKeyGroups;
+    this.maxFanOut = init.maxFanOut;
+    this.measureFanOut = init.measureFanOut ?? {};
+    this.note = init.note ?? "";
+  }
+
+  /** Point score in [0,1]: the fraction of key groups that are clean (unique at
+   * grain). 1.0 == the declared key is a true key. Mirrors Python `estimate`. */
+  get estimate(): number {
+    if (this.nKeyGroups === 0) return 1.0;
+    return 1.0 - this.duplicateKeyGroups / this.nKeyGroups;
+  }
+
+  /** Conservative score. With no resolution tier ported it collapses to the
+   * structural estimate (Python `safe_bound` with `undercount_estimate === null`). */
+  get safeBound(): number {
+    return this.estimate;
+  }
+
+  /** Advisory pass/fail: the declared key is unique at grain, doesn't fan out
+   * beyond `maxFanOut`, and clears `minEstimate`. Never enforced. */
+  isTrustworthy({ maxFanOut = 1.0, minEstimate = 1.0 }: { maxFanOut?: number; minEstimate?: number } = {}): boolean {
+    return this.isUniqueAtGrain && this.maxFanOut <= maxFanOut && this.estimate >= minEstimate;
+  }
+}
+
+function asList(x: string | readonly string[] | undefined): string[] {
+  if (x === undefined) return [];
+  return typeof x === "string" ? [x] : [...x];
+}
+
+/** Stable per-row group key over the group columns. `null`/`undefined` are a
+ * distinct group (matching pyarrow group_by), and a JSON encoding keeps a real
+ * `null` distinct from the string `"null"`. */
+function groupKey(row: readonly unknown[]): string {
+  return JSON.stringify(row.map((v) => (v === undefined ? null : v)));
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Certify a declared entity key for metric use (structural tier). Mirrors Python
+ * `certify_key_integrity`'s structural pass.
+ *
+ * @param table  column-oriented data (`{ column: values[] }`), the edge-safe
+ *   analogue of the Arrow table / dict the Python fn takes. Every column must be
+ *   the same length.
+ * @param opts.key       the declared entity key column(s).
+ * @param opts.measures  numeric columns whose SUM fan-out is quantified per key.
+ * @param opts.grain     the model's aggregation grain (advisory context by
+ *   default; folded into the grouping when `grainStrict`).
+ * @param opts.grainStrict  evaluate uniqueness/fan-out on `key + grain`.
+ */
+export function certifyKeyIntegrity(
+  table: Readonly<Record<string, readonly unknown[]>>,
+  opts: { key: string | readonly string[]; measures?: readonly string[]; grain?: readonly string[]; grainStrict?: boolean },
+): KeyIntegrityCertificate {
+  const keyColumns = asList(opts.key);
+  const measureCols = asList(opts.measures);
+  const grainCols = asList(opts.grain);
+  const grainStrict = opts.grainStrict ?? false;
+
+  if (keyColumns.length === 0) {
+    throw new Error("certifyKeyIntegrity: `key` must name at least one column");
+  }
+  const present = new Set(Object.keys(table));
+  const missingKeys = keyColumns.filter((c) => !present.has(c));
+  if (missingKeys.length) {
+    throw new Error(`certifyKeyIntegrity: key column(s) not in table: ${missingKeys.join(", ")}`);
+  }
+  const missingMeasures = measureCols.filter((c) => !present.has(c));
+  if (missingMeasures.length) {
+    throw new Error(`certifyKeyIntegrity: measure column(s) not in table: ${missingMeasures.join(", ")}`);
+  }
+  if (grainStrict && grainCols.length) {
+    const missingGrain = grainCols.filter((c) => !present.has(c));
+    if (missingGrain.length) {
+      throw new Error(`certifyKeyIntegrity: grain column(s) not in table: ${missingGrain.join(", ")}`);
+    }
+  }
+
+  const firstKeyCol = table[keyColumns[0]!]!;
+  const nRows = firstKeyCol.length;
+  const notes: string[] = [];
+
+  // numeric measures only (non-numeric skipped for fan-out, like Python)
+  const numericMeasures = measureCols.filter((m) => (table[m] ?? []).every((v) => v === null || v === undefined || isFiniteNumber(v)));
+  const skipped = measureCols.filter((m) => !numericMeasures.includes(m));
+  if (skipped.length) notes.push(`non-numeric measures skipped for fan-out: ${skipped.join(", ")}`);
+
+  const groupColumns =
+    grainStrict && grainCols.length ? [...keyColumns, ...grainCols.filter((g) => !keyColumns.includes(g))] : keyColumns;
+
+  // group-by: count rows per key-tuple + track per-measure max within the group
+  const counts = new Map<string, number>();
+  const measureMax = new Map<string, Record<string, number>>();
+  for (let i = 0; i < nRows; i++) {
+    const tuple = groupColumns.map((c) => (table[c] ?? [])[i]);
+    const gk = groupKey(tuple);
+    counts.set(gk, (counts.get(gk) ?? 0) + 1);
+    if (numericMeasures.length) {
+      const mm = measureMax.get(gk) ?? {};
+      for (const m of numericMeasures) {
+        const v = (table[m] ?? [])[i];
+        if (isFiniteNumber(v)) mm[m] = m in mm ? Math.max(mm[m]!, v) : v;
+      }
+      measureMax.set(gk, mm);
+    }
+  }
+
+  const nKeyGroups = counts.size;
+  let maxFanOut = 0;
+  let duplicateKeyGroups = 0;
+  for (const c of counts.values()) {
+    if (c > maxFanOut) maxFanOut = c;
+    if (c > 1) duplicateKeyGroups += 1;
+  }
+  const isUniqueAtGrain = nKeyGroups === nRows;
+
+  const measureFanOut: Record<string, number> = {};
+  for (const m of numericMeasures) {
+    let totalSum = 0;
+    for (const v of table[m] ?? []) if (isFiniteNumber(v)) totalSum += v;
+    let dedupSum = 0;
+    for (const mm of measureMax.values()) if (isFiniteNumber(mm[m])) dedupSum += mm[m]!;
+    measureFanOut[m] = dedupSum ? totalSum / dedupSum : 1.0;
+  }
+
+  if (grainCols.length) {
+    notes.push(
+      grainStrict
+        ? `uniqueness evaluated at grain: key + ${grainCols.join(", ")}`
+        : `grain ${grainCols.join(", ")} recorded as context; uniqueness evaluated on key`,
+    );
+  }
+
+  return new KeyIntegrityCertificate({
+    keyColumns,
+    grain: grainCols.length ? grainCols : null,
+    nRows,
+    nKeyGroups,
+    isUniqueAtGrain,
+    duplicateKeyGroups,
+    maxFanOut: nKeyGroups ? maxFanOut : 0,
+    measureFanOut,
+    note: notes.join("; "),
+  });
+}

--- a/packages/typescript/goldenmatch/src/core/semantic/serving.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/serving.ts
@@ -1,0 +1,96 @@
+/**
+ * serving.ts — certify the join keys a Customer 360 serving layer rolls up on.
+ *
+ * Edge-safe port of Python `semantic/serving.py::certify_serving_joins` +
+ * `ServingJoinCertificate`.
+ *
+ * A Customer 360 view joins the golden record to its source records (and events /
+ * relationships) on the durable `entityId`, and a dashboard typically joins a
+ * fact table to those source records on `recordId` (`{source}:{sourcePk}`) before
+ * rolling up to the entity. If a `recordId` is duplicated, that roll-up silently
+ * double-counts. This walks the store's entities, assembles the `recordId` join
+ * key, and runs `certifyKeyIntegrity` over it — turning the serving layer's
+ * implicit join-key trust into an advisory `KeyIntegrityCertificate`.
+ */
+import type { IdentityStore, IdentityNode } from "../identity/types.js";
+import { KeyIntegrityCertificate, certifyKeyIntegrity } from "./keyIntegrity.js";
+
+const PAGE = 500;
+
+/** Certifies the join keys a Customer 360 serving layer rolls metrics up on.
+ *
+ * `recordCertificate` is a `KeyIntegrityCertificate` over the source-record join
+ * key (`recordId` = `{source}:{sourcePk}`): unique means a fact joined to source
+ * records and rolled up to the entity can't double-count. `nEntities` / `nRecords`
+ * are the population it was computed over; `truncated` is true when a `maxEntities`
+ * cap stopped the scan short (so the cert covers a prefix). */
+export class ServingJoinCertificate {
+  constructor(
+    readonly recordCertificate: KeyIntegrityCertificate,
+    readonly nEntities: number,
+    readonly nRecords: number,
+    readonly truncated: boolean = false,
+  ) {}
+
+  get isTrustworthy(): boolean {
+    return this.recordCertificate.isTrustworthy();
+  }
+}
+
+/**
+ * Certify that a Customer 360 serving layer's join keys don't double-count.
+ * Mirrors Python `certify_serving_joins`.
+ *
+ * @param store  an open `IdentityStore`.
+ * @param opts.dataset  restrict to one identity-graph dataset (default: all).
+ * @param opts.status   entity status to include (default `"active"`; `null` = all).
+ * @param opts.pageSize pagination size for the entity scan.
+ * @param opts.maxEntities  cap the scan at this many entities (the cert then
+ *   covers a prefix and sets `truncated=true`); omit to scan every entity.
+ */
+export async function certifyServingJoins(
+  store: IdentityStore,
+  opts: { dataset?: string | null; status?: string | null; pageSize?: number; maxEntities?: number | null } = {},
+): Promise<ServingJoinCertificate> {
+  const dataset = opts.dataset ?? null;
+  const status = opts.status === undefined ? "active" : opts.status;
+  const pageSize = opts.pageSize ?? PAGE;
+  const maxEntities = opts.maxEntities ?? null;
+
+  const recordIds: string[] = [];
+  const entityIds: string[] = [];
+  let offset = 0;
+  let truncated = false;
+
+  for (;;) {
+    let limit = pageSize;
+    if (maxEntities !== null) {
+      const remaining = maxEntities - entityIds.length;
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      limit = Math.min(pageSize, remaining);
+    }
+    const nodes = await store.listIdentities({
+      ...(dataset !== null ? { dataset } : {}),
+      ...(status !== null ? { status: status as IdentityNode["status"] } : {}),
+      limit,
+      offset,
+    });
+    if (nodes.length === 0) break;
+    for (const node of nodes) {
+      entityIds.push(node.entityId);
+      for (const rec of await store.getRecordsForEntity(node.entityId)) {
+        recordIds.push(rec.recordId);
+      }
+    }
+    offset += nodes.length;
+    if (nodes.length < limit) break;
+  }
+
+  // certifyKeyIntegrity needs at least one row; an empty store is trivially
+  // trustworthy (no records means nothing can double-count).
+  const cert = certifyKeyIntegrity({ record_id: recordIds.length ? recordIds : [null] }, { key: "record_id" });
+  return new ServingJoinCertificate(cert, entityIds.length, recordIds.length, truncated);
+}

--- a/packages/typescript/goldenmatch/src/node/mcp/identity-tools.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/identity-tools.ts
@@ -29,6 +29,7 @@ import {
   identitySummaryStats,
   stewardWorklist,
 } from "../../core/identity/profile.js";
+import { certifyServingJoins } from "../../core/semantic/serving.js";
 import { sealAuditLog, verifyAuditChain, verificationSummary } from "../../core/identity/audit.js";
 import { pyIsoformat } from "../../core/identity/pyDatetime.js";
 import { trustForSource } from "../../core/memory/types.js";
@@ -332,6 +333,30 @@ export const IDENTITY_TOOLS: readonly Tool[] = [
         path: { type: "string", description: "Identity DB path" },
       },
       required: ["entity_id"],
+    },
+  },
+  {
+    name: "certify_serving_joins",
+    description:
+      "Certify that a Customer 360 serving layer's join keys can't double-count. " +
+      "A 360 view joins the golden record to its source records on the durable " +
+      "record_id (`{source}:{source_pk}`); if that key is duplicated, a fact " +
+      "rolled up through the 360 silently double-counts. This walks the store's " +
+      "entities, assembles the record_id join key, and returns a key-integrity " +
+      "certificate over it ({trustworthy, n_entities, n_records, truncated, " +
+      "record_id: {is_unique_at_grain, duplicate_key_groups, max_fan_out, estimate}}).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dataset: { type: "string", description: "Restrict to one identity-graph dataset." },
+        status: { type: "string", default: "active", description: "Entity status to include (default 'active')." },
+        page_size: { type: "integer", default: 500, description: "Entity-scan pagination size." },
+        max_entities: {
+          type: "integer",
+          description: "Cap the scan at this many entities (cert then covers a prefix, truncated=true).",
+        },
+        path: { type: "string", description: "Identity DB path" },
+      },
     },
   },
 ];
@@ -694,6 +719,30 @@ async function dispatch(
         ...(typeof rawLimit === "number" ? { timelineLimit: rawLimit } : {}),
       });
       return page ?? { found: false };
+    }
+
+    if (name === "certify_serving_joins") {
+      const rawMax = args["max_entities"];
+      const rawStatus = args["status"];
+      const cert = await certifyServingJoins(store, {
+        dataset: strArg(args, "dataset") ?? null,
+        status: typeof rawStatus === "string" ? rawStatus : "active",
+        pageSize: intArg(args, "page_size", 500),
+        ...(typeof rawMax === "number" ? { maxEntities: rawMax } : {}),
+      });
+      const rc = cert.recordCertificate;
+      return {
+        trustworthy: cert.isTrustworthy,
+        n_entities: cert.nEntities,
+        n_records: cert.nRecords,
+        truncated: cert.truncated,
+        record_id: {
+          is_unique_at_grain: rc.isUniqueAtGrain,
+          duplicate_key_groups: rc.duplicateKeyGroups,
+          max_fan_out: rc.maxFanOut,
+          estimate: rc.estimate,
+        },
+      };
     }
 
     return { error: `Unknown identity tool: ${name}` };

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -4,13 +4,13 @@
  *
  * Node-only: uses node:fs, node:path, node:readline. NOT edge-safe.
  *
- * Exposes 84 tools covering dedupe, match, scoring, explanation,
+ * Exposes 85 tools covering dedupe, match, scoring, explanation,
  * profiling, auto-config (shorthand), evaluation, listings, the Splink ->
  * GoldenMatch config converter (convert_splink_config), CCMS cluster
  * comparison (compare_clusters), Learning Memory (6 memory tools via
- * MEMORY_TOOLS, incl. memory_import), the Identity Graph (9 identity tools
+ * MEMORY_TOOLS, incl. memory_import), the Identity Graph (10 identity tools
  * via IDENTITY_TOOLS, incl. identity_claim + identity_resolve_conflict +
- * customer_360),
+ * customer_360 + certify_serving_joins),
  * the AgentSession skills (15 agent tools via AGENT_MCP_TOOLS, incl. the
  * healer's review_config), the stateful run tools (7 via RUN_TOOLS:
  * get_stats/list_clusters/get_cluster/get_golden_record/export_results/

--- a/packages/typescript/goldenmatch/tests/unit/mcp-identity-tools.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-identity-tools.test.ts
@@ -98,7 +98,7 @@ afterEach(() => {
 });
 
 describe("IDENTITY_TOOLS metadata", () => {
-  it("exports the 16 identity tools matching the Python sibling", () => {
+  it("exports the 17 identity tools matching the Python sibling", () => {
     expect(IDENTITY_TOOLS.map((t) => t.name)).toEqual([
       "identity_resolve",
       "identity_list",
@@ -116,8 +116,9 @@ describe("IDENTITY_TOOLS metadata", () => {
       "identity_stats",
       "identity_worklist",
       "customer_360",
+      "certify_serving_joins",
     ]);
-    expect(IDENTITY_TOOL_NAMES.size).toBe(16);
+    expect(IDENTITY_TOOL_NAMES.size).toBe(17);
     for (const t of IDENTITY_TOOLS) {
       expect(t.description.length).toBeGreaterThan(0);
       expect(t.inputSchema).toBeTypeOf("object");
@@ -399,5 +400,17 @@ describe("identity read tools (show / profile / stats / worklist)", () => {
     expect(r["relationships"]).toEqual([]);
     const missing = await call("customer_360", { entity_id: "NOPE" });
     expect(missing["found"]).toBe(false);
+  });
+
+  it("certify_serving_joins certifies the record_id join key", async () => {
+    // The seed has 2 entities (E1, E2) with distinct src:1 / src:2 -> unique.
+    const r = await call("certify_serving_joins", { dataset: "d" });
+    expect(r["trustworthy"]).toBe(true);
+    expect(r["n_entities"]).toBe(2);
+    expect(r["n_records"]).toBe(2);
+    expect(r["truncated"]).toBe(false);
+    const rc = r["record_id"] as Record<string, unknown>;
+    expect(rc["is_unique_at_grain"]).toBe(true);
+    expect(rc["duplicate_key_groups"]).toBe(0);
   });
 });

--- a/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
@@ -184,7 +184,7 @@ describe("MCP server — handleTool dispatcher", () => {
 
 describe("MCP server — agent tools wiring", () => {
   it("TOOLS exposes 80 tools (46 + 4 cross-language naming aliases, #1451; +convert_splink_config +compare_clusters +7 run tools (incl. lineage) +2 rollback tools +2 surgery tools +2 identity-conflict tools +memory_import +schema_match +config_weaknesses +analyze_blocking +certify_recall +incremental +sensitivity +retrieve_similar)", () => {
-    expect(TOOLS.length).toBe(84);
+    expect(TOOLS.length).toBe(85);
   });
 
   it("TOOLS includes the agent skill names", () => {

--- a/packages/typescript/goldenmatch/tests/unit/semantic-serving.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/semantic-serving.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Edge-safe key-integrity certifier + Customer 360 serving-join certificate.
+ * Port parity with Python tests/test_semantic_serving.py (the certify_serving_joins
+ * cases) + the structural certify_key_integrity behavior.
+ */
+import { describe, it, expect } from "vitest";
+
+import { certifyKeyIntegrity } from "../../src/core/semantic/keyIntegrity.js";
+import { certifyServingJoins, ServingJoinCertificate } from "../../src/core/semantic/serving.js";
+import { InMemoryIdentityStore } from "../../src/core/identity/in-memory-store.js";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+describe("certifyKeyIntegrity (structural tier)", () => {
+  it("a unique key is trustworthy: estimate 1.0, no duplicate groups", () => {
+    const cert = certifyKeyIntegrity({ id: ["a", "b", "c"] }, { key: "id" });
+    expect(cert.isUniqueAtGrain).toBe(true);
+    expect(cert.nRows).toBe(3);
+    expect(cert.nKeyGroups).toBe(3);
+    expect(cert.duplicateKeyGroups).toBe(0);
+    expect(cert.maxFanOut).toBe(1);
+    expect(cert.estimate).toBe(1.0);
+    expect(cert.isTrustworthy()).toBe(true);
+  });
+
+  it("a duplicated key reports fan-out and is not trustworthy", () => {
+    const cert = certifyKeyIntegrity({ id: ["a", "a", "b"] }, { key: "id" });
+    expect(cert.isUniqueAtGrain).toBe(false);
+    expect(cert.nKeyGroups).toBe(2);
+    expect(cert.duplicateKeyGroups).toBe(1);
+    expect(cert.maxFanOut).toBe(2);
+    expect(cert.estimate).toBe(0.5);
+    expect(cert.isTrustworthy()).toBe(false);
+  });
+
+  it("null is a distinct key group (not conflated with the string 'null')", () => {
+    const cert = certifyKeyIntegrity({ id: [null, "null"] }, { key: "id" });
+    expect(cert.nKeyGroups).toBe(2);
+    expect(cert.isUniqueAtGrain).toBe(true);
+  });
+
+  it("quantifies per-measure SUM fan-out for a duplicated key", () => {
+    // key a repeats with amounts 10 and 30 (max 30); dedup SUM = 30 + 5 = 35,
+    // raw SUM = 10 + 30 + 5 = 45 -> fan-out 45/35.
+    const cert = certifyKeyIntegrity(
+      { id: ["a", "a", "b"], amount: [10, 30, 5] },
+      { key: "id", measures: ["amount"] },
+    );
+    expect(cert.measureFanOut["amount"]).toBeCloseTo(45 / 35, 10);
+  });
+
+  it("rejects a missing key column", () => {
+    expect(() => certifyKeyIntegrity({ id: ["a"] }, { key: "nope" })).toThrow(/key column/);
+  });
+});
+
+async function seedStore(): Promise<InMemoryIdentityStore> {
+  const store = new InMemoryIdentityStore();
+  for (const [entityId, recordId] of [
+    ["E1", "crm:1"],
+    ["E1", "crm:2"],
+    ["E2", "crm:3"],
+  ] as const) {
+    if (!(await store.getIdentity(entityId))) {
+      await store.upsertIdentity({
+        entityId,
+        status: "active",
+        mergedInto: null,
+        goldenRecord: null,
+        confidence: 0.9,
+        dataset: "crm",
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+    }
+    await store.upsertRecord({
+      recordId,
+      source: "crm",
+      sourcePk: recordId.split(":")[1]!,
+      recordHash: recordId,
+      entityId,
+      payload: null,
+      dataset: "crm",
+      firstSeenAt: NOW,
+      lastSeenAt: NOW,
+    });
+  }
+  return store;
+}
+
+describe("certifyServingJoins", () => {
+  it("clean store: 3 distinct records across 2 entities -> trustworthy", async () => {
+    const store = await seedStore();
+    const cert = await certifyServingJoins(store, { dataset: "crm" });
+    expect(cert).toBeInstanceOf(ServingJoinCertificate);
+    expect(cert.nEntities).toBe(2);
+    expect(cert.nRecords).toBe(3);
+    expect(cert.isTrustworthy).toBe(true);
+    expect(cert.truncated).toBe(false);
+    expect(cert.recordCertificate.duplicateKeyGroups).toBe(0);
+  });
+
+  it("an empty store is trivially trustworthy", async () => {
+    const store = new InMemoryIdentityStore();
+    const cert = await certifyServingJoins(store);
+    expect(cert.nEntities).toBe(0);
+    expect(cert.nRecords).toBe(0);
+    expect(cert.isTrustworthy).toBe(true);
+  });
+
+  it("respects maxEntities and reports truncated", async () => {
+    const store = new InMemoryIdentityStore();
+    for (let i = 0; i < 5; i++) {
+      const entityId = `E${i}`;
+      await store.upsertIdentity({
+        entityId,
+        status: "active",
+        mergedInto: null,
+        goldenRecord: null,
+        confidence: 0.9,
+        dataset: "crm",
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+      await store.upsertRecord({
+        recordId: `crm:${i}`,
+        source: "crm",
+        sourcePk: String(i),
+        recordHash: `crm:${i}`,
+        entityId,
+        payload: null,
+        dataset: "crm",
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+      });
+    }
+    const cert = await certifyServingJoins(store, { dataset: "crm", pageSize: 2, maxEntities: 3 });
+    expect(cert.nEntities).toBe(3);
+    expect(cert.truncated).toBe(true);
+  });
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -66,6 +66,7 @@ mcp_tools:
   - auto_configure
   - build_clusters
   - certify_recall
+  - certify_serving_joins
   - compare_clusters
   - config_weaknesses
   - controller_telemetry
@@ -139,7 +140,6 @@ mcp_tools:
   - write_csv
   python_only:
   - certify_semantic_model
-  - certify_serving_joins
   - documents_ingest
   - documents_suggest_schema
   - emit_semantic_model_from_store
@@ -256,6 +256,7 @@ a2a_skills:
   - agent_explain_pair
   - agent_match_sources
   - agent_review_queue
+  - certify_serving_joins
   - customer_360
   - fix_quality
   - memory_import


### PR DESCRIPTION
## What and why

Surfaces `certify_serving_joins` on the TypeScript side — the last **portable** `python_only` serving surface — so the C360 serving-join certificate conforms across languages. It required porting a net-new key-integrity certifier (TS had none).

## Changes

- **`src/core/semantic/keyIntegrity.ts`** — new `certifyKeyIntegrity(table, { key, measures?, grain?, grainStrict? })` + `KeyIntegrityCertificate` (with `estimate` / `isTrustworthy()`). Edge-safe port of the **structural tier** of Python `semantic/key_integrity.py` — uniqueness at grain + per-measure SUM fan-out over column-oriented data. The `resolve=true` fragmentation/undercount tier (which runs entity resolution on record attributes) is **not** ported.
- **`src/core/semantic/serving.ts`** — `certifyServingJoins(store, opts)` + `ServingJoinCertificate`. Walks the `IdentityStore` (paged, `maxEntities`-capped → `truncated`), assembles the `recordId` join key, and certifies it can't double-count. Faithful to the Python pagination + empty-store-is-trustworthy semantics.
- **`src/core/semantic/index.ts`** re-exported from `goldenmatch/core`.
- **MCP:** new `certify_serving_joins` tool + dispatch (identity tools 16 → 17, total MCP 84 → 85).
- **Parity:** `certify_serving_joins` moves `python_only → shared` (mcp_tools); auto-advertised on the TS A2A card (built from `IDENTITY_TOOLS`) so declared `a2a_skills.ts_only`. Manifest-derived docs regenerated (suite-matrix, thesis-weaknesses, api-surface prose).

### Explicitly out of scope: `emit_semantic_model_from_store`
The other `python_only` serving surface is **not** portable in a focused PR: TS has no semantic-layer surface at all — no `ResolvedCrosswalk`, no MetricFlow/Cube/OSI YAML emitters. Porting `emit_semantic_model_from_store` means porting that entire Python-only subsystem (multiple hundred-line emitter modules + a YAML serializer + cross-language fixtures), a dedicated arc. It stays `python_only` and is noted as such in the CHANGELOG + api-surface prose.

## Testing

- `npx tsc --noEmit` clean; `npm run build` succeeds.
- `npx vitest run` — **3542 passed** / 1 expected-fail / 158 skipped, including a new `semantic-serving.test.ts` (certifier unique/duplicate/null-distinctness/measure-fanout + serving-cert clean/empty/truncated) and the MCP dispatch case.
- `python scripts/check_api_parity.py goldenmatch` — **parity OK** (the TS emitter now surfaces `certify_serving_joins`); suite-matrix / thesis-weaknesses / api-surface / api-parity gate tests pass.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (parity manifest + manifest-derived pages + CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_