### PR TITLE
feat(ts): CLI + REST surfaces for the semantic wedge (certify-keys, emit-catalog)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 87 | 7 | 0 |
-| `goldenmatch` | cli_commands | 32 | 9 | 0 |
+| `goldenmatch` | cli_commands | 33 | 8 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 15 | 13 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -67,7 +67,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `certify-keys`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `certify_serving_joins`, `customer_360`, `emit_semantic_model_from_store`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -59,7 +59,7 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldenflow` | transforms | 0 | 1 |
 | `goldenmatch` | a2a_skills | 15 | 13 |
 | `goldenmatch` | blocking_strategies | 1 | 0 |
-| `goldenmatch` | cli_commands | 9 | 0 |
+| `goldenmatch` | cli_commands | 8 | 0 |
 | `goldenmatch` | mcp_tools | 7 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -87,6 +87,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   shared` under `mcp_tools`; it is a base MCP tool (not on the TS A2A card), so it
   stays `a2a_skills.python_only`. With this, both halves of the semantic wedge —
   produce (emit) and consume (certify) — are cross-surface.
+- **Human-facing surfaces for the semantic wedge — CLI + REST.** The wedge was
+  reachable by agents (MCP) and code (library); these give a dbt/Cube developer a
+  one-command path.
+  - **CLI** `goldenmatch-js certify-keys <model> -d name=path…` (mirrors Python
+    `certify-keys`): reads a MetricFlow/Cube/OSI model + frame files, certifies
+    each declared join key, and prints the Python-parity report (`Dialect: … 
+    certified: N   untrustworthy: M`, a skipped/note line, and a `target / key /
+    unique@grain / max_fan_out / context` table), with `--fail-untrustworthy` as a
+    CI gate. Flips `certify-keys` `python_only → shared` under `cli_commands`. The
+    Python `--resolve` ER tier is deliberately not offered (structural tier only).
+  - **CLI** `goldenmatch-js identity emit-catalog <source> <source-pk> [--dialect
+    --dataset --source-target --resolved-key --out --overwrite]` (mirrors Python
+    `identity emit-catalog`): emits a conformed catalog live from the identity DB,
+    printing the YAML or writing it to `--out`. Functional parity under the
+    already-`shared` `identity` command (no manifest move).
+  - **REST** `POST /semantic/certify` (`{model, frames}` → per-key certification)
+    and `POST /semantic/emit` (`{source_name, source_pk_column, …}` → catalog YAML
+    from the bound identity store, 503 if unbound) on the thin `node/api/server.ts`.
+    These are a **net-new TS surface** — Python has no REST equivalent for the
+    wedge, so there is nothing to mirror and no parity-manifest impact (REST is not
+    a gated surface). Tests: `tests/unit/api-server.test.ts`, `api-identity.test.ts`.
 
 ## [1.26.0] - 2026-07-27
 

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -25,7 +25,12 @@ import {
 } from "./core/index.js";
 import { analyzeBlocking } from "./core/block-analyzer.js";
 import { autoConfigure } from "./core/autoconfig.js";
-import { loadConfigFile } from "./node/config-file.js";
+import {
+  certifySemanticModel,
+  emitSemanticModelFromStore,
+  type SemanticDialect,
+} from "./core/semantic/index.js";
+import { loadConfigFile, parseYamlDoc } from "./node/config-file.js";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import {
   compareClusters,
@@ -768,6 +773,95 @@ memoryCmd
     process.stdout.write(`  created_at:     ${c.createdAt.toISOString()}\n`);
   });
 
