### PR TITLE
security(deps): complete pyo3 0.29 sweep (bridge + 4 wrappers, RUSTSEC-2026-0176/0177)

### DIFF
--- a/docs/security/2026-08-02-dependency-cve-audit.md
+++ b/docs/security/2026-08-02-dependency-cve-audit.md
@@ -26,6 +26,7 @@ triage (fixed here / deferred-coordinated / no-fix / informational).
 | `quick-xml` | 0.38.4 → 0.41.0 | RUSTSEC-2026-0194 (quadratic dup-attribute check) + RUSTSEC-2026-0195 (unbounded namespace-decl allocation, memory exhaustion) | crates.io (`native-flow`, transitive via `phonenumber`) | `cargo check` clean. Low real exposure — `phonenumber` parses its own *bundled* metadata XML, not caller input — but the fix is a clean, compatible update. |
 | `crossbeam-epoch` | 0.9.18 → 0.9.20 | RUSTSEC-2026-0204 — invalid pointer deref in `fmt::Pointer` for `Atomic`/`Shared` | crates.io (`native`, transitive via `rayon`) | Semver patch. Near-zero exposure (needs `{:p}` formatting of an `Atomic`/`Shared`), taken as free hygiene. |
 | `pyo3` | 0.28.3 → 0.29.0 | RUSTSEC-2026-0176 (OOB read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators) + RUSTSEC-2026-0177 (missing `Sync` bound on `PyCFunction::new_closure`) | crates.io (`native`, `native-flow`, `analysis-native`, `goldencheck-native`, `infermap-native`, `goldenpipe-native`) | Resolved in a follow-up PR — see the note below. `numpy` 0.28 → 0.29 in `native` to match; `arrow` picked up 59.0 → **59.1** (minor, not the assumed major 60). `cargo check`/`test` clean on all six crates + `cargo fmt`. |
+| `pyo3` | 0.24 → 0.29.0 | Same advisory pair (RUSTSEC-2026-0176 / -0177) | crates.io (`bridge`, `embed-py`, `hnsw-py`, `goldenfuzz-py`, `goldenphonetic-py`) | Sweep completion — the remaining pyo3 crates. None use arrow/numpy, so 0.29 is freely reachable. The four thin abi3 wrappers compiled with **zero code change**; `bridge` needed the 0.24→0.29 GIL-API migration (`Python::with_gil` → `attach`, `prepare_freethreaded_python()` → `Python::initialize()`, `PyObject` → `Py<PyAny>`, `Bound::downcast` → `cast`). `cargo check`/`clippy`/`fmt` clean; 48/48 bridge tests that don't require a pip-installed `goldenmatch` pass (the 2 that do are env-gated, green in CI). |
 
 ## Deferred — coordinated bumps (real, but not a one-line change)
 
@@ -41,10 +42,14 @@ triage (fixed here / deferred-coordinated / no-fix / informational).
   `PyCapsule::pointer()` (→ `pointer_checked(Some(c"arrow_array_stream"))`, the
   idiom arrow-pyarrow's own consumer uses) and deprecated `PyCapsule::new` (→
   `new_with_value`). The other four abi3 crates + `goldenpipe-native` needed no
-  code change. `goldengraph-native`/`goldenprofile-native` already resolve 0.29;
-  the remaining pyo3 crates (`bridge` 0.24, `embed-py`/`hnsw-py`/`goldenfuzz-py`/
-  `goldenphonetic-py` 0.23–0.24) carry the same advisory but are a larger 0.23→0.29
-  migration and out of this PR's scope — tracked separately.
+  code change. `goldengraph-native`/`goldenprofile-native` already resolve 0.29.
+  **Sweep completed (second follow-up PR):** the remaining pyo3-0.24 crates
+  (`bridge`, `embed-py`, `hnsw-py`, `goldenfuzz-py`, `goldenphonetic-py`) were
+  also moved to `>=0.29,<0.30`. None depend on arrow/numpy, so 0.29 was freely
+  reachable; the four abi3 wrappers compiled unchanged, and `bridge` took the
+  0.24→0.29 GIL-API migration (`with_gil`→`attach`, `prepare_freethreaded_python`
+  →`Python::initialize`, `PyObject`→`Py<PyAny>`, `Bound::downcast`→`cast`). Every
+  goldenmatch pyo3 crate is now on 0.29 — RUSTSEC-2026-0176/0177 cleared suite-wide.
 - **`thrift` 0.17.0 → 0.23.0** — GHSA-2f9f-gq7v-9h6m (allocation with excessive size
   value). Transitive via `parquet`/`datafusion` in `datafusion-udf`, which pins the
   datafusion 53 / arrow 58 stack **verbatim** (mirrors `datafusion-python` 53).

