### PR TITLE
docs(semantic): end-to-end demo + docs for the key-integrity certifier

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -73,6 +73,7 @@
                   "goldenmatch/llm",
                   "goldenmatch/learning-memory",
                   "goldenmatch/identity-graph",
+                  "goldenmatch/semantic-key-integrity",
                   "goldenmatch/domain-packs",
                   "goldenmatch/reference-data",
                   "goldenmatch/streaming",

--- a/docs-site/goldenmatch/semantic-key-integrity.mdx
+++ b/docs-site/goldenmatch/semantic-key-integrity.mdx
@@ -1,0 +1,170 @@
+---
+title: "Semantic-layer key integrity"
+description: "Certify the entity keys a semantic model (dbt/MetricFlow, Cube, OSI) declares — quantify metric fan-out and entity undercount before you trust a SUM or COUNT(DISTINCT). Advisory, never mutating."
+keywords: ["semantic layer", "metricflow", "cube", "dbt", "entity key", "fan-out", "key integrity", "metric double-count", "count distinct"]
+---
+
+A semantic layer — dbt/MetricFlow, Cube, or OSI — is a **join graph**, and every
+measure is defined *relative to* an entity key. A per-customer `SUM(revenue)`,
+a `COUNT(DISTINCT customer_id)`: each is only correct if the declared key
+**uniquely identifies one real-world entity**. The semantic layer *assumes* that.
+It never resolves it.
+
+`certify_key_integrity` is the advisory artifact GoldenMatch emits over a
+declared key. It answers two questions a semantic layer can't:
+
+1. **Structural** — is the key unique at grain, and how much does a duplicated key
+   inflate a measure (**fan-out**)?
+2. **Resolution** (opt-in) — would entity resolution collapse *distinct* declared
+   keys onto one real entity (**fragmentation / undercount**)?
+
+It **reports and quantifies trust; it never mutates a number.**
+
+<Note>
+  Import it explicitly — the `semantic` subpackage is kept out of `import
+  goldenmatch` so the top-level import stays lightweight:
+  `from goldenmatch.semantic import certify_key_integrity`.
+</Note>
+
+## The problem, concretely
+
+Take an `orders` model whose declared entity key is `customer_id`. Two defects
+hide in it:
+
+- `customer_id` `c1` appears **twice at grain** → a per-customer `SUM(revenue)`
+  double-counts.
+- `c3` and `c4` are really the **same person** (Grace Hopper) under two keys →
+  `COUNT(DISTINCT customer_id)` over-counts entities.
+
+Neither shows up as an error. The metrics just return the wrong number.
+
+## Certifying the key
+
+```python
+import pyarrow as pa
+from goldenmatch.semantic import certify_key_integrity
+
+orders = pa.table({
+    "customer_id": ["c1", "c1", "c2", "c3", "c4"],
+    "name":        ["Ada Lovelace", "Ada Lovelace", "Alan Turing",
+                    "Grace Hopper", "Grace M. Hopper"],
+    "revenue":     [100.0, 100.0, 50.0, 70.0, 30.0],
+})
+
+cert = certify_key_integrity(orders, key="customer_id", measures=["revenue"])
+
+cert.is_unique_at_grain     # False
+cert.max_fan_out            # 2.0   — c1's two rows
+cert.measure_fan_out        # {"revenue": 1.4}  — SUM(revenue) is inflated 1.4x
+cert.estimate               # 0.75  — fraction of key groups that are clean
+cert.is_trustworthy()       # False
+```
+
+The **structural** pass is cheap (a group-by, single-sourced from the shared
+`key-integrity-core` Rust kernel so Python / TS / DuckDB / Postgres all agree
+byte-for-byte). It catches the double-count *before* any entity resolution runs.
+
+## The resolution tier (opt-in)
+
+Pass `resolve=True` to also run GoldenMatch entity resolution and measure whether
+distinct declared keys **fragment** one real entity:
+
+```python
+cert = certify_key_integrity(
+    orders, key="customer_id", measures=["revenue"], resolve=True,
+)
+
+cert.resolved_entities      # 2   — multi-member clusters ER found
+cert.fragmented_entities    # 1   — entities spanning >1 declared key
+cert.undercount_estimate    # 0.5 — fragmented / resolved
+cert.undercount_ci_low      # 0.0945   ┐ 95% Wilson interval on the
+cert.undercount_ci_high     # 0.9055   ┘ fragmentation rate
+cert.safe_bound             # 0.5    — discounts the point-estimate undercount
+cert.safe_bound_conservative# 0.0945 — discounts the CI-UPPER undercount
+```
+
+`undercount_estimate` is a point estimate; the **95% Wilson confidence interval**
+(`undercount_ci_low` / `undercount_ci_high`) bounds its **sampling uncertainty** —
+few resolved entities means a wide interval. `safe_bound_conservative` discounts
+the *worst plausible* undercount at the CI upper bound, so a fragmentation rate
+measured from a handful of entities is penalized more than one measured from many.
+
+<Warning>
+  The interval bounds the SAMPLING uncertainty in the fragmentation rate, **not**
+  whether ER clustered correctly. It answers "how sure are we of this rate given
+  how few entities we saw," not "did the resolver make the right call."
+</Warning>
+
+## The certificate
+
+| Field | Meaning |
+|-------|---------|
+| `is_unique_at_grain` | `n_key_groups == n_rows` — the key is a true key |
+| `max_fan_out` | worst-case row multiplicity for one key group |
+| `measure_fan_out` | per-measure `SUM` inflation ratio |
+| `estimate` | fraction of key groups that are clean (unique at grain) |
+| `resolved_entities` / `fragmented_entities` | ER tier: multi-member clusters, and those spanning >1 declared key |
+| `undercount_estimate` | `fragmented / resolved` |
+| `undercount_ci_low` / `undercount_ci_high` | 95% Wilson interval on the undercount |
+| `safe_bound` | conservative score discounting the point-estimate undercount |
+| `safe_bound_conservative` | trust floor discounting the CI-upper undercount |
+| `is_trustworthy()` | advisory pass/fail — never enforced |
+
+The `{estimate, safe_bound}` shape mirrors `RecallCertificate`, so a downstream
+reporter (the goldenanalysis `key.integrity` analyzer) consumes it uniformly.
+
+## Fixing it
+
+The certificate points at the defect; the fix is a normal survivorship step
+(dedupe the key at grain). Re-certify to a clean bill of health:
+
+```python
+# ... keep one row per declared key (real survivorship goes here) ...
+fixed = orders.take([0, 2, 3, 4])
+fcert = certify_key_integrity(fixed, key="customer_id", measures=["revenue"])
+
+fcert.is_unique_at_grain    # True
+fcert.max_fan_out           # 1.0
+fcert.is_trustworthy()      # True
+```
+
+The structural double-count is gone. The `c3`/`c4` fragmentation stays a
+resolution-tier finding for a steward to merge — the certificate keeps the two
+tiers distinct so you know *which* kind of defect you're looking at.
+
+## Certifying a whole semantic model
+
+Point `certify_semantic_model` at a dbt/MetricFlow, Cube, or OSI model (the
+dialect is auto-detected) plus the frames backing each target — it certifies
+every declared key and reports which ones a metric silently depends on that
+would miscount:
+
+```python
+from goldenmatch.semantic import certify_semantic_model
+
+result = certify_semantic_model(
+    "models/orders.yml", {"orders": orders}, resolve=True,
+)
+
+result.n_certified          # keys certified
+result.untrustworthy        # KeyCertifications whose key is not unique / fans out
+result.all_trustworthy      # bool
+```
+
+## Runnable demo
+
+A complete, self-contained walkthrough — planting both defects, certifying,
+and fixing — ships in the examples:
+
+```bash
+python examples/semantic_key_integrity.py
+```
+
+## Cross-surface
+
+The **structural** certifier is one Rust kernel (`key-integrity-core`) behind
+every surface — Python-native, TS/WASM, DuckDB (`goldenmatch_certify_structural`
+via the DuckDB UDF), and Postgres (`goldenmatch_certify_structural` via pgrx).
+The dbt `goldenmatch_key_integrity` test macro is conformance-locked to the same
+shared golden, so a semantic model certified in SQL returns the identical verdict
+as one certified in Python.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -203,6 +203,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   single-sourced with the TS port via a shared fixture
   (`emit_undercount_ci_fixture.py`, drift-guarded by `ts_parity_freshness`).
   Tests: `tests/test_undercount_ci.py`.
