### PR TITLE
feat(semantic): surface the key-integrity trust verdict on MCP, REST + CLI gate

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -616,6 +616,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `certify-keys` | `--data` | text | **required** | Frame for a model/dataset/cube as name=path (repeatable), e.g. -d orders=orders.csv |
 | `certify-keys` | `--resolve` | boolean | `False` | Also measure entity fragmentation / undercount via ER (MetricFlow dialect only). |
 | `certify-keys` | `--fail-untrustworthy` | boolean | `False` | Exit non-zero if any declared key is not unique at grain (CI gate). |
+| `certify-keys` | `--json` | boolean | `False` | Emit the verdict-rich report as JSON (the shared MCP/REST shape) — machine-readable for a CI gate. |
 | `compare-clusters` | `file_a` | text | **required** | First cluster JSON file (baseline / ER1) |
 | `compare-clusters` | `file_b` | text | **required** | Second cluster JSON file (comparison / ER2) |
 | `compare-clusters` | `--details` | boolean | `False` | Show per-cluster transformation details |

--- a/docs-site/goldenmatch/semantic-key-integrity.mdx
+++ b/docs-site/goldenmatch/semantic-key-integrity.mdx
@@ -195,6 +195,44 @@ It rides in `meta.goldenmatch` (MetricFlow / Cube) or `custom_extensions.goldenm
 cross-language fixture — so a downstream tool reads one trust contract regardless
 of which surface emitted the catalog.
 
+## Certifying keys as a build gate (CLI / MCP / REST)
+
+The verdict is exposed on three surfaces, all emitting the **same JSON** (a shared
+`certification_report_dict`) so a CI gate reads `n_untrustworthy` / `all_trustworthy`
+identically wherever it runs.
+
+**CLI** — point `certify-keys` at a semantic model + its data; `--fail-untrustworthy`
+exits non-zero when any declared key is untrustworthy for metric use:
+
+```bash
+goldenmatch certify-keys models/orders.yml -d orders=orders.csv --fail-untrustworthy
+# add --json for the machine-readable report a pipeline can parse
+goldenmatch certify-keys models/orders.yml -d orders=orders.csv --json
+```
+
+**MCP** — the `certify_semantic_model` tool returns the per-key verdict block
+(`{dialect, n_certified, n_untrustworthy, all_trustworthy, keys:[{target, key,
+key_integrity}]}`), so an agent can certify a model and act on the verdict.
+
+**REST** — `POST /semantic/certify` with `{"model": <path>, "frames": {name: path},
+"resolve": bool}` returns the same report:
+
+```json
+{
+  "dialect": "metricflow",
+  "n_certified": 1,
+  "n_untrustworthy": 1,
+  "all_trustworthy": false,
+  "keys": [
+    { "target": "orders", "key": ["customer_id"],
+      "key_integrity": { "verdict": "untrustworthy", "max_fan_out": 2.0, ... } }
+  ]
+}
+```
+
+Each key's `key_integrity` is the same trust-verdict block the catalog emitters write
+back — so certifying, gating, and the catalog tag all speak one contract.
+
 ## Cross-surface
 
 The **structural** certifier is one Rust kernel (`key-integrity-core`) behind

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -230,6 +230,7 @@
           "defines": [
             "APIHandler",
             "MatchServer",
+            "_certify_semantic_model_endpoint",
             "resolve_api_auth_token",
             "start_server"
           ],
@@ -237,11 +238,13 @@
             "goldenmatch.config.schemas",
             "goldenmatch.core.autoconfig",
             "goldenmatch.core.explainer",
+            "goldenmatch.core.io_arrow",
             "goldenmatch.core.memory.store",
             "goldenmatch.core.recall_certificate",
             "goldenmatch.core.retrieval",
             "goldenmatch.core.suggest",
             "goldenmatch.core.suggest.surface",
+            "goldenmatch.semantic",
             "goldenmatch.web.controller_telemetry"
           ]
         },
@@ -7180,6 +7183,7 @@
           "defines": [
             "KeyCertification",
             "SemanticCertification",
+            "certification_report_dict",
             "certify_semantic_model",
             "detect_dialect"
           ],

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2393,6 +2393,13 @@
               "required": false,
               "default": "False",
               "help": "Exit non-zero if any declared key is not unique at grain (CI gate)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the verdict-rich report as JSON (the shared MCP/REST shape) — machine-readable for a CI gate."
             }
           ]
         },

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -230,6 +230,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   port (`certificateVerdict`) via a shared fixture (`emit_certificate_verdict_fixture.py`,
   drift-guarded by `ts_parity_freshness`). Byte-unchanged when no certificate is
   passed. Tests: `tests/test_certificate_verdict.py`.
+- **Key-integrity trust verdict surfaced on MCP, REST, and the CLI as a build
+  gate.** A shared `certification_report_dict(report)` serializer emits the
+  verdict-rich JSON (`{dialect, n_certified, n_untrustworthy, all_trustworthy,
+  keys:[{target, key, key_integrity}]}`, each key carrying the full
+  `certificate_verdict` block) so the wire shape can't drift across surfaces. The
+  MCP `certify_semantic_model` tool now returns the per-key verdict block (was a
+  flat 4-field shape); a new REST `POST /semantic/certify` endpoint (`{model,
+  frames, resolve}`) returns the same report; and `certify-keys` gained `--json`
+  (the machine-readable report) alongside the existing `--fail-untrustworthy` CI
+  gate, whose table now shows the pass/fail verdict + undercount. So certifying,
+  gating, and the catalog write-back all speak one contract. Tests in
+  `tests/test_certify_semantic_model.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/goldenmatch/api/server.py
+++ b/packages/python/goldenmatch/goldenmatch/api/server.py
@@ -18,6 +18,7 @@ Endpoints:
     POST /shatter             Break a cluster into singletons
     POST /unmerge             Pull a record out of its cluster
     POST /certify-recall      Estimate match recall without ground truth