+// ---------- certify-keys ----------
+// Mirrors `goldenmatch certify-keys` (Python cli/certify_keys.py): certify every
+// declared identity key in a semantic model (dbt/MetricFlow, Cube, or OSI) against
+// its data frames via the structural key-integrity tier.
+
+/** Pivot parsed rows into the column-oriented frame the certifier reads
+ * (`{ column: values[] }`); null-prototype so a `__proto__` column can't pollute. */
+function rowsToColumns(rows: Array<Record<string, unknown>>): Record<string, unknown[]> {
+  const hasOwn = Object.prototype.hasOwnProperty;
+  const names = new Set<string>();
+  for (const r of rows) for (const k of Object.keys(r)) names.add(k);
+  const cols: Record<string, unknown[]> = Object.create(null);
+  for (const name of names) cols[name] = rows.map((r) => (hasOwn.call(r, name) ? r[name] : null));
+  return cols;
+}
+
+/** Python `f"{x:g}"` — general float format, trailing zeros stripped. */
+function fmtG(n: number): string {
+  return Number(n.toPrecision(6)).toString();
+}
+
+program
+  .command("certify-keys")
+  .description("Certify the entity keys a semantic model (MetricFlow/Cube/OSI) declares")
+  .argument("<model>", "Semantic-model file (dbt/MetricFlow, Cube, or OSI YAML)")
+  .option(
+    "-d, --data <spec...>",
+    "Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv",
+  )
+  .option("--fail-untrustworthy", "Exit non-zero if any declared key is not unique at grain (CI gate)")
+  .action((model: string, opts: { data?: string[]; failUntrustworthy?: boolean }) => {
+    const specs = opts.data ?? [];
+    if (specs.length === 0) {
+      process.stderr.write("--data is required (name=path, repeatable), e.g. -d orders=orders.csv\n");
+      process.exit(2);
+    }
+    const frames: Record<string, Record<string, unknown[]>> = Object.create(null);
+    for (const spec of specs) {
+      const eq = spec.indexOf("=");
+      if (eq === -1) {
+        process.stderr.write(`--data must be name=path, got ${JSON.stringify(spec)}\n`);
+        process.exit(2);
+      }
+      const name = spec.slice(0, eq).trim();
+      const path = spec.slice(eq + 1).trim();
+      frames[name] = rowsToColumns(readFile(path));
+    }
+    const doc = parseYamlDoc(readFileSync(model, "utf-8"));
+    if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+      process.stderr.write(`semantic-model file did not parse to a mapping: ${model}\n`);
+      process.exit(2);
+    }
+    const report = certifySemanticModel(doc as Record<string, unknown>, frames);
+    const nUntrust = report.untrustworthy.length;
+    process.stdout.write(
+      `Dialect: ${report.dialect}   certified: ${report.nCertified}   untrustworthy: ${nUntrust}\n`,
+    );
+    if (report.skipped.length) {
+      process.stdout.write(`skipped (no frame supplied): ${report.skipped.join(", ")}\n`);
+    }
+    if (report.note) process.stdout.write(`${report.note}\n`);
+
+    if (report.entries.length) {
+      const rows = report.entries.map((e) => ({
+        target: e.target,
+        key: e.key.join(", "),
+        unique: e.certificate.isUniqueAtGrain ? "yes" : "NO",
+        fanOut: fmtG(e.certificate.maxFanOut),
+        context: e.context,
+      }));
+      const headers = { target: "target", key: "key", unique: "unique@grain", fanOut: "max_fan_out", context: "context" };
+      const w = {
+        target: Math.max(headers.target.length, ...rows.map((r) => r.target.length)),
+        key: Math.max(headers.key.length, ...rows.map((r) => r.key.length)),
+        unique: Math.max(headers.unique.length, ...rows.map((r) => r.unique.length)),
+        fanOut: Math.max(headers.fanOut.length, ...rows.map((r) => r.fanOut.length)),
+      };
+      const line = (t: string, k: string, u: string, f: string, c: string): string =>
+        `${t.padEnd(w.target)}  ${k.padEnd(w.key)}  ${u.padEnd(w.unique)}  ${f.padStart(w.fanOut)}  ${c}\n`;
+      process.stdout.write(line(headers.target, headers.key, headers.unique, headers.fanOut, headers.context));
+      for (const r of rows) process.stdout.write(line(r.target, r.key, r.unique, r.fanOut, r.context));
+    }
+
+    if (opts.failUntrustworthy && nUntrust > 0) {
+      process.stderr.write(`${nUntrust} declared key(s) are not unique at grain.\n`);
+      process.exit(1);
+    }
+  });
+
 // ---------- identity ----------
 // Mirrors `goldenmatch identity ...` in Python (cli/identity.py). Wraps the
 // SqliteIdentityStore for inspecting nodes, source records, edges, events,
