### PR TITLE
feat(from_dbt): recognize shared-key edge/crosswalk models -> identity idioms

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/from_dbt.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_dbt.py
@@ -38,8 +38,10 @@ from goldenmatch.config.schemas import (
     GoldenFieldRule,
     GoldenMatchConfig,
     GoldenRulesConfig,
+    IdentityConfig,
     MatchkeyConfig,
     MatchkeyField,
+    RelationshipRule,
 )
 from goldenmatch.core._paths import safe_path
 
@@ -113,8 +115,40 @@ _UNRECOGNIZED_WRAP_FUNCS: frozenset[str] = frozenset(
 
 SignalKind = Literal[
     "blocking", "exact_matchkey", "fuzzy_field", "transform", "survivorship",
-    "couldnt_extract",
+    "deterministic_merge", "relationship", "couldnt_extract",
 ]
+
+# ── Pure shared-key edge / crosswalk idioms ──────────────────────────────────
+#
+# A dbt model that self-joins on a shared attribute with NO fuzzy predicate is
+# an EDGE/crosswalk model (link records that share a value), not a fuzzy
+# matcher. This is common when the probabilistic matching lives OUTSIDE dbt
+# (e.g. an external Splink step) and dbt only does deterministic post-processing
+# -- exactly the shape the fuzzy-only signal 5 misses. We map it onto the two
+# GoldenMatch identity idioms:
+#   * an authoritative government/registry id -> identity.deterministic_merge_keys
+#     (a unique id can't be split across entities);
+#   * a softer shared attribute (email/phone/org/address) -> a RelationshipRule.
+#
+# Authoritative external identifiers whose shared value is a HARD merge. Curated
+# (NOT generic ``*_id``, which is usually a surrogate key, not authoritative).
+_AUTHORITATIVE_IDS: frozenset[str] = frozenset({
+    "npi", "ssn", "ein", "duns", "dea", "nabp", "upin", "tin", "isni", "orcid",
+    "mpi", "national_provider_id", "npi_number",
+})
+
+# Soft shared attributes -> a relationship edge. field -> (kind, transform).
+_REL_KIND_BY_FIELD: dict[str, tuple[str, str | None]] = {
+    "email": ("same_email", None),
+    "email_address": ("same_email_domain", "email_domain"),
+    "phone": ("shares_phone", None),
+    "phone_number": ("shares_phone", None),
+    "org": ("same_org", "normalize_company"),
+    "org_name": ("same_org", "normalize_company"),
+    "organization": ("same_org", "normalize_company"),
+    "company": ("same_org", "normalize_company"),
+    "address": ("same_address", None),
+}
 
 
 @dataclass
@@ -499,6 +533,36 @@ def extract_signals(
             signals.extend(extras)
             break  # one dedup GROUP BY per model is enough
 
+    # 7. Pure shared-key self-join / crosswalk (NO fuzzy predicate) -> identity
+    #    edge idiom. When the probabilistic matcher lives OUTSIDE dbt (e.g. an
+    #    external Splink step), dbt's remaining ER models just LINK records that
+    #    share a value: an authoritative id (-> deterministic_merge_keys) or a
+    #    soft attribute (-> a RelationshipRule). Signal 5 handles the fuzzy-paired
+    #    self-join; this handles the deterministic one it deliberately skips.
+    if not any(s.kind == "fuzzy_field" for s in signals) and not saw_window_key:
+        seen_share: set[str] = set()
+        for m in _ON_EQUALITY_RE.finditer(compiled):
+            la, lc, ra, rc = m.groups()
+            if la == ra or lc != rc:  # need a.col = b.col (self-join on one col)
+                continue
+            col = lc.lower()
+            if col in seen_share:
+                continue
+            seen_share.add(col)
+            if col in _AUTHORITATIVE_IDS:
+                signals.append(RecognizedSignal(
+                    "deterministic_merge", [lc], {}, model, 0.8, m.group(0)[:200],
+                ))
+            elif col in _REL_KIND_BY_FIELD:
+                kind, transform = _REL_KIND_BY_FIELD[col]
+                signals.append(RecognizedSignal(
+                    "relationship", [lc],
+                    {"kind": kind, "transform": transform}, model, 0.7,
+                    m.group(0)[:200],
+                ))
+            # else: a self-join on a surrogate/unknown key is not necessarily ER;
+            # skip silently rather than emit a false identity edge.
+
     return signals
 
 
@@ -641,19 +705,26 @@ class DbtConversionCoverage:
     transforms: int
     survivorship_rules: int
     couldnt_extract: int
+    # Pure shared-key edge/crosswalk idioms (external-matcher + dbt-postprocessing
+    # shape): authoritative-id merges and soft-attribute relationship edges.
+    deterministic_merge_keys: int = 0
+    relationship_edges: int = 0
 
     @property
     def story(self) -> Literal["fuzzy-er", "exact-dedup", "none"]:
         if self.fuzzy_fields > 0:
             return "fuzzy-er"
-        if self.exact_matchkeys > 0 or self.blocking_keys > 0:
+        if (self.exact_matchkeys > 0 or self.blocking_keys > 0
+                or self.deterministic_merge_keys > 0 or self.relationship_edges > 0):
             return "exact-dedup"
         return "none"
 
     @property
     def has_config(self) -> bool:
-        """True when at least one blocking key or matchkey was extracted."""
-        return self.blocking_keys > 0 or self.exact_matchkeys > 0 or self.fuzzy_fields > 0
+        """True when at least one config idiom (matchkey/blocking/identity) was extracted."""
+        return (self.blocking_keys > 0 or self.exact_matchkeys > 0
+                or self.fuzzy_fields > 0 or self.deterministic_merge_keys > 0
+                or self.relationship_edges > 0)
 
     def line(self) -> str:
         """One-line human summary."""
@@ -668,6 +739,11 @@ class DbtConversionCoverage:
             f"{self.exact_matchkeys} exact + {self.fuzzy_fields} fuzzy comparison field(s)",
             f"{self.survivorship_rules} survivorship rule(s)",
         ]
+        if self.deterministic_merge_keys or self.relationship_edges:
+            parts.append(
+                f"{self.deterministic_merge_keys} deterministic-merge key(s) + "
+                f"{self.relationship_edges} relationship edge(s)"
+            )
         if self.couldnt_extract:
             parts.append(f"{self.couldnt_extract} construct(s) flagged for review")
         return " -- ".join(parts) + f" -- story: {story_text}"
@@ -957,7 +1033,49 @@ def _emit_config(
             )],
         ))
 
