### PR TITLE
feat(ts-semantic): metric-aware resolution-tier selection + certify-keys --resolve CLI

### DIFF
--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -162,6 +162,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   attributes under distinct keys → fragmentation; distinct records → none;
   no-attributes → skipped; structural fields untouched) rather than exact counts
   (`tests/unit/semantic-resolve-tier.test.ts`, plus MCP + REST resolve-path cases).
+- **Metric-aware attribute selection for the resolution tier + the `certify-keys
+  --resolve` CLI flag** (completes the resolve tier at full Python parity — the
+  differentiated wedge + every surface). Ports Python `semantic/blocking.py`
+  (`semanticFieldRoles` / `metricAwareAttributes` / `frameColumns` in the new
+  `core/semantic/blocking.ts`): a semantic model already declares which columns are
+  entity **keys**, **measures** (aggregation targets — never identity evidence),
+  and **dimensions** (the identity-bearing attributes). `certifySemanticModelResolved`
+  now drives the ER off those declared roles by default — it resolves on the
+  declared **dimensions** and never treats a **measure** as a match signal (no
+  pure-ER tool has this metadata; the semantic model does). Threaded through
+  `certifyCubeJoinsResolved` / `certifyOsiRelationshipsResolved` (each takes an
+  optional `roles`), and exposed as `certifySemanticModelResolved(doc, frames, {
+  metricAware })` — `metricAware` defaults **true**; a model that declares no
+  dimensions falls back to blind selection, so `metricAware: false` is byte-identical
+  to the prior blind behavior. Because the MCP `certify_semantic_model` tool and
+  `POST /semantic/certify` call the resolved certifier with defaults, their
+  `resolve=true` path is now metric-aware automatically. The TS CLI `certify-keys`
+  gains `--resolve` (run the resolution tier; surfaces each key's
+  fragmentation/undercount note below the table) and `--no-metric-aware` (force blind
+  selection), matching Python `cli/certify_keys.py`. Tests:
+  `tests/unit/semantic-metric-aware.test.ts` (deterministic role reading +
+  attribute-selection logic per dialect, plus an end-to-end case proving a differing
+  declared measure is excluded from ER).
 
 ## [1.26.0] - 2026-07-27
 

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -27,6 +27,7 @@ import { analyzeBlocking } from "./core/block-analyzer.js";
 import { autoConfigure } from "./core/autoconfig.js";
 import {
   certifySemanticModel,
+  certifySemanticModelResolved,
   emitSemanticModelFromStore,
   type SemanticDialect,
 } from "./core/semantic/index.js";
@@ -802,78 +803,106 @@ program
     "-d, --data <spec...>",
     "Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv",
   )
+  .option(
+    "--resolve",
+    "Also run entity resolution to measure entity fragmentation / undercount (the resolution tier)",
+  )
+  .option(
+    "--no-metric-aware",
+    "With --resolve, resolve on every non-key, non-measure column instead of the model's declared dimensions",
+  )
   .option("--fail-untrustworthy", "Exit non-zero if any declared key is not unique at grain (CI gate)")