+- **End-to-end demo + docs for the semantic-layer key-integrity certifier.** A
+  runnable example (`examples/semantic_key_integrity.py`) plants two defects an
+  `orders` semantic model can carry — a duplicated declared key (structural
+  fan-out that double-counts `SUM(revenue)`) and two distinct keys that are really
+  one customer (resolution-tier fragmentation / undercount) — then shows
+  `certify_key_integrity` quantifying both (measure fan-out, the 95% Wilson
+  undercount interval, and `safe_bound_conservative`) without mutating a metric,
+  and fixes it to a clean re-certification. New docs page
+  `docs-site/goldenmatch/semantic-key-integrity.mdx` (wired into the Features nav)
+  documents the structural + resolution tiers, the certificate fields, and the
+  one-kernel cross-surface story (Python / TS / DuckDB / Postgres / dbt). Docs +
+  example only — no code change.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/examples/README.md
+++ b/packages/python/goldenmatch/examples/README.md
@@ -26,6 +26,7 @@ python basic_dedupe.py
 | `agent_demo.py` | Autonomous ER agent with confidence gating and review queue | goldenmatch |
 | `benchmark.py` | DQBench ER benchmark (precision, recall, F1, throughput) | goldenmatch, dqbench |
 | `equipment_dedup.py` | Equipment/auction dedup: multi-pass blocking, ANN fallback, weighted fuzzy, LLM calibration | goldenmatch, OPENAI_API_KEY |
