### PR TITLE
feat(semantic): 95% confidence interval on the resolution-tier undercount estimate

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7244,6 +7244,7 @@
             "_structural_native",
             "_structural_pyarrow",
             "_to_arrow",
+            "_wilson_interval",
             "certify_key_integrity",
             "certify_structural_json"
           ],

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -189,6 +189,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `scripts/emit_fragmentation_reduction_fixture.py` (wired into
   `regen_ts_parity_fixtures.sh` → the `ts_parity_freshness` gate). Tests:
   `tests/test_fragmentation_reduction.py`.
+- **Resolution-tier undercount now carries a 95% confidence interval.**
+  `certify_key_integrity(..., resolve=True)` reported `undercount_estimate =
+  fragmented_entities / resolved_entities` as a bare point estimate — "undercount
+  0.5" read the same from 2 resolved entities as from 2,000. The certificate now
+  also carries `undercount_ci_low` / `undercount_ci_high`, a Wilson score interval
+  on the fragmentation rate (a binomial proportion), so a rate measured from few
+  entities honestly shows a wide interval. A new `safe_bound_conservative`
+  property discounts the CI *upper* bound (worst plausible undercount) for callers
+  who want a statistically-conservative trust floor; `safe_bound` is unchanged
+  (still the point estimate — additive, non-breaking). The interval bounds
+  *sampling* uncertainty, not whether ER clustered correctly. Pure arithmetic,
+  single-sourced with the TS port via a shared fixture
+  (`emit_undercount_ci_fixture.py`, drift-guarded by `ts_parity_freshness`).
+  Tests: `tests/test_undercount_ci.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/goldenmatch/core/key_integrity_certificate.py
+++ b/packages/python/goldenmatch/goldenmatch/core/key_integrity_certificate.py
@@ -44,6 +44,13 @@ class KeyIntegrityCertificate:
     resolved_entities: int | None = None     # multi-member clusters found by dedupe
     fragmented_entities: int | None = None   # resolved entities spanning >1 declared key value
     undercount_estimate: float | None = None # fragmented_entities / resolved_entities
+    # 95% Wilson score interval on the fragmentation rate (= undercount), a
+    # binomial proportion over `resolved_entities` observations. Bounds the
+    # SAMPLING uncertainty in `undercount_estimate` (few resolved entities → wide
+    # interval); it does NOT bound whether ER itself clustered correctly. None
+    # when resolution wasn't run or found no multi-member clusters.
+    undercount_ci_low: float | None = None
+    undercount_ci_high: float | None = None
 
     estimable: bool = True
     note: str = ""
@@ -66,6 +73,18 @@ class KeyIntegrityCertificate:
         if self.undercount_estimate is None:
             return self.estimate
         return min(self.estimate, 1.0 - self.undercount_estimate)
+
+    @property
+    def safe_bound_conservative(self) -> float | None:
+        """Statistically-conservative trust floor: like `safe_bound` but discounts
+        the WORST plausible undercount at the 95% confidence upper bound
+        (`undercount_ci_high`) rather than the point estimate — so a fragmentation
+        rate measured from few resolved entities (wide interval) is penalized more
+        than one measured from many. Falls back to `safe_bound` when the interval
+        wasn't computed (resolution not run / no multi-member clusters)."""
+        if self.undercount_ci_high is None:
+            return self.safe_bound
+        return min(self.estimate, 1.0 - self.undercount_ci_high)
 
     def is_trustworthy(self, *, max_fan_out: float = 1.0, min_estimate: float = 1.0) -> bool:
         """Advisory pass/fail: the declared key is unique at grain, doesn't fan

--- a/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py
@@ -18,6 +18,7 @@ fields None with an explanatory note and never breaks the structural certificate
 from __future__ import annotations
 
 import json
+import math
 import os
 from collections.abc import Sequence
 from typing import Any
@@ -92,6 +93,32 @@ def _reduce_fragmentation(
             fragmented += 1
     undercount = (fragmented / resolved) if resolved else 0.0
     return resolved, fragmented, undercount
+
+
+# 97.5th percentile of the standard normal → 95% two-sided Wilson interval. The
+# same literal is used by the TS port so the interval is bit-identical.
+_WILSON_Z_95 = 1.959963984540054
+
+
+def _wilson_interval(k: int, n: int, z: float = _WILSON_Z_95) -> tuple[float, float] | None:
+    """95% Wilson score interval for a binomial proportion ``k/n`` (successes over
+    trials), clamped to [0, 1]. Returns None when ``n == 0`` (no observations to
+    bound). The Wilson interval is preferred over the normal approximation because
+    it stays inside [0,1] and behaves at small ``n`` / extreme ``p`` — exactly the
+    regime the fragmentation rate lives in when few entities resolve.
+
+    Pure arithmetic (parity-locked with the TS port via a shared fixture).
+    """
+    if n <= 0:
+        return None
+    p = k / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = (p + z2 / (2.0 * n)) / denom
+    half = (z / denom) * math.sqrt(p * (1.0 - p) / n + z2 / (4.0 * n * n))
+    low = center - half
+    high = center + half
+    return (low if low > 0.0 else 0.0, high if high < 1.0 else 1.0)
 
 
 def _key_integrity_native_enabled() -> bool:
@@ -436,6 +463,9 @@ def _add_resolution(
         cert.resolved_entities = resolved
         cert.fragmented_entities = fragmented
         cert.undercount_estimate = undercount
+        ci = _wilson_interval(fragmented, resolved)
+        if ci is not None:
+            cert.undercount_ci_low, cert.undercount_ci_high = ci
         if fragmented:
             notes.append(
                 f"{fragmented}/{resolved} resolved entities span >1 declared key "

--- a/packages/python/goldenmatch/scripts/emit_undercount_ci_fixture.py
+++ b/packages/python/goldenmatch/scripts/emit_undercount_ci_fixture.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Emit the cross-language parity fixture for the resolution-tier undercount
+confidence interval (`goldenmatch.semantic.key_integrity._wilson_interval` + the
+`fragmented/resolved` point estimate).
+
+The 95% Wilson score interval on the fragmentation rate is pure arithmetic
+computed identically on Python and the TS port; this fixture (Python-generated)
+locks them bit-for-bit. Read directly by both
+`tests/test_undercount_ci.py` and
+`tests/parity/undercount-ci.parity.test.ts` -- no copy.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.semantic.key_integrity import _wilson_interval
+
+# (name, fragmented, resolved). Spans: no resolved entities (CI undefined),
+# tiny-n wide interval, large-n tight interval, p at the 0 / 1 boundaries, and
+# mid-range.
+_CASES: list[tuple[str, int, int]] = [
+    ("no_resolved", 0, 0),
+    ("half_of_two", 1, 2),
+    ("half_of_2000", 1, 2000),
+    ("none_of_five", 0, 5),
+    ("all_of_five", 5, 5),
+    ("three_of_ten", 3, 10),
+    ("half_of_hundred", 50, 100),
+    ("none_of_one", 0, 1),
+    ("all_of_one", 1, 1),
+    ("seven_of_thirteen", 7, 13),
+]
+
+_OUT = (
+    Path(__file__).resolve().parent.parent
+    / ".."
+    / ".."
+    / "typescript"
+    / "goldenmatch"
+    / "tests"
+    / "parity"
+    / "fixtures"
+    / "key-integrity"
+    / "undercount_ci_cases.json"
+)
+
+
+def _build() -> dict:
+    cases = []
+    for name, fragmented, resolved in _CASES:
+        undercount = (fragmented / resolved) if resolved else 0.0
+        ci = _wilson_interval(fragmented, resolved)
+        cases.append(
+            {
+                "name": name,
+                "fragmented": fragmented,
+                "resolved": resolved,
+                "expected": {
+                    "undercount_estimate": undercount,
+                    "ci_low": None if ci is None else ci[0],
+                    "ci_high": None if ci is None else ci[1],
+                },
+            }
+        )
+    return {
+        "_comment": (
+            "Cross-language parity oracle for the resolution-tier undercount 95% "
+            "Wilson score interval (bounds the SAMPLING uncertainty in "
+            "fragmented/resolved). Generated from the Python reference "
+            "goldenmatch.semantic.key_integrity._wilson_interval by "
+            "scripts/emit_undercount_ci_fixture.py. Read DIRECTLY by both "
+            "tests/test_undercount_ci.py and "
+            "tests/parity/undercount-ci.parity.test.ts -- no copy. ci_low/ci_high "
+            "are null when resolved == 0 (no observations to bound)."
+        ),
+        "cases": cases,
+    }
+
+
+def main() -> None:
+    _OUT.write_text(json.dumps(_build(), indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {_OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/tests/test_undercount_ci.py
+++ b/packages/python/goldenmatch/tests/test_undercount_ci.py
@@ -1,0 +1,76 @@
+"""Resolution-tier undercount confidence interval (95% Wilson score).
+
+`undercount_estimate = fragmented / resolved` is a point estimate; the Wilson
+interval bounds its SAMPLING uncertainty (few resolved entities → wide interval).
+Pure arithmetic, single-sourced with the TS port by a shared fixture (read
+directly from the TS parity tree — no copy).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.key_integrity import _wilson_interval
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / ".."
+    / ".."
+    / "typescript"
+    / "goldenmatch"
+    / "tests"
+    / "parity"
+    / "fixtures"
+    / "key-integrity"
+    / "undercount_ci_cases.json"
+)
+
+
+def test_matches_fixture() -> None:
+    cases = json.loads(FIXTURE.read_text(encoding="utf-8"))["cases"]
+    assert cases
+    for case in cases:
+        ci = _wilson_interval(case["fragmented"], case["resolved"])
+        exp = case["expected"]
+        if exp["ci_low"] is None:
+            assert ci is None, case["name"]
+        else:
+            assert ci is not None, case["name"]
+            assert abs(ci[0] - exp["ci_low"]) < 1e-12, case["name"]
+            assert abs(ci[1] - exp["ci_high"]) < 1e-12, case["name"]
+
+
+def test_interval_properties() -> None:
+    # Point estimate lies inside the interval; interval stays within [0, 1].
+    for k, n in [(1, 2), (3, 10), (50, 100), (0, 5), (5, 5)]:
+        ci = _wilson_interval(k, n)
+        assert ci is not None
+        low, high = ci
+        assert 0.0 <= low <= high <= 1.0
+        assert low <= k / n <= high
+    # Fewer observations → wider interval at the same proportion.
+    narrow = _wilson_interval(50, 100)
+    wide = _wilson_interval(1, 2)
+    assert (wide[1] - wide[0]) > (narrow[1] - narrow[0])
+
+
+def test_certificate_conservative_bound() -> None:
+    # safe_bound_conservative discounts the CI-upper undercount; falls back to
+    # safe_bound when no interval was computed.
+    cert = KeyIntegrityCertificate(
+        key_columns=["k"], grain=None, n_rows=10, n_key_groups=10,
+        is_unique_at_grain=True, duplicate_key_groups=0, max_fan_out=1.0,
+    )
+    # No resolution run → falls back to safe_bound (== estimate == 1.0).
+    assert cert.safe_bound_conservative == cert.safe_bound == 1.0
+
+    # With a CI, the conservative bound uses 1 - ci_high and is <= safe_bound.
+    cert.resolved_entities = 2
+    cert.fragmented_entities = 1
+    cert.undercount_estimate = 0.5
+    lo, hi = _wilson_interval(1, 2)
+    cert.undercount_ci_low, cert.undercount_ci_high = lo, hi
+    assert cert.safe_bound == min(1.0, 1.0 - 0.5)  # 0.5, the point-estimate floor
+    assert cert.safe_bound_conservative == min(1.0, 1.0 - hi)  # tighter (wider undercount)
+    assert cert.safe_bound_conservative < cert.safe_bound

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -236,6 +236,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   kernelizing it would pay marshaling on a small call (the goldenanalysis
   quality_rollup / regressions precedent). Test:
   `tests/parity/fragmentation-reduction.parity.test.ts`.
+- **Resolution-tier undercount confidence interval.** `KeyIntegrityCertificate`
+  gains `undercountCiLow` / `undercountCiHigh` (a 95% Wilson score interval on the
+  fragmentation rate, computed by the new exported `wilsonInterval(k, n)`) and a
+  `safeBoundConservative` accessor that discounts the CI upper bound; `safeBound`
+  is unchanged. Bounds the sampling uncertainty in `undercountEstimate` (few
+  resolved entities → wide interval). Bit-identical to the Python port (same
+  z-literal + op order), locked by the shared fixture
+  `tests/parity/fixtures/key-integrity/undercount_ci_cases.json`. Test:
+  `tests/parity/undercount-ci.parity.test.ts`.
 
 ## [1.26.0] - 2026-07-27
 

--- a/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
@@ -58,6 +58,13 @@ export class KeyIntegrityCertificate {
   resolvedEntities: number | null = null; // multi-member clusters found by dedupe
   fragmentedEntities: number | null = null; // resolved entities spanning >1 declared key value
   undercountEstimate: number | null = null; // fragmentedEntities / resolvedEntities
+  // 95% Wilson score interval on the fragmentation rate (= undercount), a
+  // binomial proportion over `resolvedEntities` observations. Bounds the SAMPLING
+  // uncertainty in `undercountEstimate` (few resolved entities → wide interval);
+  // it does NOT bound whether ER itself clustered correctly. null when resolution
+  // wasn't run or found no multi-member clusters. Mirrors Python.
+  undercountCiLow: number | null = null;
+  undercountCiHigh: number | null = null;
   estimable = true;
 
   constructor(init: KeyIntegrityCertificateInit) {
@@ -86,6 +93,17 @@ export class KeyIntegrityCertificate {
   get safeBound(): number {
     if (this.undercountEstimate === null) return this.estimate;
     return Math.min(this.estimate, 1.0 - this.undercountEstimate);
+  }
+
+  /** Statistically-conservative trust floor: like `safeBound` but discounts the
+   * WORST plausible undercount at the 95% confidence upper bound
+   * (`undercountCiHigh`) rather than the point estimate — so a fragmentation rate
+   * measured from few resolved entities (wide interval) is penalized more than
+   * one from many. Falls back to `safeBound` when the interval wasn't computed.
+   * Mirrors Python `safe_bound_conservative`. */
+  get safeBoundConservative(): number {
+    if (this.undercountCiHigh === null) return this.safeBound;
+    return Math.min(this.estimate, 1.0 - this.undercountCiHigh);
   }
 
   /** Advisory pass/fail: the declared key is unique at grain, doesn't fan out
@@ -353,6 +371,29 @@ export function reduceFragmentation(
   return { resolvedEntities: resolved, fragmentedEntities: fragmented, undercountEstimate };
 }
 
+// 97.5th percentile of the standard normal → 95% two-sided Wilson interval. The
+// same literal is used by the Python port so the interval is bit-identical.
+const WILSON_Z_95 = 1.959963984540054;
+
+/**
+ * 95% Wilson score interval for a binomial proportion `k/n` (successes over
+ * trials), clamped to [0, 1]. Returns null when `n === 0` (no observations to
+ * bound). Preferred over the normal approximation because it stays inside [0,1]
+ * and behaves at small `n` / extreme `p` — the fragmentation-rate regime. Pure
+ * arithmetic (parity-locked with the Python port via a shared fixture).
+ */
+export function wilsonInterval(k: number, n: number, z: number = WILSON_Z_95): [number, number] | null {
+  if (n <= 0) return null;
+  const p = k / n;
+  const z2 = z * z;
+  const denom = 1.0 + z2 / n;
+  const center = (p + z2 / (2.0 * n)) / denom;
+  const half = (z / denom) * Math.sqrt((p * (1.0 - p)) / n + z2 / (4.0 * n * n));
+  const low = center - half;
+  const high = center + half;
+  return [low > 0.0 ? low : 0.0, high < 1.0 ? high : 1.0];
+}
+
 async function addResolution(
   cert: KeyIntegrityCertificate,
   table: Readonly<Record<string, readonly unknown[]>>,
@@ -395,6 +436,11 @@ async function addResolution(
     cert.resolvedEntities = resolvedEntities;
     cert.fragmentedEntities = fragmentedEntities;
     cert.undercountEstimate = undercountEstimate;
+    const ci = wilsonInterval(fragmentedEntities, resolvedEntities);
+    if (ci !== null) {
+      cert.undercountCiLow = ci[0];
+      cert.undercountCiHigh = ci[1];
+    }
     if (fragmentedEntities) {
       notes.push(
         `${fragmentedEntities}/${resolvedEntities} resolved entities span >1 declared key ` +

--- a/packages/typescript/goldenmatch/tests/parity/fixtures/key-integrity/undercount_ci_cases.json
+++ b/packages/typescript/goldenmatch/tests/parity/fixtures/key-integrity/undercount_ci_cases.json
@@ -1,0 +1,105 @@
+{
+  "_comment": "Cross-language parity oracle for the resolution-tier undercount 95% Wilson score interval (bounds the SAMPLING uncertainty in fragmented/resolved). Generated from the Python reference goldenmatch.semantic.key_integrity._wilson_interval by scripts/emit_undercount_ci_fixture.py. Read DIRECTLY by both tests/test_undercount_ci.py and tests/parity/undercount-ci.parity.test.ts -- no copy. ci_low/ci_high are null when resolved == 0 (no observations to bound).",
+  "cases": [
+    {
+      "name": "no_resolved",
+      "fragmented": 0,
+      "resolved": 0,
+      "expected": {
+        "undercount_estimate": 0.0,
+        "ci_low": null,
+        "ci_high": null
+      }
+    },
+    {
+      "name": "half_of_two",
+      "fragmented": 1,
+      "resolved": 2,
+      "expected": {
+        "undercount_estimate": 0.5,
+        "ci_low": 0.09453120573423074,
+        "ci_high": 0.9054687942657693
+      }
+    },
+    {
+      "name": "half_of_2000",
+      "fragmented": 1,
+      "resolved": 2000,
+      "expected": {
+        "undercount_estimate": 0.0005,
+        "ci_low": 8.826773070546787e-05,
+        "ci_high": 0.0028268625032662133
+      }
+    },
+    {
+      "name": "none_of_five",
+      "fragmented": 0,
+      "resolved": 5,
+      "expected": {
+        "undercount_estimate": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.43448246478317476
+      }
+    },
+    {
+      "name": "all_of_five",
+      "fragmented": 5,
+      "resolved": 5,
+      "expected": {
+        "undercount_estimate": 1.0,
+        "ci_low": 0.5655175352168251,
+        "ci_high": 1.0
+      }
+    },
+    {
+      "name": "three_of_ten",
+      "fragmented": 3,
+      "resolved": 10,
+      "expected": {
+        "undercount_estimate": 0.3,
+        "ci_low": 0.10779126740630099,
+        "ci_high": 0.6032218525388546
+      }
+    },
+    {
+      "name": "half_of_hundred",
+      "fragmented": 50,
+      "resolved": 100,
+      "expected": {
+        "undercount_estimate": 0.5,
+        "ci_low": 0.4038315303659956,
+        "ci_high": 0.5961684696340044
+      }
+    },
+    {
+      "name": "none_of_one",
+      "fragmented": 0,
+      "resolved": 1,
+      "expected": {
+        "undercount_estimate": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.7934506856227626
+      }
+    },
+    {
+      "name": "all_of_one",
+      "fragmented": 1,
+      "resolved": 1,
+      "expected": {
+        "undercount_estimate": 1.0,
+        "ci_low": 0.20654931437723745,
+        "ci_high": 1.0
+      }
+    },
+    {
+      "name": "seven_of_thirteen",
+      "fragmented": 7,
+      "resolved": 13,
+      "expected": {
+        "undercount_estimate": 0.5384615384615384,
+        "ci_low": 0.29143795714506004,
+        "ci_high": 0.7679393219046169
+      }
+    }
+  ]
+}

--- a/packages/typescript/goldenmatch/tests/parity/undercount-ci.parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/undercount-ci.parity.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Cross-language parity: the resolution-tier undercount 95% Wilson score
+ * interval is bit-identical on Python and TS.
+ *
+ * `undercountEstimate = fragmented/resolved` is a point estimate; `wilsonInterval`
+ * bounds its SAMPLING uncertainty (few resolved entities → wide interval). Pure
+ * arithmetic with the same z-literal + op order both sides, so the fixture
+ * (Python-generated) locks the outputs. Read directly by both this test and
+ * `tests/test_undercount_ci.py` — no copy.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { wilsonInterval } from "../../src/core/semantic/keyIntegrity.js";
+
+interface FixtureCase {
+  name: string;
+  fragmented: number;
+  resolved: number;
+  expected: {
+    undercount_estimate: number;
+    ci_low: number | null;
+    ci_high: number | null;
+  };
+}
+
+const fixturePath = fileURLToPath(
+  new URL("./fixtures/key-integrity/undercount_ci_cases.json", import.meta.url),
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as { cases: FixtureCase[] };
+
+describe("undercount Wilson CI — parity with the Python _wilson_interval oracle", () => {
+  it("has cases", () => {
+    expect(fixture.cases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of fixture.cases) {
+    it(`${c.name}: TS Wilson interval matches Python`, () => {
+      const ci = wilsonInterval(c.fragmented, c.resolved);
+      if (c.expected.ci_low === null) {
+        expect(ci).toBeNull();
+      } else {
+        expect(ci).not.toBeNull();
+        expect(ci![0]).toBeCloseTo(c.expected.ci_low, 12);
+        expect(ci![1]).toBeCloseTo(c.expected.ci_high!, 12);
+      }
+    });
+  }
+});

--- a/scripts/regen_ts_parity_fixtures.sh
+++ b/scripts/regen_ts_parity_fixtures.sh
@@ -73,6 +73,9 @@ $PY "$GM/scripts/emit_semantic_roles_fixtures.py"
 echo "== goldenmatch: ER-resolution fragmentation reduction (key_integrity.py) =="
 $PY "$GM/scripts/emit_fragmentation_reduction_fixture.py"
 
+echo "== goldenmatch: resolution-tier undercount Wilson CI (key_integrity.py) =="
+$PY "$GM/scripts/emit_undercount_ci_fixture.py"
+
 echo "== goldenmatch: v2 (planner / EM / domain / tuners / blocker / clustering / golden) =="
 $PY "$GM/scripts/emit_v2_parity_fixtures.py" --out "$PARITY/v2-fixtures.json"
 


### PR DESCRIPTION
## What and why

`certify_key_integrity(..., resolve=True)` reported `undercount_estimate = fragmented_entities / resolved_entities` as a **bare point estimate** — "undercount 0.5" read identically whether measured from 2 resolved entities (huge uncertainty) or 2,000. This quantifies that uncertainty honestly, sharpening the ER half of the semantic-layer wedge.

**D2** of the follow-up set (**D1** = dbt conformance-lock, merged #2362).

## Changes

- **`KeyIntegrityCertificate` gains a 95% Wilson score interval** on the fragmentation rate (a binomial proportion over the resolved entities): `undercount_ci_low`/`undercount_ci_high` (Python) + `undercountCiLow`/`undercountCiHigh` (TS), computed by the new exported `_wilson_interval` / `wilsonInterval(k, n)`. Wilson over the normal approximation because it stays inside [0,1] and behaves at small `n` / extreme `p` — exactly the fragmentation-rate regime.
- **New `safe_bound_conservative` / `safeBoundConservative` accessor** discounts the CI *upper* bound (worst plausible undercount) — a statistically-conservative trust floor that penalizes a rate measured from few entities. **`safe_bound` is unchanged** (still the point estimate) — additive, non-breaking.
- **Honest about scope:** the interval bounds *sampling* uncertainty (how many entities resolved), **not** whether ER clustered correctly. Stated in the field docstring — the "never-black-box" frame.
- **Bit-identical Python ↔ TS** (same z-literal `1.959963984540054` + op order), locked by a shared Python-generated fixture `undercount_ci_cases.json` (`emit_undercount_ci_fixture.py`, wired into `regen_ts_parity_fixtures.sh` → the `ts_parity_freshness` gate — so a future change to the formula on either side is caught).

## Testing

- `uv run pytest tests/test_undercount_ci.py tests/test_key_integrity.py tests/test_fragmentation_reduction.py` — 18 passed (CI vs fixture, interval properties: point estimate inside interval, wider at smaller n; the `safe_bound_conservative` behavior).
- `npx vitest run tests/parity/undercount-ci.parity.test.ts tests/unit/semantic-resolve-tier.test.ts` — 17 passed (resolve-tier unchanged; CI bit-parity to 12dp).
- `npx tsc --noEmit` — clean. Emitter idempotent; ruff + `agent_codemap` gate clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed packages
- [x] Package `CHANGELOG.md` updated (goldenmatch Python + TS)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` — no workflow/gotcha change (mirrors the existing parity-fixture pattern)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_