### PR TITLE
feat(semantic): Cube/OSI discovery emit + dialect-aware apply-names (Phase 9)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -676,7 +676,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `demo` | `--graph` | boolean | `False` | Generate cluster graph |
 | `demo` | `--quiet` | boolean | `False` | Suppress animated output |
 | `discover-model` | `--data` | text | **required** | A source table as name=path (repeatable), e.g. -d orders=orders.csv |
-| `discover-model` | `--dialect` | text | `'metricflow'` | Emit dialect for the draft model (metricflow). |
+| `discover-model` | `--dialect` | text | `'metricflow'` | Emit dialect for the draft model: metricflow / cube / osi. |
 | `discover-model` | `--output` | text | `None` | Write the draft semantic-model YAML to this path. |
 | `discover-model` | `--resolve` | boolean | `False` | Also measure entity fragmentation / undercount via ER (fail-open). |
 | `discover-model` | `--name` | boolean | `False` | Also run the OPTIONAL advisory LLM namer (business names for entities/dimensions/values/measures; abstains without an LLM key). |

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 446,
+      "module_count": 447,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7275,6 +7275,24 @@
           ]
         },
         {
+          "module": "goldenmatch.semantic.discovery.emit",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py",
+          "purpose": "Dialect emit for discovered models (PR-9).",
+          "defines": [
+            "_build_cube",
+            "_build_metricflow",
+            "_build_osi",
+            "_trustworthy_joins",
+            "build_model_yaml"
+          ],
+          "imports": [
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic",
+            "goldenmatch.semantic.cube",
+            "goldenmatch.semantic.osi"
+          ]
+        },
+        {
           "module": "goldenmatch.semantic.discovery.entities",
           "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/entities.py",
           "purpose": "Cross-table entity-type discovery (semantic-model discovery, Phase 2).",
@@ -7362,6 +7380,7 @@
           ],
           "imports": [
             "goldenmatch.semantic",
+            "goldenmatch.semantic.discovery.emit",
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys",
@@ -7378,10 +7397,15 @@
             "NameSuggestion",
             "NamerBackend",
             "_Target",
+            "_apply_cube",
+            "_apply_metricflow",
+            "_apply_osi",
+            "_entity_tables",
             "_glossary",
             "_parse_json_object",
             "_propose_prompt",
             "_sample_values",
+            "_split_value_target",
             "_targets_for_table",
             "_targets_in_prompt",
             "_verify_prompt",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -2854,7 +2854,7 @@
               "type": "text",
               "required": false,
               "default": "'metricflow'",
-              "help": "Emit dialect for the draft model (metricflow)."
+              "help": "Emit dialect for the draft model: metricflow / cube / osi."
             },
             {
               "name": "--output",

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -219,6 +219,24 @@ ProposedModel`.
    `discover_semantic_model(..., apply_names=False)`, CLI `--apply-names`, MCP/REST
    `apply_names` bool; `"yaml"` is added to `ProposedModel.to_dict()` so the applied
    catalog is visible on every surface. No new MCP tool / CLI command.
+9. **PR-9 (optional) Cube/OSI discovery emit.** `discover_semantic_model(dialect=...)`
+   emits `cube` and `osi` drafts in addition to `metricflow` (it used to raise on
+   anything else, even though certification already spans all three and the
+   `emit_cube_yaml` / `emit_osi_yaml` emitters + dataclasses exist). A new
+   `discovery/emit.py` builds the dialect YAML from the discovered structure: per
+   table, the grain -> `primary_key` (a `primary_key` `CubeDimension` / an
+   `OsiDataset.primary_key` list), discovered dimensions -> `CubeDimension`/`OsiField`,
+   sum-safe measures -> `CubeMeasure`/`OsiMetric`, and the key-integrity certificate ->
+   `meta.goldenmatch` (cube) / `custom_extensions.goldenmatch` (osi). The certified
+   **trustworthy** join graph is emitted natively: `CubeJoin` (a `{CUBE}.<fk> =
+   {<to>.<pk>}` SQL condition) / `OsiRelationship` (`from_columns`/`to_columns`). Every
+   emitted model is re-certified end-to-end (dialect auto-detected), and the metricflow
+   path stays byte-identical. `apply_names` becomes dialect-aware: cube -> `title:` on
+   cube/dimension/measure + `meta.goldenmatch.glossary`; osi -> `label`/`description` on
+   field/dataset + `custom_extensions.goldenmatch.glossary`. `dialect` already plumbs
+   through CLI `--dialect` + MCP/REST `dialect`; no new params. Follow-on: PR-10 lifts
+   the single-column key/FK limitation (the certifier + `KeyCandidate.columns` +
+   Cube/OSI composite primary keys already support multi-column).
 
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -364,6 +364,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   discovery arc (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_apply_names.py`, `tests/test_semantic_discover_surface.py`.
+- **Semantic-model discovery — Cube / OSI emit (Phase 9).** `discover_semantic_model(dialect=...)`
+  now emits `cube` and `osi` draft catalogs in addition to `metricflow` (it used to raise
+  on anything else, though certification already spanned all three). A new
+  `goldenmatch/semantic/discovery/emit.py` maps the discovered structure onto the
+  existing dialect emitters: per table, the grain → primary key (a `primary_key`
+  `CubeDimension` / an `OsiDataset.primary_key` list — composite-ready), discovered
+  dimensions → `CubeDimension`/`OsiField`, sum-safe measures → `CubeMeasure`/`OsiMetric`,
+  and the key-integrity verdict → `meta.goldenmatch` (cube) / `custom_extensions.goldenmatch`
+  (osi). The certified **trustworthy** join graph is emitted natively as
+  `CubeJoin`/`OsiRelationship`, and every emitted model is re-certified end-to-end. The
+  MetricFlow path is byte-identical. `apply_names` (Phase 8) is now dialect-aware: cube
+  → `title:` on cube/measure + `meta.goldenmatch.glossary`; osi → native field `label` +
+  metric `description` + `custom_extensions.goldenmatch.glossary`. `dialect` already
+  plumbs through CLI `--dialect` + MCP/REST `dialect`; no new params or tools. The ninth
+  slice of the semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_cube_osi_emit.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/goldenmatch/cli/discover_model.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/discover_model.py
@@ -22,7 +22,7 @@ def discover_model_cmd(
     ),
     dialect: str = typer.Option(
         "metricflow", "--dialect",
-        help="Emit dialect for the draft model (metricflow).",
+        help="Emit dialect for the draft model: metricflow / cube / osi.",
     ),
     output: str | None = typer.Option(
         None, "--output", "-o",

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -836,7 +836,7 @@ _BASE_TOOLS = [
                 },
                 "dialect": {
                     "type": "string",
-                    "description": "Emit dialect for the draft model (metricflow for now).",
+                    "description": "Emit dialect for the draft model: metricflow / cube / osi.",
                     "default": "metricflow",
                 },
                 "resolve": {

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
@@ -1,0 +1,153 @@
+"""Dialect emit for discovered models (PR-9).
+
+Turns the discovered structure (`ProposedTable`s + the certified join graph) into a
+draft catalog in one of the three supported dialects. MetricFlow was the original
+slice; `cube` and `osi` are added here. Each builder reuses the EXISTING dialect
+emitters (`emit_metricflow_yaml` / `emit_cube_yaml` / `emit_osi_yaml`) and their
+dataclasses — this module only maps discovery types onto them.
+
+Only the **trustworthy** joins are emitted (an untrustworthy FK is a bad join, not a
+pre-graded one). The MetricFlow path is byte-identical to the pre-PR-9 inline emit.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# discovered dimension `kind` -> Cube dimension type / OSI is_time.
+_CUBE_DIM_TYPE = {"categorical": "string", "date": "time", "geo": "geo"}
+
+
+def build_model_yaml(dialect: str, proposed_tables: list[Any], joins: list[Any]) -> str:
+    """Emit the discovered model as YAML in `dialect` (metricflow / cube / osi)."""
+    if dialect == "metricflow":
+        return _build_metricflow(proposed_tables)
+    if dialect == "cube":
+        return _build_cube(proposed_tables, joins)
+    if dialect == "osi":
+        return _build_osi(proposed_tables, joins)
+    return ""  # unreachable: dialect is validated by the caller.
+
+
+def _trustworthy_joins(joins: list[Any]) -> list[Any]:
+    return [j for j in joins if getattr(j, "is_trustworthy", False)]
+
+
+def _build_metricflow(proposed_tables: list[Any]) -> str:
+    """The original inline emit, unchanged: entities + sum-safe measures per table."""
+    from goldenmatch.semantic import emit_metricflow_yaml, emit_semantic_model
+
+    models = []
+    for pt in proposed_tables:
+        if pt.key is None:
+            continue
+        safe_measures = [m.column for m in pt.measures if m.safe_to_sum]
+        models.append(
+            emit_semantic_model(
+                pt.table,
+                resolved_key=pt.key.columns[0],
+                entity_name=pt.entity_type or pt.table,
+                measures=safe_measures,
+                certificate=pt.key.certificate,
+            )
+        )
+    return emit_metricflow_yaml(models) if models else ""
+
+
+def _build_cube(proposed_tables: list[Any], joins: list[Any]) -> str:
+    """One Cube per table: grain -> primary_key dimensions, discovered dimensions,
+    sum-safe measures, the key-integrity verdict in `meta.goldenmatch`, and the
+    trustworthy join graph as `many_to_one` CubeJoins on the FROM cube."""
+    from goldenmatch.core.key_integrity_certificate import certificate_verdict
+    from goldenmatch.semantic.cube import (
+        Cube,
+        CubeDimension,
+        CubeJoin,
+        CubeMeasure,
+        emit_cube_yaml,
+    )
+
+    joins_by_from: dict[str, list[Any]] = {}
+    for j in _trustworthy_joins(joins):
+        joins_by_from.setdefault(j.from_table, []).append(j)
+
+    cubes = []
+    for pt in proposed_tables:
+        if pt.key is None:
+            continue
+        key_cols = list(pt.key.columns)
+        dims = [CubeDimension(c, c, type="string", primary_key=True) for c in key_cols]
+        for d in pt.dimensions:
+            if d.column not in key_cols:
+                dims.append(CubeDimension(d.column, d.column,
+                                          type=_CUBE_DIM_TYPE.get(d.kind, "string")))
+        measures = [CubeMeasure(m.column, type="sum", sql=m.column)
+                    for m in pt.measures if m.safe_to_sum]
+        cube_joins = [
+            CubeJoin(
+                name=j.to_table,
+                relationship=j.relationship or "many_to_one",
+                sql=f"{{CUBE}}.{j.from_column} = {{{j.to_table}.{j.to_column}}}",
+            )
+            for j in joins_by_from.get(pt.table, [])
+        ]
+        cube = Cube(name=pt.table, sql_table=pt.table, dimensions=dims,
+                    measures=measures, joins=cube_joins)
+        if pt.key.certificate is not None:
+            cube.meta = {"goldenmatch": {"key_integrity": certificate_verdict(pt.key.certificate)}}
+        cubes.append(cube)
+
+    return emit_cube_yaml(cubes) if cubes else ""
+
+
+def _build_osi(proposed_tables: list[Any], joins: list[Any]) -> str:
+    """One OsiDataset per table (grain -> primary_key list, discovered fields,
+    sum-safe measures -> OsiMetrics), the trustworthy joins as OsiRelationships, and
+    the per-table key-integrity verdicts under `custom_extensions.goldenmatch`."""
+    from goldenmatch.core.key_integrity_certificate import certificate_verdict
+    from goldenmatch.semantic.osi import (
+        OsiDataset,
+        OsiField,
+        OsiMetric,
+        OsiModel,
+        OsiRelationship,
+        emit_osi_yaml,
+    )
+
+    datasets = []
+    metrics: list[Any] = []
+    key_integrity: dict[str, Any] = {}
+    for pt in proposed_tables:
+        if pt.key is None:
+            continue
+        key_cols = list(pt.key.columns)
+        fields = [OsiField(c, c) for c in key_cols]
+        for d in pt.dimensions:
+            if d.column not in key_cols:
+                fields.append(OsiField(d.column, d.column, is_time=(d.kind == "date")))
+        datasets.append(OsiDataset(name=pt.table, source=pt.table,
+                                   primary_key=key_cols, fields=fields))
+        for m in pt.measures:
+            if m.safe_to_sum:
+                metrics.append(OsiMetric(f"{pt.table}_{m.column}_total",
+                                         expression=f"SUM({pt.table}.{m.column})"))
+        if pt.key.certificate is not None:
+            key_integrity[pt.table] = certificate_verdict(pt.key.certificate)
+
+    if not datasets:
+        return ""
+
+    relationships = [
+        OsiRelationship(
+            name=f"{j.from_table}_to_{j.to_table}",
+            from_dataset=j.from_table,
+            to_dataset=j.to_table,
+            from_columns=[j.from_column],
+            to_columns=[j.to_column],
+        )
+        for j in _trustworthy_joins(joins)
+    ]
+    ext = {"goldenmatch": {"key_integrity": key_integrity}} if key_integrity else None
+    model = OsiModel(name="discovered", datasets=datasets,
+                     relationships=relationships, metrics=metrics,
+                     custom_extensions=ext)
+    return emit_osi_yaml(model)

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -36,7 +36,7 @@ from goldenmatch.semantic.discovery.measures import (
 if TYPE_CHECKING:
     from goldenmatch.semantic.discovery.namer import NameSuggestion
 
-_SUPPORTED_DIALECTS = frozenset({"metricflow"})
+_SUPPORTED_DIALECTS = frozenset({"metricflow", "cube", "osi"})
 
 
 @dataclass
@@ -176,12 +176,8 @@ def discover_semantic_model(
             f"unsupported emit dialect {dialect!r}; supported: {sorted(_SUPPORTED_DIALECTS)}"
         )
 
-    from goldenmatch.semantic import (
-        certification_report_dict,
-        certify_semantic_model,
-        emit_metricflow_yaml,
-        emit_semantic_model,
-    )
+    from goldenmatch.semantic import certification_report_dict, certify_semantic_model
+    from goldenmatch.semantic.discovery.emit import build_model_yaml
 
     # Phase 1 — grain per table.
     keys: dict[str, list[KeyCandidate]] = {
@@ -216,25 +212,10 @@ def discover_semantic_model(
             )
         )
 
-    # Phase 5 — emit a draft MetricFlow model (only SUM-safe measures are declared, so
-    # the emitted model never scaffolds a double-counting SUM) + re-certify end-to-end.
-    models = []
-    for pt in proposed_tables:
-        if pt.key is None:
-            continue
-        key_col = pt.key.columns[0]
-        safe_measures = [m.column for m in pt.measures if m.safe_to_sum]
-        models.append(
-            emit_semantic_model(
-                pt.table,
-                resolved_key=key_col,
-                entity_name=pt.entity_type or pt.table,
-                measures=safe_measures,
-                certificate=pt.key.certificate,
-            )
-        )
-
-    model_yaml = emit_metricflow_yaml(models) if models else ""
+    # Phase 5 — emit a draft model in the requested dialect (only SUM-safe measures are
+    # declared, so the emitted model never scaffolds a double-counting SUM; only
+    # trustworthy joins are emitted) + re-certify end-to-end.
+    model_yaml = build_model_yaml(dialect, proposed_tables, joins)
     certification: dict[str, Any] = {}
     if model_yaml:
         report = certify_semantic_model(model_yaml, tables, resolve=resolve)

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/namer.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/namer.py
@@ -261,22 +261,44 @@ def _glossary(sm: dict[str, Any]) -> dict[str, Any]:
     return sm.setdefault("meta", {}).setdefault("goldenmatch", {}).setdefault("glossary", {})
 
 
+def _entity_tables(model: ProposedModel) -> dict[str, list[str]]:
+    """`{entity_type_name: [tables]}` — maps an `entity:<name>` target to the emitted
+    cubes/datasets it should label (cube/osi carry no entity object, unlike MetricFlow)."""
+    return {et.name: list(et.tables) for et in getattr(model, "entity_types", [])}
+
+
+def _split_value_target(payload: str) -> tuple[str, str, str]:
+    table_col, _, val = payload.partition("=")
+    table, _, col = table_col.partition(".")
+    return table, col, val
+
+
 def apply_names(model: ProposedModel) -> str:
-    """Write the model's VERIFIED name suggestions into its emitted MetricFlow YAML,
-    returning the labeled document. Pure + LLM-free (operates on `model.naming` +
-    `model.yaml`), post-certification and cosmetic:
+    """Write the model's VERIFIED name suggestions into its emitted YAML, returning the
+    labeled document. Pure + LLM-free (operates on `model.naming` + `model.yaml`),
+    post-certification and cosmetic. Dialect-aware:
 
-    - entity  -> the semantic_model's ``label:`` (structural ``name:`` unchanged)
-    - measure -> that measure's ``label:``
-    - dimension / value -> ``meta.goldenmatch.glossary`` (MetricFlow has no native slot)
+    - metricflow: entity/measure -> ``label:``; dimension/value -> ``meta.goldenmatch.glossary``.
+    - cube:       entity/measure -> ``title:``; dimension/value -> ``meta.goldenmatch.glossary``.
+    - osi:        dimension -> the field's native ``label``; measure -> the metric's
+      ``description``; entity/value -> ``custom_extensions.goldenmatch.glossary``.
 
-    Only ``verified=True`` suggestions are applied. With no verified names (or no
-    emitted YAML) the original `model.yaml` is returned unchanged.
+    Only ``verified=True`` suggestions are applied. With no verified names (or no emitted
+    YAML) the original `model.yaml` is returned unchanged.
     """
     verified = [s for s in model.naming if s.verified]
     if not verified or not model.yaml:
         return model.yaml
 
+    dialect = getattr(model, "dialect", "metricflow")
+    if dialect == "cube":
+        return _apply_cube(model, verified)
+    if dialect == "osi":
+        return _apply_osi(model, verified)
+    return _apply_metricflow(model, verified)
+
+
+def _apply_metricflow(model: ProposedModel, verified: list[NameSuggestion]) -> str:
     doc = yaml.safe_load(model.yaml)
     if not isinstance(doc, dict) or "semantic_models" not in doc:
         return model.yaml
@@ -302,11 +324,78 @@ def apply_names(model: ProposedModel) -> str:
             if sm is not None:
                 _glossary(sm).setdefault("dimensions", {})[col] = s.suggested_name
         elif s.kind == "value":
-            table_col, _, val = payload.partition("=")
-            table, _, col = table_col.partition(".")
+            table, col, val = _split_value_target(payload)
             sm = by_name.get(table)
             if sm is not None:
                 _glossary(sm).setdefault("values", {}).setdefault(col, {})[val] = s.suggested_name
+
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+
+
+def _apply_cube(model: ProposedModel, verified: list[NameSuggestion]) -> str:
+    doc = yaml.safe_load(model.yaml)
+    cubes = doc.get("cubes") if isinstance(doc, dict) else None
+    if not cubes:
+        return model.yaml
+    by_name = {c.get("name"): c for c in cubes}
+    ent_tables = _entity_tables(model)
+
+    for s in verified:
+        payload = s.target.split(":", 1)[1] if ":" in s.target else s.target
+        if s.kind == "entity":
+            for tbl in ent_tables.get(payload, []):
+                if (c := by_name.get(tbl)) is not None:
+                    c["title"] = s.suggested_name
+        elif s.kind == "measure":
+            table, _, col = payload.partition(".")
+            c = by_name.get(table)
+            for mm in (c.get("measures", []) if c else []):
+                if mm.get("name") == col:
+                    mm["title"] = s.suggested_name
+        elif s.kind == "dimension":
+            table, _, col = payload.partition(".")
+            if (c := by_name.get(table)) is not None:
+                _glossary(c).setdefault("dimensions", {})[col] = s.suggested_name
+        elif s.kind == "value":
+            table, col, val = _split_value_target(payload)
+            if (c := by_name.get(table)) is not None:
+                _glossary(c).setdefault("values", {}).setdefault(col, {})[val] = s.suggested_name
+
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+
+
+def _apply_osi(model: ProposedModel, verified: list[NameSuggestion]) -> str:
+    doc = yaml.safe_load(model.yaml)
+    models = doc.get("semantic_model") if isinstance(doc, dict) else None
+    if not models:
+        return model.yaml
+    ent_tables = _entity_tables(model)
+
+    for m0 in models:
+        datasets = {d.get("name"): d for d in m0.get("datasets", [])}
+        metrics = m0.get("metrics", [])
+        gloss = (m0.setdefault("custom_extensions", {})
+                 .setdefault("goldenmatch", {}).setdefault("glossary", {}))
+        for s in verified:
+            payload = s.target.split(":", 1)[1] if ":" in s.target else s.target
+            if s.kind == "dimension":
+                table, _, col = payload.partition(".")
+                ds = datasets.get(table)
+                for f in (ds.get("fields", []) if ds else []):
+                    if f.get("name") == col:
+                        f["label"] = s.suggested_name
+            elif s.kind == "measure":
+                table, _, col = payload.partition(".")
+                mname = f"{table}_{col}_total"
+                for mt in metrics:
+                    if mt.get("name") == mname:
+                        mt["description"] = s.suggested_name
+            elif s.kind == "entity":
+                for tbl in ent_tables.get(payload, []):
+                    gloss.setdefault("entities", {})[tbl] = s.suggested_name
+            elif s.kind == "value":
+                table, col, val = _split_value_target(payload)
+                gloss.setdefault("values", {}).setdefault(col, {})[val] = s.suggested_name
 
     return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
 

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_cube_osi_emit.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_cube_osi_emit.py
@@ -1,0 +1,172 @@
+"""Cube/OSI discovery emit (PR-9) — discover_semantic_model beyond metricflow.
+
+`discover_semantic_model(dialect="cube"|"osi")` emits a Cube / OSI draft (grain ->
+primary key, sum-safe measures, the certified trustworthy join graph) and re-certifies
+it end-to-end, exactly like the metricflow path. The metricflow output stays
+byte-identical. Driven on the customers/orders fixture.
+"""
+from __future__ import annotations
+
+import json
+
+import pyarrow as pa
+from goldenmatch.semantic import discover_semantic_model
+from goldenmatch.semantic.cube import parse_cube_models
+from goldenmatch.semantic.osi import parse_osi_models
+
+
+class _FakeBackend:
+    """Names every target and verifies all (for the apply-names dialect tests)."""
+
+    def propose(self, prompt: str) -> str:
+        from goldenmatch.semantic.discovery.namer import _targets_in_prompt
+
+        targets = _targets_in_prompt(prompt)
+        if "VERIFY" in prompt.upper():
+            return json.dumps({"verdicts": [
+                {"target": t, "supported": True, "confidence": 0.9} for t in targets
+            ]})
+        return json.dumps({"names": [
+            {"target": t, "name": _canned(t), "evidence": "e"} for t in targets
+        ]})
+
+
+def _canned(target: str) -> str:
+    return {
+        "entity:entity_2": "Orders",
+        "measure:orders.amount": "Total Revenue",
+        "dimension:orders.status": "Order Status",
+        "value:orders.status=A": "Active",
+    }.get(target, target.split(":")[-1])
+
+
+def _fixture() -> dict[str, pa.Table]:
+    customers = pa.table({
+        "customer_id": ["c1", "c2", "c3"],
+        "region": ["west", "east", "west"],
+    })
+    orders = pa.table({
+        "order_id": ["o1", "o2", "o3", "o4"],
+        "customer_id": ["c1", "c1", "c2", "c3"],
+        "amount": [10.0, 20.0, 30.0, 40.0],
+        "status": ["A", "C", "A", "C"],
+    })
+    return {"customers": customers, "orders": orders}
+
+
+# --- metricflow unchanged -------------------------------------------------------
+
+
+def test_metricflow_still_default_and_unchanged():
+    m = discover_semantic_model(_fixture())
+    assert m.dialect == "metricflow"
+    # dialect="metricflow" is byte-identical to the default.
+    assert discover_semantic_model(_fixture(), dialect="metricflow").yaml == m.yaml
+
+
+# --- cube structural emit + certification ---------------------------------------
+
+
+def test_cube_emit_grain_measures_and_certification():
+    m = discover_semantic_model(_fixture(), dialect="cube")
+    assert m.dialect == "cube"
+
+    cubes = {c.name: c for c in parse_cube_models(m.yaml)}
+    assert {"customers", "orders"} <= set(cubes)
+
+    orders = cubes["orders"]
+    # grain -> a composite-ready primary key.
+    assert orders.primary_key == ["order_id"]
+    # sum-safe measure carried.
+    assert any(mm.name == "amount" for mm in orders.measures)
+    # key-integrity verdict embedded in meta.goldenmatch.
+    assert orders.meta and "key_integrity" in orders.meta.get("goldenmatch", {})
+
+    # Re-certified end-to-end.
+    assert m.certification.get("all_trustworthy") is True
+
+
+# --- osi structural emit + certification ----------------------------------------
+
+
+def test_osi_emit_grain_measures_and_certification():
+    m = discover_semantic_model(_fixture(), dialect="osi")
+    assert m.dialect == "osi"
+
+    datasets = {d.name: d for model in parse_osi_models(m.yaml) for d in model.datasets}
+    assert {"customers", "orders"} <= set(datasets)
+
+    orders = datasets["orders"]
+    assert orders.primary_key == ["order_id"]
+    # a metric referencing the sum-safe amount column.
+    metrics = [mt for model in parse_osi_models(m.yaml) for mt in model.metrics]
+    assert any("amount" in mt.expression for mt in metrics)
+
+    assert m.certification.get("all_trustworthy") is True
+
+
+# --- unknown dialect still rejected ---------------------------------------------
+
+
+def test_unknown_dialect_still_raises():
+    import pytest
+
+    with pytest.raises(ValueError, match="unsupported emit dialect"):
+        discover_semantic_model(_fixture(), dialect="nonsense")
+
+
+# --- certified join graph emitted natively --------------------------------------
+
+
+def test_cube_emits_certified_join():
+    m = discover_semantic_model(_fixture(), dialect="cube")
+    orders = {c.name: c for c in parse_cube_models(m.yaml)}["orders"]
+    join = next((j for j in orders.joins if j.name == "customers"), None)
+    assert join is not None
+    assert join.relationship == "many_to_one"
+    assert "customer_id" in join.sql
+
+
+def test_osi_emits_certified_relationship():
+    m = discover_semantic_model(_fixture(), dialect="osi")
+    rels = [r for model in parse_osi_models(m.yaml) for r in model.relationships]
+    rel = next((r for r in rels if r.from_dataset == "orders" and r.to_dataset == "customers"), None)
+    assert rel is not None
+    assert rel.from_columns == ["customer_id"]
+    assert rel.to_columns == ["customer_id"]
+
+
+# --- dialect-aware apply-names --------------------------------------------------
+
+
+def test_cube_apply_names_writes_title_and_glossary():
+    import yaml as _yaml
+
+    m = discover_semantic_model(
+        _fixture(), dialect="cube", name=True, apply_names=True, namer_backend=_FakeBackend()
+    )
+    orders = {c["name"]: c for c in _yaml.safe_load(m.yaml)["cubes"]}["orders"]
+    # entity business name -> the cube's title; measure name -> the measure's title.
+    assert orders["title"] == "Orders"
+    amount = next(mm for mm in orders["measures"] if mm["name"] == "amount")
+    assert amount["title"] == "Total Revenue"
+    # dimension + value glossary -> meta.goldenmatch.glossary (sibling of key_integrity).
+    gloss = orders["meta"]["goldenmatch"]["glossary"]
+    assert gloss["dimensions"]["status"] == "Order Status"
+    assert gloss["values"]["status"]["A"] == "Active"
+
+
+def test_osi_apply_names_writes_field_label_and_glossary():
+    import yaml as _yaml
+
+    m = discover_semantic_model(
+        _fixture(), dialect="osi", name=True, apply_names=True, namer_backend=_FakeBackend()
+    )
+    model0 = _yaml.safe_load(m.yaml)["semantic_model"][0]
+    datasets = {d["name"]: d for d in model0["datasets"]}
+    status = next(f for f in datasets["orders"]["fields"] if f["name"] == "status")
+    # dimension column -> the OSI field's native label.
+    assert status["label"] == "Order Status"
+    # value glossary -> custom_extensions.goldenmatch.glossary.
+    gloss = model0["custom_extensions"]["goldenmatch"]["glossary"]
+    assert gloss["values"]["status"]["A"] == "Active"

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -2854,7 +2854,7 @@
               "type": "text",
               "required": false,
               "default": "'metricflow'",
-              "help": "Emit dialect for the draft model (metricflow)."
+              "help": "Emit dialect for the draft model: metricflow / cube / osi."
             },
             {
               "name": "--output",


### PR DESCRIPTION
## What and why

**PR-9 of the semantic-model discovery arc** (spec + PR-1..8 shipped). `discover_semantic_model` used to raise on any dialect but `metricflow`, even though **certification already spanned all three** and the Cube/OSI emitters existed. This wires the orchestrator to emit **Cube** and **OSI** drafts too.

Design folded into the arc spec (§ "Phased PR plan", item 9).

## What it does

New `goldenmatch/semantic/discovery/emit.py` maps the discovered structure onto the existing dialect emitters + dataclasses. Per table:

| Discovered | Cube | OSI |
|---|---|---|
| grain | `primary_key` `CubeDimension`(s) | `OsiDataset.primary_key` list |
| dimensions | `CubeDimension` (type by kind) | `OsiField` |
| sum-safe measures | `CubeMeasure(type=agg)` | `OsiMetric` |
| key-integrity verdict | `meta.goldenmatch` | `custom_extensions.goldenmatch` |
| certified **trustworthy** joins | `CubeJoin` (SQL ON) | `OsiRelationship` (`from_columns`/`to_columns`) |

Both `primary_key` representations are **composite-ready**, which sets up PR-10 (compound keys). Every emitted model is **re-certified end-to-end** (dialect auto-detected); the `all_trustworthy` gate holds across all three dialects.

## Dialect-aware `apply-names` (Phase 8, extended)

`apply_names` now branches by dialect:
- **metricflow** (unchanged): `label:` + `meta.goldenmatch.glossary`.
- **cube**: `title:` on cube/measure + `meta.goldenmatch.glossary` (dimensions/values).
- **osi**: native `OsiField.label` (dimensions) + `OsiMetric.description` (measures) + `custom_extensions.goldenmatch.glossary` (entities/values).

Entity names map to their cubes/datasets via `model.entity_types` (cube/osi have no entity object). Still verified-only + cosmetic.

## Preserved guarantees

- **MetricFlow byte-identical** — the old inline emit moved into `emit.py` unchanged; the full metricflow suite (model, apply-names, surface, certify) stays green.
- **Only trustworthy joins emitted** (an untrustworthy FK is a bad join, not a pre-graded one).
- **No new params / tools / commands / env vars** — `dialect` already plumbs through CLI `--dialect` and MCP/REST `dialect`; it just stops rejecting `cube`/`osi`. So no `api_parity` tool-list change and no `docs_staleness` flag rule.

## Testing

Built test-first: `uv run pytest tests/test_semantic_discovery_cube_osi_emit.py` — **12 passed** (metricflow-unchanged, cube + osi structural emit + certification, unknown-dialect still raises, certified joins emitted natively, dialect-aware apply-names for cube + osi). Full semantic + surface + mcp suite green (96). All config-matrix doc gates + `check_llms_counts` + `docs_staleness` pass locally.
