### PR TITLE
test(semantic): single-source the ER-resolution fragmentation reduction across Python + TS

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7233,6 +7233,7 @@
             "_add_resolution",
             "_as_list",
             "_key_integrity_native_enabled",
+            "_reduce_fragmentation",
             "_row_key_values",
             "_structural_native",
             "_structural_pyarrow",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -175,6 +175,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   same structural certificate as the Python / TS / WASM surfaces. Byte-identical
   across all five by construction (shared kernel + shared golden). Tests:
   `tests/test_certify_structural_json.py`.
+- **ER-resolution fragmentation reduction single-sourced with TS via a shared
+  parity fixture.** The resolution tier's cluster→{resolved, fragmented,
+  undercount} reduction (`certify_key_integrity(..., resolve=True)`) is extracted
+  into a pure `_reduce_fragmentation(member_lists, keyvals)` and locked byte-for-
+  byte against the TypeScript port with a shared, Python-generated fixture
+  (`tests/fixtures/.../fragmentation_reduction_cases.json`, read directly by both
+  surfaces — no copy). This is deliberately a data-driven fixture, NOT a Rust
+  kernel: the reduction is a scalar loop over a cluster dict (no Arrow-bulk
+  muscle) whose inputs differ per engine, so kernelizing it would pay FFI
+  marshaling on a small call — the goldenanalysis quality_rollup / regressions
+  precedent. Regenerated + drift-guarded via
+  `scripts/emit_fragmentation_reduction_fixture.py` (wired into
+  `regen_ts_parity_fixtures.sh` → the `ts_parity_freshness` gate). Tests:
+  `tests/test_fragmentation_reduction.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
@@ -62,6 +62,38 @@ def _row_key_values(table: pa.Table, key_columns: list[str]) -> list[tuple]:
     return list(zip(*cols))
 
 
+def _reduce_fragmentation(
+    member_lists: Sequence[Sequence[int]], keyvals: Sequence[Any]
+) -> tuple[int, int, float]:
+    """The resolution-tier reduction: cluster membership → fragmentation counts.
+
+    A *resolved entity* is a cluster of ≥2 records (ER decided they are one real
+    entity); it is *fragmented* when its members carry >1 distinct declared key
+    (the join therefore undercounts distinct entities). Returns
+    ``(resolved_entities, fragmented_entities, undercount_estimate)`` where
+    ``undercount_estimate = fragmented / resolved`` (0.0 when nothing resolved).
+
+    Pure + engine-agnostic: `keyvals` is indexed by member id and its elements
+    are compared only for equality, so the caller's key representation (tuple,
+    string, …) doesn't matter. Cross-language parity-locked (Python == TS) by
+    `tests/fixtures/fragmentation_reduction_cases.json` — this reduction has no
+    kernel (it is a scalar loop, not Arrow-bulk muscle), so a shared data-driven
+    fixture is the single source of truth, mirroring goldenanalysis's
+    quality_rollup / regressions parity fixtures.
+    """
+    resolved = 0
+    fragmented = 0
+    for members in member_lists:
+        if len(members) < 2:
+            continue
+        resolved += 1
+        distinct_keys = {keyvals[int(m)] for m in members}
+        if len(distinct_keys) > 1:
+            fragmented += 1
+    undercount = (fragmented / resolved) if resolved else 0.0
+    return resolved, fragmented, undercount
+
+
 def _key_integrity_native_enabled() -> bool:
     """Opt-in gate for the `key-integrity-core` kernel path.
 
@@ -395,20 +427,15 @@ def _add_resolution(
         clusters = getattr(res, "clusters", None) or {}
 
         keyvals = _row_key_values(table, key_columns)
-        resolved = 0
-        fragmented = 0
-        for cl in clusters.values():
-            members = cl.get("members", []) if isinstance(cl, dict) else getattr(cl, "members", [])
-            if len(members) < 2:
-                continue
-            resolved += 1
-            distinct_keys = {keyvals[int(m)] for m in members}
-            if len(distinct_keys) > 1:
-                fragmented += 1
+        member_lists = [
+            (cl.get("members", []) if isinstance(cl, dict) else getattr(cl, "members", []))
+            for cl in clusters.values()
+        ]
+        resolved, fragmented, undercount = _reduce_fragmentation(member_lists, keyvals)
 
         cert.resolved_entities = resolved
         cert.fragmented_entities = fragmented
-        cert.undercount_estimate = (fragmented / resolved) if resolved else 0.0
+        cert.undercount_estimate = undercount
         if fragmented:
             notes.append(
                 f"{fragmented}/{resolved} resolved entities span >1 declared key "

--- a/packages/python/goldenmatch/scripts/emit_fragmentation_reduction_fixture.py
+++ b/packages/python/goldenmatch/scripts/emit_fragmentation_reduction_fixture.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Emit the cross-language parity fixture for the ER-resolution fragmentation
+reduction (`goldenmatch.semantic.key_integrity._reduce_fragmentation`).
+
+The reduction (cluster membership -> resolved/fragmented/undercount) has NO
+shared kernel -- it's a scalar loop, not Arrow-bulk muscle, so kernelizing it
+would pay FFI marshaling on a small call (against the architecture frame).
+Instead Python and TS are single-sourced by this data-driven fixture (the
+goldenanalysis quality_rollup / regressions parity-fixture precedent): both
+surfaces run their reduction over the SAME synthetic clusters and must produce
+identical counts.
+
+The `expected` values are computed by the Python reference here, so the fixture
+is regenerated in place by `scripts/regen_ts_parity_fixtures.sh` and the
+`ts_parity_freshness` gate re-emits + diffs it -- a future change to the
+reduction on either surface is caught (TS drift against Python, and Python drift
+against the committed fixture). Read directly (no copy) by both
+`tests/test_fragmentation_reduction.py` and
+`tests/parity/fragmentation-reduction.parity.test.ts`.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.semantic.key_integrity import _reduce_fragmentation
+
+# (name, member_lists indexing into keyvals, keyvals). Synthetic clusters chosen
+# to exercise: no resolved entities, a clean multi-member cluster, a single
+# fragmented cluster, a mix, all-fragmented, empty, a large same-key cluster, a
+# three-way fragment, and unsorted member ids.
+_CASES: list[tuple[str, list[list[int]], list[str]]] = [
+    ("all_singletons", [[0], [1], [2]], ["a", "b", "c"]),
+    ("one_clean_multi", [[0, 1], [2]], ["k", "k", "x"]),
+    ("one_fragmented", [[0, 1]], ["k1", "k2"]),
+    ("mixed", [[0, 1], [2, 3, 4], [5]], ["a", "a", "b", "b", "c", "d"]),
+    ("all_fragmented", [[0, 1], [2, 3]], ["p", "q", "r", "s"]),
+    ("empty", [], []),
+    ("large_cluster_same_key", [[0, 1, 2, 3]], ["z", "z", "z", "z"]),
+    ("three_way_fragment", [[0, 1, 2]], ["a", "b", "c"]),
+    ("unsorted_members", [[2, 0], [1, 3]], ["a", "b", "a", "c"]),
+]
+
+_OUT = (
+    Path(__file__).resolve().parent.parent
+    / ".."
+    / ".."
+    / "typescript"
+    / "goldenmatch"
+    / "tests"
+    / "parity"
+    / "fixtures"
+    / "key-integrity"
+    / "fragmentation_reduction_cases.json"
+)
+
+
+def _build() -> dict:
+    cases = []
+    for name, member_lists, keyvals in _CASES:
+        resolved, fragmented, undercount = _reduce_fragmentation(member_lists, keyvals)
+        cases.append(
+            {
+                "name": name,
+                "member_lists": member_lists,
+                "keyvals": keyvals,
+                "expected": {
+                    "resolved_entities": resolved,
+                    "fragmented_entities": fragmented,
+                    "undercount_estimate": undercount,
+                },
+            }
+        )
+    return {
+        "_comment": (
+            "Cross-language parity oracle for the ER-resolution fragmentation "
+            "reduction (cluster membership -> resolved/fragmented/undercount). "
+            "Generated from the Python reference "
+            "goldenmatch.semantic.key_integrity._reduce_fragmentation by "
+            "scripts/emit_fragmentation_reduction_fixture.py. Read DIRECTLY by "
+            "both the Python test (tests/test_fragmentation_reduction.py) and the "
+            "TS test (tests/parity/fragmentation-reduction.parity.test.ts) -- no "
+            "copy, no drift surface. member_lists index into keyvals; keyvals "
+            "compared by equality only (representation-agnostic)."
+        ),
+        "cases": cases,
+    }
+
+
+def main() -> None:
+    _OUT.write_text(json.dumps(_build(), indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {_OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/tests/test_fragmentation_reduction.py
+++ b/packages/python/goldenmatch/tests/test_fragmentation_reduction.py
@@ -1,0 +1,45 @@
+"""Cross-language parity for the ER-resolution fragmentation reduction.
+
+`_reduce_fragmentation` (cluster membership → resolved/fragmented/undercount) is
+the one piece of the resolution tier with NO shared kernel — it's a scalar loop,
+not Arrow-bulk muscle, so kernelizing it would pay FFI marshaling on a small
+call (against the architecture frame). Instead it's single-sourced across Python
+and TS by a shared data-driven fixture (the goldenanalysis quality_rollup /
+regressions precedent): both surfaces run their reduction over the SAME synthetic
+clusters and must produce identical counts.
+
+Reads the fixture DIRECTLY from the TS parity tree (the single source, also read
+by `fragmentation-reduction.parity.test.ts`) — no copy, no second drift surface.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.semantic.key_integrity import _reduce_fragmentation
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / ".."
+    / ".."
+    / "typescript"
+    / "goldenmatch"
+    / "tests"
+    / "parity"
+    / "fixtures"
+    / "key-integrity"
+    / "fragmentation_reduction_cases.json"
+)
+
+
+def test_matches_fixture() -> None:
+    cases = json.loads(FIXTURE.read_text(encoding="utf-8"))["cases"]
+    assert cases, "fixture must carry cases"
+    for case in cases:
+        resolved, fragmented, undercount = _reduce_fragmentation(
+            case["member_lists"], case["keyvals"]
+        )
+        exp = case["expected"]
+        assert resolved == exp["resolved_entities"], case["name"]
+        assert fragmented == exp["fragmented_entities"], case["name"]
+        assert undercount == exp["undercount_estimate"], case["name"]

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -225,6 +225,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `key_integrity_wasm` path filter), and the `fixture_drift` catch-all
   auto-covers the build script. Python-native + SQL reroutes are the documented
   follow-ups (the crate is ready to back them).
+- **ER-resolution fragmentation reduction single-sourced with Python via a shared
+  parity fixture.** The resolution tier's cluster→{resolved, fragmented,
+  undercount} reduction (`resolveKeyIntegrity`) is extracted into a pure exported
+  `reduceFragmentation(memberLists, keyvals)` and locked byte-for-byte against the
+  Python reference by a shared fixture
+  (`tests/parity/fixtures/key-integrity/fragmentation_reduction_cases.json`,
+  Python-generated, read directly by both surfaces — no copy). Deliberately a
+  data-driven fixture, not a wasm kernel: the reduction is a scalar loop, so
+  kernelizing it would pay marshaling on a small call (the goldenanalysis
+  quality_rollup / regressions precedent). Test:
+  `tests/parity/fragmentation-reduction.parity.test.ts`.
 
 ## [1.26.0] - 2026-07-27
 

--- a/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
@@ -320,6 +320,39 @@ export async function resolveKeyIntegrity(
 /** Populate the fragmentation/undercount fields via GoldenMatch ER. Fail-open:
  * any error leaves the resolution fields null and returns an explanatory note.
  * Mirrors Python `_add_resolution`. */
+/**
+ * The resolution-tier reduction: cluster membership → fragmentation counts.
+ *
+ * A *resolved entity* is a cluster of ≥2 records; it is *fragmented* when its
+ * members carry >1 distinct declared key (the join therefore undercounts
+ * distinct entities). Returns resolved / fragmented counts +
+ * `undercountEstimate = fragmented / resolved` (0 when nothing resolved).
+ *
+ * Pure + engine-agnostic: `keyvals` is indexed by member id and compared only
+ * for equality, so the key representation doesn't matter. Cross-language
+ * parity-locked (Python == TS) by
+ * `tests/parity/fixtures/key-integrity/fragmentation_reduction_cases.json` —
+ * this reduction has no kernel (a scalar loop, not Arrow-bulk muscle), so a
+ * shared data-driven fixture is the single source of truth (the goldenanalysis
+ * quality_rollup / regressions parity-fixture precedent).
+ */
+export function reduceFragmentation(
+  memberLists: readonly (readonly number[])[],
+  keyvals: readonly unknown[],
+): { resolvedEntities: number; fragmentedEntities: number; undercountEstimate: number } {
+  let resolved = 0;
+  let fragmented = 0;
+  for (const members of memberLists) {
+    if (members.length < 2) continue;
+    resolved += 1;
+    const distinctKeys = new Set<unknown>();
+    for (const m of members) distinctKeys.add(keyvals[Math.trunc(m)]);
+    if (distinctKeys.size > 1) fragmented += 1;
+  }
+  const undercountEstimate = resolved ? fragmented / resolved : 0.0;
+  return { resolvedEntities: resolved, fragmentedEntities: fragmented, undercountEstimate };
+}
+
 async function addResolution(
   cert: KeyIntegrityCertificate,
   table: Readonly<Record<string, readonly unknown[]>>,
@@ -353,23 +386,18 @@ async function addResolution(
     const res = await dedupe(subRows, { config: subConfig });
 
     const keyvals = rowKeyValues(table, keyColumns);
-    let resolved = 0;
-    let fragmented = 0;
-    for (const cl of res.clusters.values()) {
-      const members = cl.members;
-      if (members.length < 2) continue;
-      resolved += 1;
-      const distinctKeys = new Set<string>();
-      for (const m of members) distinctKeys.add(keyvals[Math.trunc(m)]!);
-      if (distinctKeys.size > 1) fragmented += 1;
-    }
+    const memberLists = [...res.clusters.values()].map((cl) => cl.members);
+    const { resolvedEntities, fragmentedEntities, undercountEstimate } = reduceFragmentation(
+      memberLists,
+      keyvals,
+    );
 
-    cert.resolvedEntities = resolved;
-    cert.fragmentedEntities = fragmented;
-    cert.undercountEstimate = resolved ? fragmented / resolved : 0.0;
-    if (fragmented) {
+    cert.resolvedEntities = resolvedEntities;
+    cert.fragmentedEntities = fragmentedEntities;
+    cert.undercountEstimate = undercountEstimate;
+    if (fragmentedEntities) {
       notes.push(
-        `${fragmented}/${resolved} resolved entities span >1 declared key ` +
+        `${fragmentedEntities}/${resolvedEntities} resolved entities span >1 declared key ` +
           "(fragmentation → the join undercounts distinct entities)",
       );
     }

--- a/packages/typescript/goldenmatch/tests/parity/fixtures/key-integrity/fragmentation_reduction_cases.json
+++ b/packages/typescript/goldenmatch/tests/parity/fixtures/key-integrity/fragmentation_reduction_cases.json
@@ -1,0 +1,199 @@
+{
+  "_comment": "Cross-language parity oracle for the ER-resolution fragmentation reduction (cluster membership -> resolved/fragmented/undercount). Generated from the Python reference goldenmatch.semantic.key_integrity._reduce_fragmentation by scripts/emit_fragmentation_reduction_fixture.py. Read DIRECTLY by both the Python test (tests/test_fragmentation_reduction.py) and the TS test (tests/parity/fragmentation-reduction.parity.test.ts) -- no copy, no drift surface. member_lists index into keyvals; keyvals compared by equality only (representation-agnostic).",
+  "cases": [
+    {
+      "name": "all_singletons",
+      "member_lists": [
+        [
+          0
+        ],
+        [
+          1
+        ],
+        [
+          2
+        ]
+      ],
+      "keyvals": [
+        "a",
+        "b",
+        "c"
+      ],
+      "expected": {
+        "resolved_entities": 0,
+        "fragmented_entities": 0,
+        "undercount_estimate": 0.0
+      }
+    },
+    {
+      "name": "one_clean_multi",
+      "member_lists": [
+        [
+          0,
+          1
+        ],
+        [
+          2
+        ]
+      ],
+      "keyvals": [
+        "k",
+        "k",
+        "x"
+      ],
+      "expected": {
+        "resolved_entities": 1,
+        "fragmented_entities": 0,
+        "undercount_estimate": 0.0
+      }
+    },
+    {
+      "name": "one_fragmented",
+      "member_lists": [
+        [
+          0,
+          1
+        ]
+      ],
+      "keyvals": [
+        "k1",
+        "k2"
+      ],
+      "expected": {
+        "resolved_entities": 1,
+        "fragmented_entities": 1,
+        "undercount_estimate": 1.0
+      }
+    },
+    {
+      "name": "mixed",
+      "member_lists": [
+        [
+          0,
+          1
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          5
+        ]
+      ],
+      "keyvals": [
+        "a",
+        "a",
+        "b",
+        "b",
+        "c",
+        "d"
+      ],
+      "expected": {
+        "resolved_entities": 2,
+        "fragmented_entities": 1,
+        "undercount_estimate": 0.5
+      }
+    },
+    {
+      "name": "all_fragmented",
+      "member_lists": [
+        [
+          0,
+          1
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "keyvals": [
+        "p",
+        "q",
+        "r",
+        "s"
+      ],
+      "expected": {
+        "resolved_entities": 2,
+        "fragmented_entities": 2,
+        "undercount_estimate": 1.0
+      }
+    },
+    {
+      "name": "empty",
+      "member_lists": [],
+      "keyvals": [],
+      "expected": {
+        "resolved_entities": 0,
+        "fragmented_entities": 0,
+        "undercount_estimate": 0.0
+      }
+    },
+    {
+      "name": "large_cluster_same_key",
+      "member_lists": [
+        [
+          0,
+          1,
+          2,
+          3
+        ]
+      ],
+      "keyvals": [
+        "z",
+        "z",
+        "z",
+        "z"
+      ],
+      "expected": {
+        "resolved_entities": 1,
+        "fragmented_entities": 0,
+        "undercount_estimate": 0.0
+      }
+    },
+    {
+      "name": "three_way_fragment",
+      "member_lists": [
+        [
+          0,
+          1,
+          2
+        ]
+      ],
+      "keyvals": [
+        "a",
+        "b",
+        "c"
+      ],
+      "expected": {
+        "resolved_entities": 1,
+        "fragmented_entities": 1,
+        "undercount_estimate": 1.0
+      }
+    },
+    {
+      "name": "unsorted_members",
+      "member_lists": [
+        [
+          2,
+          0
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "keyvals": [
+        "a",
+        "b",
+        "a",
+        "c"
+      ],
+      "expected": {
+        "resolved_entities": 2,
+        "fragmented_entities": 1,
+        "undercount_estimate": 0.5
+      }
+    }
+  ]
+}

--- a/packages/typescript/goldenmatch/tests/parity/fragmentation-reduction.parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/fragmentation-reduction.parity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Cross-language parity: the ER-resolution fragmentation reduction (cluster
+ * membership → resolved/fragmented/undercount) is identical on Python and TS.
+ *
+ * `reduceFragmentation` has NO shared kernel — it's a scalar loop, not
+ * Arrow-bulk muscle, so kernelizing it would pay FFI marshaling on a small call
+ * (against the architecture frame). Instead it's single-sourced by this shared
+ * fixture (the goldenanalysis quality_rollup / regressions precedent): both
+ * surfaces run their reduction over the SAME synthetic clusters and must produce
+ * identical counts. The fixture is generated from the Python reference
+ * (`goldenmatch.semantic.key_integrity._reduce_fragmentation`) and read directly
+ * by both this test and `tests/test_fragmentation_reduction.py` — no copy.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { reduceFragmentation } from "../../src/core/semantic/keyIntegrity.js";
+
+interface FixtureCase {
+  name: string;
+  member_lists: number[][];
+  keyvals: unknown[];
+  expected: {
+    resolved_entities: number;
+    fragmented_entities: number;
+    undercount_estimate: number;
+  };
+}
+
+const fixturePath = fileURLToPath(
+  new URL("./fixtures/key-integrity/fragmentation_reduction_cases.json", import.meta.url),
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as { cases: FixtureCase[] };
+
+describe("fragmentation reduction — parity with the Python _reduce_fragmentation oracle", () => {
+  it("has cases", () => {
+    expect(fixture.cases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of fixture.cases) {
+    it(`${c.name}: TS reduction matches Python`, () => {
+      const got = reduceFragmentation(c.member_lists, c.keyvals);
+      expect(got.resolvedEntities).toBe(c.expected.resolved_entities);
+      expect(got.fragmentedEntities).toBe(c.expected.fragmented_entities);
+      expect(got.undercountEstimate).toBe(c.expected.undercount_estimate);
+    });
+  }
+});

--- a/scripts/regen_ts_parity_fixtures.sh
+++ b/scripts/regen_ts_parity_fixtures.sh
@@ -70,6 +70,9 @@ $PY "$GM/scripts/emit_semantic_parse_fixtures.py"
 echo "== goldenmatch: semantic metric-aware roles (blocking.py) =="
 $PY "$GM/scripts/emit_semantic_roles_fixtures.py"
 
+echo "== goldenmatch: ER-resolution fragmentation reduction (key_integrity.py) =="
+$PY "$GM/scripts/emit_fragmentation_reduction_fixture.py"
+
 echo "== goldenmatch: v2 (planner / EM / domain / tuners / blocker / clustering / golden) =="
 $PY "$GM/scripts/emit_v2_parity_fixtures.py" --out "$PARITY/v2-fixtures.json"
 


### PR DESCRIPTION
## What and why

The semantic-wedge resolution tier's cluster → {resolved, fragmented, undercount} reduction (`certify_key_integrity(..., resolve=True)`) was the one piece with **no shared source of truth** — hand-written inline in both Python (`_add_resolution`) and TS (`addResolution`). This locks the two together.

**Deliberately a cross-language parity fixture, not a Rust kernel.** The reduction is a ~10-line scalar loop over a cluster dict (no Arrow-bulk muscle), and its *inputs* (the dedupe clusters) differ per engine, so a kernel would pay FFI marshaling on a small call for zero parity benefit — against the architecture frame's "smallest stable primitive for scalar/small calls." Instead it follows the goldenanalysis `quality_rollup` / `regressions` precedent: feed both surfaces the SAME synthetic clusters and assert identical counts.

This is the **A** of the A/B/C follow-up set. For context: **C** shipped the SQL surface (#2356, merged); **B** was already done (serving-joins delegate to `certify_key_integrity`, so they inherit the single-sourced kernel transitively on both surfaces — no code needed).

## Changes

- **Extract the reduction** into a pure `_reduce_fragmentation(member_lists, keyvals)` (Python) and an exported `reduceFragmentation(memberLists, keyvals)` (TS). Both call sites delegate — behavior-preserving (`semantic-resolve-tier.test.ts` unchanged, 6/6).
- **Shared fixture** `fragmentation_reduction_cases.json` (9 synthetic cases: no-resolved, clean multi, single/three-way/all fragmented, empty, large same-key, unsorted members) generated from the Python reference and read **directly** by both `tests/test_fragmentation_reduction.py` and `tests/parity/fragmentation-reduction.parity.test.ts` — no copy, no second drift surface.
- **Regeneration + drift guard:** `scripts/emit_fragmentation_reduction_fixture.py`, wired into `regen_ts_parity_fixtures.sh`, so the `ts_parity_freshness` gate re-emits + diffs it — a future change to the reduction on either surface is caught (TS drift against Python, and Python drift against the committed fixture).

## Testing

- `uv run pytest .../test_fragmentation_reduction.py .../test_key_integrity.py` — 15 passed.
- `npx vitest run tests/parity/fragmentation-reduction.parity.test.ts tests/unit/semantic-resolve-tier.test.ts` — 16 passed.
- `npx tsc --noEmit` — clean.
- Emitter idempotent (re-emit → empty diff); ruff + `agent_codemap` gate clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed packages
- [x] Package `CHANGELOG.md` updated (goldenmatch Python + TS)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` — no workflow/gotcha change (mirrors the existing parity-fixture pattern)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_