### PR TITLE
feat(fs): end-to-end run_fs_dedupe_spill — DuckDB-free out-of-core FS dedupe

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -330,6 +330,7 @@
             "fs_streaming_route",
             "resolve_fs_block_source",
             "run_fs_dedupe_sequential",
+            "run_fs_dedupe_spill",
             "run_fs_dedupe_streaming",
             "score_fs_out_of_core",
             "spill_pair_shard",

--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -127,24 +127,35 @@ def resolve_fs_block_source() -> str:
       - ``"duckdb"`` — out-of-core: spill the prepared table to a DuckDB file and
         stream blocks + O(N) output (``score_fs_out_of_core`` /
         ``run_fs_dedupe_streaming``). The ≥40M single-box scale path.
+      - ``"spill"`` — DuckDB-FREE out-of-core: score via the SAME tuned
+        ``score_buckets_arrow`` as ``sequential``, but STREAM each pass's scored
+        pairs to Arrow IPC shards on disk (never accumulating the whole run's pair
+        table) and cluster with an external union-find that streams the shards back
+        (``run_fs_dedupe_spill`` / ``external_wcc_from_shards``). Bounds the edge
+        term (largest single pass, not the sum of all passes) with no DuckDB
+        dependency. Spec:
+        ``docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md``.
 
     Resolution (``GOLDENMATCH_FS_BLOCK_SOURCE`` is authoritative when set to a
     recognized value; the legacy ``GOLDENMATCH_FS_OUT_OF_CORE=1`` is honored only
     when ``GOLDENMATCH_FS_BLOCK_SOURCE`` is unset/empty):
       - ``FS_BLOCK_SOURCE=frame`` → ``"frame"``
       - ``FS_BLOCK_SOURCE=sequential`` → ``"sequential"``
+      - ``FS_BLOCK_SOURCE=spill`` → ``"spill"``
       - ``FS_BLOCK_SOURCE=duckdb`` → ``"duckdb"``
       - ``FS_BLOCK_SOURCE=eager`` / ``auto`` / unset → ``"eager"`` (+ legacy alias)
 
     ``auto`` currently resolves to ``eager`` — the measured RAM-floor
-    auto-escalation to ``sequential``/``duckdb`` is the documented Phase-1
-    follow-on; until it lands (and the default is flipped on a CI scale gate)
-    ``auto`` stays byte-identical to today."""
+    auto-escalation to ``sequential``/``spill``/``duckdb`` is the documented
+    Phase-1 follow-on; until it lands (and the default is flipped on a CI scale
+    gate) ``auto`` stays byte-identical to today."""
     v = os.environ.get("GOLDENMATCH_FS_BLOCK_SOURCE", "").strip().lower()
     if v == "frame":
         return "frame"
     if v == "sequential":
         return "sequential"
+    if v == "spill":
+        return "spill"
     if v == "duckdb":
         return "duckdb"
     if v in ("", "auto", "eager"):
@@ -173,6 +184,9 @@ def fs_streaming_route() -> str | None:
 
       - ``"sequential"`` → ``run_fs_dedupe_sequential`` (in-RAM Arrow/Rust batches,
         ``GOLDENMATCH_FS_BLOCK_SOURCE=sequential``).
+      - ``"spill"`` → ``run_fs_dedupe_spill`` (DuckDB-free out-of-core: per-pass
+        edge shards on disk + external union-find,
+        ``GOLDENMATCH_FS_BLOCK_SOURCE=spill``).
       - ``"duckdb"`` → ``run_fs_dedupe_streaming`` (out-of-core DuckDB spill,
         ``GOLDENMATCH_FS_OUT_OF_CORE=1`` / ``GOLDENMATCH_FS_BLOCK_SOURCE=duckdb``).
 
