### PR TITLE
docs(ts-semantic): correct certify.ts header for the ported resolve tier

### DIFF
--- a/packages/typescript/goldenmatch/src/core/semantic/certify.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/certify.ts
@@ -6,11 +6,12 @@
  * against the supplied frames via the key-integrity certifier — "point it at the
  * semantic model you already have and get a fan-out report on the first run."
  *
- * Faithful port of Python `semantic/certify.py::certify_semantic_model`, the
- * STRUCTURAL tier only (uniqueness + fan-out). The Python `resolve=true`
- * fragmentation/undercount tier runs entity resolution on the record attributes
- * and is deliberately Python-only (see `keyIntegrity.ts`). Advisory only — it
- * never mutates a metric or a key.
+ * Faithful port of Python `semantic/certify.py::certify_semantic_model`.
+ * `certifySemanticModel` is the STRUCTURAL tier (uniqueness + fan-out);
+ * `certifySemanticModelResolved` adds the `resolve=true` fragmentation/undercount
+ * tier, which runs entity resolution on the record attributes (async, since TS
+ * `dedupe()` is async — see `resolveKeyIntegrity` in `keyIntegrity.ts`). Advisory
+ * only — it never mutates a metric or a key.
  */
 
 import { type LoadedDoc } from "./parseUtil.js";


### PR DESCRIPTION
## What and why

Follow-up to #2338 (merged), addressing a Copilot review comment that couldn't
land in that PR because its branch was already in the merge queue (queue-locked).
The `certify.ts` module header still described the `resolve=true`
fragmentation/undercount tier as "deliberately Python-only" -- which #2338 made
false by adding `certifySemanticModelResolved` / `resolveKeyIntegrity`.

## Changes

- Rewrite the `certify.ts` module header to point at `certifySemanticModelResolved`
  / `resolveKeyIntegrity` as the now-ported resolve tier. Doc-comment only; no
  behavior change.

## Testing

- Doc-comment only; `npx tsc --noEmit` clean (unchanged). No runtime code touched.

## Checklist

- [x] Docs comment updated where a "Python-only" gotcha changed
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_