### PR TITLE
feat(semantic): certificate trust-verdict write-back to the catalog (Cube/OSI/MetricFlow)

### DIFF
--- a/docs-site/goldenmatch/semantic-key-integrity.mdx
+++ b/docs-site/goldenmatch/semantic-key-integrity.mdx
@@ -160,6 +160,41 @@ and fixing — ships in the examples:
 python examples/semantic_key_integrity.py
 ```
 
+## Writing the verdict back to the catalog
+
+The certificate isn't only a return value — its trust **verdict** can be written
+back into the catalog the semantic layer reads, so "resolve once, the verdict
+travels with the join." The Cube, OSI, and MetricFlow crosswalk emitters accept a
+`certificate=` and embed a single-sourced `key_integrity` block:
+
+```python
+from goldenmatch.semantic.metricflow import emit_from_crosswalk
+
+yaml_str = emit_from_crosswalk(crosswalk, "orders", measures=["revenue"], certificate=cert)
+```
+
+```yaml
+meta:
+  goldenmatch:
+    key_integrity:
+      verdict: untrustworthy          # the advisory pass/fail
+      unique_at_grain: false
+      uniqueness_estimate: 0.75
+      max_fan_out: 2.0
+      measure_fan_out:
+        revenue: 1.4
+      undercount_estimate: 0.5
+      undercount_ci: [0.0945, 0.9055]  # the 95% Wilson interval
+      safe_bound: 0.5
+      safe_bound_conservative: 0.0945
+```
+
+It rides in `meta.goldenmatch` (MetricFlow / Cube) or `custom_extensions.goldenmatch`
+(OSI). The same block is produced by `certificate_verdict(cert)` in Python and
+`certificateVerdict(cert)` in TypeScript — field-identical, locked by a
+cross-language fixture — so a downstream tool reads one trust contract regardless
+of which surface emitted the catalog.
+
 ## Cross-surface
 
 The **structural** certifier is one Rust kernel (`key-integrity-core`) behind

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -3478,7 +3478,8 @@
           "file": "packages/python/goldenmatch/goldenmatch/core/key_integrity_certificate.py",
           "purpose": "Metric-aware key-integrity certificate (semantic-layer wedge).",
           "defines": [
-            "KeyIntegrityCertificate"
+            "KeyIntegrityCertificate",
+            "certificate_verdict"
           ]
         },
         {
@@ -7230,6 +7231,7 @@
             "parse_cube_models"
           ],
           "imports": [
+            "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow"
@@ -7272,6 +7274,9 @@
             "emit_metricflow_yaml",
             "emit_semantic_model",
             "parse_semantic_models"
+          ],
+          "imports": [
+            "goldenmatch.core.key_integrity_certificate"
           ]
         },
         {
@@ -7303,6 +7308,7 @@
             "validate_osi_schema"
           ],
           "imports": [
+            "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -215,6 +215,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   documents the structural + resolution tiers, the certificate fields, and the
   one-kernel cross-surface story (Python / TS / DuckDB / Postgres / dbt). Docs +
   example only — no code change.
+- **Certificate trust-verdict write-back to the semantic catalog (MetricFlow /
+  Cube / OSI).** A new single-sourced `certificate_verdict(cert)` projects a
+  `KeyIntegrityCertificate` into the `key_integrity` metadata block a semantic
+  catalog carries — the advisory pass/fail `verdict` plus `unique_at_grain`,
+  per-measure fan-out, and the resolution-tier trust floors (`safe_bound` and the
+  CI-discounted `safe_bound_conservative`, with the 95% undercount interval). It is
+  a superset of the legacy 3-field embed. The three crosswalk emitters now share
+  it: `emit_cube_from_crosswalk` / `emit_osi_from_crosswalk` write the full verdict
+  (previously only 3 raw stats), and `emit_from_crosswalk` /
+  `emit_semantic_model` gained a `certificate=` that writes it into
+  `meta.goldenmatch.key_integrity` (MetricFlow embedded nothing before). So
+  "resolve once, the verdict travels with the join." Single-sourced with the TS
+  port (`certificateVerdict`) via a shared fixture (`emit_certificate_verdict_fixture.py`,
+  drift-guarded by `ts_parity_freshness`). Byte-unchanged when no certificate is
+  passed. Tests: `tests/test_certificate_verdict.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/goldenmatch/core/key_integrity_certificate.py
+++ b/packages/python/goldenmatch/goldenmatch/core/key_integrity_certificate.py
@@ -19,6 +19,7 @@ way `match.rates` consumes a recall certificate.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -95,3 +96,50 @@ class KeyIntegrityCertificate:
             and self.max_fan_out <= max_fan_out
             and self.estimate >= min_estimate
         )
+
+
+def certificate_verdict(certificate: Any) -> dict[str, Any]:
+    """Project a `KeyIntegrityCertificate` into the trust-verdict metadata block a
+    semantic catalog carries — the single source for the `key_integrity` tag the
+    MetricFlow / Cube / OSI emitters write back onto the catalog the semantic layer
+    reads. "Resolve once, the verdict travels with the join."
+
+    Duck-typed (getattr) so a stats-only certificate-like object degrades
+    gracefully: missing structural fields → None / omitted, so an older or partial
+    certificate still yields a well-formed block. Insertion order is fixed so the
+    emitted block is stable across surfaces (the TS `certificateVerdict` mirror
+    produces the same shape).
+
+    The block is a superset of the legacy 3-field embed
+    (`uniqueness_estimate` / `max_fan_out` / `undercount_estimate`) — those keys are
+    retained — extended with the advisory pass/fail `verdict`, `unique_at_grain`,
+    per-measure fan-out, and the resolution-tier trust floors (`safe_bound` and the
+    CI-discounted `safe_bound_conservative`, with the 95% undercount interval).
+    """
+    trustworthy: bool | None = None
+    is_trustworthy = getattr(certificate, "is_trustworthy", None)
+    if callable(is_trustworthy):
+        try:
+            trustworthy = bool(is_trustworthy())
+        except Exception:
+            trustworthy = None
+
+    block: dict[str, Any] = {
+        "verdict": None
+        if trustworthy is None
+        else ("trustworthy" if trustworthy else "untrustworthy"),
+        "unique_at_grain": getattr(certificate, "is_unique_at_grain", None),
+        "uniqueness_estimate": getattr(certificate, "estimate", None),
+        "max_fan_out": getattr(certificate, "max_fan_out", None),
+    }
+    measure_fan_out = getattr(certificate, "measure_fan_out", None)
+    if measure_fan_out:
+        block["measure_fan_out"] = dict(measure_fan_out)
+    block["undercount_estimate"] = getattr(certificate, "undercount_estimate", None)
+    ci_low = getattr(certificate, "undercount_ci_low", None)
+    ci_high = getattr(certificate, "undercount_ci_high", None)
+    if ci_low is not None and ci_high is not None:
+        block["undercount_ci"] = [ci_low, ci_high]
+    block["safe_bound"] = getattr(certificate, "safe_bound", None)
+    block["safe_bound_conservative"] = getattr(certificate, "safe_bound_conservative", None)
+    return block