@@ -180,7 +194,7 @@ def fs_streaming_route() -> str | None:
     ``score_buckets``'s in-bucket residency), so they return ``None`` and the
     caller keeps the default pipeline."""
     src = resolve_fs_block_source()
-    return src if src in ("sequential", "duckdb") else None
+    return src if src in ("sequential", "spill", "duckdb") else None
 
 
 def _fs_ooc_arrow_cluster_enabled() -> bool:
@@ -1245,6 +1259,101 @@ def run_fs_dedupe_sequential(
     res["pairs"] = n_pairs
     res["streaming"] = True
     res["sequential"] = True
+    res["fused"] = n_pairs is None
+    res["output_dir"] = out_dir
+    return res
+
+
+def run_fs_dedupe_spill(
+    prepared_df: Any,
+    blocking_config: BlockingConfig,
+    mk: MatchkeyConfig,
+    em_result,
+    config: Any,
+    out_dir: str,
+    *,
+    matched_pairs: set[tuple[int, int]] | None = None,
+    target_ids: set[int] | None = None,
+    link_threshold: float | None = None,
+) -> dict:
+    """DuckDB-free out-of-core FS dedupe: spill scored edges to disk + external WCC.
+
+    Spec: ``docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md``.
+
+    Like ``run_fs_dedupe_sequential`` (resident frame, the SAME tuned
+    ``score_buckets_arrow`` scorer) but the scored pairs are STREAMED to Arrow IPC
+    shards one PASS at a time via ``score_buckets``'s ``pair_sink`` — never
+    accumulating the whole run's pair table — and clustered by
+    ``external_wcc_from_shards`` (an O(N) union-find that streams the shards back from
+    disk). So the resident edge term is bounded by the LARGEST SINGLE PASS, not the sum
+    of all passes, and clustering never holds the full pair table + dedup table the way
+    ``_cluster_arrow_native`` does. DuckDB-free end to end (no ``duckdb.connect``);
+    polars-free except the bounded golden builder.
+
+    The fused-kernel short-circuit (already bounded — grouping+scoring+WCC in one Rust
+    call, no pair list) is reused verbatim when the config is covered; only the
+    bucket-scorer fallback takes the spill route. Partition-parity with
+    ``run_fs_dedupe_sequential`` by construction (same scorer, same edge set; the
+    external WCC is partition-exact with ``_cluster_arrow_native``).
+
+    **Remaining (spec phases):** per-BUCKET spilling (finer than per-pass; needs a hook
+    inside ``_score_single_pass``), a native array-UF ``FsExternalWcc`` kernel, and
+    frame-residency streaming during prep (this path keeps the frame resident — the edge
+    term is what it bounds)."""
+    import shutil as _shutil
+    import tempfile as _tempfile
+
+    from goldenmatch.core.frame import is_polars_lazyframe
+    from goldenmatch.core.frame import to_frame as _tf
+
+    matched_pairs = set(matched_pairs or ())
+    max_cluster_size = 100
+    if getattr(config, "golden_rules", None) is not None:
+        max_cluster_size = config.golden_rules.max_cluster_size
+
+    _fw = _tf(prepared_df)
+    if is_polars_lazyframe(_fw.native):
+        _fw = _tf(_fw.native.collect())
+    base = _fw.to_arrow()
+
+    assignments = None
+    n_pairs = None
+    if not target_ids and not matched_pairs:
+        assignments = _fused_fs_assignments(
+            base, blocking_config, mk, em_result, link_threshold,
+        )
+
+    if assignments is None:
+        from goldenmatch.backends.score_buckets import score_buckets_arrow
+
+        shard_dir = _tempfile.mkdtemp(prefix="gm_fs_spill_")
+        try:
+            shard_paths: list[str] = []
+
+            def _sink(tbl: Any) -> None:
+                # One shard per non-empty pass; the pass's edges leave RAM here.
+                if tbl.num_rows:
+                    shard_paths.append(
+                        spill_pair_shard(tbl, shard_dir, len(shard_paths))
+                    )
+
+            # Sink consumes every pass table -> returns empty; no full pair stream.
+            score_buckets_arrow(
+                base, blocking_config, mk, set(matched_pairs),
+                n_buckets=getattr(config, "n_buckets", None),
+                target_ids=target_ids, em_result=em_result, pair_sink=_sink,
+            )
+            assignments, n_pairs = external_wcc_from_shards(
+                shard_paths, _prep_all_ids_frame(base), max_cluster_size,
+                link_threshold,
+            )
+        finally:
+            _shutil.rmtree(shard_dir, ignore_errors=True)
+
+    res = _stream_fs_dedupe_output_arrow(base, assignments, config, out_dir)
+    res["pairs"] = n_pairs
+    res["streaming"] = True
+    res["spill"] = True
     res["fused"] = n_pairs is None
     res["output_dir"] = out_dir
     return res

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1193,8 +1193,18 @@ def score_buckets(
     target_ids: set[int] | None = None,
     em_result=None,
     _emit: str = "list",
+    pair_sink: Any = None,
 ) -> Any:
     """Score all blocks via hash-bucketed partition_by, no per-block LazyFrame.
