### PR TITLE
feat(semantic): metrics derivation (semantic-model discovery, Phase 12)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 448,
+      "module_count": 449,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7273,6 +7273,7 @@
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys",
             "goldenmatch.semantic.discovery.measures",
+            "goldenmatch.semantic.discovery.metrics",
             "goldenmatch.semantic.discovery.model",
             "goldenmatch.semantic.discovery.namer"
           ]
@@ -7385,6 +7386,15 @@
           ]
         },
         {
+          "module": "goldenmatch.semantic.discovery.metrics",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/metrics.py",
+          "purpose": "Metrics derivation (PR-12).",
+          "defines": [
+            "Metric",
+            "discover_metrics"
+          ]
+        },
+        {
           "module": "goldenmatch.semantic.discovery.model",
           "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py",
           "purpose": "Semantic-model discovery orchestrator (Phase 5) — the front door.",
@@ -7402,6 +7412,7 @@
             "goldenmatch.semantic.discovery.joins",
             "goldenmatch.semantic.discovery.keys",
             "goldenmatch.semantic.discovery.measures",
+            "goldenmatch.semantic.discovery.metrics",
             "goldenmatch.semantic.discovery.namer"
           ]
         },

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -274,6 +274,17 @@ actually query. All are deterministic (no LLM) and default-on unless noted.
     grains), cardinality (m:n bridge / 1:1), SCD dimensions, a model completeness score,
     warehouse-scale derivation off `information_schema`, catalog reconciliation, and
     real-LLM namer validation.
