### PR TITLE
fix(ts): harden the semantic-wedge CLI + REST surfaces (CodeQL + review follow-up)

### DIFF
--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -1133,13 +1133,19 @@ identityCmd
           resolvedKey: opts.resolvedKey,
         });
         if (opts.out) {
-          if (existsSync(opts.out) && !opts.overwrite) {
-            process.stderr.write(`${opts.out} already exists; pass --overwrite to replace it\n`);
-            process.exit(1);
-          }
           const dir = dirname(opts.out);
           if (dir) mkdirSync(dir, { recursive: true });
-          writeFileSync(opts.out, yamlStr, "utf-8");
+          try {
+            // `wx` = create-and-fail-if-exists (atomic, O_EXCL): the clobber
+            // guard IS the write, so there is no check-then-write race.
+            writeFileSync(opts.out, yamlStr, { encoding: "utf-8", flag: opts.overwrite ? "w" : "wx" });
+          } catch (err) {
+            if (!opts.overwrite && (err as NodeJS.ErrnoException).code === "EEXIST") {
+              process.stderr.write(`${opts.out} already exists; pass --overwrite to replace it\n`);
+              process.exit(1);
+            }
+            throw err;
+          }
           process.stdout.write(`Wrote ${opts.dialect} catalog to ${opts.out}\n`);
         } else {
           process.stdout.write(yamlStr);

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -820,12 +820,25 @@ program
       const path = spec.slice(eq + 1).trim();
       frames[name] = rowsToColumns(readFile(path));
     }
