### PR TITLE
feat(semantic): compound + self-referential keys (semantic-model discovery, Phase 10)

### DIFF
--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -237,6 +237,20 @@ ProposedModel`.
    through CLI `--dialect` + MCP/REST `dialect`; no new params. Follow-on: PR-10 lifts
    the single-column key/FK limitation (the certifier + `KeyCandidate.columns` +
    Cube/OSI composite primary keys already support multi-column).
+10. **PR-10 (optional) compound + self-referential keys.** Lifts the single-column
+    restriction on the discovery side (the certifier, `KeyCandidate.columns`, and all
+    three emit paths already carry multi-column keys). `discover_keys` gains a
+    **fallback pairs** compound search: when no single-column candidate is trustworthy
+    (the grain double-counts), it takes the signal-bearing key-ish columns (capped,
+    highest-cardinality first), certifies each **pair** with `certify_key_integrity`
+    (which already accepts `key=[c1, c2]`), and admits the trustworthy compounds
+    (`signals=["compound"]`), re-ranked trustworthy-first. `discover_joins` lifts the
+    self-join exclusion for **self-referential single-column FKs** (a column whose
+    values are a subset of the table's OWN certified key, `fk_col != key_col` — e.g.
+    `employees.manager_id -> employees.employee_id`); same value-subset + certification
+    path. Compound (multi-column) FKs and 3+-column keys stay documented follow-ons. No
+    surface change — a compound grain flows through the existing metricflow entity /
+    Cube `primary_key` dims / OSI `primary_key` list emit; nothing new to plumb.
 
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -381,6 +381,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   slice of the semantic-model discovery arc (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_cube_osi_emit.py`.
+- **Semantic-model discovery — compound + self-referential keys (Phase 10).** Lifts the
+  single-column restriction on the discovery side (the certifier, `KeyCandidate.columns`,
+  and all three emit paths already carried multi-column keys). `discover_keys` gains a
+  **fallback pairs** compound search: when no single-column candidate is unique at grain
+  (the grain double-counts), it certifies 2-column combinations of the key-eligible
+  columns (highest-cardinality first, pool-capped) and admits the trustworthy compounds
+  (`signals=["compound"]`), re-ranked trustworthy-first — so a `(order_id, product_id)`
+  order-items grain is discovered where neither column is unique alone. `discover_joins`
+  lifts the self-join exclusion for **self-referential single-column FKs** (a column whose
+  values are a subset of its OWN table's certified key, `fk_col != key_col`, e.g.
+  `employees.manager_id → employees.employee_id`; the self side reuses the table's key
+  certificate since `certify_cube_joins` can't certify a cube joined to itself). Compound
+  grains emit natively in Cube (`primary_key` dims) / OSI (`primary_key` list); MetricFlow,
+  which has no composite primary entity, declares the first column (a documented limit).
+  Compound (multi-column) FKs and 3+-column keys remain follow-ons. No surface change. The
+  tenth slice of the semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_compound_selfref.py`.
 
 ### Changed
 - **FS out-of-core streaming: single `resolve_fs_block_source` knob + DuckDB

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py
@@ -18,8 +18,10 @@ Discovery is hypothesis generation; certification is the falsification test:
     fans out and double-counts. That's exactly what `certify_cube_joins` checks, so the
     proposed join is re-proven in join context via a minimal `Cube` model.
 
-Scoped to SINGLE-column foreign keys referencing the caller-supplied per-table keys;
-compound FKs and self-referential joins are documented follow-ons. Design:
+Scoped to SINGLE-column foreign keys referencing the caller-supplied per-table keys,
+including SELF-referential FKs (a column referencing its own table's certified key, e.g.
+`employees.manager_id -> employees.employee_id`). Compound (multi-column) FKs are a
+documented follow-on. Design:
 `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`.
 
 Design: advisory only — it proposes + grades; a human approves. Never a black box.
@@ -188,8 +190,6 @@ def discover_joins(
             key_type = col_types.get(to_table, {}).get(key_col)
 
             for from_table, source in tables.items():
-                if from_table == to_table:
-                    continue  # self-joins are a documented follow-on
                 from goldenmatch.core.frame import to_frame
 
                 try:
@@ -197,6 +197,10 @@ def discover_joins(
                 except Exception:  # noqa: BLE001
                     continue
                 for fk_col in source_cols:
+                    # Self-referential FK (from_table == to_table) is allowed, but a
+                    # column can never be a foreign key onto its OWN referenced key.
+                    if from_table == to_table and fk_col == key_col:
+                        continue
                     fk_values = _distinct_nonnull(source, fk_col)
                     if len(fk_values) < min_fk_distinct:
                         continue
@@ -213,25 +217,33 @@ def discover_joins(
                     if key_type is not None and fk_type == key_type:
                         signals.append("type_match")
 
-                    # Re-prove the one-side key's cardinality IN JOIN CONTEXT.
-                    many = Cube(
-                        name=from_table,
-                        joins=[CubeJoin(
-                            name=to_table,
-                            relationship="many_to_one",
-                            sql=f"{{CUBE}}.{fk_col} = {{{to_table}.{key_col}}}",
-                        )],
-                    )
-                    try:
-                        certified = certify_cube_joins(
-                            [many], {from_table: source, to_table: tables[to_table]},
-                            resolve=resolve,
+                    # Re-prove the one-side key's cardinality IN JOIN CONTEXT. A
+                    # self-referential FK's one side IS the table's own certified key
+                    # (and `certify_cube_joins` can't certify a cube joined to itself),
+                    # so reuse that certificate directly.
+                    if from_table == to_table:
+                        if key_cand is None:
+                            continue
+                        cert = key_cand.certificate
+                    else:
+                        many = Cube(
+                            name=from_table,
+                            joins=[CubeJoin(
+                                name=to_table,
+                                relationship="many_to_one",
+                                sql=f"{{CUBE}}.{fk_col} = {{{to_table}.{key_col}}}",
+                            )],
                         )
-                    except Exception:  # noqa: BLE001 - a bad pair never breaks the sweep
-                        continue
-                    if not certified:
-                        continue
-                    cert = certified[0]["certificate"]
+                        try:
+                            certified = certify_cube_joins(
+                                [many], {from_table: source, to_table: tables[to_table]},
+                                resolve=resolve,
+                            )
+                        except Exception:  # noqa: BLE001 - a bad pair never breaks the sweep
+                            continue
+                        if not certified:
+                            continue
+                        cert = certified[0]["certificate"]
                     candidates.append(
                         JoinCandidate(
                             from_table=from_table,

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/keys.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/keys.py
@@ -17,14 +17,17 @@ cheap signals propose candidates; the certifier decides which are real:
     cardinality signal rather than duplicating it.)
 
 Every proposed column is then certified: unique at grain? measure fan-out? The
-result is ranked trustworthy-first. Scoped to SINGLE-column keys for this slice;
-compound/grain-ambiguous keys are a documented follow-on (see the design spec
+result is ranked trustworthy-first. Single-column keys are proposed first; when NONE
+is unique at grain, a fallback COMPOUND search certifies 2-column combinations of the
+key-eligible columns (the certifier already accepts a multi-column key). 3+-column
+keys are a documented follow-on (see the design spec
 `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`).
 
 Design: advisory only — it proposes + grades; a human approves. Never a black box.
 """
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -43,6 +46,10 @@ _DEFAULT_FD_MIN_CONFIDENCE = 0.98
 # a key — so the cardinality signal skips these col_types. (The `identifier` and
 # `fd` signals are unaffected; a genuine id classifies as `identifier`.)
 _NON_KEY_COL_TYPES = frozenset({"numeric", "date", "geo", "description"})
+
+# Cap on the key-eligible column pool the fallback compound search pairs over, so the
+# search stays C(cap, 2) certifications rather than combinatorial on wide tables.
+_COMPOUND_POOL_CAP = 6
 
 
 @dataclass
@@ -170,6 +177,28 @@ def discover_keys(
                 ),
             )
         )
+
+    # Fallback COMPOUND search (pairs): when no single column is unique at grain the
+    # grain double-counts, so try 2-column combinations of the key-eligible columns
+    # (highest cardinality first, pool-capped). The certifier already accepts a
+    # multi-column key; a trustworthy pair is the real grain.
+    if not any(c.is_trustworthy for c in candidates):
+        pool = [
+            p.name
+            for p in sorted(
+                (p for p in profiles if p.col_type not in _NON_KEY_COL_TYPES),
+                key=lambda p: -p.cardinality_ratio,
+            )
+        ][:_COMPOUND_POOL_CAP]
+        for c1, c2 in itertools.combinations(pool, 2):
+            try:
+                cert = certify_key_integrity(table, key=[c1, c2])
+            except Exception:  # noqa: BLE001 - a bad combination never breaks the sweep
+                continue
+            if cert.is_trustworthy():
+                candidates.append(
+                    KeyCandidate(columns=[c1, c2], signals=["compound"], certificate=cert)
+                )
 
     # Trustworthy first, then cleaner (score desc), then lower fan-out, then more
     # corroborating signals, then name for determinism.

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_compound_selfref.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_compound_selfref.py
@@ -1,0 +1,111 @@
+"""Compound + self-referential keys (PR-10).
+
+Lifts the single-column restriction on the discovery side:
+- `discover_keys` proposes a certified COMPOUND key (fallback pairs) when no single
+  column is unique at grain.
+- `discover_joins` proposes a SELF-REFERENTIAL single-column FK (a column referencing
+  the table's own certified key).
+
+The certifier, `KeyCandidate.columns`, and all three emit paths already carry
+multi-column keys, so this is a discovery-side change.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import discover_semantic_model
+from goldenmatch.semantic.discovery.joins import discover_joins
+from goldenmatch.semantic.discovery.keys import discover_keys
+
+
+def _order_items() -> pa.Table:
+    """A classic composite grain: neither order_id nor product_id is unique, but the
+    pair (order_id, product_id) is."""
+    return pa.table({
+        "order_id": ["o1", "o1", "o2", "o2", "o3", "o3"],
+        "product_id": ["p1", "p2", "p1", "p2", "p1", "p2"],
+        "qty": [1, 2, 3, 4, 5, 6],
+    })
+
+
+def _employees() -> pa.Table:
+    """employee_id is the PK; manager_id is a self-referential FK into employee_id."""
+    return pa.table({
+        "employee_id": ["e1", "e2", "e3", "e4", "e5"],
+        "manager_id": ["e1", "e1", "e2", "e2", "e3"],
+        "name": ["Ann", "Bob", "Cy", "Dee", "Ed"],
+    })
+
+
+# --- compound key discovery -----------------------------------------------------
+
+
+def test_discover_keys_proposes_certified_compound_key():
+    cands = discover_keys(_order_items())
+    # No single column is trustworthy...
+    singles = [c for c in cands if len(c.columns) == 1]
+    assert all(not c.is_trustworthy for c in singles)
+    # ...but a trustworthy compound (order_id, product_id) is proposed, ranked first.
+    compound = next((c for c in cands if len(c.columns) == 2 and c.is_trustworthy), None)
+    assert compound is not None
+    assert set(compound.columns) == {"order_id", "product_id"}
+    assert cands[0] is compound  # trustworthy compound ranks ahead of the untrustworthy singles
+
+
+def test_single_column_key_suppresses_compound_search():
+    # customers.customer_id is a clean single key -> the fallback compound search never fires.
+    customers = pa.table({"customer_id": ["c1", "c2", "c3"], "region": ["w", "e", "w"]})
+    cands = discover_keys(customers)
+    assert any(c.is_trustworthy for c in cands if len(c.columns) == 1)
+    assert all(len(c.columns) == 1 for c in cands)
+
+
+def test_compound_grain_flows_through_discover_semantic_model():
+    from goldenmatch.semantic.cube import parse_cube_models
+
+    # The compound grain is discovered and certified (dialect-agnostic).
+    m = discover_semantic_model({"order_items": _order_items()}, dialect="cube")
+    pt = next(p for p in m.tables if p.table == "order_items")
+    assert pt.key is not None
+    assert set(pt.key.columns) == {"order_id", "product_id"}
+    assert pt.grain_trustworthy  # the discovery certificate is trustworthy
+
+    # Cube expresses the full COMPOSITE primary key natively (MetricFlow, which has no
+    # composite primary entity, can only declare the first column — a documented limit).
+    oi = {c.name: c for c in parse_cube_models(m.yaml)}["order_items"]
+    assert set(oi.primary_key) == {"order_id", "product_id"}
+
+
+# --- self-referential FK discovery ----------------------------------------------
+
+
+def test_discover_joins_finds_self_referential_fk():
+    tables = {"employees": _employees()}
+    keys = {"employees": discover_keys(_employees())}
+    joins = discover_joins(tables, keys)
+
+    self_ref = next(
+        (j for j in joins
+         if j.from_table == "employees" and j.to_table == "employees"), None
+    )
+    assert self_ref is not None
+    assert self_ref.from_column == "manager_id"
+    assert self_ref.to_column == "employee_id"
+    assert self_ref.is_trustworthy  # employee_id is unique -> the "one" side certifies
+
+
+def test_self_referential_join_flows_through_discover_semantic_model():
+    m = discover_semantic_model({"employees": _employees()})
+    self_ref = next(
+        (j for j in m.joins
+         if j.from_table == "employees" and j.to_table == "employees"), None
+    )
+    assert self_ref is not None
+    assert self_ref.from_column == "manager_id"
+
+
+def test_no_spurious_self_join_on_the_key_itself():
+    # A table's key column must never be proposed as a self-FK onto itself.
+    m = discover_semantic_model({"employees": _employees()})
+    assert not any(
+        j.from_table == j.to_table and j.from_column == j.to_column for j in m.joins
+    )

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_keys.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_keys.py
@@ -58,12 +58,13 @@ def test_numeric_and_dimension_columns_are_not_proposed_as_keys() -> None:
 
 
 def test_no_clean_key_returns_only_untrustworthy_candidates() -> None:
-    # A table whose every id-shaped column duplicates → the loud "this grain will
-    # double-count" signal: proposed candidates exist, none trustworthy.
+    # A table with a fully DUPLICATED row → no unique key at any arity (not even the
+    # fallback compound), the loud "this grain will double-count" signal: proposed
+    # candidates exist, none trustworthy.
     t = pa.table(
         {
-            "order_id": ["o1", "o1", "o2"],   # duplicated
-            "customer_id": ["c1", "c2", "c2"],  # duplicated
+            "order_id": ["o1", "o1", "o2"],     # duplicated
+            "customer_id": ["c1", "c1", "c2"],  # (o1, c1) repeats -> compound isn't unique either
         }
     )
     cands = discover_keys(t)


### PR DESCRIPTION
## What and why

**PR-10 of the semantic-model discovery arc** (spec + PR-1..9 shipped) — lifts the single-column key/FK limitation. The certifier, `KeyCandidate.columns`, and all three emit paths already carried multi-column keys (PR-9 made Cube/OSI composite-ready), so this is a **discovery-side** change.

Design folded into the arc spec (§ "Phased PR plan", item 10).

## Compound keys (fallback pairs)

`discover_keys` gains a compound search that fires **only when no single-column candidate is unique at grain** (the grain double-counts). It certifies 2-column combinations of the key-eligible columns (highest-cardinality first, pool-capped at 6) via `certify_key_integrity` (which already accepts `key=[c1, c2]`), and admits the trustworthy compounds (`signals=["compound"]`), re-ranked trustworthy-first.

So an `order_items` table where neither `order_id` nor `product_id` is unique, but `(order_id, product_id)` is, now yields a certified compound grain. A clean single key **suppresses** the search (fallback-only, bounded cost).

## Self-referential FKs

`discover_joins` lifts the self-join exclusion for **single-column self-referential FKs** — a column whose values are a subset of its *own* table's certified key (`fk_col != key_col`), e.g. `employees.manager_id → employees.employee_id`. The self side reuses the table's key certificate directly, because `certify_cube_joins` **raises on a cube joined to itself** (`'str' has no attribute 'get'`) — and the "one" side of a self-FK *is* the table's own certified key, so no join-context re-cert is needed. A column is never proposed as a self-FK onto itself.

## Emit + honest boundary

Compound grains emit natively in **Cube** (`primary_key` dims) and **OSI** (`primary_key` list). **MetricFlow has no composite primary entity**, so it declares the first key column — a documented limit surfaced in the tests (the compound integration test asserts the composite via Cube). Compound (multi-column) FKs and 3+-column keys remain follow-ons.

**No surface change** — no new params, tools, CLI commands, or env vars.

## Testing

Built test-first: `uv run pytest tests/test_semantic_discovery_compound_selfref.py` — **6 passed** (compound discovered + ranked first; single-key suppresses compound; compound flows through + emits composite in Cube; self-ref FK found + trustworthy; self-ref flows through; no spurious self-FK onto the key). Full semantic + surface + mcp suite green (**102**). One existing keys-test fixture that *accidentally* had a compound key was made genuinely keyless (a duplicated row) so its "no clean key → untrustworthy" intent still holds. All config-matrix gates + `check_llms_counts` + `docs_staleness` pass locally.