+
+    ``pair_sink`` (arrow mode only): an optional ``callable(pa.Table)`` invoked with
+    each PASS's ``PAIR_STREAM`` table AS SOON AS the pass is scored, INSTEAD of
+    accumulating the passes into one returned table — so a caller streaming edges to
+    disk (``run_fs_dedupe_spill``) never holds more than one pass's pairs resident.
+    The per-pass table is exactly what the accumulating path would concat, so it
+    preserves the ``multi_pass`` block-collision dedup (parity-exact). When set, the
+    function returns an EMPTY pair stream (the sink consumed everything); ``None``
+    (default) is byte-identical to today.
 
     ``_emit`` (internal): ``"list"`` (default) returns
     ``list[tuple[int,int,float]]`` and mutates ``matched_pairs`` in place — the
@@ -2442,7 +2452,14 @@ def score_buckets(
             # (converted per BUCKET, B2c) -- accumulate it directly; no per-pass
             # list ever exists. See the PR-B design doc.
             n_emitted += pass_result.num_rows
-            pass_tables.append(pass_result)
+            if pair_sink is not None:
+                # Stream this pass's edges out (e.g. to a disk shard) and drop them
+                # -- never accumulate across passes. The per-pass table is identical
+                # to what `pass_tables.append` would collect, so downstream WCC sees
+                # the same edge set (parity-exact); only the residency differs.
+                pair_sink(pass_result)
+            else:
+                pass_tables.append(pass_result)
             del pass_result
         else:
             n_emitted += len(pass_result)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -623,10 +623,13 @@ def _run_fs_streaming_dedupe(
         "F-S EM: converged=%s, iterations=%d, match_rate=%.4f",
         em_result.converged, em_result.iterations, em_result.proportion_matched,
     )
-    _orchestrator = {
-        "sequential": run_fs_dedupe_sequential,
-        "spill": run_fs_dedupe_spill,
-    }.get(fs_streaming_route(), run_fs_dedupe_streaming)
+    _route = fs_streaming_route()
+    if _route == "sequential":
+        _orchestrator = run_fs_dedupe_sequential
+    elif _route == "spill":
+        _orchestrator = run_fs_dedupe_spill
+    else:
+        _orchestrator = run_fs_dedupe_streaming
     res = _orchestrator(
         score_frame, blocking, scoring_mk, em_result, config, output_dir,
         link_threshold=link_threshold,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -583,6 +583,7 @@ def _run_fs_streaming_dedupe(
     from goldenmatch.backends.fs_out_of_core import (
         fs_streaming_route,
         run_fs_dedupe_sequential,
+        run_fs_dedupe_spill,
         run_fs_dedupe_streaming,
     )
     from goldenmatch.core.blocker import collect_blocking_fields
@@ -622,11 +623,10 @@ def _run_fs_streaming_dedupe(
         "F-S EM: converged=%s, iterations=%d, match_rate=%.4f",
         em_result.converged, em_result.iterations, em_result.proportion_matched,
     )
-    _orchestrator = (
-        run_fs_dedupe_sequential
-        if fs_streaming_route() == "sequential"
-        else run_fs_dedupe_streaming
-    )
+    _orchestrator = {
+        "sequential": run_fs_dedupe_sequential,
+        "spill": run_fs_dedupe_spill,
+    }.get(fs_streaming_route(), run_fs_dedupe_streaming)
     res = _orchestrator(
         score_frame, blocking, scoring_mk, em_result, config, output_dir,
         link_threshold=link_threshold,

--- a/packages/python/goldenmatch/tests/test_fs_out_of_core.py
+++ b/packages/python/goldenmatch/tests/test_fs_out_of_core.py
@@ -482,6 +482,7 @@ def test_resolve_fs_block_source_default_is_eager(monkeypatch):
     "block_source,expected",
     [("frame", "frame"), ("duckdb", "duckdb"), ("eager", "eager"),
      ("sequential", "sequential"), (" Sequential ", "sequential"),
+     ("spill", "spill"), (" Spill ", "spill"),
      ("auto", "eager"), ("AUTO", "eager"), (" DuckDB ", "duckdb"),
      ("nonsense", "eager")],
 )
@@ -577,12 +578,65 @@ def test_sequential_and_duckdb_orchestrators_agree(tmp_path):
         assert seq[k] == ooc[k], k
 
 
+def test_end_to_end_spill_dedupe(tmp_path):
+    """run_fs_dedupe_spill: score -> per-pass edge shards on disk -> external WCC ->
+    streamed parquet. DuckDB-free. Rows preserved, planted dups found, a golden per
+    multi-member cluster."""
+    import types
+
+    from goldenmatch.backends.fs_out_of_core import run_fs_dedupe_spill
+
+    df = _bigger_df()
+    mk = _make_probabilistic_mk()
+    blocking = BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])])
+    em = _train(df, blocking, mk)
+    cfg = types.SimpleNamespace(golden_rules=None)
+
+    res = run_fs_dedupe_spill(df, blocking, mk, em, cfg, str(tmp_path))
+
+    assert res["spill"] is True
+    assert res["streaming"] is True
+    assert res["unique_count"] + res["dupes_count"] == df.height
+    assert res["dupes_count"] >= 2
+    assert res["golden_count"] >= 1
+
+
+def test_spill_and_sequential_orchestrators_agree(tmp_path):
+    """run_fs_dedupe_spill and run_fs_dedupe_sequential write the SAME
+    unique/dupes/golden counts. Both score via score_buckets_arrow over the SAME
+    edge set; the spill path streams those edges through disk shards + external
+    union-find (partition-exact with _cluster_arrow_native), the sequential path
+    clusters in RAM — so the output-row counts must match by construction."""
+    import types
+
+    from goldenmatch.backends.fs_out_of_core import (
+        run_fs_dedupe_sequential,
+        run_fs_dedupe_spill,
+    )
+
+    df = _bigger_df()
+    mk = _make_probabilistic_mk()
+    blocking = BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])])
+    em = _train(df, blocking, mk)
+    cfg = types.SimpleNamespace(golden_rules=None)
+
+    seq = run_fs_dedupe_sequential(df, blocking, mk, em, cfg, str(tmp_path / "seq"))
+    spill = run_fs_dedupe_spill(df, blocking, mk, em, cfg, str(tmp_path / "spill"))
+    for k in ("unique_count", "dupes_count", "golden_count"):
+        assert seq[k] == spill[k], k
+
+    # Same records land in the dupes partition (not just the same counts).
+    seq_parts = _partition_set_from_parquet(seq["dupes_path"])
+    spill_parts = _partition_set_from_parquet(spill["dupes_path"])
+    assert seq_parts == spill_parts
+
+
 def test_fs_streaming_route_selects_orchestrator(monkeypatch):
     from goldenmatch.backends.fs_out_of_core import fs_streaming_route
 
     monkeypatch.delenv("GOLDENMATCH_FS_OUT_OF_CORE", raising=False)
     for src, expected in (
-        ("sequential", "sequential"), ("duckdb", "duckdb"),
+        ("sequential", "sequential"), ("spill", "spill"), ("duckdb", "duckdb"),
         ("frame", None), ("eager", None), ("auto", None),
     ):
         monkeypatch.setenv("GOLDENMATCH_FS_BLOCK_SOURCE", src)
