### PR TITLE
test(fs): lock cross-route parity for missing="disagree" semantics

### DIFF
--- a/packages/python/goldenmatch/tests/test_fs_disagree_route_parity.py
+++ b/packages/python/goldenmatch/tests/test_fs_disagree_route_parity.py
@@ -68,9 +68,10 @@ def _ps(pairs) -> dict[tuple[int, int], float]:
     return {(min(a, b), max(a, b)): round(s, 4) for a, b, s in pairs}
 
 
-def _same(a: dict, b: dict, tol: float = 0.02) -> bool:
+def _same(a: dict, b: dict, tol: float = 0.01) -> bool:
     """Same canonical pair SET, and per-pair scores within native/rapidfuzz
-    tolerance (the same tol the vectorized-parity suite uses)."""
+    tolerance. ``tol=0.01`` matches ``test_probabilistic_vectorized``'s
+    ``pytest.approx(abs=0.01)`` scalar-vs-vectorized parity bound."""
     if set(a) != set(b):
         return False
     return all(abs(a[k] - b[k]) <= tol for k in a)
@@ -82,11 +83,17 @@ class TestDisagreeRouteParity:
 
     def test_fixture_is_discriminating(self):
         """Guard the guard: if ``disagree`` == ``unobserved`` on this fixture, a
-        route ignoring the mode would pass parity vacuously. It must not."""
+        route ignoring the mode would pass parity vacuously. It must not.
+
+        Score ONE ``EMResult`` under both modes so the delta is attributable to
+        scoring-time missing-value semantics alone -- retraining EM per mode
+        would let mode-dependent m/u estimation (not the scoring route) explain
+        the difference, weakening the invariant this guards."""
         mk_d, mk_u = _mk("disagree"), _mk("unobserved")
         df = _df()
