### PR TITLE
fix(security): jail goldenpipe MCP run_pipeline file reads to the working dir

### DIFF
--- a/docs-site/goldenpipe/config-matrix.mdx
+++ b/docs-site/goldenpipe/config-matrix.mdx
@@ -178,8 +178,9 @@ _`BUILTIN_STAGES` -- `StageSpec.use`._
 
 ## Environment variables (index)
 
-1 `GOLDENPIPE_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
+2 `GOLDENPIPE_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
 
+- **ALLOWED** (1): `GOLDENPIPE_ALLOWED_ROOT`
 - **NATIVE** (1): `GOLDENPIPE_NATIVE`
 
 {/* config-matrix:generated:end */}

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -11917,6 +11917,7 @@
             "_frame_head_dicts",
             "_frame_rows",
             "_is_frame",
+            "_jail_path",
             "_result_to_dict",
             "_summarize_output",
             "create_server",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -8920,6 +8920,9 @@
         }
       ],
       "env_vars": {
+        "ALLOWED": [
+          "GOLDENPIPE_ALLOWED_ROOT"
+        ],
         "NATIVE": [
           "GOLDENPIPE_NATIVE"
         ]

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -207,7 +207,15 @@ def _result_to_dict(result: Any, preview_rows: int = 10) -> dict[str, Any]:
 def explain_pipeline_tool(config_path: str) -> dict[str, Any]:
     """Explain what a pipeline config will do."""
     from goldenpipe.config.loader import load_config
-    config = load_config(config_path)
+    # Jail the caller-supplied config path (public unauthenticated MCP surface),
+    # same as run_pipeline. Surface an escape / load failure as data instead of
+    # opening an out-of-root file or echoing a YAML parse error (file contents).
+    try:
+        config = load_config(_jail_path(config_path))
+    except ValueError as exc:  # jail escape / NUL byte -- message is already generic
+        return {"error": str(exc)}
+    except Exception:  # missing / malformed config -- don't leak server internals
+        return {"error": "failed to load config"}
     reg = StageRegistry()
     reg.discover()
     try:

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -36,7 +36,10 @@ def _jail_path(value: str) -> str:
     resolved = Path(raw).resolve()
     root = Path(os.environ.get("GOLDENPIPE_ALLOWED_ROOT") or os.getcwd()).resolve()
     if resolved != root and not resolved.is_relative_to(root):
-        raise ValueError(f"path {str(resolved)!r} is outside the allowed root {str(root)!r}")
+        # Generic message on purpose: this is a public, unauthenticated endpoint,
+        # so the error must not disclose the resolved absolute path or the server's
+        # root directory back to the caller.
+        raise ValueError("path is outside the allowed root")
     return str(resolved)
 
 
@@ -101,8 +104,11 @@ def run_pipeline_tool(
         elif config_path:
             from goldenpipe.config.loader import load_config
             cfg = load_config(_jail_path(config_path))
-    except ValueError as exc:  # path escaped the allowed root
+    except ValueError as exc:  # jail escape / NUL byte -- message is already generic
         return {"error": str(exc)}
+    except Exception:  # missing / malformed config -- surface as data, don't crash
+        # the request or leak the underlying filesystem error on a public endpoint.
+        return {"error": "failed to load config"}
 
     try:
         pipe = Pipeline(config=cfg, identity_opts=identity_opts)

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from typing import Any
 
 try:
@@ -15,6 +17,27 @@ except ImportError:
 from goldenpipe.engine.registry import StageRegistry
 from goldenpipe.engine.resolver import Resolver, WiringError
 from goldenpipe.models.config import PipelineConfig, StageSpec
+
+
+def _jail_path(value: str) -> str:
+    """Resolve a caller-supplied path and reject escapes from the allowed root.
+
+    The ``run_pipeline`` ``source`` / ``config_path`` args are attacker-controllable
+    over the HTTP transport (this server is deployed as a public remote MCP), so a
+    path that escapes the server's working directory -- or contains a NUL byte -- is
+    rejected instead of being opened. Mirrors the goldenmatch / infermap MCP path
+    jail. The root defaults to the process working directory; override it with
+    ``GOLDENPIPE_ALLOWED_ROOT`` (e.g. a mounted data volume). Returns the resolved
+    absolute path string on success; raises ``ValueError`` on escape.
+    """
+    raw = os.fspath(value)
+    if "\x00" in raw:
+        raise ValueError("path contains NUL byte")
+    resolved = Path(raw).resolve()
+    root = Path(os.environ.get("GOLDENPIPE_ALLOWED_ROOT") or os.getcwd()).resolve()
+    if resolved != root and not resolved.is_relative_to(root):
+        raise ValueError(f"path {str(resolved)!r} is outside the allowed root {str(root)!r}")
+    return str(resolved)
 
 
 def list_stages_tool() -> dict[str, Any]:
@@ -72,11 +95,14 @@ def run_pipeline_tool(
     # Config: inline stages > YAML path > zero-config auto. An explicit (even
     # empty) ``stages`` list wins over auto; ``None`` means zero-config.
     cfg = None
-    if stages is not None:
-        cfg = PipelineConfig(pipeline="inline", stages=[StageSpec(use=s) for s in stages])
-    elif config_path:
-        from goldenpipe.config.loader import load_config
-        cfg = load_config(config_path)
+    try:
+        if stages is not None:
+            cfg = PipelineConfig(pipeline="inline", stages=[StageSpec(use=s) for s in stages])
+        elif config_path:
+            from goldenpipe.config.loader import load_config
+            cfg = load_config(_jail_path(config_path))
+    except ValueError as exc:  # path escaped the allowed root
+        return {"error": str(exc)}
 
     try:
         pipe = Pipeline(config=cfg, identity_opts=identity_opts)
@@ -86,7 +112,7 @@ def run_pipeline_tool(
             import io
             result = pipe.run(df=pl.read_csv(io.StringIO(csv_text), ignore_errors=True))
         elif source:
-            result = pipe.run(source=source)
+            result = pipe.run(source=_jail_path(source))
         else:
             return {"error": (
                 "provide one input: 'source' (file path), 'records' (list of "

--- a/packages/python/goldenpipe/tests/test_mcp.py
+++ b/packages/python/goldenpipe/tests/test_mcp.py
@@ -4,6 +4,7 @@ import pytest
 
 try:
     from goldenpipe.mcp.server import (
+        _jail_path,
         _result_to_dict,
         _summarize_output,
         list_stages_tool,
@@ -134,3 +135,41 @@ class TestRunPipelineDedupe:
         assert isinstance(output["golden_preview"], list)
         assert output["golden_preview"]  # non-empty
         assert output["match_stats"]["total_records"] == 4
+
+
+class TestPathJail:
+    """The run_pipeline `source`/`config_path` reads are jailed to the working
+    dir (network-exposed MCP hardening) -- a path escaping the root is rejected."""
+
+    def test_jail_allows_paths_inside_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        f = tmp_path / "data.csv"
+        f.write_text("x\n")
+        assert _jail_path("data.csv") == str(f.resolve())
+        assert _jail_path(str(f)) == str(f.resolve())
+
+    def test_jail_rejects_escape(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(ValueError):
+            _jail_path("/etc/passwd")
+        with pytest.raises(ValueError):
+            _jail_path("../../etc/passwd")
+
+    def test_jail_rejects_nul_byte(self):
+        with pytest.raises(ValueError):
+            _jail_path("a\x00b")
+
+    def test_jail_honors_allowed_root_env(self, tmp_path, monkeypatch):
+        root = tmp_path / "allowed"
+        root.mkdir()
+        monkeypatch.setenv("GOLDENPIPE_ALLOWED_ROOT", str(root))
+        assert _jail_path(str(root / "ok.csv")) == str((root / "ok.csv").resolve())
+        with pytest.raises(ValueError):
+            _jail_path(str(tmp_path / "outside.csv"))
+
+    def test_run_pipeline_rejects_escaping_source(self, tmp_path, monkeypatch):
+        # A traversal `source` must be refused as data (no file read), not opened.
+        monkeypatch.chdir(tmp_path)
+        out = run_pipeline_tool(source="/etc/passwd")
+        assert "error" in out
+        assert "outside the allowed root" in out["error"]

--- a/packages/python/goldenpipe/tests/test_mcp.py
+++ b/packages/python/goldenpipe/tests/test_mcp.py
@@ -7,6 +7,7 @@ try:
         _jail_path,
         _result_to_dict,
         _summarize_output,
+        explain_pipeline_tool,
         list_stages_tool,
         run_pipeline_tool,
         validate_pipeline_tool,
@@ -199,4 +200,16 @@ class TestPathJail:
         # the request (load_config raises FileNotFoundError past the jail check).
         monkeypatch.chdir(tmp_path)
         out = run_pipeline_tool(config_path="nonexistent.yml")
+        assert out.get("error") == "failed to load config"
+
+    def test_explain_pipeline_rejects_escaping_config_path(self, tmp_path, monkeypatch):
+        # explain_pipeline reads config_path too -- it must be jailed the same way.
+        monkeypatch.chdir(tmp_path)
+        out = explain_pipeline_tool(config_path="/etc/passwd")
+        assert "error" in out
+        assert "outside the allowed root" in out["error"]
+
+    def test_explain_pipeline_missing_config_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        out = explain_pipeline_tool(config_path="nonexistent.yml")
         assert out.get("error") == "failed to load config"

--- a/packages/python/goldenpipe/tests/test_mcp.py
+++ b/packages/python/goldenpipe/tests/test_mcp.py
@@ -167,9 +167,36 @@ class TestPathJail:
         with pytest.raises(ValueError):
             _jail_path(str(tmp_path / "outside.csv"))
 
+    def test_escape_message_is_generic(self, tmp_path, monkeypatch):
+        # Public unauthenticated endpoint: the error must NOT leak the resolved
+        # absolute path or the server's root directory.
+        monkeypatch.chdir(tmp_path)
+        try:
+            _jail_path("/etc/passwd")
+            raise AssertionError("expected ValueError")
+        except ValueError as exc:
+            msg = str(exc)
+        assert msg == "path is outside the allowed root"
+        assert "/etc/passwd" not in msg
+        assert str(tmp_path) not in msg
+
     def test_run_pipeline_rejects_escaping_source(self, tmp_path, monkeypatch):
         # A traversal `source` must be refused as data (no file read), not opened.
         monkeypatch.chdir(tmp_path)
         out = run_pipeline_tool(source="/etc/passwd")
         assert "error" in out
         assert "outside the allowed root" in out["error"]
+
+    def test_run_pipeline_rejects_escaping_config_path(self, tmp_path, monkeypatch):
+        # `config_path` is jailed too -- a traversal is refused as data, not opened.
+        monkeypatch.chdir(tmp_path)
+        out = run_pipeline_tool(config_path="/etc/shadow")
+        assert "error" in out
+        assert "outside the allowed root" in out["error"]
+
+    def test_run_pipeline_missing_config_returns_error(self, tmp_path, monkeypatch):
+        # A jailed-but-nonexistent config must return an error payload, not crash
+        # the request (load_config raises FileNotFoundError past the jail check).
+        monkeypatch.chdir(tmp_path)
+        out = run_pipeline_tool(config_path="nonexistent.yml")
+        assert out.get("error") == "failed to load config"

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -8920,6 +8920,9 @@
         }
       ],
       "env_vars": {
+        "ALLOWED": [
+          "GOLDENPIPE_ALLOWED_ROOT"
+        ],
         "NATIVE": [
           "GOLDENPIPE_NATIVE"
         ]


### PR DESCRIPTION
## What and why

The goldenpipe MCP `run_pipeline` tool reads a caller-supplied `source` (and `config_path`) file path and returns row previews. The server is deployed as a **public remote MCP** (`goldenpipe-mcp` on Railway) with no enforced auth, so this was an **unauthenticated arbitrary-file read**: `run_pipeline(source="/etc/passwd")` would open the file and echo rows back to the caller.

This is the **safe partial mitigation** from the security sweep — no bind/auth change, no deploy impact — that removes the arbitrary-file-read teeth while the fail-closed auth guard (which touches the live Railway deploy) is coordinated separately.

## Changes

- **`goldenpipe/mcp/server.py`** — new `_jail_path` helper resolves the caller path and rejects anything that escapes the allowed root (or contains a NUL byte). `run_pipeline`'s `source`/`config_path` now pass through it before being opened; an escaping path is returned as `{"error": ...}` data, not opened. The root defaults to the process working directory and is overridable via `GOLDENPIPE_ALLOWED_ROOT` (e.g. a mounted data volume — mirrors goldenmatch's `GOLDENMATCH_ALLOWED_ROOT` and the goldenmatch/infermap MCP path jails). The **A2A server dispatches the same tool function, so it inherits the jail**.

## What this deliberately does NOT do

- **No auth change, no bind change.** The fail-closed guard (refuse a non-loopback bind without a token) crash-loops the Railway deploy unless the token env is set first, so it's a separate, coordinated change. This PR is deploy-safe on its own.
- **goldencheck A2A (TS)** has the same unjailed-read shape but is not on a live Railway deploy (self-hosted library server) — lower priority, tracked as a follow-up.

## Testing

- `pytest tests/test_mcp.py::TestPathJail` → **5 passed**: allow-in-cwd, reject-escape (`/etc/passwd`, `../../`), reject-NUL, `GOLDENPIPE_ALLOWED_ROOT` override, and `run_pipeline(source="/etc/passwd")` refused as an error (no file read).

## Checklist

- [x] Tests added and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] No bind/auth/deploy change (path-containment mitigation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_