### PR TITLE
feat(fs): DuckDB-free out-of-core FS — external union-find over spilled edge shards (phase 1)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -325,12 +325,14 @@
             "_sql_ident",
             "_sql_lit",
             "_stream_fs_dedupe_output_arrow",
+            "external_wcc_from_shards",
             "fs_out_of_core_enabled",
             "fs_streaming_route",
             "resolve_fs_block_source",
             "run_fs_dedupe_sequential",
             "run_fs_dedupe_streaming",
             "score_fs_out_of_core",
+            "spill_pair_shard",
             "stream_fs_dedupe_output"
           ],
           "imports": [

--- a/docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md
+++ b/docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md
@@ -1,0 +1,96 @@
+# DuckDB-free out-of-core FS: spillable edge stream + external WCC
+
+**Status:** design + phase-1 implementation
+**Predecessor:** `2026-07-20-fs-frame-residency-bucket-streaming-design.md` (the DuckDB-spilled `run_fs_dedupe_streaming` + the in-RAM `run_fs_dedupe_sequential`).
+
+## Problem
+
+There are two single-box out-of-core-ish FS paths today, and **both hold the entire
+emitted-pair table in RAM before clustering**:
+
+- `run_fs_dedupe_streaming` (DuckDB): spills the *frame* to a DuckDB file and streams
+  blocks, but `score_fs_out_of_core(emit="arrow")` accumulates one `PAIR_STREAM` table
+  per wave into `pair_tables` and concatenates; `_cluster_arrow_native` then dedups +
+  runs `build_clusters_arrow_native` over the **whole** table. Needs DuckDB.
+- `run_fs_dedupe_sequential` (in-RAM): holds the frame resident AND the full pair table.
+  Its own docstring calls it "the fast path for frames that FIT in RAM" — not out-of-core.
+
+So the only genuine out-of-core path is DuckDB-spilled, and even it holds all edges in
+RAM (~20 B/pair Arrow; ~1.3 GB at 66M pairs, but super-linear in dup rate / loose
+blocking / ≥100M). There is **no DuckDB-free out-of-core path**, and **no path with a
+bounded edge term.**
+
+## Key insight
+
+**WCC state is O(N records), not O(edges).** A union-find parent array is bounded by the
+row count; edges can be applied one at a time and then discarded. Two corollaries:
+
+1. **Edges can be spilled to disk** as they are scored (bounded write buffer) and read
+   back one shard at a time for clustering — the full pair table never lives in RAM.
+2. **The global max-score dedup can be skipped entirely.** It exists only to shrink the
+   in-RAM pair table before the in-RAM WCC; union-find membership is invariant to which
+   duplicate survives. With streaming union we apply every edge as it arrives.
+   - The `link_threshold` filter stays correct under streaming: filter each edge
+     (`score >= link_threshold`) *before* union. A pair scored 0.4 in pass A and 0.6 in
+     pass B unions when the 0.6 edge arrives — i.e. iff **any** occurrence clears the cut,
+     which equals "best cross-pass score >= cut" because `max` is monotone. This is
+     byte-equivalent to the current filter-after-max-dedup.
+
+Net: an **external union-find** streaming spilled edge shards over an O(N) parent array is
+memory O(N records) + streamed I/O, with **no full edge table in RAM** and **no DuckDB.**
+
+## Design
+
+Three bounded mechanisms, mirroring the predecessor's A/B/C decomposition:
+
+### (A) Spillable edge producer
+Score blocks in bounded waves (the existing `score_fs_out_of_core` / sequential wave
+loop), and instead of appending each wave's `PAIR_STREAM` `pa.Table` to an in-RAM list,
+**write it to an Arrow IPC shard on disk** (`edges-<pass>-<wave>.arrow`) via a bounded
+`RecordBatchFileWriter`. The resident scoring working set is unchanged (one wave of
+gathered blocks); the edge term drops from "sum of all emitted pairs" to "one wave's
+pairs + the OS write buffer".
+
+### (B) External WCC over spilled shards — `external_wcc_from_shards`
+Stream the shard files one at a time; for each `(id_a, id_b, score)` with
+`score >= link_threshold`, `union(id_a, id_b)` over a union-find keyed by row id (only ids
+that appear in an edge get an entry — bounded by `min(2·edges, N)`). After all shards,
+fold in the singleton `all_ids` and assign a stable `__cluster_id__` per component.
+Returns the same `(assignments pa.Table {__row_id__, __cluster_id__}, n_pairs)` shape
+`_cluster_arrow_native` returns, so the existing `_stream_fs_dedupe_output_arrow` output
+streamer consumes it unchanged.
+
+*Phase 1* uses the Python `core.cluster.UnionFind` (dict-backed) — correctness-first,
+proves the bounded-edge architecture. *Phase 2* kernelizes it: a stateful native
+`FsExternalWcc(n_rows)` with `.union_arrow(shard)` (applies a shard's edges over an O(N)
+`Vec<i64>` parent array in Rust) + `.finalize() -> assignments` — array UF is ~10× tighter
+than the dict and keeps the per-edge union off the Python interpreter at 66M+ edges.
+
+### (C) End-to-end — `run_fs_dedupe_spill`
+`prep frame → score in waves (spill shards) → external_wcc_from_shards → stream O(N)
+output` (the existing pure-pyarrow `_stream_fs_dedupe_output_arrow`). DuckDB-free
+(no `duckdb.connect`), polars-free except the bounded golden builder. Routed via a new
+`resolve_fs_block_source()` value **`spill`** (alongside `eager`/`frame`/`duckdb`),
+reachable through `gm.dedupe_to_parquet(*files, out_dir=…)`.
+
+**Remaining after phase 1** (staged, not in the first slice):
+- Frame-residency streaming during prep (input parquet → arrow batches → score without a
+  single resident frame) — the predecessor's open "load-peak below ~1× frame" item. The
+  spill path keeps the frame resident for now; the edge term is what this phase unbinds.
+- The native `FsExternalWcc` kernel (phase 2).
+- CI proof that a shape whose *edge* count OOMs the in-RAM/DuckDB pair table completes
+  under `spill`.
+
+## Correctness gate
+
+`external_wcc_from_shards` is parity-gated against `_cluster_arrow_native` on the SAME
+`PAIR_STREAM` table (partitioned into shards): identical component partition + identical
+`link_threshold` semantics, on adversarial shapes (a pair split across shards with
+different scores straddling the threshold; chains split across shards; singletons folded
+from `all_ids`). Because clustering is a pure function of the edge set, this is an exact
+partition-equality gate, not a fuzzy one.
+
+## Why not just reuse the distributed WCC
+`distributed/clustering.two_phase_wcc` / `distributed_wcc` are Ray-based (collect-to-driver
+or Ray-streaming-executor bound) — a different substrate. This is a single-box, disk-spill
+external UF: no Ray, no cluster, thesis-aligned (Arrow/Rust, DuckDB-free).

--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -941,6 +941,116 @@ def _cluster_arrow_native(
     return asn, n_pairs
 
 
+def spill_pair_shard(pair_table: Any, shard_dir: str, idx: int) -> str:
+    """Write one ``PAIR_STREAM`` ``pa.Table`` (``id_a``/``id_b`` int64, ``score``
+    float64) to an Arrow IPC shard on disk and return its path.
+
+    The bounded-edge producer half of the DuckDB-free spill path
+    (``docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md``):
+    a scored WAVE's edges leave RAM the moment its shard is flushed, so the resident
+    edge term is one wave's pairs, never the whole run's pair table. Arrow IPC (not
+    parquet) so the read-back in ``external_wcc_from_shards`` is a zero-copy mmap."""
+    import os as _os
+
+    import pyarrow as pa
+
+    _os.makedirs(shard_dir, exist_ok=True)
+    path = _os.path.join(shard_dir, f"edges-{idx:06d}.arrow")
+    with pa.OSFile(path, "wb") as sink:
+        with pa.ipc.RecordBatchFileWriter(sink, pair_table.schema) as writer:
+            writer.write_table(pair_table)
+    return path
+
+
+def external_wcc_from_shards(
+    shard_paths: Any,
+    all_ids: Any,
+    max_cluster_size: int,
+    link_threshold: float | None,
+) -> tuple[Any, int]:
+    """External union-find over spilled ``PAIR_STREAM`` shards — the bounded-edge WCC.
+
+    Streams each Arrow IPC shard (``id_a``/``id_b``/``score``) one at a time and applies
+    ``union(a, b)`` for every edge clearing ``link_threshold``, so the FULL edge set
+    NEVER lives in RAM — only the union-find (keyed by the row ids that actually appear
+    in an edge, bounded by ``min(2*edges, N)``) plus the O(N) assignment does. This is
+    the DuckDB-free, disk-spill analogue of ``_cluster_arrow_native``, which instead
+    holds the whole deduped pair ``pa.Table`` resident.
+
+    **Cluster-parity with ``_cluster_arrow_native``** (partition-exact): clustering is a
+    pure function of the edge SET; the global max-score dedup that path runs is a memory
+    optimisation union-find membership is invariant to; and per-edge threshold filtering
+    equals filter-after-max-dedup because ``max`` is monotone (a pair unions iff ANY
+    cross-pass occurrence clears the cut == its best score clears the cut). Cluster-id
+    VALUES differ (independent numbering), the PARTITION does not — and the downstream
+    ``_stream_fs_dedupe_output_arrow`` groups by cluster id, so numbering is irrelevant.
+
+    Returns ``(assignments pa.Table {__row_id__, __cluster_id__}, n_pairs)``.
+    ``n_pairs`` is the RAW linked-edge count (cross-pass duplicates INCLUDED — this path
+    never materialises the deduped set), a stat, not a parity surface.
+    ``max_cluster_size`` is accepted for signature-parity but not applied: oversized
+    splitting is a scoring/output-stage concern, and the output streamer already routes
+    by cluster size; the WCC emits raw components.
+    """
+    import pyarrow as pa
+
+    from goldenmatch.core.cluster import UnionFind
+
+    uf = UnionFind()
+    parent = uf._parent
+    n_pairs = 0
+    for path in shard_paths:
+        with pa.memory_map(path, "r") as source:
+            reader = pa.ipc.open_file(source)
+            for bi in range(reader.num_record_batches):
+                batch = reader.get_batch(bi)
+                a_col = batch.column("id_a").to_pylist()
+                b_col = batch.column("id_b").to_pylist()
+                s_col = batch.column("score").to_pylist()
+                for k in range(len(a_col)):
+                    if link_threshold is not None and s_col[k] < link_threshold:
+                        continue
+                    a, b = a_col[k], b_col[k]
+                    if a not in parent:
+                        parent[a] = a
+                        uf._rank[a] = 0
+                    if b not in parent:
+                        parent[b] = b
+                        uf._rank[b] = 0
+                    uf.union(a, b)
+                    n_pairs += 1
+        # batch/table references dropped here -> the shard's edges leave RAM.
+
+    if isinstance(all_ids, (pa.Array, pa.ChunkedArray)):
+        ids = all_ids.to_pylist()
+    else:
+        ids = list(all_ids)
+
+    # Assign a stable cluster id per connected component; a row absent from any edge
+    # is its own singleton. O(N) in the row count, independent of the edge count.
+    root_to_cid: dict[int, int] = {}
+    rid_out: list[int] = []
+    cid_out: list[int] = []
+    next_cid = 0
+    for rid in ids:
+        root = uf.find(rid) if rid in parent else rid
+        cid = root_to_cid.get(root)
+        if cid is None:
+            cid = next_cid
+            root_to_cid[root] = cid
+            next_cid += 1
+        rid_out.append(rid)
+        cid_out.append(cid)
+
+    asn = pa.table(
+        {
+            "__row_id__": pa.array(rid_out, pa.int64()),
+            "__cluster_id__": pa.array(cid_out, pa.int64()),
+        }
+    )
+    return asn, n_pairs
+
+
 def run_fs_dedupe_streaming(
     prepared_df: Any,
     blocking_config: BlockingConfig,

--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -941,7 +941,17 @@ def _cluster_arrow_native(
     return asn, n_pairs
 
 
-def spill_pair_shard(pair_table: Any, shard_dir: str, idx: int) -> str:
+# Cap the rows per Arrow IPC record batch in a spilled shard, so the read-back in
+# `external_wcc_from_shards` materialises at most this many edges per `get_batch`
+# regardless of how large a single wave's pair table is — a single giant batch would
+# otherwise force the whole wave's edges into RAM at once, undermining the bounded
+# claim. 65_536 edges ≈ ~1.5 MB of int64/float64 buffers per batch.
+_SPILL_SHARD_CHUNK_ROWS = 65_536
+
+
+def spill_pair_shard(
+    pair_table: Any, shard_dir: str, idx: int, *, max_chunksize: int | None = None
+) -> str:
     """Write one ``PAIR_STREAM`` ``pa.Table`` (``id_a``/``id_b`` int64, ``score``
     float64) to an Arrow IPC shard on disk and return its path.
 
@@ -949,16 +959,22 @@ def spill_pair_shard(pair_table: Any, shard_dir: str, idx: int) -> str:
     (``docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md``):
     a scored WAVE's edges leave RAM the moment its shard is flushed, so the resident
     edge term is one wave's pairs, never the whole run's pair table. Arrow IPC (not
-    parquet) so the read-back in ``external_wcc_from_shards`` is a zero-copy mmap."""
+    parquet) so the read-back in ``external_wcc_from_shards`` is a zero-copy mmap.
+
+    ``max_chunksize`` (default ``_SPILL_SHARD_CHUNK_ROWS``) caps the rows per record
+    batch, so a large single-chunk wave table is split into predictably-sized batches
+    rather than one giant batch — the read-back then materialises at most one batch of
+    edges at a time, keeping the bound per-batch not per-wave."""
     import os as _os
 
     import pyarrow as pa
 
+    chunk = _SPILL_SHARD_CHUNK_ROWS if max_chunksize is None else max_chunksize
     _os.makedirs(shard_dir, exist_ok=True)
     path = _os.path.join(shard_dir, f"edges-{idx:06d}.arrow")
     with pa.OSFile(path, "wb") as sink:
         with pa.ipc.RecordBatchFileWriter(sink, pair_table.schema) as writer:
-            writer.write_table(pair_table)
+            writer.write_table(pair_table, max_chunksize=chunk)
     return path
 
 
@@ -997,26 +1013,28 @@ def external_wcc_from_shards(
     from goldenmatch.core.cluster import UnionFind
 
     uf = UnionFind()
-    parent = uf._parent
     n_pairs = 0
     for path in shard_paths:
         with pa.memory_map(path, "r") as source:
             reader = pa.ipc.open_file(source)
             for bi in range(reader.num_record_batches):
                 batch = reader.get_batch(bi)
-                a_col = batch.column("id_a").to_pylist()
-                b_col = batch.column("id_b").to_pylist()
-                s_col = batch.column("score").to_pylist()
-                for k in range(len(a_col)):
-                    if link_threshold is not None and s_col[k] < link_threshold:
-                        continue
-                    a, b = a_col[k], b_col[k]
-                    if a not in parent:
-                        parent[a] = a
-                        uf._rank[a] = 0
-                    if b not in parent:
-                        parent[b] = b
-                        uf._rank[b] = 0
+                # Zero-copy numeric views of the mmap'd buffers; vectorise the
+                # threshold filter so only surviving edges become Python ints.
+                a_np = batch.column("id_a").to_numpy(zero_copy_only=False)
+                b_np = batch.column("id_b").to_numpy(zero_copy_only=False)
+                if link_threshold is not None:
+                    mask = (
+                        batch.column("score").to_numpy(zero_copy_only=False)
+                        >= link_threshold
+                    )
+                    a_np = a_np[mask]
+                    b_np = b_np[mask]
+                # `.tolist()` -> native Python ints so UF keys match the Python-int
+                # `all_ids` fold below (a bounded batch, not the whole wave).
+                for a, b in zip(a_np.tolist(), b_np.tolist()):
+                    uf.add(a)  # public API: resilient to UnionFind internals
+                    uf.add(b)
                     uf.union(a, b)
                     n_pairs += 1
         # batch/table references dropped here -> the shard's edges leave RAM.
@@ -1032,8 +1050,9 @@ def external_wcc_from_shards(
     rid_out: list[int] = []
     cid_out: list[int] = []
     next_cid = 0
+    seen = uf._parent  # membership check: a row absent here never appeared in an edge
     for rid in ids:
-        root = uf.find(rid) if rid in parent else rid
+        root = uf.find(rid) if rid in seen else rid
         cid = root_to_cid.get(root)
         if cid is None:
             cid = next_cid

--- a/packages/python/goldenmatch/tests/test_fs_out_of_core.py
+++ b/packages/python/goldenmatch/tests/test_fs_out_of_core.py
@@ -615,3 +615,117 @@ def test_dedupe_to_parquet_sequential_parity_with_in_memory(tmp_path, monkeypatc
     stream_parts = _partition_set_from_parquet(res["dupes_path"])
 
     assert stream_parts == sorted(mem_parts)
+
+
+# ── external WCC over spilled edge shards (DuckDB-free bounded-edge clustering) ──
+# Spec: docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md
+
+
+def _ref_partition(pairs, all_ids, link_threshold):
+    """Reference partition: a whole-set union-find over the threshold-filtered edge
+    list + singleton fold. The ground truth external_wcc_from_shards must match."""
+    parent = {i: i for i in all_ids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b, s in pairs:
+        if link_threshold is not None and s < link_threshold:
+            continue
+        parent.setdefault(a, a)
+        parent.setdefault(b, b)
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    comps: dict[int, set] = {}
+    for rid in all_ids:
+        comps.setdefault(find(rid), set()).add(rid)
+    return {frozenset(v) for v in comps.values()}
+
+
+def _asn_partition(asn):
+    """(__row_id__, __cluster_id__) pa.Table -> {frozenset(row_ids) per cluster}."""
+    groups: dict[int, set] = {}
+    for r, c in zip(
+        asn.column("__row_id__").to_pylist(), asn.column("__cluster_id__").to_pylist()
+    ):
+        groups.setdefault(c, set()).add(r)
+    return {frozenset(v) for v in groups.values()}
+
+
+def _spill_pairs(pairs, shard_dir, n_shards):
+    """Split a pair list into n_shards Arrow IPC shards (a pair may straddle shards)."""
+    from goldenmatch.backends.fs_out_of_core import spill_pair_shard
+    from goldenmatch.backends.score_buckets import pairs_to_pair_stream
+
+    per = max(1, (len(pairs) + n_shards - 1) // n_shards)
+    paths = []
+    for i in range(0, len(pairs), per):
+        tbl = pairs_to_pair_stream(pairs[i : i + per])
+        paths.append(spill_pair_shard(tbl, shard_dir, len(paths)))
+    return paths
+
+
+def test_external_wcc_matches_reference_across_shards(tmp_path):
+    """external_wcc_from_shards streams edges from disk one shard at a time and
+    produces the SAME component partition a whole-set union-find would — including a
+    chain split across shards and singletons folded from all_ids."""
+    from goldenmatch.backends.fs_out_of_core import external_wcc_from_shards
+
+    # 0-1-2 chain, 3-4 pair, 5/6 singletons; edges deliberately out of order.
+    pairs = [(2, 1, 0.9), (0, 1, 0.8), (3, 4, 0.95)]
+    all_ids = list(range(7))
+    paths = _spill_pairs(pairs, str(tmp_path), n_shards=3)  # chain crosses shards
+
+    asn, n_pairs = external_wcc_from_shards(paths, all_ids, 100, None)
+    assert n_pairs == 3
+    assert _asn_partition(asn) == _ref_partition(pairs, all_ids, None)
+    # Every row assigned exactly once.
+    assert sorted(asn.column("__row_id__").to_pylist()) == all_ids
+
+
+def test_external_wcc_threshold_uses_best_cross_shard_score(tmp_path):
+    """A pair emitted twice across shards with scores straddling the cut unions iff
+    its BEST occurrence clears the cut (max is monotone) — the per-edge streaming
+    filter equals filter-after-max-dedup."""
+    from goldenmatch.backends.fs_out_of_core import external_wcc_from_shards
+
+    # (0,1) appears at 0.4 (shard A) and 0.7 (shard B); (2,3) only at 0.4.
+    pairs = [(0, 1, 0.4), (2, 3, 0.4), (0, 1, 0.7)]
+    all_ids = list(range(4))
+    paths = _spill_pairs(pairs, str(tmp_path), n_shards=3)
+
+    asn, _ = external_wcc_from_shards(paths, all_ids, 100, 0.5)
+    part = _asn_partition(asn)
+    assert frozenset({0, 1}) in part          # best score 0.7 >= 0.5 -> linked
+    assert frozenset({2}) in part and frozenset({3}) in part  # 0.4 < 0.5 -> split
+    assert part == _ref_partition(pairs, all_ids, 0.5)
+
+
+def test_external_wcc_partition_parity_with_cluster_arrow_native(tmp_path):
+    """The disk-spill external WCC yields the SAME partition as the in-RAM
+    _cluster_arrow_native on the identical pair set (cluster-id VALUES may differ;
+    the PARTITION does not)."""
+    from goldenmatch.backends.fs_out_of_core import (
+        _cluster_arrow_native,
+        external_wcc_from_shards,
+    )
+    from goldenmatch.backends.score_buckets import pairs_to_pair_stream
+
+    pairs = [
+        (0, 1, 0.9), (1, 2, 0.85), (3, 4, 0.6), (4, 5, 0.7),
+        (6, 7, 0.55), (0, 2, 0.95),  # redundant edge (already connected)
+    ]
+    all_ids = list(range(9))  # 8 is a singleton
+    link_threshold = 0.5
+
+    ref_asn, _ = _cluster_arrow_native(
+        all_ids, pairs_to_pair_stream(pairs), 100, link_threshold
+    )
+    paths = _spill_pairs(pairs, str(tmp_path), n_shards=4)
+    got_asn, _ = external_wcc_from_shards(paths, all_ids, 100, link_threshold)
+
+    assert _asn_partition(got_asn) == _asn_partition(ref_asn)


### PR DESCRIPTION
Phase 1 of the DuckDB-free out-of-core FS path — the next scale lever after the fused-kernel coverage that just merged (#2289). Spec: `docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md`.

## Why

Both current single-box FS paths **hold the entire emitted-pair table in RAM before clustering**:
- `run_fs_dedupe_streaming` (DuckDB) accumulates every wave's `PAIR_STREAM` table and runs `_cluster_arrow_native` over the whole deduped `pa.Table` — and needs DuckDB.
- `run_fs_dedupe_sequential` (in-RAM) holds the frame resident *and* the full pair table.

So there's no DuckDB-free out-of-core path and no path with a **bounded edge term** (the pair table is ~20 B/pair Arrow, but super-linear in dup rate / loose blocking / ≥100M rows).

## Key insight

**WCC state is O(N records), not O(edges).** A union-find parent set is bounded by row count; edges can be applied one at a time and then discarded. So edges can be spilled to disk and streamed back for clustering, and the global max-score dedup can be skipped entirely (union-find membership is invariant to which duplicate survives).

## What's in this phase

- **`spill_pair_shard`** — writes a scored wave's `PAIR_STREAM` to an Arrow IPC shard on disk (bounded write buffer); the wave's edges leave RAM on flush.
- **`external_wcc_from_shards`** — streams the shards one at a time, unioning every edge clearing `link_threshold` over a union-find keyed by the ids that appear in an edge, so the **full edge set never lives in RAM**. Returns the same `(assignments, n_pairs)` shape `_cluster_arrow_native` does, so the existing pure-pyarrow `_stream_fs_dedupe_output_arrow` streamer consumes it unchanged.

**Partition-exact with `_cluster_arrow_native`:** clustering is a pure function of the edge set; the max-score dedup is a memory optimization membership is invariant to; and per-edge threshold filtering equals filter-after-max-dedup because `max` is monotone (a pair links iff its best cross-pass score clears the cut).

Phase 1 uses the Python `UnionFind` (correctness-first). Staged follow-ons in the spec: a native `FsExternalWcc(n_rows)` array-UF kernel; the per-wave spilling producer + end-to-end `run_fs_dedupe_spill` wired via a new `spill` block source; and frame-residency streaming during prep.

## Testing

Three parity cases in `tests/test_fs_out_of_core.py` (all green; full file 34 pass, ruff clean):
- cross-shard chain + singleton fold vs a whole-set reference union-find,
- threshold-straddling best-cross-shard-score semantics,
- partition-parity vs the in-RAM `_cluster_arrow_native` on the identical pair set.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] Package `CHANGELOG.md` updated *(deferred to the end-to-end wiring phase — this is an internal primitive, not yet a user-facing path)*
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZwKBG8GTuk57kg1w7hGmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZwKBG8GTuk57kg1w7hGmq)_