@@ -993,6 +1087,63 @@ identityCmd
           `Split ${recordIds.length} record(s) from ${entityId}\n`,
         );
         process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+// Mirrors `goldenmatch identity emit-catalog` (Python cli/identity.py): emit a
+// conformed semantic-layer catalog (the resolved_entity_id join a MetricFlow /
+// Cube / OSI model should group metrics by) live from the durable identity store.
+identityCmd
+  .command("emit-catalog")
+  .description("Emit a conformed semantic-layer catalog from the identity store")
+  .argument("<source-name>", "Logical source name the records were ingested under")
+  .argument("<source-pk-column>", "Column holding each record's source primary key")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .option("--dialect <dialect>", "metricflow | cube | osi", "metricflow")
+  .option("--dataset <name>", "Identity-graph dataset scope")
+  .option("--source-target <name>", "Source model/cube/dataset the join points at (defaults to source-name)")
+  .option("--resolved-key <col>", "The conformed join column name", "resolved_entity_id")
+  .option("--out <path>", "Write the emitted YAML to this catalog file")
+  .option("--overwrite", "Overwrite an existing catalog file at --out")
+  .action(
+    async (
+      sourceName: string,
+      sourcePkColumn: string,
+      opts: {
+        path: string;
+        dialect: string;
+        dataset?: string;
+        sourceTarget?: string;
+        resolvedKey: string;
+        out?: string;
+        overwrite?: boolean;
+      },
+    ) => {
+      const store = await openIdentityStoreForCli(opts.path);
+      try {
+        const yamlStr = await emitSemanticModelFromStore(store, {
+          sourceName,
+          sourcePkColumn,
+          dialect: opts.dialect as SemanticDialect,
+          dataset: opts.dataset ?? null,
+          ...(opts.sourceTarget !== undefined ? { sourceTarget: opts.sourceTarget } : {}),
+          resolvedKey: opts.resolvedKey,
+        });
+        if (opts.out) {
+          if (existsSync(opts.out) && !opts.overwrite) {
+            process.stderr.write(`${opts.out} already exists; pass --overwrite to replace it\n`);
+            process.exit(1);
+          }
+          const dir = dirname(opts.out);
+          if (dir) mkdirSync(dir, { recursive: true });
+          writeFileSync(opts.out, yamlStr, "utf-8");
+          process.stdout.write(`Wrote ${opts.dialect} catalog to ${opts.out}\n`);
+        } else {
+          process.stdout.write(yamlStr);
+        }
       } finally {
         await store.close();
       }

--- a/packages/typescript/goldenmatch/src/node/api/server.ts
+++ b/packages/typescript/goldenmatch/src/node/api/server.ts
@@ -13,6 +13,8 @@
  *   POST /clusters                   - return clusters from dedupe
  *   GET  /reviews                    - list pending review items
  *   POST /reviews/decide             - accept/reject a review item
+ *   POST /semantic/certify           - certify a semantic model's keys vs frames
+ *   POST /semantic/emit              - emit a conformed catalog from the store
  *
  * Ports ideas from goldenmatch/api/server.py.
  */
@@ -31,6 +33,12 @@ import {
 } from "../../core/types.js";
 import { explainPair } from "../../core/explain.js";
 import { profileRows } from "../../core/profiler.js";
+import {
+  certifySemanticModel,
+  emitSemanticModelFromStore,
+  type SemanticDialect,
+  type SemanticFrames,
+} from "../../core/semantic/index.js";
 
 // ---------------------------------------------------------------------------
 // In-memory review queue
@@ -336,6 +344,82 @@ async function handleRequest(
           sample_values: c.sampleValues,
         })),
       });
