### PR TITLE
feat(from_dbt): --select to scope ER-model analysis

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -759,6 +759,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `import-dbt` | `--catalog` | text | `None` | dbt catalog.json (from `dbt docs generate`); supplies model column lists so recognized most-recent survivorship is emitted as golden_rules (otherwise it is only reported) |
 | `import-dbt` | `--strict` | boolean | `False` | Fail on any lossy finding (warnings), not just errors |
 | `import-dbt` | `--min-confidence` | float | `0.5` | ER-model identification confidence floor for signal extraction |
+| `import-dbt` | `--select` | text | `[]` | Scope to specific ER models (repeatable), dbt-style; without it a full warehouse over-extracts. Globs the model name (`dedup_*`), or `path:*entity_resolution*`, or `tag:&lt;name>`. Selected models bypass --min-confidence. |
 | `import-dbt` | `--verify` | text | `None` | Prove the distillation reproduces your dbt pipeline: run the converted config on a sample of --source and report pairwise cluster agreement against this output table (parquet/csv; first two columns = id, cluster_id). Needs --source. |
 | `import-dbt` | `--source` | text | `None` | Source rows the dbt ER model consumed (parquet/csv), for --verify |
 | `import-dbt` | `--verify-sample` | integer | `5000` | Rows of --source to run through GoldenMatch for --verify |

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1079,6 +1079,7 @@
             "_model_columns",
             "_name_signal",
             "_order_by_survivorship",
