### PR TITLE
feat(ts-semantic): port the ER resolution tier (resolve=true) for key-integrity certification

### DIFF
--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -132,6 +132,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   the dialect with `trim().toLowerCase()` **before** validating and pass the
   normalized value through, matching the core emitter's contract — so `"Cube"` /
   `" cube "` are accepted rather than rejected.
+- **ER resolution tier for key-integrity certification (`resolveKeyIntegrity` +
+  `certifySemanticModelResolved`).** Ports the last Python-only certification
+  capability — `semantic/key_integrity.py::certify_key_integrity(resolve=True)`
+  (`_add_resolution`) — into TS now that the port has a `dedupe()` pipeline. Beyond
+  the structural tier (unique-at-grain + fan-out), the resolution tier runs entity
+  resolution on each record's ATTRIBUTE columns (all columns except the key +
+  measures) and checks whether any resolved entity (a ≥2-member cluster) spans more
+  than one distinct declared key — fragmentation, i.e. the join silently
+  **undercounts** distinct entities, the defect a semantic layer can't detect
+  itself. `KeyIntegrityCertificate` now carries the resolve fields
+  (`resolvedEntities` / `fragmentedEntities` / `undercountEstimate` / `estimable`)
+  and `safeBound` discounts a measured undercount (`min(estimate, 1 −
+  undercountEstimate)`), matching the Python dataclass. `resolveKeyIntegrity` is
+  async (TS `dedupe()` is async where Python's `dedupe_df` is sync) and **fail-open**
+  — any resolution failure leaves the resolve fields null with an explanatory note,
+  the structural certificate always intact. Threaded through
+  `certifyCubeJoinsResolved` / `certifyOsiRelationshipsResolved` /
+  `certifySemanticModelResolved` (blind attribute selection across all three
+  dialects, matching Python's non-metric-aware path), and surfaced via the new
+  `resolve` flag on the `certify_semantic_model` MCP tool and the
+  `POST /semantic/certify` REST endpoint (additive per-key resolve fields, null
+  unless measured). Attribute selection is BLIND for now — the metric-aware,
+  dimension-driven selection (Python `certify_semantic_model(metric_aware=True)`,
+  which needs the `semantic/blocking.py` roles reader) is a follow-up; pass an
+  explicit `attributes` list to drive it caller-side. Parity is BEHAVIORAL, not a
+  byte-parity fixture: the tier runs `dedupe()`, whose zero-config output is
+  engine/version-sensitive, so the tests assert the invariants (identical
+  attributes under distinct keys → fragmentation; distinct records → none;
+  no-attributes → skipped; structural fields untouched) rather than exact counts
+  (`tests/unit/semantic-resolve-tier.test.ts`, plus MCP + REST resolve-path cases).
 
 ## [1.26.0] - 2026-07-27
 

--- a/packages/typescript/goldenmatch/src/core/semantic/certify.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/certify.ts
@@ -16,10 +16,10 @@
 import { type LoadedDoc } from "./parseUtil.js";
 import type { SemanticFrames } from "./frame.js";
 import type { KeyIntegrityCertificate } from "./keyIntegrity.js";
-import { certifyKeyIntegrity } from "./keyIntegrity.js";
+import { certifyKeyIntegrity, resolveKeyIntegrity } from "./keyIntegrity.js";
 import { parseSemanticModels } from "./metricflow.js";
-import { certifyCubeJoins } from "./cube.js";
-import { certifyOsiRelationships } from "./osi.js";
+import { certifyCubeJoins, certifyCubeJoinsResolved } from "./cube.js";
+import { certifyOsiRelationships, certifyOsiRelationshipsResolved } from "./osi.js";
 import type { SemanticDialect } from "./catalog.js";
 
 /** One certified declared key: which target declared it, the key column(s), the
@@ -122,6 +122,65 @@ export function certifySemanticModel(doc: LoadedDoc, frames: SemanticFrames): Se
     }
   } else {
     for (const rep of certifyOsiRelationships(doc, frames)) {
+      entries.push({
+        target: rep.dataset,
+        key: [...rep.key],
+        certificate: rep.certificate,
+        context: `relationship ${rep.relationship}`,
+      });
+    }
+  }
+
+  return new SemanticCertification({ dialect, entries, skipped });
+}
+
+/**
+ * Async resolve-tier counterpart of {@link certifySemanticModel}: certifies every
+ * declared identity key AND runs entity resolution on each frame's attributes to
+ * measure fragmentation / undercount — the part a semantic layer can't do itself.
+ * Mirrors Python `certify_semantic_model(..., resolve=True)`.
+ *
+ * Attribute selection is BLIND (all non-key, non-measure columns for MetricFlow;
+ * all non-key columns for Cube/OSI, matching Python which passes no measures on
+ * those paths). The metric-aware role-driven selection (`metric_aware=True`, which
+ * resolves on the model's declared **dimensions** only) needs the
+ * `semantic/blocking.py` roles reader and is a follow-up — a model that declares
+ * no dimensions is byte-identical to blind selection, so this covers that case.
+ * Each key's resolution is fail-open; a failure leaves the resolve fields null.
+ */
+export async function certifySemanticModelResolved(
+  doc: LoadedDoc,
+  frames: SemanticFrames,
+): Promise<SemanticCertification> {
+  const dialect = detectDialect(doc);
+  const entries: KeyCertification[] = [];
+  const skipped: string[] = [];
+
+  if (dialect === "metricflow") {
+    for (const spec of parseSemanticModels(doc)) {
+      const df = frames[spec.model];
+      if (df === undefined) {
+        skipped.push(spec.model);
+        continue;
+      }
+      const cert = await resolveKeyIntegrity(df, {
+        key: spec.key,
+        measures: spec.measures,
+        ...(spec.grain !== null ? { grain: spec.grain } : {}),
+      });
+      entries.push({ target: spec.model, key: [...spec.key], certificate: cert, context: "" });
+    }
+  } else if (dialect === "cube") {
+    for (const rep of await certifyCubeJoinsResolved(doc, frames)) {
+      entries.push({
+        target: rep.toCube,
+        key: [...rep.key],
+        certificate: rep.certificate,
+        context: `join from ${rep.fromCube}`,
+      });
+    }
+  } else {
+    for (const rep of await certifyOsiRelationshipsResolved(doc, frames)) {
       entries.push({
         target: rep.dataset,
         key: [...rep.key],

--- a/packages/typescript/goldenmatch/src/core/semantic/cube.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/cube.ts
@@ -14,7 +14,7 @@ import { type YamlValue, dumpYaml, pyFloat } from "./yamlEmit.js";
 import { pyRound6 } from "./crosswalk.js";
 import type { ResolvedCrosswalk } from "./crosswalk.js";
 import { type LoadedDoc, asList, asStr, asStrStripped, isObj } from "./parseUtil.js";
-import { certifyKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
+import { certifyKeyIntegrity, resolveKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
 import type { SemanticFrame, SemanticFrames } from "./frame.js";
 
 /** An optional key-integrity certificate whose stats ride in `meta.goldenmatch`. */
@@ -270,7 +270,7 @@ export interface CertifiedJoin {
  * → the joined (`to`) cube; `one_to_many` → the declaring (`from`) cube (its key
  * must be unique). A join whose one-side frame is absent or whose one-side columns
  * can't be parsed is skipped. Mirrors Python `certify_cube_joins` (`resolve=false`
- * structural path — the ER fragmentation tier is Python-only).
+ * structural path — {@link certifyCubeJoinsResolved} is the ER fragmentation tier).
  */
 export function certifyCubeJoins(doc: LoadedDoc, frames: SemanticFrames): CertifiedJoin[] {
   const out: CertifiedJoin[] = [];
@@ -283,6 +283,33 @@ export function certifyCubeJoins(doc: LoadedDoc, frames: SemanticFrames): Certif
       const df = frames[oneCube];
       if (df === undefined || oneColumns.length === 0) continue;
       const cert = certifyKeyIntegrity(df, { key: oneColumns });
+      out.push({ fromCube: jk.fromCube, toCube: jk.toCube, key: [...oneColumns], certificate: cert });
+    }
+  }
+  return out;
+}
+
+/**
+ * Async resolve-tier counterpart of {@link certifyCubeJoins}: certifies each
+ * join's one-side key AND runs entity resolution on that frame's attributes to
+ * measure fragmentation / undercount. Mirrors Python `certify_cube_joins(...,
+ * resolve=True)` — blind attribute selection (all columns except the key; Cube's
+ * measures are NOT passed to the certifier, matching Python). Fail-open per key.
+ */
+export async function certifyCubeJoinsResolved(
+  doc: LoadedDoc,
+  frames: SemanticFrames,
+): Promise<CertifiedJoin[]> {
+  const out: CertifiedJoin[] = [];
+  for (const cube of parseCubeModels(doc)) {
+    for (const jk of cubeJoinKeys(cube)) {
+      const [oneCube, oneColumns] =
+        jk.relationship === "one_to_many"
+          ? [jk.fromCube, jk.fromColumns]
+          : [jk.toCube, jk.toColumns];
+      const df = frames[oneCube];
+      if (df === undefined || oneColumns.length === 0) continue;
+      const cert = await resolveKeyIntegrity(df, { key: oneColumns });
       out.push({ fromCube: jk.fromCube, toCube: jk.toCube, key: [...oneColumns], certificate: cert });
     }
   }

--- a/packages/typescript/goldenmatch/src/core/semantic/index.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/index.ts
@@ -11,6 +11,7 @@
 export {
   KeyIntegrityCertificate,
   certifyKeyIntegrity,
+  resolveKeyIntegrity,
   type KeyIntegrityCertificateInit,
 } from "./keyIntegrity.js";
 export { ServingJoinCertificate, certifyServingJoins } from "./serving.js";
@@ -34,6 +35,7 @@ export {
   emitCubeYaml,
   cubeJoinKeys,
   certifyCubeJoins,
+  certifyCubeJoinsResolved,
   type EmitCubeFromCrosswalkOptions,
   type CubeKeyIntegrityCertificateLike,
   type ParsedCube,
@@ -49,6 +51,7 @@ export {
   emitOsiYaml,
   osiJoinKeys,
   certifyOsiRelationships,
+  certifyOsiRelationshipsResolved,
   OSI_VERSION,
   DEFAULT_DIALECT,
   type EmitOsiFromCrosswalkOptions,
@@ -68,6 +71,7 @@ export {
 } from "./catalog.js";
 export {
   certifySemanticModel,
+  certifySemanticModelResolved,
   detectDialect,
   SemanticCertification,
   type KeyCertification,

--- a/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
@@ -12,11 +12,18 @@
  * and how much would a duplicated key inflate a `SUM`/`COUNT(DISTINCT)` (fan-out)?
  * It never mutates a number; it reports and quantifies.
  *
- * SCOPE: the **structural** tier only (uniqueness + fan-out), which is all the
- * serving-join certificate needs. The Python `resolve=true` fragmentation/
- * undercount tier (which runs entity resolution on the record's attributes) is
- * NOT ported here.
+ * SCOPE: `certifyKeyIntegrity` computes the **structural** tier only (uniqueness
+ * + fan-out), which is all the serving-join certificate needs and stays
+ * synchronous. The Python `resolve=true` fragmentation/undercount tier — which
+ * runs entity resolution on the record's attributes — is ported as the async
+ * {@link resolveKeyIntegrity} (ER via `dedupe()` is async in TS). The certificate
+ * carries the resolve fields either way (null until a resolve pass runs).
  */
+
+import type { GoldenMatchConfig, Row } from "../types.js";
+import { getMatchkeys } from "../types.js";
+import { autoConfigureRows } from "../autoconfig.js";
+import { dedupe } from "../api.js";
 
 export interface KeyIntegrityCertificateInit {
   keyColumns: string[];
@@ -42,6 +49,15 @@ export class KeyIntegrityCertificate {
   readonly measureFanOut: Record<string, number>; // per-measure SUM inflation ratio
   note: string;
 
+  // Resolution tier (opt-in via resolveKeyIntegrity): does ER collapse distinct
+  // declared keys? null until a resolve pass populates them (mirrors Python's
+  // KeyIntegrityCertificate defaults). Mutated in place by the resolve tier, as
+  // the Python dataclass is.
+  resolvedEntities: number | null = null; // multi-member clusters found by dedupe
+  fragmentedEntities: number | null = null; // resolved entities spanning >1 declared key value
+  undercountEstimate: number | null = null; // fragmentedEntities / resolvedEntities
+  estimable = true;
+
   constructor(init: KeyIntegrityCertificateInit) {
     this.keyColumns = init.keyColumns;
     this.grain = init.grain;
@@ -61,10 +77,13 @@ export class KeyIntegrityCertificate {
     return 1.0 - this.duplicateKeyGroups / this.nKeyGroups;
   }
 
-  /** Conservative score. With no resolution tier ported it collapses to the
-   * structural estimate (Python `safe_bound` with `undercount_estimate === null`). */
+  /** Conservative score: also discounts entity fragmentation when it was
+   * measured (a fragmented entity is a silent join defect the structural pass
+   * can't see). Collapses to the structural estimate when the resolution tier
+   * hasn't run (Python `safe_bound` with `undercount_estimate === null`). */
   get safeBound(): number {
-    return this.estimate;
+    if (this.undercountEstimate === null) return this.estimate;
+    return Math.min(this.estimate, 1.0 - this.undercountEstimate);
   }
 
   /** Advisory pass/fail: the declared key is unique at grain, doesn't fan out
@@ -197,4 +216,123 @@ export function certifyKeyIntegrity(
     measureFanOut,
     note: notes.join("; "),
   });
+}
+
+/** Per-row declared-key tuple, encoded as a stable string (positional; row i ==
+ * cluster member id i). `null`/`undefined` normalize together, and the JSON
+ * encoding keeps a real `null` distinct from the string `"null"` — mirroring
+ * `groupKey` and Python's `_row_key_values` tuple identity. */
+function rowKeyValues(table: Readonly<Record<string, readonly unknown[]>>, keyColumns: string[]): string[] {
+  const cols = keyColumns.map((c) => table[c] ?? []);
+  const n = cols.length ? cols[0]!.length : 0;
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(groupKey(cols.map((col) => col[i])));
+  }
+  return out;
+}
+
+/**
+ * Certify a declared entity key AND run the resolution tier — the async, edge-safe
+ * port of Python `certify_key_integrity(..., resolve=True)` (`_add_resolution`).
+ *
+ * Computes the structural certificate (via {@link certifyKeyIntegrity}), then runs
+ * zero-config entity resolution over the record's ATTRIBUTE columns (every column
+ * that isn't the key or a measure, unless `attributes` is given) and checks whether
+ * any resolved entity (a ≥2-member cluster) spans more than one distinct declared
+ * key tuple — fragmentation, i.e. the join undercounts distinct entities. It NEVER
+ * mutates the data and is **fail-open**: any resolution failure leaves the resolve
+ * fields null, sets `estimable` from the structural pass, and records an explanatory
+ * note — the structural certificate is always returned intact.
+ *
+ * ER is run async here because TS `dedupe()` is async (Python's `dedupe_df` is sync);
+ * the returned certificate carries the same `resolvedEntities` / `fragmentedEntities`
+ * / `undercountEstimate` / `estimable` contract as the Python dataclass. Attribute
+ * selection is BLIND (all non-key, non-measure columns) — the metric-aware
+ * role-driven selection (`metric_aware=True` in Python's `certify_semantic_model`,
+ * which needs the `semantic/blocking.py` roles reader) is a follow-up; pass an
+ * explicit `attributes` list to drive it caller-side.
+ */
+export async function resolveKeyIntegrity(
+  table: Readonly<Record<string, readonly unknown[]>>,
+  opts: {
+    key: string | readonly string[];
+    measures?: readonly string[];
+    grain?: readonly string[];
+    grainStrict?: boolean;
+    attributes?: readonly string[];
+  },
+): Promise<KeyIntegrityCertificate> {
+  const cert = certifyKeyIntegrity(table, opts);
+  const keyColumns = asList(opts.key);
+  const measureCols = asList(opts.measures);
+  const resNotes = await addResolution(cert, table, keyColumns, measureCols, opts.attributes);
+  cert.note = [cert.note, ...resNotes].filter((s) => s.length > 0).join("; ");
+  return cert;
+}
+
+/** Populate the fragmentation/undercount fields via GoldenMatch ER. Fail-open:
+ * any error leaves the resolution fields null and returns an explanatory note.
+ * Mirrors Python `_add_resolution`. */
+async function addResolution(
+  cert: KeyIntegrityCertificate,
+  table: Readonly<Record<string, readonly unknown[]>>,
+  keyColumns: string[],
+  measureCols: string[],
+  attributes: readonly string[] | undefined,
+): Promise<string[]> {
+  const notes: string[] = [];
+  const exclude = new Set<string>([...keyColumns, ...measureCols]);
+  const attrs =
+    attributes !== undefined ? [...attributes] : Object.keys(table).filter((c) => !exclude.has(c));
+  if (attrs.length === 0) {
+    notes.push("resolution skipped: no attribute columns to resolve on");
+    return notes;
+  }
+
+  try {
+    const nRows = (table[keyColumns[0]!] ?? []).length;
+    const subRows: Row[] = [];
+    for (let i = 0; i < nRows; i++) {
+      const row: Record<string, unknown> = {};
+      for (const a of attrs) row[a] = (table[a] ?? [])[i];
+      subRows.push(row);
+    }
+
+    // Zero-config, then disable rerank/cross-encoder so the certification path
+    // never blocks on a model download (offline-safe), mirroring Python.
+    const cfg = autoConfigureRows(subRows);
+    const matchkeys = getMatchkeys(cfg).map((mk) => ({ ...mk, rerank: false }));
+    const subConfig: GoldenMatchConfig = { ...cfg, matchkeys };
+    const res = await dedupe(subRows, { config: subConfig });
+
+    const keyvals = rowKeyValues(table, keyColumns);
+    let resolved = 0;
+    let fragmented = 0;
+    for (const cl of res.clusters.values()) {
+      const members = cl.members;
+      if (members.length < 2) continue;
+      resolved += 1;
+      const distinctKeys = new Set<string>();
+      for (const m of members) distinctKeys.add(keyvals[Math.trunc(m)]!);
+      if (distinctKeys.size > 1) fragmented += 1;
+    }
+
+    cert.resolvedEntities = resolved;
+    cert.fragmentedEntities = fragmented;
+    cert.undercountEstimate = resolved ? fragmented / resolved : 0.0;
+    if (fragmented) {
+      notes.push(
+        `${fragmented}/${resolved} resolved entities span >1 declared key ` +
+          "(fragmentation → the join undercounts distinct entities)",
+      );
+    }
+  } catch (err) {
+    // fail-open: never break the structural certificate
+    cert.estimable = cert.isUniqueAtGrain && !cert.duplicateKeyGroups;
+    const name = err instanceof Error ? err.constructor.name : "Error";
+    const msg = err instanceof Error ? err.message : String(err);
+    notes.push(`resolution unavailable (${name}: ${msg})`);
+  }
+  return notes;
 }

--- a/packages/typescript/goldenmatch/src/core/semantic/osi.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/osi.ts
@@ -16,7 +16,7 @@ import { pyRound6 } from "./crosswalk.js";
 import type { ResolvedCrosswalk } from "./crosswalk.js";
 import type { CubeKeyIntegrityCertificateLike } from "./cube.js";
 import { type LoadedDoc, asList, asStr, isObj } from "./parseUtil.js";
-import { certifyKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
+import { certifyKeyIntegrity, resolveKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
 import type { SemanticFrames } from "./frame.js";
 
 export const OSI_VERSION = "0.2.0.dev0";
@@ -292,8 +292,8 @@ export interface CertifiedRelationship {
  * For each relationship in an OSI model, certify the ONE-side key it joins on
  * (the referenced PK) — the identity the metrics depend on (structural tier).
  * Datasets without a supplied frame are skipped. Uses the FIRST model, mirroring
- * Python `certify_osi_relationships` (`resolve=false` structural path; the ER
- * fragmentation tier is Python-only).
+ * Python `certify_osi_relationships` (`resolve=false` structural path;
+ * {@link certifyOsiRelationshipsResolved} is the ER fragmentation tier).
  */
 export function certifyOsiRelationships(doc: LoadedDoc, frames: SemanticFrames): CertifiedRelationship[] {
   const models = parseOsiModels(doc);
@@ -304,6 +304,30 @@ export function certifyOsiRelationships(doc: LoadedDoc, frames: SemanticFrames):
     const df = frames[rel.toDataset];
     if (df === undefined || rel.toColumns.length === 0) continue;
     const cert = certifyKeyIntegrity(df, { key: rel.toColumns });
+    out.push({ relationship: rel.name, dataset: rel.toDataset, key: [...rel.toColumns], certificate: cert });
+  }
+  return out;
+}
+
+/**
+ * Async resolve-tier counterpart of {@link certifyOsiRelationships}: certifies
+ * each relationship's one-side key AND runs entity resolution on that dataset's
+ * frame to measure fragmentation / undercount. Mirrors Python
+ * `certify_osi_relationships(..., resolve=True)` — blind attribute selection (all
+ * columns except the key). Fail-open per key.
+ */
+export async function certifyOsiRelationshipsResolved(
+  doc: LoadedDoc,
+  frames: SemanticFrames,
+): Promise<CertifiedRelationship[]> {
+  const models = parseOsiModels(doc);
+  if (!models.length) return [];
+  const model = models[0]!;
+  const out: CertifiedRelationship[] = [];
+  for (const rel of model.relationships) {
+    const df = frames[rel.toDataset];
+    if (df === undefined || rel.toColumns.length === 0) continue;
+    const cert = await resolveKeyIntegrity(df, { key: rel.toColumns });
     out.push({ relationship: rel.name, dataset: rel.toDataset, key: [...rel.toColumns], certificate: cert });
   }
   return out;

--- a/packages/typescript/goldenmatch/src/node/api/server.ts
+++ b/packages/typescript/goldenmatch/src/node/api/server.ts
@@ -35,6 +35,7 @@ import { explainPair } from "../../core/explain.js";
 import { profileRows } from "../../core/profiler.js";
 import {
   certifySemanticModel,
+  certifySemanticModelResolved,
   emitSemanticModelFromStore,
   type SemanticDialect,
   type SemanticFrames,
@@ -350,10 +351,11 @@ async function handleRequest(
     }
 
     if (pathname === "/semantic/certify" && method === "POST") {
-      // Certify a semantic model's declared join keys against supplied frames
-      // (structural tier). Body: { model: <loaded dbt/Cube/OSI doc object>,
-      // frames: { name: { column: [values] } } }. The REST body carries the
-      // already-parsed model + column frames, so no file I/O here.
+      // Certify a semantic model's declared join keys against supplied frames.
+      // Body: { model: <loaded dbt/Cube/OSI doc object>,
+      // frames: { name: { column: [values] } }, resolve?: boolean }. The REST
+      // body carries the already-parsed model + column frames, so no file I/O
+      // here. resolve=true also runs the ER fragmentation/undercount tier.
       const body = await readJsonBody(req);
       const model = body["model"];
       const framesArg = body["frames"];
@@ -384,9 +386,12 @@ async function handleRequest(
         }
         frames[name] = cols;
       }
+      const resolveTier = body["resolve"] === true;
       let report;
       try {
-        report = certifySemanticModel(model as Record<string, unknown>, frames as SemanticFrames);
+        report = resolveTier
+          ? await certifySemanticModelResolved(model as Record<string, unknown>, frames as SemanticFrames)
+          : certifySemanticModel(model as Record<string, unknown>, frames as SemanticFrames);
       } catch (err) {
         sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) });
         return;
@@ -404,6 +409,13 @@ async function handleRequest(
           max_fan_out: e.certificate.maxFanOut,
           estimate: e.certificate.estimate,
           measure_fan_out: e.certificate.measureFanOut,
+          // Resolution tier — null unless resolve=true measured it.
+          resolved_entities: e.certificate.resolvedEntities,
+          fragmented_entities: e.certificate.fragmentedEntities,
+          undercount_estimate: e.certificate.undercountEstimate,
+          safe_bound: e.certificate.safeBound,
+          estimable: e.certificate.estimable,
+          note: e.certificate.note,
         })),
       });
       return;

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -36,7 +36,7 @@ import { dedupe, match, scoreStrings } from "../../core/api.js";
 import { readFile, writeCsv, writeJson } from "../connectors/file.js";
 import { loadConfigFile, parseYamlDoc } from "../config-file.js";
 import { autoMapColumns } from "../../core/schema-match.js";
-import { certifySemanticModel } from "../../core/semantic/index.js";
+import { certifySemanticModel, certifySemanticModelResolved } from "../../core/semantic/index.js";
 import { runPPRL, type PPRLConfig } from "../../core/pprl/protocol.js";
 import { diagnoseConfig } from "../../core/config-critique.js";
 import type { Row, MatchkeyField } from "../../core/types.js";
@@ -486,8 +486,10 @@ const EXISTING_TOOLS: readonly Tool[] = [
       "Cube, or OSI/Ossie -- auto-detected) against its data files. A metric is " +
       "only correct if the key its joins run on uniquely identifies one entity; " +
       "this reports, per key, whether it is unique at grain and how much a " +
-      "duplicated key would inflate a SUM/COUNT (fan-out). Structural tier only " +
-      "(the resolve=true entity-resolution fragmentation tier is Python-only). " +
+      "duplicated key would inflate a SUM/COUNT (fan-out). With resolve=true it " +
+      "ALSO runs entity resolution on each frame's attributes to measure whether " +
+      "distinct declared keys collapse onto one real entity (fragmentation -> " +
+      "undercount) -- the part a semantic layer can't do itself. " +
       "Returns {dialect, n_certified, all_trustworthy, skipped, keys:[...]}.",
     inputSchema: {
       type: "object",
@@ -501,6 +503,12 @@ const EXISTING_TOOLS: readonly Tool[] = [
           description:
             "Maps each model/dataset/cube name to a data file path (csv/tsv/json/jsonl). " +
             "A target with no supplied frame is skipped.",
+        },
+        resolve: {
+          type: "boolean",
+          description:
+            "Also run entity resolution to measure fragmentation / undercount " +
+            "(the resolution tier). Default false (structural tier only).",
         },
       },
       required: ["model_path", "frames"],
@@ -1292,9 +1300,12 @@ export async function handleTool(
             return { error: `could not read data for '${target}' (${p}): ${err instanceof Error ? err.message : String(err)}` };
           }
         }
+        const resolve = args["resolve"] === true;
         let report;
         try {
-          report = certifySemanticModel(doc as Record<string, unknown>, frames);
+          report = resolve
+            ? await certifySemanticModelResolved(doc as Record<string, unknown>, frames)
+            : certifySemanticModel(doc as Record<string, unknown>, frames);
         } catch (err) {
           return { error: err instanceof Error ? err.message : String(err) };
         }
@@ -1311,6 +1322,13 @@ export async function handleTool(
             max_fan_out: e.certificate.maxFanOut,
             estimate: e.certificate.estimate,
             measure_fan_out: e.certificate.measureFanOut,
+            // Resolution tier — null unless resolve=true measured it.
+            resolved_entities: e.certificate.resolvedEntities,
+            fragmented_entities: e.certificate.fragmentedEntities,
+            undercount_estimate: e.certificate.undercountEstimate,
+            safe_bound: e.certificate.safeBound,
+            estimable: e.certificate.estimable,
+            note: e.certificate.note,
           })),
         };
       }

--- a/packages/typescript/goldenmatch/tests/unit/api-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/api-server.test.ts
@@ -268,6 +268,48 @@ describe("REST API server", () => {
     expect(body.keys[0]!.max_fan_out).toBe(2);
   });
 
+  it("POST /semantic/certify resolve=true measures fragmentation / undercount", async () => {
+    const res = await fetch(baseUrl + "/semantic/certify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: {
+          semantic_models: [
+            {
+              name: "customers",
+              entities: [{ name: "customer", type: "primary", expr: "customer_id" }],
+            },
+          ],
+        },
+        frames: {
+          customers: {
+            customer_id: [1, 2, 3, 4],
+            name: ["Alice Smith", "Alice Smith", "Bob Jones", "Carol White"],
+            email: ["alice@x.com", "alice@x.com", "bob@y.com", "carol@z.com"],
+          },
+        },
+        resolve: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      keys: Array<{
+        is_unique_at_grain: boolean;
+        estimate: number;
+        resolved_entities: number | null;
+        fragmented_entities: number | null;
+        undercount_estimate: number | null;
+        safe_bound: number;
+      }>;
+    };
+    const k = body.keys[0]!;
+    expect(k.is_unique_at_grain).toBe(true); // structural pass is clean
+    expect(k.resolved_entities).not.toBeNull();
+    expect(k.fragmented_entities as number).toBeGreaterThanOrEqual(1);
+    expect(k.undercount_estimate as number).toBeGreaterThan(0);
+    expect(k.safe_bound).toBeLessThan(k.estimate);
+  }, 20000);
+
   it("POST /semantic/certify rejects a non-object model", async () => {
     const res = await fetch(baseUrl + "/semantic/certify", {
       method: "POST",

--- a/packages/typescript/goldenmatch/tests/unit/mcp-certify-semantic-model.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-certify-semantic-model.test.ts
@@ -75,6 +75,50 @@ describe("certify_semantic_model MCP tool", () => {
     expect(keys[0]!["estimate"]).toBe(0.5);
   });
 
+  it("resolve=true measures fragmentation / undercount", async () => {
+    const modelPath = writeUnder("model.json", MODEL);
+    // resolved_entity_id is unique at grain (structural pass is clean), but the
+    // two duplicate-attribute rows are the same real customer under distinct
+    // customer_id-derived keys... here the declared key is resolved_entity_id and
+    // rows e1/e2 share identical attributes -> ER collapses them (fragmentation).
+    const framePath = writeUnder(
+      "orders.csv",
+      "resolved_entity_id,revenue,name,email\n" +
+        "e1,10,Alice Smith,alice@x.com\n" +
+        "e2,20,Alice Smith,alice@x.com\n" +
+        "e3,30,Bob Jones,bob@y.com\n" +
+        "e4,40,Carol White,carol@z.com\n",
+    );
+    const r = (await handleTool("certify_semantic_model", {
+      model_path: modelPath,
+      frames: { orders: framePath },
+      resolve: true,
+    })) as Record<string, unknown>;
+    expect(r["n_certified"]).toBe(1);
+    const keys = r["keys"] as Array<Record<string, unknown>>;
+    const k = keys[0]!;
+    expect(k["is_unique_at_grain"]).toBe(true); // structural pass sees a clean key
+    expect(k["resolved_entities"]).not.toBeNull();
+    expect(k["fragmented_entities"] as number).toBeGreaterThanOrEqual(1);
+    expect(k["undercount_estimate"] as number).toBeGreaterThan(0);
+    expect(k["safe_bound"] as number).toBeLessThan(k["estimate"] as number);
+  }, 20000);
+
+  it("resolve defaults off: resolution fields are null", async () => {
+    const modelPath = writeUnder("model.json", MODEL);
+    const framePath = writeUnder(
+      "orders.csv",
+      "resolved_entity_id,customer_id,revenue\ne1,1,10\ne2,2,20\ne3,3,30\n",
+    );
+    const r = (await handleTool("certify_semantic_model", {
+      model_path: modelPath,
+      frames: { orders: framePath },
+    })) as Record<string, unknown>;
+    const keys = r["keys"] as Array<Record<string, unknown>>;
+    expect(keys[0]!["resolved_entities"]).toBeNull();
+    expect(keys[0]!["undercount_estimate"]).toBeNull();
+  });
+
   it("errors clearly on missing model_path / frames", async () => {
     const r1 = (await handleTool("certify_semantic_model", { frames: {} })) as Record<string, unknown>;
     expect(String(r1["error"])).toMatch(/model_path is required/);

--- a/packages/typescript/goldenmatch/tests/unit/semantic-resolve-tier.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/semantic-resolve-tier.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Behavioral tests for the ER resolution tier of the key-integrity certifier —
+ * the TS port of Python `certify_key_integrity(..., resolve=True)` (`_add_resolution`).
+ *
+ * These are BEHAVIORAL, not cross-language byte-parity: the resolve tier runs
+ * `dedupe()`, whose zero-config output is engine/version-sensitive (the
+ * goldenmatch-kg lesson — a toy-frame merge varies by version), so a byte-parity
+ * fixture on resolution output would be flaky and meaningless across the Python
+ * and TS engines. Instead we assert the invariants the tier guarantees:
+ *   - two records with IDENTICAL attributes but DIFFERENT declared keys →
+ *     fragmentation (one resolved entity spans >1 declared key) → undercount;
+ *   - fully-distinct records → no fragmentation;
+ *   - a table with no attribute columns → resolution skipped with a note;
+ *   - fail-open: the structural certificate is always intact;
+ *   - the certificate's `safeBound` discounts a measured undercount.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  certifyKeyIntegrity,
+  resolveKeyIntegrity,
+} from "../../src/core/semantic/keyIntegrity.js";
+import { certifySemanticModelResolved } from "../../src/core/semantic/certify.js";
+import type { SemanticFrames } from "../../src/core/semantic/frame.js";
+
+describe("resolveKeyIntegrity — ER fragmentation/undercount tier", () => {
+  it("detects fragmentation: identical attributes under two distinct keys", async () => {
+    // Rows 0 & 1 are the SAME real person recorded under different customer_id
+    // (a fragmented entity). Rows 2 & 3 are clearly distinct people.
+    const table = {
+      customer_id: [1, 2, 3, 4],
+      name: ["Alice Smith", "Alice Smith", "Bob Jones", "Carol White"],
+      email: ["alice@x.com", "alice@x.com", "bob@y.com", "carol@z.com"],
+      city: ["New York", "New York", "Los Angeles", "San Francisco"],
+    };
+
+    const cert = await resolveKeyIntegrity(table, { key: "customer_id" });
+
+    // The declared key IS unique at grain (4 distinct ids over 4 rows), so the
+    // structural pass sees nothing wrong — the whole point of the resolution tier.
+    expect(cert.isUniqueAtGrain).toBe(true);
+    expect(cert.estimate).toBe(1.0);
+
+    expect(cert.estimable).toBe(true);
+    expect(cert.resolvedEntities).not.toBeNull();
+    expect(cert.resolvedEntities!).toBeGreaterThanOrEqual(1);
+    expect(cert.fragmentedEntities!).toBeGreaterThanOrEqual(1);
+    expect(cert.undercountEstimate!).toBeGreaterThan(0);
+    // safeBound must discount the measured undercount below the clean structural estimate.
+    expect(cert.safeBound).toBeLessThan(cert.estimate);
+    expect(cert.safeBound).toBeCloseTo(Math.min(cert.estimate, 1 - cert.undercountEstimate!), 10);
+    expect(cert.note).toContain("fragmentation");
+  }, 15000);
+
+  it("clean data: fully-distinct records → no fragmentation, undercount 0", async () => {
+    const table = {
+      customer_id: [1, 2, 3],
+      name: ["Alice Smith", "Bob Jones", "Carol White"],
+      email: ["alice@x.com", "bob@y.com", "carol@z.com"],
+      city: ["New York", "Los Angeles", "San Francisco"],
+    };
+
+    const cert = await resolveKeyIntegrity(table, { key: "customer_id" });
+
+    expect(cert.estimable).toBe(true);
+    expect(cert.fragmentedEntities).toBe(0);
+    expect(cert.undercountEstimate).toBe(0.0);
+    // No measured undercount → safeBound collapses to the structural estimate.
+    expect(cert.safeBound).toBeCloseTo(cert.estimate, 10);
+  }, 15000);
+
+  it("skips resolution when there are no attribute columns to resolve on", async () => {
+    // Every column is either the key or a declared measure → nothing to resolve on.
+    const table = { customer_id: [1, 2, 3], revenue: [10, 20, 30] };
+
+    const cert = await resolveKeyIntegrity(table, {
+      key: "customer_id",
+      measures: ["revenue"],
+    });
+
+    expect(cert.resolvedEntities).toBeNull();
+    expect(cert.fragmentedEntities).toBeNull();
+    expect(cert.undercountEstimate).toBeNull();
+    expect(cert.estimable).toBe(true);
+    expect(cert.note).toContain("resolution skipped");
+    // Structural tier is intact and safeBound collapses to the estimate.
+    expect(cert.safeBound).toBeCloseTo(cert.estimate, 10);
+  }, 15000);
+
+  it("honors an explicit attributes list", async () => {
+    const table = {
+      customer_id: [1, 2, 3, 4],
+      name: ["Alice Smith", "Alice Smith", "Bob Jones", "Carol White"],
+      email: ["alice@x.com", "alice@x.com", "bob@y.com", "carol@z.com"],
+      note_col: ["p", "q", "r", "s"],
+    };
+    // Resolve only on name+email (ignore note_col, which would otherwise separate
+    // the two Alice records).
+    const cert = await resolveKeyIntegrity(table, {
+      key: "customer_id",
+      attributes: ["name", "email"],
+    });
+    expect(cert.fragmentedEntities!).toBeGreaterThanOrEqual(1);
+    expect(cert.undercountEstimate!).toBeGreaterThan(0);
+  }, 15000);
+});
+
+describe("certifyKeyIntegrity (structural) — resolve fields default null", () => {
+  it("leaves the resolution fields null and safeBound == estimate", () => {
+    const table = { customer_id: [1, 2, 2], amt: [1, 2, 3] };
+    const cert = certifyKeyIntegrity(table, { key: "customer_id", measures: ["amt"] });
+    expect(cert.resolvedEntities).toBeNull();
+    expect(cert.fragmentedEntities).toBeNull();
+    expect(cert.undercountEstimate).toBeNull();
+    expect(cert.estimable).toBe(true);
+    expect(cert.safeBound).toBe(cert.estimate);
+  });
+});
+
+describe("certifySemanticModelResolved — resolve tier across a semantic model", () => {
+  it("populates the resolution tier for a MetricFlow model", async () => {
+    const model = {
+      semantic_models: [
+        {
+          name: "customers",
+          entities: [{ name: "customer", type: "primary", expr: "customer_id" }],
+          measures: [{ name: "revenue" }],
+          dimensions: [{ name: "created", type: "time" }],
+        },
+      ],
+    };
+    const frames: SemanticFrames = {
+      customers: {
+        customer_id: [1, 2, 3, 4],
+        revenue: [10, 20, 30, 40],
+        name: ["Alice Smith", "Alice Smith", "Bob Jones", "Carol White"],
+        email: ["alice@x.com", "alice@x.com", "bob@y.com", "carol@z.com"],
+        created: ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"],
+      },
+    };
+
+    const report = await certifySemanticModelResolved(model, frames);
+    expect(report.dialect).toBe("metricflow");
+    expect(report.nCertified).toBe(1);
+    const cert = report.entries[0]!.certificate;
+    // revenue is a declared measure → excluded from attribute resolution; the
+    // duplicated Alice records still fragment across customer_id.
+    expect(cert.resolvedEntities).not.toBeNull();
+    expect(cert.fragmentedEntities!).toBeGreaterThanOrEqual(1);
+    expect(cert.undercountEstimate!).toBeGreaterThan(0);
+  }, 20000);
+});


### PR DESCRIPTION
## What and why

Wires the last Python-only certification capability into the TypeScript port:
`semantic/key_integrity.py::certify_key_integrity(resolve=True)` (`_add_resolution`).
The TS `certifyKeyIntegrity` was structural-tier only; now that the port has a
`dedupe()` pipeline, the ER resolution tier can run. Beyond structural
uniqueness + fan-out, the resolution tier runs entity resolution on each record's
ATTRIBUTE columns and checks whether any resolved entity (a >=2-member cluster)
spans more than one distinct declared key -- fragmentation, i.e. the join
silently undercounts distinct entities, the defect a semantic layer can't detect
itself.

## Changes

- `KeyIntegrityCertificate` gains the resolve fields (`resolvedEntities` /
  `fragmentedEntities` / `undercountEstimate` / `estimable`); `safeBound` now
  discounts a measured undercount (`min(estimate, 1 - undercountEstimate)`),
  matching the Python dataclass. Structural `certifyKeyIntegrity` leaves them null.
- `resolveKeyIntegrity(table, opts)` -- async, edge-safe port of `_add_resolution`
  (TS `dedupe()` is async where Python's `dedupe_df` is sync). Fail-open: any
  failure leaves the resolve fields null with an explanatory note; the structural
  certificate is always intact. Blind attribute selection (all columns except key
  + measures); pass an explicit `attributes` list to override.
- `certifyCubeJoinsResolved` / `certifyOsiRelationshipsResolved` /
  `certifySemanticModelResolved` thread the resolve tier across all three dialects
  (blind selection, matching Python's non-metric-aware path).
- New `resolve` flag on the `certify_semantic_model` MCP tool and the
  `POST /semantic/certify` REST endpoint, with additive per-key resolve fields
  (null unless measured).
- Exported from `core/semantic/index.js`; CHANGELOG entry; corrected the now-stale
  "the ER fragmentation tier is Python-only" doc comments in `cube.ts` / `osi.ts`.

The metric-aware, dimension-driven attribute selection (Python
`certify_semantic_model(metric_aware=True)`, which needs the `semantic/blocking.py`
roles reader) is a documented follow-up.

## Testing

- `npx tsc --noEmit` -- clean.
- `npx vitest run` -- full suite green (223 files, 3605 passing / 1 expected fail / 158 skipped).
- New: `tests/unit/semantic-resolve-tier.test.ts` (behavioral invariants of the
  resolve tier) + MCP and REST resolve-path cases in
  `tests/unit/mcp-certify-semantic-model.test.ts` / `tests/unit/api-server.test.ts`.
- Parity is BEHAVIORAL, not a byte-parity fixture: the tier runs `dedupe()`, whose
  zero-config output is engine/version-sensitive, so the tests assert the
  invariants (identical attributes under distinct keys -> fragmentation; distinct
  records -> none; no-attributes -> skipped; structural fields untouched) rather
  than exact counts.
- `pnpm build` -- success.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated (behavior added)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs comments updated where a "Python-only" gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_