### PR TITLE
ci(security): scope CodeQL to shipping source to cut SAST alert noise

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,43 @@
+# CodeQL configuration — scopes the security-extended scan to SHIPPING source.
+#
+# Why: the workflow scans the Python + JS/TS surface with the broad
+# `security-extended` suite. Run over the whole tree that also pulled in
+# ~2,900 non-shipping files (test suites, benchmarks, examples), where SAST
+# throws high-volume, low-value findings (fixture credentials, mock SSRF,
+# clear-text logging in tests) that bury the real product alerts. Excluding
+# those below focuses the scan on code that actually ships. On the next scan
+# of `main`, alerts located only in these paths auto-resolve as "no longer
+# detected". Product source, the web/API/MCP servers, and the docs-site remain
+# scanned.
+#
+# Keep the query suite here (single source of truth) — the workflow references
+# this file via `config-file:` instead of passing `queries:` inline.
+name: "goldenmatch CodeQL config"
+
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  # Test suites (pytest + vitest/jest) — the dominant noise source.
+  - "**/tests/**"
+  - "**/test/**"
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+  - "**/*.test.mjs"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/conftest.py"
+  # Benchmarks and runnable examples — demonstration code, not shipped surface.
+  - "**/benchmarks/**"
+  - "**/examples/**"
+  # Retained pre-fold repo history (working-tree source, if ever checked out).
+  - "_archive/**"
+  # Generated / build / vendored output.
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/.next/**"
+  - "**/__pycache__/**"
+  - "**/*.min.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,9 +50,11 @@ jobs:
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
         with:
           languages: ${{ matrix.language }}
-          # Use the security-extended query suite — the default is too
-          # conservative for what we want from SAST gating.
-          queries: security-extended
+          # Config file scopes the scan to shipping source (paths-ignore for
+          # tests/benchmarks/examples/generated) and pins the query suite
+          # (security-extended — the default is too conservative for SAST
+          # gating). Single source of truth: .github/codeql/codeql-config.yml.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         # Python + JS are interpreted; autobuild is a no-op but the action


### PR DESCRIPTION
## What and why

The CodeQL workflow ran the broad `security-extended` suite across the **whole** Python + JS/TS tree with **no path scoping** — so ~2,900 non-shipping files (test suites, benchmarks, examples) were analyzed. SAST throws high-volume, low-value findings on that code (fixture credentials, mock SSRF, clear-text logging in tests) that bury the real product alerts and inflated the open count to ~190. This scopes the scan to code that actually ships.

Root cause: `.github/workflows/codeql.yml` passed `queries: security-extended` inline with no `config-file` and no `paths-ignore`.

## Changes

- **Add `.github/codeql/codeql-config.yml`** — `paths-ignore` for `**/tests/**`, `**/test/**`, `**/__tests__/**`, `**/*.test.*` / `**/*.spec.*`, `**/conftest.py`, `**/benchmarks/**`, `**/examples/**`, `_archive/**`, and generated/build output (`dist`, `build`, `.next`, `__pycache__`, `*.min.js`). The `security-extended` suite moves into this file as the single source of truth.
- **`.github/workflows/codeql.yml`** — the init step now references `config-file: ./.github/codeql/codeql-config.yml` instead of the inline `queries:`.

## Effect

- Scannable Python/JS/TS files: **8,513 → 5,683** (−2,830, ~33%).
- All **product source**, the **web / API / MCP servers**, and the **docs-site** remain scanned — only non-shipping test/benchmark/example/generated code is excluded.
- On the next `main` scan after merge, alerts located **only** in the ignored paths auto-resolve as "no longer detected", surfacing the genuine remaining alerts for triage.

This is the "scope now" half of a two-part cleanup — once the noise clears (and given code-scanning read access), the real remaining alerts get triaged and fixed as a follow-up.

## Testing

- `python -c "yaml.safe_load(...)"` on both files → parse OK; verified the init step carries `config-file` and no inline `queries`.
- The CodeQL workflow runs on this PR, which validates the action accepts the new `config-file`.
- File-count delta measured with `find` (excluding the ignored globs) → 8,513 → 5,683.

## Checklist

- [x] Config + workflow validated (YAML parse + wiring assertion)
- [ ] `pre-commit run --all-files` — n/a (CI config only)
- [ ] Package `CHANGELOG.md` — n/a (CI/security config)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs — the config file is self-documenting (rationale in header comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_