### PR TITLE
fix(security): patch known-vulnerable transitive deps (pyspark, quick-xml, crossbeam-epoch)

### DIFF
--- a/docs/security/2026-08-02-dependency-cve-audit.md
+++ b/docs/security/2026-08-02-dependency-cve-audit.md
@@ -1,0 +1,81 @@
+# Dependency / CVE audit — 2026-08-02
+
+Full-tree dependency vulnerability audit across the three ecosystems, with
+triage (fixed here / deferred-coordinated / no-fix / informational).
+
+## Tooling
+
+| Ecosystem | Scanner | Scope |
+|---|---|---|
+| Python | `pip-audit` (OSV + PyPI advisory DB) | `uv export` of the whole workspace, base **and** all extras (avoiding the declared `sail`/`inhouse-embeddings` conflict) — 214 resolved packages |
+| TypeScript | `pnpm audit` (npm advisory DB) | root `pnpm-lock.yaml` — 476 packages |
+| Rust | `osv-scanner` 2.4.0 (OSV + RUSTSEC) | all 15 `packages/rust/extensions/**/Cargo.lock` |
+| cross-check | `osv-scanner` 2.4.0 | `uv.lock` + `pnpm-lock.yaml` (agrees with the per-ecosystem scanners) |
+
+## Result summary
+
+- **TypeScript:** 0 vulnerabilities.
+- **Python base workspace:** 0. With all optional extras: 2 packages / 3 advisories.
+- **Rust:** 5 advisories with a fix + 3 informational (unmaintained) advisories.
+
+## Fixed in this change (verified compiling / resolving)
+
+| Package | From → To | Advisory | Ecosystem / crate | Notes |
+|---|---|---|---|---|
+| `pyspark` | 3.5.1 → 3.5.2 | PYSEC-2025-184 / GHSA-6p6v-m64v-jx8q — Apache Spark inadequate RPC encryption strength | PyPI (`[sail]` extra) | Within the existing `>=3.5,<4` pin. **Consequence:** pyspark 3.5.2+ caps `numpy<2`, so the `sail` extra now resolves `numpy 1.26.4` (non-sail keeps `2.4.4`); the fork is isolated to the optional sail tier and validated by the `sail` CI lane. |
+| `quick-xml` | 0.38.4 → 0.41.0 | RUSTSEC-2026-0194 (quadratic dup-attribute check) + RUSTSEC-2026-0195 (unbounded namespace-decl allocation, memory exhaustion) | crates.io (`native-flow`, transitive via `phonenumber`) | `cargo check` clean. Low real exposure — `phonenumber` parses its own *bundled* metadata XML, not caller input — but the fix is a clean, compatible update. |
+| `crossbeam-epoch` | 0.9.18 → 0.9.20 | RUSTSEC-2026-0204 — invalid pointer deref in `fmt::Pointer` for `Atomic`/`Shared` | crates.io (`native`, transitive via `rayon`) | Semver patch. Near-zero exposure (needs `{:p}` formatting of an `Atomic`/`Shared`), taken as free hygiene. |
+
+## Deferred — coordinated bumps (real, but not a one-line change)
+
+- **`pyo3` 0.28.3 → 0.29.0** — RUSTSEC-2026-0176 (OOB read in `nth`/`nth_back` for
+  `PyList`/`PyTuple` iterators) + RUSTSEC-2026-0177 (missing `Sync` bound on
+  `PyCFunction::new_closure`). Affects the 5 abi3 crates `native`, `native-flow`,
+  `analysis-native`, `goldencheck-native`, `infermap-native`. These pin
+  `pyo3 = ">=0.28,<0.29"` **on purpose** because `arrow = "59"`'s `pyarrow` feature
+  pins pyo3 0.28 (see the CLAUDE.md gotcha: *"bumping arrow drags pyo3+numpy — never
+  a one-line bump"*). Reaching pyo3 0.29 needs `arrow 60` across all five crates +
+  a matching `numpy` bump + the 0.28→0.29 migration, and only builds in the native
+  lane. **Track for the next arrow bump; own PR.** Exploitability is low here — the
+  OOB read needs out-of-bounds `nth`/`nth_back` on a `PyList`/`PyTuple` iterator (the
+  kernels iterate Arrow value buffers, not Python sequences), and `new_closure` is
+  unused — but the advisory is genuine.
+- **`thrift` 0.17.0 → 0.23.0** — GHSA-2f9f-gq7v-9h6m (allocation with excessive size
+  value). Transitive via `parquet`/`datafusion` in `datafusion-udf`, which pins the
+  datafusion 53 / arrow 58 stack **verbatim** (mirrors `datafusion-python` 53).
+  Bumping thrift needs a datafusion major upgrade. Isolated crate, not on a
+  network-input path. **Track with the datafusion upgrade.**
+
+## No fix available (upstream)
+
+- **`diskcache` 5.6.3** — PYSEC-2026-2447 / GHSA-w8v5-vhqr-4h9v (uses Python `pickle`
+  for serialization by default). No patched release exists; it is a design property
+  of the library. Transitive (LLM/embeddings tier). Not exploitable in goldenmatch's
+  use — the cache is process-local, not fed attacker-controlled bytes. Revisit if
+  upstream ships a safe-serializer opt-in or a maintained fork replaces it.
+
+## Informational — unmaintained crates (RUSTSEC maintenance advisories, no fix, not vulnerabilities)
+
+- `generational-arena` 0.2.9 (RUSTSEC-2024-0014) — `datafusion-udf`.
+- `paste` 1.0.15 (RUSTSEC-2024-0436) — `datafusion-udf`.
+- `atomic-polyfill` 1.0.3 (RUSTSEC-2023-0089) — `goldenflow-wasm`, `native-flow`.
+
+These are "no longer maintained" notices, not exploitable defects. They clear when
+the pinning parents (datafusion 53; the embedded-HAL stack behind `atomic-polyfill`)
+advance. No action.
+
+## Reproduce
+
+```sh
+# Python (all extras, minus the declared sail/inhouse conflict)
+uv export --format requirements-txt --all-packages --all-extras \
+  --no-extra inhouse-embeddings --no-emit-workspace --no-hashes -o /tmp/reqs.txt
+uvx pip-audit -r /tmp/reqs.txt
+
+# TypeScript
+pnpm audit
+
+# Rust (+ cross-check of the Python/TS lockfiles)
+osv-scanner scan $(find packages/rust -name Cargo.lock -printf '--lockfile %p ') \
+  --lockfile uv.lock --lockfile pnpm-lock.yaml
+```

--- a/docs/security/2026-08-02-dependency-cve-audit.md
+++ b/docs/security/2026-08-02-dependency-cve-audit.md
@@ -76,6 +76,7 @@ uvx pip-audit -r /tmp/reqs.txt
 pnpm audit
 
 # Rust (+ cross-check of the Python/TS lockfiles)
-osv-scanner scan $(find packages/rust -name Cargo.lock -printf '--lockfile %p ') \
-  --lockfile uv.lock --lockfile pnpm-lock.yaml
+# POSIX-portable arg build (avoids GNU `find -printf`):
+args=""; for f in $(find packages/rust -name Cargo.lock); do args="$args --lockfile $f"; done
+osv-scanner scan $args --lockfile uv.lock --lockfile pnpm-lock.yaml
 ```

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -685,7 +685,8 @@ name = "diptest"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "psutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/0b/92a00796fb3a7e0fd1aea26ebcacfd6282857789ea72e847662e5103b24e/diptest-0.11.0.tar.gz", hash = "sha256:cd74d61d4e2620aa4c40900b7ff0ff48b7517fd00871c9066f737ba4081b2f81", size = 88751, upload-time = "2026-04-24T15:02:30.192Z" }
@@ -988,7 +989,8 @@ agent = [
     { name = "aiohttp" },
 ]
 baseline = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "polars" },
 ]
 db = [
@@ -1212,7 +1214,8 @@ dependencies = [
     { name = "duckdb" },
     { name = "goldenmatch-native", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or sys_platform == 'darwin' or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-goldenmatch-inhouse-embeddings' and extra == 'extra-11-goldenmatch-sail') or (sys_platform == 'linux' and extra == 'extra-11-goldenmatch-inhouse-embeddings' and extra == 'extra-11-goldenmatch-sail') or (sys_platform == 'win32' and extra == 'extra-11-goldenmatch-inhouse-embeddings' and extra == 'extra-11-goldenmatch-sail')" },
     { name = "goldenphonetic" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "openpyxl" },
     { name = "psutil" },
     { name = "pyarrow" },
@@ -2027,7 +2030,8 @@ source = { editable = "packages/python/infermap" }
 dependencies = [
     { name = "goldencheck-types" },
     { name = "goldenfuzz" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "polars" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -2328,7 +2332,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
     { name = "jinja2" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/0f/8e03877aa9ea79890cf64f6d12d47f4daced663d0dd6abe482fe6483e7e6/llama_cpp_python-0.3.29.tar.gz", hash = "sha256:21122165951bdc25ba27c0483a2f44082c860d89422945548c64df08b6029ce4", size = 70016946, upload-time = "2026-06-13T19:42:12.153Z" }
@@ -2571,7 +2576,7 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -2789,8 +2794,42 @@ wheels = [
 
 [[package]]
 name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554, upload-time = "2024-02-05T23:51:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127, upload-time = "2024-02-05T23:52:15.314Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994, upload-time = "2024-02-05T23:52:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005, upload-time = "2024-02-05T23:53:15.637Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297, upload-time = "2024-02-05T23:53:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+]
+
+[[package]]
+name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version < '3.12'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/c6/4218570d8c8ecc9704b5157a3348e486e84ef4be0ed3e38218ab473c83d2/numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db", size = 16976799, upload-time = "2026-03-29T13:18:15.438Z" },
@@ -3024,7 +3063,7 @@ version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
     { name = "protobuf" },
     { name = "typing-extensions" },
 ]
@@ -3051,7 +3090,7 @@ version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "protobuf" },
 ]
@@ -3120,7 +3159,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -3706,7 +3746,8 @@ version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "pyarrow" },
 ]
 wheels = [
@@ -3819,19 +3860,19 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "3.5.1"
+version = "3.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/e5/c9eb78cc982dafb7b5834bc5c368fe596216c8b9f7c4b4ffa104c4d2ab8f/pyspark-3.5.1.tar.gz", hash = "sha256:dd6569e547365eadc4f887bf57f153e4d582a68c4b490de475d55b9981664910", size = 316955685, upload-time = "2024-02-26T02:41:49.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/12/461c29d25f91c246842fb09e9cfb21ab82a9ab8ea8dd35667cc8b708f715/pyspark-3.5.2.tar.gz", hash = "sha256:bbb36eba09fa24e86e0923d7e7a986041b90c714e11c6aa976f9791fe9edde5e", size = 317276210, upload-time = "2024-08-12T14:57:56.062Z" }
 
 [package.optional-dependencies]
 connect = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
     { name = "grpcio-status" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "pandas" },
     { name = "pyarrow" },
 ]
@@ -4396,7 +4437,8 @@ version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
@@ -4433,7 +4475,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4497,7 +4540,8 @@ version = "5.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "torch" },
@@ -4616,7 +4660,8 @@ version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
@@ -4649,7 +4694,8 @@ dependencies = [
     { name = "duckdb" },
     { name = "igraph" },
     { name = "jinja2" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "pandas" },
     { name = "sqlglot" },
 ]
@@ -4904,7 +4950,8 @@ version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-sail'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-goldenmatch-inhouse-embeddings' or extra != 'extra-11-goldenmatch-sail'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },


### PR DESCRIPTION
## What and why

Full-tree dependency **CVE audit** across all three ecosystems, plus the safe, verified fixes. Scanners: `pip-audit` (Python/uv, base + all extras), `pnpm audit` (TS), and `osv-scanner` 2.4.0 over all 15 Rust `Cargo.lock` files (+ cross-check of `uv.lock`/`pnpm-lock.yaml`). **TS is clean; Python base is clean.** Full triage — including the deferred/coordinated and no-fix items — is recorded in `docs/security/2026-08-02-dependency-cve-audit.md`.

## Changes

Applies the three fixes that are safe within existing version constraints and verified locally:

- **`pyspark` 3.5.1 → 3.5.2** — PYSEC-2025-184 / GHSA-6p6v-m64v-jx8q (Apache Spark inadequate RPC encryption strength). Within the existing `>=3.5,<4` pin.
  - ⚠️ **Consequence:** pyspark 3.5.2+ caps `numpy<2`, so the optional **`[sail]` extra** now resolves `numpy 1.26.4` (non-sail resolution keeps `2.4.4`). The fork is isolated to the sail tier and is validated by the `sail` CI lane.
- **`quick-xml` 0.38.4 → 0.41.0** — RUSTSEC-2026-0194 (quadratic dup-attribute check) + RUSTSEC-2026-0195 (unbounded namespace-decl allocation → memory exhaustion). Transitive via `phonenumber` in `native-flow`. Low real exposure (phonenumber parses its own bundled metadata XML, not caller input) but a clean compatible fix.
- **`crossbeam-epoch` 0.9.18 → 0.9.20** — RUSTSEC-2026-0204 (invalid pointer deref in `fmt::Pointer` for `Atomic`/`Shared`). Transitive via `rayon` in `native`. Semver patch; taken as free hygiene.
- **`docs/security/2026-08-02-dependency-cve-audit.md`** — the full audit record.

**Deferred with rationale** (in the doc, not fixed here): `pyo3` 0.28→0.29 (coordinated `arrow 59→60` bump across 5 abi3 crates — the documented "arrow drags pyo3+numpy" gotcha; own PR), `thrift` 0.17→0.23 (pinned by the datafusion-53 stack in `datafusion-udf`), `diskcache` pickle-by-design (no upstream fix; process-local cache, not attacker-fed), and 3 informational unmaintained-crate advisories.

## Testing

- `uvx pip-audit -r <all-extras export>` → 3 advisories in 2 packages (pyspark, diskcache); `pnpm audit` → 0.
- `osv-scanner scan` over all Rust lockfiles → the 5 fixable + 3 informational advisories triaged in the doc.
- `cargo check` on `native` (crossbeam patch) and `native-flow` (quick-xml patch) → **both exit 0**.
- `uv lock --upgrade-package pyspark==3.5.2` → resolved 233 packages cleanly.

## Checklist

- [x] Verified locally for the changed lockfiles (`cargo check` ×2, `uv lock` resolve, re-scan)
- [ ] `pre-commit run --all-files` — n/a (lockfile + doc only; no source changed)
- [ ] Package `CHANGELOG.md` — n/a (transitive dependency bumps)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated — added the audit record under `docs/security/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_