--- a/packages/rust/extensions/bridge/Cargo.toml
+++ b/packages/rust/extensions/bridge/Cargo.toml
@@ -10,7 +10,7 @@ description = "Python bridge for GoldenMatch SQL extensions"
 # Pinned to >=0.24.1 for the GHSA buffer-overflow fix in PyString::from_object
 # (affected range: >=0.23.0, <0.24.1). Upper bound <0.25 keeps us on the same
 # API line as the native crate.
-pyo3 = { version = ">=0.24.1, <0.25", features = ["auto-initialize"] }
+pyo3 = { version = ">=0.29, <0.30", features = ["auto-initialize"] }
 thiserror = "2"
 
 [dev-dependencies]

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -243,7 +243,7 @@ pub struct MatchResult {
 pub fn dedupe(table: &convert::TableData, config_json: &str) -> Result<DedupeResult, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -314,7 +314,7 @@ pub fn dedupe_full(
 ) -> Result<DedupeResult, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -381,7 +381,7 @@ pub fn dedupe_bundle(
 ) -> Result<DedupeBundle, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -492,7 +492,7 @@ pub fn autoconfig(table: &convert::TableData, mode: &str) -> Result<AutoConfigRe
         }
     };
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let df = convert::table_to_arrow_df(py, table)?;
         let autoconfig_mod = py.import("goldenmatch.core.autoconfig")?;
         let cfg = autoconfig_mod.call_method1(fn_name, (df,))?;