+      return;
+    }
+
+    if (pathname === "/semantic/certify" && method === "POST") {
+      // Certify a semantic model's declared join keys against supplied frames
+      // (structural tier). Body: { model: <loaded dbt/Cube/OSI doc object>,
+      // frames: { name: { column: [values] } } }. The REST body carries the
+      // already-parsed model + column frames, so no file I/O here.
+      const body = await readJsonBody(req);
+      const model = body["model"];
+      const framesArg = body["frames"];
+      if (typeof model !== "object" || model === null || Array.isArray(model)) {
+        sendJson(res, 400, { error: "'model' must be a loaded semantic-model object" });
+        return;
+      }
+      if (typeof framesArg !== "object" || framesArg === null || Array.isArray(framesArg)) {
+        sendJson(res, 400, { error: "'frames' must map a model/dataset/cube name to a column frame" });
+        return;
+      }
+      let report;
+      try {
+        report = certifySemanticModel(model as Record<string, unknown>, framesArg as SemanticFrames);
+      } catch (err) {
+        sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) });
+        return;
+      }
+      sendJson(res, 200, {
+        dialect: report.dialect,
+        n_certified: report.nCertified,
+        all_trustworthy: report.allTrustworthy,
+        skipped: report.skipped,
+        keys: report.entries.map((e) => ({
+          target: e.target,
+          key: e.key,
+          context: e.context,
+          is_unique_at_grain: e.certificate.isUniqueAtGrain,
+          max_fan_out: e.certificate.maxFanOut,
+          estimate: e.certificate.estimate,
+          measure_fan_out: e.certificate.measureFanOut,
+        })),
+      });
+      return;
+    }
+
+    if (pathname === "/semantic/emit" && method === "POST") {
+      // Emit a conformed semantic-layer catalog (the resolved_entity_id join
+      // declaration) live from the bound identity store.
+      if (!serverIdentityStore) {
+        sendJson(res, 503, {
+          error: "IdentityStore not bound to server",
+          hint: "call setServerIdentityStore(store) at startup",
+        });
+        return;
+      }
+      const body = await readJsonBody(req);
+      const sourceName = typeof body["source_name"] === "string" ? (body["source_name"] as string) : "";
+      const sourcePkColumn = typeof body["source_pk_column"] === "string" ? (body["source_pk_column"] as string) : "";
+      if (!sourceName) {
+        sendJson(res, 400, { error: "'source_name' is required" });
+        return;
+      }
+      if (!sourcePkColumn) {
+        sendJson(res, 400, { error: "'source_pk_column' is required" });
+        return;
+      }
+      const dialectRaw = typeof body["dialect"] === "string" ? (body["dialect"] as string) : "metricflow";
+      const dataset = typeof body["dataset"] === "string" ? (body["dataset"] as string) : null;
+      const yamlStr = await emitSemanticModelFromStore(serverIdentityStore, {
+        sourceName,
+        sourcePkColumn,
+        dialect: dialectRaw as SemanticDialect,
+        dataset,
+        ...(typeof body["source_target"] === "string" ? { sourceTarget: body["source_target"] as string } : {}),
+        resolvedKey: typeof body["resolved_key"] === "string" ? (body["resolved_key"] as string) : "resolved_entity_id",
+      });
+      sendJson(res, 200, { yaml: yamlStr });
       return;
     }
 

--- a/packages/typescript/goldenmatch/tests/unit/api-identity.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/api-identity.test.ts
@@ -203,4 +203,21 @@ describe("REST API /identities", () => {
     // Restore for any subsequent tests
     setServerIdentityStore(store);
   });