-    const doc = parseYamlDoc(readFileSync(model, "utf-8"));
+    let doc: unknown;
+    try {
+      doc = parseYamlDoc(readFileSync(model, "utf-8"));
+    } catch (err) {
+      process.stderr.write(`could not read/parse ${model}: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(2);
+    }
     if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
       process.stderr.write(`semantic-model file did not parse to a mapping: ${model}\n`);
       process.exit(2);
     }
-    const report = certifySemanticModel(doc as Record<string, unknown>, frames);
+    let report;
+    try {
+      report = certifySemanticModel(doc as Record<string, unknown>, frames);
+    } catch (err) {
+      // e.g. dialect detection failed (no cubes/semantic_models/semantic_model key).
+      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(2);
+    }
     const nUntrust = report.untrustworthy.length;
     process.stdout.write(
       `Dialect: ${report.dialect}   certified: ${report.nCertified}   untrustworthy: ${nUntrust}\n`,
@@ -1122,6 +1135,10 @@ identityCmd
         overwrite?: boolean;
       },
     ) => {
+      if (!["metricflow", "cube", "osi"].includes(opts.dialect)) {
+        process.stderr.write(`unknown dialect '${opts.dialect}'; expected metricflow | cube | osi\n`);
+        process.exit(2);
+      }
       const store = await openIdentityStoreForCli(opts.path);
       try {
         const yamlStr = await emitSemanticModelFromStore(store, {

--- a/packages/typescript/goldenmatch/src/node/api/server.ts
+++ b/packages/typescript/goldenmatch/src/node/api/server.ts
@@ -40,6 +40,8 @@ import {
   type SemanticFrames,
 } from "../../core/semantic/index.js";
 
+const SEMANTIC_DIALECTS: ReadonlySet<string> = new Set(["metricflow", "cube", "osi"]);
+
 // ---------------------------------------------------------------------------
 // In-memory review queue
 // ---------------------------------------------------------------------------
@@ -363,9 +365,28 @@ async function handleRequest(
         sendJson(res, 400, { error: "'frames' must map a model/dataset/cube name to a column frame" });
         return;
       }
+      // Sanitize the untrusted frames into null-prototype maps + validate each
+      // column is an array, so a crafted name (`__proto__`) or a non-frame value
+      // can't yield surprising prototype-chain reads inside the certifier.
+      const frames: Record<string, Record<string, readonly unknown[]>> = Object.create(null);
+      for (const [name, frame] of Object.entries(framesArg as Record<string, unknown>)) {
+        if (typeof frame !== "object" || frame === null || Array.isArray(frame)) {
+          sendJson(res, 400, { error: `frame '${name}' must be a { column: values[] } object` });
+          return;
+        }
+        const cols: Record<string, readonly unknown[]> = Object.create(null);
+        for (const [col, vals] of Object.entries(frame as Record<string, unknown>)) {
+          if (!Array.isArray(vals)) {
+            sendJson(res, 400, { error: `frame '${name}' column '${col}' must be an array` });
+            return;
+          }
+          cols[col] = vals;
+        }
+        frames[name] = cols;
+      }
       let report;
       try {
-        report = certifySemanticModel(model as Record<string, unknown>, framesArg as SemanticFrames);
+        report = certifySemanticModel(model as Record<string, unknown>, frames as SemanticFrames);
       } catch (err) {
         sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) });
         return;
@@ -410,6 +431,10 @@ async function handleRequest(
         return;
       }
       const dialectRaw = typeof body["dialect"] === "string" ? (body["dialect"] as string) : "metricflow";
+      if (!SEMANTIC_DIALECTS.has(dialectRaw)) {
+        sendJson(res, 400, { error: `unknown dialect '${dialectRaw}'; expected metricflow | cube | osi` });
+        return;
+      }
       const dataset = typeof body["dataset"] === "string" ? (body["dataset"] as string) : null;
       const yamlStr = await emitSemanticModelFromStore(serverIdentityStore, {
         sourceName,

--- a/packages/typescript/goldenmatch/tests/unit/api-identity.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/api-identity.test.ts
@@ -220,4 +220,17 @@ describe("REST API /identities", () => {
     expect(body.yaml).toContain("expr: resolved_entity_id");
     expect(body.yaml).toContain("- name: customer_id\n    type: unique\n    expr: customer_id");
   });
+
+  it("POST /semantic/emit returns 400 for an unknown dialect", async () => {
+    const res = await fetch(`${baseUrl}/semantic/emit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        source_name: "customers",
+        source_pk_column: "customer_id",
+        dialect: "looker",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## What and why

Follow-up hardening for the semantic-wedge CLI + REST surfaces from #2327. Those fixes were written while #2327 was in review, but the PR reached the merge queue and merged before they could be pushed (the branch is locked while queued), so they land here. Closes the CodeQL "high" alert introduced on `main` and addresses the four Copilot review comments.

## Changes

- **CodeQL (high) — TOCTOU:** the `identity emit-catalog --out` writer did `existsSync`-then-`writeFileSync` (a check-then-write race). Replaced with an atomic exclusive write (`flag: "wx"` = create-fail-if-exists); `--overwrite` uses `flag: "w"`. Same fix as the `emit_semantic_model_from_store` MCP handler.
- **REST `/semantic/certify` (Copilot):** the untrusted `frames` JSON body is now sanitized into null-prototype maps with each column validated as an array before reaching the certifier, so a crafted name (`__proto__`) or a non-frame value can't yield prototype-chain reads.
- **REST `/semantic/emit` (Copilot):** `dialect` is validated against `{metricflow, cube, osi}` → **400** for an unknown value (was a 500 bubbling from the core throw).
- **CLI `certify-keys` (Copilot):** `parseYamlDoc` + `certifySemanticModel` are wrapped in try/catch → a concise stderr message + exit 2 (was an unhandled stack trace on bad YAML / undetectable dialect).
- **CLI `identity emit-catalog` (Copilot):** `--dialect` is validated early → clean error + exit 2.

## Testing

- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/api-server.test.ts tests/unit/api-identity.test.ts` — 27 passed, incl. a new `/semantic/emit` 400-on-unknown-dialect test.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (no user-facing behavior change; hardening only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_