+    POST /semantic/certify    Certify a semantic model's declared keys (verdict + gate)
     POST /retrieve            Semantic retrieval: records most similar to a query
 """
 
@@ -494,6 +495,44 @@ def resolve_api_auth_token(host: str) -> str | None:
     return token
 
 
+def _certify_semantic_model_endpoint(
+    model: Any, frames: Any, resolve: bool,
+) -> dict[str, Any]:
+    """Stateless `POST /semantic/certify` handler: certify every declared key in a
+    semantic model against its data files and return the verdict-rich report.
+
+    Body: ``{"model": <path>, "frames": {name: path, ...}, "resolve": bool}``.
+    Returns the same JSON shape as the MCP `certify_semantic_model` tool + the CLI
+    `certify-keys --json` (the shared `certification_report_dict`), so a build gate
+    can read `n_untrustworthy` / `all_trustworthy` identically on any surface.
+    """
+    if not model or not isinstance(model, str):
+        return {"error": "model is required (path to a MetricFlow/Cube/OSI YAML)."}
+    if not isinstance(frames, dict) or not frames:
+        return {"error": "frames must map a model/dataset/cube name to a data file path."}
+
+    from goldenmatch.core.io_arrow import read_table_arrow
+    from goldenmatch.semantic import certification_report_dict, certify_semantic_model
+
+    loaded: dict[str, object] = {}
+    for target, fpath in frames.items():
+        try:
+            loaded[str(target)] = read_table_arrow(str(fpath))
+        except FileNotFoundError:
+            return {"error": f"data file not found for {target!r}: {fpath}"}
+        except Exception as exc:  # noqa: BLE001 - surface a clean API error
+            return {"error": f"could not read data for {target!r} ({fpath}): {exc}"}
+
+    try:
+        report = certify_semantic_model(model, loaded, resolve=resolve)
+    except FileNotFoundError:
+        return {"error": f"semantic-model file not found: {model}"}
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return certification_report_dict(report)
+
+
 class APIHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the GoldenMatch API."""
 
