### PR TITLE
fix(bench): harden ab_lever gate — fail-closed on empty/unknown panel

### DIFF
--- a/docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
+++ b/docs/superpowers/specs/2026-08-01-fs-lever-enablement-design.md
@@ -75,11 +75,11 @@ Ran `scripts/bench_er_headtohead/ab_lever.py` (the Phase 0 gate) over the 5-data
 
 | lever (env) | gate | headline |
 |---|---|---|
-| `FS_CALIBRATE_THRESHOLD` (link_threshold) | **FAIL** | historical_50k −0.063 F1 (P −0.16) |
-| `FS_DOMAIN_COMPARATORS` | **FAIL** | historical_50k −0.013 F1; febrl3 +0.0014; else flat |
-| `FS_STRIP_HONORIFICS` | PASS | net-flat; historical_50k **P 0.928→0.957** / R 0.777→0.754 (precision/recall trade) |
-| `BLOCKING_PRUNE_PASSES` | PASS | +0.0000 on every dataset (no-op on this panel) |
-| `FS_TF_ADJUSTMENT` | PASS | +0.0000 on every dataset (no-op on this panel) |
+| `GOLDENMATCH_FS_CALIBRATE_THRESHOLD` (link_threshold) | **FAIL** | historical_50k −0.063 F1 (P −0.16) |
+| `GOLDENMATCH_FS_DOMAIN_COMPARATORS` | **FAIL** | historical_50k −0.013 F1; febrl3 +0.0014; else flat |
+| `GOLDENMATCH_FS_STRIP_HONORIFICS` | PASS | net-flat; historical_50k **P 0.928→0.957** / R 0.777→0.754 (precision/recall trade) |
+| `GOLDENMATCH_BLOCKING_PRUNE_PASSES` | PASS | +0.0000 on every dataset (no-op on this panel) |
+| `GOLDENMATCH_FS_TF_ADJUSTMENT` | PASS | +0.0000 on every dataset (no-op on this panel) |
 
 **Finding: there is no clean F1 win among the cheap levers on the validated panel.** Two regress on
 a naive default-flip; three pass the gate but are flat/no-op on F1. The audit's optimistic framing

--- a/scripts/bench_er_headtohead/ab_lever.py
+++ b/scripts/bench_er_headtohead/ab_lever.py
@@ -32,16 +32,22 @@ _PANEL = ["person", "febrl3", "ncvr_synthetic", "dblp_acm", "historical_50k"]
 
 
 def _load(name: str):
+    """Load a panel dataset.
+
+    Raises ``KeyError`` on an UNKNOWN dataset name (a typo / config error the
+    gate must NOT silently swallow into a smaller panel). Returns ``None`` only
+    when a KNOWN loader reports the dataset is unavailable (optional dep or
+    vendored file absent -> that dataset is skipped, surfaced by the caller). A
+    real loader exception propagates (a genuine bug, not an expected skip)."""
     from scripts.autoconfig_quality import datasets as D
 
     fn = getattr(D, f"_{name}", None)
     if fn is None:
-        return None
-    try:
-        return fn()
-    except Exception as exc:  # dep/file absent -> skip
-        print(f"  [skip] {name}: {type(exc).__name__}: {exc}", file=sys.stderr)
-        return None
+        raise KeyError(
+            f"unknown panel dataset {name!r} "
+            f"(no loader _{name} in scripts.autoconfig_quality.datasets)"
+        )
+    return fn()  # loader returns None when its dep/vendored file is absent -> skip
 
 
 def _f1(name: str) -> dict | None:
@@ -79,15 +85,30 @@ def main() -> int:
     os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"
     datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
 
-    rows: list[tuple[str, dict | None, dict | None]] = []
+    rows: list[tuple[str, dict, dict]] = []
+    skipped: list[str] = []
     for name in datasets:
+        # KeyError (unknown name) intentionally propagates -- a typo must not
+        # silently shrink the panel. A None result = a known-unavailable dataset.
         os.environ[args.env] = args.off
         off = _f1(name)
         if off is None:
+            skipped.append(name)
             continue
         os.environ[args.env] = args.on
         on = _f1(name)
+        assert on is not None, f"{name}: measurable OFF but unmeasurable ON"
         rows.append((name, off, on))
+
+    if skipped:
+        print(f"[skipped] {len(skipped)} unavailable dataset(s): {', '.join(skipped)}",
+              file=sys.stderr)
+    # A regression gate that measured NOTHING must FAIL, never PASS -- an empty
+    # panel is a broken environment, not a clean bill of health.
+    if not rows:
+        print(f"\nGATE: FAIL — 0 datasets measured (requested {len(datasets)}, "
+              f"all unavailable). A gate that measures nothing cannot PASS.")
+        return 1
 
     print(f"\nA/B lever: {args.env}  (OFF={args.off}  ON={args.on})  tol={args.tol}")
     print(f"{'dataset':18s} {'F1 off':>8s} {'F1 on':>8s} {'dF1':>8s} "


### PR DESCRIPTION
## What and why

Follow-up to #2332 (FS/Lever Enablement Phase 0). Copilot's review of the `ab_lever` gate raised three valid correctness/clarity points that landed after #2332 was already in the merge queue, so they didn't make that merge. This carries them into main.

A regression gate must be **fail-closed**: it should never report a clean bill of health when it actually measured nothing or when the panel was silently shrunk by a typo.

## Changes (`scripts/bench_er_headtohead/ab_lever.py` + the spec)

- **FAIL (not PASS) when 0 datasets are measured** — an empty panel (all datasets unavailable) is a broken environment, not a pass.
- **`_load()` raises `KeyError` on an unknown dataset name** (a typo must not silently reduce the panel) and no longer swallows real loader exceptions; only a *known-unavailable* dataset (loader returns `None` because an optional dep / vendored file is absent) is skipped, and skips are surfaced explicitly on stderr.
- **Spec:** use fully-qualified `GOLDENMATCH_*` env-var names in the screening table so the measurements are reproducible.

## Testing

- `ab_lever --datasets bogus_name` → raises `KeyError: unknown panel dataset 'bogus_name'`, exits 1 (was: silently skipped → false PASS).
- `ab_lever --datasets person` → still measures + PASS (1 dataset).
- `ruff check` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package - n/a (bench tool + doc; exercised via the runs above)
- [x] `pre-commit run --all-files` is clean (ruff clean)
- [ ] Package `CHANGELOG.md` updated if behavior changed - n/a (bench tooling only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYTw8x9M6kEY6PGyvhYPB)_