--- a/packages/python/goldenmatch/goldenmatch/semantic/cube.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/cube.py
@@ -269,11 +269,9 @@ def emit_cube_from_crosswalk(
         "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
     }
     if certificate is not None:
-        gm["key_integrity"] = {
-            "uniqueness_estimate": getattr(certificate, "estimate", None),
-            "max_fan_out": getattr(certificate, "max_fan_out", None),
-            "undercount_estimate": getattr(certificate, "undercount_estimate", None),
-        }
+        from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+        gm["key_integrity"] = certificate_verdict(certificate)
     xw.meta = {"goldenmatch": gm}
 
     # The source cube declares the conformed join to the crosswalk (many source

--- a/packages/python/goldenmatch/goldenmatch/semantic/metricflow.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/metricflow.py
@@ -148,6 +148,7 @@ def emit_semantic_model(
     grain: list[str] | str | None = None,
     model_ref: str | None = None,
     measure_agg: str = "sum",
+    certificate: Any = None,
 ) -> dict[str, Any]:
     """Build ONE MetricFlow `semantic_models[]` entry declaring `resolved_key` as
     the PRIMARY entity — the GoldenMatch-conformed join key every metric inherits.
@@ -166,6 +167,10 @@ def emit_semantic_model(
         model_ref: the `model:` ref expression (defaults to `ref('<model>')`).
         measure_agg: the aggregation stamped on each measure (a scaffold default —
             set the real aggregation per measure in your project).
+        certificate: an optional key-integrity certificate whose trust verdict is
+            written back into the model's `meta.goldenmatch.key_integrity` — the
+            MetricFlow analogue of the Cube `meta.goldenmatch` / OSI
+            `custom_extensions.goldenmatch` embed.
     """
     entities: list[dict[str, Any]] = [
         {"name": entity_name or model, "type": "primary", "expr": resolved_key},
@@ -187,6 +192,11 @@ def emit_semantic_model(
         sm["measures"] = [
             {"name": m, "agg": measure_agg, "expr": m} for m in measures
         ]
+
+    if certificate is not None:
+        from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+        sm["meta"] = {"goldenmatch": {"key_integrity": certificate_verdict(certificate)}}
     return sm
 
 
@@ -208,10 +218,15 @@ def emit_from_crosswalk(
     measures: list[str] | tuple[str, ...] = (),
     grain: list[str] | str | None = None,
     model_ref: str | None = None,
+    certificate: Any = None,
 ) -> str:
     """Emit the `semantic_models` YAML for a `ResolvedCrosswalk`: its
     `resolved_key` becomes the primary entity, its `source_pk_column` the `unique`
-    source key. Convenience over `emit_semantic_model` + `emit_metricflow_yaml`."""
+    source key. Convenience over `emit_semantic_model` + `emit_metricflow_yaml`.
+
+    Pass `certificate` to write the key-integrity trust verdict back into the
+    model's `meta.goldenmatch.key_integrity` (parity with the Cube / OSI emitters).
+    """
     sm = emit_semantic_model(
         model,
         resolved_key=getattr(crosswalk, "resolved_key", "resolved_entity_id"),
@@ -220,5 +235,6 @@ def emit_from_crosswalk(
         measures=measures,
         grain=grain,
         model_ref=model_ref,
+        certificate=certificate,
     )
     return emit_metricflow_yaml(sm)

--- a/packages/python/goldenmatch/goldenmatch/semantic/osi.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/osi.py
@@ -305,11 +305,9 @@ def emit_osi_from_crosswalk(
         "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
     }
     if certificate is not None:
-        gm["key_integrity"] = {
-            "uniqueness_estimate": getattr(certificate, "estimate", None),
-            "max_fan_out": getattr(certificate, "max_fan_out", None),
-            "undercount_estimate": getattr(certificate, "undercount_estimate", None),
-        }
+        from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+        gm["key_integrity"] = certificate_verdict(certificate)
 
     model = OsiModel(
         name=model_name or f"{source_dataset}_resolved",

--- a/packages/python/goldenmatch/scripts/emit_certificate_verdict_fixture.py
+++ b/packages/python/goldenmatch/scripts/emit_certificate_verdict_fixture.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Emit the cross-language parity fixture for the certificate trust-verdict block
+(`goldenmatch.core.key_integrity_certificate.certificate_verdict`).
+
+The verdict block is the `key_integrity` metadata a semantic catalog carries — the
+single-sourced projection the Cube / OSI / MetricFlow emitters write back. It is a
+pure projection of a `KeyIntegrityCertificate`'s fields, computed identically on
+Python and the TS port (`certificateVerdict`); this fixture (Python-generated)
+locks them field-for-field. Read directly by both
+`tests/test_certificate_verdict.py` and
+`tests/parity/certificate-verdict.parity.test.ts` — no copy.
+
+Each case carries the certificate's constructor `init` fields + optional
+`resolution` mutations so both languages reconstruct the SAME certificate, then
+assert `certificate_verdict(cert)` == the emitted `expected` block.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.core.key_integrity_certificate import (
+    KeyIntegrityCertificate,
+    certificate_verdict,
+)
+from goldenmatch.semantic.key_integrity import _wilson_interval
+
+# name -> (init kwargs, resolution kwargs | None). The resolution kwargs mutate
+# the certificate in place (as the ER tier does). undercount CI is derived from
+# _wilson_interval so the fixture stays consistent with the D2 helper.
+_CASES: list[tuple[str, dict, dict | None]] = [
+    (
+        "clean_unique_with_measure",
+        dict(
+            key_columns=["customer_id"], grain=None, n_rows=4, n_key_groups=4,
+            is_unique_at_grain=True, duplicate_key_groups=0, max_fan_out=1.0,
+            measure_fan_out={"revenue": 1.0},
+        ),
+        None,
+    ),
+    (
+        "structural_fanout_no_resolution",
+        dict(
+            key_columns=["customer_id"], grain=None, n_rows=5, n_key_groups=4,
+            is_unique_at_grain=False, duplicate_key_groups=1, max_fan_out=2.0,
+            measure_fan_out={"revenue": 1.4},
+        ),
+        None,
+    ),
+    (
+        "resolved_with_fragmentation_ci",
+        dict(
+            key_columns=["customer_id"], grain=None, n_rows=5, n_key_groups=4,
+            is_unique_at_grain=False, duplicate_key_groups=1, max_fan_out=2.0,
+            measure_fan_out={"revenue": 1.4},
+        ),
+        dict(resolved_entities=2, fragmented_entities=1),
+    ),
+    (
+        "clean_no_measures",
+        dict(
+            key_columns=["order_id"], grain=None, n_rows=3, n_key_groups=3,
+            is_unique_at_grain=True, duplicate_key_groups=0, max_fan_out=1.0,
+            measure_fan_out={},
+        ),
+        None,
+    ),
+    (
+        "resolved_no_fragments",
+        dict(
+            key_columns=["customer_id"], grain=["day"], n_rows=6, n_key_groups=6,
+            is_unique_at_grain=True, duplicate_key_groups=0, max_fan_out=1.0,
+            measure_fan_out={"revenue": 1.0, "units": 1.0},
+        ),
+        dict(resolved_entities=3, fragmented_entities=0),
+    ),
+]
+
+_OUT = (
+    Path(__file__).resolve().parent.parent
+    / ".."
+    / ".."
+    / "typescript"
+    / "goldenmatch"
+    / "tests"
+    / "parity"
+    / "fixtures"
+    / "key-integrity"
+    / "certificate_verdict_cases.json"
+)
+
+
+def _build() -> dict:
+    cases = []
+    for name, init, resolution in _CASES:
+        cert = KeyIntegrityCertificate(**init)
+        res_out: dict | None = None
+        if resolution is not None:
+            resolved = resolution["resolved_entities"]
+            fragmented = resolution["fragmented_entities"]
+            cert.resolved_entities = resolved
+            cert.fragmented_entities = fragmented
+            cert.undercount_estimate = (fragmented / resolved) if resolved else 0.0
+            ci = _wilson_interval(fragmented, resolved)
+            if ci is not None:
+                cert.undercount_ci_low, cert.undercount_ci_high = ci
+            res_out = {
+                "resolved_entities": resolved,
+                "fragmented_entities": fragmented,
+                "undercount_estimate": cert.undercount_estimate,
+                "undercount_ci_low": cert.undercount_ci_low,
+                "undercount_ci_high": cert.undercount_ci_high,
+            }
+        case: dict = {
+            "name": name,
+            "init": {
+                "keyColumns": init["key_columns"],
+                "grain": init["grain"],
+                "nRows": init["n_rows"],
+                "nKeyGroups": init["n_key_groups"],
+                "isUniqueAtGrain": init["is_unique_at_grain"],
+                "duplicateKeyGroups": init["duplicate_key_groups"],
+                "maxFanOut": init["max_fan_out"],
+                "measureFanOut": init["measure_fan_out"],
+            },
+            "resolution": res_out,
+            "expected": certificate_verdict(cert),
+        }
+        cases.append(case)
+    return {
+        "_comment": (
+            "Cross-language parity oracle for the certificate trust-verdict block "
+            "(the `key_integrity` catalog tag the Cube/OSI/MetricFlow emitters write "
+            "back). Generated from the Python reference "
+            "goldenmatch.core.key_integrity_certificate.certificate_verdict by "
+            "scripts/emit_certificate_verdict_fixture.py. Read DIRECTLY by both "
+            "tests/test_certificate_verdict.py and "
+            "tests/parity/certificate-verdict.parity.test.ts -- no copy. Each case's "
+            "`init` (+ optional `resolution` mutation) reconstructs the same "
+            "certificate on both surfaces; `expected` is certificate_verdict(cert)."
+        ),
+        "cases": cases,
+    }
+
+
+def main() -> None:
+    _OUT.write_text(json.dumps(_build(), indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {_OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/tests/test_certificate_verdict.py
+++ b/packages/python/goldenmatch/tests/test_certificate_verdict.py
@@ -1,0 +1,142 @@
+"""Certificate trust-verdict block (`certificate_verdict`) + its cross-surface
+write-back into the Cube / OSI / MetricFlow catalog emitters.
+
+`certificate_verdict` is a pure projection of a `KeyIntegrityCertificate` into the
+`key_integrity` metadata a semantic catalog carries — the single source the three
+dialect emitters embed. Single-sourced with the TS port (`certificateVerdict`) via
+a shared fixture (read directly from the TS parity tree — no copy).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.core.key_integrity_certificate import (
+    KeyIntegrityCertificate,
+    certificate_verdict,
+)
+from goldenmatch.semantic.key_integrity import _wilson_interval
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / ".."
+    / ".."
+    / "typescript"
+    / "goldenmatch"
+    / "tests"
+    / "parity"
+    / "fixtures"
+    / "key-integrity"
+    / "certificate_verdict_cases.json"
+)
+
+
+def _cert_from_case(case: dict) -> KeyIntegrityCertificate:
+    init = case["init"]
+    cert = KeyIntegrityCertificate(
+        key_columns=init["keyColumns"],
+        grain=init["grain"],
+        n_rows=init["nRows"],
+        n_key_groups=init["nKeyGroups"],
+        is_unique_at_grain=init["isUniqueAtGrain"],
+        duplicate_key_groups=init["duplicateKeyGroups"],
+        max_fan_out=init["maxFanOut"],
+        measure_fan_out=dict(init["measureFanOut"]),
+    )
+    res = case["resolution"]
+    if res is not None:
+        cert.resolved_entities = res["resolved_entities"]
+        cert.fragmented_entities = res["fragmented_entities"]
+        cert.undercount_estimate = res["undercount_estimate"]
+        cert.undercount_ci_low = res["undercount_ci_low"]
+        cert.undercount_ci_high = res["undercount_ci_high"]
+    return cert
+
+
+def test_matches_fixture() -> None:
+    cases = json.loads(FIXTURE.read_text(encoding="utf-8"))["cases"]
+    assert cases
+    for case in cases:
+        cert = _cert_from_case(case)
+        assert certificate_verdict(cert) == case["expected"], case["name"]
+
+
+def test_structural_only_omits_resolution_keys() -> None:
+    cert = KeyIntegrityCertificate(
+        key_columns=["k"], grain=None, n_rows=5, n_key_groups=4,
+        is_unique_at_grain=False, duplicate_key_groups=1, max_fan_out=2.0,
+        measure_fan_out={"revenue": 1.4},
+    )
+    block = certificate_verdict(cert)
+    assert block["verdict"] == "untrustworthy"
+    assert block["unique_at_grain"] is False
+    assert block["uniqueness_estimate"] == 0.75
+    assert block["measure_fan_out"] == {"revenue": 1.4}
+    # No resolution run → no undercount interval, safe_bound collapses to estimate.
+    assert "undercount_ci" not in block
+    assert block["undercount_estimate"] is None
+    assert block["safe_bound"] == 0.75
+    assert block["safe_bound_conservative"] == 0.75
+
+
+def test_measure_fan_out_omitted_when_empty() -> None:
+    cert = KeyIntegrityCertificate(
+        key_columns=["k"], grain=None, n_rows=3, n_key_groups=3,
+        is_unique_at_grain=True, duplicate_key_groups=0, max_fan_out=1.0,
+    )
+    block = certificate_verdict(cert)
+    assert "measure_fan_out" not in block
+    assert block["verdict"] == "trustworthy"
+
+
+def test_conservative_bound_discounts_ci_upper() -> None:
+    cert = KeyIntegrityCertificate(
+        key_columns=["k"], grain=None, n_rows=5, n_key_groups=4,
+        is_unique_at_grain=False, duplicate_key_groups=1, max_fan_out=2.0,
+        measure_fan_out={"revenue": 1.4},
+    )
+    cert.resolved_entities = 2
+    cert.fragmented_entities = 1
+    cert.undercount_estimate = 0.5
+    lo, hi = _wilson_interval(1, 2)
+    cert.undercount_ci_low, cert.undercount_ci_high = lo, hi
+    block = certificate_verdict(cert)
+    assert block["undercount_ci"] == [lo, hi]
+    assert block["safe_bound"] == 0.5
+    assert block["safe_bound_conservative"] == min(0.75, 1.0 - hi)
+
+
+def test_emitters_write_back_the_verdict() -> None:
+    # All three dialect emitters embed the same verdict block for a resolved cert.
+    import pyarrow as pa
+    from goldenmatch.semantic.crosswalk import ResolvedCrosswalk
+    from goldenmatch.semantic.cube import emit_cube_from_crosswalk
+    from goldenmatch.semantic.metricflow import emit_from_crosswalk
+    from goldenmatch.semantic.osi import emit_osi_from_crosswalk
+
+    cert = KeyIntegrityCertificate(
+        key_columns=["customer_id"], grain=None, n_rows=5, n_key_groups=4,
+        is_unique_at_grain=False, duplicate_key_groups=1, max_fan_out=2.0,
+        measure_fan_out={"revenue": 1.4},
+    )
+    cert.resolved_entities = 2
+    cert.fragmented_entities = 1
+    cert.undercount_estimate = 0.5
+    cert.undercount_ci_low, cert.undercount_ci_high = _wilson_interval(1, 2)
+
+    xw = ResolvedCrosswalk(
+        table=pa.table({"source": [], "source_pk": [], "resolved_entity_id": []}),
+        source="orders", source_pk_column="customer_id",
+        resolved_key="resolved_entity_id", n_records=5, n_entities=4,
+    )
+    for out in (
+        emit_cube_from_crosswalk(xw, source_cube="orders", certificate=cert),
+        emit_osi_from_crosswalk(xw, source_dataset="orders", certificate=cert),
+        emit_from_crosswalk(xw, "orders", measures=["revenue"], certificate=cert),
+    ):
+        assert "verdict: untrustworthy" in out
+        assert "safe_bound_conservative:" in out
+
+    # No certificate → no key_integrity block (unchanged default).
+    assert "key_integrity" not in emit_cube_from_crosswalk(xw, source_cube="orders")
+    assert "key_integrity" not in emit_from_crosswalk(xw, "orders")

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -245,6 +245,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   z-literal + op order), locked by the shared fixture
   `tests/parity/fixtures/key-integrity/undercount_ci_cases.json`. Test:
   `tests/parity/undercount-ci.parity.test.ts`.
