### PR TITLE
fix(security): match `..` path segment exactly in the REST path jail

### DIFF
--- a/packages/typescript/goldenflow/src/node/api/server.ts
+++ b/packages/typescript/goldenflow/src/node/api/server.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { resolve, isAbsolute, relative } from "node:path";
+import { resolve, isAbsolute, relative, sep } from "node:path";
 import { readFile } from "../connectors/file.js";
 import { TransformEngine } from "../../core/engine/transformer.js";
 import { listTransforms } from "../../core/transforms/index.js";
@@ -14,7 +14,10 @@ function sanitizePath(raw: string): string {
   // (`/srv/app-secrets` vs cwd `/srv/app`), a root cwd (`/`, `C:\`) that a
   // `cwd + sep` prefix check would wrongly reject, and cross-drive paths.
   const rel = relative(cwd, resolved);
-  if (rel.startsWith("..") || isAbsolute(rel)) {
+  // Escape iff the first segment is exactly `..` (or rel is absolute, e.g. a
+  // different Windows drive). A raw `startsWith("..")` would wrongly reject a
+  // contained file whose name merely begins with `..` (e.g. `..env`).
+  if (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) {
     throw new Error(`Path '${raw}' is outside the working directory`);
   }
   return resolved;

--- a/packages/typescript/goldenpipe/src/node/api/server.ts
+++ b/packages/typescript/goldenpipe/src/node/api/server.ts
@@ -20,7 +20,7 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { resolve, isAbsolute, relative } from "node:path";
+import { resolve, isAbsolute, relative, sep } from "node:path";
 import { handleTool } from "../mcp/server.js";
 import { run } from "../run.js";
 
@@ -36,7 +36,10 @@ function sanitizePath(raw: string): string {
   // (`/srv/app-secrets` vs cwd `/srv/app`), a root cwd (`/`, `C:\`) that a
   // `cwd + sep` prefix check would wrongly reject, and cross-drive paths.
   const rel = relative(cwd, resolved);
-  if (rel.startsWith("..") || isAbsolute(rel)) {
+  // Escape iff the first segment is exactly `..` (or rel is absolute, e.g. a
+  // different Windows drive). A raw `startsWith("..")` would wrongly reject a
+  // contained file whose name merely begins with `..` (e.g. `..env`).
+  if (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) {
     throw new Error(`Path '${raw}' is outside the working directory`);
   }
   return resolved;


### PR DESCRIPTION
## What and why

Final correctness fix for the `goldenflow`/`goldenpipe` REST path jail, addressing the Copilot review on #2324. The `path.relative`-based check landed there used `rel.startsWith("..")`, which is too broad: a legitimately-contained file whose name merely **begins** with `..` (e.g. `..env`, `...gitkeep`) resolves to a relative like `..env` and was wrongly rejected — contradicting the "no behavior change for contained paths" goal.

## Changes

- Both REST `sanitizePath` jails now treat a path as an escape only when its **first segment is exactly `..`**: `rel === ".." || rel.startsWith(".." + sep)` (plus the existing `isAbsolute(rel)` check for a different Windows drive). This is the canonical containment form.

## Testing

- Verified across the edge matrix: `..env` / `...gitkeep` inside cwd → **allow**; `../etc`, sibling-prefix (`/srv/app-secrets` vs `/srv/app`), and cross-drive → **reject**; legit child and cwd-exact → **allow**.
- `npx tsc --noEmit` on goldenflow → clean; goldenflow path/server tests → **19 passed**.

## Checklist

- [x] Verification passing locally for the changed packages
- [x] No secrets, tokens, or `.env` files committed
- [x] Restores correct behavior for contained paths (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_