### PR TITLE
feat(semantic): semantic-model discovery (PR-1..6): certified keys, joins, entities, measures, orchestrator + MCP/REST/CLI surface

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -673,6 +673,12 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `demo` | `--dashboard` | boolean | `False` | Generate before/after dashboard |
 | `demo` | `--graph` | boolean | `False` | Generate cluster graph |
 | `demo` | `--quiet` | boolean | `False` | Suppress animated output |
+| `discover-model` | `--data` | text | **required** | A source table as name=path (repeatable), e.g. -d orders=orders.csv |
+| `discover-model` | `--dialect` | text | `'metricflow'` | Emit dialect for the draft model (metricflow). |
+| `discover-model` | `--output` | text | `None` | Write the draft semantic-model YAML to this path. |
+| `discover-model` | `--resolve` | boolean | `False` | Also measure entity fragmentation / undercount via ER (fail-open). |
+| `discover-model` | `--fail-untrustworthy` | boolean | `False` | Exit non-zero if any proposed key is not unique at grain (CI gate). |
+| `discover-model` | `--json` | boolean | `False` | Emit the full proposed model (shape + certification) as JSON. |
 | `evaluate` | `files` | text | **required** | Input files (path or path:source_name) |
 | `evaluate` | `--config` | path | **required** | Config YAML path |
 | `evaluate` | `--ground-truth` | path | `None` | Ground truth CSV path (required unless --certify) |

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -940,7 +940,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 ## MCP tools
 
-94 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
+95 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
 
 | Tool | Description |
 |---|---|
@@ -966,6 +966,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `create_domain` | Create a custom domain extraction rulebook. Define patterns for a specific data domain (medical devices, automotive parts, real estate, etc.). |
 | `customer_360` | The unified Customer 360 serving view of one entity, composed from the durable store in one call: the golden record + per-field source provenance, every linked source record, the event timeline, and the relationship neighborhood. This is the same durable entity_id a resolved crosswalk (semantic-layer wedge) groups metrics by, so a metric row drills straight through to the customer. Returns &#123;found: false&#125; when no such entity exists. |
 | `dedupe` | Alias for `find_duplicates`. Find duplicate matches for a record. Provide field values to search against the loaded dataset. |
+| `discover_semantic_model` | Generative half of the semantic-layer front door: point GoldenMatch at a set of source tables and it PROPOSES a draft semantic model -- entity types, keys, joins, measures, dimensions -- where every declared key is already graded by the certifier (unique-at-grain + fan-out). Discovery is hypothesis generation; certification is the falsification test, so the draft is pre-proven against the data. Advisory; nothing is auto-applied. |
 | `documents_ingest` | Extract records from documents (PDF/image) against a target schema into rows ready for dedupe_df. Returns records + an ingest report. |
 | `documents_suggest_schema` | Propose a target extraction schema (JSON) from a sample document image/PDF. |
 | `emit_semantic_model_from_store` | Emit a conformed semantic-layer catalog (the `resolved_entity_id` join a MetricFlow / Cube / OSI model should group metrics by) directly from the durable identity store — 'keep the semantic layer's identity join live against the control plane'. Returns the emitted YAML; when `path` is set, also writes it to that catalog file (refuses to clobber unless overwrite=true). |

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.26.0` | `goldenmatch` | 94 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.10.0` | `1.26.0` | `goldenmatch` | 95 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
@@ -59,9 +59,10 @@ neglect:
   (`read_file`, `write_csv`, `server_info`) were the last holdouts, and Python now
   exposes all eight.
 