+- **Certificate trust-verdict write-back to the semantic catalog (Cube / OSI /
+  MetricFlow).** New single-sourced `certificateVerdict(cert)` projects a
+  `KeyIntegrityCertificate` into the `key_integrity` metadata block the catalog
+  emitters embed — the advisory `verdict` plus `unique_at_grain`, per-measure
+  fan-out, and the resolution-tier trust floors (`safe_bound` / the CI-discounted
+  `safe_bound_conservative`, with the 95% undercount interval); a superset of the
+  legacy 3-field embed. `emitCubeFromCrosswalk` / `emitOsiFromCrosswalk` now write
+  the full verdict, and `emitFromCrosswalk` / `emitSemanticModel` gained a
+  `certificate` option that writes it into `meta.goldenmatch.key_integrity`
+  (MetricFlow embedded nothing before). Field-identical to the Python port
+  (`certificate_verdict`), locked by the shared fixture
+  `tests/parity/fixtures/key-integrity/certificate_verdict_cases.json`. Test:
+  `tests/parity/certificate-verdict.parity.test.ts`.
 
 ## [1.26.0] - 2026-07-27
 

--- a/packages/typescript/goldenmatch/src/core/semantic/cube.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/cube.ts
@@ -14,12 +14,22 @@ import { type YamlValue, dumpYaml, pyFloat } from "./yamlEmit.js";
 import { pyRound6 } from "./crosswalk.js";
 import type { ResolvedCrosswalk } from "./crosswalk.js";
 import { type LoadedDoc, asList, asStr, asStrStripped, isObj } from "./parseUtil.js";
