### PR TITLE
ci(security): archive CodeQL SARIF as a build artifact + workflow_dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ on:
   schedule:
     # Weekly fresh sweep on Sunday early-morning UTC.
     - cron: "23 7 * * 0"
+  # On-demand run (e.g. to refresh the archived SARIF artifact below without
+  # waiting for a push or the weekly sweep).
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -66,3 +69,20 @@ jobs:
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
         with:
           category: "/language:${{ matrix.language }}"
+          # Also write the SARIF locally so it can be archived as a build
+          # artifact (below). This lets maintainers/automation pull the exact
+          # findings via the Actions API without needing code-scanning:read;
+          # the analyze action still uploads to the Security tab (upload
+          # defaults to true).
+          output: sarif-results
+
+      - name: Archive SARIF as a build artifact
+        # Always upload — even when the scan surfaces findings — so the
+        # artifact is available for offline triage regardless of outcome.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results/*.sarif
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## What and why

Makes the exact CodeQL findings pullable via the **Actions API** (which only needs `actions:read`) instead of `code-scanning:read`, so triage automation can fetch them without elevated permissions. Follow-up to #2340 (which scoped the scan) — this is how we retrieve the settled alert set for triage.

## Changes

- **`analyze` step** now sets `output: sarif-results` so the SARIF is written to the runner. The scan still uploads to the **Security tab** unchanged (`upload` defaults to true) — this only *adds* a local copy.
- **New step** `actions/upload-artifact` publishes `sarif-results/*.sarif` as a per-language artifact `codeql-sarif-<language>` (14-day retention, `if-no-files-found: warn`).
- **`workflow_dispatch`** trigger added so the artifact can be refreshed on demand without waiting for a push or the weekly sweep.

No change to the query suite, scoping, or Security-tab behavior; permissions block is untouched (artifact upload uses the Actions runtime token, not `GITHUB_TOKEN` scopes).

## Testing

- `yaml.safe_load` on the workflow → parses; asserted `workflow_dispatch` present, `analyze.output == sarif-results`, and the upload step targets `sarif-results/*.sarif` as `codeql-sarif-${{ matrix.language }}`.
- The CodeQL workflow runs on this PR, exercising the new steps end-to-end (SARIF written + artifact uploaded).

## Checklist

- [x] Workflow validated (YAML parse + wiring assertions)
- [ ] `pre-commit run --all-files` — n/a (CI config only)
- [ ] Package `CHANGELOG.md` — n/a (CI/security tooling)
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_