+            "_select_matches",
             "_shape_signal",
             "_split_top_level",
             "_unique_test_columns",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -3490,6 +3490,13 @@
               "help": "ER-model identification confidence floor for signal extraction"
             },
             {
+              "name": "--select",
+              "type": "text",
+              "required": false,
+              "default": "[]",
+              "help": "Scope to specific ER models (repeatable), dbt-style; without it a full warehouse over-extracts. Globs the model name (`dedup_*`), or `path:*entity_resolution*`, or `tag:<name>`. Selected models bypass --min-confidence."
+            },
+            {
               "name": "--verify",
               "type": "text",
               "required": false,

--- a/packages/python/goldenmatch/goldenmatch/cli/import_dbt.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/import_dbt.py
@@ -131,6 +131,17 @@ def import_dbt_cmd(
         "--min-confidence",
         help="ER-model identification confidence floor for signal extraction",
     ),
+    select: list[str] = typer.Option(
+        [],
+        "--select",
+        "-s",
+        help=(
+            "Scope to specific ER models (repeatable), dbt-style; without it a full "
+            "warehouse over-extracts. Globs the model name (`dedup_*`), or "
+            "`path:*entity_resolution*`, or `tag:<name>`. Selected models bypass "
+            "--min-confidence."
+        ),
+    ),
     verify: str | None = typer.Option(
         None,
         "--verify",
@@ -163,6 +174,7 @@ def import_dbt_cmd(
     try:
         conversion = from_dbt(
             manifest, catalog_path=catalog, strict=strict, min_confidence=min_confidence,
+            select=select or None,
         )
     except DbtConversionError as exc:
         err_console.print(f"[red]dbt conversion failed:[/red] {exc}")

--- a/packages/python/goldenmatch/goldenmatch/config/from_dbt.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_dbt.py
@@ -21,6 +21,7 @@ polars-free (it only parses JSON + regexes SQL); ``verify_against_dbt`` lives in
 """
 from __future__ import annotations
 
+import fnmatch
 import json
 import re
 from dataclasses import dataclass
@@ -657,6 +658,36 @@ def _unique_test_columns(manifest: dict) -> dict[str, list[str]]:
     return out
 
 
+def _select_matches(node: dict, patterns: list[str] | tuple[str, ...]) -> bool:
+    """True if a manifest node matches at least one dbt-style ``--select`` pattern.
+
+    Model identification is inherently fuzzy on a full warehouse (every ``dim_`` /
+    ``xref`` / unique-tested staging model looks a little like ER), so a real
+    project scopes the converter the same way it runs dbt: with a selector.
+    Patterns (case-insensitive):
+
+    - ``tag:<name>``  -> the node's ``tags`` contains ``<name>``
+    - ``path:<glob>`` -> ``fnmatch`` on the node's file path
+    - ``<glob>``      -> ``fnmatch`` on the model NAME (e.g. ``dedup_*``)
+    """
+    name = str(node.get("name", "")).lower()
+    path = str(node.get("original_file_path") or node.get("path") or "").lower()
+    tags = {str(t).lower() for t in (node.get("tags") or [])}
+    for raw in patterns:
+        p = str(raw).strip().lower()
+        if not p:
+            continue
+        if p.startswith("tag:"):
+            if p[4:] in tags:
+                return True
+        elif p.startswith("path:"):
+            if fnmatch.fnmatch(path, p[5:]):
+                return True
+        elif fnmatch.fnmatch(name, p):
+            return True
+    return False
+
+
 def identify_er_models(manifest: dict) -> list[ErModel]:
     """Rank the manifest's models by how strongly they look like ER models."""
     unique_tests = _unique_test_columns(manifest)
@@ -861,6 +892,7 @@ def from_dbt(
     catalog_path: dict | str | Path | None = None,
     strict: bool = False,
     min_confidence: float = 0.5,
+    select: list[str] | tuple[str, ...] | None = None,
 ) -> DbtConversion:
     """Distill a dbt project's hand-rolled ER logic into a GoldenMatch config.
 
@@ -878,7 +910,14 @@ def from_dbt(
             :class:`DbtConversionError`. When False (default), only a malformed
             manifest raises -- a partial extraction is the expected outcome.
         min_confidence: models identified below this ER-confidence are reported
-            (in ``er_models``) but NOT analyzed for signal extraction.
+            (in ``er_models``) but NOT analyzed for signal extraction. Ignored for
+            models matched by ``select`` (an explicit selection is authoritative).
+        select: optional dbt-style scope patterns; when given, only ER-candidate
+            models matching one are analyzed. Without it a full warehouse
+            over-extracts (every ``dim_`` / ``xref`` / unique-tested staging model
+            looks a little like ER). Patterns: ``dedup_*`` (glob on the model
+            name), ``path:*entity_resolution*`` (glob on the file path), or
+            ``tag:<name>``. Case-insensitive.
 
     Returns:
         A :class:`DbtConversion` with a validated ``GoldenMatchConfig`` (or
@@ -897,9 +936,29 @@ def from_dbt(
         if n.get("resource_type") == "model"
     )
     er_models = identify_er_models(manifest)
-    analyzed = [m for m in er_models if m.confidence >= min_confidence]
+    if select:
+        nodes_all = manifest.get("nodes", {})
+        before = len(er_models)
+        er_models = [
+            m for m in er_models
+            if _select_matches(nodes_all.get(m.unique_id, {}), select)
+        ]
+        report.info(
+            "select",
+            f"--select {list(select)} scoped {before} ER-candidate model(s) down to "
+            f"{len(er_models)}; the selection is authoritative (the confidence gate is "
+            "not applied to selected models).",
+            mapped_to=None,
+        )
+        # An explicit selection asserts "these ARE my ER models", so analyze all of
+        # them regardless of the heuristic confidence gate.
+        analyzed = list(er_models)
+    else:
+        analyzed = [m for m in er_models if m.confidence >= min_confidence]
+
+    analyzed_ids = {m.unique_id for m in analyzed}
     for m in er_models:
-        if m.confidence >= min_confidence:
+        if m.unique_id in analyzed_ids:
             report.info(
                 f"model:{m.name}",
                 f"identified as ER (confidence {m.confidence:.2f}): "

--- a/packages/python/goldenmatch/tests/test_from_dbt_select.py
+++ b/packages/python/goldenmatch/tests/test_from_dbt_select.py
@@ -1,0 +1,78 @@
+"""from_dbt --select: scope analysis to the ER models on a real warehouse.
+
+Model identification is fuzzy at warehouse scale (every dim_/xref/unique-tested
+staging model looks a little like ER), so from_dbt over-extracts without a
+scope. A dbt-style selector (name glob / path: / tag:) restricts analysis to the
+models the user asserts are ER, and those bypass the confidence gate.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.from_dbt import from_dbt
+
+
+def _model(name: str, sql: str, *, path: str = "", tags: list[str] | None = None) -> dict:
+    return {
+        "resource_type": "model",
+        "name": name,
+        "unique_id": f"model.proj.{name}",
+        "compiled_code": sql,
+        "original_file_path": path or f"models/{name}.sql",
+        "tags": tags or [],
+    }
+
+
+def _manifest(*models: dict) -> dict:
+    return {"metadata": {"adapter_type": "snowflake"}, "nodes": {m["unique_id"]: m for m in models}}
+
+
+# A real ER model (npi crosswalk self-join) + noise that the loose heuristics
+# would sweep in (a dim_, a unique-tested staging model).
+ER_SQL = (
+    "select a.id, b.id from persons a join persons b "
+    "on a.npi = b.npi and a.last_name = b.last_name where a.id < b.id"
+)
+NOISE_SQL = "select brand_id, brand_name from raw.brands"
+
+
+def _manifest_mixed() -> dict:
+    return _manifest(
+        _model("dedup_shared_npi", ER_SQL, path="models/core/entity_resolution/dedup_shared_npi.sql", tags=["entity_resolution"]),
+        _model("dim_brand", NOISE_SQL, path="models/marts/dim_brand.sql"),
+        _model("stg_workday__suppliers", "select supplier_id from raw.suppliers", path="models/staging/stg_workday__suppliers.sql"),
+    )
+
+
+def test_without_select_over_extracts():
+    conv = from_dbt(_manifest_mixed())
+    # dim_brand + stg_* get swept in alongside the real ER model.
+    assert conv.coverage.er_models_analyzed >= 2
+
+
+def test_select_name_glob_scopes_to_er_models():
+    conv = from_dbt(_manifest_mixed(), select=["dedup_*"])
+    assert conv.coverage.er_models_analyzed == 1
+    assert conv.config is not None and conv.config.identity is not None
+    assert conv.config.identity.deterministic_merge_keys == ["npi"]
+
+
+def test_select_by_path():
+    conv = from_dbt(_manifest_mixed(), select=["path:*entity_resolution*"])
+    assert conv.coverage.er_models_analyzed == 1
+    assert conv.config.identity.deterministic_merge_keys == ["npi"]
+
+
+def test_select_by_tag():
+    conv = from_dbt(_manifest_mixed(), select=["tag:entity_resolution"])
+    assert conv.coverage.er_models_analyzed == 1
+
+
+def test_select_is_case_insensitive():
+    conv = from_dbt(_manifest_mixed(), select=["DEDUP_*"])
+    assert conv.coverage.er_models_analyzed == 1
+
+
+def test_select_overrides_confidence_gate():
+    # A model whose only ER signal is a name hint (confidence 0.5) is still
+    # analyzed when explicitly selected, even with a high min_confidence.
+    conv = from_dbt(_manifest_mixed(), select=["dedup_*"], min_confidence=0.99)
+    assert conv.coverage.er_models_analyzed == 1

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -3490,6 +3490,13 @@
               "help": "ER-model identification confidence floor for signal extraction"
             },
             {
+              "name": "--select",
+              "type": "text",
+              "required": false,
+              "default": "[]",
+              "help": "Scope to specific ER models (repeatable), dbt-style; without it a full warehouse over-extracts. Globs the model name (`dedup_*`), or `path:*entity_resolution*`, or `tag:<name>`. Selected models bypass --min-confidence."
+            },
+            {
               "name": "--verify",
               "type": "text",
               "required": false,


### PR DESCRIPTION
## What

`from_dbt` over-extracts on a real warehouse: ER-model identification is inherently fuzzy at scale (every `dim_` / `xref` / unique-tested staging model looks a little like ER), so on a multi-hundred-model project it flags hundreds of models and emits an unusable firehose config (a matchkey with ~200 fields, 100+ blocking passes). There was no way to scope it.

## How

Adds a dbt-style `select` (Python arg) / `--select` / `-s` (CLI, repeatable). Patterns match case-insensitively:
- `dedup_*` — glob on the model **name**
- `path:*entity_resolution*` — glob on the file **path**
- `tag:<name>` — the model's dbt **tags**

When given, only ER-candidate models matching a pattern are analyzed, and the selection is **authoritative** — selected models bypass the `--min-confidence` gate, matching dbt's mental model of `--select`. Omitting it is unchanged (backward-compatible full-warehouse scan).

On a real ~740-model warehouse this takes the analyzed set from ~395 (firehose) down to the ~27 actual ER models, producing a clean, usable config.

## Tests

`test_from_dbt_select.py` (6): over-extract without select; name-glob / `path:` / `tag:` scoping; case-insensitive; selection overrides the confidence gate. All existing dbt tests unchanged. ruff + doc gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)