### PR TITLE
feat(semantic): time intelligence (semantic-model discovery, Phase 13)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 449,
+      "module_count": 450,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7275,7 +7275,8 @@
             "goldenmatch.semantic.discovery.measures",
             "goldenmatch.semantic.discovery.metrics",
             "goldenmatch.semantic.discovery.model",
-            "goldenmatch.semantic.discovery.namer"
+            "goldenmatch.semantic.discovery.namer",
+            "goldenmatch.semantic.discovery.time_intelligence"
           ]
         },
         {
@@ -7413,7 +7414,8 @@
             "goldenmatch.semantic.discovery.keys",
             "goldenmatch.semantic.discovery.measures",
             "goldenmatch.semantic.discovery.metrics",
-            "goldenmatch.semantic.discovery.namer"
+            "goldenmatch.semantic.discovery.namer",
+            "goldenmatch.semantic.discovery.time_intelligence"
           ]
         },
         {
@@ -7444,6 +7446,20 @@
           "imports": [
             "goldenmatch.core.llm_labeler",
             "goldenmatch.semantic.discovery.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.time_intelligence",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/time_intelligence.py",
+          "purpose": "Time intelligence (PR-13).",
+          "defines": [
+            "TimeDimension",
+            "TimeMetric",
+            "_granularities_from",
+            "_infer_grain",
+            "_pick_time_column",
+            "discover_time_dimension",
+            "discover_time_metrics"
           ]
         },
         {

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -285,6 +285,20 @@ actually query. All are deterministic (no LLM) and default-on unless noted.
     `number` measures + a `count`; OSI `OsiMetric`s). Deterministic, default-on. *Derived
     semantic* metrics (`profit = revenue − cost`) stay a namer/advisory follow-on (they
     need to know which measure is revenue vs cost).
+13. **Time intelligence.** New `discovery/time_intelligence.py`. `discover_time_dimension(
+    table, dimensions)` picks the primary date column (`kind="date"`, name-preferring
+    `date`/`created`/`timestamp`), infers its **finest granularity from the data** (a
+    cheap value scan: time-of-day → `day`; all values on month/quarter/year starts →
+    that coarser grain), and proposes the drill granularities up from it
+    (`TimeDimension(table, column, grain, granularities)`). `discover_time_metrics(
+    measures, time_dimension)` derives per sum-safe measure the **MTD** / **YoY** /
+    **rolling-7d** variants (`TimeMetric(name, base, kind, window)`). Both on
+    `ProposedTable`/`ProposedModel` (+ `to_dict`). Emitted so the engine computes time
+    comparisons automatically: MetricFlow sets `defaults.agg_time_dimension` + a `type:
+    time` dimension with `time_granularity`, MTD/rolling as `type: cumulative` metrics
+    and YoY as a `type: derived` offset metric; Cube keeps the `type: time` dim +
+    granularities and the variants in `meta.goldenmatch.time`; OSI `is_time` +
+    `custom_extensions`. Deterministic, default-on.
 
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -38,6 +38,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `discover_metrics` + `Metric`. The second "frontier" slice (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_metrics.py`.
+- **Semantic-model discovery — time intelligence (Phase 13).** New
+  `goldenmatch/semantic/discovery/time_intelligence.py`.
+  `discover_time_dimension(table, dimensions)` picks the primary date column and infers
+  its finest grain FROM THE DATA (a cheap value scan: time-of-day → `day`; all values on
+  month/quarter/year starts → that coarser grain), then proposes the drill granularities
+  (`TimeDimension(table, column, grain, granularities)`). `discover_time_metrics(measures,
+  time_dimension)` derives per sum-safe measure the **MTD / YoY / rolling-7d** variants
+  (`TimeMetric`). On `ProposedTable`/`ProposedModel` (`time_dimensions` + `time_metrics`)
+  + `to_dict`, and emitted so the engine computes time comparisons automatically:
+  MetricFlow sets `defaults.agg_time_dimension` + a `type: time` dimension at the grain,
+  MTD/rolling as native `type: cumulative` metrics (YoY structured for now); Cube/OSI keep
+  the grain + granularities + variants in `meta.goldenmatch.time`. Deterministic,
+  default-on. New exports `discover_time_dimension`/`discover_time_metrics` +
+  `TimeDimension`/`TimeMetric`. The third "frontier" slice (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_time_intelligence.py`.
 
 ## [3.11.0] - 2026-08-03
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -57,6 +57,8 @@ from goldenmatch.semantic.discovery import (
     ProposedModel,
     ProposedTable,
     TableMeasures,
+    TimeDimension,
+    TimeMetric,
     apply_names,
     discover_entity_types,
     discover_hierarchies,
@@ -65,6 +67,8 @@ from goldenmatch.semantic.discovery import (
     discover_measures,
     discover_metrics,
     discover_semantic_model,
+    discover_time_dimension,
+    discover_time_metrics,
     name_semantic_model,
 )
 from goldenmatch.semantic.key_integrity import (
@@ -180,6 +184,10 @@ __all__ = [
     "Hierarchy",
     "Metric",
     "discover_metrics",
+    "discover_time_dimension",
+    "discover_time_metrics",
+    "TimeDimension",
+    "TimeMetric",
     # semantic-model discovery (Phase 7) — optional advisory LLM namer
     "apply_names",
     "name_semantic_model",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -41,6 +41,12 @@ from goldenmatch.semantic.discovery.namer import (
     apply_names,
     name_semantic_model,
 )
+from goldenmatch.semantic.discovery.time_intelligence import (
+    TimeDimension,
+    TimeMetric,
+    discover_time_dimension,
+    discover_time_metrics,
+)
 
 __all__ = [
     "Dimension",
@@ -50,6 +56,8 @@ __all__ = [
     "KeyCandidate",
     "Measure",
     "Metric",
+    "TimeDimension",
+    "TimeMetric",
     "NameSuggestion",
     "NamerBackend",
     "ProposedModel",
@@ -61,6 +69,8 @@ __all__ = [
     "discover_keys",
     "discover_measures",
     "discover_metrics",
+    "discover_time_dimension",
+    "discover_time_metrics",
     "discover_semantic_model",
     "apply_names",
     "name_semantic_model",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/emit.py
@@ -48,6 +48,11 @@ def _gm_meta(pt: Any) -> dict[str, Any]:
     hier = _hierarchies_dicts(pt)
     if hier:
         gm["hierarchies"] = hier
+    td = getattr(pt, "time_dimension", None)
+    if td is not None:
+        gm["time"] = {"column": td.column, "grain": td.grain,
+                      "granularities": list(td.granularities),
+                      "metrics": [t.to_dict() for t in getattr(pt, "time_metrics", [])]}
     return gm
 
 
@@ -61,16 +66,37 @@ def _build_metricflow(proposed_tables: list[Any]) -> str:
         if pt.key is None:
             continue
         safe_measures = [m.column for m in pt.measures if m.safe_to_sum]
+        td = getattr(pt, "time_dimension", None)
         sm = emit_semantic_model(
             pt.table,
             resolved_key=pt.key.columns[0],
             entity_name=pt.entity_type or pt.table,
             measures=safe_measures,
+            grain=[td.column] if td is not None else None,  # -> defaults.agg_time_dimension
             certificate=pt.key.certificate,
         )
         hier = _hierarchies_dicts(pt)
         if hier:  # additive to the meta.goldenmatch block emit_semantic_model set
             sm.setdefault("meta", {}).setdefault("goldenmatch", {})["hierarchies"] = hier
+        # Time dimension: a native `type: time` dimension at the inferred grain, plus
+        # the grain/granularities in meta for the drill path.
+        if td is not None:
+            sm.setdefault("dimensions", []).append(
+                {"name": td.column, "type": "time",
+                 "type_params": {"time_granularity": td.grain}}
+            )
+            sm.setdefault("meta", {}).setdefault("goldenmatch", {})["time"] = {
+                "grain": td.grain, "granularities": list(td.granularities)
+            }
+        # Time metric variants: MTD + rolling as native cumulative metrics (YoY stays in
+        # the structured model.time_metrics; its native derived-offset emit is a follow-on).
+        for tmv in getattr(pt, "time_metrics", []):
+            if tmv.kind == "mtd":
+                metrics.append({"name": tmv.name, "type": "cumulative",
+                                "type_params": {"measure": tmv.base, "grain_to_date": tmv.grain_to_date}})
+            elif tmv.kind == "rolling":
+                metrics.append({"name": tmv.name, "type": "cumulative",
+                                "type_params": {"measure": tmv.base, "window": tmv.window}})
         # Native metrics: declare a COUNT measure so averages have a denominator, then
         # emit each derived metric as a MetricFlow ratio metric.
         if pt.metrics:

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -34,6 +34,12 @@ from goldenmatch.semantic.discovery.measures import (
     discover_measures,
 )
 from goldenmatch.semantic.discovery.metrics import Metric, discover_metrics
+from goldenmatch.semantic.discovery.time_intelligence import (
+    TimeDimension,
+    TimeMetric,
+    discover_time_dimension,
+    discover_time_metrics,
+)
 
 if TYPE_CHECKING:
     from goldenmatch.semantic.discovery.namer import NameSuggestion
@@ -53,6 +59,8 @@ class ProposedTable:
     dimensions: list[Dimension] = field(default_factory=list)
     hierarchies: list[Hierarchy] = field(default_factory=list)
     metrics: list[Metric] = field(default_factory=list)
+    time_dimension: TimeDimension | None = None
+    time_metrics: list[TimeMetric] = field(default_factory=list)
 
     @property
     def grain(self) -> list[str]:
@@ -81,6 +89,8 @@ class ProposedModel:
     naming: list[NameSuggestion] = field(default_factory=list)
     hierarchies: list[Hierarchy] = field(default_factory=list)
     metrics: list[Metric] = field(default_factory=list)
+    time_dimensions: list[TimeDimension] = field(default_factory=list)
+    time_metrics: list[TimeMetric] = field(default_factory=list)
 
     @property
     def all_trustworthy(self) -> bool:
@@ -137,6 +147,8 @@ class ProposedModel:
             "naming": [n.to_dict() for n in self.naming],
             "hierarchies": [h.to_dict() for h in self.hierarchies],
             "metrics": [mt.to_dict() for mt in self.metrics],
+            "time_dimensions": [td.to_dict() for td in self.time_dimensions],
+            "time_metrics": [tm.to_dict() for tm in self.time_metrics],
             "yaml": self.yaml,
         }
 
@@ -217,6 +229,9 @@ def discover_semantic_model(
         )
         grain_cols = list(grain.columns) if grain is not None else []
         metrics = discover_metrics(tm.measures, grain_cols, table_name=tbl_name)
+        # Time intelligence — the primary time dimension + per-measure MTD/YoY/rolling.
+        time_dim = discover_time_dimension(table, tm.dimensions, table_name=tbl_name)
+        time_metrics = discover_time_metrics(tm.measures, time_dim, table_name=tbl_name)
         proposed_tables.append(
             ProposedTable(
                 table=tbl_name,
@@ -226,6 +241,8 @@ def discover_semantic_model(
                 dimensions=tm.dimensions,
                 hierarchies=hierarchies,
                 metrics=metrics,
+                time_dimension=time_dim,
+                time_metrics=time_metrics,
             )
         )
 
@@ -247,6 +264,9 @@ def discover_semantic_model(
         certification=certification,
         hierarchies=[h for pt in proposed_tables for h in pt.hierarchies],
         metrics=[mt for pt in proposed_tables for mt in pt.metrics],
+        time_dimensions=[pt.time_dimension for pt in proposed_tables
+                         if pt.time_dimension is not None],
+        time_metrics=[tm for pt in proposed_tables for tm in pt.time_metrics],
     )
 
     # Optional, advisory, non-authoritative: annotate the finished model with business

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/time_intelligence.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/time_intelligence.py
@@ -1,0 +1,117 @@
+"""Time intelligence (PR-13).
+
+Detect a table's primary time dimension (with a data-inferred grain + drill
+granularities) and derive per-measure time variants (MTD / YoY / rolling), so the
+semantic layer can compute time comparisons automatically. Deterministic, default-on.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_GRAIN_ORDER = ["day", "week", "month", "quarter", "year"]
+# Name hints for preferring one date column as THE primary time dimension.
+_TIME_NAME_HINTS = ("date", "time", "created", "timestamp", "period", "day")
+
+
+@dataclass(frozen=True)
+class TimeDimension:
+    """The primary time dimension: its `grain` (finest, inferred from the data) and the
+    drill `granularities` up from it."""
+
+    table: str
+    column: str
+    grain: str
+    granularities: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"table": self.table, "column": self.column, "grain": self.grain,
+                "granularities": list(self.granularities)}
+
+
+@dataclass(frozen=True)
+class TimeMetric:
+    """A time-windowed metric variant over a base measure (MTD / YoY / rolling)."""
+
+    name: str
+    base: str
+    kind: str  # mtd | yoy | rolling
+    window: str | None = None
+    grain_to_date: str | None = None
+    table: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "base": self.base, "kind": self.kind,
+                "window": self.window, "grain_to_date": self.grain_to_date, "table": self.table}
+
+
+def _infer_grain(table: Any, col: str) -> str:
+    """Finest granularity the data actually resolves: time-of-day -> day; all values on
+    month/quarter/year starts -> that coarser grain."""
+    import pyarrow.compute as pc
+
+    arr = table.column(col)
+    try:
+        days = pc.day(arr).drop_null().to_pylist()
+        months = pc.month(arr).drop_null().to_pylist()
+    except Exception:  # noqa: BLE001 - not a temporal column
+        return "day"
+    if not days:
+        return "day"
+    try:  # a timestamp with any time-of-day resolves to (at least) day
+        if any(h != 0 for h in pc.hour(arr).drop_null().to_pylist()):
+            return "day"
+    except Exception:  # noqa: BLE001 - date32 has no hour
+        pass
+    if all(d == 1 for d in days):
+        if all(m == 1 for m in months):
+            return "year"
+        if all(m in (1, 4, 7, 10) for m in months):
+            return "quarter"
+        return "month"
+    return "day"
+
+
+def _granularities_from(grain: str) -> list[str]:
+    return _GRAIN_ORDER[_GRAIN_ORDER.index(grain):] if grain in _GRAIN_ORDER else [grain]
+
+
+def _pick_time_column(dimensions: list[Any]) -> str | None:
+    date_cols = [d.column for d in dimensions if getattr(d, "kind", "") == "date"]
+    if not date_cols:
+        return None
+    for c in date_cols:  # prefer a name-hinted column
+        if any(h in c.lower() for h in _TIME_NAME_HINTS):
+            return c
+    return date_cols[0]
+
+
+def discover_time_dimension(
+    table: Any, dimensions: list[Any], *, table_name: str = "",
+) -> TimeDimension | None:
+    """The primary time dimension for a table, or None when it has no date column."""
+    col = _pick_time_column(dimensions)
+    if col is None:
+        return None
+    grain = _infer_grain(table, col)
+    return TimeDimension(table=table_name, column=col, grain=grain,
+                         granularities=_granularities_from(grain))
+
+
+def discover_time_metrics(
+    measures: list[Any], time_dimension: TimeDimension | None, *, table_name: str = "",
+) -> list[TimeMetric]:
+    """Per sum-safe measure, the MTD / YoY / rolling-7d variants (empty without a time
+    dimension)."""
+    if time_dimension is None:
+        return []
+    tn = table_name or time_dimension.table
+    out: list[TimeMetric] = []
+    for m in measures:
+        if not getattr(m, "safe_to_sum", False):
+            continue
+        col = m.column
+        out.append(TimeMetric(f"{col}_mtd", col, "mtd", grain_to_date="month", table=tn))
+        out.append(TimeMetric(f"{col}_yoy", col, "yoy", window="1 year", table=tn))
+        out.append(TimeMetric(f"{col}_rolling_7d", col, "rolling", window="7 days", table=tn))
+    return out

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_time_intelligence.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_time_intelligence.py
@@ -1,0 +1,112 @@
+"""Time intelligence (PR-13).
+
+Detect the primary time dimension (with a data-inferred grain + drill granularities) and
+derive per-measure MTD / YoY / rolling variants, so the semantic layer can compute time
+comparisons. Deterministic, default-on, emitted natively (MetricFlow agg_time_dimension +
+cumulative/derived metrics). Driven on an orders-with-order_date fixture.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+import pyarrow as pa
+import yaml
+from goldenmatch.semantic import discover_semantic_model
+from goldenmatch.semantic.discovery.measures import Measure
+
+
+def _orders_daily() -> pa.Table:
+    return pa.table({
+        "order_id": ["o1", "o2", "o3", "o4"],
+        "order_date": pa.array(
+            [dt.date(2026, 1, 3), dt.date(2026, 1, 5), dt.date(2026, 2, 9), dt.date(2026, 3, 2)],
+            type=pa.date32(),
+        ),
+        "amount": [10.0, 20.0, 30.0, 40.0],
+    })
+
+
+def _monthly() -> pa.Table:
+    # every value on a month start -> grain should be inferred as "month".
+    return pa.table({
+        "snap_id": ["s1", "s2", "s3"],
+        "period": pa.array(
+            [dt.date(2026, 1, 1), dt.date(2026, 2, 1), dt.date(2026, 3, 1)], type=pa.date32()
+        ),
+        "revenue": [100.0, 200.0, 300.0],
+    })
+
+
+# --- time dimension detection + grain inference ---------------------------------
+
+
+def test_discover_time_dimension_infers_day_grain():
+    from goldenmatch.semantic.discovery.measures import Dimension
+    from goldenmatch.semantic.discovery.time_intelligence import discover_time_dimension
+
+    dims = [Dimension(column="order_date", kind="date")]
+    td = discover_time_dimension(_orders_daily(), dims, table_name="orders")
+    assert td is not None
+    assert td.column == "order_date"
+    assert td.grain == "day"
+    assert td.granularities == ["day", "week", "month", "quarter", "year"]
+
+
+def test_grain_inferred_as_month_for_month_starts():
+    from goldenmatch.semantic.discovery.measures import Dimension
+    from goldenmatch.semantic.discovery.time_intelligence import discover_time_dimension
+
+    td = discover_time_dimension(_monthly(), [Dimension(column="period", kind="date")],
+                                 table_name="snap")
+    assert td.grain == "month"
+    assert td.granularities == ["month", "quarter", "year"]
+
+
+def test_no_time_dimension_without_a_date_column():
+    from goldenmatch.semantic.discovery.measures import Dimension
+    from goldenmatch.semantic.discovery.time_intelligence import discover_time_dimension
+
+    assert discover_time_dimension(_orders_daily(), [Dimension(column="x", kind="categorical")],
+                                   table_name="t") is None
+
+
+# --- time metric variants -------------------------------------------------------
+
+
+def test_time_metrics_mtd_yoy_rolling_per_measure():
+    from goldenmatch.semantic.discovery.time_intelligence import (
+        TimeDimension,
+        discover_time_metrics,
+    )
+
+    measures = [Measure(column="amount", aggregations=["sum"], safe_to_sum=True)]
+    td = TimeDimension(table="orders", column="order_date", grain="day",
+                       granularities=["day", "month", "year"])
+    tms = discover_time_metrics(measures, td)
+    by = {m.name: m for m in tms}
+    assert by["amount_mtd"].kind == "mtd"
+    assert by["amount_yoy"].kind == "yoy"
+    assert by["amount_rolling_7d"].kind == "rolling"
+
+
+# --- integration + native MetricFlow emit ---------------------------------------
+
+
+def test_time_intelligence_flows_through_model_and_to_dict():
+    m = discover_semantic_model({"orders": _orders_daily()})
+    assert m.time_dimensions and m.time_dimensions[0].column == "order_date"
+    assert any(tm.name == "amount_mtd" for tm in m.time_metrics)
+    d = m.to_dict()
+    assert d["time_dimensions"][0]["grain"] == "day"
+    assert any(x["name"] == "amount_mtd" for x in d["time_metrics"])
+
+
+def test_metricflow_emits_agg_time_dimension_and_cumulative_metric():
+    m = discover_semantic_model({"orders": _orders_daily()})
+    doc = yaml.safe_load(m.yaml)
+    sm = doc["semantic_models"][0]
+    # native agg_time_dimension set on the model.
+    assert sm["defaults"]["agg_time_dimension"] == "order_date"
+    # MTD emitted as a native cumulative metric.
+    cumulative = [x for x in doc.get("metrics", []) if x.get("type") == "cumulative"]
+    assert any(x["name"] == "amount_mtd" for x in cumulative)


### PR DESCRIPTION
Third **frontier** slice — a real time dimension + variants so the engine computes time comparisons.

`discover_time_dimension` picks the primary date column and **infers the grain from the data** (time-of-day → day; month/quarter/year starts → that grain) + drill granularities. `discover_time_metrics` derives per measure **MTD / YoY / rolling-7d**. Emitted natively: MetricFlow `defaults.agg_time_dimension` + `type: time` dim + `type: cumulative` metrics (YoY structured); Cube/OSI in `meta.goldenmatch.time`. Deterministic, default-on.

Tests: `test_semantic_discovery_time_intelligence.py` (6). Full suite green (99).

Frontier: hierarchies ✅, metrics ✅, **time intelligence ✅**, next: cardinality (m:n bridge / 1:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)