-  .action((model: string, opts: { data?: string[]; failUntrustworthy?: boolean }) => {
-    const specs = opts.data ?? [];
-    if (specs.length === 0) {
-      process.stderr.write("--data is required (name=path, repeatable), e.g. -d orders=orders.csv\n");
-      process.exit(2);
-    }
-    const frames: Record<string, Record<string, unknown[]>> = Object.create(null);
-    for (const spec of specs) {
-      const eq = spec.indexOf("=");
-      if (eq === -1) {
-        process.stderr.write(`--data must be name=path, got ${JSON.stringify(spec)}\n`);
+  .action(
+    async (
+      model: string,
+      opts: { data?: string[]; resolve?: boolean; metricAware?: boolean; failUntrustworthy?: boolean },
+    ) => {
+      const specs = opts.data ?? [];
+      if (specs.length === 0) {
+        process.stderr.write("--data is required (name=path, repeatable), e.g. -d orders=orders.csv\n");
         process.exit(2);
       }
-      const name = spec.slice(0, eq).trim();
-      const path = spec.slice(eq + 1).trim();
-      frames[name] = rowsToColumns(readFile(path));
-    }
-    let doc: unknown;
-    try {
-      doc = parseYamlDoc(readFileSync(model, "utf-8"));
-    } catch (err) {
-      process.stderr.write(`could not read/parse ${model}: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(2);
-    }
-    if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
-      process.stderr.write(`semantic-model file did not parse to a mapping: ${model}\n`);
-      process.exit(2);
-    }
-    let report;
-    try {
-      report = certifySemanticModel(doc as Record<string, unknown>, frames);
-    } catch (err) {
-      // e.g. dialect detection failed (no cubes/semantic_models/semantic_model key).
-      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(2);
-    }
-    const nUntrust = report.untrustworthy.length;
-    process.stdout.write(
-      `Dialect: ${report.dialect}   certified: ${report.nCertified}   untrustworthy: ${nUntrust}\n`,
-    );
-    if (report.skipped.length) {
-      process.stdout.write(`skipped (no frame supplied): ${report.skipped.join(", ")}\n`);
-    }
-    if (report.note) process.stdout.write(`${report.note}\n`);
+      const frames: Record<string, Record<string, unknown[]>> = Object.create(null);
+      for (const spec of specs) {
+        const eq = spec.indexOf("=");
+        if (eq === -1) {
+          process.stderr.write(`--data must be name=path, got ${JSON.stringify(spec)}\n`);
+          process.exit(2);
+        }
+        const name = spec.slice(0, eq).trim();
+        const path = spec.slice(eq + 1).trim();
+        frames[name] = rowsToColumns(readFile(path));
+      }
+      let doc: unknown;
+      try {
+        doc = parseYamlDoc(readFileSync(model, "utf-8"));
+      } catch (err) {
+        process.stderr.write(`could not read/parse ${model}: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(2);
+      }
+      if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+        process.stderr.write(`semantic-model file did not parse to a mapping: ${model}\n`);
+        process.exit(2);
+      }
+      let report;
+      try {
+        // commander maps --no-metric-aware to opts.metricAware === false; default (flag
+        // absent) leaves it undefined, so metric-aware is on by default when resolving.
+        report =
+          opts.resolve === true
+            ? await certifySemanticModelResolved(doc as Record<string, unknown>, frames, {
+                metricAware: opts.metricAware !== false,
+              })
+            : certifySemanticModel(doc as Record<string, unknown>, frames);
+      } catch (err) {
+        // e.g. dialect detection failed (no cubes/semantic_models/semantic_model key).
+        process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(2);
+      }
+      const nUntrust = report.untrustworthy.length;
+      process.stdout.write(
+        `Dialect: ${report.dialect}   certified: ${report.nCertified}   untrustworthy: ${nUntrust}\n`,
+      );
+      if (report.skipped.length) {
+        process.stdout.write(`skipped (no frame supplied): ${report.skipped.join(", ")}\n`);
+      }
+      if (report.note) process.stdout.write(`${report.note}\n`);
 
-    if (report.entries.length) {
-      const rows = report.entries.map((e) => ({
-        target: e.target,
-        key: e.key.join(", "),
-        unique: e.certificate.isUniqueAtGrain ? "yes" : "NO",
-        fanOut: fmtG(e.certificate.maxFanOut),
-        context: e.context,
-      }));
-      const headers = { target: "target", key: "key", unique: "unique@grain", fanOut: "max_fan_out", context: "context" };
-      const w = {
-        target: Math.max(headers.target.length, ...rows.map((r) => r.target.length)),
-        key: Math.max(headers.key.length, ...rows.map((r) => r.key.length)),
-        unique: Math.max(headers.unique.length, ...rows.map((r) => r.unique.length)),
-        fanOut: Math.max(headers.fanOut.length, ...rows.map((r) => r.fanOut.length)),
-      };
-      const line = (t: string, k: string, u: string, f: string, c: string): string =>
-        `${t.padEnd(w.target)}  ${k.padEnd(w.key)}  ${u.padEnd(w.unique)}  ${f.padStart(w.fanOut)}  ${c}\n`;
-      process.stdout.write(line(headers.target, headers.key, headers.unique, headers.fanOut, headers.context));
-      for (const r of rows) process.stdout.write(line(r.target, r.key, r.unique, r.fanOut, r.context));
-    }
+      if (report.entries.length) {
+        const rows = report.entries.map((e) => ({
+          target: e.target,
+          key: e.key.join(", "),
+          unique: e.certificate.isUniqueAtGrain ? "yes" : "NO",
+          fanOut: fmtG(e.certificate.maxFanOut),
+          context: e.context,
+        }));
+        const headers = { target: "target", key: "key", unique: "unique@grain", fanOut: "max_fan_out", context: "context" };
+        const w = {
+          target: Math.max(headers.target.length, ...rows.map((r) => r.target.length)),
+          key: Math.max(headers.key.length, ...rows.map((r) => r.key.length)),
+          unique: Math.max(headers.unique.length, ...rows.map((r) => r.unique.length)),
+          fanOut: Math.max(headers.fanOut.length, ...rows.map((r) => r.fanOut.length)),
+        };
+        const line = (t: string, k: string, u: string, f: string, c: string): string =>
+          `${t.padEnd(w.target)}  ${k.padEnd(w.key)}  ${u.padEnd(w.unique)}  ${f.padStart(w.fanOut)}  ${c}\n`;
+        process.stdout.write(line(headers.target, headers.key, headers.unique, headers.fanOut, headers.context));
+        for (const r of rows) process.stdout.write(line(r.target, r.key, r.unique, r.fanOut, r.context));
 
-    if (opts.failUntrustworthy && nUntrust > 0) {
-      process.stderr.write(`${nUntrust} declared key(s) are not unique at grain.\n`);
-      process.exit(1);
-    }
-  });
+        // With --resolve, surface each key's resolution note (fragmentation /
+        // undercount) below the table — that's where the ER verdict lives.
+        if (opts.resolve === true) {
+          for (const e of report.entries) {
+            if (e.certificate.note) process.stdout.write(`  ${e.target}: ${e.certificate.note}\n`);
+          }
+        }
+      }
+
+      if (opts.failUntrustworthy && nUntrust > 0) {
+        process.stderr.write(`${nUntrust} declared key(s) are not unique at grain.\n`);
+        process.exit(1);
+      }
+    },
+  );
 
 // ---------- identity ----------
 // Mirrors `goldenmatch identity ...` in Python (cli/identity.py). Wraps the

--- a/packages/typescript/goldenmatch/src/core/semantic/blocking.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/blocking.ts
@@ -1,0 +1,152 @@
+/**
+ * Metric-aware attribute selection for the semantic-layer resolution tier
+ * (edge-safe port of Python `semantic/blocking.py`).
+ *
+ * A semantic model already declares which columns are entity **keys**, which are
+ * **measures** (numeric aggregation targets — NOT identity evidence), and which
+ * are **dimensions** (the identity-bearing attributes a metric groups by). The
+ * resolution tier (`resolveKeyIntegrity`) runs entity resolution to detect key
+ * fragmentation; feeding that ER the model's own measure/dimension metadata —
+ * instead of blindly profiling every column — is the differentiated wedge. A
+ * measure like `revenue` must never be a match signal, and a declared dimension
+ * like `email` is exactly the attribute to resolve on. No pure-ER tool has this
+ * metadata; the semantic model does.
+ *
+ * `semanticFieldRoles(doc)` reads the declared roles from any of the three
+ * dialects (dbt/MetricFlow, Cube, OSI/Ossie). `metricAwareAttributes(roles,
+ * columns)` turns them into the ER attribute allow-list: the declared dimensions
+ * present in the frame (measures and keys always excluded), with a safe fallback
+ * to "every non-key, non-measure column" when a model declares no dimensions — so
+ * a model that declares dimensions gets the metric-aware selection and one that
+ * doesn't is byte-identical to the blind selection the resolution tier used
+ * before.
+ */
+
+import { type LoadedDoc, asList, isObj } from "./parseUtil.js";
+import { detectDialect } from "./certify.js";
+import { entityColumn, measureColumn } from "./metricflow.js";
+import { parseCubeModels } from "./cube.js";
+import { parseOsiModels } from "./osi.js";
+import type { SemanticFrame } from "./frame.js";
+
+/** The column roles a semantic model declares, unioned across all of its
+ * models / cubes / datasets.
+ *
+ * - `keys` — declared entity key columns (primary / natural / unique).
+ * - `dimensions` — declared dimension columns (identity-bearing attributes).
+ * - `measures` — declared measure columns (aggregation targets, never identity).
+ */
+export interface SemanticFieldRoles {
+  keys: string[];
+  dimensions: string[];
+  measures: string[];
+}
+
+/** Order-preserving de-duplication (a column may be declared more than once). */
+function dedup(seq: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const c of seq) {
+    if (c && !seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+/** Column names of a TS semantic frame (a `{ column: values[] }` map). Mirrors
+ * Python `_frame_columns` for the one table shape the edge-safe port carries. */
+export function frameColumns(df: SemanticFrame): string[] {
+  return Object.keys(df);
+}
+
+/**
+ * Read the declared `{keys, dimensions, measures}` roles from a semantic model.
+ * Mirrors Python `semantic_field_roles`. The dialect is auto-detected from the
+ * loaded document; roles are unioned across every model / cube / dataset.
+ */
+export function semanticFieldRoles(doc: LoadedDoc): SemanticFieldRoles {
+  const dialect = detectDialect(doc);
+  const keys: string[] = [];
+  const dimensions: string[] = [];
+  const measures: string[] = [];
+
+  if (dialect === "metricflow") {
+    for (const sm of asList(doc["semantic_models"])) {
+      if (!isObj(sm)) continue;
+      for (const ent of asList(sm["entities"])) {
+        if (isObj(ent)) {
+          const col = entityColumn(ent);
+          if (col) keys.push(col);
+        }
+      }
+      for (const dim of asList(sm["dimensions"])) {
+        // dimensions share the entity `expr`-or-`name` column shape
+        if (isObj(dim)) {
+          const col = entityColumn(dim);
+          if (col) dimensions.push(col);
+        }
+      }
+      for (const m of asList(sm["measures"])) {
+        if (isObj(m)) {
+          const col = measureColumn(m);
+          if (col) measures.push(col);
+        }
+      }
+    }
+  } else if (dialect === "cube") {
+    for (const cube of parseCubeModels(doc)) {
+      for (const d of cube.dimensions) {
+        (d.primaryKey ? keys : dimensions).push(d.name);
+      }
+      for (const m of cube.measures) measures.push(m.name);
+    }
+  } else {
+    // osi
+    for (const model of parseOsiModels(doc)) {
+      for (const ds of model.datasets) {
+        keys.push(...ds.primaryKey);
+        const keySet = new Set(ds.primaryKey);
+        for (const f of ds.fields) {
+          if (!keySet.has(f.name)) dimensions.push(f.name);
+        }
+      }
+      // OSI metrics are aggregation expressions (often derived names, not raw
+      // frame columns); record them so an incidental same-named column is still
+      // excluded from identity evidence.
+      for (const metric of model.metrics) {
+        if (metric.name) measures.push(metric.name);
+      }
+    }
+  }
+
+  return { keys: dedup(keys), dimensions: dedup(dimensions), measures: dedup(measures) };
+}
+
+/**
+ * The entity-resolution attribute allow-list for a frame, given declared roles.
+ * Mirrors Python `metric_aware_attributes`.
+ *
+ * Measures and keys are always excluded (a measure is an aggregation target, a
+ * key is what resolution is checking — neither is identity evidence). When the
+ * model declares dimensions, the result is exactly the declared dimensions
+ * present in the frame; otherwise it falls back to every remaining column, so a
+ * model that declares no dimensions is byte-identical to the blind selection. The
+ * result preserves frame-column order for determinism.
+ */
+export function metricAwareAttributes(
+  roles: SemanticFieldRoles,
+  columns: readonly string[],
+): string[] {
+  const cols = [...columns];
+  const excluded = new Set<string>([...roles.keys, ...roles.measures]);
+  const colSet = new Set(cols);
+  const declaredDims = roles.dimensions.filter((c) => colSet.has(c) && !excluded.has(c));
+  if (declaredDims.length) {
+    const keep = new Set(declaredDims);
+    return cols.filter((c) => keep.has(c));
+  }
+  // No declared dimensions present → blind fallback (measures/keys still excluded).
+  return cols.filter((c) => !excluded.has(c));
+}

--- a/packages/typescript/goldenmatch/src/core/semantic/certify.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/certify.ts
@@ -22,6 +22,8 @@ import { parseSemanticModels } from "./metricflow.js";
 import { certifyCubeJoins, certifyCubeJoinsResolved } from "./cube.js";
 import { certifyOsiRelationships, certifyOsiRelationshipsResolved } from "./osi.js";
 import type { SemanticDialect } from "./catalog.js";
+import { semanticFieldRoles, metricAwareAttributes, frameColumns } from "./blocking.js";
+import type { SemanticFieldRoles } from "./blocking.js";
 
 /** One certified declared key: which target declared it, the key column(s), the
  * advisory certificate, and the join/relationship it feeds. */
@@ -141,21 +143,26 @@ export function certifySemanticModel(doc: LoadedDoc, frames: SemanticFrames): Se
  * measure fragmentation / undercount — the part a semantic layer can't do itself.
  * Mirrors Python `certify_semantic_model(..., resolve=True)`.
  *
- * Attribute selection is BLIND (all non-key, non-measure columns for MetricFlow;
- * all non-key columns for Cube/OSI, matching Python which passes no measures on
- * those paths). The metric-aware role-driven selection (`metric_aware=True`, which
- * resolves on the model's declared **dimensions** only) needs the
- * `semantic/blocking.py` roles reader and is a follow-up — a model that declares
- * no dimensions is byte-identical to blind selection, so this covers that case.
- * Each key's resolution is fail-open; a failure leaves the resolve fields null.
+ * When `metricAware` (default), the ER is driven off the model's own declared
+ * roles — it resolves on the declared **dimensions** and never treats a
+ * **measure** as identity evidence (the differentiated wedge). A model that
+ * declares no dimensions falls back to blind selection (every non-key, non-measure
+ * column), so it is byte-identical to `metricAware: false`. Each key's resolution
+ * is fail-open; a failure leaves the resolve fields null.
  */
 export async function certifySemanticModelResolved(
   doc: LoadedDoc,
   frames: SemanticFrames,
+  opts: { metricAware?: boolean } = {},
 ): Promise<SemanticCertification> {
+  const metricAware = opts.metricAware ?? true;
   const dialect = detectDialect(doc);
   const entries: KeyCertification[] = [];
   const skipped: string[] = [];
+
+  // Read the model's declared roles once, so the resolution tier is metric-aware
+  // across every dialect (a measure is never identity evidence).
+  const roles: SemanticFieldRoles | null = metricAware ? semanticFieldRoles(doc) : null;
 
   if (dialect === "metricflow") {
     for (const spec of parseSemanticModels(doc)) {
@@ -164,15 +171,17 @@ export async function certifySemanticModelResolved(
         skipped.push(spec.model);
         continue;
       }
+      const attributes = roles !== null ? metricAwareAttributes(roles, frameColumns(df)) : undefined;
       const cert = await resolveKeyIntegrity(df, {
         key: spec.key,
         measures: spec.measures,
         ...(spec.grain !== null ? { grain: spec.grain } : {}),
+        ...(attributes !== undefined ? { attributes } : {}),
       });
       entries.push({ target: spec.model, key: [...spec.key], certificate: cert, context: "" });
     }
   } else if (dialect === "cube") {
-    for (const rep of await certifyCubeJoinsResolved(doc, frames)) {
+    for (const rep of await certifyCubeJoinsResolved(doc, frames, roles)) {
       entries.push({
         target: rep.toCube,
         key: [...rep.key],
@@ -181,7 +190,7 @@ export async function certifySemanticModelResolved(
       });
     }
   } else {
-    for (const rep of await certifyOsiRelationshipsResolved(doc, frames)) {
+    for (const rep of await certifyOsiRelationshipsResolved(doc, frames, roles)) {
       entries.push({
         target: rep.dataset,
         key: [...rep.key],

--- a/packages/typescript/goldenmatch/src/core/semantic/cube.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/cube.ts
@@ -16,6 +16,8 @@ import type { ResolvedCrosswalk } from "./crosswalk.js";
 import { type LoadedDoc, asList, asStr, asStrStripped, isObj } from "./parseUtil.js";
 import { certifyKeyIntegrity, resolveKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
 import type { SemanticFrame, SemanticFrames } from "./frame.js";
+import { metricAwareAttributes, frameColumns } from "./blocking.js";
+import type { SemanticFieldRoles } from "./blocking.js";
 
 /** An optional key-integrity certificate whose stats ride in `meta.goldenmatch`. */
 export interface CubeKeyIntegrityCertificateLike {
@@ -293,12 +295,15 @@ export function certifyCubeJoins(doc: LoadedDoc, frames: SemanticFrames): Certif
  * Async resolve-tier counterpart of {@link certifyCubeJoins}: certifies each
  * join's one-side key AND runs entity resolution on that frame's attributes to
  * measure fragmentation / undercount. Mirrors Python `certify_cube_joins(...,
- * resolve=True)` — blind attribute selection (all columns except the key; Cube's
- * measures are NOT passed to the certifier, matching Python). Fail-open per key.
+ * resolve=True, roles=...)`. Pass `roles` (from `semanticFieldRoles`) to make the
+ * ER metric-aware — it resolves on the model's declared dimensions and excludes
+ * measures; `null` (the default) is blind selection (all columns except the key).
+ * Fail-open per key.
  */
 export async function certifyCubeJoinsResolved(
   doc: LoadedDoc,
   frames: SemanticFrames,
+  roles: SemanticFieldRoles | null = null,
 ): Promise<CertifiedJoin[]> {
   const out: CertifiedJoin[] = [];
   for (const cube of parseCubeModels(doc)) {
@@ -309,7 +314,11 @@ export async function certifyCubeJoinsResolved(
           : [jk.toCube, jk.toColumns];
       const df = frames[oneCube];
       if (df === undefined || oneColumns.length === 0) continue;
-      const cert = await resolveKeyIntegrity(df, { key: oneColumns });
+      const attributes = roles !== null ? metricAwareAttributes(roles, frameColumns(df)) : undefined;
+      const cert = await resolveKeyIntegrity(df, {
+        key: oneColumns,
+        ...(attributes !== undefined ? { attributes } : {}),
+      });
       out.push({ fromCube: jk.fromCube, toCube: jk.toCube, key: [...oneColumns], certificate: cert });
     }
   }

--- a/packages/typescript/goldenmatch/src/core/semantic/index.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/index.ts
@@ -76,4 +76,10 @@ export {
   SemanticCertification,
   type KeyCertification,
 } from "./certify.js";
+export {
+  semanticFieldRoles,
+  metricAwareAttributes,
+  frameColumns,
+  type SemanticFieldRoles,
+} from "./blocking.js";
 export type { SemanticFrame, SemanticFrames } from "./frame.js";

--- a/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
@@ -248,10 +248,10 @@ function rowKeyValues(table: Readonly<Record<string, readonly unknown[]>>, keyCo
  * ER is run async here because TS `dedupe()` is async (Python's `dedupe_df` is sync);
  * the returned certificate carries the same `resolvedEntities` / `fragmentedEntities`
  * / `undercountEstimate` / `estimable` contract as the Python dataclass. Attribute
- * selection is BLIND (all non-key, non-measure columns) — the metric-aware
- * role-driven selection (`metric_aware=True` in Python's `certify_semantic_model`,
- * which needs the `semantic/blocking.py` roles reader) is a follow-up; pass an
- * explicit `attributes` list to drive it caller-side.
+ * selection here is BLIND by default (all non-key, non-measure columns); pass an
+ * explicit `attributes` list for the metric-aware, role-driven selection —
+ * `certifySemanticModelResolved` computes it from the model's declared dimensions
+ * via `blocking.ts` (`metricAwareAttributes`).
  */
 export async function resolveKeyIntegrity(
   table: Readonly<Record<string, readonly unknown[]>>,

--- a/packages/typescript/goldenmatch/src/core/semantic/metricflow.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/metricflow.ts
@@ -23,14 +23,16 @@ export interface DeclaredKeySpec {
   foreignKeys: string[]; // foreign entities (join edges)
 }
 
-/** The physical column an entity maps to: `expr` if given, else `name`. */
-function entityColumn(entity: Record<string, unknown>): string {
+/** The physical column an entity maps to: `expr` if given, else `name`.
+ * Exported for the metric-aware roles reader (`blocking.ts`), which reads the
+ * same entity/dimension column shape. */
+export function entityColumn(entity: Record<string, unknown>): string {
   const expr = entity["expr"];
   if (typeof expr === "string" && expr.trim()) return expr.trim();
   return asStrStripped(entity["name"]);
 }
 
-function measureColumn(measure: Record<string, unknown>): string {
+export function measureColumn(measure: Record<string, unknown>): string {
   const expr = measure["expr"];
   if (typeof expr === "string" && expr.trim()) return expr.trim();
   return asStrStripped(measure["name"]);

--- a/packages/typescript/goldenmatch/src/core/semantic/osi.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/osi.ts
@@ -18,6 +18,8 @@ import type { CubeKeyIntegrityCertificateLike } from "./cube.js";
 import { type LoadedDoc, asList, asStr, isObj } from "./parseUtil.js";
 import { certifyKeyIntegrity, resolveKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
 import type { SemanticFrames } from "./frame.js";
+import { metricAwareAttributes, frameColumns } from "./blocking.js";
+import type { SemanticFieldRoles } from "./blocking.js";
 
 export const OSI_VERSION = "0.2.0.dev0";
 export const DEFAULT_DIALECT = "ANSI_SQL";
@@ -313,12 +315,15 @@ export function certifyOsiRelationships(doc: LoadedDoc, frames: SemanticFrames):
  * Async resolve-tier counterpart of {@link certifyOsiRelationships}: certifies
  * each relationship's one-side key AND runs entity resolution on that dataset's
  * frame to measure fragmentation / undercount. Mirrors Python
- * `certify_osi_relationships(..., resolve=True)` — blind attribute selection (all
- * columns except the key). Fail-open per key.
+ * `certify_osi_relationships(..., resolve=True, roles=...)`. Pass `roles` (from
+ * `semanticFieldRoles`) to make the ER metric-aware — it resolves on the model's
+ * declared dimensions and excludes measures; `null` (the default) is blind
+ * selection (all columns except the key). Fail-open per key.
  */
 export async function certifyOsiRelationshipsResolved(
   doc: LoadedDoc,
   frames: SemanticFrames,
+  roles: SemanticFieldRoles | null = null,
 ): Promise<CertifiedRelationship[]> {
   const models = parseOsiModels(doc);
   if (!models.length) return [];
@@ -327,7 +332,11 @@ export async function certifyOsiRelationshipsResolved(
   for (const rel of model.relationships) {
     const df = frames[rel.toDataset];
     if (df === undefined || rel.toColumns.length === 0) continue;
-    const cert = await resolveKeyIntegrity(df, { key: rel.toColumns });
+    const attributes = roles !== null ? metricAwareAttributes(roles, frameColumns(df)) : undefined;
+    const cert = await resolveKeyIntegrity(df, {
+      key: rel.toColumns,
+      ...(attributes !== undefined ? { attributes } : {}),
+    });
     out.push({ relationship: rel.name, dataset: rel.toDataset, key: [...rel.toColumns], certificate: cert });
   }
   return out;

--- a/packages/typescript/goldenmatch/tests/unit/semantic-metric-aware.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/semantic-metric-aware.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Metric-aware attribute selection for the resolution tier (port of Python
+ * `semantic/blocking.py`). `semanticFieldRoles` reads the declared
+ * {keys, dimensions, measures} from each dialect; `metricAwareAttributes` turns
+ * them into the ER attribute allow-list (declared dimensions, never a key or a
+ * measure, with a blind fallback). The roles/selection logic is deterministic and
+ * tested directly; a small end-to-end case confirms the selection is actually
+ * threaded into `certifySemanticModelResolved`.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  semanticFieldRoles,
+  metricAwareAttributes,
+  frameColumns,
+  type SemanticFieldRoles,
+} from "../../src/core/semantic/blocking.js";
+import { certifySemanticModelResolved } from "../../src/core/semantic/certify.js";
+import type { SemanticFrames } from "../../src/core/semantic/frame.js";
+
+describe("semanticFieldRoles — declared roles per dialect", () => {
+  it("MetricFlow: entities → keys, dimensions → dimensions, measures → measures", () => {
+    const doc = {
+      semantic_models: [
+        {
+          name: "orders",
+          entities: [{ name: "orders", type: "primary", expr: "resolved_entity_id" }],
+          dimensions: [{ name: "email", type: "categorical" }, { name: "city" }],
+          measures: [{ name: "revenue", agg: "sum", expr: "revenue" }],
+        },
+      ],
+    };
+    const roles = semanticFieldRoles(doc);
+    expect(roles.keys).toEqual(["resolved_entity_id"]);
+    expect(roles.dimensions).toEqual(["email", "city"]);
+    expect(roles.measures).toEqual(["revenue"]);
+  });
+
+  it("Cube: primary_key dimension → key, other dimensions → dimensions, measures → measures", () => {
+    const doc = {
+      cubes: [
+        {
+          name: "orders",
+          sql_table: "public.orders",
+          dimensions: [
+            { name: "id", sql: "id", primary_key: true },
+            { name: "status", sql: "status" },
+          ],
+          measures: [{ name: "count", type: "count" }],
+        },
+      ],
+    };
+    const roles = semanticFieldRoles(doc);
+    expect(roles.keys).toEqual(["id"]);
+    expect(roles.dimensions).toEqual(["status"]);
+    expect(roles.measures).toEqual(["count"]);
+  });
+
+  it("OSI: primary_key → keys, non-key fields → dimensions, metrics → measures", () => {
+    const doc = {
+      version: "0.1",
+      semantic_model: [
+        {
+          name: "sales",
+          datasets: [
+            {
+              name: "orders",
+              primary_key: ["id"],
+              fields: [{ name: "id" }, { name: "email" }, { name: "city" }],
+            },
+          ],
+          metrics: [{ name: "revenue", expression: "SUM(orders.amount)" }],
+        },
+      ],
+    };
+    const roles = semanticFieldRoles(doc);
+    expect(roles.keys).toEqual(["id"]);
+    expect(roles.dimensions).toEqual(["email", "city"]);
+    expect(roles.measures).toEqual(["revenue"]);
+  });
+
+  it("de-dups columns declared more than once, preserving order", () => {
+    const doc = {
+      semantic_models: [
+        { name: "a", dimensions: [{ name: "email" }, { name: "email" }, { name: "city" }] },
+        { name: "b", dimensions: [{ name: "city" }] },
+      ],
+    };
+    expect(semanticFieldRoles(doc).dimensions).toEqual(["email", "city"]);
+  });
+});
+
+describe("metricAwareAttributes — the ER attribute allow-list", () => {
+  const roles: SemanticFieldRoles = {
+    keys: ["customer_id"],
+    dimensions: ["email", "city"],
+    measures: ["revenue"],
+  };
+
+  it("keeps declared dimensions present in the frame, in frame order", () => {
+    // frame order (city before email) drives the output order, not roles order.
+    const cols = ["customer_id", "revenue", "city", "email", "notes"];
+    expect(metricAwareAttributes(roles, cols)).toEqual(["city", "email"]);
+  });
+
+  it("never includes a key or a measure", () => {
+    const out = metricAwareAttributes(roles, ["customer_id", "revenue", "email"]);
+    expect(out).not.toContain("customer_id");
+    expect(out).not.toContain("revenue");
+    expect(out).toEqual(["email"]);
+  });
+
+  it("blind fallback (every non-key, non-measure column) when no declared dimension is present", () => {
+    const noDims: SemanticFieldRoles = { keys: ["customer_id"], dimensions: [], measures: ["revenue"] };
+    const cols = ["customer_id", "revenue", "name", "phone"];
+    expect(metricAwareAttributes(noDims, cols)).toEqual(["name", "phone"]);
+  });
+
+  it("blind fallback when declared dimensions are absent from the frame", () => {
+    const cols = ["customer_id", "revenue", "name"]; // no email/city present
+    expect(metricAwareAttributes(roles, cols)).toEqual(["name"]);
+  });
+
+  it("frameColumns returns the frame's column names", () => {
+    expect(frameColumns({ a: [1], b: [2] })).toEqual(["a", "b"]);
+  });
+});
+
+describe("certifySemanticModelResolved — metric-aware selection is threaded through", () => {
+  it("excludes a declared measure from ER: fragmentation still found despite a differing revenue", async () => {
+    // Rows 0 & 1 are the same person (same declared dimension email/name) recorded
+    // under distinct customer_id, and their revenue DIFFERS. Metric-aware selection
+    // resolves on the declared dimensions only (email), so the differing measure
+    // can't split them -> fragmentation is detected.
+    const model = {
+      semantic_models: [
+        {
+          name: "customers",
+          entities: [{ name: "customer", type: "primary", expr: "customer_id" }],
+          dimensions: [{ name: "email" }, { name: "name" }],
+          measures: [{ name: "revenue", agg: "sum", expr: "revenue" }],
+        },
+      ],
+    };
+    const frames: SemanticFrames = {
+      customers: {
+        customer_id: [1, 2, 3, 4],
+        email: ["alice@x.com", "alice@x.com", "bob@y.com", "carol@z.com"],
+        name: ["Alice Smith", "Alice Smith", "Bob Jones", "Carol White"],
+        revenue: [10, 999999, 30, 40], // differs across the duplicate pair
+      },
+    };
+
+    const report = await certifySemanticModelResolved(model, frames); // metricAware defaults on
+    const cert = report.entries[0]!.certificate;
+    expect(cert.resolvedEntities).not.toBeNull();
+    expect(cert.fragmentedEntities as number).toBeGreaterThanOrEqual(1);
+    expect(cert.undercountEstimate as number).toBeGreaterThan(0);
+  }, 20000);
+
+  it("metricAware:false falls back to blind selection and still runs", async () => {
+    const model = {
+      semantic_models: [
+        {
+          name: "customers",
+          entities: [{ name: "customer", type: "primary", expr: "customer_id" }],
+          dimensions: [{ name: "email" }],
+          measures: [{ name: "revenue", agg: "sum", expr: "revenue" }],
+        },
+      ],
+    };
+    const frames: SemanticFrames = {
+      customers: {
+        customer_id: [1, 2, 3],
+        email: ["a@x.com", "b@y.com", "c@z.com"],
+        revenue: [10, 20, 30],
+      },
+    };
+    const report = await certifySemanticModelResolved(model, frames, { metricAware: false });
+    expect(report.nCertified).toBe(1);
+    const cert = report.entries[0]!.certificate;
+    // Distinct records → the blind path runs and stays estimable (fail-open keeps
+    // the structural certificate intact either way); no spurious fragmentation.
+    expect(cert.estimable).toBe(true);
+    expect(cert.fragmentedEntities ?? 0).toBe(0);
+  }, 20000);
+});

--- a/packages/typescript/goldenmatch/tests/unit/semantic-resolve-tier.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/semantic-resolve-tier.test.ts
@@ -125,7 +125,9 @@ describe("certifySemanticModelResolved — resolve tier across a semantic model"
           name: "customers",
           entities: [{ name: "customer", type: "primary", expr: "customer_id" }],
           measures: [{ name: "revenue" }],
-          dimensions: [{ name: "created", type: "time" }],
+          // Declare the identity-bearing attributes as dimensions so the (default)
+          // metric-aware ER resolves on name/email, not the differing `created`.
+          dimensions: [{ name: "name" }, { name: "email" }, { name: "created", type: "time" }],
         },
       ],
     };


### PR DESCRIPTION
## What and why

Completes the ER resolution tier (shipped in #2338) at full Python parity: the
**metric-aware** attribute selection (the differentiated wedge) plus the CLI
surface. Follow-on to #2338 / #2339.

A semantic model already declares which columns are entity **keys**, **measures**
(aggregation targets — never identity evidence), and **dimensions** (the
identity-bearing attributes). Feeding the resolution-tier ER those declared roles
— instead of blindly profiling every column — is the wedge no pure-ER tool can do.

## Changes

- **`core/semantic/blocking.ts`** — edge-safe port of Python `semantic/blocking.py`:
  `semanticFieldRoles(doc)` reads `{keys, dimensions, measures}` from all three
  dialects; `metricAwareAttributes(roles, columns)` builds the ER attribute
  allow-list (declared dimensions, never a key or measure, with a blind fallback);
  `frameColumns(df)`.
- **`certifySemanticModelResolved(doc, frames, { metricAware })`** now drives the ER
  off declared roles by default (`metricAware` defaults **true**). A model that
  declares no dimensions falls back to blind selection, so `metricAware: false` is
  byte-identical to the prior blind behavior. Threaded through
  `certifyCubeJoinsResolved` / `certifyOsiRelationshipsResolved` (each takes an
  optional `roles`). The MCP `certify_semantic_model` tool and `POST /semantic/certify`
  call the resolved certifier with defaults, so their `resolve=true` path is now
  metric-aware automatically — matching Python's `certify_semantic_model(metric_aware=True)`.
- **CLI `certify-keys`** gains `--resolve` (runs the resolution tier; surfaces each
  key's fragmentation/undercount note below the table) and `--no-metric-aware`
  (force blind selection), matching Python `cli/certify_keys.py`.
- Exported `entityColumn` / `measureColumn` from `metricflow.ts` for the roles reader;
  exported the new blocking helpers from `core/semantic/index.ts`.

## Testing

- `npx tsc --noEmit` — clean.
- `npx vitest run` — full suite green (224 files, 3615 passing / 1 expected fail / 158 skipped).
- New `tests/unit/semantic-metric-aware.test.ts`: deterministic role reading +
  attribute-selection logic per dialect, plus an end-to-end case proving a differing
  declared measure is excluded from ER.
- Updated the #2338 metricflow resolve-tier test to declare its identity dimensions
  (metric-aware default-on now correctly resolves on declared dimensions, not blindly).
- `certify-keys --resolve` and `--no-metric-aware` smoke-tested against a temp model;
  `pnpm build` — success.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated (behavior added)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs comments updated (resolveKeyIntegrity JSDoc; cube/osi resolved variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_