+
+  it("POST /semantic/emit emits a MetricFlow catalog live from the bound store", async () => {
+    const res = await fetch(`${baseUrl}/semantic/emit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        source_name: "customers",
+        source_pk_column: "customer_id",
+        dataset: "test",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { yaml: string };
+    expect(body.yaml).toContain("semantic_models:");
+    expect(body.yaml).toContain("expr: resolved_entity_id");
+    expect(body.yaml).toContain("- name: customer_id\n    type: unique\n    expr: customer_id");
+  });
 });

--- a/packages/typescript/goldenmatch/tests/unit/api-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/api-server.test.ts
@@ -236,4 +236,53 @@ describe("REST API server", () => {
     const decBody = (await dec.json()) as { decided: { status: string } };
     expect(decBody.decided.status).toBe("accepted");
   });
+
+  it("POST /semantic/certify certifies a model's declared keys against frames", async () => {
+    const res = await fetch(baseUrl + "/semantic/certify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: {
+          semantic_models: [
+            {
+              name: "orders",
+              entities: [{ name: "orders", type: "primary", expr: "resolved_entity_id" }],
+            },
+          ],
+        },
+        frames: { orders: { resolved_entity_id: ["e1", "e1", "e2"] } },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      dialect: string;
+      n_certified: number;
+      all_trustworthy: boolean;
+      keys: Array<{ target: string; is_unique_at_grain: boolean; max_fan_out: number }>;
+    };
+    expect(body.dialect).toBe("metricflow");
+    expect(body.n_certified).toBe(1);
+    expect(body.all_trustworthy).toBe(false); // e1 duplicated
+    expect(body.keys[0]!.target).toBe("orders");
+    expect(body.keys[0]!.is_unique_at_grain).toBe(false);
+    expect(body.keys[0]!.max_fan_out).toBe(2);
+  });
+
+  it("POST /semantic/certify rejects a non-object model", async () => {
+    const res = await fetch(baseUrl + "/semantic/certify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nope", frames: {} }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /semantic/emit is 503 when no identity store is bound", async () => {
+    const res = await fetch(baseUrl + "/semantic/emit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source_name: "customers", source_pk_column: "customer_id" }),
+    });
+    expect(res.status).toBe(503);
+  });
 });

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -155,6 +155,7 @@ cli_commands:
   - analyze-blocking
   - anomalies
   - autoconfig
+  - certify-keys
   - compare-clusters
   - config
   - dedupe
@@ -184,7 +185,6 @@ cli_commands:
   - tui
   - unmerge
   python_only:
-  - certify-keys
   - import-dbt
   - ingest-docs
   - llm


### PR DESCRIPTION
## What and why

The semantic-layer wedge (key certification + catalog emission) was reachable by agents (MCP) and code (library), but a dbt/Cube developer couldn't run it directly. This adds the human-facing surfaces — a `certify-keys` CLI, an `identity emit-catalog` CLI, and two REST endpoints — turning it into a one-command workflow. Follows the emit (#2316) + certify (#2320) library ports.

## Changes

**CLI**
- `goldenmatch-js certify-keys <model> -d name=path…` — mirrors Python `certify-keys`: reads a MetricFlow/Cube/OSI model + frame files, certifies each declared join key (structural tier), and prints the Python-parity report (`Dialect: …   certified: N   untrustworthy: M`, a skipped/note line, and a `target / key / unique@grain / max_fan_out / context` table). `--fail-untrustworthy` is a CI gate. **Flips `certify-keys` `python_only → shared` under `cli_commands`.** The Python `--resolve` ER tier is deliberately not offered (TS certification is structural-only, matching `certifyKeyIntegrity`).
- `goldenmatch-js identity emit-catalog <source> <source-pk> [--dialect --dataset --source-target --resolved-key --out --overwrite]` — mirrors Python `identity emit-catalog`: emits a conformed catalog live from the identity DB, printing YAML or writing to `--out`. Functional parity under the already-`shared` `identity` command (no manifest move).

**REST** (net-new TS surface — Python has **no** REST equivalent for the wedge, confirmed by research, so nothing to mirror and no parity-manifest impact; REST is not a gated surface)
- `POST /semantic/certify` — `{model, frames}` → per-key certification.
- `POST /semantic/emit` — `{source_name, source_pk_column, …}` → catalog YAML from the bound identity store (503 if unbound).

## Testing

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 3590 passed / 1 expected-fail / 158 skipped (221 files). Per repo convention the CLI commands wrap already-parity-tested cores (`certifySemanticModel` / `emitSemanticModelFromStore` — locked in `semantic-certify.test.ts` / `semantic-catalog.test.ts`); the two REST endpoints get in-process server tests (`api-server.test.ts` for `/semantic/certify` + the unbound-store 503, `api-identity.test.ts` for `/semantic/emit` against a bound store).
- `npm run build` — clean; verified `emit_ts_surface.mjs` reports `certify-keys` under `cli_commands`, matching the manifest.
- All generated-doc `--check` gates pass locally (`gen_suite_matrix`, `gen_thesis_weaknesses`, `gen_api_surface`, `check_thesis_conformance`).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_