+12. **Metrics.** New `discovery/metrics.py`: `discover_metrics(measures, grain)` proposes
+    certifiable business metrics **only when the grain is trustworthy** (so the ratios
+    don't double-count): per sum-safe measure an **average** (`avg_m = SUM(m)/COUNT(grain)`
+    — always meaningful at a clean grain, MetricFlow's canonical *ratio* metric), and per
+    sum-safe measure PAIR a **ratio** (`m1_per_m2 = SUM(m1)/SUM(m2)`, pool-capped to bound
+    the pair explosion). `Metric(name, kind, numerator, denominator, expression)`; on
+    `ProposedTable`/`ProposedModel.metrics` + `to_dict`, emitted NATIVELY (MetricFlow
+    top-level `metrics:` ratio metrics + a declared count measure; Cube calculated
+    `number` measures + a `count`; OSI `OsiMetric`s). Deterministic, default-on. *Derived
+    semantic* metrics (`profit = revenue − cost`) stay a namer/advisory follow-on (they
+    need to know which measure is revenue vs cost).
 
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -23,6 +23,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   layer (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_hierarchies.py`.
+- **Semantic-model discovery — metrics (Phase 12).**
+  `goldenmatch.semantic.discover_metrics(measures, grain)` turns the grain-gated
+  measures into certifiable business metrics — proposed ONLY when the grain is
+  trustworthy (the measures are `safe_to_sum`), so the ratios can't double-count: per
+  sum-safe measure an **average** (`avg_m = SUM(m)/COUNT(grain)`), and per sum-safe
+  measure PAIR a **ratio** (`m1_per_m2 = SUM(m1)/SUM(m2)`, pool-capped to `C(5,2)`).
+  `Metric(name, kind, numerator, denominator, expression)` on
+  `ProposedTable`/`ProposedModel.metrics` + `to_dict`, emitted **natively** per dialect:
+  MetricFlow top-level `metrics:` ratio metrics (plus a declared `count` measure so
+  averages have a denominator), Cube calculated `number` measures + a `count`, and OSI
+  dataset-qualified `OsiMetric`s. Deterministic, default-on. Derived *semantic* metrics
+  (`profit = revenue − cost`) stay a namer/advisory follow-on. New exports
+  `discover_metrics` + `Metric`. The second "frontier" slice (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_metrics.py`.
 
 ## [3.11.0] - 2026-08-03
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -52,6 +52,7 @@ from goldenmatch.semantic.discovery import (
     JoinCandidate,
     KeyCandidate,
     Measure,
+    Metric,
     NameSuggestion,
     ProposedModel,
     ProposedTable,
@@ -62,6 +63,7 @@ from goldenmatch.semantic.discovery import (
     discover_joins,
     discover_keys,
     discover_measures,
+    discover_metrics,
     discover_semantic_model,
     name_semantic_model,
 )
@@ -176,6 +178,8 @@ __all__ = [
     # semantic-model discovery (Phase 11) — dimension hierarchies via FD
     "discover_hierarchies",
     "Hierarchy",
+    "Metric",
+    "discover_metrics",
     # semantic-model discovery (Phase 7) — optional advisory LLM namer
     "apply_names",
     "name_semantic_model",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -29,6 +29,7 @@ from goldenmatch.semantic.discovery.measures import (
     TableMeasures,
     discover_measures,
 )
+from goldenmatch.semantic.discovery.metrics import Metric, discover_metrics
 from goldenmatch.semantic.discovery.model import (
     ProposedModel,
     ProposedTable,
@@ -48,6 +49,7 @@ __all__ = [
     "JoinCandidate",
     "KeyCandidate",
     "Measure",
+    "Metric",
     "NameSuggestion",
     "NamerBackend",
     "ProposedModel",
@@ -58,6 +60,7 @@ __all__ = [
     "discover_joins",
     "discover_keys",
     "discover_measures",
+    "discover_metrics",
     "discover_semantic_model",
     "apply_names",
     "name_semantic_model",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
@@ -56,6 +56,7 @@ def _build_metricflow(proposed_tables: list[Any]) -> str:
     from goldenmatch.semantic import emit_metricflow_yaml, emit_semantic_model
 
     models = []
+    metrics: list[dict[str, Any]] = []
     for pt in proposed_tables:
         if pt.key is None:
             continue
@@ -70,8 +71,30 @@ def _build_metricflow(proposed_tables: list[Any]) -> str:
         hier = _hierarchies_dicts(pt)
         if hier:  # additive to the meta.goldenmatch block emit_semantic_model set
             sm.setdefault("meta", {}).setdefault("goldenmatch", {})["hierarchies"] = hier
+        # Native metrics: declare a COUNT measure so averages have a denominator, then
+        # emit each derived metric as a MetricFlow ratio metric.
+        if pt.metrics:
+            count_name = f"{pt.table}_count"
+            sm.setdefault("measures", []).append(
+                {"name": count_name, "agg": "count", "expr": pt.key.columns[0]}
+            )
+            for mt in pt.metrics:
+                denom = count_name if mt.kind == "average" else mt.denominator
+                metrics.append({
+                    "name": mt.name, "type": "ratio",
+                    "type_params": {"numerator": mt.numerator, "denominator": denom},
+                })
         models.append(sm)
-    return emit_metricflow_yaml(models) if models else ""
+    if not models:
+        return ""
+    if metrics:
+        import yaml as _yaml
+
+        return _yaml.safe_dump(
+            {"semantic_models": models, "metrics": metrics},
+            sort_keys=False, default_flow_style=False,
+        )
+    return emit_metricflow_yaml(models)
 
 
 def _build_cube(proposed_tables: list[Any], joins: list[Any]) -> str:
@@ -102,6 +125,12 @@ def _build_cube(proposed_tables: list[Any], joins: list[Any]) -> str:
                                           type=_CUBE_DIM_TYPE.get(d.kind, "string")))
         measures = [CubeMeasure(m.column, type="sum", sql=m.column)
                     for m in pt.measures if m.safe_to_sum]
+        if pt.metrics:  # a count + calculated number measures referencing the sums
+            measures.append(CubeMeasure("count", type="count"))
+            for mt in pt.metrics:
+                denom = "count" if mt.kind == "average" else mt.denominator
+                measures.append(CubeMeasure(
+                    mt.name, type="number", sql=f"{{{mt.numerator}}} / {{{denom}}}"))
         cube_joins = [
             CubeJoin(
                 name=j.to_table,
@@ -152,6 +181,14 @@ def _build_osi(proposed_tables: list[Any], joins: list[Any]) -> str:
             if m.safe_to_sum:
                 metrics.append(OsiMetric(f"{pt.table}_{m.column}_total",
                                          expression=f"SUM({pt.table}.{m.column})"))
+        # Derived metrics (averages + ratios) as dataset-qualified OSI metrics.
+        grain_key = pt.key.columns[0]
+        for mt in pt.metrics:
+            if mt.kind == "average":
+                expr = f"SUM({pt.table}.{mt.numerator}) / COUNT({pt.table}.{grain_key})"
+            else:
+                expr = f"SUM({pt.table}.{mt.numerator}) / SUM({pt.table}.{mt.denominator})"
+            metrics.append(OsiMetric(mt.name, expression=expr))
         if pt.key.certificate is not None:
             key_integrity[pt.table] = certificate_verdict(pt.key.certificate)
         hier = _hierarchies_dicts(pt)

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/metrics.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/metrics.py
@@ -1,0 +1,77 @@
+"""Metrics derivation (PR-12).
+
+Turns the grain-gated measures into certifiable business metrics. A metric is only
+proposed when the grain is trustworthy (the measures are `safe_to_sum`), so the ratios
+can't silently double-count:
+
+  * **average** — `avg_<m> = SUM(m) / COUNT(grain)` per sum-safe measure (always
+    meaningful at a clean grain; MetricFlow's canonical *ratio* metric).
+  * **ratio** — `<m1>_per_<m2> = SUM(m1) / SUM(m2)` per sum-safe measure PAIR
+    (pool-capped so the pair count stays C(cap, 2), not combinatorial on wide facts).
+
+Deterministic, default-on. *Derived semantic* metrics (`profit = revenue - cost`) need
+to know which measure is revenue vs cost, so they stay a namer/advisory follow-on.
+"""
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+# Cap on the sum-safe measure pool the ratio search pairs over.
+_METRIC_PAIR_POOL_CAP = 5
+
+
+@dataclass(frozen=True)
+class Metric:
+    """A proposed business metric. `denominator` is `None` for an average (the
+    denominator is `COUNT(grain)`); `expression` is the human-readable formula."""
+
+    name: str
+    kind: str  # average | ratio
+    numerator: str
+    denominator: str | None
+    expression: str
+    table: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "expression": self.expression,
+            "table": self.table,
+        }
+
+
+def discover_metrics(
+    measures: list[Any],
+    grain: list[str],
+    *,
+    table_name: str = "",
+) -> list[Metric]:
+    """Propose average + ratio metrics from the sum-safe `measures` at `grain`.
+
+    Returns `[]` when nothing is sum-safe (a fanned-out / untrustworthy grain — a ratio
+    there would double-count) or the grain is empty.
+    """
+    sum_safe = [m.column for m in measures if getattr(m, "safe_to_sum", False)]
+    if not sum_safe or not grain:
+        return []
+    grain_key = grain[0]
+
+    out: list[Metric] = []
+    for col in sum_safe:
+        out.append(Metric(
+            name=f"avg_{col}", kind="average", numerator=col, denominator=None,
+            expression=f"SUM({col}) / COUNT({grain_key})", table=table_name,
+        ))
+
+    pool = sorted(sum_safe)[:_METRIC_PAIR_POOL_CAP]
+    for c1, c2 in itertools.combinations(pool, 2):
+        out.append(Metric(
+            name=f"{c1}_per_{c2}", kind="ratio", numerator=c1, denominator=c2,
+            expression=f"SUM({c1}) / SUM({c2})", table=table_name,
+        ))
+    return out

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -33,6 +33,7 @@ from goldenmatch.semantic.discovery.measures import (
     TableMeasures,
     discover_measures,
 )
+from goldenmatch.semantic.discovery.metrics import Metric, discover_metrics
 
 if TYPE_CHECKING:
     from goldenmatch.semantic.discovery.namer import NameSuggestion
@@ -51,6 +52,7 @@ class ProposedTable:
     measures: list[Measure] = field(default_factory=list)
     dimensions: list[Dimension] = field(default_factory=list)
     hierarchies: list[Hierarchy] = field(default_factory=list)
+    metrics: list[Metric] = field(default_factory=list)
 
     @property
     def grain(self) -> list[str]:
@@ -78,6 +80,7 @@ class ProposedModel:
     certification: dict[str, Any] = field(default_factory=dict)
     naming: list[NameSuggestion] = field(default_factory=list)
     hierarchies: list[Hierarchy] = field(default_factory=list)
+    metrics: list[Metric] = field(default_factory=list)
 
     @property
     def all_trustworthy(self) -> bool:
@@ -133,6 +136,7 @@ class ProposedModel:
             "certification": self.certification,
             "naming": [n.to_dict() for n in self.naming],
             "hierarchies": [h.to_dict() for h in self.hierarchies],
+            "metrics": [mt.to_dict() for mt in self.metrics],
             "yaml": self.yaml,
         }
 
@@ -206,10 +210,13 @@ def discover_semantic_model(
         grain = grains[tbl_name]
         tm = discover_measures(table, key=grain, table_name=tbl_name)
         per_table_measures[tbl_name] = tm
-        # Phase 4.5 — deterministic dimension hierarchies (FD chains among the dims).
+        # Phase 4.5 — deterministic dimension hierarchies (FD chains among the dims)
+        # and certifiable metrics (averages + ratios over the sum-safe measures).
         hierarchies = discover_hierarchies(
             table, [d.column for d in tm.dimensions], table_name=tbl_name
         )
+        grain_cols = list(grain.columns) if grain is not None else []
+        metrics = discover_metrics(tm.measures, grain_cols, table_name=tbl_name)
         proposed_tables.append(
             ProposedTable(
                 table=tbl_name,
@@ -218,6 +225,7 @@ def discover_semantic_model(
                 measures=tm.measures,
                 dimensions=tm.dimensions,
                 hierarchies=hierarchies,
+                metrics=metrics,
             )
         )
 
@@ -238,6 +246,7 @@ def discover_semantic_model(
         yaml=model_yaml,
         certification=certification,
         hierarchies=[h for pt in proposed_tables for h in pt.hierarchies],
+        metrics=[mt for pt in proposed_tables for mt in pt.metrics],
     )
 
     # Optional, advisory, non-authoritative: annotate the finished model with business

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_metrics.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_metrics.py
@@ -1,0 +1,90 @@
+"""Metrics derivation (PR-12).
+
+Derive certifiable business metrics from the grain-gated measures: per sum-safe
+measure an average (SUM/COUNT at a trustworthy grain), and per sum-safe measure pair a
+ratio (SUM/SUM). Deterministic, default-on, emitted natively per dialect. Driven on an
+orders fixture with two measures.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+import yaml
+from goldenmatch.semantic import discover_semantic_model
+from goldenmatch.semantic.discovery.measures import Measure
+
+
+def _orders() -> pa.Table:
+    return pa.table({
+        "order_id": ["o1", "o2", "o3", "o4"],
+        "amount": [10.0, 20.0, 30.0, 40.0],
+        "quantity": [1, 2, 3, 4],
+    })
+
+
+# --- discover_metrics ------------------------------------------------------------
+
+
+def test_discover_metrics_averages_and_ratio():
+    from goldenmatch.semantic.discovery.metrics import discover_metrics
+
+    measures = [
+        Measure(column="amount", aggregations=["sum"], safe_to_sum=True),
+        Measure(column="quantity", aggregations=["sum"], safe_to_sum=True),
+    ]
+    ms = discover_metrics(measures, grain=["order_id"], table_name="orders")
+    by_name = {m.name: m for m in ms}
+
+    # per-measure averages (SUM(m)/COUNT(grain)).
+    assert by_name["avg_amount"].kind == "average"
+    assert by_name["avg_amount"].numerator == "amount"
+    assert "COUNT(order_id)" in by_name["avg_amount"].expression
+    assert "avg_quantity" in by_name
+
+    # a measure-pair ratio (SUM/SUM), deterministically sorted numerator/denominator.
+    ratio = by_name["amount_per_quantity"]
+    assert ratio.kind == "ratio"
+    assert (ratio.numerator, ratio.denominator) == ("amount", "quantity")
+
+
+def test_no_metrics_without_trustworthy_sum_safe_measures():
+    from goldenmatch.semantic.discovery.metrics import discover_metrics
+
+    # fanned-out grain -> nothing is sum-safe -> no metrics (they'd double-count).
+    measures = [Measure(column="amount", aggregations=["count"], safe_to_sum=False)]
+    assert discover_metrics(measures, grain=["order_id"], table_name="orders") == []
+
+
+def test_ratio_pairs_are_capped():
+    from goldenmatch.semantic.discovery.metrics import _METRIC_PAIR_POOL_CAP, discover_metrics
+
+    measures = [Measure(column=f"m{i}", aggregations=["sum"], safe_to_sum=True)
+                for i in range(10)]
+    ratios = [m for m in discover_metrics(measures, grain=["k"], table_name="t")
+              if m.kind == "ratio"]
+    cap = _METRIC_PAIR_POOL_CAP
+    assert len(ratios) == cap * (cap - 1) // 2  # C(cap, 2), not C(10, 2)
+
+
+# --- integration + native emit --------------------------------------------------
+
+
+def test_metrics_flow_through_model_and_to_dict():
+    m = discover_semantic_model({"orders": _orders()})
+    names = {mm.name for mm in m.metrics}
+    assert {"avg_amount", "avg_quantity", "amount_per_quantity"} <= names
+    d = m.to_dict()
+    assert any(x["name"] == "avg_amount" for x in d["metrics"])
+
+
+def test_metrics_emitted_natively_metricflow_and_osi():
+    # MetricFlow: a top-level metrics: block.
+    mf = discover_semantic_model({"orders": _orders()})
+    doc = yaml.safe_load(mf.yaml)
+    assert "metrics" in doc
+    assert any(x["name"] == "avg_amount" for x in doc["metrics"])
+
+    # OSI: OsiMetrics carry the derived metrics.
+    osi = discover_semantic_model({"orders": _orders()}, dialect="osi")
+    metrics = [mt for model in yaml.safe_load(osi.yaml)["semantic_model"]
+               for mt in model["metrics"]]
+    assert any(mt["name"] == "avg_amount" for mt in metrics)


### PR DESCRIPTION
Second **frontier** slice — turn grain-gated measures into certifiable business metrics.

`discover_metrics(measures, grain)` proposes metrics **only at a trustworthy grain** (measures `safe_to_sum`, so ratios can't double-count): per measure an **average** (`avg_m = SUM(m)/COUNT(grain)`); per measure PAIR a **ratio** (`m1_per_m2`, pool-capped to C(5,2)). Emitted **natively** — MetricFlow top-level `metrics:` (+ a declared `count` measure), Cube calculated `number` measures + `count`, OSI `OsiMetric`s. Deterministic, default-on. Derived semantic metrics (profit = revenue − cost) stay a namer follow-on.

Tests: `test_semantic_discovery_metrics.py` (5). Full suite green (112). New exports `discover_metrics` + `Metric`.

Frontier progress: hierarchies ✅, **metrics ✅**, next: time intelligence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)