-    if not matchkeys and not blocking_keys:
+    # Pure shared-key edge/crosswalk models -> identity idioms: an authoritative
+    # id becomes a deterministic_merge_key (a unique id can't split across
+    # entities); a soft shared attribute becomes a RelationshipRule.
+    det_keys: list[str] = []
+    for sig in signals:
+        if sig.kind != "deterministic_merge":
+            continue
+        col = sig.columns[0]
+        if col not in det_keys:
+            det_keys.append(col)
+            report.info(
+                f"model:{sig.source_model}",
+                f"self-join on authoritative id '{col}' with no fuzzy predicate "
+                "-> identity.deterministic_merge_keys",
+                mapped_to=f"identity.deterministic_merge_keys[{len(det_keys) - 1}]",
+            )
+    rel_rules: list[RelationshipRule] = []
+    rel_seen: set[tuple[str, str]] = set()
+    for sig in signals:
+        if sig.kind != "relationship":
+            continue
+        col, kind = sig.columns[0], sig.params["kind"]
+        if (col, kind) in rel_seen:
+            continue
+        rel_seen.add((col, kind))
+        rel_rules.append(RelationshipRule(
+            field=col, kind=kind, transform=sig.params.get("transform"),
+        ))
+        report.info(
+            f"model:{sig.source_model}",
+            f"self-join on shared '{col}' with no fuzzy predicate -> relationship "
+            f"edge '{kind}'",
+            mapped_to=f"identity.relationships[{len(rel_rules) - 1}]",
+        )
+    identity: IdentityConfig | None = None
+    if det_keys or rel_rules:
+        identity = IdentityConfig(
+            enabled=True,
+            deterministic_merge_keys=det_keys,
+            relationships=rel_rules,
+        )
+
+    if not matchkeys and not blocking_keys and identity is None:
         return None
 
     blocking: BlockingConfig | None = None