+| `semantic_key_integrity.py` | Certify a semantic-model key -- catch a metric double-count (structural fan-out) + entity undercount with a 95% CI, then fix it | goldenmatch |
 | `verification_inspection.py` | v1.5.0 preflight + postflight walkthrough -- inspect findings, signals, advisories, and adjustments | goldenmatch |
 | `strict_mode_parity.py` | v1.5.0 `strict=True` for deterministic parity / regression runs | goldenmatch |
 

--- a/packages/python/goldenmatch/examples/semantic_key_integrity.py
+++ b/packages/python/goldenmatch/examples/semantic_key_integrity.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""Certify a semantic-model key -- catch a silent metric double-count.
+
+A semantic layer (dbt/MetricFlow, Cube, OSI) is a join graph, and every measure
+is defined *relative to* an entity key. If that declared key does not uniquely
+identify one real entity, every `SUM`/`COUNT(DISTINCT)` built on it is silently
+wrong -- and the semantic layer never tells you, because it ASSUMES the key is
+clean.
+
+This walkthrough plants two defects an `orders` model can carry and shows
+`certify_key_integrity` quantifying both without ever mutating a number:
+
+  1. STRUCTURAL fan-out -- the declared key `customer_id` is duplicated at grain,
+     so a `SUM(revenue)` per customer double-counts. The certificate reports the
+     fan-out ratio (how inflated the measure is) before you trust the metric.
+
+  2. RESOLUTION undercount (opt-in `resolve=True`) -- two DISTINCT declared keys
+     that are really the same customer, so `COUNT(DISTINCT customer_id)` over-
+     counts entities. Entity resolution collapses them and the certificate
+     reports the fragmentation rate with a 95% confidence interval + a
+     statistically-conservative trust floor.
+
+Then it applies the fix (dedupe the key at grain) and re-certifies to a clean
+bill of health.
+
+Usage:
+    pip install goldenmatch
+    python examples/semantic_key_integrity.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+
+os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+if sys.stdout.encoding != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+
+def _fmt(x: float | None) -> str:
+    return "n/a" if x is None else f"{x:.4f}"
+
+
+def print_certificate(cert, title: str) -> None:
+    print(f"\n{title}")
+    print("-" * len(title))
+    print(f"  key columns:        {cert.key_columns}")
+    print(f"  rows / key groups:  {cert.n_rows} / {cert.n_key_groups}")
+    print(f"  unique at grain:    {cert.is_unique_at_grain}")
+    print(f"  duplicate groups:   {cert.duplicate_key_groups}")
+    print(f"  max fan-out:        {cert.max_fan_out:.2f}x")
+    if cert.measure_fan_out:
+        pretty = ", ".join(f"{m}={r:.2f}x" for m, r in cert.measure_fan_out.items())
+        print(f"  measure fan-out:    {pretty}   (SUM inflation per measure)")
+    if cert.resolved_entities is not None:
+        print(f"  resolved entities:  {cert.resolved_entities}")
+        print(f"  fragmented:         {cert.fragmented_entities}")
+        print(f"  undercount est.:    {_fmt(cert.undercount_estimate)}")
+        print(
+            f"  undercount 95% CI:  [{_fmt(cert.undercount_ci_low)}, "
+            f"{_fmt(cert.undercount_ci_high)}]   (sampling uncertainty)"
+        )
+    print(f"  estimate (clean %): {_fmt(cert.estimate)}")
+    print(f"  safe_bound:         {_fmt(cert.safe_bound)}")
+    print(f"  conservative bound: {_fmt(cert.safe_bound_conservative)}")
+    print(f"  trustworthy:        {cert.is_trustworthy()}")
+
+
+if __name__ == "__main__":
+    import pyarrow as pa
+    from goldenmatch.semantic import certify_key_integrity
+
+    print("=" * 64)
+    print("GoldenMatch -- Semantic-layer key-integrity certificate")
+    print("=" * 64)
+
+    # An `orders` semantic model. `customer_id` is the declared entity key that
+    # every per-customer measure joins + aggregates on. TWO defects are planted:
+    #   * customer_id "c1" appears twice at grain      -> structural fan-out
+    #   * "c3" / "c4" are the same person, two keys     -> resolution undercount
+    orders = pa.table(
+        {
+            "customer_id": ["c1", "c1", "c2", "c3", "c4"],
+            "name": [
+                "Ada Lovelace",
+                "Ada Lovelace",
+                "Alan Turing",
+                "Grace Hopper",
+                "Grace M. Hopper",
+            ],
+            "email": [
+                "ada@ex.com",
+                "ada@ex.com",
+                "alan@ex.com",
+                "grace@ex.com",
+                "grace@ex.com",
+            ],
+            "revenue": [100.0, 100.0, 50.0, 70.0, 30.0],
+        }
+    )
+    print(f"\nInput `orders` model: {orders.num_rows} rows")
+    print(f"  SUM(revenue)              = {sum(orders.column('revenue').to_pylist()):.0f}")
+    print(f"  declared distinct keys    = {len(set(orders.column('customer_id').to_pylist()))}")
+
+    # --- 1. Structural certificate (cheap, no ER) ---
+    cert = certify_key_integrity(orders, key="customer_id", measures=["revenue"])
+    print_certificate(cert, "1. STRUCTURAL certificate (customer_id, measure=revenue)")
+    print(
+        "\n  -> customer_id is NOT unique at grain: c1's two rows inflate "
+        f"SUM(revenue) by {cert.measure_fan_out['revenue']:.1f}x. A per-customer "
+        "revenue metric double-counts before any ER."
+    )
+
+    # --- 2. Resolution certificate (opt-in ER: does the key FRAGMENT an entity?) ---
+    # ER prints controller/quality progress to stdout; quiet it so the
+    # certificate stands alone in the output.
+    with contextlib.redirect_stdout(io.StringIO()):
+        rcert = certify_key_integrity(
+            orders, key="customer_id", measures=["revenue"], resolve=True
+        )
+    print_certificate(rcert, "2. RESOLUTION certificate (resolve=True)")
+    print(
+        "\n  -> entity resolution finds distinct declared keys that are really "
+        "ONE customer (Grace Hopper under c3 + c4), so COUNT(DISTINCT customer_id) "
+        "OVERCOUNTS entities. The undercount estimate carries a 95% Wilson CI "
+        "(wide here -- few resolved entities), and `safe_bound_conservative` "
+        "discounts the CI-UPPER undercount for a statistically honest trust floor."
+    )
+
+    # --- 3. The fix: dedupe the key at grain, then re-certify ---
+    # Keep the first row per declared key (a stand-in for the real survivorship
+    # step) so customer_id is unique at grain again.
+    seen: set[str] = set()
+    keep = []
+    for i, cid in enumerate(orders.column("customer_id").to_pylist()):
+        if cid not in seen:
+            seen.add(cid)
+            keep.append(i)
+    fixed = orders.take(keep)
+    fcert = certify_key_integrity(fixed, key="customer_id", measures=["revenue"])
+    print_certificate(fcert, "3. AFTER FIX -- deduped key, re-certified")
+    print(
+        f"\n  -> customer_id is now unique at grain (fan-out {fcert.max_fan_out:.1f}x), "
+        f"SUM(revenue) = {sum(fixed.column('revenue').to_pylist()):.0f} is trustworthy. "
+        "The structural double-count is gone; the c3/c4 fragmentation stays a "
+        "resolution-tier finding for a steward to merge."
+    )
+
+    print("\n" + "=" * 64)
+    print("The certificate REPORTS and QUANTIFIES trust; it never mutates a metric.")
+    print("=" * 64)


