### PR TITLE
perf(fs): Lever 1 narrow-base + per-shard xform recompute (A/B, default OFF)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -105,6 +105,22 @@ def _fs_out_of_core_legacy_flag() -> bool:
     )
 
 
+def _fs_xform_per_shard_enabled() -> bool:
+    """Lever 1 (frame-residency): ``GOLDENMATCH_FS_XFORM_PER_SHARD=1`` makes the
+    ``bucketed`` FS route skip the whole-frame ``__xform_`` materialization (so the
+    resident ``base`` is ~40% narrower ⇒ lower peak ⇒ higher single-box max scale)
+    and recompute each matchkey transform PER BUCKET SHARD (~1/64 of the frame) at
+    score time instead. Default OFF (byte-identical to the wide-base path: the
+    native FS fast path prefers the precomputed ``__xform_`` column, a −82%
+    ``bucket_score`` win the wide base keeps). Measurement-gated — trades that
+    per-call win for a lower peak; the A/B must show the peak win outweighs the
+    per-shard recompute. Spec:
+    ``docs/superpowers/specs/2026-08-03-fs-frame-residency-disk-spill-design.md``."""
+    return os.environ.get("GOLDENMATCH_FS_XFORM_PER_SHARD", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
 def _fs_spill_force_shard() -> bool:
     """``GOLDENMATCH_FS_SPILL_FORCE_SHARD=1`` makes ``run_fs_dedupe_spill`` SKIP the
     fused-kernel short-circuit and always take the edge-shard spill path
@@ -1868,6 +1884,15 @@ def run_fs_dedupe_bucketed(
         _fw = _tf(_fw.native.collect())
     base = _fw.to_arrow()
 
+    # Lever 1 (frame-residency): when the caller skipped the whole-frame
+    # __xform_ materialization (GOLDENMATCH_FS_XFORM_PER_SHARD; pipeline passes a
+    # narrow base), the base carries NO __xform_ columns. Detect that and
+    # recompute the transforms PER SHARD (~1/64 of the frame) below so the native
+    # fast path still engages — byte-identical pairs, ~40% narrower resident base.
+    _narrow = _fs_xform_per_shard_enabled() and not any(
+        c.startswith("__xform_") for c in base.column_names
+    )
+
     passes = _bucketed_passes(blocking_config)
     shard_dir = _tempfile.mkdtemp(prefix="gm_fs_bucketed_")
     try:
@@ -1907,6 +1932,16 @@ def run_fs_dedupe_bucketed(
             single_pass = _BlockingConfig(strategy="static", keys=[passes[pi]])
             with pa.memory_map(sp, "r") as src:
                 bucket_tbl = pa.ipc.open_file(src).read_all()
+            if _narrow and bucket_tbl.num_rows >= 2:
+                # Lever 1: recompute __xform_ on this shard so score_buckets_arrow's
+                # native fast path engages exactly as on a wide base. The shard is
+                # ~1/64 of the frame, so the recompute is bounded and transient.
+                from goldenmatch.core.matchkey import (
+                    precompute_matchkey_transforms_frame,
+                )
+                bucket_tbl = precompute_matchkey_transforms_frame(
+                    _tf(bucket_tbl), [mk]
+                ).native
             if bucket_tbl.num_rows >= 2:
                 score_buckets_arrow(
                     bucket_tbl, single_pass, mk, set(matched_pairs),
@@ -1939,6 +1974,10 @@ def run_fs_dedupe_bucketed(
     res["bucketed"] = True
     res["fused"] = False
     res["output_dir"] = out_dir
+    # Lever 1 A/B mechanism check: resident base width (narrow arm drops the
+    # ~40% __xform_ block) + whether per-shard recompute was active.
+    res["base_ncols"] = base.num_columns
+    res["xform_per_shard"] = _narrow
     return res
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -289,9 +289,19 @@ def _xform_sig(field: MatchkeyField) -> str:
 
 
 def precompute_matchkey_transforms(
-    df: pl.DataFrame, matchkeys: list[MatchkeyConfig]
+    df: pl.DataFrame, matchkeys: list[MatchkeyConfig], *, xform: bool = True
 ) -> pl.DataFrame:
     """Add one __xform_<sig>__ column per unique (field, transforms) signature.
+
+    ``xform=False`` (Lever 1, frame-residency) materializes the synthesized
+    ``derive_from`` NE/field columns but SKIPS the wide ``__xform_<sig>__``
+    block, returning a ~40%-narrower frame. The bucketed FS out-of-core route
+    uses this to keep the resident ``base`` narrow and recompute each
+    ``__xform_`` per bucket shard at score time instead. Byte-identical
+    downstream: EM applies transforms from raw source (never reads
+    ``__xform_``), and the per-shard recompute re-adds the exact same columns
+    the native fast path expects. See
+    ``docs/superpowers/specs/2026-08-03-fs-frame-residency-disk-spill-design.md``.
 
     Same field+transforms across multiple matchkeys reuses one column — dedup
     is automatic via the signature. Native chains use vectorized Polars
@@ -398,6 +408,11 @@ def precompute_matchkey_transforms(
     if _derived_exprs:
         df = df.with_columns(_derived_exprs)
 
+    if not xform:
+        # Lever 1: keep derived-NE columns (EM + scoring read them) but skip the
+        # wide __xform_ block; the bucketed route recomputes per shard.
+        return df
+
     for mk in matchkeys:
         for field in mk.fields:
             _materialize_xform(field)
@@ -427,7 +442,9 @@ def precompute_matchkey_transforms(
     return df
 
 
-def precompute_matchkey_transforms_frame(frame, matchkeys: list[MatchkeyConfig]):
+def precompute_matchkey_transforms_frame(
+    frame, matchkeys: list[MatchkeyConfig], *, xform: bool = True
+):
     """Frame-level twin of ``precompute_matchkey_transforms`` (D2s-b, spine
     descent). Accepts a seam ``Frame`` (or a native frame) and returns a Frame
     of the same backend with the identical ``__xform_<sig>__`` / derived-NE
@@ -451,7 +468,7 @@ def precompute_matchkey_transforms_frame(frame, matchkeys: list[MatchkeyConfig])
 
     f = to_frame(frame)
     if isinstance(f, PolarsFrame):
-        return PolarsFrame(precompute_matchkey_transforms(f.native, matchkeys))
+        return PolarsFrame(precompute_matchkey_transforms(f.native, matchkeys, xform=xform))
 
     # Synthesized NE columns first (matchkey.py legacy order): a derived NE
     # field must exist before its xform signature materializes below.
@@ -472,6 +489,10 @@ def precompute_matchkey_transforms_frame(frame, matchkeys: list[MatchkeyConfig])
             f = _maybe_derive(f, ne, " ")
         for field in mk.fields:
             f = _maybe_derive(f, field, getattr(field, "derive_separator", " ") or " ")
+
+    if not xform:
+        # Lever 1: keep derived-NE columns, skip the wide __xform_ block.
+        return f
 
     seen: set[str] = set()
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -566,6 +566,30 @@ def _fs_streaming_dedupe_eligible(
     return True
 
 
+def _fs_narrow_base_active(
+    config: GoldenMatchConfig, matchkeys: list, output_dir: str | None
+) -> bool:
+    """Lever 1 (frame-residency) gate: skip the whole-frame ``__xform_``
+    materialization so the resident ``base`` stays ~40% narrower, and let the
+    ``bucketed`` route recompute each transform per shard at score time. Active
+    ONLY when ``GOLDENMATCH_FS_XFORM_PER_SHARD`` is on AND this run takes the
+    eligible ``bucketed`` streaming route (so no other route ever sees a base
+    missing its ``__xform_`` columns). Byte-identical output — EM applies
+    transforms from raw source and the per-shard recompute re-adds the exact
+    columns the native fast path needs. Spec:
+    ``docs/superpowers/specs/2026-08-03-fs-frame-residency-disk-spill-design.md``."""
+    from goldenmatch.backends.fs_out_of_core import (
+        _fs_xform_per_shard_enabled,
+        resolve_fs_block_source,
+    )
+
+    return (
+        _fs_xform_per_shard_enabled()
+        and resolve_fs_block_source() == "bucketed"
+        and _fs_streaming_dedupe_eligible(config, matchkeys, output_dir)
+    )
+
+
 def _run_fs_streaming_dedupe(
     collected_df: Any,
     config: GoldenMatchConfig,
@@ -3117,7 +3141,11 @@ def _run_dedupe_pipeline(
             _apply_memory_pre(memory_store, config, matchkeys)
 
         with stage("precompute_matchkey_transforms"):
-            collected_frame = precompute_matchkey_transforms_frame(_frame, matchkeys)
+            collected_frame = precompute_matchkey_transforms_frame(
+                _frame,
+                matchkeys,
+                xform=not _fs_narrow_base_active(config, matchkeys, output_dir),
+            )
         collected_df = collected_frame.native
         combined_lf = collected_frame
         # W-5: mirror the classic prep tail -- auto-suggest runs after the
@@ -3364,7 +3392,11 @@ def _run_dedupe_pipeline(
         with stage("combined_lf_collect"):
             _collected_pre_mk = combined_lf.collect()
         with stage("precompute_matchkey_transforms"):
-            collected_df = precompute_matchkey_transforms(_collected_pre_mk, matchkeys)
+            collected_df = precompute_matchkey_transforms(
+                _collected_pre_mk,
+                matchkeys,
+                xform=not _fs_narrow_base_active(config, matchkeys, output_dir),
+            )
         combined_lf = collected_df.lazy()
     with stage("auto_suggest_blocking"):
         _run_auto_suggest(collected_df, config)

--- a/packages/python/goldenmatch/tests/test_fs_out_of_core.py
+++ b/packages/python/goldenmatch/tests/test_fs_out_of_core.py
@@ -464,6 +464,59 @@ def test_dedupe_to_parquet_streaming_parity_with_in_memory(tmp_path, monkeypatch
     assert stream_parts == sorted(mem_parts)
 
 
+def _sorted_rows(path):
+    """Column-order-checked, row-order-independent view of a parquet file for
+    byte-identity comparison."""
+    import pyarrow.parquet as pq
+
+    t = pq.read_table(path)
+    rows = sorted(tuple(sorted(r.items())) for r in t.to_pylist())
+    return (list(t.column_names), rows)
+
+
+def test_bucketed_narrow_base_lever1_parity(tmp_path, monkeypatch):
+    """Lever 1 (frame-residency): the bucketed route with
+    GOLDENMATCH_FS_XFORM_PER_SHARD=1 (narrow resident base + per-shard __xform_
+    recompute) is BYTE-IDENTICAL to the wide-base bucketed route in
+    unique/dupes/golden + pairs, and the resident base is strictly narrower (the
+    __xform_ block dropped). This is the parity gate for the Lever 1 A/B."""
+    from goldenmatch import dedupe_to_parquet
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    monkeypatch.setenv("GOLDENMATCH_FS_BLOCK_SOURCE", "bucketed")
+
+    csv_path = tmp_path / "people.csv"
+    _make_person_csv(csv_path)
+    cfg = _fs_person_config()
+
+    # Arm A: wide base (flag off).
+    monkeypatch.delenv("GOLDENMATCH_FS_XFORM_PER_SHARD", raising=False)
+    wide = dedupe_to_parquet(str(csv_path), out_dir=str(tmp_path / "wide"), config=cfg)
+
+    # Arm B: narrow base + per-shard recompute (flag on).
+    monkeypatch.setenv("GOLDENMATCH_FS_XFORM_PER_SHARD", "1")
+    narrow = dedupe_to_parquet(str(csv_path), out_dir=str(tmp_path / "narrow"), config=cfg)
+
+    # Both take the bucketed streaming route.
+    assert wide["bucketed"] is True and narrow["bucketed"] is True
+    # Mechanism: wide kept the __xform_ block, narrow dropped it (per-shard on).
+    assert wide["xform_per_shard"] is False
+    assert narrow["xform_per_shard"] is True
+    assert narrow["base_ncols"] < wide["base_ncols"]
+
+    # Byte-identical counts + pairs.
+    for k in ("unique_count", "dupes_count", "golden_count", "pairs"):
+        assert wide[k] == narrow[k], k
+
+    # Byte-identical row-id partitions + unique/golden row sets (columns + values).
+    assert _partition_set_from_parquet(wide["dupes_path"]) == _partition_set_from_parquet(
+        narrow["dupes_path"]
+    )
+    assert _sorted_rows(wide["unique_path"]) == _sorted_rows(narrow["unique_path"])
+    if wide["golden_count"]:
+        assert _sorted_rows(wide["golden_path"]) == _sorted_rows(narrow["golden_path"])
+
+
 # ── resolve_fs_block_source: the single knob unifying the two streaming lanes ──
 
 def test_resolve_fs_block_source_default_is_eager(monkeypatch):

--- a/scripts/bench_fs_out_of_core_scale.py
+++ b/scripts/bench_fs_out_of_core_scale.py
@@ -178,7 +178,10 @@ def main() -> None:
     ap.add_argument("--rows", type=int, required=True)
     ap.add_argument(
         "--mode",
-        choices=["streaming", "sequential", "spill", "bucketed", "in_memory"],
+        choices=[
+            "streaming", "sequential", "spill", "bucketed", "bucketed_narrow",
+            "in_memory",
+        ],
         required=True,
         help=(
             "streaming=DuckDB out-of-core (FS_BLOCK_SOURCE=duckdb); "
@@ -187,7 +190,10 @@ def main() -> None:
             "disk + external union-find (FS_BLOCK_SOURCE=spill), the bounded-edge "
             "path; bucketed=frame-residency out-of-core -- hash-bucket the frame to "
             "disk per pass + score bucket-by-bucket (FS_BLOCK_SOURCE=bucketed), the "
-            "bounded-FRAME path (never a whole-frame scoring copy); in_memory="
+            "bounded-FRAME path (never a whole-frame scoring copy); bucketed_narrow="
+            "bucketed + Lever 1 (GOLDENMATCH_FS_XFORM_PER_SHARD=1): skip whole-frame "
+            "__xform_ materialization (~40% narrower resident base) and recompute "
+            "per shard -- the arm B of the frame-residency A/B; in_memory="
             "default pipeline contrast (EXPECTED OOM at 50M)"
         ),
     )
@@ -242,7 +248,9 @@ def main() -> None:
     sampler.start()
     t0 = time.perf_counter()
     try:
-        if args.mode in ("streaming", "sequential", "spill", "bucketed"):
+        if args.mode in (
+            "streaming", "sequential", "spill", "bucketed", "bucketed_narrow",
+        ):
             # streaming -> DuckDB out-of-core; sequential -> in-RAM Arrow/Rust
             # batches + end-WCC; spill -> DuckDB-FREE out-of-core (per-pass edge
             # shards on disk + external union-find); bucketed -> frame-residency
@@ -255,7 +263,15 @@ def main() -> None:
                 "sequential": "sequential",
                 "spill": "spill",
                 "bucketed": "bucketed",
+                "bucketed_narrow": "bucketed",
             }[args.mode]
+            # Lever 1 arm B: narrow resident base + per-shard __xform_ recompute.
+            # Arm A (plain "bucketed") explicitly clears the flag so a stale env
+            # can't contaminate the same-box A/B.
+            if args.mode == "bucketed_narrow":
+                os.environ["GOLDENMATCH_FS_XFORM_PER_SHARD"] = "1"
+            else:
+                os.environ.pop("GOLDENMATCH_FS_XFORM_PER_SHARD", None)
             if args.mode == "spill" and args.force_shard:
                 # Skip the fused short-circuit so the edge-shard spill mechanism
                 # (pair_sink shards + external_wcc_from_shards) actually runs.
@@ -277,7 +293,9 @@ def main() -> None:
                 result["internal_path"] = (
                     "fused" if res.get("fused") else "edge_shard"
                 )
-            elif args.mode == "bucketed" and not result["bucketed_engaged"]:
+            elif args.mode in ("bucketed", "bucketed_narrow") and not result[
+                "bucketed_engaged"
+            ]:
                 result["error"] = (
                     "bucketed route did NOT engage -- streaming ran a different "
                     "orchestrator; the frame-residency bucketing was not exercised"
@@ -286,6 +304,9 @@ def main() -> None:
             result["dupes_count"] = res.get("dupes_count")
             result["golden_count"] = res.get("golden_count")
             result["pairs"] = res.get("pairs")
+            # Lever 1 A/B mechanism metrics: resident base width + per-shard flag.
+            result["base_ncols"] = res.get("base_ncols")
+            result["xform_per_shard"] = res.get("xform_per_shard")
             if not result["streaming_engaged"]:
                 result["error"] = (
                     "streaming short-circuit did NOT engage -- fell back to "


### PR DESCRIPTION
## What

Frame-residency **Lever 1** (spec `docs/superpowers/specs/2026-08-03-fs-frame-residency-disk-spill-design.md`), gated behind `GOLDENMATCH_FS_XFORM_PER_SHARD=1`, **default OFF**.

The bucketed FS out-of-core route's peak is ~1x the resident `base` frame (~0.8 GB/M). `base` carries ~5 `__xform_<sig>__` columns (~40% of its width) that `precompute_matchkey_transforms` materializes on the whole frame. Lever 1 skips that materialization (narrower resident base -> lower peak -> higher single-box max scale, ~75M -> ~120M on 64 GB) and recomputes each transform **per bucket shard** (~1/64 of the frame) at score time.

## Byte-identical by construction

- **EM** applies `apply_transforms` on raw source values and never reads `__xform_` (probabilistic.py:617-957) -> unaffected by dropping the wide block; the narrow frame keeps derived-NE columns EM does read.
- **Per-shard recompute** re-adds exactly the `__xform_<sig>__` columns `_resolve_fast_path` needs, so the native fast path engages identically -> identical pairs.
- **Output** already excludes `__xform_` (record_cols filter) -> identical rows.

Parity gate: `test_bucketed_narrow_base_lever1_parity` asserts arm A (wide) == arm B (narrow) on unique/dupes/golden + pairs, and `base_ncols` strictly narrower with the flag on.

## The A/B (measurement gate)

Same-box back-to-back on the 64 GB bench runner (lesson: cross-runner wall is noise): [run 30824543298](https://github.com/benseverndev-oss/goldenmatch/actions/runs/30824543298), `modes="bucketed bucketed_narrow"` x `scales="4000000 8000000"`. The spec gate: arm B must (a) lower peak ~= the `__xform_` width fraction and (b) not regress wall by more than a few %.

**Do not merge on green CI alone** - the merge decision is gated on that A/B verdict. CI here validates the byte-identical parity gate in the native-built env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)