@@ -999,6 +1117,7 @@ def _emit_config(
         matchkeys=matchkeys or None,
         blocking=blocking,
         golden_rules=golden_rules,
+        identity=identity,
     )
 
 
@@ -1090,6 +1209,10 @@ def _build_coverage(
     transforms = sum(1 for s in signals if s.kind == "transform")
     survivorship = sum(1 for s in signals if s.kind == "survivorship")
     couldnt = sum(1 for s in signals if s.kind == "couldnt_extract")
+    det_keys = rel_edges = 0
+    if config is not None and config.identity is not None:
+        det_keys = len(config.identity.deterministic_merge_keys)
+        rel_edges = len(config.identity.relationships or [])
     return DbtConversionCoverage(
         total_models=total_models,
         er_models_analyzed=er_analyzed,
@@ -1099,4 +1222,6 @@ def _build_coverage(
         transforms=transforms,
         survivorship_rules=survivorship,
         couldnt_extract=couldnt,
+        deterministic_merge_keys=det_keys,
+        relationship_edges=rel_edges,
     )

--- a/packages/python/goldenmatch/tests/test_from_dbt_identity_edges.py
+++ b/packages/python/goldenmatch/tests/test_from_dbt_identity_edges.py
@@ -1,0 +1,104 @@
+"""from_dbt: pure shared-key edge / crosswalk models -> identity idioms.
+
+The MVP recognizers target IN-dbt fuzzy matching (window-dedup, GROUP BY,
+levenshtein/soundex). But when the probabilistic matcher lives OUTSIDE dbt (e.g.
+an external Splink step), dbt's remaining ER models are deterministic edge /
+crosswalk self-joins on a shared value -- which the fuzzy-only self-join signal
+deliberately skips. These map onto GoldenMatch's identity idioms: an
+authoritative id -> deterministic_merge_keys; a soft attribute -> a
+RelationshipRule.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.from_dbt import from_dbt
+
+
+def _model(name: str, sql: str) -> dict:
+    return {
+        "resource_type": "model",
+        "name": name,
+        "unique_id": f"model.proj.{name}",
+        "compiled_code": sql,
+    }
+
+
+def _manifest(*models: dict) -> dict:
+    return {
+        "metadata": {"adapter_type": "snowflake"},
+        "nodes": {m["unique_id"]: m for m in models},
+    }
+
+
+def test_npi_crosswalk_selfjoin_becomes_deterministic_merge_key():
+    # NPI_CROSSWALK idiom: link records sharing an NPI (+ a same-name guard), no
+    # fuzzy predicate. NPI is authoritative -> a deterministic merge key.
+    sql = (
+        "select a.id as left_id, b.id as right_id "
+        "from persons a join persons b "
+        "on a.npi = b.npi and a.last_name = b.last_name "
+        "where a.id < b.id"
+    )
+    conv = from_dbt(_manifest(_model("int_er__npi_crosswalk", sql)))
+    assert conv.config is not None
+    assert conv.config.identity is not None
+    assert conv.config.identity.enabled is True
+    assert conv.config.identity.deterministic_merge_keys == ["npi"]
+    assert conv.coverage.deterministic_merge_keys == 1
+
+
+def test_phone_edge_selfjoin_becomes_relationship_rule():
+    # EMAIL/PHONE edge idiom: link records sharing a soft attribute -> a
+    # relationship edge, not a hard merge.
+    sql = (
+        "select a.id, b.id from contacts a join contacts b "
+        "on a.phone_number = b.phone_number where a.id <> b.id"
+    )
+    conv = from_dbt(_manifest(_model("int_identity__phone_xref", sql)))
+    assert conv.config is not None
+    assert conv.config.identity is not None
+    rels = conv.config.identity.relationships
+    assert rels is not None and len(rels) == 1
+    assert rels[0].field == "phone_number"
+    assert rels[0].kind == "shares_phone"
+    assert conv.coverage.relationship_edges == 1
+
+
+def test_org_edge_carries_normalize_company_transform():
+    sql = (
+        "select a.id, b.id from accounts a join accounts b "
+        "on a.org_name = b.org_name where a.id < b.id"
+    )
+    conv = from_dbt(_manifest(_model("int_xref__org_crosswalk", sql)))
+    assert conv.config is not None and conv.config.identity is not None
+    rel = conv.config.identity.relationships[0]
+    assert rel.field == "org_name"
+    assert rel.kind == "same_org"
+    assert rel.transform == "normalize_company"
+
+
+def test_fuzzy_selfjoin_is_not_treated_as_identity_edge():
+    # A self-join PAIRED with a fuzzy predicate stays the existing blocking-key
+    # path -- signal 7 must not fire (no identity edges emitted for it).
+    sql = (
+        "select a.id, b.id from persons a join persons b "
+        "on a.npi = b.npi where jaro_winkler_similarity(a.last_name, b.last_name) > 0.9"
+    )
+    conv = from_dbt(_manifest(_model("int_er__fuzzy_dedupe", sql)))
+    # config exists (fuzzy field extracted), but no deterministic-merge idiom.
+    ident = conv.config.identity if conv.config else None
+    assert ident is None or ident.deterministic_merge_keys == []
+    assert conv.coverage.deterministic_merge_keys == 0
+
+
+def test_surrogate_key_selfjoin_is_ignored():
+    # A self-join on a non-authoritative surrogate key is not necessarily ER;
+    # signal 7 stays silent rather than emit a false identity edge.
+    sql = (
+        "select a.*, b.val from t a join t b "
+        "on a.customer_id = b.customer_id where a.id < b.id"
+    )
+    conv = from_dbt(_manifest(_model("int_er__cust_selfjoin", sql)))
+    ident = conv.config.identity if conv.config else None
+    assert ident is None or (
+        ident.deterministic_merge_keys == [] and not ident.relationships
+    )


### PR DESCRIPTION
## What

Closes a real gap in the existing `from_dbt` converter for the **external-matcher + dbt-postprocessing** shape.

`from_dbt`'s recognizers target **in-dbt** fuzzy matching (window-dedup, GROUP BY, levenshtein/soundex). But when the probabilistic matcher lives **outside** dbt (e.g. an external Splink step), the remaining dbt ER models are deterministic **edge / crosswalk self-joins** on a shared value. The fuzzy-only self-join path (signal 5) deliberately skips those, so nothing was extracted from that whole shape.

## How

New **signal 7**: a self-join `a.col = b.col` with **no fuzzy predicate** present is an edge/crosswalk idiom, mapped onto GoldenMatch's identity idioms:
- an **authoritative** government/registry id (`npi`, `ssn`, `ein`, `dea`, `nabp`, …) → `identity.deterministic_merge_keys` (a unique id can't split across entities);
- a **soft** shared attribute (email/phone/org/address) → a `RelationshipRule` with the right `kind` + `transform` (e.g. `org_name` → `same_org` / `normalize_company`);
- a surrogate/unknown key → stays silent (no false identity edge).

`_emit_config` now emits an enabled `IdentityConfig(deterministic_merge_keys, relationships)`, and the coverage scorecard gains `deterministic_merge_keys` + `relationship_edges` counts. This maps a crosswalk/edge model that links records sharing an authoritative id or soft attribute onto the relationship-graph (#2245) and deterministic-merge (#2389) features.

## Tests

`test_from_dbt_identity_edges.py` (5): npi crosswalk → merge key; phone/org edge → relationship rule + transform; fuzzy self-join **not** hijacked (signal 5 preserved); surrogate key ignored. All existing dbt tests unchanged. ruff + doc gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)