### PR DESCRIPTION
## What and why

Close the semantic-layer key-integrity wedge with an end-to-end story: a runnable demo and a docs page that show `certify_key_integrity` catching a real metric double-count and an entity undercount, then fixing it. Docs + example only, no code change. (Direction D3 of the "All 4" follow-ups; D1/D2/C already merged.)

## Changes

- `examples/semantic_key_integrity.py` — a self-contained walkthrough. It plants two defects an `orders` semantic model can carry:
  - a duplicated declared key (`customer_id` appears twice at grain) → structural fan-out that double-counts `SUM(revenue)`, and
  - two distinct keys that are really one customer (Grace Hopper under `c3`/`c4`) → resolution-tier fragmentation / undercount.
  It certifies both (structural fan-out, plus the opt-in `resolve=True` tier reporting the 95% Wilson undercount interval and `safe_bound_conservative`), then applies the fix (dedupe the key at grain) and re-certifies to a clean bill of health. Controller/quality progress is redirected so the certificate stands alone in the output.
- `examples/README.md` — new table row for the demo.
- `docs-site/goldenmatch/semantic-key-integrity.mdx` — new Features page documenting the structural + resolution tiers, the certificate fields, and the one-kernel cross-surface story (Python / TS / DuckDB / Postgres / dbt). Wired into the Features nav in `docs-site/docs.json`.
- `CHANGELOG.md` — entry at the bottom of `### Added`.

## Testing

- `python examples/semantic_key_integrity.py` — runs clean; structural cert reports fan-out `revenue=1.40x`, resolution cert reports undercount 0.5 with CI `[0.0945, 0.9055]` and conservative bound 0.0945, post-fix cert is trustworthy.
- `uv run ruff check examples/semantic_key_integrity.py` — clean.
- `docs.json` validated as JSON; the new page path matches the nav entry.

## Checklist

- [x] Example runs and is self-contained
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (new MDX page + nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_