-So GoldenMatch's **85 TS tools vs 94 Python** breaks down as 85 shared operations,
-**zero TS-only**, and 9 Python-only tools (the VLM document-ingest pair, the
-distributed routing trio, `list_plugins`, `pprl_auto_config`, and the
+So GoldenMatch's **85 TS tools vs 95 Python** breaks down as 85 shared operations,
+**zero TS-only**, and 10 Python-only tools (the VLM document-ingest pair, the
+distributed routing trio, `list_plugins`, `pprl_auto_config`, the
+semantic-model discovery front door `discover_semantic_model`, and the
 semantic-layer catalog front doors — `certify_semantic_model` and
 `emit_semantic_model_from_store` (the dialect emitters are Python-only)). The TS MCP surface
 is now a strict subset of the Python one — every TS tool has a Python counterpart of
@@ -130,7 +131,7 @@ graph, privacy-preserving linkage. The flagship — a native wheel, SQL extensio
 
 **Servers** — REST (`goldenmatch serve`: `/match`, `/autoconfig`, `/clusters`,
 `/reviews`, `/controller/telemetry`, …) · A2A (`goldenmatch agent-serve`) · local
-web UI (`goldenmatch serve-ui`) · **94 MCP tools**.
+web UI (`goldenmatch serve-ui`) · **95 MCP tools**.
 
 **Native / SQL** — `goldenmatch-native` wheel, a Postgres extension (pgrx:
 `goldenmatch_dedupe`, `goldenmatch_autoconfig`, `goldenmatch_connected_components`, …),

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,13 +14,13 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 94 | 202 | 51 | 42 | Yes | Yes |
+| `goldenmatch` | 95 | 202 | 51 | 42 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
 | `goldenanalysis` | 4 | 8 | — | 4 | Yes | Yes |
 | `infermap` | 4 | 19 | — | 5 | Yes | Yes |
-| **suite** | **135** | | | | | |
+| **suite** | **136** | | | | | |
 
 ## Compute substrate — the Rust `-core` kernel is the reference
 
@@ -41,7 +41,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 87 | 7 | 0 |
+| `goldenmatch` | mcp_tools | 87 | 8 | 0 |
 | `goldenmatch` | cli_commands | 33 | 9 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 15 | 13 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
@@ -66,7 +66,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
+- `goldenmatch` **mcp_tools** — Python-only: `discover_semantic_model`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
 - `goldenmatch` **cli_commands** — Python-only: `discover-model`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `certify_serving_joins`, `customer_360`, `emit_semantic_model_from_store`, `fix_quality`, `memory_import`, `scan_quality`, `score`.

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 94 | 202 | 51 | 41 | Yes | Yes |
+| `goldenmatch` | 94 | 202 | 51 | 42 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 87 | 7 | 0 |
-| `goldenmatch` | cli_commands | 33 | 8 | 0 |
+| `goldenmatch` | cli_commands | 33 | 9 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 15 | 13 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -67,7 +67,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `discover-model`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `certify_serving_joins`, `customer_360`, `emit_semantic_model_from_store`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -59,7 +59,7 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldenflow` | transforms | 0 | 1 |
 | `goldenmatch` | a2a_skills | 15 | 13 |
 | `goldenmatch` | blocking_strategies | 1 | 0 |
-| `goldenmatch` | cli_commands | 8 | 0 |
+| `goldenmatch` | cli_commands | 9 | 0 |
 | `goldenmatch` | mcp_tools | 7 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -60,7 +60,7 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldenmatch` | a2a_skills | 15 | 13 |
 | `goldenmatch` | blocking_strategies | 1 | 0 |
 | `goldenmatch` | cli_commands | 9 | 0 |
-| `goldenmatch` | mcp_tools | 7 | 0 |
+| `goldenmatch` | mcp_tools | 8 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 
 ## Resolved (archived)

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 440,
+      "module_count": 441,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7249,6 +7249,26 @@
           "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py",
           "purpose": "Semantic-model discovery (the generative half of the semantic wedge).",
           "imports": [
+            "goldenmatch.semantic.discovery.joins",
+            "goldenmatch.semantic.discovery.keys"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.joins",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py",
+          "purpose": "Certified join / foreign-key discovery (semantic-model discovery, Phase 3).",
+          "defines": [
+            "JoinCandidate",
+            "_distinct_nonnull",
+            "_key_columns",
+            "_null_rate",
+            "discover_joins"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.cube",
             "goldenmatch.semantic.discovery.keys"
           ]
         },

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 441,
+      "module_count": 442,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7249,6 +7249,31 @@
           "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py",
           "purpose": "Semantic-model discovery (the generative half of the semantic wedge).",
           "imports": [
+            "goldenmatch.semantic.discovery.entities",
+            "goldenmatch.semantic.discovery.joins",
+            "goldenmatch.semantic.discovery.keys"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.entities",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/entities.py",
+          "purpose": "Cross-table entity-type discovery (semantic-model discovery, Phase 2).",
+          "defines": [
+            "EntityType",
+            "_best_key",
+            "_canonical_token",
+            "_identity_columns",
+            "_is_near_unique",
+            "_jaccard",
+            "_name_for",
+            "_signature",
+            "_value_overlap",
+            "discover_entity_types"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.schema_match",
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys"
           ]

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 438,
+      "module_count": 440,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7134,6 +7134,7 @@
             "goldenmatch.semantic.certify",
             "goldenmatch.semantic.crosswalk",
             "goldenmatch.semantic.cube",
+            "goldenmatch.semantic.discovery",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi",
@@ -7241,6 +7242,30 @@
             "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py",
+          "purpose": "Semantic-model discovery (the generative half of the semantic wedge).",
+          "imports": [
+            "goldenmatch.semantic.discovery.keys"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.keys",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/keys.py",
+          "purpose": "Certified key discovery (semantic-model discovery, Phase 1).",
+          "defines": [
+            "KeyCandidate",
+            "_to_polars",
+            "discover_keys"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.core.quality",
+            "goldenmatch.semantic.key_integrity"
           ]
         },
         {

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 442,
+      "module_count": 443,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7251,7 +7251,8 @@
           "imports": [
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.joins",
-            "goldenmatch.semantic.discovery.keys"
+            "goldenmatch.semantic.discovery.keys",
+            "goldenmatch.semantic.discovery.measures"
           ]
         },
         {
@@ -7311,6 +7312,23 @@
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.core.quality",
             "goldenmatch.semantic.key_integrity"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.measures",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/measures.py",
+          "purpose": "Measure & dimension proposal (semantic-model discovery, Phase 4).",
+          "defines": [
+            "Dimension",
+            "Measure",
+            "TableMeasures",
+            "_grain_spec",
+            "discover_measures"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.discovery.keys"
           ]
         },
         {

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 443,
+      "module_count": 445,
       "modules": [
         {
           "module": "goldenmatch",
@@ -571,6 +571,18 @@
           ]
         },
         {
+          "module": "goldenmatch.cli.discover_model",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/discover_model.py",
+          "purpose": "CLI `discover-model` command — the semantic-model discovery front door.",
+          "defines": [
+            "discover_model_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core.io_arrow",
+            "goldenmatch.semantic"
+          ]
+        },
+        {
           "module": "goldenmatch.cli.evaluate",
           "file": "packages/python/goldenmatch/goldenmatch/cli/evaluate.py",
           "purpose": "CLI evaluate command for GoldenMatch.",
@@ -770,6 +782,7 @@
             "goldenmatch.cli.compare",
             "goldenmatch.cli.dedupe",
             "goldenmatch.cli.demo",
+            "goldenmatch.cli.discover_model",
             "goldenmatch.cli.evaluate",
             "goldenmatch.cli.explain",
             "goldenmatch.cli.identity",
@@ -7252,7 +7265,8 @@
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys",
-            "goldenmatch.semantic.discovery.measures"
+            "goldenmatch.semantic.discovery.measures",
+            "goldenmatch.semantic.discovery.model"
           ]
         },
         {
@@ -7329,6 +7343,24 @@
             "goldenmatch.core.autoconfig",
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.discovery.keys"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.model",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py",
+          "purpose": "Semantic-model discovery orchestrator (Phase 5) — the front door.",
+          "defines": [
+            "ProposedModel",
+            "ProposedTable",
+            "_best_key",
+            "discover_semantic_model"
+          ],
+          "imports": [
+            "goldenmatch.semantic",
+            "goldenmatch.semantic.discovery.entities",
+            "goldenmatch.semantic.discovery.joins",
+            "goldenmatch.semantic.discovery.keys",
+            "goldenmatch.semantic.discovery.measures"
           ]
         },
         {

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -231,6 +231,7 @@
             "APIHandler",
             "MatchServer",
             "_certify_semantic_model_endpoint",
+            "_discover_semantic_model_endpoint",
             "resolve_api_auth_token",
             "start_server"
           ],
@@ -6562,6 +6563,7 @@
             "_tool_config_weaknesses",
             "_tool_convert_splink_config",
             "_tool_create_domain",
+            "_tool_discover_semantic_model",
             "_tool_evaluate",
             "_tool_explain_match",
             "_tool_export_results",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2827,6 +2827,52 @@
           ]
         },
         {
+          "command": "discover-model",
+          "options": [
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "A source table as name=path (repeatable), e.g. -d orders=orders.csv"
+            },
+            {
+              "name": "--dialect",
+              "type": "text",
+              "required": false,
+              "default": "'metricflow'",
+              "help": "Emit dialect for the draft model (metricflow)."
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the draft semantic-model YAML to this path."
+            },
+            {
+              "name": "--resolve",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Also measure entity fragmentation / undercount via ER (fail-open)."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any proposed key is not unique at grain (CI gate)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the full proposed model (shape + certification) as JSON."
+            }
+          ]
+        },
+        {
           "command": "evaluate",
           "options": [
             {

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -4959,6 +4959,10 @@
           "description": "Alias for `find_duplicates`. Find duplicate matches for a record. Provide field values to search against the loaded dataset."
         },
         {
+          "name": "discover_semantic_model",
+          "description": "Generative half of the semantic-layer front door: point GoldenMatch at a set of source tables and it PROPOSES a draft semantic model -- entity types, keys, joins, measures, dimensions -- where every declared key is already graded by the certifier (unique-at-grain + fan-out). Discovery is hypothesis generation; certification is the falsification test, so the draft is pre-proven against the data. Advisory; nothing is auto-applied."
+        },
+        {
           "name": "documents_ingest",
           "description": "Extract records from documents (PDF/image) against a target schema into rows ready for dedupe_df. Returns records + an ingest report."
         },

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -1,0 +1,212 @@
+# Semantic-model discovery ("GoldenModel") — design
+
+Status: **PROPOSED (design only, not implemented)** — a scoped feature that sits on
+top of the existing engines. This spec decomposes it into phases, names the exact
+existing functions each phase reuses vs. the new glue, and gives a phased PR plan.
+No code lands until this design is approved.
+
+Program: Semantic-layer wedge (follows the certify/write-back arc:
+`certify_key_integrity` → catalog write-back D4 → MCP/REST/CLI gate E). This is the
+*generative* half — discovery — where the certify arc was the *validating* half.
+
+## Thesis
+
+Point GoldenMatch at a set of source tables (warehouse, files, connectors) and it
+**proposes** a semantic model — entity types, keys, joins, measures, dimensions —
+where **every declared key already carries its trust verdict**. A human reviews and
+approves in their catalog; nothing auto-ships.
+
+The differentiator is NOT better guessing. Every generic auto-semantic-model tool
+(LLM-based especially) emits confident guesses. GoldenMatch's edge is that it
+**already owns the falsification test**: `certify_key_integrity` /
+`certify_cube_joins` prove each structural claim (this IS the key, this join is
+many-to-one, this measure won't double-count) against the actual data. So discovery
+is hypothesis generation and certification is the proof — the proposed model comes
+**pre-graded**.
+
+This is deliberately the zero-config / approach-the-expert / never-black-box
+posture (`context-network/foundation/project-definition.md` decision tests): propose
++ certify + hand to the expert, never a silent oracle.
+
+## Architecture-frame fit (`one-product-two-engines.md`)
+
+- **One authoritative semantic owner per capability.** The certifier stays the
+  single source of "is this structurally valid." Discovery REUSES it; it never
+  forks a second validator. Same for ER (identity graph is the entity owner) and
+  classification (auto-config classifier / InferMap).
+- **Conformance defines correctness.** Every proposed key / join / measure is
+  VALIDATED against the actual data before it reaches the draft — not asserted.
+- **Compute vs. control stay distinct.** Profiling / classification / ER /
+  certification = the Arrow-native batch **compute** engine (existing). The
+  discovered model + its provenance + versioning = a **control-plane** artifact
+  (new, but a document, not a kernel).
+- **Kernelize on measurement.** The heavy math (FD discovery, key certification)
+  already has kernels. Discovery is orchestration + light inference heuristics —
+  NOT a new kernel. Do not kernelize the proposer loops.
+
+## Raw material — what already exists (verified 2026-08-03)
+
+| Capability | Existing entry point |
+|---|---|
+| Column semantic-type classification + profile | `core/autoconfig.py::profile_columns`, `auto_configure_df`; InferMap (GoldenSchema) domain/concept mapping |
+| Functional-dependency discovery (the key backbone) | `core/quality.py::fd_identity_scores` → `goldencheck.functional_dependencies` |
+| Cross-table column alignment | `core/schema_match.py::auto_map_columns` |
+| Entity resolution + durable entities | `dedupe_df`, Identity Graph (`goldenmatch/identity/`), `resolve_clusters` |
+| **Key certification (the falsification test)** | `semantic/key_integrity.py::certify_key_integrity` |
+| **Join-cardinality certification** | `semantic/cube.py::certify_cube_joins`, `semantic/osi.py::certify_osi_relationships`, `semantic/serving.py::certify_serving_joins` |
+| Whole-model certification | `semantic/certify.py::certify_semantic_model`, `certification_report_dict` |
+| Catalog emitters (write the proposed model out) | `semantic/{metricflow,cube,osi}.py::emit_*`, `certify=` write-back (D4), `crosswalk.py::build_resolved_crosswalk` |
+
+So the certifier, the entity engine, the FD/key math, the classifier, and the
+emitters are all in place. The discovery layer is largely **wiring + a few new
+inference heuristics**, with the certifier as the backbone.
+
+## The pipeline
+
+```
+tables ─▶ [0 profile/classify] ─▶ [1 FD + key-CERTIFY] ─▶ [2 ER: entity types]
+                                                                   │
+                                        ┌──────────────────────────┘
+                                        ▼
+                             [3 FK + join-CERTIFY] ─▶ [4 measure/dim propose]
+                                        │                       │
+                                        └───────────┬───────────┘
+                                                    ▼
+                       [5 emit model + certify_semantic_model] ─▶ pre-graded draft ─▶ human approves
+```
+
+### Phase 0 — Profile & classify (REUSE)
+`profile_columns` over each table: per column semantic type (`email`/`identifier`/
+`date`/`geo`/`numeric`/`description`/…), cardinality ratio, null rate, parse rates,
+samples. This is the vocabulary the rest reasons over. No new code.
+
+### Phase 1 — Key discovery (NEW ranker; certifier proves)
+Candidate keys per table from three signals: near-unique cardinality (`ratio ≈
+1.0`), `col_type == identifier`, and — the strong one — **FD discovery**
+(`fd_identity_scores`: a column-set that functionally determines the rest of the row
+is the key). Then the differentiator: **certify each candidate with
+`certify_key_integrity`** — is it unique at grain, what is the fan-out. Output: a
+ranked list of *certified* keys per table + a loud flag on tables with NO clean key
+(the ones that will silently double-count). NEW: `KeyCandidate` ranker
+(`semantic/discovery/keys.py`).
+
+### Phase 2 — Entity discovery (REUSE ER; NEW clustering)
+Which tables describe the same real-world thing. Resolve across tables (or read the
+Identity Graph): if `customers`, `app_users`, `crm_contacts` resolve to overlapping
+entities they are the `Person` entity type. `auto_map_columns` aligns their columns.
+NEW: cross-table **entity-type clustering** (`semantic/discovery/entities.py`) over
+(resolved-entity overlap + column-semantic signature). Output: entity types +
+tables/keys that realize each + the conformed `resolved_entity_id`.
+
+### Phase 3 — Join / relationship discovery (NEW inference; certifier proves cardinality)
+FK inference: a column in table B whose values are a subset of table A's certified
+key, with matching semantic type → candidate join. Then validate the **cardinality**
+with the SAME machinery — the "one" side of a `many_to_one` must be unique at grain,
+which is exactly what `certify_cube_joins` / `certify_serving_joins` already check.
+Output: a certified join graph with directions, no spurious fan-outs. NEW: FK
+inference (`semantic/discovery/joins.py`); certification is reused.
+
+### Phase 4 — Measure & dimension proposal (NEW proposer, certifier-gated)
+- **Measures:** numeric columns on fact-shaped tables (high row count, FK-heavy) →
+  propose `SUM`/`COUNT`/`AVG`. A measure is proposed safe-to-`SUM` ONLY if its grain
+  key certified clean — the Phase-1 fan-out directly gates which measures are
+  trustworthy.
+- **Dimensions:** low-cardinality categorical/date/geo columns + resolved entity
+  attributes.
+- **Grain:** the certified key from Phase 1.
+
+NEW: `semantic/discovery/measures.py`.
+
+### Phase 5 — Emit, certify, hand off (REUSE)
+Assemble a draft MetricFlow / Cube / OSI model via the existing emitters, run
+`certify_semantic_model` over the whole thing, attach the `key_integrity` verdict
+block to every key (D4 write-back). Deliverable: a **draft model where every key is
+already graded** — the human reviews/approves in their catalog. Nothing auto-ships.
+Public entry point: `discover_semantic_model(tables, *, dialect="metricflow") ->
+ProposedModel`.
+
+## New surface (the glue) vs. reused
+
+| REUSE (exists) | BUILD (new) |
+|---|---|
+| classifier, profiling | key-candidate **ranker** (Phase 1) |
+| `fd_identity_scores` | cross-table **entity-type clustering** (Phase 2) |
+| ER + Identity Graph | **FK / join inference** (Phase 3) |
+| `auto_map_columns` | **measure/dimension proposer** (Phase 4) |
+| `certify_key_integrity` / `certify_cube_joins` | the **orchestrator** `discover_semantic_model` + `ProposedModel` dataclass |
+| emitters + `certify_semantic_model` | *(optional, advisory)* LLM **namer** |
+
+## Honest boundaries (what it will NOT do)
+
+- **Structure, not intent.** It discovers that `status` determines the row and is
+  low-cardinality (→ a dimension). It does NOT know `status='C'` means "churned."
+  Business naming/glossary needs a human or an *advisory* LLM namer — bolted on the
+  SAME way the config-suggestion healer is (`context-network/decisions/0027-healer-wasm-ts.md`):
+  opt-in, self-verified, never authoritative. Default off; the structural discovery
+  is byte-deterministic without it.
+- **A draft, not an oracle.** Gets the expert to ~80% and marks its own uncertainty
+  (every key carries its verdict + confidence). Matches the North Star decision
+  tests.
+- **Certification is the honest core; discovery is the accelerator.** The reason to
+  trust GM's proposal over a pure-LLM one is that each guess is PROVEN against the
+  data before you see it — not that the guesses are cleverer.
+
+## Cross-surface posture
+
+- **Python-first.** `discover_semantic_model` + `ProposedModel` in
+  `goldenmatch/semantic/discovery/`. Emits via the existing dialect emitters, so the
+  output is a normal MetricFlow/Cube/OSI file.
+- **CLI:** `goldenmatch discover-model <tables...> --dialect metricflow -o model.yml`
+  (proposes + certifies + writes; prints the per-key verdict table). Mirrors
+  `certify-keys`.
+- **MCP / REST:** a `discover_semantic_model` tool + `POST /semantic/discover`,
+  returning the proposed model + `certification_report_dict` (same shared serializer
+  as the certify surface — one contract).
+- **TS parity:** the *classifier/certifier* halves are already TS-ported; the
+  discovery orchestrator is a Python-only follow-up (it leans on ER + FD discovery,
+  which are Python-side — the "distributed/ER is Python-only by design" boundary in
+  the TS CLAUDE.md). Declare it Python-only up front, not a silent gap.
+
+## Phased PR plan (each additive, no-op when unused)
+
+1. **PR-1 `ProposedModel` + Phase 1 key discovery.** `semantic/discovery/keys.py`:
+   `discover_keys(table) -> list[KeyCandidate]` (FD + cardinality + `col_type`,
+   certified via `certify_key_integrity`). Pure, testable on fixtures. No orchestrator
+   yet.
+2. **PR-2 Phase 3 join discovery** over caller-supplied keys: `discover_joins(tables,
+   keys) -> list[JoinCandidate]`, cardinality-certified via `certify_cube_joins`.
+3. **PR-3 Phase 2 entity typing:** `discover_entity_types(tables) -> list[EntityType]`
+   over ER overlap + column signatures.
+4. **PR-4 Phase 4 measure/dimension proposer** (fan-out-gated measures).
+5. **PR-5 orchestrator + emit:** `discover_semantic_model(tables) -> ProposedModel`
+   assembling PR-1..4, emitting via the dialect emitters + `certify_semantic_model`,
+   attaching the D4 verdict block. CLI `discover-model`.
+6. **PR-6 MCP/REST surfaces** (`discover_semantic_model` tool + `POST /semantic/discover`),
+   shared serializer.
+7. **PR-7 (optional) advisory LLM namer**, default off, self-verified.
+
+Each PR is independently useful (PR-1 alone gives "certified key discovery per
+table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at
+every step.
+
+## Open questions
+
+- **Entity-typing threshold:** how much cross-table resolved-entity overlap declares
+  "same entity type"? Calibrate against a labeled multi-table corpus (the
+  `_pick_missing_semantics` precedent — calibrate, don't derive).
+- **FK inference at scale:** value-subset checks are O(distinct) per column pair;
+  bound with the profiler's cardinality + a bloom/minhash pre-filter before the exact
+  check.
+- **Grain ambiguity:** a table can have several certified keys at different grains
+  (order_id vs order_id+line_no). Propose the finest certified grain + surface the
+  coarser ones as alternates, don't guess one.
+
+## Success criteria
+
+- On a labeled multi-table corpus, the proposed model's keys/joins match the
+  ground-truth semantic model at ≥ target precision, AND every proposed key's verdict
+  is correct (a certified-trustworthy key IS unique at grain in the data).
+- Zero false "trustworthy" verdicts — the certifier's guarantee must hold end-to-end
+  (an untrustworthy key never ships graded trustworthy).
+- A human accepts the draft with fewer edits than starting from scratch (the
+  accelerator claim), measured on a real project.

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - DQbench composite 91.04; PPRL 92.4% F1 on FEBRL4; a durable Identity Graph (stable entity_ids that survive across runs)
 
 ## AI-native surface
-- Every package ships an MCP server (135 tools across the suite), a REST API, and most an A2A agent surface
+- Every package ships an MCP server (136 tools across the suite), a REST API, and most an A2A agent surface
 - One aggregator container exposes the whole suite: `docker run ghcr.io/benseverndev-oss/goldensuite-mcp:latest`
 - Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benseverndev-oss/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -258,6 +258,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   compound/grain-ambiguous keys + the entity/join/measure phases + the
   `discover_semantic_model` orchestrator are the following PRs. Tests:
   `tests/test_semantic_discovery_keys.py`.
+- **Semantic-model discovery — certified join / FK discovery (Phase 3).**
+  `goldenmatch.semantic.discover_joins(tables, keys)` proposes the foreign-key joins
+  across a set of tables and PROVES each join's cardinality with the same certifier
+  the certify wedge uses. FK inference is the hypothesis (a column whose non-null
+  values are a subset of another table's certified key, matching semantic type →
+  a `many_to_one` join); `certify_cube_joins` is the falsification test (the "one"
+  side must be unique at grain, else a metric joined across it double-counts). A
+  returned `JoinCandidate` is pre-graded (`is_trustworthy`, fan-out, the certificate
+  on the referenced key); ranked trustworthy-first. Numeric/date/geo columns are
+  never proposed as foreign keys, and an untrustworthy target `KeyCandidate` is
+  skipped (an unsound grain makes an unsound join). Single-column FKs referencing the
+  caller-supplied per-table keys for this slice; compound/self-referential joins are
+  follow-ons. The second slice of the semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_joins.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -289,6 +289,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   discovery arc (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_entities.py`.
+- **Semantic-model discovery — grain-gated measure/dimension proposal (Phase 4).**
+  `goldenmatch.semantic.discover_measures(table, key=…)` proposes the measures +
+  dimensions a semantic model would declare over a table, and gates each measure's
+  `SUM`-safety on the grain key's Phase-1 CERTIFICATE. `COUNT`/`AVG`/`MIN`/`MAX` are
+  always proposed (fan-out-independent); `SUM` is proposed ONLY when the grain
+  certified clean (`max_fan_out == 1.0`) — on a fanned-out (or unknown) grain the
+  measure is returned with `safe_to_sum == False` and `SUM` withheld, the loud "this
+  would double-count" signal. Dimensions are the low-cardinality categorical columns +
+  dates + geo; the grain and id/reference columns are neither measure nor dimension.
+  So the certifier that graded the key directly grades the measures. The fourth slice
+  of the semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_measures.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -302,6 +302,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   of the semantic-model discovery arc (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_measures.py`.
+- **Semantic-model discovery — orchestrator + `discover-model` CLI (Phase 5).**
+  `goldenmatch.semantic.discover_semantic_model(tables)` assembles all four discovery
+  phases (keys → entity types → certified join graph → grain-gated measures) into a
+  draft MetricFlow model, emits it through the existing dialect emitters, and
+  re-certifies it end-to-end — the deliverable is a normal MetricFlow file plus a
+  verdict-rich `certification_report_dict` where EVERY key is already graded. Only
+  `SUM`-safe measures are declared in the emitted model, so a draft never scaffolds a
+  double-counting `SUM`. `ProposedModel.all_trustworthy` is the headline build-gate
+  signal; `.to_dict()` is the JSON shape the discover surfaces emit. New CLI
+  `goldenmatch discover-model -d name=path ... [--dialect metricflow] [-o model.yml]
+  [--json] [--fail-untrustworthy]` (Python-only, mirrors `certify-keys`). Nothing
+  auto-ships — a human reviews the graded draft. The fifth slice of the semantic-model
+  discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_model.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -317,6 +317,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   discovery arc (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_model.py`.
+- **Semantic-model discovery — MCP tool + REST endpoint (Phase 6).** Surfaces
+  `discover_semantic_model` on MCP (`discover_semantic_model` tool) and REST
+  (`POST /semantic/discover`), both returning the same `ProposedModel.to_dict()`
+  wire shape the `discover-model` CLI emits — one contract across every surface, so a
+  build gate reads `all_trustworthy` identically whether it calls the tool, the
+  endpoint, or the CLI. Input is `frames` (table name → data file path), `dialect`
+  (default `metricflow`), and `resolve`; bad input / unreadable files / an
+  unsupported dialect return a clean `{"error": ...}` rather than raising. Python-only,
+  mirroring the `certify_semantic_model` surface. The sixth slice of the
+  semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discover_surface.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -242,6 +242,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   gate, whose table now shows the pass/fail verdict + undercount. So certifying,
   gating, and the catalog write-back all speak one contract. Tests in
   `tests/test_certify_semantic_model.py`.
+- **Semantic-model discovery — certified key discovery (Phase 1).**
+  `goldenmatch.semantic.discover_keys(table)` proposes a table's candidate entity
+  keys from three cheap signals (identifier col_type / near-unique cardinality /
+  functional-dependency determinant via `fd_identity_scores`) and PROVES each with
+  `certify_key_integrity` — so a returned `KeyCandidate` is pre-graded
+  (`is_trustworthy`, fan-out, the certificate). Ranked trustworthy-first; a table
+  with no clean key returns only untrustworthy candidates (the loud "this grain
+  double-counts" signal). Numeric/date/geo/description columns are excluded from
+  the key-cardinality signal (they're measures/dimensions, not keys). The first
+  slice of the semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`) — the
+  generative half of the semantic wedge, where discovery is hypothesis generation
+  and the certifier is the falsification test. Single-column keys for this slice;
+  compound/grain-ambiguous keys + the entity/join/measure phases + the
+  `discover_semantic_model` orchestrator are the following PRs. Tests:
+  `tests/test_semantic_discovery_keys.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -273,6 +273,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   follow-ons. The second slice of the semantic-model discovery arc (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_joins.py`.
+- **Semantic-model discovery — cross-table entity typing (Phase 2).**
+  `goldenmatch.semantic.discover_entity_types(tables)` groups source tables into the
+  real-world entity types they realize, so the later phases conform one shared key /
+  one dimension per entity instead of one per table. Two signals decide it: a
+  **column-semantic signature** (columns canonicalize to shared tokens via the
+  `schema_match` synonym map + profiled `col_type`; high Jaccard → same kind of thing)
+  and **value overlap** on a shared identity column (email/phone/id-shaped) — but the
+  value-overlap "same entity" signal fires ONLY when the shared column is near-unique
+  on BOTH sides (the same population enumerated twice), so a foreign-key reference
+  (e.g. `orders.customer_id` into `customers`) is correctly read as a Phase-3 join, not
+  as sameness. Each `EntityType` names itself from its dominant hint (`person` /
+  `organization` / `entity_N`), records the per-table conformance key when keys are
+  supplied, and ranks multi-table-first. The third slice of the semantic-model
+  discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_entities.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -106,7 +106,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 91.04 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **94 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **95 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### Run on unstructured input (document ingest)
@@ -217,7 +217,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 - **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
-- **REST API + MCP Server** — 94 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
+- **REST API + MCP Server** — 95 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
 - **A2A Agent** — 51 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
@@ -731,7 +731,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (94 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (95 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |
@@ -1294,7 +1294,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-94 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+95 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
 
 ### Local files with the remote server
 

--- a/packages/python/goldenmatch/goldenmatch/api/server.py
+++ b/packages/python/goldenmatch/goldenmatch/api/server.py
@@ -19,6 +19,7 @@ Endpoints:
     POST /unmerge             Pull a record out of its cluster
     POST /certify-recall      Estimate match recall without ground truth
     POST /semantic/certify    Certify a semantic model's declared keys (verdict + gate)
+    POST /semantic/discover   Discover a draft semantic model from source tables (pre-graded)
     POST /retrieve            Semantic retrieval: records most similar to a query
 """
 
@@ -533,6 +534,42 @@ def _certify_semantic_model_endpoint(
     return certification_report_dict(report)
 
 
+def _discover_semantic_model_endpoint(
+    frames: Any, dialect: Any, resolve: bool,
+) -> dict[str, Any]:
+    """Stateless `POST /semantic/discover` handler: propose a draft semantic model
+    from a set of source tables, pre-graded by the certifier.
+
+    Body: ``{"frames": {name: path, ...}, "dialect": "metricflow", "resolve": bool}``.
+    Returns the same JSON shape as the MCP `discover_semantic_model` tool + the CLI
+    `discover-model` (the shared `ProposedModel.to_dict()`), so a build gate can read
+    `all_trustworthy` identically on any surface.
+    """
+    if not isinstance(frames, dict) or not frames:
+        return {"error": "frames must map a table name to a data file path."}
+
+    from goldenmatch.core.io_arrow import read_table_arrow
+    from goldenmatch.semantic import discover_semantic_model
+
+    loaded: dict[str, object] = {}
+    for target, fpath in frames.items():
+        try:
+            loaded[str(target)] = read_table_arrow(str(fpath))
+        except FileNotFoundError:
+            return {"error": f"data file not found for {target!r}: {fpath}"}
+        except Exception as exc:  # noqa: BLE001 - surface a clean API error
+            return {"error": f"could not read data for {target!r} ({fpath}): {exc}"}
+
+    try:
+        model = discover_semantic_model(
+            loaded, dialect=str(dialect or "metricflow"), resolve=resolve
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return model.to_dict()
+
+
 class APIHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the GoldenMatch API."""
 
@@ -682,6 +719,13 @@ class APIHandler(BaseHTTPRequestHandler):
                 bool(data.get("resolve", False)),
             )
             self._json_response(result, 400 if "error" in result else 200)
+        elif path == "/semantic/discover":
+            result = _discover_semantic_model_endpoint(
+                data.get("frames"),
+                data.get("dialect", "metricflow"),
+                bool(data.get("resolve", False)),
+            )
+            self._json_response(result, 400 if "error" in result else 200)
         elif path == "/retrieve":
             query = data.get("query")
             column = data.get("column")
@@ -774,6 +818,7 @@ def start_server(
     print("   GET  /reviews             Review queue (steward)")
     print("   POST /reviews/decide      Approve/reject a pair")
     print("   POST /semantic/certify    Certify a semantic model's declared keys")
+    print("   POST /semantic/discover   Discover a draft semantic model (pre-graded)")
     print("   POST /retrieve            Semantic retrieval by query")
     print("\n   Press Ctrl+C to stop.\n")
 

--- a/packages/python/goldenmatch/goldenmatch/cli/discover_model.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/discover_model.py
@@ -1,0 +1,112 @@
+"""CLI `discover-model` command — the semantic-model discovery front door.
+
+Surfaces ``goldenmatch.semantic.discover_semantic_model``: point it at a set of source
+tables and get a DRAFT semantic model (MetricFlow) where every key is PRE-GRADED by the
+certifier — grain, entity types, a certified join graph, and grain-gated measures. It
+proposes + proves; a human reviews and approves. Advisory only; nothing auto-ships.
+Mirrors `certify-keys`.
+"""
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def discover_model_cmd(
+    data: list[str] = typer.Option(
+        ..., "--data", "-d",
+        help="A source table as name=path (repeatable), e.g. -d orders=orders.csv",
+    ),
+    dialect: str = typer.Option(
+        "metricflow", "--dialect",
+        help="Emit dialect for the draft model (metricflow).",
+    ),
+    output: str | None = typer.Option(
+        None, "--output", "-o",
+        help="Write the draft semantic-model YAML to this path.",
+    ),
+    resolve: bool = typer.Option(
+        False, "--resolve",
+        help="Also measure entity fragmentation / undercount via ER (fail-open).",
+    ),
+    fail_untrustworthy: bool = typer.Option(
+        False, "--fail-untrustworthy",
+        help="Exit non-zero if any proposed key is not unique at grain (CI gate).",
+    ),
+    as_json: bool = typer.Option(
+        False, "--json",
+        help="Emit the full proposed model (shape + certification) as JSON.",
+    ),
+) -> None:
+    """Discover a draft semantic model from source tables, every key pre-graded."""
+    import json
+
+    from goldenmatch.core.io_arrow import read_table_arrow
+    from goldenmatch.semantic import discover_semantic_model
+
+    tables: dict[str, object] = {}
+    for spec in data:
+        if "=" not in spec:
+            console.print(f"[red]--data must be name=path, got {spec!r}[/red]")
+            raise typer.Exit(code=2)
+        name, path = spec.split("=", 1)
+        tables[name.strip()] = read_table_arrow(path.strip())
+
+    try:
+        model = discover_semantic_model(tables, dialect=dialect, resolve=resolve)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    if output:
+        with open(output, "w", encoding="utf-8") as fh:
+            fh.write(model.yaml)
+
+    if as_json:
+        print(json.dumps(model.to_dict(), indent=2))
+    else:
+        console.print(
+            f"[bold]Dialect:[/bold] {model.dialect}   "
+            f"[bold]tables:[/bold] {len(model.tables)}   "
+            f"[bold]entity types:[/bold] {len(model.entity_types)}   "
+            f"[bold]joins:[/bold] {len(model.joins)}   "
+            f"[bold]all_trustworthy:[/bold] "
+            f"{'[#2ecc71]yes[/]' if model.all_trustworthy else '[red]no[/]'}"
+        )
+        if model.tables:
+            tbl = Table(show_header=True, header_style="bold")
+            tbl.add_column("table")
+            tbl.add_column("entity")
+            tbl.add_column("grain")
+            tbl.add_column("verdict")
+            tbl.add_column("measures", justify="right")
+            tbl.add_column("dimensions", justify="right")
+            for pt in model.tables:
+                ok = pt.grain_trustworthy
+                tbl.add_row(
+                    pt.table,
+                    pt.entity_type or "-",
+                    ", ".join(pt.grain) or "-",
+                    "[#2ecc71]trustworthy[/]" if ok else "[red]UNTRUSTWORTHY[/]",
+                    str(len(pt.measures)),
+                    str(len(pt.dimensions)),
+                )
+            console.print(tbl)
+        if model.joins:
+            console.print("[bold]Joins[/bold]")
+            for j in model.joins:
+                arrow = "[#2ecc71]->[/]" if j.is_trustworthy else "[red]-x[/]"
+                console.print(
+                    f"  {j.from_table}.{j.from_column} {arrow} "
+                    f"{j.to_table}.{j.to_column} ({j.relationship})"
+                )
+        if output:
+            console.print(f"[dim]wrote {output}[/dim]")
+
+    if fail_untrustworthy and not model.all_trustworthy:
+        if not as_json:
+            console.print("[red]one or more proposed keys are untrustworthy for metric use.[/red]")
+        raise typer.Exit(code=1)

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -18,6 +18,7 @@ from goldenmatch.cli.certify_keys import certify_keys_cmd
 from goldenmatch.cli.compare import compare_clusters_cmd
 from goldenmatch.cli.dedupe import dedupe_cmd
 from goldenmatch.cli.demo import demo_cmd
+from goldenmatch.cli.discover_model import discover_model_cmd
 from goldenmatch.cli.evaluate import evaluate_cmd
 from goldenmatch.cli.explain import explain_cmd
 from goldenmatch.cli.identity import identity_app
@@ -146,6 +147,7 @@ app.command("incremental", help="Match new records against an existing base data
 app.command("compare-clusters", help="Compare two ER clustering outcomes (CCMS).")(compare_clusters_cmd)
 app.command("sensitivity", help="Analyze parameter sensitivity using CCMS comparison.")(sensitivity_cmd)
 app.command("certify-keys", help="Certify the entity keys a semantic model (MetricFlow/Cube/OSI) declares.")(certify_keys_cmd)
+app.command("discover-model", help="Discover a draft semantic model from source tables, every key pre-graded by the certifier.")(discover_model_cmd)
 
 
 @app.command("analyze-blocking")

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -814,6 +814,40 @@ _BASE_TOOLS = [
             "required": ["model_path", "frames"],
         },
     ),
+    Tool(
+        name="discover_semantic_model",
+        description=(
+            "Generative half of the semantic-layer front door: point GoldenMatch at a "
+            "set of source tables and it PROPOSES a draft semantic model -- entity "
+            "types, keys, joins, measures, dimensions -- where every declared key is "
+            "already graded by the certifier (unique-at-grain + fan-out). Discovery is "
+            "hypothesis generation; certification is the falsification test, so the "
+            "draft is pre-proven against the data. Advisory; nothing is auto-applied."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "frames": {
+                    "type": "object",
+                    "description": (
+                        "Map of table name -> data file path, e.g. "
+                        "{\"orders\": \"orders.csv\", \"customers\": \"customers.csv\"}."
+                    ),
+                },
+                "dialect": {
+                    "type": "string",
+                    "description": "Emit dialect for the draft model (metricflow for now).",
+                    "default": "metricflow",
+                },
+                "resolve": {
+                    "type": "boolean",
+                    "description": "Also measure entity fragmentation/undercount via ER (fail-open).",
+                    "default": False,
+                },
+            },
+            "required": ["frames"],
+        },
+    ),
 ]
 
 # --- Cross-language naming aliases (Python<->TS MCP parity) -----------------
@@ -1356,6 +1390,12 @@ def _handle_tool(name: str, args: dict) -> dict:
         return _tool_certify_semantic_model(
             args.get("model_path", ""), args.get("frames", {}), args.get("resolve", False)
         )
+    elif name == "discover_semantic_model":
+        return _tool_discover_semantic_model(
+            args.get("frames", {}),
+            args.get("dialect", "metricflow"),
+            args.get("resolve", False),
+        )
     else:
         return {"error": f"Unknown tool: {name}"}
 
@@ -1394,6 +1434,39 @@ def _tool_certify_semantic_model(model_path: str, frames: dict, resolve: bool) -
     # resolution-tier undercount bounds), the single-sourced projection the
     # catalog emitters + REST + CLI share.
     return certification_report_dict(report)
+
+
+def _tool_discover_semantic_model(frames: dict, dialect: str, resolve: bool) -> dict:
+    """Discover a draft semantic model from a set of source tables.
+
+    ``frames`` maps table name -> data file path; each is loaded into a pyarrow
+    Table. Returns the JSON-serializable ``ProposedModel.to_dict()`` -- the same
+    wire shape the REST ``/semantic/discover`` endpoint + the ``discover-model``
+    CLI emit. Every proposed key is pre-graded by the certifier.
+    """
+    if not isinstance(frames, dict) or not frames:
+        return {"error": "frames must map a table name to a data file path."}
+
+    from goldenmatch.core.io_arrow import read_table_arrow
+    from goldenmatch.semantic import discover_semantic_model
+
+    loaded: dict[str, object] = {}
+    for target, path in frames.items():
+        try:
+            loaded[str(target)] = read_table_arrow(str(path))
+        except FileNotFoundError:
+            return {"error": f"data file not found for {target!r}: {path}"}
+        except Exception as exc:  # noqa: BLE001 - surface a clean tool error
+            return {"error": f"could not read data for {target!r} ({path}): {exc}"}
+
+    try:
+        model = discover_semantic_model(
+            loaded, dialect=str(dialect or "metricflow"), resolve=bool(resolve)
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return model.to_dict()
 
 
 def _tool_get_stats() -> dict:

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -51,11 +51,14 @@ from goldenmatch.semantic.discovery import (
     JoinCandidate,
     KeyCandidate,
     Measure,
+    ProposedModel,
+    ProposedTable,
     TableMeasures,
     discover_entity_types,
     discover_joins,
     discover_keys,
     discover_measures,
+    discover_semantic_model,
 )
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
@@ -163,4 +166,8 @@ __all__ = [
     "Measure",
     "Dimension",
     "TableMeasures",
+    # semantic-model discovery (Phase 5) — the orchestrator (assemble + emit + certify)
+    "discover_semantic_model",
+    "ProposedModel",
+    "ProposedTable",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -45,6 +45,7 @@ from goldenmatch.semantic.cube import (
     emit_cube_yaml,
     parse_cube_models,
 )
+from goldenmatch.semantic.discovery import KeyCandidate, discover_keys
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
     certify_structural_json,
@@ -137,4 +138,7 @@ __all__ = [
     "CubeDimension",
     "CubeMeasure",
     "CubeJoin",
+    # semantic-model discovery (Phase 1) — certified key discovery per table
+    "discover_keys",
+    "KeyCandidate",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -46,8 +46,10 @@ from goldenmatch.semantic.cube import (
     parse_cube_models,
 )
 from goldenmatch.semantic.discovery import (
+    EntityType,
     JoinCandidate,
     KeyCandidate,
+    discover_entity_types,
     discover_joins,
     discover_keys,
 )
@@ -146,6 +148,9 @@ __all__ = [
     # semantic-model discovery (Phase 1) — certified key discovery per table
     "discover_keys",
     "KeyCandidate",
+    # semantic-model discovery (Phase 2) — cross-table entity-type discovery
+    "discover_entity_types",
+    "EntityType",
     # semantic-model discovery (Phase 3) — certified join / FK discovery across tables
     "discover_joins",
     "JoinCandidate",

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -45,7 +45,12 @@ from goldenmatch.semantic.cube import (
     emit_cube_yaml,
     parse_cube_models,
 )
-from goldenmatch.semantic.discovery import KeyCandidate, discover_keys
+from goldenmatch.semantic.discovery import (
+    JoinCandidate,
+    KeyCandidate,
+    discover_joins,
+    discover_keys,
+)
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
     certify_structural_json,
@@ -141,4 +146,7 @@ __all__ = [
     # semantic-model discovery (Phase 1) — certified key discovery per table
     "discover_keys",
     "KeyCandidate",
+    # semantic-model discovery (Phase 3) — certified join / FK discovery across tables
+    "discover_joins",
+    "JoinCandidate",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -46,12 +46,16 @@ from goldenmatch.semantic.cube import (
     parse_cube_models,
 )
 from goldenmatch.semantic.discovery import (
+    Dimension,
     EntityType,
     JoinCandidate,
     KeyCandidate,
+    Measure,
+    TableMeasures,
     discover_entity_types,
     discover_joins,
     discover_keys,
+    discover_measures,
 )
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
@@ -154,4 +158,9 @@ __all__ = [
     # semantic-model discovery (Phase 3) — certified join / FK discovery across tables
     "discover_joins",
     "JoinCandidate",
+    # semantic-model discovery (Phase 4) — grain-gated measure/dimension proposal
+    "discover_measures",
+    "Measure",
+    "Dimension",
+    "TableMeasures",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -9,13 +9,22 @@ Design + phased plan:
 `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
 
 Phase 1: `discover_keys` — certified single-column key discovery per table.
+Phase 2: `discover_entity_types` — cross-table entity-type discovery.
 Phase 3: `discover_joins` — certified foreign-key join discovery across tables.
-Later phases (entity typing, measure/dimension proposal, the
-`discover_semantic_model` orchestrator) build on these.
+Later phases (measure/dimension proposal, the `discover_semantic_model`
+orchestrator) build on these.
 """
 from __future__ import annotations
 
+from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
 from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
 
-__all__ = ["JoinCandidate", "KeyCandidate", "discover_joins", "discover_keys"]
+__all__ = [
+    "EntityType",
+    "JoinCandidate",
+    "KeyCandidate",
+    "discover_entity_types",
+    "discover_joins",
+    "discover_keys",
+]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -12,7 +12,8 @@ Phase 1: `discover_keys` — certified single-column key discovery per table.
 Phase 2: `discover_entity_types` — cross-table entity-type discovery.
 Phase 3: `discover_joins` — certified foreign-key join discovery across tables.
 Phase 4: `discover_measures` — grain-gated measure/dimension proposal per table.
-Later phases (the `discover_semantic_model` orchestrator) build on these.
+Phase 5: `discover_semantic_model` — the orchestrator assembling all phases into a
+    draft model, emitted + re-certified end-to-end.
 """
 from __future__ import annotations
 
@@ -25,6 +26,11 @@ from goldenmatch.semantic.discovery.measures import (
     TableMeasures,
     discover_measures,
 )
+from goldenmatch.semantic.discovery.model import (
+    ProposedModel,
+    ProposedTable,
+    discover_semantic_model,
+)
 
 __all__ = [
     "Dimension",
@@ -32,9 +38,12 @@ __all__ = [
     "JoinCandidate",
     "KeyCandidate",
     "Measure",
+    "ProposedModel",
+    "ProposedTable",
     "TableMeasures",
     "discover_entity_types",
     "discover_joins",
     "discover_keys",
     "discover_measures",
+    "discover_semantic_model",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -1,0 +1,19 @@
+"""Semantic-model discovery (the generative half of the semantic wedge).
+
+Propose a semantic model from source tables where every key comes PRE-GRADED by the
+certifier. Discovery is hypothesis generation; `certify_key_integrity` /
+`certify_cube_joins` are the falsification test — so the proposed model is proven
+against the data, not just guessed.
+
+Design + phased plan:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+
+Phase 1 (this slice): `discover_keys` — certified single-column key discovery per
+table. Later phases (entity typing, join discovery, measure/dimension proposal, the
+`discover_semantic_model` orchestrator) build on this.
+"""
+from __future__ import annotations
+
+from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
+
+__all__ = ["KeyCandidate", "discover_keys"]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -11,20 +11,30 @@ Design + phased plan:
 Phase 1: `discover_keys` — certified single-column key discovery per table.
 Phase 2: `discover_entity_types` — cross-table entity-type discovery.
 Phase 3: `discover_joins` — certified foreign-key join discovery across tables.
-Later phases (measure/dimension proposal, the `discover_semantic_model`
-orchestrator) build on these.
+Phase 4: `discover_measures` — grain-gated measure/dimension proposal per table.
+Later phases (the `discover_semantic_model` orchestrator) build on these.
 """
 from __future__ import annotations
 
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
 from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
+from goldenmatch.semantic.discovery.measures import (
+    Dimension,
+    Measure,
+    TableMeasures,
+    discover_measures,
+)
 
 __all__ = [
+    "Dimension",
     "EntityType",
     "JoinCandidate",
     "KeyCandidate",
+    "Measure",
+    "TableMeasures",
     "discover_entity_types",
     "discover_joins",
     "discover_keys",
+    "discover_measures",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -8,12 +8,14 @@ against the data, not just guessed.
 Design + phased plan:
 `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
 
-Phase 1 (this slice): `discover_keys` — certified single-column key discovery per
-table. Later phases (entity typing, join discovery, measure/dimension proposal, the
-`discover_semantic_model` orchestrator) build on this.
+Phase 1: `discover_keys` — certified single-column key discovery per table.
+Phase 3: `discover_joins` — certified foreign-key join discovery across tables.
+Later phases (entity typing, measure/dimension proposal, the
+`discover_semantic_model` orchestrator) build on these.
 """
 from __future__ import annotations
 
+from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
 from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
 
-__all__ = ["KeyCandidate", "discover_keys"]
+__all__ = ["JoinCandidate", "KeyCandidate", "discover_joins", "discover_keys"]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/entities.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/entities.py
@@ -1,0 +1,306 @@
+"""Cross-table entity-type discovery (semantic-model discovery, Phase 2).
+
+Which source tables describe the same real-world THING. `customers`, `app_users`, and
+`crm_contacts` are three surfaces of one `Person` entity; `orders` and `line_items` are
+transactions, not entities. Grouping tables into entity types is what lets the later
+phases conform a shared key and propose one dimension per real entity instead of one per
+table.
+
+Two complementary signals decide it (spec Phase 2 — "resolved-entity overlap +
+column-semantic signature"):
+
+  * **Column-semantic signature (the cheap, deterministic backbone).** Each table's
+    columns canonicalize to semantic tokens (`first_name`/`email`/`zip`/… via the shared
+    `schema_match` synonym map, plus the profiled `col_type`). Two tables with a high
+    Jaccard overlap of tokens describe the same kind of thing.
+  * **Value overlap (the ER-flavored corroboration).** If two tables share an
+    identifier/email-shaped column whose *values* substantially overlap, they realize the
+    same population — a strong same-entity signal that also merges tables whose column
+    names differ.
+
+Tables are unioned into entity types by either signal; each type is named from its
+dominant semantic hint (`person` / `organization` / …) or falls back to `entity_N`.
+
+Advisory only — it proposes the entity typing; a human approves. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.core.schema_match import _SYNONYM_MAP
+from goldenmatch.semantic.discovery.joins import _distinct_nonnull
+from goldenmatch.semantic.discovery.keys import KeyCandidate
+
+# Two tables describe the same entity type when their semantic-token signatures overlap
+# at least this much (Jaccard).
+_DEFAULT_MIN_SIMILARITY = 0.5
+# A shared identifier/email column whose values overlap at least this much is a
+# same-population (same-entity) signal on its own.
+_DEFAULT_MIN_VALUE_OVERLAP = 0.5
+# The value-overlap signal only means "same entity" when the shared column is the
+# IDENTITY of BOTH tables (each near-unique) — i.e. the same population enumerated
+# twice. If it is near-unique on one side and repeats on the other, that's a
+# foreign-key REFERENCE (a Phase-3 join), not sameness. This is the cardinality floor
+# that separates the two.
+_NEAR_UNIQUE_RATIO = 0.95
+
+# Semantic tokens that name an entity type. First match (in order) wins.
+_ENTITY_NAME_HINTS: list[tuple[str, frozenset[str]]] = [
+    ("person", frozenset({"first_name", "last_name", "dob", "gender"})),
+    ("organization", frozenset({"company"})),
+]
+# Column tokens/col_types whose VALUES carry cross-table identity (used for the
+# value-overlap signal — a shared email/id links populations; a shared city does not).
+_IDENTITY_TOKENS = frozenset({"email", "phone", "id"})
+_IDENTITY_COL_TYPES = frozenset({"identifier", "email", "phone"})
+
+
+@dataclass
+class EntityType:
+    """A real-world entity type realized by one or more source tables.
+
+    `tables` are the surfaces of this entity; `signature` is the shared semantic-token
+    backbone; `key_by_table` records the best certified key per table (when the caller
+    supplied per-table keys) — the conformance anchor the later phases join on.
+    """
+
+    name: str
+    tables: list[str]
+    signature: list[str] = field(default_factory=list)
+    key_by_table: dict[str, str] = field(default_factory=dict)
+    signals: list[str] = field(default_factory=list)
+    confidence: float = 0.0
+
+    @property
+    def is_multi_table(self) -> bool:
+        """True when the entity type is realized by more than one table — the case where
+        conforming a shared key actually buys something."""
+        return len(self.tables) > 1
+
+
+def _canonical_token(name: str) -> str:
+    return _SYNONYM_MAP.get(name.lower(), name.lower())
+
+
+def _signature(table: Any) -> tuple[set[str], dict[str, str]]:
+    """The table's semantic-token signature + a `{token: col_type}` map."""
+    from goldenmatch.core.autoconfig import profile_columns
+    from goldenmatch.core.frame import to_frame
+
+    tokens: set[str] = set()
+    token_types: dict[str, str] = {}
+    try:
+        col_types = {p.name: p.col_type for p in profile_columns(table)}
+    except Exception:  # noqa: BLE001 - profiling is advisory
+        col_types = {}
+    try:
+        cols = [c for c in to_frame(table).columns if not c.startswith("__")]
+    except Exception:  # noqa: BLE001
+        cols = list(col_types)
+    for col in cols:
+        tok = _canonical_token(col)
+        tokens.add(tok)
+        ct = col_types.get(col)
+        if ct:
+            token_types[tok] = ct
+    return tokens, token_types
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _value_overlap(t1: Any, c1: str, t2: Any, c2: str) -> float:
+    """Symmetric value overlap of two columns (min-normalized containment)."""
+    v1, v2 = _distinct_nonnull(t1, c1), _distinct_nonnull(t2, c2)
+    if not v1 or not v2:
+        return 0.0
+    return len(v1 & v2) / min(len(v1), len(v2))
+
+
+def _is_near_unique(table: Any, column: str) -> bool:
+    """True when a column is the identity of its table (distinct ≈ row count) — so a
+    value overlap on it means same population, not a foreign-key reference."""
+    from goldenmatch.core.frame import to_frame
+
+    try:
+        height = to_frame(table).height
+    except Exception:  # noqa: BLE001
+        return False
+    if height == 0:
+        return False
+    return len(_distinct_nonnull(table, column)) / height >= _NEAR_UNIQUE_RATIO
+
+
+def _identity_columns(table: Any, token_types: dict[str, str]) -> list[str]:
+    """Columns whose VALUES carry cross-table identity (email/phone/id-shaped)."""
+    from goldenmatch.core.frame import to_frame
+
+    try:
+        cols = [c for c in to_frame(table).columns if not c.startswith("__")]
+    except Exception:  # noqa: BLE001
+        return []
+    out: list[str] = []
+    for col in cols:
+        tok = _canonical_token(col)
+        if tok in _IDENTITY_TOKENS or token_types.get(tok) in _IDENTITY_COL_TYPES:
+            out.append(col)
+    return out
+
+
+def _name_for(signature: set[str]) -> str | None:
+    for label, hints in _ENTITY_NAME_HINTS:
+        if signature & hints:
+            return label
+    return None
+
+
+def _best_key(entry: Any) -> str | None:
+    """The best (trustworthy) single-column key from a per-table entry — the
+    conformance anchor. Prefers a candidate carrying the `identifier` signal (a real
+    id column) over an incidental unique field, then falls back to the top rank."""
+    if entry is None:
+        return None
+    if isinstance(entry, KeyCandidate):
+        entry = [entry]
+    if isinstance(entry, str):
+        return entry
+    trustworthy = [
+        item for item in entry
+        if isinstance(item, KeyCandidate) and len(item.columns) == 1 and item.is_trustworthy
+    ]
+    for item in trustworthy:
+        if "identifier" in item.signals:
+            return item.columns[0]
+    if trustworthy:
+        return trustworthy[0].columns[0]
+    for item in entry:
+        if isinstance(item, str):
+            return item
+    return None
+
+
+def discover_entity_types(
+    tables: dict[str, Any],
+    *,
+    keys: dict[str, Any] | None = None,
+    min_similarity: float = _DEFAULT_MIN_SIMILARITY,
+    min_value_overlap: float = _DEFAULT_MIN_VALUE_OVERLAP,
+) -> list[EntityType]:
+    """Group source tables into the real-world entity types they realize.
+
+    Args:
+        tables: `{table_name: table}` — the source tables.
+        keys: optional `{table_name: keys}` (the `discover_keys` output, a
+            `KeyCandidate`, or a column name) — used to record the conformance key per
+            table on each `EntityType`.
+        min_similarity: Jaccard threshold on semantic-token signatures for two tables
+            to be the same entity type.
+        min_value_overlap: value-overlap threshold on a shared identity column for two
+            tables to be the same entity type (the ER-flavored signal).
+
+    Returns:
+        `EntityType`s ranked multi-table-first (the ones where conforming a shared key
+        matters), then by confidence, then name. A single isolated table still yields
+        its own single-table entity type.
+    """
+    keys = keys or {}
+    names = list(tables)
+    sigs: dict[str, set[str]] = {}
+    sig_types: dict[str, dict[str, str]] = {}
+    for name in names:
+        s, st = _signature(tables[name])
+        sigs[name] = s
+        sig_types[name] = st
+
+    # Union-find over the two same-entity signals.
+    parent = {n: n for n in names}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[max(ra, rb)] = min(ra, rb)
+
+    edge_signals: dict[frozenset[str], set[str]] = {}
+    for i, a in enumerate(names):
+        for b in names[i + 1:]:
+            linked: set[str] = set()
+            if _jaccard(sigs[a], sigs[b]) >= min_similarity:
+                linked.add("signature")
+            # value overlap on a shared identity column
+            a_ids = _identity_columns(tables[a], sig_types[a])
+            b_ids = _identity_columns(tables[b], sig_types[b])
+            for ca in a_ids:
+                if not _is_near_unique(tables[a], ca):
+                    continue  # an FK, not this table's identity → a join, not sameness
+                for cb in b_ids:
+                    if not _is_near_unique(tables[b], cb):
+                        continue
+                    if _value_overlap(tables[a], ca, tables[b], cb) >= min_value_overlap:
+                        linked.add("value_overlap")
+                        break
+                if "value_overlap" in linked:
+                    break
+            if linked:
+                union(a, b)
+                edge_signals[frozenset({a, b})] = linked
+
+    # Assemble components into entity types.
+    groups: dict[str, list[str]] = {}
+    for n in names:
+        groups.setdefault(find(n), []).append(n)
+
+    entity_types: list[EntityType] = []
+    used_names: set[str] = set()
+    for idx, members in enumerate(sorted(groups.values(), key=lambda g: (-len(g), g))):
+        members = sorted(members)
+        shared = set.intersection(*(sigs[m] for m in members)) if members else set()
+        signals: set[str] = set()
+        for e in edge_signals:
+            if e <= set(members):
+                signals |= edge_signals[e]
+        # confidence: mean pairwise signature Jaccard within the group (1.0 for a lone
+        # table, which is trivially self-consistent), lifted when value-overlap corroborates.
+        if len(members) == 1:
+            conf = 1.0
+        else:
+            pair_scores = [
+                _jaccard(sigs[a], sigs[b])
+                for i, a in enumerate(members) for b in members[i + 1:]
+            ]
+            conf = sum(pair_scores) / len(pair_scores) if pair_scores else 0.0
+            if "value_overlap" in signals:
+                conf = min(1.0, conf + 0.2)
+        label = _name_for(shared) or _name_for(set().union(*(sigs[m] for m in members)))
+        if label is None or label in used_names:
+            label = label or "entity"
+            label = f"{label}_{idx + 1}" if label in used_names else label
+        used_names.add(label)
+        key_by_table = {}
+        for m in members:
+            k = _best_key(keys.get(m))
+            if k is not None:
+                key_by_table[m] = k
+        entity_types.append(
+            EntityType(
+                name=label,
+                tables=members,
+                signature=sorted(shared),
+                key_by_table=key_by_table,
+                signals=sorted(signals),
+                confidence=round(conf, 4),
+            )
+        )
+
+    entity_types.sort(key=lambda e: (not e.is_multi_table, -e.confidence, e.name))
+    return entity_types

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py
@@ -1,0 +1,263 @@
+"""Certified join / foreign-key discovery (semantic-model discovery, Phase 3).
+
+Given a set of source tables and the certified keys discovered per table (Phase 1
+`discover_keys`), PROPOSE the foreign-key joins between them and — the differentiator
+— PROVE each join's cardinality against the data with the SAME certifier the certify
+wedge uses. So a discovered join comes **pre-graded**: a `JoinCandidate` carries the
+trust verdict on its "one" side (is the referenced key actually unique at grain?), not
+just a structural guess.
+
+Discovery is hypothesis generation; certification is the falsification test:
+
+  * **FK inference (the hypothesis).** A column in table B whose non-null values are a
+    SUBSET of table A's certified key values — and whose semantic type is compatible —
+    is a candidate foreign key `B.fk -> A.key`, a `many_to_one` join (many B rows point
+    at one A row).
+  * **Cardinality certification (the test).** The join is only sound if the "one" side
+    (A's key) is genuinely unique at grain — otherwise a metric joined across it
+    fans out and double-counts. That's exactly what `certify_cube_joins` checks, so the
+    proposed join is re-proven in join context via a minimal `Cube` model.
+
+Scoped to SINGLE-column foreign keys referencing the caller-supplied per-table keys;
+compound FKs and self-referential joins are documented follow-ons. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+
+Design: advisory only — it proposes + grades; a human approves. Never a black box.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.discovery.keys import _NON_KEY_COL_TYPES, KeyCandidate
+
+# A candidate FK column must carry real referential signal: enough distinct values to
+# be a key reference, not a near-constant flag that trivially sits inside any key set.
+_DEFAULT_MIN_FK_DISTINCT = 2
+# The referenced key values a candidate FK covers must be a genuine containment, not a
+# one-row accident. Require the FK's distinct values to be a (near-)subset of the key.
+_DEFAULT_MIN_CONTAINMENT = 1.0
+
+
+@dataclass
+class JoinCandidate:
+    """A proposed foreign-key join between two tables, already certified.
+
+    `B.fk_column -> A.key_column` as a `many_to_one` join. `certificate` grades the
+    "one" side (A's referenced key): the join is only trustworthy if that key is
+    genuinely unique at grain. `signals` records the corroborating evidence
+    (`value_subset` always; `type_match` when the FK and key share a semantic type).
+    """
+
+    from_table: str          # the "many" side — holds the foreign key
+    from_column: str         # the foreign-key column on the many side
+    to_table: str            # the "one" side — holds the referenced key
+    to_column: str           # the referenced (certified) key column
+    relationship: str        # always "many_to_one" for this slice
+    certificate: KeyIntegrityCertificate  # the proof on the one-side key
+    signals: list[str] = field(default_factory=list)
+    containment: float = 1.0  # fraction of the FK's distinct values found in the key
+    fk_null_rate: float = 0.0  # coverage context: how many many-side rows have no FK
+    _profile: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_trustworthy(self) -> bool:
+        """The certifier's advisory pass/fail on the join's one-side key — unique at
+        grain, no fan-out. An untrustworthy join would silently double-count a metric."""
+        return self.certificate.is_trustworthy()
+
+    @property
+    def score(self) -> float:
+        """Ranking score in [0, 1]: the one-side key's structural cleanliness,
+        rewarded for corroborating signals + full containment. Trustworthiness is the
+        primary sort key (see `discover_joins`); this breaks ties."""
+        base = self.certificate.estimate
+        bonus = 0.025 * (len(self.signals) - 1) + 0.025 * (self.containment >= 1.0)
+        return min(1.0, base + bonus)
+
+
+def _distinct_nonnull(table: Any, column: str) -> set:
+    """Distinct non-null values of a column, as a set (best-effort; empty on error)."""
+    from goldenmatch.core.frame import to_frame
+
+    try:
+        frame = to_frame(table)
+        if column not in frame.columns:
+            return set()
+        col = frame.column(column)
+        return {v for v in col.drop_nulls().unique().to_list() if v is not None}
+    except Exception:  # noqa: BLE001 - a bad column never breaks the sweep
+        return set()
+
+
+def _null_rate(table: Any, column: str) -> float:
+    from goldenmatch.core.frame import to_frame
+
+    try:
+        frame = to_frame(table)
+        if column not in frame.columns or frame.height == 0:
+            return 0.0
+        col = frame.column(column)
+        return col.null_count() / len(col)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _key_columns(entry: Any) -> list[tuple[str, KeyCandidate | None]]:
+    """Normalize a per-table `keys` entry into `[(column, candidate_or_None)]`.
+
+    Accepts the output of `discover_keys` (`list[KeyCandidate]`), a single
+    `KeyCandidate`, a bare column name, or a list of column names — so a caller can
+    hand us either graded candidates or plain declared keys.
+    """
+    if entry is None:
+        return []
+    if isinstance(entry, KeyCandidate):
+        entry = [entry]
+    if isinstance(entry, str):
+        return [(entry, None)]
+    out: list[tuple[str, KeyCandidate | None]] = []
+    for item in entry:
+        if isinstance(item, KeyCandidate):
+            # single-column keys only for this slice
+            if len(item.columns) == 1:
+                out.append((item.columns[0], item))
+        elif isinstance(item, str):
+            out.append((item, None))
+    return out
+
+
+def discover_joins(
+    tables: dict[str, Any],
+    keys: dict[str, Any],
+    *,
+    resolve: bool = False,
+    min_fk_distinct: int = _DEFAULT_MIN_FK_DISTINCT,
+    min_containment: float = _DEFAULT_MIN_CONTAINMENT,
+    max_candidates: int = 64,
+) -> list[JoinCandidate]:
+    """Propose and certify foreign-key joins across a set of tables.
+
+    Args:
+        tables: `{table_name: table}` — the source tables (any input
+            `certify_key_integrity` accepts).
+        keys: `{table_name: keys}` — the referenced ("one" side) keys per table.
+            Each value may be the `discover_keys` output (`list[KeyCandidate]`), a
+            single `KeyCandidate`, a column name, or a list of column names. Only
+            single-column keys are used as join targets in this slice; a `KeyCandidate`
+            that is not trustworthy is skipped (an unsound grain makes an unsound join).
+        resolve: forwarded to `certify_cube_joins` — also measures entity
+            fragmentation / undercount on the one-side key via ER (fail-open).
+        min_fk_distinct: minimum distinct non-null values for a column to be a
+            candidate foreign key (filters near-constant flags).
+        min_containment: minimum fraction of the FK's distinct values that must be
+            found in the referenced key set (1.0 = strict subset).
+        max_candidates: cap on returned candidates.
+
+    Returns:
+        `JoinCandidate`s ranked trustworthy-first, then by `score` (cleaner one-side
+        key), then lower fan-out, then more corroborating signals. A join whose
+        one-side key does NOT certify unique is returned flagged
+        `is_trustworthy == False` — the loud signal that joining across it double-counts.
+    """
+    from goldenmatch.core.autoconfig import profile_columns
+    from goldenmatch.semantic.cube import Cube, CubeJoin, certify_cube_joins
+
+    # Profile every table once, so the semantic-type match is cheap.
+    col_types: dict[str, dict[str, str]] = {}
+    for name, table in tables.items():
+        try:
+            col_types[name] = {p.name: p.col_type for p in profile_columns(table)}
+        except Exception:  # noqa: BLE001 - profiling is advisory; type_match just won't fire
+            col_types[name] = {}
+
+    candidates: list[JoinCandidate] = []
+    for to_table, key_entry in keys.items():
+        if to_table not in tables:
+            continue
+        for key_col, key_cand in _key_columns(key_entry):
+            # An unsound grain makes an unsound join — skip a graded-but-untrustworthy
+            # target key (a plain declared column, candidate None, is trusted to the
+            # certifier below).
+            if key_cand is not None and not key_cand.is_trustworthy:
+                continue
+            key_values = _distinct_nonnull(tables[to_table], key_col)
+            if len(key_values) < min_fk_distinct:
+                continue
+            key_type = col_types.get(to_table, {}).get(key_col)
+
+            for from_table, source in tables.items():
+                if from_table == to_table:
+                    continue  # self-joins are a documented follow-on
+                from goldenmatch.core.frame import to_frame
+
+                try:
+                    source_cols = to_frame(source).columns
+                except Exception:  # noqa: BLE001
+                    continue
+                for fk_col in source_cols:
+                    fk_values = _distinct_nonnull(source, fk_col)
+                    if len(fk_values) < min_fk_distinct:
+                        continue
+                    # A pure measure/date/geo column is a value, not a reference.
+                    fk_type = col_types.get(from_table, {}).get(fk_col)
+                    if fk_type in _NON_KEY_COL_TYPES:
+                        continue
+                    contained = len(fk_values & key_values)
+                    containment = contained / len(fk_values)
+                    if containment < min_containment:
+                        continue
+
+                    signals = ["value_subset"]
+                    if key_type is not None and fk_type == key_type:
+                        signals.append("type_match")
+
+                    # Re-prove the one-side key's cardinality IN JOIN CONTEXT.
+                    many = Cube(
+                        name=from_table,
+                        joins=[CubeJoin(
+                            name=to_table,
+                            relationship="many_to_one",
+                            sql=f"{{CUBE}}.{fk_col} = {{{to_table}.{key_col}}}",
+                        )],
+                    )
+                    try:
+                        certified = certify_cube_joins(
+                            [many], {from_table: source, to_table: tables[to_table]},
+                            resolve=resolve,
+                        )
+                    except Exception:  # noqa: BLE001 - a bad pair never breaks the sweep
+                        continue
+                    if not certified:
+                        continue
+                    cert = certified[0]["certificate"]
+                    candidates.append(
+                        JoinCandidate(
+                            from_table=from_table,
+                            from_column=fk_col,
+                            to_table=to_table,
+                            to_column=key_col,
+                            relationship="many_to_one",
+                            certificate=cert,
+                            signals=signals,
+                            containment=containment,
+                            fk_null_rate=_null_rate(source, fk_col),
+                            _profile={"fk_type": fk_type, "key_type": key_type},
+                        )
+                    )
+
+    # Trustworthy first, then cleaner one-side key (score desc), then lower fan-out,
+    # then more corroborating signals, then names for determinism.
+    candidates.sort(
+        key=lambda j: (
+            not j.is_trustworthy,
+            -j.score,
+            j.certificate.max_fan_out,
+            -len(j.signals),
+            j.from_table,
+            j.from_column,
+            j.to_table,
+        )
+    )
+    return candidates[:max_candidates]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/keys.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/keys.py
@@ -1,0 +1,185 @@
+"""Certified key discovery (semantic-model discovery, Phase 1).
+
+The generative half of the semantic wedge: given a source table, PROPOSE its
+candidate entity keys and — the differentiator — PROVE each one against the data
+with `certify_key_integrity`. So a discovered key comes **pre-graded**: a
+`KeyCandidate` carries the trust verdict, not just a guess.
+
+Discovery is hypothesis generation; certification is the falsification test. Three
+cheap signals propose candidates; the certifier decides which are real:
+
+  * **identifier** — the column classifies as an id (`col_type == "identifier"`).
+  * **cardinality** — near-unique (`cardinality_ratio >= min_cardinality`), the
+    shape of a primary key.
+  * **fd** — a functional-dependency determinant (`fd_identity_scores`): a column
+    that determines the rest of the row is, by construction, a key backbone. (FD
+    discovery excludes perfectly-unique columns as trivial, so it COMPLEMENTS the
+    cardinality signal rather than duplicating it.)
+
+Every proposed column is then certified: unique at grain? measure fan-out? The
+result is ranked trustworthy-first. Scoped to SINGLE-column keys for this slice;
+compound/grain-ambiguous keys are a documented follow-on (see the design spec
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`).
+
+Design: advisory only — it proposes + grades; a human approves. Never a black box.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+
+# A near-unique column is primary-key-shaped. 0.9 (not 1.0) admits keys with a few
+# dup rows so the certifier can REPORT the fan-out rather than the candidate being
+# silently dropped before it's graded.
+_DEFAULT_MIN_CARDINALITY = 0.9
+# A functional-dependency determinant is only a key-backbone signal when the FD is
+# (near-)strict; a weak approximate FD is a dimension, not a key.
+_DEFAULT_FD_MIN_CONFIDENCE = 0.98
+
+# An entity key is not a measure or a timestamp. A numeric/date/geo/description
+# column that happens to be unique in a small sample is a MEASURE or attribute, not
+# a key — so the cardinality signal skips these col_types. (The `identifier` and
+# `fd` signals are unaffected; a genuine id classifies as `identifier`.)
+_NON_KEY_COL_TYPES = frozenset({"numeric", "date", "geo", "description"})
+
+
+@dataclass
+class KeyCandidate:
+    """A proposed entity key for a table, already certified against the data.
+
+    `signals` records which cheap heuristics proposed it (`identifier` /
+    `cardinality` / `fd`); `certificate` is the proof. The candidate is only
+    trustworthy if the certifier says so — the signals are hypotheses, not verdicts.
+    """
+
+    columns: list[str]
+    signals: list[str]
+    certificate: KeyIntegrityCertificate
+    fd_confidence: float | None = None  # the FD determinant strength, when the fd signal fired
+    _profile: dict[str, Any] = field(default_factory=dict)  # cardinality_ratio / null_rate for context
+
+    @property
+    def is_trustworthy(self) -> bool:
+        """The certifier's advisory pass/fail — unique at grain, no fan-out."""
+        return self.certificate.is_trustworthy()
+
+    @property
+    def score(self) -> float:
+        """Ranking score in [0, 1]: the structural cleanliness estimate, lightly
+        rewarded for corroborating signals. Trustworthiness is the primary sort
+        key (see `discover_keys`); this breaks ties among same-verdict candidates."""
+        base = self.certificate.estimate
+        # up to +0.05 for multiple corroborating signals (bounded, never overtakes
+        # a genuinely cleaner key).
+        return min(1.0, base + 0.025 * (len(self.signals) - 1))
+
+
+def _to_polars(table: Any):
+    """Best-effort polars view for the FD signal, which is polars-typed. Returns
+    None when polars is unavailable or the table can't be coerced (the fd signal is
+    then skipped — fail-open, the other two signals still fire)."""
+    try:
+        import polars as pl
+    except ImportError:
+        return None
+    try:
+        if isinstance(table, pl.DataFrame):
+            return table
+        import pyarrow as pa
+
+        if isinstance(table, pa.Table):
+            return pl.from_arrow(table)
+        return pl.DataFrame(table)
+    except Exception:  # noqa: BLE001 - fd is advisory; never break discovery
+        return None
+
+
+def discover_keys(
+    table: Any,
+    *,
+    min_cardinality: float = _DEFAULT_MIN_CARDINALITY,
+    fd_min_confidence: float = _DEFAULT_FD_MIN_CONFIDENCE,
+    max_candidates: int = 8,
+) -> list[KeyCandidate]:
+    """Propose and certify single-column entity keys for one table.
+
+    Args:
+        table: the source table (pyarrow / polars / pandas / dict) — same inputs
+            `certify_key_integrity` accepts.
+        min_cardinality: near-unique threshold for the cardinality signal.
+        fd_min_confidence: minimum FD determinant strength for the fd signal.
+        max_candidates: cap on returned candidates.
+
+    Returns:
+        `KeyCandidate`s ranked trustworthy-first, then by `score` (cleaner keys),
+        then fan-out (lower is better), then signal count. A table with no clean
+        key returns candidates all flagged `is_trustworthy == False` — the loud
+        signal that a metric on this grain would double-count.
+    """
+    from goldenmatch.core.autoconfig import profile_columns
+    from goldenmatch.core.quality import fd_identity_scores
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    pl_frame = _to_polars(table)
+    # profile_columns coerces via the Frame seam (accepts arrow/polars); prefer the
+    # polars view when we have it so profiling + FD see the same frame.
+    profiles = profile_columns(pl_frame if pl_frame is not None else table)
+    by_name = {p.name: p for p in profiles}
+
+    # signal -> per-column. Single-column candidates only for this slice.
+    signals: dict[str, set[str]] = {}
+    for p in profiles:
+        col_signals: set[str] = set()
+        if p.col_type == "identifier":
+            col_signals.add("identifier")
+        if p.cardinality_ratio >= min_cardinality and p.col_type not in _NON_KEY_COL_TYPES:
+            col_signals.add("cardinality")
+        if col_signals:
+            signals.setdefault(p.name, set()).update(col_signals)
+
+    # FD signal (fail-open): a strong determinant is a key backbone. FD discovery
+    # excludes cardinality-1.0 columns, so this ADDS anchors the cardinality signal
+    # can't see — but only admit strict-ish FDs as *key* candidates.
+    fd_conf: dict[str, float] = {}
+    fd_scores = fd_identity_scores(pl_frame) if pl_frame is not None else None
+    if fd_scores:
+        for det, conf in fd_scores.items():
+            if det in by_name and conf >= fd_min_confidence:
+                signals.setdefault(det, set()).add("fd")
+                fd_conf[det] = conf
+
+    candidates: list[KeyCandidate] = []
+    for col, sigs in signals.items():
+        try:
+            cert = certify_key_integrity(table, key=col)
+        except Exception:  # noqa: BLE001 - a bad column never breaks the sweep
+            continue
+        prof = by_name.get(col)
+        candidates.append(
+            KeyCandidate(
+                columns=[col],
+                signals=sorted(sigs),
+                certificate=cert,
+                fd_confidence=fd_conf.get(col),
+                _profile=(
+                    {"cardinality_ratio": prof.cardinality_ratio, "null_rate": prof.null_rate}
+                    if prof is not None
+                    else {}
+                ),
+            )
+        )
+
+    # Trustworthy first, then cleaner (score desc), then lower fan-out, then more
+    # corroborating signals, then name for determinism.
+    candidates.sort(
+        key=lambda k: (
+            not k.is_trustworthy,
+            -k.score,
+            k.certificate.max_fan_out,
+            -len(k.signals),
+            k.columns[0],
+        )
+    )
+    return candidates[:max_candidates]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/measures.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/measures.py
@@ -1,0 +1,164 @@
+"""Measure & dimension proposal (semantic-model discovery, Phase 4).
+
+Given a table and its grain (a Phase-1 key), propose the MEASURES and DIMENSIONS a
+semantic model would declare over it — and, the differentiator, gate each measure's
+`SUM`-safety on the grain key's CERTIFICATE. A metric summed over a grain that fans out
+double-counts; the Phase-1 fan-out verdict is exactly what tells us whether a `SUM` is
+sound, so the certifier that graded the key directly grades the measures.
+
+  * **Measures.** Numeric columns → propose aggregations. `COUNT`/`AVG`/`MIN`/`MAX` are
+    always safe (order-independent of grain fan-out). `SUM` is proposed ONLY when the
+    grain key certified clean (`max_fan_out == 1.0`); on a fanned-out grain the measure
+    is returned with `safe_to_sum == False` and `SUM` withheld — the loud "this would
+    double-count" signal.
+  * **Dimensions.** Low-cardinality categorical columns, dates, and geo columns — the
+    attributes you group/slice by. High-cardinality free text and the grain/id columns
+    themselves are not dimensions.
+  * **Grain.** The certified key from Phase 1.
+
+Advisory only — it proposes; a human approves. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
+from goldenmatch.semantic.discovery.keys import KeyCandidate
+
+# A categorical column is a dimension when it is low-cardinality enough to group by.
+_DEFAULT_MAX_DIM_CARDINALITY = 0.5
+# Aggregations that are always sound regardless of grain fan-out (they don't accumulate
+# across duplicated rows the way SUM does).
+_FANOUT_SAFE_AGGS = ("count", "avg", "min", "max")
+# col_types that are dimensions by nature (grouped/sliced, never summed).
+_DIMENSION_COL_TYPES = frozenset({"date", "geo"})
+# col_types that are neither measures nor dimensions on their own (keys / references /
+# free text handled elsewhere).
+_CATEGORICAL_EXCLUDED = frozenset({"numeric", "identifier", "description"})
+
+
+@dataclass
+class Measure:
+    """A proposed numeric measure over a table, with its grain-gated SUM-safety."""
+
+    column: str
+    aggregations: list[str]  # the proposed aggregations (SUM present only when safe)
+    safe_to_sum: bool        # True only when the grain key certified clean
+    grain: list[str] = field(default_factory=list)
+    reason: str = ""
+
+
+@dataclass
+class Dimension:
+    """A proposed dimension (group-by / slice attribute)."""
+
+    column: str
+    kind: str  # "categorical" | "date" | "geo"
+    cardinality_ratio: float = 0.0
+
+
+@dataclass
+class TableMeasures:
+    """The measures + dimensions proposed for one table at a certified grain."""
+
+    table: str
+    grain: list[str]
+    grain_trustworthy: bool
+    measures: list[Measure] = field(default_factory=list)
+    dimensions: list[Dimension] = field(default_factory=list)
+
+
+def _grain_spec(key: Any) -> tuple[list[str], KeyIntegrityCertificate | None]:
+    """Normalize a grain key into `(columns, certificate_or_None)`."""
+    if key is None:
+        return [], None
+    if isinstance(key, KeyCandidate):
+        return list(key.columns), key.certificate
+    if isinstance(key, str):
+        return [key], None
+    if isinstance(key, (list, tuple)):
+        return [str(c) for c in key], None
+    return [], None
+
+
+def discover_measures(
+    table: Any,
+    *,
+    key: Any = None,
+    grain_certificate: KeyIntegrityCertificate | None = None,
+    table_name: str = "table",
+    max_dim_cardinality: float = _DEFAULT_MAX_DIM_CARDINALITY,
+) -> TableMeasures:
+    """Propose measures + dimensions for one table at a certified grain.
+
+    Args:
+        table: the source table (any input `profile_columns` accepts).
+        key: the grain key — a `KeyCandidate` (carries its own certificate), a column
+            name, or a list of columns. When a `KeyCandidate` is passed its certificate
+            gates `SUM`-safety; otherwise pass `grain_certificate` explicitly.
+        grain_certificate: the grain key's certificate, when `key` is not a
+            `KeyCandidate`. If neither is available the grain is treated as untrusted
+            and no measure is proposed `SUM`-safe (conservative).
+        table_name: label recorded on the result.
+        max_dim_cardinality: a categorical column is a dimension only at or below this
+            cardinality ratio.
+
+    Returns:
+        A `TableMeasures` with grain-gated measures and dimensions. A measure over a
+        fanned-out grain is returned with `safe_to_sum == False` and `SUM` withheld.
+    """
+    from goldenmatch.core.autoconfig import profile_columns
+
+    grain_cols, cert = _grain_spec(key)
+    if grain_certificate is not None:
+        cert = grain_certificate
+    grain_trustworthy = bool(cert is not None and cert.is_trustworthy())
+    grain_set = set(grain_cols)
+
+    try:
+        profiles = profile_columns(table)
+    except Exception:  # noqa: BLE001 - proposal is advisory; empty on profiling failure
+        return TableMeasures(table_name, grain_cols, grain_trustworthy)
+
+    measures: list[Measure] = []
+    dimensions: list[Dimension] = []
+    for p in profiles:
+        if p.name in grain_set:
+            continue  # the grain is neither a measure nor a dimension
+        if p.col_type == "numeric":
+            aggs = list(_FANOUT_SAFE_AGGS)
+            if grain_trustworthy:
+                aggs = ["sum", *aggs]
+                reason = "grain certified unique at grain — SUM is sound"
+            else:
+                reason = (
+                    "grain fans out (or grain unknown) — SUM withheld, would double-count"
+                )
+            measures.append(
+                Measure(
+                    column=p.name,
+                    aggregations=aggs,
+                    safe_to_sum=grain_trustworthy,
+                    grain=list(grain_cols),
+                    reason=reason,
+                )
+            )
+        elif p.col_type in _DIMENSION_COL_TYPES:
+            dimensions.append(Dimension(p.name, p.col_type, p.cardinality_ratio))
+        elif (
+            p.col_type not in _CATEGORICAL_EXCLUDED
+            and p.cardinality_ratio <= max_dim_cardinality
+        ):
+            dimensions.append(Dimension(p.name, "categorical", p.cardinality_ratio))
+
+    measures.sort(key=lambda m: (not m.safe_to_sum, m.column))
+    dimensions.sort(key=lambda d: (d.kind, d.column))
+    return TableMeasures(
+        table=table_name,
+        grain=grain_cols,
+        grain_trustworthy=grain_trustworthy,
+        measures=measures,
+        dimensions=dimensions,
+    )

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -1,0 +1,241 @@
+"""Semantic-model discovery orchestrator (Phase 5) — the front door.
+
+`discover_semantic_model(tables)` assembles the four discovery phases into a single
+DRAFT semantic model where **every key is already graded by the certifier**:
+
+  1. `discover_keys` per table  → the grain of each table (Phase 1).
+  2. `discover_entity_types`     → which tables are surfaces of the same real thing (Phase 2).
+  3. `discover_joins`            → the certified foreign-key graph (Phase 3).
+  4. `discover_measures`         → grain-gated measures + dimensions per table (Phase 4).
+
+The draft is emitted through the EXISTING dialect emitters (MetricFlow for this slice)
+and then re-certified end-to-end with `certify_semantic_model`, so the deliverable is a
+normal MetricFlow file plus a verdict-rich certification report — the same shared
+`certification_report_dict` shape the certify surface emits. Nothing auto-ships: the
+human reviews the graded draft in their catalog.
+
+The reason to trust this over a pure-LLM proposal is not that the guesses are cleverer —
+it's that each guess is PROVEN against the data before you see it. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
+from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
+from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
+from goldenmatch.semantic.discovery.measures import (
+    Dimension,
+    Measure,
+    TableMeasures,
+    discover_measures,
+)
+
+_SUPPORTED_DIALECTS = frozenset({"metricflow"})
+
+
+@dataclass
+class ProposedTable:
+    """One table's discovered semantic shape: its certified grain, entity type, and
+    grain-gated measures + dimensions."""
+
+    table: str
+    entity_type: str | None
+    key: KeyCandidate | None
+    measures: list[Measure] = field(default_factory=list)
+    dimensions: list[Dimension] = field(default_factory=list)
+
+    @property
+    def grain(self) -> list[str]:
+        return list(self.key.columns) if self.key is not None else []
+
+    @property
+    def grain_trustworthy(self) -> bool:
+        return bool(self.key is not None and self.key.is_trustworthy)
+
+
+@dataclass
+class ProposedModel:
+    """A draft semantic model discovered from source tables, pre-graded by the certifier.
+
+    `yaml` is the emitted (MetricFlow) model; `certification` is the verdict-rich
+    `certification_report_dict` over that model — `all_trustworthy` is the headline
+    build-gate signal.
+    """
+
+    dialect: str
+    tables: list[ProposedTable]
+    entity_types: list[EntityType]
+    joins: list[JoinCandidate]
+    yaml: str = ""
+    certification: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def all_trustworthy(self) -> bool:
+        """True when every certified key in the emitted model is unique at grain."""
+        return bool(self.certification.get("all_trustworthy", False))
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable view — the shape the MCP/REST discover surfaces emit."""
+        return {
+            "dialect": self.dialect,
+            "all_trustworthy": self.all_trustworthy,
+            "tables": [
+                {
+                    "table": t.table,
+                    "entity_type": t.entity_type,
+                    "grain": t.grain,
+                    "grain_trustworthy": t.grain_trustworthy,
+                    "measures": [
+                        {
+                            "column": m.column,
+                            "aggregations": m.aggregations,
+                            "safe_to_sum": m.safe_to_sum,
+                        }
+                        for m in t.measures
+                    ],
+                    "dimensions": [
+                        {"column": d.column, "kind": d.kind} for d in t.dimensions
+                    ],
+                }
+                for t in self.tables
+            ],
+            "entity_types": [
+                {
+                    "name": e.name,
+                    "tables": e.tables,
+                    "signature": e.signature,
+                    "key_by_table": e.key_by_table,
+                    "confidence": e.confidence,
+                }
+                for e in self.entity_types
+            ],
+            "joins": [
+                {
+                    "from_table": j.from_table,
+                    "from_column": j.from_column,
+                    "to_table": j.to_table,
+                    "to_column": j.to_column,
+                    "relationship": j.relationship,
+                    "is_trustworthy": j.is_trustworthy,
+                }
+                for j in self.joins
+            ],
+            "certification": self.certification,
+        }
+
+
+def _best_key(candidates: list[KeyCandidate]) -> KeyCandidate | None:
+    """The grain for a table: the top-ranked trustworthy single-column key, else the
+    top-ranked candidate (which `discover_keys` already sorts best-first), else None."""
+    if not candidates:
+        return None
+    for c in candidates:
+        if c.is_trustworthy:
+            return c
+    return candidates[0]
+
+
+def discover_semantic_model(
+    tables: dict[str, Any],
+    *,
+    dialect: str = "metricflow",
+    resolve: bool = False,
+) -> ProposedModel:
+    """Discover a draft semantic model from a set of source tables.
+
+    Args:
+        tables: `{table_name: table}` — the source tables (any input the certifier and
+            profiler accept).
+        dialect: the emit dialect. `"metricflow"` for this slice (Cube/OSI emit is a
+            follow-on; certification already spans all three).
+        resolve: forwarded to join discovery + re-certification — also measures entity
+            fragmentation / undercount via ER (fail-open).
+
+    Returns:
+        A `ProposedModel` with per-table shape, entity types, the certified join graph,
+        the emitted MetricFlow YAML, and the end-to-end certification report. Every key
+        is pre-graded; nothing is auto-applied.
+
+    Raises:
+        ValueError: on an unsupported emit dialect.
+    """
+    if dialect not in _SUPPORTED_DIALECTS:
+        raise ValueError(
+            f"unsupported emit dialect {dialect!r}; supported: {sorted(_SUPPORTED_DIALECTS)}"
+        )
+
+    from goldenmatch.semantic import (
+        certification_report_dict,
+        certify_semantic_model,
+        emit_metricflow_yaml,
+        emit_semantic_model,
+    )
+
+    # Phase 1 — grain per table.
+    keys: dict[str, list[KeyCandidate]] = {
+        name: discover_keys(t) for name, t in tables.items()
+    }
+    grains: dict[str, KeyCandidate | None] = {n: _best_key(keys[n]) for n in tables}
+
+    # Phase 2 — entity types (name each table's entity).
+    entity_types = discover_entity_types(tables, keys=keys)
+    entity_of: dict[str, str] = {}
+    for et in entity_types:
+        for tbl in et.tables:
+            entity_of[tbl] = et.name
+
+    # Phase 3 — certified join graph.
+    joins = discover_joins(tables, keys, resolve=resolve)
+
+    # Phase 4 — measures + dimensions per table.
+    proposed_tables: list[ProposedTable] = []
+    per_table_measures: dict[str, TableMeasures] = {}
+    for name, table in tables.items():
+        grain = grains[name]
+        tm = discover_measures(table, key=grain, table_name=name)
+        per_table_measures[name] = tm
+        proposed_tables.append(
+            ProposedTable(
+                table=name,
+                entity_type=entity_of.get(name),
+                key=grain,
+                measures=tm.measures,
+                dimensions=tm.dimensions,
+            )
+        )
+
+    # Phase 5 — emit a draft MetricFlow model (only SUM-safe measures are declared, so
+    # the emitted model never scaffolds a double-counting SUM) + re-certify end-to-end.
+    models = []
+    for pt in proposed_tables:
+        if pt.key is None:
+            continue
+        key_col = pt.key.columns[0]
+        safe_measures = [m.column for m in pt.measures if m.safe_to_sum]
+        models.append(
+            emit_semantic_model(
+                pt.table,
+                resolved_key=key_col,
+                entity_name=pt.entity_type or pt.table,
+                measures=safe_measures,
+                certificate=pt.key.certificate,
+            )
+        )
+
+    model_yaml = emit_metricflow_yaml(models) if models else ""
+    certification: dict[str, Any] = {}
+    if model_yaml:
+        report = certify_semantic_model(model_yaml, tables, resolve=resolve)
+        certification = certification_report_dict(report)
+
+    return ProposedModel(
+        dialect=dialect,
+        tables=proposed_tables,
+        entity_types=entity_types,
+        joins=joins,
+        yaml=model_yaml,
+        certification=certification,
+    )

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -6,8 +6,8 @@
 Zero-config gets good results and returns the config it chose; the healer (`review_config`) reviews the results and suggests ranked, self-verified tweaks; apply them, results improve, repeat — closing the gap to expert-tuned without you being the expert. Wired into the default pipeline: `dedupe_df` attaches candidate suggestions to `result.suggestions` when a free signal fires (`dedupe_df(suggest=True)` verified, `heal=True` full loop; disable with `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`). Needs `goldenmatch[native]`; degrades gracefully without it. Docs: https://docs.bensevern.dev/goldenmatch/config-suggestions
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (94 tools across data, agent, identity, memory, routing, and document groups)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (94 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- MCP Server: `goldenmatch mcp-serve` (95 tools across data, agent, identity, memory, routing, and document groups)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (95 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (51 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~202 exports

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -26,9 +26,9 @@ def test_total_tool_count_is_94():
     assert len(AGENT_TOOLS) == 19   # +1 retrieve_similar (#1089) +1 upload_dataset
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 18  # +1 customer_360 (D1b) +2 serving surfaces (D)
-    assert len(_BASE_TOOLS) == 45   # +5 core primitives +3 host helpers +1 certify_semantic_model
+    assert len(_BASE_TOOLS) == 46   # +5 core primitives +3 host helpers +1 certify_semantic_model +1 discover_semantic_model
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 94   # +2 serving surfaces (certify_serving_joins, emit_semantic_model_from_store)
+    assert len(TOOLS) == 95   # +2 serving surfaces (certify_serving_joins, emit_semantic_model_from_store) +1 discover_semantic_model
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_semantic_discover_surface.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discover_surface.py
@@ -1,0 +1,104 @@
+"""MCP + REST surface for semantic-model discovery (PR-6).
+
+`discover_semantic_model` is surfaced on MCP (`discover_semantic_model` tool) and
+REST (`POST /semantic/discover`), both returning the same `ProposedModel.to_dict()`
+wire shape the `discover-model` CLI emits. These tests drive both entry points on
+the canonical customers/orders fixture and cover the clean error paths (both
+surfaces return `{"error": ...}` rather than raising).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write_fixture(tmp_path: Path) -> dict[str, str]:
+    """customers (customer_id unique) + orders (order_id unique, customer_id FK,
+    amount measure). Both grains are clean, so the draft is fully trustworthy."""
+    customers = tmp_path / "customers.csv"
+    customers.write_text(
+        "customer_id,region\nc1,west\nc2,east\nc3,west\n", encoding="utf-8"
+    )
+    orders = tmp_path / "orders.csv"
+    orders.write_text(
+        "order_id,customer_id,amount\no1,c1,10.0\no2,c1,20.0\no3,c2,30.0\n",
+        encoding="utf-8",
+    )
+    return {"customers": str(customers), "orders": str(orders)}
+
+
+def test_mcp_discover_tool_registered():
+    from goldenmatch.mcp.server import _BASE_TOOLS
+
+    tool = next((t for t in _BASE_TOOLS if t.name == "discover_semantic_model"), None)
+    assert tool is not None
+    props = tool.inputSchema["properties"]
+    assert set(props) == {"frames", "dialect", "resolve"}
+    assert tool.inputSchema["required"] == ["frames"]
+    assert props["dialect"]["default"] == "metricflow"
+
+
+def test_mcp_discover_tool_on_fixture(tmp_path: Path):
+    from goldenmatch.mcp.server import _tool_discover_semantic_model
+
+    frames = _write_fixture(tmp_path)
+    out = _tool_discover_semantic_model(frames, "metricflow", False)
+
+    assert "error" not in out
+    assert out["dialect"] == "metricflow"
+    assert out["all_trustworthy"] is True
+    tables = {t["table"] for t in out["tables"]}
+    assert tables == {"customers", "orders"}
+    # A certified FK join from orders -> customers was proposed.
+    assert any(
+        j["from_table"] == "orders" and j["to_table"] == "customers"
+        for j in out["joins"]
+    )
+    # The end-to-end certification report is attached.
+    assert out["certification"].get("all_trustworthy") is True
+
+
+def test_mcp_discover_tool_error_paths(tmp_path: Path):
+    from goldenmatch.mcp.server import _tool_discover_semantic_model
+
+    # Empty / non-dict frames.
+    assert "error" in _tool_discover_semantic_model({}, "metricflow", False)
+    # Missing data file.
+    assert "error" in _tool_discover_semantic_model(
+        {"orders": str(tmp_path / "nope.csv")}, "metricflow", False
+    )
+    # Unsupported dialect -> ValueError surfaced as a clean error.
+    frames = _write_fixture(tmp_path)
+    out = _tool_discover_semantic_model(frames, "no-such-dialect", False)
+    assert "error" in out
+    assert "no-such-dialect" in out["error"]
+
+
+def test_rest_semantic_discover_endpoint(tmp_path: Path):
+    from goldenmatch.api.server import _discover_semantic_model_endpoint
+
+    frames = _write_fixture(tmp_path)
+    out = _discover_semantic_model_endpoint(frames, "metricflow", False)
+
+    assert "error" not in out
+    assert out["all_trustworthy"] is True
+    assert {t["table"] for t in out["tables"]} == {"customers", "orders"}
+
+    # Error paths mirror the certify endpoint: clean {"error": ...}, never raise.
+    assert "error" in _discover_semantic_model_endpoint({}, "metricflow", False)
+    assert "error" in _discover_semantic_model_endpoint(
+        {"orders": "/nope.csv"}, "metricflow", False
+    )
+    assert "error" in _discover_semantic_model_endpoint(
+        frames, "no-such-dialect", False
+    )
+
+
+def test_mcp_and_rest_agree(tmp_path: Path):
+    """One wire contract: the MCP tool and the REST endpoint return identical shapes."""
+    from goldenmatch.api.server import _discover_semantic_model_endpoint
+    from goldenmatch.mcp.server import _tool_discover_semantic_model
+
+    frames = _write_fixture(tmp_path)
+    mcp_out = _tool_discover_semantic_model(frames, "metricflow", False)
+    rest_out = _discover_semantic_model_endpoint(frames, "metricflow", False)
+    assert mcp_out == rest_out

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_entities.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_entities.py
@@ -1,0 +1,102 @@
+"""Cross-table entity-type discovery (semantic-model discovery, Phase 2).
+
+`discover_entity_types` groups source tables into the real-world entity types they
+realize, via column-semantic signature + value overlap. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import EntityType, discover_entity_types, discover_keys
+
+
+def _crm() -> pa.Table:
+    return pa.table(
+        {
+            "customer_id": ["c1", "c2", "c3"],
+            "first_name": ["Ann", "Bob", "Cy"],
+            "last_name": ["Lee", "Ng", "Poe"],
+            "email": ["ann@x.com", "bob@y.com", "cy@z.com"],
+        }
+    )
+
+
+def _app_users() -> pa.Table:
+    # Different column names for the same Person entity (fname/surname/mail).
+    return pa.table(
+        {
+            "uid": ["u1", "u2", "u3"],
+            "fname": ["Dee", "Eli", "Fay"],
+            "surname": ["Ray", "Sol", "Tan"],
+            "mail": ["dee@a.com", "eli@b.com", "fay@c.com"],
+        }
+    )
+
+
+def _orders() -> pa.Table:
+    return pa.table(
+        {
+            "order_id": ["o1", "o2", "o3", "o4"],
+            "customer_id": ["c1", "c1", "c2", "c3"],
+            "amount": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+
+def test_same_shaped_tables_are_one_entity_type() -> None:
+    ets = discover_entity_types({"crm": _crm(), "app_users": _app_users()})
+    assert ets
+    # crm + app_users are both Person surfaces (first_name/last_name/email vs
+    # fname/surname/mail canonicalize to the same semantic tokens).
+    person = [e for e in ets if set(e.tables) == {"app_users", "crm"}]
+    assert person, f"expected crm+app_users grouped, got {[(e.name, e.tables) for e in ets]}"
+    e = person[0]
+    assert isinstance(e, EntityType)
+    assert e.is_multi_table is True
+    assert e.name == "person"
+    assert "signature" in e.signals
+
+
+def test_transaction_table_is_its_own_entity_type() -> None:
+    ets = discover_entity_types({"crm": _crm(), "orders": _orders()})
+    # orders (order_id/customer_id/amount) does not share the person signature.
+    by_tables = {frozenset(e.tables): e for e in ets}
+    assert frozenset({"orders"}) in by_tables
+    assert frozenset({"crm"}) in by_tables
+
+
+def test_value_overlap_links_tables_by_shared_ids() -> None:
+    # Two tables with different schemas but an overlapping email column → same entity.
+    a = pa.table({"a_id": ["1", "2"], "email": ["p@x.com", "q@x.com"], "note": ["m", "n"]})
+    b = pa.table({"b_id": ["9", "8"], "email": ["p@x.com", "q@x.com"], "flag": ["y", "n"]})
+    ets = discover_entity_types({"a": a, "b": b})
+    linked = [e for e in ets if set(e.tables) == {"a", "b"}]
+    assert linked, f"value overlap on email should link a+b, got {[(e.name, e.tables) for e in ets]}"
+    assert "value_overlap" in linked[0].signals
+
+
+def test_key_by_table_is_recorded_when_keys_supplied() -> None:
+    tables = {"crm": _crm(), "app_users": _app_users()}
+    keys = {name: discover_keys(t) for name, t in tables.items()}
+    ets = discover_entity_types(tables, keys=keys)
+    person = [e for e in ets if e.is_multi_table][0]
+    # Each table's trustworthy key is recorded as the conformance anchor.
+    assert set(person.key_by_table) == {"crm", "app_users"}
+    # crm.customer_id classifies as an identifier → preferred anchor.
+    assert person.key_by_table["crm"] == "customer_id"
+    # app_users has no name/shape-classified id column, so the anchor is some
+    # trustworthy unique column (a genuinely ambiguous choice in a toy sample).
+    assert person.key_by_table["app_users"] in {"uid", "fname", "surname", "mail"}
+
+
+def test_multi_table_types_rank_before_singletons() -> None:
+    ets = discover_entity_types({"crm": _crm(), "app_users": _app_users(), "orders": _orders()})
+    # The person (multi-table) type ranks ahead of the lone orders table.
+    assert ets[0].is_multi_table is True
+    assert "orders" not in ets[0].tables
+
+
+def test_confidence_in_range() -> None:
+    ets = discover_entity_types({"crm": _crm(), "app_users": _app_users()})
+    for e in ets:
+        assert 0.0 <= e.confidence <= 1.0

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_joins.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_joins.py
@@ -1,0 +1,112 @@
+"""Certified join / FK discovery (semantic-model discovery, Phase 3).
+
+`discover_joins` proposes foreign-key joins across tables via value-subset
+containment and PROVES each join's one-side cardinality with `certify_cube_joins`, so
+a `JoinCandidate` is pre-graded. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    JoinCandidate,
+    KeyCandidate,
+    discover_joins,
+    discover_keys,
+)
+
+
+def _customers() -> pa.Table:
+    # customer_id is the clean primary key (the "one" side).
+    return pa.table(
+        {
+            "customer_id": ["c1", "c2", "c3"],
+            "name": ["Acme", "Globex", "Initech"],
+            "region": ["west", "east", "west"],
+        }
+    )
+
+
+def _orders() -> pa.Table:
+    # customer_id here is a foreign key into customers (a subset, many rows/customer).
+    return pa.table(
+        {
+            "order_id": ["o1", "o2", "o3", "o4"],
+            "customer_id": ["c1", "c1", "c2", "c3"],
+            "amount": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+
+def _tables() -> dict[str, pa.Table]:
+    return {"customers": _customers(), "orders": _orders()}
+
+
+def _keys() -> dict[str, list[KeyCandidate]]:
+    return {name: discover_keys(t) for name, t in _tables().items()}
+
+
+def test_foreign_key_join_is_discovered_and_certified() -> None:
+    joins = discover_joins(_tables(), _keys())
+    assert joins, "should discover at least one join"
+    # orders.customer_id -> customers.customer_id, many_to_one, certified trustworthy
+    # (customers.customer_id is a clean grain).
+    match = [
+        j for j in joins
+        if j.from_table == "orders" and j.from_column == "customer_id"
+        and j.to_table == "customers" and j.to_column == "customer_id"
+    ]
+    assert match, f"expected orders->customers FK, got {[(j.from_table, j.from_column, j.to_table, j.to_column) for j in joins]}"
+    j = match[0]
+    assert isinstance(j, JoinCandidate)
+    assert j.relationship == "many_to_one"
+    assert j.is_trustworthy is True
+    assert j.certificate.max_fan_out == 1.0
+    assert "value_subset" in j.signals
+
+
+def test_join_onto_fanned_out_key_is_flagged_untrustworthy() -> None:
+    # If we (wrongly) declare orders.customer_id as the referenced key, the "one" side
+    # fans out (c1 appears twice) -> a join across it double-counts.
+    tables = _tables()
+    keys = {"orders": ["customer_id"]}  # a plain declared (untrustworthy) key
+    joins = discover_joins(tables, keys)
+    onto_orders = [j for j in joins if j.to_table == "orders" and j.to_column == "customer_id"]
+    assert onto_orders, "a join onto orders.customer_id should still be proposed"
+    assert all(not j.is_trustworthy for j in onto_orders)
+    assert any(j.certificate.max_fan_out > 1.0 for j in onto_orders)
+
+
+def test_untrustworthy_target_key_candidate_is_skipped() -> None:
+    # A KeyCandidate that is NOT trustworthy must not be used as a join target.
+    orders = _orders()
+    cust_key = [c for c in discover_keys(orders) if c.columns == ["customer_id"]][0]
+    assert cust_key.is_trustworthy is False
+    joins = discover_joins({"orders": orders, "customers": _customers()}, {"orders": [cust_key]})
+    assert all(j.to_column != "customer_id" or j.to_table != "orders" for j in joins)
+
+
+def test_measure_column_is_not_a_foreign_key() -> None:
+    joins = discover_joins(_tables(), _keys())
+    # `amount` is numeric (a measure) — never proposed as a foreign key.
+    assert all(j.from_column != "amount" for j in joins)
+
+
+def test_no_join_when_values_do_not_overlap() -> None:
+    a = pa.table({"a_id": ["a1", "a2", "a3"]})
+    b = pa.table({"b_id": ["z9", "z8", "z7"]})  # disjoint from a_id
+    joins = discover_joins({"a": a, "b": b}, {"a": ["a_id"]})
+    assert joins == []
+
+
+def test_score_and_signals_are_populated() -> None:
+    joins = discover_joins(_tables(), _keys())
+    top = joins[0]
+    assert 0.0 <= top.score <= 1.0
+    assert top.signals == sorted(top.signals) or "value_subset" in top.signals
+    assert top.is_trustworthy is True
+
+
+def test_max_candidates_caps_output() -> None:
+    joins = discover_joins(_tables(), _keys(), max_candidates=1)
+    assert len(joins) <= 1

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_keys.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_keys.py
@@ -1,0 +1,84 @@
+"""Certified key discovery (semantic-model discovery, Phase 1).
+
+`discover_keys` proposes single-column entity keys via cheap signals
+(identifier / cardinality / fd) and PROVES each with `certify_key_integrity`, so a
+`KeyCandidate` is pre-graded. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import KeyCandidate, discover_keys
+
+
+def _orders() -> pa.Table:
+    # order_id is the clean key; customer_id fans out (c1 twice); status is a
+    # low-cardinality dimension; amount is a numeric measure.
+    return pa.table(
+        {
+            "order_id": ["o1", "o2", "o3", "o4"],
+            "customer_id": ["c1", "c1", "c2", "c3"],
+            "status": ["new", "new", "done", "new"],
+            "amount": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+
+def test_clean_key_is_proposed_and_certified_trustworthy() -> None:
+    cands = discover_keys(_orders())
+    assert cands, "should propose at least one candidate"
+    top = cands[0]
+    assert isinstance(top, KeyCandidate)
+    # The clean primary key ranks first and is certified trustworthy.
+    assert top.columns == ["order_id"]
+    assert top.is_trustworthy is True
+    assert top.certificate.max_fan_out == 1.0
+    assert "identifier" in top.signals and "cardinality" in top.signals
+
+
+def test_fanned_out_key_is_flagged_untrustworthy() -> None:
+    cands = {c.columns[0]: c for c in discover_keys(_orders())}
+    # customer_id is proposed (it's identifier-shaped) but certified UNTRUSTWORTHY:
+    # a metric grouped on it would double-count.
+    assert "customer_id" in cands
+    cust = cands["customer_id"]
+    assert cust.is_trustworthy is False
+    assert cust.certificate.max_fan_out == 2.0
+    # It ranks below the clean key.
+    order = [c.columns[0] for c in discover_keys(_orders())]
+    assert order.index("order_id") < order.index("customer_id")
+
+
+def test_numeric_and_dimension_columns_are_not_proposed_as_keys() -> None:
+    proposed = {c.columns[0] for c in discover_keys(_orders())}
+    # `amount` is numeric (a measure) — excluded from the cardinality signal even
+    # though it's unique in this tiny sample. `status` is low-cardinality (a dim).
+    assert "amount" not in proposed
+    assert "status" not in proposed
+
+
+def test_no_clean_key_returns_only_untrustworthy_candidates() -> None:
+    # A table whose every id-shaped column duplicates → the loud "this grain will
+    # double-count" signal: proposed candidates exist, none trustworthy.
+    t = pa.table(
+        {
+            "order_id": ["o1", "o1", "o2"],   # duplicated
+            "customer_id": ["c1", "c2", "c2"],  # duplicated
+        }
+    )
+    cands = discover_keys(t)
+    assert cands  # candidates are still proposed (id-shaped)
+    assert all(not c.is_trustworthy for c in cands)
+
+
+def test_signals_and_score_are_populated() -> None:
+    top = discover_keys(_orders())[0]
+    assert top.signals == sorted(top.signals)  # deterministic order
+    assert 0.0 <= top.score <= 1.0
+    # a certified-clean key scores at the top of the range.
+    assert top.score >= top.certificate.estimate
+
+
+def test_max_candidates_caps_output() -> None:
+    t = pa.table({f"id{i}": [f"v{i}{j}" for j in range(4)] for i in range(6)})
+    assert len(discover_keys(t, max_candidates=3)) <= 3

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_measures.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_measures.py
@@ -1,0 +1,98 @@
+"""Measure & dimension proposal (semantic-model discovery, Phase 4).
+
+`discover_measures` proposes measures + dimensions over a table and gates each
+measure's SUM-safety on the grain key's certificate — a fanned-out grain withholds
+SUM (it would double-count). Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    Dimension,
+    Measure,
+    TableMeasures,
+    discover_keys,
+    discover_measures,
+)
+
+
+def _orders() -> pa.Table:
+    return pa.table(
+        {
+            "order_id": ["o1", "o2", "o3", "o4"],
+            "customer_id": ["c1", "c1", "c2", "c3"],
+            "status": ["new", "new", "done", "new"],
+            "amount": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+
+def _clean_key():
+    return [c for c in discover_keys(_orders()) if c.columns == ["order_id"]][0]
+
+
+def _fanned_key():
+    return [c for c in discover_keys(_orders()) if c.columns == ["customer_id"]][0]
+
+
+def test_sum_is_safe_on_a_certified_clean_grain() -> None:
+    tm = discover_measures(_orders(), key=_clean_key(), table_name="orders")
+    assert isinstance(tm, TableMeasures)
+    assert tm.grain == ["order_id"]
+    assert tm.grain_trustworthy is True
+    amount = [m for m in tm.measures if m.column == "amount"]
+    assert amount, "amount (numeric) should be proposed as a measure"
+    m = amount[0]
+    assert isinstance(m, Measure)
+    assert m.safe_to_sum is True
+    assert "sum" in m.aggregations
+    assert "avg" in m.aggregations and "count" in m.aggregations
+
+
+def test_sum_is_withheld_on_a_fanned_out_grain() -> None:
+    # Grouped on the fanned-out customer_id grain, SUM(amount) would double-count.
+    tm = discover_measures(_orders(), key=_fanned_key(), table_name="orders")
+    assert tm.grain_trustworthy is False
+    m = [m for m in tm.measures if m.column == "amount"][0]
+    assert m.safe_to_sum is False
+    assert "sum" not in m.aggregations
+    # the always-safe aggregations are still proposed.
+    assert "count" in m.aggregations and "avg" in m.aggregations
+
+
+def test_no_grain_is_conservative() -> None:
+    tm = discover_measures(_orders(), table_name="orders")
+    m = [m for m in tm.measures if m.column == "amount"][0]
+    assert m.safe_to_sum is False
+    assert "sum" not in m.aggregations
+
+
+def test_low_cardinality_categorical_is_a_dimension() -> None:
+    tm = discover_measures(_orders(), key=_clean_key(), table_name="orders")
+    dims = {d.column for d in tm.dimensions}
+    # status (low-card categorical) is a dimension; amount (numeric) is not.
+    assert "status" in dims
+    assert "amount" not in dims
+    assert all(isinstance(d, Dimension) for d in tm.dimensions)
+
+
+def test_grain_and_identifiers_are_not_measures_or_dimensions() -> None:
+    tm = discover_measures(_orders(), key=_clean_key(), table_name="orders")
+    all_cols = {m.column for m in tm.measures} | {d.column for d in tm.dimensions}
+    # order_id is the grain; customer_id is an identifier/FK — neither is proposed.
+    assert "order_id" not in all_cols
+    assert "customer_id" not in all_cols
+
+
+def test_measures_rank_sum_safe_first() -> None:
+    t = pa.table(
+        {
+            "id": ["a", "b", "c"],
+            "x": [1.0, 2.0, 3.0],
+            "y": [4.0, 5.0, 6.0],
+        }
+    )
+    key = [c for c in discover_keys(t) if c.columns == ["id"]][0]
+    tm = discover_measures(t, key=key, table_name="t")
+    assert all(m.safe_to_sum for m in tm.measures)

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_model.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_model.py
@@ -1,0 +1,130 @@
+"""Semantic-model discovery orchestrator (Phase 5).
+
+`discover_semantic_model` assembles keys + entity types + joins + measures into a draft
+MetricFlow model, emits it via the existing emitters, and re-certifies end-to-end. The
+CLI `discover-model` is the front door. Design:
+`docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from goldenmatch.semantic import ProposedModel, discover_semantic_model
+
+
+def _customers() -> pa.Table:
+    return pa.table(
+        {
+            "customer_id": ["c1", "c2", "c3"],
+            "name": ["Acme", "Globex", "Initech"],
+            "region": ["west", "east", "west"],
+        }
+    )
+
+
+def _orders() -> pa.Table:
+    return pa.table(
+        {
+            "order_id": ["o1", "o2", "o3", "o4"],
+            "customer_id": ["c1", "c1", "c2", "c3"],
+            "status": ["new", "new", "done", "new"],
+            "amount": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+
+def _tables() -> dict[str, pa.Table]:
+    return {"customers": _customers(), "orders": _orders()}
+
+
+def test_orchestrator_assembles_all_phases() -> None:
+    m = discover_semantic_model(_tables())
+    assert isinstance(m, ProposedModel)
+    assert m.dialect == "metricflow"
+    assert {t.table for t in m.tables} == {"customers", "orders"}
+    # certified FK graph is present
+    fk = [
+        j for j in m.joins
+        if j.from_table == "orders" and j.from_column == "customer_id"
+        and j.to_table == "customers"
+    ]
+    assert fk and fk[0].is_trustworthy
+
+
+def test_emitted_yaml_round_trips_and_is_certified() -> None:
+    m = discover_semantic_model(_tables())
+    assert "semantic_models" in m.yaml
+    # the emitted model round-trips through the parser
+    from goldenmatch.semantic import parse_semantic_models
+
+    specs = {s.model for s in parse_semantic_models(m.yaml)}
+    assert {"customers", "orders"} <= specs
+    # end-to-end certification ran and reports per-key verdicts
+    assert m.certification.get("dialect") == "metricflow"
+    assert m.certification.get("n_certified", 0) >= 2
+
+
+def test_sum_safe_measure_only_on_clean_grain() -> None:
+    m = discover_semantic_model(_tables())
+    orders = [t for t in m.tables if t.table == "orders"][0]
+    # orders' grain is the clean order_id, so amount is SUM-safe.
+    amount = [x for x in orders.measures if x.column == "amount"][0]
+    assert amount.safe_to_sum is True
+    assert "amount" in m.yaml  # the safe measure is declared in the emitted model
+
+
+def test_all_trustworthy_headline() -> None:
+    m = discover_semantic_model(_tables())
+    # both tables have a clean single-column key → the whole model certifies trustworthy.
+    assert m.all_trustworthy is True
+    d = m.to_dict()
+    assert d["all_trustworthy"] is True
+    assert d["tables"] and d["joins"]
+
+
+def test_unsupported_dialect_raises() -> None:
+    with pytest.raises(ValueError):
+        discover_semantic_model(_tables(), dialect="looker")
+
+
+def test_cli_discover_model(tmp_path) -> None:
+    import csv
+
+    from goldenmatch.cli.main import app
+    from typer.testing import CliRunner
+
+    # write the two tables as CSVs
+    paths = {}
+    for name, cols in {
+        "customers": [
+            ("customer_id", "name"), ("c1", "Acme"), ("c2", "Globex"), ("c3", "Initech"),
+        ],
+        "orders": [
+            ("order_id", "customer_id", "amount"),
+            ("o1", "c1", "10"), ("o2", "c1", "20"), ("o3", "c2", "30"), ("o4", "c3", "40"),
+        ],
+    }.items():
+        p = tmp_path / f"{name}.csv"
+        with open(p, "w", newline="", encoding="utf-8") as fh:
+            csv.writer(fh).writerows(cols)
+        paths[name] = str(p)
+
+    out = tmp_path / "model.yml"
+    result = CliRunner().invoke(
+        app,
+        [
+            "discover-model",
+            "-d", f"customers={paths['customers']}",
+            "-d", f"orders={paths['orders']}",
+            "-o", str(out),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert "semantic_models" in out.read_text()
+    import json
+
+    payload = json.loads(result.output)
+    assert payload["dialect"] == "metricflow"
+    assert {t["table"] for t in payload["tables"]} == {"customers", "orders"}

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2827,6 +2827,52 @@
           ]
         },
         {
+          "command": "discover-model",
+          "options": [
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "A source table as name=path (repeatable), e.g. -d orders=orders.csv"
+            },
+            {
+              "name": "--dialect",
+              "type": "text",
+              "required": false,
+              "default": "'metricflow'",
+              "help": "Emit dialect for the draft model (metricflow)."
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the draft semantic-model YAML to this path."
+            },
+            {
+              "name": "--resolve",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Also measure entity fragmentation / undercount via ER (fail-open)."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any proposed key is not unique at grain (CI gate)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the full proposed model (shape + certification) as JSON."
+            }
+          ]
+        },
+        {
           "command": "evaluate",
           "options": [
             {

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -4959,6 +4959,10 @@
           "description": "Alias for `find_duplicates`. Find duplicate matches for a record. Provide field values to search against the loaded dataset."
         },
         {
+          "name": "discover_semantic_model",
+          "description": "Generative half of the semantic-layer front door: point GoldenMatch at a set of source tables and it PROPOSES a draft semantic model -- entity types, keys, joins, measures, dimensions -- where every declared key is already graded by the certifier (unique-at-grain + fan-out). Discovery is hypothesis generation; certification is the falsification test, so the draft is pre-proven against the data. Advisory; nothing is auto-applied."
+        },
+        {
           "name": "documents_ingest",
           "description": "Extract records from documents (PDF/image) against a target schema into rows ready for dedupe_df. Returns records + an ingest report."
         },

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -141,6 +141,7 @@ mcp_tools:
   - upload_dataset
   - write_csv
   python_only:
+  - discover_semantic_model
   - documents_ingest
   - documents_suggest_schema
   - explain_routing

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -185,6 +185,7 @@ cli_commands:
   - tui
   - unmerge
   python_only:
+  - discover-model
   - import-dbt
   - ingest-docs
   - llm


### PR DESCRIPTION
## What and why

The design spec for **semantic-model discovery** ("GoldenModel") **plus the full implementation arc (PR-1..6)**. Point GoldenMatch at source tables and it proposes a draft semantic model where every key, join, and measure comes **pre-graded** with its trust verdict. Thesis: discovery is hypothesis generation; the existing certifier (`certify_key_integrity` / `certify_cube_joins`) is the falsification test, so the proposal is proven against the data, not just guessed. Advisory only; nothing auto-ships.

Design: `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md` (7-PR phased plan).

## Slices in this PR (phase-by-phase in history)

- **PR-1: certified key discovery** (`discovery/keys.py`): `discover_keys(table) -> list[KeyCandidate]` proposes single-column entity keys (identifier col_type / near-unique cardinality / FD determinant) and **certifies each** with `certify_key_integrity`. Ranked trustworthy-first; a table with no clean key returns only untrustworthy candidates.
- **PR-2: certified join / FK discovery** (`discovery/joins.py`): `discover_joins(tables, keys) -> list[JoinCandidate]` infers foreign keys by value-subset containment + `col_type` match, then re-proves the "one" side's cardinality via `certify_cube_joins` (a `many_to_one` join whose referenced key must be unique at grain). Numeric/date/geo columns are never FKs; an untrustworthy target key is skipped.
- **PR-3: cross-table entity typing** (`discovery/entities.py`): `discover_entity_types(tables) -> list[EntityType]` groups tables into the real-world entities they realize, via column-semantic signature (Jaccard over the `schema_match` synonym map + col_type) OR value overlap on a shared identity column, where the value-overlap "same entity" signal fires only when the shared column is near-unique on **both** sides (so a foreign-key reference reads as a Phase-3 join, not sameness).
- **PR-4: grain-gated measure/dimension proposal** (`discovery/measures.py`): `discover_measures(table, key=…) -> TableMeasures`. `COUNT/AVG/MIN/MAX` always; `SUM` only when the grain key certified clean (`max_fan_out == 1.0`), and a fanned-out grain withholds SUM with `safe_to_sum=False`, the loud "this would double-count" signal.
- **PR-5: orchestrator + CLI** (`discovery/model.py`, `cli/discover_model.py`): `discover_semantic_model(tables) -> ProposedModel` assembles all four phases into a draft MetricFlow model, emits it via the existing dialect emitters (declaring only SUM-safe measures), and re-certifies end-to-end with `certify_semantic_model`, so every key is pre-graded and `ProposedModel.all_trustworthy` is the headline gate. New Python-only CLI `goldenmatch discover-model` (mirrors `certify-keys`).
- **PR-6: MCP tool + REST endpoint** (`mcp/server.py`, `api/server.py`): surfaces `discover_semantic_model` on MCP (the `discover_semantic_model` tool) and REST (`POST /semantic/discover`), both returning the same `ProposedModel.to_dict()` wire shape the `discover-model` CLI emits, so a build gate reads `all_trustworthy` identically on any surface. `frames` required; `dialect` (default `metricflow`) + `resolve` optional; bad input / unreadable files / an unsupported dialect return a clean `{"error": ...}` rather than raising. Python-only (declared under `mcp_tools: python_only` in `parity/goldenmatch.yaml`, mirroring the `discover-model` CLI). Bumped the MCP tool-count assertions and regenerated every surface-derived doc (config-matrix, suite-matrix, thesis-weaknesses, agent-codemap, agent-manifest).

## Testing

`uv run pytest tests/test_semantic_discovery_{keys,joins,entities,measures,model}.py tests/test_semantic_discover_surface.py` — **37 passed** (31 discovery + 6 MCP/REST surface). MCP tool-count assertions in `tests/test_mcp_new_tools.py` updated (`_BASE_TOOLS` 46, `TOOLS` 95).

## Status

Design + PR-1..6 complete. PR-7 (optional advisory LLM namer, default-off and non-authoritative) remains optional; the arc is useful without it. Auto-merge is **off**; open for review.