@@ -535,7 +535,7 @@ pub fn match_tables(
 ) -> Result<MatchResult, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -625,7 +625,7 @@ pub fn match_pairs(
 ) -> Result<Vec<MatchedPair>, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -691,7 +691,7 @@ pub fn match_pairs(
 pub fn score_strings(value_a: &str, value_b: &str, scorer: &str) -> Result<f64, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let result = gm.call_method1("score_strings", (value_a, value_b, scorer))?;
         let score: f64 = result.extract()?;
@@ -709,7 +709,7 @@ pub fn score_pair(
 ) -> Result<f64, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -745,7 +745,7 @@ pub fn explain_pair(
 ) -> Result<String, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -778,7 +778,7 @@ pub fn dedupe_pairs(
 ) -> Result<Vec<ScoredPair>, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
 
         let df = convert::table_to_arrow_df(py, table)?;
@@ -808,7 +808,7 @@ pub fn dedupe_clusters(
 ) -> Result<Vec<ClusterMember>, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
 
         let df = convert::table_to_arrow_df(py, table)?;
@@ -881,7 +881,7 @@ fn open_identity_store<'py>(
 /// view JSON. Returns ``{"found": false}`` when no identity owns the record.
 pub fn identity_resolve(record_id: &str, db_path: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let find_by_record = identity.getattr("find_by_record")?;
         let store = open_identity_store(py, db_path)?;
@@ -904,7 +904,7 @@ pub fn identity_resolve(record_id: &str, db_path: &str) -> Result<String, Bridge
 /// Return the full identity view JSON keyed by ``entity_id``.
 pub fn identity_view(entity_id: &str, db_path: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let get_entity = identity.getattr("get_entity")?;
         let store = open_identity_store(py, db_path)?;
@@ -927,7 +927,7 @@ pub fn identity_view(entity_id: &str, db_path: &str) -> Result<String, BridgeErr
 /// Return the temporal event log for an identity as a JSON array.
 pub fn identity_history(entity_id: &str, db_path: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let history_fn = identity.getattr("history")?;
         let store = open_identity_store(py, db_path)?;
@@ -947,7 +947,7 @@ pub fn identity_history(entity_id: &str, db_path: &str) -> Result<String, Bridge
 /// means "all datasets".
 pub fn identity_conflicts(dataset: &str, db_path: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let find_conflicts = identity.getattr("find_conflicts")?;
         let store = open_identity_store(py, db_path)?;
@@ -973,7 +973,7 @@ pub fn identity_conflicts(dataset: &str, db_path: &str) -> Result<String, Bridge
 /// Empty strings = no filter on that dimension.
 pub fn identity_list(dataset: &str, status: &str, db_path: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let list_entities = identity.getattr("list_entities")?;
         let store = open_identity_store(py, db_path)?;
@@ -1043,7 +1043,7 @@ pub fn resolve_identities(
         ));
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
@@ -1054,7 +1054,7 @@ pub fn resolve_identities(
         // (rather than on the built Pydantic object) keeps it simple and dodges
         // assignment-validation quirks; a non-dict/garbage blob coerces to {}.
         let loaded = json_mod.call_method1("loads", (config_json,))?;
-        let cfg_map: Bound<'_, PyDict> = match loaded.downcast::<PyDict>() {
+        let cfg_map: Bound<'_, PyDict> = match loaded.cast::<PyDict>() {
             Ok(d) => d.clone(),
             Err(_) => PyDict::new(py),
         };
@@ -1062,7 +1062,7 @@ pub fn resolve_identities(
         // Preserve any existing identity sub-config (e.g. source_pk_column,
         // emit_singletons) and override only the backend/connection/enabled.
         let identity_map: Bound<'_, PyDict> = match cfg_map.get_item("identity")? {
-            Some(v) => match v.downcast::<PyDict>() {
+            Some(v) => match v.cast::<PyDict>() {
                 Ok(d) => d.clone(),
                 Err(_) => PyDict::new(py),
             },
@@ -1079,7 +1079,7 @@ pub fn resolve_identities(
         // Name the run for idempotent replay when the caller supplies one.
         if !run_name.is_empty() {
             let output_map: Bound<'_, PyDict> = match cfg_map.get_item("output")? {
-                Some(v) => match v.downcast::<PyDict>() {
+                Some(v) => match v.cast::<PyDict>() {
                     Ok(d) => d.clone(),
                     Err(_) => PyDict::new(py),
                 },
@@ -1140,7 +1140,7 @@ pub fn identity_merge(
                 .to_string(),
         ));
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let merge_fn = identity.getattr("manual_merge")?;
         let store = open_identity_store(py, dsn)?;
@@ -1193,7 +1193,7 @@ pub fn identity_split(
                 .to_string(),
         ));
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let split_fn = identity.getattr("manual_split")?;
         let store = open_identity_store(py, dsn)?;
@@ -1242,7 +1242,7 @@ fn dumps_default_str<'py>(py: Python<'py>, obj: Bound<'py, PyAny>) -> Result<Str
 /// (the pgrx wrapper substitutes the in-DB DSN when the caller passes empty).
 pub fn identity_audit(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let audit_page = identity.getattr("audit_log_page")?;
         let store = open_identity_store(py, store_ref)?;
@@ -1260,7 +1260,7 @@ pub fn identity_audit(store_ref: &str, dataset: &str) -> Result<String, BridgeEr
 /// JSON verdict (`{"ok", "events_checked", ..., "summary"}`).
 pub fn identity_audit_verify(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let verify = identity.getattr("verify_audit_chain")?;
         let store = open_identity_store(py, store_ref)?;
@@ -1279,7 +1279,7 @@ pub fn identity_audit_verify(store_ref: &str, dataset: &str) -> Result<String, B
 /// not exist (mirrors `identity_resolve`'s absent-record shape).
 pub fn identity_profile(store_ref: &str, entity_id: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let profile_fn = identity.getattr("entity_profile")?;
         let store = open_identity_store(py, store_ref)?;
@@ -1297,7 +1297,7 @@ pub fn identity_profile(store_ref: &str, entity_id: &str) -> Result<String, Brid
 /// Graph-level identity health summary (JSON). Empty `dataset` = whole graph.
 pub fn identity_stats(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let stats_fn = identity.getattr("identity_summary_stats")?;
         let store = open_identity_store(py, store_ref)?;
@@ -1316,7 +1316,7 @@ pub fn identity_stats(store_ref: &str, dataset: &str) -> Result<String, BridgeEr
 /// open conflicts and/or weak confidence). Empty `dataset` = all datasets.
 pub fn identity_worklist(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let worklist_fn = identity.getattr("steward_worklist_page")?;
         let store = open_identity_store(py, store_ref)?;
@@ -1341,7 +1341,7 @@ pub fn identity_audit_seal(dsn: &str, dataset: &str, actor: &str) -> Result<Stri
                 .to_string(),
         ));
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let seal_fn = identity.getattr("seal_audit_log")?;
         let seal_result = identity.getattr("seal_result_dict")?;
@@ -1378,7 +1378,7 @@ pub fn identity_resolve_conflict(
                 .to_string(),
         ));
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let mediate = identity.getattr("mediate_conflict")?;
         let store = open_identity_store(py, dsn)?;
@@ -1414,7 +1414,7 @@ pub fn identity_claim(
                 .to_string(),
         ));
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let identity = py.import("goldenmatch.identity")?;
         let claim = identity.getattr("claim_record")?;
         let store = open_identity_store(py, dsn)?;
@@ -1486,7 +1486,7 @@ pub fn correction_add(args: CorrectionAddArgs<'_>) -> Result<String, BridgeError
         )));
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let store_mod = py.import("goldenmatch.core.memory.store")?;
         let datetime_mod = py.import("datetime")?;
         let uuid_mod = py.import("uuid")?;
@@ -1611,7 +1611,7 @@ pub fn correction_list(
     memory_path: Option<&str>,
 ) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let store_mod = py.import("goldenmatch.core.memory.store")?;
         let json_mod = py.import("json")?;
         let store_cls = store_mod.getattr("MemoryStore")?;
@@ -1655,7 +1655,7 @@ pub fn memory_learn(
     memory_path: Option<&str>,
 ) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let store_mod = py.import("goldenmatch.core.memory.store")?;
         let learner_mod = py.import("goldenmatch.core.memory.learner")?;
         let json_mod = py.import("json")?;
@@ -1697,7 +1697,7 @@ pub fn memory_learn(
 /// Cheap; safe for status checks. Mirrors the Python MCP `memory_stats` tool.
 pub fn memory_stats(memory_path: Option<&str>) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let store_mod = py.import("goldenmatch.core.memory.store")?;
         let json_mod = py.import("json")?;
         let dataclasses = py.import("dataclasses")?;
@@ -1813,7 +1813,7 @@ fn build_probabilistic_frame<'py>(
 /// the profile report as a JSON object (or `{"error": ...}` on failure).
 pub fn profile_table(table: &convert::TableData) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let df = convert::table_to_arrow_df(py, table)?;
@@ -1830,7 +1830,7 @@ pub fn profile_table(table: &convert::TableData) -> Result<String, BridgeError> 
 /// the DuckDB `null_handling="special"` registration.
 pub fn suggest_threshold(scores_json: &str) -> Result<Option<f64>, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<Option<f64>, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let json_mod = py.import("json")?;
@@ -1862,7 +1862,7 @@ pub fn suggest_threshold(scores_json: &str) -> Result<Option<f64>, BridgeError> 
 /// list of column names. Returns the dataclass as a JSON object.
 pub fn detect_domain(columns_json: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let domain = py.import("goldenmatch.core.domain")?;
             let dataclasses = py.import("dataclasses")?;
@@ -1894,7 +1894,7 @@ pub fn detect_domain(columns_json: &str) -> Result<String, BridgeError> {
 /// unknown-kind / missing-text error JSON.
 pub fn extract_features(text: &str, kind: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let domain = py.import("goldenmatch.core.domain")?;
             let dataclasses = py.import("dataclasses")?;
@@ -1932,7 +1932,7 @@ pub fn extract_features(text: &str, kind: &str) -> Result<String, BridgeError> {
 /// `EvalResult.summary()` dict.
 pub fn evaluate(pairs_json: &str, ground_truth_json: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let json_mod = py.import("json")?;
@@ -1996,7 +1996,7 @@ pub fn evaluate(pairs_json: &str, ground_truth_json: &str) -> Result<String, Bri
 /// the `CompareResult.summary()` dict.
 pub fn compare_clusters(a_json: &str, b_json: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let json_mod = py.import("json")?;
@@ -2035,7 +2035,7 @@ pub fn compare_clusters(a_json: &str, b_json: &str) -> Result<String, BridgeErro
 /// `{report, valid_rows, quarantine_rows, quarantine}` JSON.
 pub fn validate_table(table: &convert::TableData, rules_json: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let validate_mod = py.import("goldenmatch.core.validate")?;
             let json_mod = py.import("json")?;
@@ -2088,7 +2088,7 @@ pub fn validate_table(table: &convert::TableData, rules_json: &str) -> Result<St
 /// `{fixes, fixed_rows, rows}` JSON.
 pub fn autofix_table(table: &convert::TableData) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let df = convert::table_to_arrow_df(py, table)?;
@@ -2114,7 +2114,7 @@ pub fn detect_anomalies(
     sensitivity: &str,
 ) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let df = convert::table_to_arrow_df(py, table)?;
@@ -2138,7 +2138,7 @@ pub fn detect_anomalies(
 /// Returns `{has_errors, config_was_modified, findings}` JSON.
 pub fn preflight(table: &convert::TableData, config_json: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let verify = py.import("goldenmatch.core.autoconfig_verify")?;
             let dataclasses = py.import("dataclasses")?;
@@ -2172,7 +2172,7 @@ pub fn preflight(table: &convert::TableData, config_json: &str) -> Result<String
 /// `{signals, adjustments, advisories}` JSON.
 pub fn postflight(table: &convert::TableData, config_json: &str) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
             let verify = py.import("goldenmatch.core.autoconfig_verify")?;
@@ -2216,7 +2216,7 @@ pub fn train_em(
     params_json: &str,
 ) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let schemas = py.import("goldenmatch.config.schemas")?;
             let prob = py.import("goldenmatch.core.probabilistic")?;
@@ -2267,7 +2267,7 @@ pub fn score_probabilistic(
     em_result_json: &str,
 ) -> Result<String, BridgeError> {
     crate::init()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result: Result<String, BridgeError> = (|| {
             let schemas = py.import("goldenmatch.config.schemas")?;
             let prob = py.import("goldenmatch.core.probabilistic")?;
@@ -2279,7 +2279,7 @@ pub fn score_probabilistic(
 
             let em_cls = prob.getattr("EMResult")?;
             let em_dict = json_mod.call_method1("loads", (em_result_json,))?;
-            let em_kwargs = em_dict.downcast::<PyDict>().map_err(|e| {
+            let em_kwargs = em_dict.cast::<PyDict>().map_err(|e| {
                 BridgeError::PythonRuntime(format!("em_result_json must be a JSON object: {}", e))
             })?;
             let em = em_cls.call((), Some(em_kwargs))?;
@@ -2328,7 +2328,7 @@ pub fn score_probabilistic(
 pub fn goldenflow_transform(transform_name: &str, value: &str) -> Result<String, BridgeError> {
     crate::init()?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // fail-open closure: on any pyo3 error inside, fall back to the input.
         let applied: Option<String> = (|| -> Result<Option<String>, BridgeError> {
             // Lazy import: goldenflow + polars may be absent. Treat as

--- a/packages/rust/extensions/bridge/src/convert.rs
+++ b/packages/rust/extensions/bridge/src/convert.rs
@@ -51,7 +51,7 @@ pub enum TableData {
 /// all-NULL column) and the table is assembled via `pa.Table.from_pydict`. The
 /// per-type mapping is chosen in `spi::read_table` so the resulting schema +
 /// data match `json_to_arrow_df` exactly (proven in `tests::columnar_matches_json`).
-pub fn columns_to_arrow_df(py: Python<'_>, cols: &TableColumns) -> Result<PyObject, BridgeError> {
+pub fn columns_to_arrow_df(py: Python<'_>, cols: &TableColumns) -> Result<Py<PyAny>, BridgeError> {
     let pa = py.import("pyarrow")?;
     let dict = PyDict::new(py);
     for (name, col) in cols.names.iter().zip(cols.columns.iter()) {
@@ -83,7 +83,7 @@ pub fn columns_to_arrow_df(py: Python<'_>, cols: &TableColumns) -> Result<PyObje
 /// Dispatch table rows to a `pa.Table`: JSON via [`json_to_arrow_df`], columns
 /// via [`columns_to_arrow_df`]. The single choke point every table-op bridge fn
 /// funnels through, so parity is anchored in one place.
-pub fn table_to_arrow_df(py: Python<'_>, data: &TableData) -> Result<PyObject, BridgeError> {
+pub fn table_to_arrow_df(py: Python<'_>, data: &TableData) -> Result<Py<PyAny>, BridgeError> {
     match data {
         TableData::Json(json) => json_to_arrow_df(py, json),
         TableData::Columns(cols) => columns_to_arrow_df(py, cols),
@@ -100,7 +100,7 @@ pub fn table_to_arrow_df(py: Python<'_>, data: &TableData) -> Result<PyObject, B
 ///
 /// For table data from Postgres SPI (JSON via `row_to_json`), `from_pylist`
 /// infers the schema the same way `pl.read_json` did.
-pub fn json_to_arrow_df(py: Python<'_>, json_records: &str) -> Result<PyObject, BridgeError> {
+pub fn json_to_arrow_df(py: Python<'_>, json_records: &str) -> Result<Py<PyAny>, BridgeError> {
     let json_mod = py.import("json")?;
     let pa = py.import("pyarrow")?;
 
@@ -119,7 +119,7 @@ pub fn json_to_arrow_df(py: Python<'_>, json_records: &str) -> Result<PyObject, 
 /// one on the polars lane) passes through `write_json` unchanged for
 /// byte-identical output. `DedupeResult.golden` / `MatchResult.matched` are
 /// pyarrow Tables since v3.0.0, so the arrow branch is the default.
-pub fn arrow_df_to_json(py: Python<'_>, df: &PyObject) -> Result<String, BridgeError> {
+pub fn arrow_df_to_json(py: Python<'_>, df: &Py<PyAny>) -> Result<String, BridgeError> {
     let bound = df.bind(py);
     if bound.hasattr("write_json")? {
         // Genuine polars frame -> byte-identical legacy path (polars present).
@@ -140,9 +140,9 @@ mod tests {
 
     #[test]
     fn test_json_roundtrip() {
-        pyo3::prepare_freethreaded_python();
+        pyo3::Python::initialize();
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Arrow-native path: needs pyarrow (a hard goldenmatch dep), NOT polars.
             if py.import("pyarrow").is_err() {
                 eprintln!("Skipping test (pyarrow not installed)");
@@ -170,8 +170,8 @@ mod tests {
     /// Python scalar → arrow).
     #[test]
     fn columnar_matches_json() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             if py.import("pyarrow").is_err() {
                 eprintln!("Skipping test (pyarrow not installed)");
                 return;

--- a/packages/rust/extensions/bridge/src/lib.rs
+++ b/packages/rust/extensions/bridge/src/lib.rs
@@ -17,9 +17,9 @@ static INIT_RESULT: OnceLock<Result<(), String>> = OnceLock::new();
 /// Returns Ok(()) if goldenmatch is importable, Err otherwise.
 pub fn init() -> Result<(), error::BridgeError> {
     let result = INIT_RESULT.get_or_init(|| {
-        pyo3::prepare_freethreaded_python();
+        pyo3::Python::initialize();
 
-        Python::with_gil(|py| match py.import("goldenmatch") {
+        Python::attach(|py| match py.import("goldenmatch") {
             Ok(gm) => {
                 match gm.getattr("__version__") {
                     Ok(ver) => {
@@ -55,7 +55,7 @@ mod tests {
         // that pyo3 links against. Skip gracefully if not available.
         match init() {
             Ok(()) => {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let gm = py.import("goldenmatch").unwrap();
                     let ver: String = gm.getattr("__version__").unwrap().extract().unwrap();
                     assert!(!ver.is_empty());

--- a/packages/rust/extensions/embed-py/Cargo.toml
+++ b/packages/rust/extensions/embed-py/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
 # extension-module: don't link libpython (this .so is imported BY CPython).
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.29, <0.30", features = ["extension-module", "abi3-py311"] }
 # The pyo3-free kernel this wheel wraps. Pulls `ort` (onnxruntime) transitively;
 # that dependency is confined to this wheel by construction.
 goldenembed = { path = "../goldenembed" }

--- a/packages/rust/extensions/goldenfuzz-py/Cargo.toml
+++ b/packages/rust/extensions/goldenfuzz-py/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.29, <0.30", features = ["extension-module", "abi3-py311"] }
 # The pyo3-free kernel this wheel wraps. Zero C deps.
 goldenfuzz-core = { path = "../goldenfuzz-core" }
 

--- a/packages/rust/extensions/goldenphonetic-py/Cargo.toml
+++ b/packages/rust/extensions/goldenphonetic-py/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.29, <0.30", features = ["extension-module", "abi3-py311"] }
 # The pyo3-free kernel this wheel wraps. Zero C deps.
 goldenphonetic-core = { path = "../goldenphonetic-core" }
 

--- a/packages/rust/extensions/hnsw-py/Cargo.toml
+++ b/packages/rust/extensions/hnsw-py/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
 # extension-module: don't link libpython (this .so is imported BY CPython).
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.29, <0.30", features = ["extension-module", "abi3-py311"] }
 # The pyo3-free HNSW kernel this wheel wraps. Zero C deps.
 goldenhnsw = { path = "../goldenhnsw" }
 


### PR DESCRIPTION
## What and why

Finishes the pyo3 CVE sweep started in #2373 (the abi3/arrow crates). Moves the **remaining pyo3-0.24 crates** to 0.29, clearing RUSTSEC-2026-0176 (OOB read in `PyList`/`PyTuple` iterator `nth`/`nth_back`) and RUSTSEC-2026-0177 (missing `Sync` bound on `PyCFunction::new_closure`) **suite-wide** — every goldenmatch pyo3 crate is now on 0.29.

None of these five depend on arrow/numpy, so 0.29 was freely reachable (no arrow gate like the abi3/arrow crates had).

## Changes

- **`embed-py`, `hnsw-py`, `goldenfuzz-py`, `goldenphonetic-py`** — thin abi3 wrappers over pyo3-free kernels. `pyo3 >=0.29,<0.30`, **zero code change** (their small surface -- `#[pyfunction]`/`wrap_pyfunction!`/`PyResult` -- is unaffected by the 0.24→0.29 churn).
- **`bridge`** (embeds CPython via `auto-initialize`) -- the real 0.24→0.29 migration:
  - `Python::with_gil` → `Python::attach`
  - `pyo3::prepare_freethreaded_python()` → `pyo3::Python::initialize()`
  - `PyObject` (removed in 0.29) → `Py<PyAny>`
  - `Bound::downcast::<T>()` → `Bound::cast::<T>()`
- Audit doc updated: the sweep is marked complete.

## Testing

- `cargo check` clean: `embed-py`, `hnsw-py`, `goldenfuzz-py`, `goldenphonetic-py`.
- `bridge`: `cargo check` + `cargo clippy` + `cargo fmt --check` clean; `cargo test` (with the documented `ARROW_DEFAULT_MEMORY_POOL=system`) → **48/50 pass**. The 2 failures are the pre-existing env precondition (`ModuleNotFoundError: goldenmatch` -- the Python package isn't pip-installed in this sandbox; CI installs it and they pass there), not a regression -- the changes are mechanical API renames.

The wrapper wheels (`embed_wheel`/`hnsw_wheel`/`goldenfuzz`/`goldenphonetic`) and the `rust`/`rust_pgrx` lanes (which build `bridge`) validate the full matrix in CI.

## Checklist

- [x] Tests passing locally for the changed crates (bridge 48/50, 2 env-gated)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (security audit record)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_