### PR TITLE
feat(config,identity): config fingerprint + run lineage (versioned configs)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -131,6 +131,7 @@ Every config object in the pydantic tree(s), generated from the package schema. 
 
 | Field | Type | Default | Choices / notes |
 |---|---|---|---|
+| `schema_version` | int | `1` | Config schema version; set by GoldenMatch (not user-tuned). Recorded with a run's config fingerprint for lineage/migration. Excluded from the fingerprint so a semantics-preserving schema bump keeps the same config id. |
 | `input` | InputConfig \| None | `None` | [`InputConfig`](#inputconfig) -- Input files to load; omit when passing a DataFrame directly to the API. |
 | `output` | OutputConfig | _(default OutputConfig)_ | [`OutputConfig`](#outputconfig) -- Where and how results are written. |
 | `match_settings` | MatchSettingsConfig \| None | `None` | [`MatchSettingsConfig`](#matchsettingsconfig) -- Nested matchkeys container; an alternative to the top-level matchkeys field. |

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -20,6 +20,13 @@
           "name": "GoldenMatchConfig",
           "fields": [
             {
+              "name": "schema_version",
+              "type": "int",
+              "required": false,
+              "default": "1",
+              "description": "Config schema version; set by GoldenMatch (not user-tuned). Recorded with a run's config fingerprint for lineage/migration. Excluded from the fingerprint so a semantics-preserving schema bump keeps the same config id."
+            },
+            {
               "name": "input",
               "type": "InputConfig | None",
               "required": false,

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -2110,7 +2112,18 @@ class SemanticBlockingConfig(BaseModel):
     )
 
 
+#: Current GoldenMatchConfig schema version. Bumped when the config surface
+#: changes in a way that needs migration. Recorded alongside a run's config
+#: fingerprint so lineage survives schema evolution; deliberately EXCLUDED from
+#: config_fingerprint() so a no-op schema bump doesn't change a config's id.
+CONFIG_SCHEMA_VERSION = 1
+
+
 class GoldenMatchConfig(BaseModel):
+    schema_version: int = Field(
+        default=CONFIG_SCHEMA_VERSION,
+        description="Config schema version; set by GoldenMatch (not user-tuned). Recorded with a run's config fingerprint for lineage/migration. Excluded from the fingerprint so a semantics-preserving schema bump keeps the same config id.",
+    )
     input: InputConfig | None = Field(
         default=None,
         description="Input files to load; omit when passing a DataFrame directly to the API.",
@@ -2301,6 +2314,32 @@ class GoldenMatchConfig(BaseModel):
         if self.match_settings:
             return self.match_settings.matchkeys
         return []
+
+    def config_fingerprint(self) -> str:
+        """Deterministic content hash of this config's matching semantics.
+
+        sha256 over the canonical JSON dump (sorted keys), so two configs that
+        would resolve identically get the same id and a diff is a byte diff.
+        Excludes the per-run ``output.run_name`` and the ``schema_version``
+        (a semantics-preserving schema bump must not change the id). Stamp the
+        return value on a resolve run to answer "which config produced this
+        entity" and to diff configs across runs. Returns ``"sha256:<64 hex>"``.
+        """
+        data = self.model_dump(mode="json", exclude_none=False)
+        data.pop("schema_version", None)
+        out = data.get("output")
+        if isinstance(out, dict):
+            out.pop("run_name", None)
+        canon = json.dumps(data, sort_keys=True, separators=(",", ":"), default=str)
+        return "sha256:" + hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+    @property
+    def config_id(self) -> str:
+        """Short form of :meth:`config_fingerprint` for display/labels.
+
+        ``"sha256:"`` plus the first 8 hex chars, e.g. ``"sha256:9f3c8a1b"``.
+        """
+        return self.config_fingerprint()[: len("sha256:") + 8]
 
 
 # RulesPayload's `blocking` field forward-references BlockingConfig (defined

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1381,6 +1381,11 @@ def _resolve_identities(
             weak_confidence_threshold=config.identity.weak_confidence_threshold,
             relationships=config.identity.relationships,
             deterministic_merge_keys=config.identity.deterministic_merge_keys,
+            # Config lineage (#config-fingerprint): stamp this run's config into
+            # identity_runs so an entity resolves back to the config that made it.
+            config_id=config.config_fingerprint(),
+            config_schema_version=config.schema_version,
+            config_json=config.model_dump_json(),
             pair_score_view=pair_score_view,
             cluster_frames=cluster_frames,
         )

--- a/packages/python/goldenmatch/goldenmatch/identity/resolution_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolution_batch.py
@@ -42,7 +42,7 @@ class ResolutionBatch:
     ``evidence_edges`` UNIQUE) -- ``run_id`` is the caller-facing half of that key.
     """
 
-    CONTRACT_VERSION: ClassVar[int] = 2
+    CONTRACT_VERSION: ClassVar[int] = 3
 
     run_id: str = ""
     dataset: str | None = None
@@ -63,6 +63,13 @@ class ResolutionBatch:
     # Deterministic merge: authoritative id columns (e.g. ['npi']) whose shared value
     # collapses fragmented entities post-resolve. None/empty = off.
     deterministic_merge_keys: list | None = None
+    # Config lineage (#config-fingerprint): the fingerprint + serialized form of the
+    # GoldenMatchConfig that produced this batch. Recorded once per run in
+    # identity_runs so an entity's events resolve back to their config. All None
+    # (default) = no lineage recorded (byte-identical to pre-lineage behavior).
+    config_id: str | None = None
+    config_schema_version: int | None = None
+    config_json: str | None = None
     # Frame-residency budget: the write side flushes every ``flush_rows`` records so
     # it never stacks a second O(N) term on the compute prep floor (manifesto §3).
     # A contract term now, not just ``GOLDENMATCH_IDENTITY_BULK_FLUSH_ROWS``.
@@ -127,6 +134,9 @@ class ResolutionBatch:
         field_strategies: dict[str, Any] | None = None,
         relationships: list | None = None,
         deterministic_merge_keys: list | None = None,
+        config_id: str | None = None,
+        config_schema_version: int | None = None,
+        config_json: str | None = None,
     ) -> ResolutionBatch:
         """Build a batch from the loose resolve args, filling the residency budget
         from the env default when unspecified. This is the adapter seam:
@@ -144,6 +154,9 @@ class ResolutionBatch:
             field_strategies=field_strategies,
             relationships=relationships,
             deterministic_merge_keys=deterministic_merge_keys,
+            config_id=config_id,
+            config_schema_version=config_schema_version,
+            config_json=config_json,
         )
 
 

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -460,6 +460,9 @@ def resolve_clusters(
     cluster_frames: ClusterFrames | None = None,
     actor: str = "pipeline",
     field_strategies: dict[str, Any] | None = None,
+    config_id: str | None = None,
+    config_schema_version: int | None = None,
+    config_json: str | None = None,
     batch: ResolutionBatch | None = None,
 ) -> ResolveSummary:
     """Resolve run-local clusters to durable identities.
@@ -507,6 +510,9 @@ def resolve_clusters(
             field_strategies=field_strategies,
             relationships=relationships,
             deterministic_merge_keys=deterministic_merge_keys,
+            config_id=config_id,
+            config_schema_version=config_schema_version,
+            config_json=config_json,
         )
     # C1 follow-on: fold the bulk DATA parts (cluster partition / record frame /
     # scored-pair stream / pair-score view) into the batch, so the whole
@@ -554,6 +560,22 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
 
     if emit_singletons:
         _maybe_warn_singleton_sqlite_ceiling(store, _n_input_rows)
+
+    # Config lineage (#config-fingerprint): record which config produced this
+    # run so an entity's events (which carry run_name) resolve back to it via
+    # identity_runs. Only when a fingerprint was threaded through -- keeps the
+    # no-lineage path byte-identical (no identity_runs write).
+    if batch.config_id is not None:
+        try:
+            store.record_run(
+                run_name,
+                config_id=batch.config_id,
+                schema_version=batch.config_schema_version,
+                config_json=batch.config_json,
+                dataset=dataset,
+            )
+        except Exception as e:  # noqa: BLE001 -- lineage is advisory, never fails a resolve
+            log.warning("config-lineage record_run failed: %s", e)
 
     # Iteration source: ascending-cluster_id ``(cluster_id, info)`` pairs.
     # For the dict path this is ``clusters.items()`` (insertion order = build's

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -233,6 +233,21 @@ CREATE TABLE IF NOT EXISTS identity_relationships (
 CREATE INDEX IF NOT EXISTS idx_rel_a    ON identity_relationships(entity_a_id);
 CREATE INDEX IF NOT EXISTS idx_rel_b    ON identity_relationships(entity_b_id);
 CREATE INDEX IF NOT EXISTS idx_rel_kind ON identity_relationships(kind);
+
+-- Config lineage (#config-fingerprint): one row per named resolve run,
+-- recording the fingerprint of the GoldenMatchConfig that produced it. Events
+-- carry run_name, so entity -> its events' run_name -> identity_runs.config_id
+-- answers "which config produced this entity" across incremental runs, and two
+-- runs' config_id / config_json can be diffed. Written once per apply_batch.
+CREATE TABLE IF NOT EXISTS identity_runs (
+    run_name       TEXT PRIMARY KEY,
+    config_id      TEXT,
+    schema_version INTEGER,
+    config_json    TEXT,
+    dataset        TEXT,
+    created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_runs_config ON identity_runs(config_id);
 """
 
 
@@ -678,6 +693,18 @@ class IdentityStore:
         CREATE INDEX IF NOT EXISTS idx_rel_a    ON identity_relationships(entity_a_id);
         CREATE INDEX IF NOT EXISTS idx_rel_b    ON identity_relationships(entity_b_id);
         CREATE INDEX IF NOT EXISTS idx_rel_kind ON identity_relationships(kind);
+
+        -- Config lineage (#config-fingerprint): one row per named resolve run
+        -- (see _SCHEMA). entity -> events.run_name -> identity_runs.config_id.
+        CREATE TABLE IF NOT EXISTS identity_runs (
+            run_name       TEXT PRIMARY KEY,
+            config_id      TEXT,
+            schema_version INTEGER,
+            config_json    TEXT,
+            dataset        TEXT,
+            created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_runs_config ON identity_runs(config_id);
         """
         with self._conn.cursor() as cur:
             cur.execute(ddl)
@@ -2246,6 +2273,48 @@ class IdentityStore:
             (event.entity_id,),
         )
         return int(row["event_id"]) if row and row["event_id"] is not None else None
+
+    def record_run(
+        self,
+        run_name: str,
+        *,
+        config_id: str | None = None,
+        schema_version: int | None = None,
+        config_json: str | None = None,
+        dataset: str | None = None,
+    ) -> None:
+        """Record config lineage for a resolve run (idempotent by run_name).
+
+        Stamps the fingerprint of the config that produced ``run_name``. Events
+        carry run_name, so entity -> events.run_name -> this row's ``config_id``
+        answers "which config produced this entity". First writer wins on a
+        repeated run_name; calling with no ``config_id`` records the run bare.
+        No-op on the mongo backend.
+        """
+        if not run_name or self._backend == "mongo":
+            return
+        self._exec(
+            "INSERT INTO identity_runs "
+            "(run_name, config_id, schema_version, config_json, dataset) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT (run_name) DO NOTHING",
+            (run_name, config_id, schema_version, config_json, dataset),
+        )
+
+    def run_config(self, run_name: str) -> dict[str, Any] | None:
+        """The recorded config lineage for ``run_name`` (or None).
+
+        Keys: ``run_name``, ``config_id``, ``schema_version``, ``config_json``,
+        ``dataset``, ``created_at``.
+        """
+        if self._backend == "mongo":
+            return None
+        row = self._fetchone(
+            "SELECT run_name, config_id, schema_version, config_json, dataset, "
+            "created_at FROM identity_runs WHERE run_name = ?",
+            (run_name,),
+        )
+        return dict(row) if row else None
 
     def history(
         self, entity_id: str, limit: int | None = None

--- a/packages/python/goldenmatch/tests/identity/test_relationships.py
+++ b/packages/python/goldenmatch/tests/identity/test_relationships.py
@@ -356,3 +356,39 @@ def test_deterministic_merge_hub_guard(store):
     _resolve(store, df, _singletons(4), None)
     assert store.merge_by_shared_field("d", "npi", max_group=2) == (0, 0)  # 4 > cap
     assert store.merge_by_shared_field("d", "npi", max_group=10) == (3, 1)  # collapses
+
+
+def test_config_lineage_records_run_and_resolves_entity_to_config(store):
+    """A resolve stamps identity_runs with the config fingerprint, and an entity's
+    events (which carry run_name) resolve back to that config_id."""
+    df = _df([{"id": "1", "name": "Al", "phone": "555"}])
+    resolve_clusters(
+        _singletons(1), df, [], "mk", store, run_name="run1", source_pk_col="id",
+        dataset="d", emit_singletons=True,
+        config_id="sha256:deadbeef", config_schema_version=1,
+        config_json='{"matchkeys": []}',
+    )
+    run = store.run_config("run1")
+    assert run is not None
+    assert run["config_id"] == "sha256:deadbeef"
+    assert run["schema_version"] == 1
+    assert run["config_json"] == '{"matchkeys": []}'
+    # entity -> its events' run_name -> the recorded config_id
+    ent = store.find_entity_by_record("src:1")
+    run_names = {ev.run_name for ev in store.history(ent)}
+    assert "run1" in run_names
+    assert store.run_config("run1")["config_id"] == "sha256:deadbeef"
+
+
+def test_config_lineage_absent_when_no_fingerprint(store):
+    """No config_id threaded through -> no identity_runs row (byte-identical path)."""
+    df = _df([{"id": "1", "name": "Al", "phone": "555"}])
+    _resolve(store, df, _singletons(1), None, run_name="bare")
+    assert store.run_config("bare") is None
+
+
+def test_config_lineage_idempotent_on_repeated_run_name(store):
+    """First writer wins on a repeated run_name (idempotent replay)."""
+    store.record_run("rx", config_id="sha256:aaaa", schema_version=1)
+    store.record_run("rx", config_id="sha256:bbbb", schema_version=2)
+    assert store.run_config("rx")["config_id"] == "sha256:aaaa"

--- a/packages/python/goldenmatch/tests/identity/test_resolution_batch_c1.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolution_batch_c1.py
@@ -22,9 +22,10 @@ from .test_resolve_bulk_writes_1886 import (
 
 def test_batch_is_versioned():
     # v2 added the field_strategies survivorship-config term.
-    assert ResolutionBatch.CONTRACT_VERSION == 2
+    # v3 added the config-lineage terms (config_id / config_schema_version / config_json).
+    assert ResolutionBatch.CONTRACT_VERSION == 3
     b = ResolutionBatch.from_args(run_id="r1")
-    assert b.contract_version == 2
+    assert b.contract_version == 3
 
 
 def test_batch_is_immutable():

--- a/packages/python/goldenmatch/tests/test_config_fingerprint.py
+++ b/packages/python/goldenmatch/tests/test_config_fingerprint.py
@@ -1,0 +1,60 @@
+"""Config fingerprint / lineage identity (config_fingerprint, config_id).
+
+A config's fingerprint is a deterministic hash of its matching semantics, so a
+run can record "which config produced this" and two configs can be diffed by
+id. Per-run (``output.run_name``) and versioning (``schema_version``) noise must
+not move the id; a real matching-semantic change must.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.schemas import (
+    CONFIG_SCHEMA_VERSION,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    OutputConfig,
+)
+
+
+def _cfg(field: str = "npi") -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="mk1", type="exact", fields=[MatchkeyField(field=field)])]
+    )
+
+
+def test_fingerprint_is_deterministic_and_prefixed() -> None:
+    a, b = _cfg(), _cfg()
+    assert a.config_fingerprint() == b.config_fingerprint()
+    assert a.config_fingerprint().startswith("sha256:")
+    assert len(a.config_fingerprint()) == len("sha256:") + 64
+
+
+def test_config_id_is_short_form() -> None:
+    c = _cfg()
+    assert c.config_id == c.config_fingerprint()[: len("sha256:") + 8]
+    assert len(c.config_id) == len("sha256:") + 8
+
+
+def test_schema_version_defaults_and_is_excluded_from_fingerprint() -> None:
+    c = _cfg()
+    assert c.schema_version == CONFIG_SCHEMA_VERSION
+    bumped = _cfg()
+    bumped.schema_version = CONFIG_SCHEMA_VERSION + 100
+    # A semantics-preserving schema bump must not change the id.
+    assert bumped.config_fingerprint() == c.config_fingerprint()
+
+
+def test_run_name_is_excluded_from_fingerprint() -> None:
+    a = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="mk1", type="exact", fields=[MatchkeyField(field="npi")])],
+        output=OutputConfig(run_name="run_A"),
+    )
+    b = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="mk1", type="exact", fields=[MatchkeyField(field="npi")])],
+        output=OutputConfig(run_name="run_B"),
+    )
+    assert a.config_fingerprint() == b.config_fingerprint()
+
+
+def test_matching_semantic_change_changes_fingerprint() -> None:
+    assert _cfg("npi").config_fingerprint() != _cfg("email").config_fingerprint()

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -20,6 +20,13 @@
           "name": "GoldenMatchConfig",
           "fields": [
             {
+              "name": "schema_version",
+              "type": "int",
+              "required": false,
+              "default": "1",
+              "description": "Config schema version; set by GoldenMatch (not user-tuned). Recorded with a run's config fingerprint for lineage/migration. Excluded from the fingerprint so a semantics-preserving schema bump keeps the same config id."
+            },
+            {
               "name": "input",
               "type": "InputConfig | None",
               "required": false,


### PR DESCRIPTION
## What

Makes a config's identity first-class and records **which config produced each resolve run**, so you can answer "which config produced this entity?" and diff configs across runs. Backs the "versioned configs" capability.

## Config identity (`config/schemas.py`)

- `CONFIG_SCHEMA_VERSION` + `GoldenMatchConfig.schema_version` (GM-set, not user-tuned).
- `config_fingerprint() -> "sha256:<64hex>"` — deterministic hash of the config's **matching semantics** (canonical JSON, sorted keys). Excludes the per-run `output.run_name` and `schema_version`, so the same semantics hash identically across runs and across a semantics-preserving schema bump; a real matching change flips it. `config_id` is the short display form.

## Run lineage (identity store)

- New **`identity_runs`** table (`run_name` PK, `config_id`, `schema_version`, `config_json`, `dataset`, `created_at`) on both SQLite and Postgres — pure `CREATE TABLE IF NOT EXISTS`, so it self-migrates onto existing stores.
- `store.record_run()` (idempotent, first-writer-wins) + `store.run_config()`.
- Plumbed through `ResolutionBatch` (`CONTRACT_VERSION` 2→3), `resolve_clusters`, and `apply_batch` (records the run once before the write). The pipeline stamps `config.config_fingerprint()` / `schema_version` / `model_dump_json()`.
- Events already carry `run_name`, so **entity → `events.run_name` → `identity_runs.config_id`** gives lineage even as an entity absorbs records across multiple configs over time.

## Design notes

- No `ResolveSummary` / TS-parity change: `config_id` is lineage metadata, not a count, so it stays out of the counts contract.
- **All `None`** (no fingerprint threaded through) = no `identity_runs` write — byte-identical to the prior path.
- The distributed (`resolve_identities_distributed`) branch is a follow-on; this wires the in-memory/Postgres `apply_batch` path.

## Tests

`test_config_fingerprint.py` (5: determinism, short form, run_name/schema_version exclusion, semantic-change sensitivity) + 3 lineage tests in `test_relationships.py` (run recorded + entity→config resolution, absent when no fingerprint, idempotent replay). Doc gates regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)