### PR TITLE
feat(fs): extend Phase 3a threshold-refit to all FS scoring routes

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -3909,6 +3909,7 @@
             "_golden_records_to_df",
             "_is_columnar_eligible",
             "_load_input_frames",
+            "_maybe_refit_link_threshold",
             "_open_identity_store",
             "_open_memory_store",
             "_prep_cache_clear",

--- a/docs/superpowers/specs/2026-08-02-fs-refit-loop-design.md
+++ b/docs/superpowers/specs/2026-08-02-fs-refit-loop-design.md
@@ -37,11 +37,25 @@ alone regressed):
 **MEASURED (dedupe_df, flag on vs off):** household_hardneg F1 **0.947 → 1.000
 (+0.053)**; the full panel (febrl3 / ncvr_synthetic / dblp_acm / person /
 historical_50k) is **flat, worst ΔF1 +0.0000** (ab_lever GATE PASS). Re-cluster
-only (no re-scoring). Wired into the default B2c columnar FS route
-(`_score_probabilistic_matchkey`); the out-of-core / arrow-stream / list routes
-keep the fixed cutoff (documented follow-on). Tests:
-`tests/test_fs_refit_threshold.py` (12). Helpers: `probabilistic.fs_refit_threshold`
-(pure valley), `_score_distribution_valley`, `fs_refit_link_threshold` (guarded).
+only (no re-scoring). Tests: `tests/test_fs_refit_threshold.py` (16). Helpers:
+`probabilistic.fs_refit_threshold` (pure valley), `_score_distribution_valley`,
+`fs_refit_link_threshold` (guarded).
+
+**ROUTE-EXTENSION (2026-08-02).** The refit was initially wired into the default
+B2c columnar route only. It now resolves through ONE shared helper
+(`pipeline._maybe_refit_link_threshold`, accepting a pair-list OR a
+`PAIR_STREAM_SCHEMA` table) called on EVERY FS scoring route: B2c columnar,
+arrow-stream, list/batched (the non-native fallback), external-blocks (lsh/ann/
+learned/canopy/SN), and out-of-core. Each computes the refit from its own scored
+pairs (down to the review cut) before the link/review split — same distribution,
+same guarded objective, route-independent. Only the per-block **bench-dump**
+diagnostic path keeps the fixed cutoff (it scores per-block for candidate
+accounting; the refit needs the whole distribution). **Measured (household_hardneg,
+flag on vs off): +0.0529 on ALL of B2c / list-batched / arrow-stream** (the
+non-columnar routes previously kept 0.947); **person flat +0.0000 on all** —
+no-regression preserved per-route. Route-agnostic contract locked by
+`TestMaybeRefitAcrossRoutes` (list==table, flag-off no-op, explicit-threshold
+respected, min-pairs guard).
 
 ---
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -639,6 +639,45 @@ def _run_fs_streaming_dedupe(
     return res
 
 
+def _maybe_refit_link_threshold(
+    mk: Any,
+    link_threshold: float,
+    *,
+    pairs: list | None = None,
+    table: Any = None,
+) -> float:
+    """Phase 3a threshold refit, applied UNIFORMLY across every FS scoring route.
+
+    Returns the refit link cutoff when the refit flag is on, the caller set no
+    explicit ``mk.link_threshold``, and there are ``>= _REFIT_MIN_PAIRS`` scored
+    pairs; otherwise returns ``link_threshold`` unchanged (byte-identical default).
+    Pass EITHER ``pairs`` (a ``list[(id_a, id_b, score)]``) OR ``table`` (a
+    ``PAIR_STREAM_SCHEMA`` ``pa.Table``) -- both hold the SAME scored-pair
+    distribution down to the review cut, so the valley/guard sees the sub-link
+    region on every route. Re-cluster only (no re-scoring); this only moves the
+    cutoff used for the link/review split. See ``fs_refit_link_threshold``.
+    """
+    from goldenmatch.core.probabilistic import (
+        _REFIT_MIN_PAIRS,
+        _fs_refit_threshold_enabled,
+        fs_refit_link_threshold,
+    )
+
+    if mk.link_threshold is not None or not _fs_refit_threshold_enabled():
+        return link_threshold
+    if table is not None:
+        if table.num_rows < _REFIT_MIN_PAIRS:
+            return link_threshold
+        d = table.to_pydict()
+        return fs_refit_link_threshold(d["id_a"], d["id_b"], d["score"], link_threshold)
+    if pairs is not None and len(pairs) >= _REFIT_MIN_PAIRS:
+        return fs_refit_link_threshold(
+            [p[0] for p in pairs], [p[1] for p in pairs], [p[2] for p in pairs],
+            link_threshold,
+        )
+    return link_threshold
+
+
 def _score_probabilistic_matchkey(
     mk: Any,
     config: GoldenMatchConfig,
@@ -687,10 +726,7 @@ def _score_probabilistic_matchkey(
     """
     from goldenmatch.core.blocker import collect_blocking_fields
     from goldenmatch.core.probabilistic import (
-        _REFIT_MIN_PAIRS,
-        _fs_refit_threshold_enabled,
         fs_model_preloaded,
-        fs_refit_link_threshold,
         load_or_train_em,
         probabilistic_block_scorer,
         score_probabilistic_blocks_batched,
@@ -815,6 +851,7 @@ def _score_probabilistic_matchkey(
                 score_frame, config.blocking, scoring_mk, matched_pairs, em_result,
                 target_ids=target_ids, db_path="auto",
             )
+            link_threshold = _maybe_refit_link_threshold(mk, link_threshold, pairs=pairs)
             pairs, candidates = _split_probabilistic_pairs(pairs, link_threshold)
             review_pairs.extend(candidates)
             all_pairs.extend(pairs)
@@ -855,15 +892,9 @@ def _score_probabilistic_matchkey(
             # cluster-shape guard rejects it there). No-op unless the flag is on and
             # no explicit user threshold. Scores are already computed (re-cluster
             # only, no re-scoring); only the cutoff used for the split moves.
-            if (
-                _fs_refit_threshold_enabled()
-                and mk.link_threshold is None
-                and _pair_table.num_rows >= _REFIT_MIN_PAIRS
-            ):
-                _d = _pair_table.to_pydict()
-                link_threshold = fs_refit_link_threshold(
-                    _d["id_a"], _d["id_b"], _d["score"], link_threshold
-                )
+            link_threshold = _maybe_refit_link_threshold(
+                mk, link_threshold, table=_pair_table
+            )
             # Stay Arrow end-to-end (NO polars): split link/review on the pa.Table
             # itself. score_buckets_arrow already floors the table at the review
             # cut, so `score < link_threshold` is exactly the review band. The
@@ -907,6 +938,9 @@ def _score_probabilistic_matchkey(
                 n_buckets=config.n_buckets,
                 em_result=em_result,
             )
+            link_threshold = _maybe_refit_link_threshold(
+                mk, link_threshold, table=_pair_table
+            )
             pairs, candidates = _split_pair_stream(_pair_table, link_threshold)
             del _pair_table
             review_pairs.extend(candidates)
@@ -926,6 +960,7 @@ def _score_probabilistic_matchkey(
             target_ids=target_ids,
             em_result=em_result,
         )
+        link_threshold = _maybe_refit_link_threshold(mk, link_threshold, pairs=pairs)
         pairs, candidates = _split_probabilistic_pairs(pairs, link_threshold)
         review_pairs.extend(candidates)
         all_pairs.extend(pairs)
@@ -959,6 +994,7 @@ def _score_probabilistic_matchkey(
             em_result, target_ids=target_ids,
         )
         pairs = _across_files_filter(pairs)
+        link_threshold = _maybe_refit_link_threshold(mk, link_threshold, pairs=pairs)
         pairs, candidates = _split_probabilistic_pairs(pairs, link_threshold)
         review_pairs.extend(candidates)
         all_pairs.extend(pairs)
@@ -993,6 +1029,7 @@ def _score_probabilistic_matchkey(
         target_ids=target_ids,
     )
     pairs = _across_files_filter(pairs)
+    link_threshold = _maybe_refit_link_threshold(mk, link_threshold, pairs=pairs)
     pairs, candidates = _split_probabilistic_pairs(pairs, link_threshold)
     review_pairs.extend(candidates)
     all_pairs.extend(pairs)

--- a/packages/python/goldenmatch/tests/test_fs_refit_threshold.py
+++ b/packages/python/goldenmatch/tests/test_fs_refit_threshold.py
@@ -145,3 +145,74 @@ class TestClusterShapeGuard:
             pairs.append((a, a + 1, 0.95))   # true matches at 0.95
         ia = [p[0] for p in pairs]; ib = [p[1] for p in pairs]; sc = [p[2] for p in pairs]
         assert fs_refit_link_threshold(ia, ib, sc, default_link=0.50) == 0.50
+
+
+# ── Route-uniformity: the shared pipeline helper all FS routes call ────────────
+
+
+class TestMaybeRefitAcrossRoutes:
+    """Phase 3a route-extension: every FS scoring route (B2c columnar, arrow-
+    stream, list/batched, out-of-core, external-blocks) resolves its link cutoff
+    through the ONE ``_maybe_refit_link_threshold`` helper, so the refit fires
+    uniformly regardless of route. These lock the helper's route-agnostic contract
+    for BOTH pair representations (list of tuples + pa.Table) and the guards."""
+
+    @staticmethod
+    def _over_merge_pairs():
+        # 15-node weak clique (0.55) + 150 tight true pairs (0.92): a valley
+        # between the bands that cutting shatters -> refit raises the cutoff.
+        pairs = []
+        for i in range(15):
+            for j in range(i + 1, 15):
+                pairs.append((i, j, 0.55))
+        for k in range(150):
+            a = 1000 + 2 * k
+            pairs.append((a, a + 1, 0.92))
+        return pairs
+
+    class _MK:  # minimal matchkey stand-in: no explicit user threshold
+        link_threshold = None
+
+    class _MKExplicit:
+        link_threshold = 0.5
+
+    def _table(self, pairs):
+        import pyarrow as pa
+        return pa.table({
+            "id_a": pa.array([p[0] for p in pairs], pa.int64()),
+            "id_b": pa.array([p[1] for p in pairs], pa.int64()),
+            "score": pa.array([p[2] for p in pairs], pa.float64()),
+        })
+
+    def test_list_and_table_agree(self, monkeypatch):
+        # The list-route and arrow-route representations of the SAME pairs must
+        # resolve to the SAME refit cutoff -- that's what "uniform across routes"
+        # means. Both raise it above the default on the over-merge shape.
+        from goldenmatch.core.pipeline import _maybe_refit_link_threshold
+        monkeypatch.setenv("GOLDENMATCH_FS_REFIT_THRESHOLD", "1")
+        pairs = self._over_merge_pairs()
+        t_list = _maybe_refit_link_threshold(self._MK(), 0.50, pairs=pairs)
+        t_tbl = _maybe_refit_link_threshold(self._MK(), 0.50, table=self._table(pairs))
+        assert t_list == t_tbl
+        assert t_list > 0.50
+
+    def test_flag_off_is_noop_both_forms(self, monkeypatch):
+        from goldenmatch.core.pipeline import _maybe_refit_link_threshold
+        monkeypatch.delenv("GOLDENMATCH_FS_REFIT_THRESHOLD", raising=False)
+        pairs = self._over_merge_pairs()
+        assert _maybe_refit_link_threshold(self._MK(), 0.50, pairs=pairs) == 0.50
+        assert _maybe_refit_link_threshold(self._MK(), 0.50, table=self._table(pairs)) == 0.50
+
+    def test_explicit_user_threshold_is_respected(self, monkeypatch):
+        # A caller-set mk.link_threshold must never be overridden by the refit.
+        from goldenmatch.core.pipeline import _maybe_refit_link_threshold
+        monkeypatch.setenv("GOLDENMATCH_FS_REFIT_THRESHOLD", "1")
+        pairs = self._over_merge_pairs()
+        assert _maybe_refit_link_threshold(self._MKExplicit(), 0.50, pairs=pairs) == 0.50
+
+    def test_below_min_pairs_is_noop(self, monkeypatch):
+        from goldenmatch.core.pipeline import _maybe_refit_link_threshold
+        monkeypatch.setenv("GOLDENMATCH_FS_REFIT_THRESHOLD", "1")
+        tiny = [(0, 1, 0.9), (2, 3, 0.6)]
+        assert len(tiny) < _REFIT_MIN_PAIRS
+        assert _maybe_refit_link_threshold(self._MK(), 0.50, pairs=tiny) == 0.50


### PR DESCRIPTION
## What and why

Phase 3a wired the FS threshold-refit loop into the default **B2c columnar** route only; the other FS routes kept the fixed 0.50 cutoff, so the shipped win didn't apply there. This extends it to every route via one shared helper.

## Changes

- `pipeline._maybe_refit_link_threshold(mk, link_threshold, *, pairs=None, table=None)` — one helper (accepts a pair-list **or** a `PAIR_STREAM_SCHEMA` table) that resolves the link cutoff, called on **every** FS scoring route:
  - B2c columnar (refactored from inline to the helper — byte-identical, guarded by the existing 12 parity tests)
  - arrow-stream
  - list/batched (the non-native fallback)
  - external-blocks (lsh / ann / learned / canopy / sorted-neighborhood)
  - out-of-core
- Each computes the refit from its own scored pairs (down to the review cut) before the link/review split — same distribution, same guarded valley objective, route-independent.
- Only the per-block **bench-dump** diagnostic path keeps the fixed cutoff (it scores per-block for candidate accounting; the refit needs the whole distribution).

## Measured (household_hardneg, flag on vs off)

| route | ΔF1 |
|---|---|
| B2c columnar | +0.0529 |
| **list/batched** | **+0.0529** (was fixed 0.947 before) |
| **arrow-stream** | **+0.0529** (was fixed 0.947 before) |

`person` (0.50-optimal) stays **flat +0.0000 on all routes** — the per-route no-regression guarantee holds. Default-OFF is byte-identical everywhere.

## Testing

```
python -m pytest tests/test_fs_refit_threshold.py -q                          # 16 passed (12 + 4 route-agnostic)
python -m pytest tests/test_probabilistic.py tests/test_pair_stream_columnar_parity.py \
                 tests/test_fs_out_of_core.py tests/test_bucket_fuzzy_arrow_lane.py -q  # 226 passed total
ruff check ...                                                                # clean
```

New tests (`TestMaybeRefitAcrossRoutes`) lock the route-agnostic contract: list==table resolution, flag-off no-op (both forms), explicit user threshold respected, min-pairs guard.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` clean on changed files
- [ ] `CHANGELOG.md` — N/A (opt-in flag stays default-off; default path byte-identical)
- [x] No secrets committed
- [x] Docs / spec updated (route-extension recorded in the refit-loop design doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bYTw8x9M6kEY6PGyvhYPB

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYTw8x9M6kEY6PGyvhYPB)_