@@ -612,6 +666,35 @@ def test_dedupe_to_parquet_sequential_parity_with_in_memory(tmp_path, monkeypatc
     res = dedupe_to_parquet(str(csv_path), out_dir=str(out_dir), config=cfg)
     assert res["streaming"] is True
     assert res["sequential"] is True
+    stream_parts = _partition_set_from_parquet(res["dupes_path"])
+
+    assert stream_parts == sorted(mem_parts)
+
+
+def test_dedupe_to_parquet_spill_parity_with_in_memory(tmp_path, monkeypatch):
+    """dedupe_to_parquet under GOLDENMATCH_FS_BLOCK_SOURCE=spill (the DuckDB-free
+    per-pass-shard + external-WCC route) partitions the SAME records as the default
+    in-memory FS route — end-to-end through the pipeline dispatch."""
+    import polars as pl
+    from goldenmatch import dedupe_df, dedupe_to_parquet
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    monkeypatch.delenv("GOLDENMATCH_FS_OUT_OF_CORE", raising=False)
+
+    csv_path = tmp_path / "people.csv"
+    _make_person_csv(csv_path)
+    df = pl.read_csv(csv_path)
+    cfg = _fs_person_config()
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BLOCK_SOURCE", "eager")
+    mem = dedupe_df(df, config=cfg)
+    mem_parts = _partitions(mem)
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BLOCK_SOURCE", "spill")
+    out_dir = tmp_path / "out"
+    res = dedupe_to_parquet(str(csv_path), out_dir=str(out_dir), config=cfg)
+    assert res["streaming"] is True
+    assert res["spill"] is True
     stream_parts = _partition_set_from_parquet(res["dupes_path"])
 
     assert stream_parts == sorted(mem_parts)


### PR DESCRIPTION
## What and why

Wire the spill + external-WCC primitives landed in #2336 (`spill_pair_shard`, `external_wcc_from_shards`) into a runnable end-to-end DuckDB-free out-of-core Fellegi-Sunter dedupe path. This is the "genuinely DuckDB-free out-of-core path with a spillable edge stream + external WCC" lever the predecessor spec left open: it bounds the edge term (largest single pass, not the sum of all passes) with no DuckDB dependency.

## Changes

- **`run_fs_dedupe_spill`** (`backends/fs_out_of_core.py`) — new orchestrator mirroring `run_fs_dedupe_sequential` (resident frame, the same tuned `score_buckets_arrow` scorer, the same fused-kernel short-circuit) but streams each pass's scored pairs to Arrow IPC shards on disk and clusters via `external_wcc_from_shards` (O(N) union-find that streams the shards back). The whole run's pair table never lives in RAM; DuckDB-free end to end.
- **`score_buckets` `pair_sink` seam** (`backends/score_buckets.py`) — an opt-in `callable(pa.Table)` invoked with each pass's `PAIR_STREAM` table as soon as it is scored, instead of accumulating the passes into the returned table. The per-pass table is exactly what the accumulating path would concat, so the `multi_pass` block-collision dedup is preserved (parity-exact). Default `None` is byte-identical to today; passes through `score_buckets_arrow`.
- **Routing** — `resolve_fs_block_source()` recognizes a new `"spill"` value (alongside `eager`/`frame`/`sequential`/`duckdb`); `fs_streaming_route()` returns it; the `core/pipeline.py` FS-streaming dispatch selects `run_fs_dedupe_spill` for it. Reachable via `gm.dedupe_to_parquet(*files, out_dir=…)` with `GOLDENMATCH_FS_BLOCK_SOURCE=spill`.

Partition-parity with `run_fs_dedupe_sequential` by construction — same scorer, same edge set; `external_wcc_from_shards` is partition-exact with `_cluster_arrow_native`.

## Testing

`uv run pytest tests/test_fs_out_of_core.py` — 39 passed. New cases:
- `test_end_to_end_spill_dedupe` — rows preserved, planted dups found, one golden per multi-member cluster.
- `test_spill_and_sequential_orchestrators_agree` — spill and sequential write the same unique/dupes/golden counts AND the same dupes partition.
- `test_dedupe_to_parquet_spill_parity_with_in_memory` — end-to-end through the pipeline dispatch, same partition as the in-memory route.
- Resolver / route recognition of `"spill"`.

Also ran `ruff check` (clean) and `scripts/test_agent_codemap.py` (4 passed; codemap regenerated for the new `run_fs_dedupe_spill` public symbol).

Spec: `docs/superpowers/specs/2026-08-02-fs-duckdb-free-spill-external-wcc-design.md`

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed — new opt-in route, default path byte-unchanged; no changelog entry
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated — the design spec landed with #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZwKBG8GTuk57kg1w7hGmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZwKBG8GTuk57kg1w7hGmq)_