### PR TITLE
FS/Lever Enablement — Phase 0: A/B-a-lever gate + scoping spec

### DIFF
--- a/docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
+++ b/docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
@@ -1,0 +1,174 @@
+# FS / Lever Enablement — design
+
+**Date:** 2026-08-01
+**Status:** Proposed (scoping)
+**Author:** perf/quality exploration follow-up
+
+## Problem
+
+GoldenMatch's zero-config auto-config decides the **structural** levers well and per-dataset
+(which columns become fields, blocking strategy/passes/anchor, `max_block_size`, pair budget,
+backend/plan, weighted-path threshold, FS missing-mode). But an audit of the full lever surface
+(config schema + ~100 `GOLDENMATCH_*` env flags) found a systematic gap:
+
+1. **A tier of *quality* levers is stranded** as global env flags or hardcoded constants, so the
+   per-dataset decision layer structurally cannot tune them per dataset. Several ship
+   **default-OFF despite documented measured wins** — the env flag became the permanent home
+   instead of a rollout stage.
+2. **The FS (Fellegi-Sunter) path — the default for messy person data since 2026-07-17 — is not
+   iterated.** The controller's refit loop (the actual "smarter config" engine, `autoconfig_rules.py`
+   `DEFAULT_RULES`) is almost entirely `mk.type == "weighted"`-gated. FS returns early from the v0
+   heuristic (`autoconfig.py`) and receives a **single-shot config with no iterative refinement**.
+   The path that handles the hardest data is the path the refinement engine skips.
+
+Naming it: this is not one feature. It is a program to **move quality levers from
+"global flag / constant" into "per-dataset auto-config decision," and to give the FS path real
+refinement.** Because most of the decision *logic already exists* (inert behind a flag or a
+constant), the effort is mostly **wiring + validation**, not new algorithms — but the validation is
+the real cost, because unlike mechanical perf fixes, every lever here **changes match output**.
+
+## Evidence
+
+### The three ways levers are stranded
+
+| Mechanism | Fix | Examples (file refs are `core/…`) |
+|---|---|---|
+| **A. Hardcoded constant** | wire the decision to data the controller already has | `link_threshold` = 0.50 (`probabilistic.py:2320`); `levels`/`partial_threshold` fixed by scorer family (`autoconfig.py:5236`); scorer-per-`col_type` fixed map (`autoconfig.py:704`) |
+| **B. Env-flag gate (logic exists, inert)** | flip gate from "global env" → "auto-config decides + env override" | `tf_adjustment` (`_tf_adjustment_for`, `autoconfig.py:830`, gated `FS_TF_ADJUSTMENT` off); domain comparators (`FS_DOMAIN_COMPARATORS` off, `autoconfig.py:768`); honorific strip (`FS_STRIP_HONORIFICS` off); blocking-pass pruning (`BLOCKING_PRUNE_PASSES` off); quality-aware blocking (`QUALITY_AWARE_BLOCKING` off) |
+| **C. Structural (FS not iterated)** | give FS a refit loop / make controller rules matchkey-type-aware | `autoconfig_rules.py` `DEFAULT_RULES` are weighted-gated; FS never re-enters refinement |
+
+Genuinely data-driven per-dataset today (the bright spots): field admission, blocking
+strategy/passes/anchor + `max_block_size` + pair budget, backend/plan (v3 planner), weighted
+threshold, and **FS missing-mode** (`_pick_missing_semantics`, `autoconfig.py:5272`) — notably the
+exact lever a reverted feature (pair-dedup, #2295→#2304) got wrong; the engine knew the right
+answer, the feature just didn't read it.
+
+### The measurement that reshapes the plan
+
+The audit flagged `link_threshold` as the "cheap first win": the fixed 0.50 constant has a
+data-driven alternative (`_calibrate_link_threshold`, Otsu-on-training-pairs, `probabilistic.py:2402`)
+that is **already wired end-to-end** — it just sits behind `GOLDENMATCH_FS_CALIBRATE_THRESHOLD` (off).
+Its docstring cites a measured **+0.04 F1** (historical_50k) / **+0.49** (dblp_acm) on a *simple*
+auto-config.
+
+Measured on **today's default config** (`historical_50k`, current auto-config incl. the #2145
+orthogonal-anchor blocking), fixed-0.50 vs Otsu-on:
+
+| threshold | F1 | precision | recall | clusters |
+|---|---|---|---|---|
+| fixed 0.50 (default) | **0.8456** | 0.928 | 0.777 | 11,113 |
+| Otsu (flag on) | 0.7826 | **0.768** | 0.798 | 10,131 |
+
+Flipping the "obvious win" **regresses F1 −0.063 and precision −0.16** on the flagship dataset. This
+reproduces the docstring's own warning: the Otsu selector calibrates on the EM **training-pair**
+distribution, but the actual **scored** population (post-orthogonal-blocking) differs, so the cut is
+mis-set. **Enablement here is not "wire it" — it is "harden the selector," and the naive flip is a
+real regression.** This single measurement is the justification for the whole program's gating
+discipline: the decision levers must be measured on the *current* config, not trusted from a
+docstring number taken on an older/simpler one.
+
+## The plan
+
+### Phase 0 — the enablement gate (prereq, non-negotiable)
+
+Every lever here changes output, so nothing lands without a gate. Stand up a one-command
+**"A/B a lever"** runner over the `bench_er_headtohead` panel (historical_50k, febrl3/4, synthetic,
+dblp_acm/scholar, amazon_google) **plus** `qis_gate` scale-neutrality (50K→5M). Most of this exists
+(the `bench-probabilistic.yml` `panel-v1-v2` lane); formalize it as *the* enablement gate: a lever
+flips its default only after the panel shows **no per-dataset F1 regression** on the *current* config
+and `qis_gate` shows scale-neutrality. **This is the real cost of the program** — the validation
+cycles, not the code.
+
+Effort: **S/M**, 1 PR. Blocks everything below.
+
+### Phase 1 — constants → data-driven
+
+- **`link_threshold` — M/L, medium-HIGH risk (revised up by the measurement).** Not a wiring task:
+  the Otsu-on-training path is already wired and *regresses* on the default config (evidence above).
+  The hardening work is one of:
+  1. calibrate on the **actual scored-pair distribution** (the `compute_thresholds(scored_weights=…)`
+     percentile branch at `probabilistic.py:2303` exists but is *never fed* the scored pairs —
+     plumb the post-scoring weight distribution back), which matches the real population instead of
+     the training sample; and/or
+  2. a **precision-health guard** that rejects a calibrated cut which would drop the training-pair
+     precision proxy below the fixed-cut baseline (fail-safe to 0.50).
+  Gate on the full panel — this lever is the canary for the whole program.
+- **`levels` / `partial_threshold` from the score histogram — M.** Choose bands from the score
+  distribution instead of the fixed 2/3 + 0.8/0.9. Higher blast radius (every field); gate carefully.
+
+### Phase 2 — env-flag → auto-config-owned (one lever per PR, each through the gate)
+
+Each is a *small* code change (flip the gate from "env truthy" to "auto-config decides from the
+profile + env override") but a *full* validation cycle. Ordered by measured-win magnitude and by
+risk (additive/scale-neutral first):
+
+- **domain comparators** (`date_diff`/`numeric_diff`/`geo_haversine`) — likely the lowest-risk first
+  ship: kernel-backed, additive, and already documented scale-neutral. Today dates get magnitude-blind
+  `levenshtein` and numeric fields are dropped entirely.
+- **blocking-pass pruning** + **quality-aware blocking** — also *perf* levers (fewer candidate pairs
+  → less scoring/clustering), so they advance both axes.
+- **`tf_adjustment`** — `_tf_adjustment_for` is already frequency-shaped; targets the precision /
+  over-merge regime.
+- **honorific stripping** — measured +0.011 F1 / +0.024 precision.
+- **FS negative evidence — M (bigger).** `promote_negative_evidence` currently *skips* probabilistic
+  matchkeys (`autoconfig_negative_evidence.py:148`); the FS scorer already honors NE fields, so this
+  is "add an FS-appropriate promotion," not new scoring.
+
+### Phase 3 — structural: FS gets refinement (the real answer, L, spec-first)
+
+Today FS is single-shot. Two options:
+- **3a (cheaper, partial):** make the *blocking* refit rules matchkey-type-agnostic — most already
+  mutate `blocking`, which FS uses — so at least blocking is iterated on FS.
+- **3b (the answer):** a dedicated FS refit loop keyed on signals that already exist in
+  `ComplexityProfile` (score-histogram dip → threshold/levels; precision signal → tf_adjustment;
+  date/numeric detection → comparator upgrade). This is where the Phase 1–2 levers become *iterated*
+  decisions.
+
+Gated hardest: iteration adds planning wall (the "smarter config costs wall to decide" tension), so
+it must prove net-positive at scale, not just on a fixed sample.
+
+### Sequencing
+
+```
+P0 gate harness ─┐
+P1 link_threshold─┼─ each ships independently, each gated on the current config
+P2 flag-flips ×5–6┘   (domain comparators first — additive/scale-neutral; then perf-dual levers)
+        ↓ (levers now reachable + individually validated)
+P3 FS refit loop ── spec-first epic, consumes the P1/P2 levers as iterated decisions
+```
+
+Rough sizing: **P0** 1 PR · **P1** 1–2 PRs (higher risk than first thought) · **P2** ~6 PRs (small
+code, gated) · **P3** a design doc + 3–5 PRs.
+
+## Non-goals / guardrails
+
+- **Not inventing new levers** — this is about *reaching existing ones*. New comparators/strategies
+  are separate work.
+- **Leave frontier-neutral levers alone** — calibration mode (`FS_CALIBRATED`) is documented
+  F1-neutral; stays env-only, no auto-config decision needed.
+- **Keep every env flag as an override** — the flag becomes the escape hatch, never the
+  decision-maker. Precedence stays: explicit config field > env override > auto-config decision >
+  constant default.
+- **One lever per PR through the gate.** The reason these are stranded is "not hardened for the
+  controller"; batching flips reproduces exactly that risk.
+- **Measure on the *current* config, not a docstring.** The `link_threshold` measurement shows a
+  docstring win from a simpler config can be a live regression today.
+
+## Open questions
+
+1. `link_threshold`: is scored-pair-distribution calibration (option 1) enough, or is the
+   precision-health guard (option 2) also required? Prototype both against the panel.
+2. Phase 3: dedicated FS refit loop vs. generalizing the weighted rules — how much of the existing
+   rule set is genuinely type-agnostic vs. needs FS-specific signals?
+3. Does a central lever/flag registry with decision provenance (surfaced on `RunHistory.decisions`)
+   pay for itself as part of P0, or is it a separate cleanup? ~100 flags are read inline today with
+   no registry.
+
+## Appendix — measurement reproduction
+
+`historical_50k`, `auto_configure_probabilistic_df` + `dedupe_df`, one host:
+
+```
+GOLDENMATCH_FS_CALIBRATE_THRESHOLD=0  →  F1 0.8456  P 0.9280  R 0.7766  (11,113 clusters)
+GOLDENMATCH_FS_CALIBRATE_THRESHOLD=1  →  F1 0.7826  P 0.7682  R 0.7976  (10,131 clusters)
+```

--- a/docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
+++ b/docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
@@ -67,6 +67,35 @@ real regression.** This single measurement is the justification for the whole pr
 discipline: the decision levers must be measured on the *current* config, not trusted from a
 docstring number taken on an older/simpler one.
 
+### Measured screening of the "cheap" levers (2026-08-01, the Phase 0 gate's first run)
+
+Ran `scripts/bench_er_headtohead/ab_lever.py` (the Phase 0 gate) over the 5-dataset F1 panel
+(person / febrl3 / ncvr_synthetic / dblp_acm / historical_50k), each lever OFF vs ON, on the
+*current* default auto-config:
+
+| lever (env) | gate | headline |
+|---|---|---|
+| `FS_CALIBRATE_THRESHOLD` (link_threshold) | **FAIL** | historical_50k −0.063 F1 (P −0.16) |
+| `FS_DOMAIN_COMPARATORS` | **FAIL** | historical_50k −0.013 F1; febrl3 +0.0014; else flat |
+| `FS_STRIP_HONORIFICS` | PASS | net-flat; historical_50k **P 0.928→0.957** / R 0.777→0.754 (precision/recall trade) |
+| `BLOCKING_PRUNE_PASSES` | PASS | +0.0000 on every dataset (no-op on this panel) |
+| `FS_TF_ADJUSTMENT` | PASS | +0.0000 on every dataset (no-op on this panel) |
+
+**Finding: there is no clean F1 win among the cheap levers on the validated panel.** Two regress on
+a naive default-flip; three pass the gate but are flat/no-op on F1. The audit's optimistic framing
+("measured wins held back by a flag") does not survive a multi-dataset gate on the *current* config —
+the docstring wins were taken on older/simpler configs. This re-scopes the program away from
+"flip stranded flags" and toward **per-dataset decisions** (and FS refinement), which is where the
+value actually is. The signals that *do* exist are decision-shaped, not flip-shaped:
+
+- **domain comparators**: `date_diff` *helps* febrl3 (+0.0014) but *hurts* corrupted-DOB historical_50k
+  (−0.013). The right enablement is a **per-column decision** (use `date_diff` only where the date
+  column is reliable, keep `levenshtein` when corrupted), not a global flip.
+- **honorific stripping**: a genuine **precision** lever (+0.029 P on historical_50k) that trades
+  recall — a candidate for a precision-starved *decision*, not a blanket default.
+- **blocking-pass pruning / tf_adjustment**: perf / skewed-frequency levers whose value is at scale
+  or on shapes not in this panel — F1-neutral here, so not F1-enablement candidates.
+
 ## The plan
 
 ### Phase 0 — the enablement gate (prereq, non-negotiable)
@@ -96,23 +125,28 @@ Effort: **S/M**, 1 PR. Blocks everything below.
 - **`levels` / `partial_threshold` from the score histogram — M.** Choose bands from the score
   distribution instead of the fixed 2/3 + 0.8/0.9. Higher blast radius (every field); gate carefully.
 
-### Phase 2 — env-flag → auto-config-owned (one lever per PR, each through the gate)
+### Phase 2 — per-dataset DECISIONS, not flag-flips (revised by the screening)
 
-Each is a *small* code change (flip the gate from "env truthy" to "auto-config decides from the
-profile + env override") but a *full* validation cycle. Ordered by measured-win magnitude and by
-risk (additive/scale-neutral first):
+The screening killed the original "flip stranded flags for free wins" framing — none is a clean win.
+So Phase 2 is not "flip the gate to default-on"; it is "make auto-config **decide** the lever
+per-dataset (or per-column) from the profile, gated." One decision per PR, each through the gate:
 
-- **domain comparators** (`date_diff`/`numeric_diff`/`geo_haversine`) — likely the lowest-risk first
-  ship: kernel-backed, additive, and already documented scale-neutral. Today dates get magnitude-blind
-  `levenshtein` and numeric fields are dropped entirely.
-- **blocking-pass pruning** + **quality-aware blocking** — also *perf* levers (fewer candidate pairs
-  → less scoring/clustering), so they advance both axes.
-- **`tf_adjustment`** — `_tf_adjustment_for` is already frequency-shaped; targets the precision /
-  over-merge regime.
-- **honorific stripping** — measured +0.011 F1 / +0.024 precision.
+- **Per-column domain comparators (the tractable first real decision).** Emit `date_diff` for a date
+  column only when it is *reliable* (low corruption / high parse rate), else keep `levenshtein`;
+  emit `numeric_diff`/`geo_haversine` where numeric/coord columns parse cleanly. This targets the
+  febrl3 win without the historical_50k regression the global flip caused. Requires a per-column
+  reliability signal from the profiler (parse rate / corruption score already computed by GoldenCheck
+  indicators).
+- **Honorific stripping as a precision decision** — apply when the config is precision-starved
+  (name-only fuzzy, high over-merge risk), not as a blanket default. Data-gated on the same signals
+  the controller's precision-anchor rule already uses.
 - **FS negative evidence — M (bigger).** `promote_negative_evidence` currently *skips* probabilistic
   matchkeys (`autoconfig_negative_evidence.py:148`); the FS scorer already honors NE fields, so this
-  is "add an FS-appropriate promotion," not new scoring.
+  is "add an FS-appropriate promotion," not new scoring. Gate hard (NE changes precision/recall
+  balance directly).
+- **blocking-pass pruning / tf_adjustment** — de-prioritized for the *F1* program (no-op on the
+  panel). Their value is perf (fewer pairs) / skewed-frequency precision; revisit under the perf
+  track or at scale, not here.
 
 ### Phase 3 — structural: FS gets refinement (the real answer, L, spec-first)
 

--- a/scripts/bench_er_headtohead/ab_lever.py
+++ b/scripts/bench_er_headtohead/ab_lever.py
@@ -1,0 +1,112 @@
+"""A/B-a-lever gate — the FS/Lever-Enablement regression gate (Phase 0).
+
+Measures the F1 / precision / recall delta of a single auto-config lever across
+the locally-available ``bench_er_headtohead`` panel datasets, and reports a
+per-dataset PASS/FAIL: a lever may only flip its default when NO panel dataset
+regresses beyond ``--tol``.
+
+The lever is toggled via an environment variable read lazily by the engine
+(e.g. ``GOLDENMATCH_FS_DOMAIN_COMPARATORS``), so both arms run in one process by
+flipping ``os.environ`` between runs. Zero-config: each dataset goes through
+``auto_configure_probabilistic_df`` + ``dedupe_df`` (the real default FS path),
+scored against committed ground truth via ``evaluate_clusters``.
+
+Usage:
+    python -m scripts.bench_er_headtohead.ab_lever \
+        --env GOLDENMATCH_FS_DOMAIN_COMPARATORS --off 0 --on 1
+    # optional: --datasets historical_50k,febrl3  --tol 0.005
+
+Design spec: docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+# The real F1 panel (anchor shapes with no positive ground-truth pairs are
+# excluded — they gate structure, not F1). Skipped automatically when a
+# dataset's optional dep / vendored file is absent (loader returns None).
+_PANEL = ["person", "febrl3", "ncvr_synthetic", "dblp_acm", "historical_50k"]
+
+
+def _load(name: str):
+    from scripts.autoconfig_quality import datasets as D
+
+    fn = getattr(D, f"_{name}", None)
+    if fn is None:
+        return None
+    try:
+        return fn()
+    except Exception as exc:  # dep/file absent -> skip
+        print(f"  [skip] {name}: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return None
+
+
+def _f1(name: str) -> dict | None:
+    """Run zero-config FS dedupe on one dataset, return the F1 summary (or None
+    to skip). Reads the lever from the CURRENT os.environ."""
+    loaded = _load(name)
+    if loaded is None:
+        return None
+    df, gt = loaded
+    if not gt:  # anchor shape, no positive pairs -> not an F1 dataset
+        return None
+    import goldenmatch
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from goldenmatch.core.evaluate import evaluate_clusters
+
+    cfg = auto_configure_probabilistic_df(df)
+    t0 = time.perf_counter()
+    res = goldenmatch.dedupe_df(df, config=cfg)
+    wall = time.perf_counter() - t0
+    ev = evaluate_clusters(res.clusters, gt).summary()
+    return {"f1": ev["f1"], "p": ev["precision"], "r": ev["recall"], "wall": wall}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="A/B one auto-config lever across the F1 panel.")
+    ap.add_argument("--env", required=True, help="env var toggling the lever")
+    ap.add_argument("--off", default="0", help="OFF value (baseline)")
+    ap.add_argument("--on", default="1", help="ON value (candidate)")
+    ap.add_argument("--datasets", default=",".join(_PANEL), help="comma list")
+    ap.add_argument("--tol", type=float, default=0.005,
+                    help="max allowed per-dataset F1 regression before FAIL")
+    args = ap.parse_args()
+
+    # Isolate the measurement from cross-run auto-config memory.
+    os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"
+    datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
+
+    rows: list[tuple[str, dict | None, dict | None]] = []
+    for name in datasets:
+        os.environ[args.env] = args.off
+        off = _f1(name)
+        if off is None:
+            continue
+        os.environ[args.env] = args.on
+        on = _f1(name)
+        rows.append((name, off, on))
+
+    print(f"\nA/B lever: {args.env}  (OFF={args.off}  ON={args.on})  tol={args.tol}")
+    print(f"{'dataset':18s} {'F1 off':>8s} {'F1 on':>8s} {'dF1':>8s} "
+          f"{'P off':>7s} {'P on':>7s} {'R off':>7s} {'R on':>7s}  verdict")
+    worst = 0.0
+    any_regress = False
+    for name, off, on in rows:
+        d = on["f1"] - off["f1"]
+        worst = min(worst, d)
+        regress = d < -args.tol
+        any_regress = any_regress or regress
+        verdict = "REGRESS" if regress else ("win" if d > args.tol else "flat")
+        print(f"{name:18s} {off['f1']:8.4f} {on['f1']:8.4f} {d:+8.4f} "
+              f"{off['p']:7.3f} {on['p']:7.3f} {off['r']:7.3f} {on['r']:7.3f}  {verdict}")
+
+    print(f"\nGATE: {'FAIL' if any_regress else 'PASS'} "
+          f"(worst dF1 {worst:+.4f}, tol {args.tol}); {len(rows)} datasets measured")
+    return 1 if any_regress else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What and why

Phase 0 of the **FS/Lever Enablement** program: a reusable gate for validating auto-config lever changes, plus the scoping spec — grounded in a full lever-surface audit and measured on the local F1 panel. No product-behavior change (adds a script + a design doc).

Motivation: an audit found that auto-config decides *structural* levers well but a tier of *quality* levers is stranded as global env flags / hardcoded constants (so the per-dataset decision layer can't tune them), and the default FS path isn't iterated by the controller.

## Changes

- **`scripts/bench_er_headtohead/ab_lever.py`** — the A/B-a-lever gate. Toggles one lever's env var OFF vs ON and measures F1/precision/recall across the local `bench_er_headtohead` F1 panel (person / febrl3 / ncvr_synthetic / dblp_acm / historical_50k), reporting a per-dataset PASS/FAIL: a lever may only flip its default when no dataset regresses beyond `--tol`. Skips datasets whose optional dep / vendored file is absent.
- **`docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md`** — the scoping spec: the three ways levers are stranded (constant / env-flag / structural), the phased plan (P0 gate → P1 threshold-hardening → P2 per-dataset decisions → P3 FS refit loop), guardrails, and the measured evidence below.

## The measured finding (the gate's first run)

Screened all five "cheap" candidate levers OFF vs ON on the current default config:

| lever | gate | headline |
|---|---|---|
| `link_threshold` (Otsu) | **FAIL** | historical_50k −0.063 F1 (P −0.16) |
| domain comparators | **FAIL** | historical_50k −0.013 F1; febrl3 +0.0014; else flat |
| honorific stripping | PASS | net-flat (P 0.928→0.957 / R 0.777→0.754) |
| blocking-pass pruning | PASS | +0.0000 everywhere (no-op on panel) |
| tf_adjustment | PASS | +0.0000 everywhere (no-op on panel) |

**There is no clean F1 win among the cheap levers on the validated panel** — two regress on a naive default-flip, three are flat/no-op. The audit's "measured wins held back by a flag" framing doesn't survive a multi-dataset gate on the *current* config (the docstring wins were on older/simpler configs). This re-scopes the program away from "flip stranded flags" and toward **per-dataset decisions** (and FS refinement) — and the gate is what makes that conclusion evidence-based rather than a guess. It's the same measure-before-shipping discipline that reverted the pair-dedup lever (#2304).

## Testing

- `python -m scripts.bench_er_headtohead.ab_lever --env GOLDENMATCH_FS_DOMAIN_COMPARATORS --off 0 --on 1` → the table above (the gate correctly FAILs on the −0.013 regression).
- No engine code touched; existing behavior byte-unchanged (env defaults unchanged).

## Checklist

- [x] Tests added/updated and passing locally for the changed package - n/a (bench tool + doc; exercised via the runs above)
- [x] `pre-commit run --all-files` is clean (ruff clean on the new script)
- [ ] Package `CHANGELOG.md` updated if behavior changed - n/a (no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYTw8x9M6kEY6PGyvhYPB)_