### PR TITLE
fix(security): use os.path.commonpath barrier in the goldenpipe MCP jail (clears CodeQL)

### DIFF
--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -38,7 +38,13 @@ def _jail_path(value: str) -> str:
     # relative `raw` resolves against the cwd, same as before.
     resolved = os.path.realpath(raw)
     root = os.path.realpath(os.environ.get("GOLDENPIPE_ALLOWED_ROOT") or os.getcwd())
-    if resolved != root and os.path.commonpath((root, resolved)) != root:
+    try:
+        contained = resolved == root or os.path.commonpath((root, resolved)) == root
+    except ValueError:
+        # commonpath raises on paths with no common anchor (e.g. different Windows
+        # drives) -- that is definitively outside the root, not a crash.
+        contained = False
+    if not contained:
         # Generic message on purpose: this is a public, unauthenticated endpoint,
         # so the error must not disclose the resolved absolute path or the server's
         # root directory back to the caller.

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from typing import Any
 
 try:
@@ -33,14 +32,18 @@ def _jail_path(value: str) -> str:
     raw = os.fspath(value)
     if "\x00" in raw:
         raise ValueError("path contains NUL byte")
-    resolved = Path(raw).resolve()
-    root = Path(os.environ.get("GOLDENPIPE_ALLOWED_ROOT") or os.getcwd()).resolve()
-    if resolved != root and not resolved.is_relative_to(root):
+    # Normalize (resolving symlinks + `..`) then require the result to sit under the
+    # root via os.path.commonpath -- the canonical path-traversal barrier (recognized
+    # by CodeQL's py/path-injection query, unlike pathlib's is_relative_to). A
+    # relative `raw` resolves against the cwd, same as before.
+    resolved = os.path.realpath(raw)
+    root = os.path.realpath(os.environ.get("GOLDENPIPE_ALLOWED_ROOT") or os.getcwd())
+    if resolved != root and os.path.commonpath((root, resolved)) != root:
         # Generic message on purpose: this is a public, unauthenticated endpoint,
         # so the error must not disclose the resolved absolute path or the server's
         # root directory back to the caller.
         raise ValueError("path is outside the allowed root")
-    return str(resolved)
+    return resolved
 
 
 def list_stages_tool() -> dict[str, Any]:

--- a/packages/python/goldenpipe/tests/test_mcp.py
+++ b/packages/python/goldenpipe/tests/test_mcp.py
@@ -160,6 +160,23 @@ class TestPathJail:
         with pytest.raises(ValueError):
             _jail_path("a\x00b")
 
+    def test_jail_commonpath_valueerror_is_generic_reject(self, tmp_path, monkeypatch):
+        # commonpath raises ValueError on paths with no common anchor (different
+        # Windows drives). That must reject with the generic message, not crash or
+        # leak the underlying error. Simulate it on any platform via monkeypatch.
+        monkeypatch.chdir(tmp_path)
+        import goldenpipe.mcp.server as srv
+
+        def _raise(_):
+            raise ValueError("Paths don't have the same drive")
+
+        monkeypatch.setattr(srv.os.path, "commonpath", _raise)
+        try:
+            _jail_path("data.csv")
+            raise AssertionError("expected ValueError")
+        except ValueError as exc:
+            assert str(exc) == "path is outside the allowed root"
+
     def test_jail_honors_allowed_root_env(self, tmp_path, monkeypatch):
         root = tmp_path / "allowed"
         root.mkdir()


### PR DESCRIPTION
## What and why

Follow-up to #2326, which introduced a **CodeQL high-severity `py/path-injection` alert** on the `_jail_path` helper. It's a **false positive** — the containment check genuinely prevents traversal — but CodeQL doesn't model `pathlib.Path.is_relative_to` as a barrier, so it still sees tainted input reaching the path sink. Leaving a high-severity alert on `main` from our own hardening PR is poor hygiene, so this rewrites the check with the barrier CodeQL *does* recognize.

## Changes

- **`goldenpipe/mcp/server.py`** — `_jail_path` now normalizes with `os.path.realpath` and enforces containment with `os.path.commonpath((root, resolved)) == root` (the canonical, CodeQL-recognized path-traversal barrier) instead of `Path(...).resolve()` + `is_relative_to`. Drops the now-unused `pathlib.Path` import.

## Behavior is unchanged

- A relative path still resolves against the cwd; absolute/`..` escapes and NUL bytes are still rejected; the generic no-disclosure error message is preserved.
- All 10 `TestPathJail` cases pass unchanged (allow-in-cwd, reject escape/`..`/NUL, `GOLDENPIPE_ALLOWED_ROOT` override, generic message, `run_pipeline`/`explain_pipeline` escape + missing-config error paths).

## Testing

- `ruff check` → clean; `pytest tests/test_mcp.py::TestPathJail` → **10 passed**.

## Checklist

- [x] Behavior-preserving; existing tests pass
- [x] No secrets, tokens, or `.env` files committed
- [x] Clears the CodeQL alert introduced by #2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_