-        dis = _ps(score_probabilistic_vectorized(df, mk_d, train_em(df, mk_d, n_sample_pairs=200)))
-        obs = _ps(score_probabilistic_vectorized(df, mk_u, train_em(df, mk_u, n_sample_pairs=200)))
+        em = train_em(df, mk_d, n_sample_pairs=200)
+        dis = _ps(score_probabilistic_vectorized(df, mk_d, em))
+        obs = _ps(score_probabilistic_vectorized(df, mk_u, em))
         assert dis != obs, (
             "fixture does not exercise the disagree/unobserved difference; "
             "the parity assertions below would be vacuous"
@@ -135,11 +142,17 @@ class TestDisagreeViaEnvOverride:
 
     def test_env_override_actually_changes_output(self, monkeypatch):
         """Sanity: the override is not a no-op — output differs from the
-        config-declared unobserved run."""
+        config-declared unobserved run.
+
+        Reuse ONE ``EMResult`` across both runs so the delta isolates the
+        scoring-time env override reaching the route (not mode-dependent EM
+        parameters). The env is unset when EM trains, so both runs share
+        identical m/u weights; only scoring differs."""
         df, mk = _df(), _mk("unobserved")
-        obs = _ps(score_probabilistic_vectorized(df, mk, train_em(df, mk, n_sample_pairs=200)))
+        em = train_em(df, mk, n_sample_pairs=200)
+        obs = _ps(score_probabilistic_vectorized(df, mk, em))
         monkeypatch.setenv("GOLDENMATCH_FS_MISSING", "disagree")
-        dis = _ps(score_probabilistic_vectorized(df, mk, train_em(df, mk, n_sample_pairs=200)))
+        dis = _ps(score_probabilistic_vectorized(df, mk, em))
         assert dis != obs
 
 

--- a/packages/python/goldenmatch/tests/test_fs_disagree_route_parity.py
+++ b/packages/python/goldenmatch/tests/test_fs_disagree_route_parity.py
@@ -1,0 +1,163 @@
+"""Cross-route parity for FS ``missing="disagree"`` semantics.
+
+#1846 made missing-value semantics toggleable (``unobserved`` vs ``disagree``);
+``test_fs_missing_semantics_1846.py`` locks the ONE origin
+(:func:`comparison_vector`) and ``test_fs_native_missing_mode.py`` locks the
+native-eligibility gate. What was UNGUARDED is that the several live FS scoring
+routes all honor ``disagree`` IDENTICALLY:
+
+  * scalar        :func:`score_probabilistic`         (the reference)
+  * vectorized    :func:`score_probabilistic_vectorized`      (default pipeline)
+  * batch         :func:`score_probabilistic_vectorized_batch` (small-block coalesce)
+  * dispatch      :func:`probabilistic_block_scorer`   (what the pipeline actually calls)
+
+This gap is not hypothetical: the reverted candidate-pair-dedup lever (PR #2295)
+was a scoring route that silently IGNORED ``fs_missing_mode`` — on a ``disagree``
+config it treated nulls as neutral instead of level-0-against, collapsing
+precision 0.928 -> 0.365 before it was caught by hand. A route that drops
+``disagree`` still produces plausible-looking pairs, so only a parity assertion
+catches it. Any NEW FS scoring route must be added here.
+
+The fixture carries nulls in every comparison field, and each test asserts the
+fixture is DISCRIMINATING (``disagree`` output actually differs from
+``unobserved``) so it cannot silently degrade into a no-op that would pass even
+if a route ignored the mode.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.probabilistic import (
+    fs_missing_mode,
+    probabilistic_block_scorer,
+    score_probabilistic,
+    score_probabilistic_vectorized,
+    score_probabilistic_vectorized_batch,
+    train_em,
+)
+
+
+def _df() -> pl.DataFrame:
+    """A single block with nulls in every comparison field, so ``disagree``
+    (missing -> level 0) diverges from ``unobserved`` (missing -> no evidence)."""
+    return pl.DataFrame({
+        "__row_id__": list(range(1, 11)),
+        "first_name": ["John", "Jon", "Jane", "Janet", "Bob",
+                       "Robert", "Alice", "Alicia", "Tom", "Thomas"],
+        "last_name": ["Smith", "Smith", None, "Doe", "Jones",
+                      None, "Brown", "Brown", None, "Wilson"],
+        "zip": ["90210", "90210", "10001", "10001", "60601",
+                "60601", "30301", None, "20001", "20001"],
+    })
+
+
+def _mk(missing: str | None = "disagree") -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="fs", type="probabilistic", missing=missing, link_threshold=0.0,
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.8),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.85),
+            MatchkeyField(field="zip", scorer="exact", levels=2),
+        ],
+    )
+
+
+def _ps(pairs) -> dict[tuple[int, int], float]:
+    return {(min(a, b), max(a, b)): round(s, 4) for a, b, s in pairs}
+
+
+def _same(a: dict, b: dict, tol: float = 0.02) -> bool:
+    """Same canonical pair SET, and per-pair scores within native/rapidfuzz
+    tolerance (the same tol the vectorized-parity suite uses)."""
+    if set(a) != set(b):
+        return False
+    return all(abs(a[k] - b[k]) <= tol for k in a)
+
+
+class TestDisagreeRouteParity:
+    """Every scoring route must produce the same ``disagree`` output as the
+    scalar reference — and the fixture must be discriminating."""
+
+    def test_fixture_is_discriminating(self):
+        """Guard the guard: if ``disagree`` == ``unobserved`` on this fixture, a
+        route ignoring the mode would pass parity vacuously. It must not."""
+        mk_d, mk_u = _mk("disagree"), _mk("unobserved")
+        df = _df()
+        dis = _ps(score_probabilistic_vectorized(df, mk_d, train_em(df, mk_d, n_sample_pairs=200)))
+        obs = _ps(score_probabilistic_vectorized(df, mk_u, train_em(df, mk_u, n_sample_pairs=200)))
+        assert dis != obs, (
+            "fixture does not exercise the disagree/unobserved difference; "
+            "the parity assertions below would be vacuous"
+        )
+
+    def test_vectorized_matches_scalar(self):
+        df, mk = _df(), _mk("disagree")
+        em = train_em(df, mk, n_sample_pairs=200)
+        assert fs_missing_mode(mk) == "disagree"
+        sca = _ps(score_probabilistic(df, mk, em))
+        vec = _ps(score_probabilistic_vectorized(df, mk, em))
+        assert _same(sca, vec), f"scalar={sca} vectorized={vec}"
+
+    def test_batch_matches_scalar(self):
+        df, mk = _df(), _mk("disagree")
+        em = train_em(df, mk, n_sample_pairs=200)
+        sca = _ps(score_probabilistic(df, mk, em))
+        bat = _ps(score_probabilistic_vectorized_batch([df], mk, em))
+        assert _same(sca, bat), f"scalar={sca} batch={bat}"
+
+    def test_block_scorer_dispatch_matches_scalar(self):
+        """The pipeline calls ``probabilistic_block_scorer(mk, em)`` — the dispatch
+        that selects vectorized vs scalar — so it must honor disagree too."""
+        df, mk = _df(), _mk("disagree")
+        em = train_em(df, mk, n_sample_pairs=200)
+        fn = probabilistic_block_scorer(mk, em)
+        sca = _ps(score_probabilistic(df, mk, em))
+        assert _same(sca, _ps(fn(df))), "block-scorer dispatch dropped disagree"
+
+
+class TestDisagreeViaEnvOverride:
+    """The reverted #2295 lever's failing config reached ``disagree`` via the
+    per-dataset auto-config pick, resolved through ``GOLDENMATCH_FS_MISSING``.
+    The env override must reach every route identically — a matchkey declared
+    ``unobserved`` but overridden to ``disagree`` scores as ``disagree``."""
+
+    def test_env_override_reaches_all_routes(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_FS_MISSING", "disagree")
+        df, mk = _df(), _mk("unobserved")  # config says unobserved; env overrides
+        assert fs_missing_mode(mk) == "disagree"
+        em = train_em(df, mk, n_sample_pairs=200)
+        sca = _ps(score_probabilistic(df, mk, em))
+        vec = _ps(score_probabilistic_vectorized(df, mk, em))
+        bat = _ps(score_probabilistic_vectorized_batch([df], mk, em))
+        assert _same(sca, vec) and _same(sca, bat)
+
+    def test_env_override_actually_changes_output(self, monkeypatch):
+        """Sanity: the override is not a no-op — output differs from the
+        config-declared unobserved run."""
+        df, mk = _df(), _mk("unobserved")
+        obs = _ps(score_probabilistic_vectorized(df, mk, train_em(df, mk, n_sample_pairs=200)))
+        monkeypatch.setenv("GOLDENMATCH_FS_MISSING", "disagree")
+        dis = _ps(score_probabilistic_vectorized(df, mk, train_em(df, mk, n_sample_pairs=200)))
+        assert dis != obs
+
+
+class TestDisagreeCoalesceInvariance:
+    """The small-block coalesce (batch) route slices per-block diagonals out of a
+    shared matrix. Under ``disagree`` — where nulls are forced ``observed`` — a
+    two-block batch must emit the SAME within-block pairs as scoring each block
+    alone (no cross-block null contamination)."""
+
+    def test_two_block_batch_equals_per_block(self):
+        df = _df()
+        b1 = df.head(5)
+        b2 = df.tail(5)
+        mk = _mk("disagree")
+        em = train_em(df, mk, n_sample_pairs=200)
+        per_block = _ps(
+            score_probabilistic_vectorized(b1, mk, em)
+            + score_probabilistic_vectorized(b2, mk, em)
+        )
+        batched = _ps(score_probabilistic_vectorized_batch([b1, b2], mk, em))
+        assert _same(per_block, batched), f"per_block={per_block} batched={batched}"


### PR DESCRIPTION
## What and why

The several live Fellegi-Sunter scoring routes must all honor `fs_missing_mode` identically. #1846 locked the single origin (`comparison_vector`) and the native-eligibility gate, but no test asserted the routes AGREE under `disagree`. This adds a cross-route parity guard.

That gap was not hypothetical: the reverted candidate-pair-dedup lever (PR #2295) was a scoring route that silently ignored `fs_missing_mode` — on a `disagree` config it treated nulls as neutral instead of level-0-against, collapsing precision 0.928 to 0.365 before it was caught by hand. A route that drops `disagree` still emits plausible-looking pairs, so only a parity assertion catches it.

## Changes

- New test module `tests/test_fs_disagree_route_parity.py` asserting the four live FS scoring routes agree under `missing="disagree"`:
  - scalar `score_probabilistic` (the reference)
  - vectorized `score_probabilistic_vectorized` (default pipeline path)
  - small-block batch `score_probabilistic_vectorized_batch` (coalesce path)
  - `probabilistic_block_scorer` dispatch (what the pipeline actually calls)
- Covers both config-level `disagree` and the `GOLDENMATCH_FS_MISSING` env override (the path the auto-config per-dataset pick resolves through).
- A coalesce-invariance check: a two-block batch emits the same within-block pairs as scoring each block alone (no cross-block null contamination under `disagree`).
- Null-bearing fixture (nulls in every comparison field). Each test first asserts the fixture is DISCRIMINATING (`disagree` output actually differs from `unobserved`) so the parity checks cannot pass vacuously.
- Test-only; no scorer/tool/command surface change, so no api-parity / config-matrix drift.

## Testing

```
python -m pytest tests/test_fs_disagree_route_parity.py -q          # 7 passed
python -m pytest tests/test_fs_missing_semantics_1846.py \
                 tests/test_fs_native_missing_mode.py \
                 tests/test_probabilistic_vectorized.py -q          # 49 passed
ruff check tests/test_fs_disagree_route_parity.py                   # clean
```

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the new file
- [ ] Package `CHANGELOG.md` updated if behavior changed — N/A (test-only, no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — N/A (locks existing documented behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bYTw8x9M6kEY6PGyvhYPB

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYTw8x9M6kEY6PGyvhYPB)_