### PR TITLE
feat(semantic): dimension hierarchies via FD (semantic-model discovery, Phase 11)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 447,
+      "module_count": 448,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7269,6 +7269,7 @@
           "purpose": "Semantic-model discovery (the generative half of the semantic wedge).",
           "imports": [
             "goldenmatch.semantic.discovery.entities",
+            "goldenmatch.semantic.discovery.hierarchies",
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys",
             "goldenmatch.semantic.discovery.measures",
@@ -7284,6 +7285,8 @@
             "_build_cube",
             "_build_metricflow",
             "_build_osi",
+            "_gm_meta",
+            "_hierarchies_dicts",
             "_trustworthy_joins",
             "build_model_yaml"
           ],
@@ -7316,6 +7319,17 @@
             "goldenmatch.core.schema_match",
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.hierarchies",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/hierarchies.py",
+          "purpose": "Dimension hierarchy discovery via functional dependencies (PR-11).",
+          "defines": [
+            "Hierarchy",
+            "_distinct_count",
+            "_fd_strength",
+            "discover_hierarchies"
           ]
         },
         {
@@ -7384,6 +7398,7 @@
             "goldenmatch.semantic",
             "goldenmatch.semantic.discovery.emit",
             "goldenmatch.semantic.discovery.entities",
+            "goldenmatch.semantic.discovery.hierarchies",
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys",
             "goldenmatch.semantic.discovery.measures",

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -252,6 +252,29 @@ ProposedModel`.
     surface change — a compound grain flows through the existing metricflow entity /
     Cube `primary_key` dims / OSI `primary_key` list emit; nothing new to plumb.
 
+## Frontier: from certified structure to a full semantic layer
+
+The PR-1..10 arc derives the certified *structure* (grain, joins, entities, grain-gated
+measures/dimensions). These slices close the gap to a semantic layer a human would
+actually query. All are deterministic (no LLM) and default-on unless noted.
+
+11. **Dimension hierarchies via FD.** New `discovery/hierarchies.py`:
+    `discover_hierarchies(table, columns) -> list[Hierarchy]`. Among a table's dimension
+    columns, detect **near-functional-dependencies** (a finer level determines a coarser
+    one: `city → state → country`, threshold default 0.95 to survive dirty rows via a
+    group-by "fraction of determinant groups mapping to a single dependent value" test),
+    pick each column's **immediate parent** (the highest-cardinality coarser column it
+    determines), and extract maximal coarse→fine chains as `Hierarchy(table,
+    levels=[country, state, city], confidence)`. Deterministic → default-on, attached to
+    `ProposedTable.hierarchies` + `ProposedModel.hierarchies` and emitted into
+    `meta.goldenmatch.hierarchies` (Cube/OSI/MetricFlow — no dialect has a native
+    hierarchy slot in these dataclasses); `to_dict` includes it. Reuses the FD machinery
+    (`fd_identity_scores` is per-column; this adds the pairwise group-by check). Follow-on
+    frontier slices: metrics (ratios/derived/cumulative), time intelligence (time spine +
+    grains), cardinality (m:n bridge / 1:1), SCD dimensions, a model completeness score,
+    warehouse-scale derivation off `information_schema`, catalog reconciliation, and
+    real-LLM namer validation.
+
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at
 every step.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+- **Semantic-model discovery — dimension hierarchies via FD (Phase 11).**
+  `goldenmatch.semantic.discover_hierarchies(table, columns)` detects drill-down
+  hierarchies (`country > state > city`) among a table's dimension columns by finding
+  **near-functional-dependencies** (a finer level determines a coarser one; a group-by
+  "fraction of determinant groups mapping to a single dependent value" test, default
+  threshold 0.95 so a few dirty rows don't kill a genuine hierarchy). Each column's
+  *immediate* parent is the highest-cardinality coarser column it determines, yielding
+  clean coarse→fine chains (`Hierarchy(table, levels, confidence)`) rather than
+  transitive-closure noise. Deterministic (no LLM) and **default-on**: attached to
+  `ProposedTable.hierarchies` + `ProposedModel.hierarchies`, included in `to_dict`, and
+  emitted into `meta.goldenmatch.hierarchies` (MetricFlow/Cube) /
+  `custom_extensions.goldenmatch.hierarchies` (OSI) — no dialect has a native hierarchy
+  slot. The first "frontier" slice turning certified structure into a queryable semantic
+  layer (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_hierarchies.py`.
+
 ## [3.11.0] - 2026-08-03
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -48,6 +48,7 @@ from goldenmatch.semantic.cube import (
 from goldenmatch.semantic.discovery import (
     Dimension,
     EntityType,
+    Hierarchy,
     JoinCandidate,
     KeyCandidate,
     Measure,
@@ -57,6 +58,7 @@ from goldenmatch.semantic.discovery import (
     TableMeasures,
     apply_names,
     discover_entity_types,
+    discover_hierarchies,
     discover_joins,
     discover_keys,
     discover_measures,
@@ -171,6 +173,9 @@ __all__ = [
     "TableMeasures",
     # semantic-model discovery (Phase 5) — the orchestrator (assemble + emit + certify)
     "discover_semantic_model",
+    # semantic-model discovery (Phase 11) — dimension hierarchies via FD
+    "discover_hierarchies",
+    "Hierarchy",
     # semantic-model discovery (Phase 7) — optional advisory LLM namer
     "apply_names",
     "name_semantic_model",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -20,6 +20,7 @@ Phase 7 (optional): `name_semantic_model` — advisory, self-verified LLM busine
 from __future__ import annotations
 
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
+from goldenmatch.semantic.discovery.hierarchies import Hierarchy, discover_hierarchies
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
 from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
 from goldenmatch.semantic.discovery.measures import (
@@ -43,6 +44,7 @@ from goldenmatch.semantic.discovery.namer import (
 __all__ = [
     "Dimension",
     "EntityType",
+    "Hierarchy",
     "JoinCandidate",
     "KeyCandidate",
     "Measure",
@@ -52,6 +54,7 @@ __all__ = [
     "ProposedTable",
     "TableMeasures",
     "discover_entity_types",
+    "discover_hierarchies",
     "discover_joins",
     "discover_keys",
     "discover_measures",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
@@ -32,6 +32,25 @@ def _trustworthy_joins(joins: list[Any]) -> list[Any]:
     return [j for j in joins if getattr(j, "is_trustworthy", False)]
 
 
+def _hierarchies_dicts(pt: Any) -> list[dict[str, Any]]:
+    return [{"levels": list(h.levels), "confidence": h.confidence}
+            for h in getattr(pt, "hierarchies", []) or []]
+
+
+def _gm_meta(pt: Any) -> dict[str, Any]:
+    """The `goldenmatch` meta block for a table: the key-integrity verdict + any
+    discovered dimension hierarchies. Empty dict when neither is present."""
+    from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+    gm: dict[str, Any] = {}
+    if pt.key is not None and pt.key.certificate is not None:
+        gm["key_integrity"] = certificate_verdict(pt.key.certificate)
+    hier = _hierarchies_dicts(pt)
+    if hier:
+        gm["hierarchies"] = hier
+    return gm
+
+
 def _build_metricflow(proposed_tables: list[Any]) -> str:
     """The original inline emit, unchanged: entities + sum-safe measures per table."""
     from goldenmatch.semantic import emit_metricflow_yaml, emit_semantic_model
@@ -41,15 +60,17 @@ def _build_metricflow(proposed_tables: list[Any]) -> str:
         if pt.key is None:
             continue
         safe_measures = [m.column for m in pt.measures if m.safe_to_sum]
-        models.append(
-            emit_semantic_model(
-                pt.table,
-                resolved_key=pt.key.columns[0],
-                entity_name=pt.entity_type or pt.table,
-                measures=safe_measures,
-                certificate=pt.key.certificate,
-            )
+        sm = emit_semantic_model(
+            pt.table,
+            resolved_key=pt.key.columns[0],
+            entity_name=pt.entity_type or pt.table,
+            measures=safe_measures,
+            certificate=pt.key.certificate,
         )
+        hier = _hierarchies_dicts(pt)
+        if hier:  # additive to the meta.goldenmatch block emit_semantic_model set
+            sm.setdefault("meta", {}).setdefault("goldenmatch", {})["hierarchies"] = hier
+        models.append(sm)
     return emit_metricflow_yaml(models) if models else ""
 
 
@@ -57,7 +78,6 @@ def _build_cube(proposed_tables: list[Any], joins: list[Any]) -> str:
     """One Cube per table: grain -> primary_key dimensions, discovered dimensions,
     sum-safe measures, the key-integrity verdict in `meta.goldenmatch`, and the
     trustworthy join graph as `many_to_one` CubeJoins on the FROM cube."""
-    from goldenmatch.core.key_integrity_certificate import certificate_verdict
     from goldenmatch.semantic.cube import (
         Cube,
         CubeDimension,
@@ -92,8 +112,9 @@ def _build_cube(proposed_tables: list[Any], joins: list[Any]) -> str:
         ]
         cube = Cube(name=pt.table, sql_table=pt.table, dimensions=dims,
                     measures=measures, joins=cube_joins)
-        if pt.key.certificate is not None:
-            cube.meta = {"goldenmatch": {"key_integrity": certificate_verdict(pt.key.certificate)}}
+        gm = _gm_meta(pt)
+        if gm:
+            cube.meta = {"goldenmatch": gm}
         cubes.append(cube)
 
     return emit_cube_yaml(cubes) if cubes else ""
@@ -116,6 +137,7 @@ def _build_osi(proposed_tables: list[Any], joins: list[Any]) -> str:
     datasets = []
     metrics: list[Any] = []
     key_integrity: dict[str, Any] = {}
+    hierarchies: dict[str, Any] = {}
     for pt in proposed_tables:
         if pt.key is None:
             continue
@@ -132,6 +154,9 @@ def _build_osi(proposed_tables: list[Any], joins: list[Any]) -> str:
                                          expression=f"SUM({pt.table}.{m.column})"))
         if pt.key.certificate is not None:
             key_integrity[pt.table] = certificate_verdict(pt.key.certificate)
+        hier = _hierarchies_dicts(pt)
+        if hier:
+            hierarchies[pt.table] = hier
 
     if not datasets:
         return ""
@@ -146,7 +171,12 @@ def _build_osi(proposed_tables: list[Any], joins: list[Any]) -> str:
         )
         for j in _trustworthy_joins(joins)
     ]
-    ext = {"goldenmatch": {"key_integrity": key_integrity}} if key_integrity else None
+    gm_ext: dict[str, Any] = {}
+    if key_integrity:
+        gm_ext["key_integrity"] = key_integrity
+    if hierarchies:
+        gm_ext["hierarchies"] = hierarchies
+    ext = {"goldenmatch": gm_ext} if gm_ext else None
     model = OsiModel(name="discovered", datasets=datasets,
                      relationships=relationships, metrics=metrics,
                      custom_extensions=ext)

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/hierarchies.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/hierarchies.py
@@ -1,0 +1,105 @@
+"""Dimension hierarchy discovery via functional dependencies (PR-11).
+
+A drill-down hierarchy (`country > state > city`) is a chain of functional
+dependencies: the finer level determines the coarser (each city has exactly one
+state). This module detects those FDs among a table's dimension columns and assembles
+the maximal coarse->fine chains.
+
+Deterministic (no LLM) and default-on. The FD test is a **near**-FD (a configurable
+fraction of determinant groups map to a single dependent value, default 0.95) so a few
+dirty rows don't kill a genuine hierarchy. Each column's *immediate* parent is the
+highest-cardinality coarser column it determines, which yields clean chains rather than
+transitive-closure noise.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_DEFAULT_FD_THRESHOLD = 0.95
+
+
+@dataclass(frozen=True)
+class Hierarchy:
+    """A discovered drill-down hierarchy. `levels` are ordered coarse -> fine (the
+    drill path); `confidence` is the weakest FD edge in the chain."""
+
+    table: str
+    levels: list[str]
+    confidence: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"table": self.table, "levels": list(self.levels), "confidence": self.confidence}
+
+
+def _distinct_count(table: Any, col: str) -> int:
+    import pyarrow.compute as pc
+
+    return len(pc.unique(table.column(col)))
+
+
+def _fd_strength(table: Any, det: str, dep: str) -> float:
+    """Fraction of `det` groups that map to a single `dep` value — the near-FD
+    strength of ``det -> dep``. 1.0 = a perfect functional dependency."""
+    import pyarrow as pa
+
+    t = pa.table({det: table.column(det), dep: table.column(dep)})
+    grouped = t.group_by(det).aggregate([(dep, "count_distinct")])
+    counts = grouped.column(f"{dep}_count_distinct").to_pylist()
+    if not counts:
+        return 0.0
+    return sum(1 for c in counts if c == 1) / len(counts)
+
+
+def discover_hierarchies(
+    table: Any,
+    columns: list[str],
+    *,
+    table_name: str = "",
+    threshold: float = _DEFAULT_FD_THRESHOLD,
+) -> list[Hierarchy]:
+    """Detect coarse->fine dimension hierarchies among `columns` of `table`.
+
+    Only pyarrow Tables are read (the shape discovery runs on); a column not present
+    is skipped. Returns one `Hierarchy` per maximal chain of length >= 2, sorted for
+    determinism.
+    """
+    cols = [c for c in columns if c in table.column_names]
+    if len(cols) < 2:
+        return []
+
+    card = {c: _distinct_count(table, c) for c in cols}
+
+    # immediate parent(a) = the highest-cardinality STRICTLY-coarser column that `a`
+    # near-determines (the closest coarser level, not a transitive grandparent).
+    parent: dict[str, str] = {}
+    conf: dict[str, float] = {}
+    for a in cols:
+        best: tuple[int, float, str] | None = None
+        for b in cols:
+            if b == a or card[b] >= card[a]:  # a parent must be strictly coarser
+                continue
+            s = _fd_strength(table, a, b)
+            if s >= threshold and (best is None or card[b] > best[0]):
+                best = (card[b], s, b)
+        if best is not None:
+            parent[a], conf[a] = best[2], best[1]
+
+    parents = set(parent.values())
+    leaves = [c for c in cols if c in parent and c not in parents]  # finest ends of a chain
+
+    out: list[Hierarchy] = []
+    for leaf in leaves:
+        path = [leaf]  # fine -> coarse
+        confs: list[float] = []
+        node = leaf
+        while node in parent:
+            confs.append(conf[node])
+            node = parent[node]
+            path.append(node)
+        if len(path) >= 2:
+            out.append(Hierarchy(table=table_name, levels=list(reversed(path)),
+                                 confidence=min(confs)))
+
+    out.sort(key=lambda h: h.levels)
+    return out

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
+from goldenmatch.semantic.discovery.hierarchies import Hierarchy, discover_hierarchies
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
 from goldenmatch.semantic.discovery.keys import KeyCandidate, discover_keys
 from goldenmatch.semantic.discovery.measures import (
@@ -49,6 +50,7 @@ class ProposedTable:
     key: KeyCandidate | None
     measures: list[Measure] = field(default_factory=list)
     dimensions: list[Dimension] = field(default_factory=list)
+    hierarchies: list[Hierarchy] = field(default_factory=list)
 
     @property
     def grain(self) -> list[str]:
@@ -75,6 +77,7 @@ class ProposedModel:
     yaml: str = ""
     certification: dict[str, Any] = field(default_factory=dict)
     naming: list[NameSuggestion] = field(default_factory=list)
+    hierarchies: list[Hierarchy] = field(default_factory=list)
 
     @property
     def all_trustworthy(self) -> bool:
@@ -129,6 +132,7 @@ class ProposedModel:
             ],
             "certification": self.certification,
             "naming": [n.to_dict() for n in self.naming],
+            "hierarchies": [h.to_dict() for h in self.hierarchies],
             "yaml": self.yaml,
         }
 
@@ -202,6 +206,10 @@ def discover_semantic_model(
         grain = grains[tbl_name]
         tm = discover_measures(table, key=grain, table_name=tbl_name)
         per_table_measures[tbl_name] = tm
+        # Phase 4.5 — deterministic dimension hierarchies (FD chains among the dims).
+        hierarchies = discover_hierarchies(
+            table, [d.column for d in tm.dimensions], table_name=tbl_name
+        )
         proposed_tables.append(
             ProposedTable(
                 table=tbl_name,
@@ -209,6 +217,7 @@ def discover_semantic_model(
                 key=grain,
                 measures=tm.measures,
                 dimensions=tm.dimensions,
+                hierarchies=hierarchies,
             )
         )
 
@@ -228,6 +237,7 @@ def discover_semantic_model(
         joins=joins,
         yaml=model_yaml,
         certification=certification,
+        hierarchies=[h for pt in proposed_tables for h in pt.hierarchies],
     )
 
     # Optional, advisory, non-authoritative: annotate the finished model with business

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_hierarchies.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_hierarchies.py
@@ -1,0 +1,76 @@
+"""Dimension hierarchies via FD (PR-11).
+
+Among a table's dimension columns, detect near-functional-dependencies (a finer level
+determines a coarser one) and extract coarse->fine drill hierarchies. Deterministic,
+default-on, attached to ProposedModel.hierarchies + emitted into
+meta.goldenmatch.hierarchies. Driven on a stores geo fixture.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+import yaml
+from goldenmatch.semantic import discover_semantic_model
+
+
+def _stores() -> pa.Table:
+    """store_id is the grain; city -> state -> country is a clean geo hierarchy
+    (each city has one state, each state one country)."""
+    return pa.table({
+        "store_id": ["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"],
+        "city": ["NYC", "NYC", "Boston", "LA", "LA", "SF", "Toronto", "Toronto"],
+        "state": ["NY", "NY", "MA", "CA", "CA", "CA", "ON", "ON"],
+        "country": ["US", "US", "US", "US", "US", "US", "CA", "CA"],
+    })
+
+
+# --- FD hierarchy detection -----------------------------------------------------
+
+
+def test_discover_hierarchies_finds_geo_chain():
+    from goldenmatch.semantic.discovery.hierarchies import discover_hierarchies
+
+    hs = discover_hierarchies(_stores(), ["city", "state", "country"])
+    assert len(hs) == 1
+    # Ordered coarse -> fine (the drill-down path).
+    assert hs[0].levels == ["country", "state", "city"]
+    assert hs[0].confidence >= 0.95
+
+
+def test_no_hierarchy_among_independent_columns():
+    from goldenmatch.semantic.discovery.hierarchies import discover_hierarchies
+
+    # color and size are independent — neither determines the other.
+    t = pa.table({
+        "color": ["red", "blue", "red", "blue", "green", "green"],
+        "size": ["S", "S", "M", "M", "L", "S"],
+    })
+    assert discover_hierarchies(t, ["color", "size"]) == []
+
+
+def test_near_fd_tolerates_a_dirty_row():
+    from goldenmatch.semantic.discovery.hierarchies import discover_hierarchies
+
+    # One mis-keyed row (LA -> NY) must NOT kill the city->state hierarchy (near-FD).
+    t = pa.table({
+        "city": ["NYC", "NYC", "LA", "LA", "LA", "LA", "LA", "LA", "LA", "NY_BUG_LA"],
+        "state": ["NY", "NY", "CA", "CA", "CA", "CA", "CA", "CA", "CA", "NY"],
+    })
+    hs = discover_hierarchies(t, ["city", "state"])
+    assert any(h.levels == ["state", "city"] for h in hs)
+
+
+# --- integration: default-on, on the model + emitted meta -----------------------
+
+
+def test_hierarchies_flow_through_discover_semantic_model_and_to_dict():
+    m = discover_semantic_model({"stores": _stores()})
+    assert any(set(h.levels) == {"city", "state", "country"} for h in m.hierarchies)
+    d = m.to_dict()
+    assert any(h["levels"] == ["country", "state", "city"] for h in d["hierarchies"])
+
+
+def test_hierarchies_emitted_into_cube_meta():
+    m = discover_semantic_model({"stores": _stores()}, dialect="cube")
+    cube = {c["name"]: c for c in yaml.safe_load(m.yaml)["cubes"]}["stores"]
+    hier = cube["meta"]["goldenmatch"]["hierarchies"]
+    assert any(h["levels"] == ["country", "state", "city"] for h in hier)


### PR DESCRIPTION
First **frontier** slice past the certified-structure arc (PR-1..10 shipped) — deriving drill-down hierarchies so the semantic layer is queryable by level.

`discover_hierarchies(table, columns)` finds **near-FDs** among a table's dimension columns (finer determines coarser — `country > state > city`) via a group-by test (default threshold 0.95, tolerating dirty rows). Immediate parent = highest-cardinality coarser column determined → clean coarse→fine chains, no transitive noise.

**Deterministic, default-on** (like measures/dimensions): on `ProposedTable`/`ProposedModel.hierarchies`, in `to_dict`, emitted to `meta.goldenmatch.hierarchies` (MetricFlow/Cube) / `custom_extensions.goldenmatch.hierarchies` (OSI). Certification unaffected. New exports `discover_hierarchies` + `Hierarchy`.

**Tests:** `test_semantic_discovery_hierarchies.py` (5 — geo chain, independence, dirty-row tolerance, model+to_dict flow, cube-meta emit). Full semantic + surface + mcp suite green (107). All gates + `docs_staleness` pass locally.

Next frontier slices queued: metrics → time intelligence → cardinality → SCD → completeness score → warehouse-scale → catalog reconcile → real-LLM namer validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)