-import { certifyKeyIntegrity, resolveKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
+import {
+  certificateVerdict,
+  certifyKeyIntegrity,
+  resolveKeyIntegrity,
+  type CertificateVerdictLike,
+  type KeyIntegrityCertificate,
+} from "./keyIntegrity.js";
 import type { SemanticFrame, SemanticFrames } from "./frame.js";
 import { metricAwareAttributes, frameColumns } from "./blocking.js";
 import type { SemanticFieldRoles } from "./blocking.js";
 
-/** An optional key-integrity certificate whose stats ride in `meta.goldenmatch`. */
+/** An optional key-integrity certificate whose trust verdict rides in
+ * `meta.goldenmatch.key_integrity`. A full `KeyIntegrityCertificate` yields the
+ * complete verdict; a stats-only object degrades gracefully (see
+ * `certificateVerdict`). Retained for back-compat — `CertificateVerdictLike` is
+ * the superset the emitter reads. */
 export interface CubeKeyIntegrityCertificateLike {
   estimate?: number | null;
   maxFanOut?: number | null;
@@ -32,7 +42,7 @@ export interface EmitCubeFromCrosswalkOptions {
   crosswalkCube?: string;
   crosswalkSqlTable?: string | null;
   resolvedField?: string;
-  certificate?: CubeKeyIntegrityCertificateLike | null;
+  certificate?: CertificateVerdictLike | null;
 }
 
 /**
@@ -66,11 +76,7 @@ export function emitCubeFromCrosswalk(
     reduction_ratio: pyFloat(pyRound6(crosswalk.reductionRatio ?? 0.0)),
   };
   if (opts.certificate != null) {
-    gm["key_integrity"] = {
-      uniqueness_estimate: opts.certificate.estimate ?? null,
-      max_fan_out: opts.certificate.maxFanOut ?? null,
-      undercount_estimate: opts.certificate.undercountEstimate ?? null,
-    };
+    gm["key_integrity"] = certificateVerdict(opts.certificate) as YamlValue;
   }
 
   // emit_cube key order: name, (sql_table|sql), joins, dimensions, measures, meta.

--- a/packages/typescript/goldenmatch/src/core/semantic/index.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/index.ts
@@ -10,8 +10,10 @@
  */
 export {
   KeyIntegrityCertificate,
+  certificateVerdict,
   certifyKeyIntegrity,
   resolveKeyIntegrity,
+  type CertificateVerdictLike,
   type KeyIntegrityCertificateInit,
 } from "./keyIntegrity.js";
 export { ServingJoinCertificate, certifyServingJoins } from "./serving.js";

--- a/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts
@@ -113,6 +113,60 @@ export class KeyIntegrityCertificate {
   }
 }
 
+/** The (partial) certificate shape `certificateVerdict` reads — a full
+ * `KeyIntegrityCertificate` satisfies it; a stats-only object degrades
+ * gracefully (missing fields → null / omitted), mirroring Python's getattr. */
+export interface CertificateVerdictLike {
+  isUniqueAtGrain?: boolean | null;
+  estimate?: number | null;
+  maxFanOut?: number | null;
+  measureFanOut?: Record<string, number> | null;
+  undercountEstimate?: number | null;
+  undercountCiLow?: number | null;
+  undercountCiHigh?: number | null;
+  safeBound?: number | null;
+  safeBoundConservative?: number | null;
+  isTrustworthy?: (opts?: { maxFanOut?: number; minEstimate?: number }) => boolean;
+}
+
+/**
+ * Project a certificate into the trust-verdict metadata block a semantic catalog
+ * carries — the single source (mirrors Python `certificate_verdict`) for the
+ * `key_integrity` tag the Cube / OSI / MetricFlow emitters write back. snake_case
+ * keys + fixed insertion order so the emitted block is byte-identical across
+ * surfaces. Superset of the legacy 3-field embed (`uniqueness_estimate` /
+ * `max_fan_out` / `undercount_estimate`), extended with the pass/fail `verdict`,
+ * `unique_at_grain`, per-measure fan-out, and the resolution-tier trust floors.
+ */
+export function certificateVerdict(cert: CertificateVerdictLike): Record<string, unknown> {
+  let trustworthy: boolean | null = null;
+  if (typeof cert.isTrustworthy === "function") {
+    try {
+      trustworthy = Boolean(cert.isTrustworthy());
+    } catch {
+      trustworthy = null;
+    }
+  }
+
+  const block: Record<string, unknown> = {
+    verdict: trustworthy === null ? null : trustworthy ? "trustworthy" : "untrustworthy",
+    unique_at_grain: cert.isUniqueAtGrain ?? null,
+    uniqueness_estimate: cert.estimate ?? null,
+    max_fan_out: cert.maxFanOut ?? null,
+  };
+  const mfo = cert.measureFanOut;
+  if (mfo && Object.keys(mfo).length > 0) {
+    block["measure_fan_out"] = { ...mfo };
+  }
+  block["undercount_estimate"] = cert.undercountEstimate ?? null;
+  if (cert.undercountCiLow != null && cert.undercountCiHigh != null) {
+    block["undercount_ci"] = [cert.undercountCiLow, cert.undercountCiHigh];
+  }
+  block["safe_bound"] = cert.safeBound ?? null;
+  block["safe_bound_conservative"] = cert.safeBoundConservative ?? null;
+  return block;
+}
+
 function asList(x: string | readonly string[] | undefined): string[] {
   if (x === undefined) return [];
   return typeof x === "string" ? [x] : [...x];

--- a/packages/typescript/goldenmatch/src/core/semantic/metricflow.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/metricflow.ts
@@ -10,6 +10,7 @@
 
 import { type YamlValue, dumpYaml } from "./yamlEmit.js";
 import type { ResolvedCrosswalk } from "./crosswalk.js";
+import { certificateVerdict, type CertificateVerdictLike } from "./keyIntegrity.js";
 import { type LoadedDoc, asList, asStrStripped, isObj } from "./parseUtil.js";
 
 const PRIMARY_ENTITY_TYPES = new Set(["primary", "natural"]);
@@ -100,6 +101,9 @@ export interface EmitSemanticModelOptions {
   grain?: readonly string[] | string | null;
   modelRef?: string;
   measureAgg?: string;
+  /** Optional key-integrity certificate — its trust verdict is written back into
+   * `meta.goldenmatch.key_integrity` (parity with the Cube / OSI emitters). */
+  certificate?: CertificateVerdictLike | null;
 }
 
 /**
@@ -136,6 +140,10 @@ export function emitSemanticModel(
   if (measures.length > 0) {
     sm["measures"] = measures.map((m) => ({ name: m, agg: measureAgg, expr: m }));
   }
+
+  if (opts.certificate != null) {
+    sm["meta"] = { goldenmatch: { key_integrity: certificateVerdict(opts.certificate) as YamlValue } };
+  }
   return sm;
 }
 
@@ -162,6 +170,7 @@ export function emitFromCrosswalk(
     measures?: readonly string[];
     grain?: readonly string[] | string | null;
     modelRef?: string;
+    certificate?: CertificateVerdictLike | null;
   } = {},
 ): string {
   const sm = emitSemanticModel(model, {
@@ -171,6 +180,7 @@ export function emitFromCrosswalk(
     ...(opts.measures !== undefined ? { measures: opts.measures } : {}),
     ...(opts.grain !== undefined ? { grain: opts.grain } : {}),
     ...(opts.modelRef !== undefined ? { modelRef: opts.modelRef } : {}),
+    ...(opts.certificate != null ? { certificate: opts.certificate } : {}),
   });
   return emitMetricflowYaml(sm);
 }

--- a/packages/typescript/goldenmatch/src/core/semantic/osi.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/osi.ts
@@ -14,9 +14,14 @@
 import { type YamlValue, dumpYaml, pyFloat } from "./yamlEmit.js";
 import { pyRound6 } from "./crosswalk.js";
 import type { ResolvedCrosswalk } from "./crosswalk.js";
-import type { CubeKeyIntegrityCertificateLike } from "./cube.js";
 import { type LoadedDoc, asList, asStr, isObj } from "./parseUtil.js";
-import { certifyKeyIntegrity, resolveKeyIntegrity, type KeyIntegrityCertificate } from "./keyIntegrity.js";
+import {
+  certificateVerdict,
+  certifyKeyIntegrity,
+  resolveKeyIntegrity,
+  type CertificateVerdictLike,
+  type KeyIntegrityCertificate,
+} from "./keyIntegrity.js";
 import type { SemanticFrames } from "./frame.js";
 import { metricAwareAttributes, frameColumns } from "./blocking.js";
 import type { SemanticFieldRoles } from "./blocking.js";
@@ -57,7 +62,7 @@ export interface EmitOsiFromCrosswalkOptions {
   crosswalkDataset?: string;
   crosswalkSource?: string | null;
   resolvedField?: string;
-  certificate?: CubeKeyIntegrityCertificateLike | null;
+  certificate?: CertificateVerdictLike | null;
   modelName?: string;
 }
 
@@ -102,11 +107,7 @@ export function emitOsiFromCrosswalk(
     reduction_ratio: pyFloat(pyRound6(crosswalk.reductionRatio ?? 0.0)),
   };
   if (opts.certificate != null) {
-    gm["key_integrity"] = {
-      uniqueness_estimate: opts.certificate.estimate ?? null,
-      max_fan_out: opts.certificate.maxFanOut ?? null,
-      undercount_estimate: opts.certificate.undercountEstimate ?? null,
-    };
+    gm["key_integrity"] = certificateVerdict(opts.certificate) as YamlValue;
   }
 
   // emit_osi_model order: name, (description), (datasets), (relationships),

--- a/packages/typescript/goldenmatch/tests/parity/certificate-verdict.parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/certificate-verdict.parity.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Cross-language parity: the certificate trust-verdict block (`certificateVerdict`)
+ * — the `key_integrity` metadata the Cube / OSI / MetricFlow emitters write back —
+ * is field-identical on Python and TS.
+ *
+ * `certificateVerdict` is a pure projection of a `KeyIntegrityCertificate`; the
+ * fixture (Python-generated) reconstructs the same certificate from each case's
+ * `init` (+ optional `resolution` mutation) and pins the emitted block. Read
+ * directly by both this test and `tests/test_certificate_verdict.py` — no copy.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  KeyIntegrityCertificate,
+  certificateVerdict,
+} from "../../src/core/semantic/keyIntegrity.js";
+
+interface FixtureCase {
+  name: string;
+  init: {
+    keyColumns: string[];
+    grain: string[] | null;
+    nRows: number;
+    nKeyGroups: number;
+    isUniqueAtGrain: boolean;
+    duplicateKeyGroups: number;
+    maxFanOut: number;
+    measureFanOut: Record<string, number>;
+  };
+  resolution: {
+    resolved_entities: number;
+    fragmented_entities: number;
+    undercount_estimate: number;
+    undercount_ci_low: number | null;
+    undercount_ci_high: number | null;
+  } | null;
+  expected: Record<string, unknown>;
+}
+
+const fixturePath = fileURLToPath(
+  new URL("./fixtures/key-integrity/certificate_verdict_cases.json", import.meta.url),
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as { cases: FixtureCase[] };
+
+function certFromCase(c: FixtureCase): KeyIntegrityCertificate {
+  const cert = new KeyIntegrityCertificate({
+    keyColumns: c.init.keyColumns,
+    grain: c.init.grain,
+    nRows: c.init.nRows,
+    nKeyGroups: c.init.nKeyGroups,
+    isUniqueAtGrain: c.init.isUniqueAtGrain,
+    duplicateKeyGroups: c.init.duplicateKeyGroups,
+    maxFanOut: c.init.maxFanOut,
+    measureFanOut: { ...c.init.measureFanOut },
+  });
+  if (c.resolution) {
+    cert.resolvedEntities = c.resolution.resolved_entities;
+    cert.fragmentedEntities = c.resolution.fragmented_entities;
+    cert.undercountEstimate = c.resolution.undercount_estimate;
+    cert.undercountCiLow = c.resolution.undercount_ci_low;
+    cert.undercountCiHigh = c.resolution.undercount_ci_high;
+  }
+  return cert;
+}
+
+describe("certificateVerdict — parity with the Python certificate_verdict oracle", () => {
+  it("has cases", () => {
+    expect(fixture.cases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of fixture.cases) {
+    it(`${c.name}: TS verdict block matches Python`, () => {
+      const block = certificateVerdict(certFromCase(c));
+      // Same keys (order-independent) + same values. Numbers compare to 12 dp
+      // (pure arithmetic single-sourced with Python, same as the undercount CI).
+      expect(Object.keys(block).sort()).toEqual(Object.keys(c.expected).sort());
+      for (const [k, v] of Object.entries(c.expected)) {
+        if (k === "undercount_ci") {
+          const got = block[k] as number[];
+          const want = v as number[];
+          expect(got[0]).toBeCloseTo(want[0]!, 12);
+          expect(got[1]).toBeCloseTo(want[1]!, 12);
+        } else if (k === "measure_fan_out") {
+          const got = block[k] as Record<string, number>;
+          const want = v as Record<string, number>;
+          expect(Object.keys(got).sort()).toEqual(Object.keys(want).sort());
+          for (const [mk, mv] of Object.entries(want)) expect(got[mk]).toBeCloseTo(mv, 12);
+        } else if (typeof v === "number") {
+          expect(block[k]).toBeCloseTo(v, 12);
+        } else {
+          expect(block[k]).toEqual(v);
+        }
+      }
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/parity/fixtures/key-integrity/certificate_verdict_cases.json
+++ b/packages/typescript/goldenmatch/tests/parity/fixtures/key-integrity/certificate_verdict_cases.json
@@ -1,0 +1,174 @@
+{
+  "_comment": "Cross-language parity oracle for the certificate trust-verdict block (the `key_integrity` catalog tag the Cube/OSI/MetricFlow emitters write back). Generated from the Python reference goldenmatch.core.key_integrity_certificate.certificate_verdict by scripts/emit_certificate_verdict_fixture.py. Read DIRECTLY by both tests/test_certificate_verdict.py and tests/parity/certificate-verdict.parity.test.ts -- no copy. Each case's `init` (+ optional `resolution` mutation) reconstructs the same certificate on both surfaces; `expected` is certificate_verdict(cert).",
+  "cases": [
+    {
+      "name": "clean_unique_with_measure",
+      "init": {
+        "keyColumns": [
+          "customer_id"
+        ],
+        "grain": null,
+        "nRows": 4,
+        "nKeyGroups": 4,
+        "isUniqueAtGrain": true,
+        "duplicateKeyGroups": 0,
+        "maxFanOut": 1.0,
+        "measureFanOut": {
+          "revenue": 1.0
+        }
+      },
+      "resolution": null,
+      "expected": {
+        "verdict": "trustworthy",
+        "unique_at_grain": true,
+        "uniqueness_estimate": 1.0,
+        "max_fan_out": 1.0,
+        "measure_fan_out": {
+          "revenue": 1.0
+        },
+        "undercount_estimate": null,
+        "safe_bound": 1.0,
+        "safe_bound_conservative": 1.0
+      }
+    },
+    {
+      "name": "structural_fanout_no_resolution",
+      "init": {
+        "keyColumns": [
+          "customer_id"
+        ],
+        "grain": null,
+        "nRows": 5,
+        "nKeyGroups": 4,
+        "isUniqueAtGrain": false,
+        "duplicateKeyGroups": 1,
+        "maxFanOut": 2.0,
+        "measureFanOut": {
+          "revenue": 1.4
+        }
+      },
+      "resolution": null,
+      "expected": {
+        "verdict": "untrustworthy",
+        "unique_at_grain": false,
+        "uniqueness_estimate": 0.75,
+        "max_fan_out": 2.0,
+        "measure_fan_out": {
+          "revenue": 1.4
+        },
+        "undercount_estimate": null,
+        "safe_bound": 0.75,
+        "safe_bound_conservative": 0.75
+      }
+    },
+    {
+      "name": "resolved_with_fragmentation_ci",
+      "init": {
+        "keyColumns": [
+          "customer_id"
+        ],
+        "grain": null,
+        "nRows": 5,
+        "nKeyGroups": 4,
+        "isUniqueAtGrain": false,
+        "duplicateKeyGroups": 1,
+        "maxFanOut": 2.0,
+        "measureFanOut": {
+          "revenue": 1.4
+        }
+      },
+      "resolution": {
+        "resolved_entities": 2,
+        "fragmented_entities": 1,
+        "undercount_estimate": 0.5,
+        "undercount_ci_low": 0.09453120573423074,
+        "undercount_ci_high": 0.9054687942657693
+      },
+      "expected": {
+        "verdict": "untrustworthy",
+        "unique_at_grain": false,
+        "uniqueness_estimate": 0.75,
+        "max_fan_out": 2.0,
+        "measure_fan_out": {
+          "revenue": 1.4
+        },
+        "undercount_estimate": 0.5,
+        "undercount_ci": [
+          0.09453120573423074,
+          0.9054687942657693
+        ],
+        "safe_bound": 0.5,
+        "safe_bound_conservative": 0.09453120573423068
+      }
+    },
+    {
+      "name": "clean_no_measures",
+      "init": {
+        "keyColumns": [
+          "order_id"
+        ],
+        "grain": null,
+        "nRows": 3,
+        "nKeyGroups": 3,
+        "isUniqueAtGrain": true,
+        "duplicateKeyGroups": 0,
+        "maxFanOut": 1.0,
+        "measureFanOut": {}
+      },
+      "resolution": null,
+      "expected": {
+        "verdict": "trustworthy",
+        "unique_at_grain": true,
+        "uniqueness_estimate": 1.0,
+        "max_fan_out": 1.0,
+        "undercount_estimate": null,
+        "safe_bound": 1.0,
+        "safe_bound_conservative": 1.0
+      }
+    },
+    {
+      "name": "resolved_no_fragments",
+      "init": {
+        "keyColumns": [
+          "customer_id"
+        ],
+        "grain": [
+          "day"
+        ],
+        "nRows": 6,
+        "nKeyGroups": 6,
+        "isUniqueAtGrain": true,
+        "duplicateKeyGroups": 0,
+        "maxFanOut": 1.0,
+        "measureFanOut": {
+          "revenue": 1.0,
+          "units": 1.0
+        }
+      },
+      "resolution": {
+        "resolved_entities": 3,
+        "fragmented_entities": 0,
+        "undercount_estimate": 0.0,
+        "undercount_ci_low": 0.0,
+        "undercount_ci_high": 0.5614970317550455
+      },
+      "expected": {
+        "verdict": "trustworthy",
+        "unique_at_grain": true,
+        "uniqueness_estimate": 1.0,
+        "max_fan_out": 1.0,
+        "measure_fan_out": {
+          "revenue": 1.0,
+          "units": 1.0
+        },
+        "undercount_estimate": 0.0,
+        "undercount_ci": [
+          0.0,
+          0.5614970317550455
+        ],
+        "safe_bound": 1.0,
+        "safe_bound_conservative": 0.4385029682449545
+      }
+    }
+  ]
+}

--- a/scripts/regen_ts_parity_fixtures.sh
+++ b/scripts/regen_ts_parity_fixtures.sh
@@ -76,6 +76,9 @@ $PY "$GM/scripts/emit_fragmentation_reduction_fixture.py"
 echo "== goldenmatch: resolution-tier undercount Wilson CI (key_integrity.py) =="
 $PY "$GM/scripts/emit_undercount_ci_fixture.py"
 
+echo "== goldenmatch: certificate trust-verdict block (key_integrity_certificate.py) =="
+$PY "$GM/scripts/emit_certificate_verdict_fixture.py"
+
 echo "== goldenmatch: v2 (planner / EM / domain / tuners / blocker / clustering / golden) =="
 $PY "$GM/scripts/emit_v2_parity_fixtures.py" --out "$PARITY/v2-fixtures.json"
 


### PR DESCRIPTION
## What and why

Write the key-integrity **trust verdict** back into the catalog the semantic layer reads, so "resolve once, the verdict travels with the join." Before this, the Cube/OSI emitters embedded only 3 raw stats (`uniqueness_estimate`/`max_fan_out`/`undercount_estimate`) — not the actual pass/fail verdict or the D2 conservative bounds — and MetricFlow embedded nothing. (Direction D4 of the "All 4" follow-ups; D1/D2/D3/C already merged.)

## Changes

- **New single-sourced projection** `certificate_verdict(cert)` (Python, `core/key_integrity_certificate.py`) / `certificateVerdict(cert)` (TS, `core/semantic/keyIntegrity.ts`) — projects a `KeyIntegrityCertificate` into the `key_integrity` metadata block: the advisory `verdict` (trustworthy/untrustworthy) plus `unique_at_grain`, per-measure fan-out, and the resolution-tier trust floors (`safe_bound` and the CI-discounted `safe_bound_conservative`, with the 95% undercount interval). Duck-typed so a stats-only cert degrades gracefully. A **superset** of the legacy 3-field embed (those keys retained).
- **Wired into all three crosswalk emitters, both surfaces:**
  - `emit_cube_from_crosswalk` / `emitCubeFromCrosswalk` and `emit_osi_from_crosswalk` / `emitOsiFromCrosswalk` now write the full verdict.
  - `emit_from_crosswalk` / `emitFromCrosswalk` and `emit_semantic_model` / `emitSemanticModel` gained a `certificate=` option that writes it into `meta.goldenmatch.key_integrity` (MetricFlow embedded nothing before).
- **Cross-language parity fixture** `emit_certificate_verdict_fixture.py` → `tests/parity/fixtures/key-integrity/certificate_verdict_cases.json`, wired into `regen_ts_parity_fixtures.sh` (drift-guarded by `ts_parity_freshness`). Read directly by both the Python test and the TS parity test — no copy.
- Byte-unchanged when no certificate is passed. Docs section added to `semantic-key-integrity.mdx`; CHANGELOG entries on both packages.

## Testing

- `uv run python -m pytest tests/test_certificate_verdict.py tests/test_undercount_ci.py` — 8 passed (verdict projection, structural-only omission, empty-measure omission, CI-upper conservative bound, all three emitters write the verdict).
- `pnpm --filter goldenmatch typecheck` — clean.
- `npx vitest run tests/parity/ tests/unit/semantic-*.test.ts` — 1941 passed (incl. the new `certificate-verdict.parity.test.ts`).
- Fixture regeneration is idempotent (no diff on re-emit).

## Checklist

- [x] Tests added/updated and passing locally (Python + TS)
- [x] Cross-language parity locked by a shared fixture
- [x] Package `CHANGELOG.md` updated (both packages)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_