@@ -636,6 +675,13 @@ class APIHandler(BaseHTTPRequestHandler):
         elif path == "/certify-recall":
             result = _server_instance.certify_recall()
             self._json_response(result, 400 if "error" in result else 200)
+        elif path == "/semantic/certify":
+            result = _certify_semantic_model_endpoint(
+                data.get("model"),
+                data.get("frames"),
+                bool(data.get("resolve", False)),
+            )
+            self._json_response(result, 400 if "error" in result else 200)
         elif path == "/retrieve":
             query = data.get("query")
             column = data.get("column")
@@ -727,6 +773,7 @@ def start_server(
     print("   GET  /suggest             Config-healer suggestions (self-verified)")
     print("   GET  /reviews             Review queue (steward)")
     print("   POST /reviews/decide      Approve/reject a pair")
+    print("   POST /semantic/certify    Certify a semantic model's declared keys")
     print("   POST /retrieve            Semantic retrieval by query")
     print("\n   Press Ctrl+C to stop.\n")
 

--- a/packages/python/goldenmatch/goldenmatch/cli/certify_keys.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/certify_keys.py
@@ -29,10 +29,17 @@ def certify_keys_cmd(
         False, "--fail-untrustworthy",
         help="Exit non-zero if any declared key is not unique at grain (CI gate).",
     ),
+    as_json: bool = typer.Option(
+        False, "--json",
+        help="Emit the verdict-rich report as JSON (the shared MCP/REST shape) — "
+             "machine-readable for a CI gate.",
+    ),
 ) -> None:
     """Certify every declared key in a semantic model against its data."""
+    import json
+
     from goldenmatch.core.io_arrow import read_table_arrow
-    from goldenmatch.semantic import certify_semantic_model
+    from goldenmatch.semantic import certification_report_dict, certify_semantic_model
 
     frames: dict[str, object] = {}
     for spec in data:
@@ -44,32 +51,48 @@ def certify_keys_cmd(
 
     report = certify_semantic_model(model, frames, resolve=resolve)
 
-    console.print(f"[bold]Dialect:[/bold] {report.dialect}   "
-                  f"[bold]certified:[/bold] {report.n_certified}   "
-                  f"[bold]untrustworthy:[/bold] {len(report.untrustworthy)}")
-    if report.skipped:
-        console.print(f"[dim]skipped (no frame supplied): {', '.join(report.skipped)}[/dim]")
-    if report.note:
-        console.print(f"[dim]{report.note}[/dim]")
+    if as_json:
+        # Plain print (not the rich console) so the JSON is clean on stdout.
+        print(json.dumps(certification_report_dict(report), indent=2))
+    else:
+        console.print(f"[bold]Dialect:[/bold] {report.dialect}   "
+                      f"[bold]certified:[/bold] {report.n_certified}   "
+                      f"[bold]untrustworthy:[/bold] {len(report.untrustworthy)}")
+        if report.skipped:
+            console.print(f"[dim]skipped (no frame supplied): {', '.join(report.skipped)}[/dim]")
+        if report.note:
+            console.print(f"[dim]{report.note}[/dim]")
 
-    if report.entries:
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("target")
-        table.add_column("key")
-        table.add_column("unique@grain")
-        table.add_column("max_fan_out", justify="right")
-        table.add_column("context", style="dim")
-        for e in report.entries:
-            ok = e.certificate.is_unique_at_grain
-            table.add_row(
-                e.target,
-                ", ".join(e.key),
-                "[#2ecc71]yes[/]" if ok else "[red]NO[/]",
-                f"{e.certificate.max_fan_out:g}",
-                e.context,
+        if report.entries:
+            show_undercount = any(
+                e.certificate.undercount_estimate is not None for e in report.entries
             )
-        console.print(table)
+            table = Table(show_header=True, header_style="bold")
+            table.add_column("target")
+            table.add_column("key")
+            table.add_column("verdict")
+            table.add_column("max_fan_out", justify="right")
+            if show_undercount:
+                table.add_column("undercount", justify="right")
+            table.add_column("context", style="dim")
+            for e in report.entries:
+                cert = e.certificate
+                ok = cert.is_trustworthy()
+                row = [
+                    e.target,
+                    ", ".join(e.key),
+                    "[#2ecc71]trustworthy[/]" if ok else "[red]UNTRUSTWORTHY[/]",
+                    f"{cert.max_fan_out:g}",
+                ]
+                if show_undercount:
+                    uc = cert.undercount_estimate
+                    row.append("-" if uc is None else f"{uc:.2f}")
+                row.append(e.context)
+                table.add_row(*row)
+            console.print(table)
 
     if fail_untrustworthy and report.untrustworthy:
-        console.print(f"[red]{len(report.untrustworthy)} declared key(s) are not unique at grain.[/red]")
+        n = len(report.untrustworthy)
+        if not as_json:
+            console.print(f"[red]{n} declared key(s) are untrustworthy for metric use.[/red]")
         raise typer.Exit(code=1)

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1372,7 +1372,7 @@ def _tool_certify_semantic_model(model_path: str, frames: dict, resolve: bool) -
         return {"error": "frames must map a model/dataset/cube name to a data file path."}
 
     from goldenmatch.core.io_arrow import read_table_arrow
-    from goldenmatch.semantic import certify_semantic_model
+    from goldenmatch.semantic import certification_report_dict, certify_semantic_model
 
     loaded: dict[str, object] = {}
     for target, path in frames.items():
@@ -1390,25 +1390,10 @@ def _tool_certify_semantic_model(model_path: str, frames: dict, resolve: bool) -
     except ValueError as exc:
         return {"error": str(exc)}
 
-    return {
-        "dialect": report.dialect,
-        "n_certified": report.n_certified,
-        "all_trustworthy": report.all_trustworthy,
-        "skipped": report.skipped,
-        "note": report.note,
-        "keys": [
-            {
-                "target": e.target,
-                "key": e.key,
-                "context": e.context,
-                "is_unique_at_grain": e.certificate.is_unique_at_grain,
-                "max_fan_out": e.certificate.max_fan_out,
-                "estimate": e.certificate.estimate,
-                "measure_fan_out": e.certificate.measure_fan_out,
-            }
-            for e in report.entries
-        ],
-    }
+    # Each key carries the full trust-verdict block (verdict + fan-out + the
+    # resolution-tier undercount bounds), the single-sourced projection the
+    # catalog emitters + REST + CLI share.
+    return certification_report_dict(report)
 
 
 def _tool_get_stats() -> dict:

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -29,6 +29,7 @@ from goldenmatch.semantic.catalog import (
 from goldenmatch.semantic.certify import (
     KeyCertification,
     SemanticCertification,
+    certification_report_dict,
     certify_semantic_model,
     detect_dialect,
 )
@@ -80,6 +81,7 @@ from goldenmatch.semantic.serving import (
 
 __all__ = [
     # zero-config front door — certify a whole semantic model (any dialect)
+    "certification_report_dict",
     "certify_semantic_model",
     "SemanticCertification",
     "KeyCertification",

--- a/packages/python/goldenmatch/goldenmatch/semantic/certify.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/certify.py
@@ -150,3 +150,36 @@ def certify_semantic_model(
             ))
 
     return SemanticCertification(dialect=dialect, entries=entries, skipped=skipped)
+
+
+def certification_report_dict(report: SemanticCertification) -> dict[str, Any]:
+    """JSON-serializable view of a `SemanticCertification` — the single source the
+    MCP `certify_semantic_model` tool, the REST `POST /semantic/certify` endpoint,
+    and the CLI `certify-keys --json` output all emit, so the wire shape can't
+    drift across surfaces.
+
+    Each key carries the full trust-verdict block (`certificate_verdict`) — the
+    same `key_integrity` projection the catalog emitters write back — so a consumer
+    reads the advisory `verdict` plus fan-out, per-measure inflation, and the
+    resolution-tier undercount bounds in one place. `n_untrustworthy` /
+    `all_trustworthy` are the build-gate signals.
+    """
+    from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+    return {
+        "dialect": report.dialect,
+        "n_certified": report.n_certified,
+        "n_untrustworthy": len(report.untrustworthy),
+        "all_trustworthy": report.all_trustworthy,
+        "skipped": list(report.skipped),
+        "note": report.note,
+        "keys": [
+            {
+                "target": e.target,
+                "key": list(e.key),
+                "context": e.context,
+                "key_integrity": certificate_verdict(e.certificate),
+            }
+            for e in report.entries
+        ],
+    }

--- a/packages/python/goldenmatch/tests/test_certify_semantic_model.py
+++ b/packages/python/goldenmatch/tests/test_certify_semantic_model.py
@@ -135,3 +135,87 @@ def test_accepts_path(tmp_path):
     frames = {"orders": pa.table({"order_id": [1, 2], "amount": [1.0, 2.0]})}
     rep = certify_semantic_model(str(p), frames)
     assert rep.dialect == "metricflow" and rep.n_certified == 1
+
+
+# --- E: verdict-rich report serializer + MCP/REST/CLI surfaces -----------------
+
+
+def test_certification_report_dict_carries_the_verdict_block():
+    from goldenmatch.semantic import certification_report_dict
+
+    frames = {"orders": pa.table({"order_id": [1, 1, 2], "amount": [10.0, 10.0, 5.0]})}
+    rep = certify_semantic_model(_METRICFLOW, frames)
+    d = certification_report_dict(rep)
+
+    assert d["dialect"] == "metricflow"
+    assert d["n_certified"] == 1
+    assert d["n_untrustworthy"] == 1
+    assert d["all_trustworthy"] is False
+    key = d["keys"][0]
+    assert key["target"] == "orders" and key["key"] == ["order_id"]
+    # The full trust-verdict block (the same projection the catalog emitters embed).
+    ki = key["key_integrity"]
+    assert ki["verdict"] == "untrustworthy"
+    assert ki["unique_at_grain"] is False
+    assert ki["max_fan_out"] == 2.0
+    assert ki["measure_fan_out"]["amount"] > 1.0
+    assert "safe_bound_conservative" in ki
+
+
+def test_certification_report_dict_clean_key_is_trustworthy():
+    from goldenmatch.semantic import certification_report_dict
+
+    frames = {"orders": pa.table({"order_id": [1, 2, 3], "amount": [1.0, 2.0, 3.0]})}
+    d = certification_report_dict(certify_semantic_model(_METRICFLOW, frames))
+    assert d["all_trustworthy"] is True and d["n_untrustworthy"] == 0
+    assert d["keys"][0]["key_integrity"]["verdict"] == "trustworthy"
+
+
+def test_rest_semantic_certify_endpoint(tmp_path):
+    from goldenmatch.api.server import _certify_semantic_model_endpoint
+
+    model = tmp_path / "sm.yml"
+    model.write_text(_METRICFLOW, encoding="utf-8")
+    data = tmp_path / "orders.csv"
+    data.write_text("order_id,amount\n1,10\n1,10\n2,5\n", encoding="utf-8")
+
+    out = _certify_semantic_model_endpoint(str(model), {"orders": str(data)}, False)
+    assert out["n_untrustworthy"] == 1 and out["all_trustworthy"] is False
+    assert out["keys"][0]["key_integrity"]["verdict"] == "untrustworthy"
+
+    # Error paths return {"error": ...} (→ 400), never raise.
+    assert "error" in _certify_semantic_model_endpoint(None, {"orders": str(data)}, False)
+    assert "error" in _certify_semantic_model_endpoint(str(model), {}, False)
+    assert "error" in _certify_semantic_model_endpoint(str(model), {"orders": "/nope.csv"}, False)
+
+
+def test_cli_certify_keys_json_and_gate(tmp_path):
+    from goldenmatch.cli.main import app
+    from typer.testing import CliRunner
+
+    model = tmp_path / "sm.yml"
+    model.write_text(_METRICFLOW, encoding="utf-8")
+    data = tmp_path / "orders.csv"
+    data.write_text("order_id,amount\n1,10\n1,10\n2,5\n", encoding="utf-8")
+
+    runner = CliRunner()
+    # --json + --fail-untrustworthy on an unsafe key: JSON on stdout, exit 1.
+    res = runner.invoke(
+        app,
+        ["certify-keys", str(model), "-d", f"orders={data}", "--json", "--fail-untrustworthy"],
+    )
+    assert res.exit_code == 1
+    import json as _json
+
+    payload = _json.loads(res.output)
+    assert payload["n_untrustworthy"] == 1
+    assert payload["keys"][0]["key_integrity"]["verdict"] == "untrustworthy"
+
+    # A clean key passes the gate (exit 0).
+    clean = tmp_path / "clean.csv"
+    clean.write_text("order_id,amount\n1,10\n2,5\n", encoding="utf-8")
+    ok = runner.invoke(
+        app,
+        ["certify-keys", str(model), "-d", f"orders={clean}", "--fail-untrustworthy"],
+    )
+    assert ok.exit_code == 0

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2393,6 +2393,13 @@
               "required": false,
               "default": "False",
               "help": "Exit non-zero if any declared key is not unique at grain (CI gate)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the verdict-rich report as JSON (the shared MCP/REST shape) — machine-readable for a CI gate."
             }
           ]
         },


### PR DESCRIPTION
## What and why

Expose the key-integrity certification **verdict** as a build gate on every surface, all emitting one shared JSON shape so the contract can't drift. Complements the D4 catalog write-back: now certifying, gating, and the catalog tag all speak the same trust contract. (Follow-up the user asked for after the D1–D4 arc.)

## Changes

- **Shared serializer** `certification_report_dict(report)` (`semantic/certify.py`) — `{dialect, n_certified, n_untrustworthy, all_trustworthy, skipped, note, keys:[{target, key, context, key_integrity}]}`, where each `key_integrity` is the full `certificate_verdict` block (verdict + fan-out + per-measure inflation + resolution-tier undercount bounds). `n_untrustworthy` / `all_trustworthy` are the gate signals.
- **MCP** — `certify_semantic_model` now returns the per-key verdict block (was a flat 4-field shape) via the shared serializer.
- **REST** — new stateless `POST /semantic/certify` (`{model, frames, resolve}`) in `api/server.py`, returning the same report; error paths return `{"error": ...}` (400), never raise. Added to the endpoint docstring + banner.
- **CLI** — `certify-keys` gains `--json` (machine-readable report) alongside the existing `--fail-untrustworthy` CI gate; the human table now shows the pass/fail **verdict** + undercount (when resolved).
- Regenerated `agent-codemap.json` / `config-matrix.mdx` / `agent-manifest.json` for the new public symbol + `--json` flag. Docs: a "Certifying keys as a build gate" section on the semantic-key-integrity page. CHANGELOG entry.

## Testing

- `uv run pytest tests/test_certify_semantic_model.py` — 12 passed (serializer verdict block, clean-key trustworthy, REST endpoint + all error paths, CLI `--json` + gate exit codes).
- `uv run pytest tests/test_a2a.py -k certify_semantic` — passes (a2a dispatch through the rewired MCP handler is compatible).
- `uv run pytest scripts/test_agent_codemap.py scripts/test_config_matrix.py scripts/test_api_surface.py scripts/test_docs_sections.py` — 64 passed.
- `uv run python scripts/check_api_parity.py goldenmatch` — parity OK (no new tool/command/skill drift; `certify_semantic_model` already existed, `--json` is a flag not a command).

## Checklist

- [x] Tests added/updated and passing locally
- [x] `CHANGELOG.md` updated
- [x] Codemap / config-matrix / manifest regenerated for the new surface
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016S73QkJsDGxwTsSdNDMJQH)_