### PR TITLE
feat(semantic): cardinality — 1:1 + m:n bridges (semantic-model discovery, Phase 14)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 450,
+      "module_count": 451,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7270,6 +7270,7 @@
           "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py",
           "purpose": "Semantic-model discovery (the generative half of the semantic wedge).",
           "imports": [
+            "goldenmatch.semantic.discovery.cardinality",
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.hierarchies",
             "goldenmatch.semantic.discovery.joins",
@@ -7279,6 +7280,15 @@
             "goldenmatch.semantic.discovery.model",
             "goldenmatch.semantic.discovery.namer",
             "goldenmatch.semantic.discovery.time_intelligence"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.cardinality",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/cardinality.py",
+          "purpose": "Cardinality (PR-14): many-to-many bridge / junction detection.",
+          "defines": [
+            "Bridge",
+            "discover_bridges"
           ]
         },
         {
@@ -7343,6 +7353,7 @@
           "defines": [
             "JoinCandidate",
             "_distinct_nonnull",
+            "_is_unique_column",
             "_key_columns",
             "_null_rate",
             "discover_joins"
@@ -7409,6 +7420,7 @@
           ],
           "imports": [
             "goldenmatch.semantic",
+            "goldenmatch.semantic.discovery.cardinality",
             "goldenmatch.semantic.discovery.emit",
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.hierarchies",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -54,6 +54,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `TimeDimension`/`TimeMetric`. The third "frontier" slice (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_time_intelligence.py`.
+- **Semantic-model discovery — cardinality: 1:1 + m:n bridges (Phase 14).** Two lifts of
+  the "everything is many_to_one" limitation. `discover_joins` now sets
+  `relationship="one_to_one"` when the FK column is UNIQUE on the from side (each from-row
+  references a distinct to-row) — flowing straight into the Cube `CubeJoin`/OSI relationship
+  emit. New `goldenmatch/semantic/discovery/cardinality.py`:
+  `discover_bridges(proposed_tables, joins)` detects **many-to-many** junction tables — a
+  trustworthy 2-column compound key (PR-10) whose columns are certified FKs (PR-3) to two
+  DIFFERENT tables — as `Bridge(bridge_table, left_table, left_column, right_table,
+  right_column)` on `ProposedModel.bridges` + `to_dict`. Deterministic, default-on. New
+  exports `discover_bridges` + `Bridge`. The fourth "frontier" slice (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_cardinality.py`.
 
 ## [3.11.0] - 2026-08-03
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -46,6 +46,7 @@ from goldenmatch.semantic.cube import (
     parse_cube_models,
 )
 from goldenmatch.semantic.discovery import (
+    Bridge,
     Dimension,
     EntityType,
     Hierarchy,
@@ -60,6 +61,7 @@ from goldenmatch.semantic.discovery import (
     TimeDimension,
     TimeMetric,
     apply_names,
+    discover_bridges,
     discover_entity_types,
     discover_hierarchies,
     discover_joins,
@@ -167,6 +169,8 @@ __all__ = [
     "discover_keys",
     "KeyCandidate",
     # semantic-model discovery (Phase 2) — cross-table entity-type discovery
+    "discover_bridges",
+    "Bridge",
     "discover_entity_types",
     "EntityType",
     # semantic-model discovery (Phase 3) — certified join / FK discovery across tables

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -19,6 +19,7 @@ Phase 7 (optional): `name_semantic_model` — advisory, self-verified LLM busine
 """
 from __future__ import annotations
 
+from goldenmatch.semantic.discovery.cardinality import Bridge, discover_bridges
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
 from goldenmatch.semantic.discovery.hierarchies import Hierarchy, discover_hierarchies
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
@@ -49,6 +50,7 @@ from goldenmatch.semantic.discovery.time_intelligence import (
 )
 
 __all__ = [
+    "Bridge",
     "Dimension",
     "EntityType",
     "Hierarchy",
@@ -63,6 +65,7 @@ __all__ = [
     "ProposedModel",
     "ProposedTable",
     "TableMeasures",
+    "discover_bridges",
     "discover_entity_types",
     "discover_hierarchies",
     "discover_joins",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/cardinality.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/cardinality.py
@@ -1,0 +1,53 @@
+"""Cardinality (PR-14): many-to-many bridge / junction detection.
+
+A junction table (a trustworthy COMPOUND key of exactly two columns, each a certified
+FK to a DIFFERENT table) realizes a many-to-many relationship between the two entities.
+Reuses the compound keys (PR-10) + the certified join graph (PR-3). The complementary
+one-to-one refinement lives in `discover_joins` (an FK unique on the from side).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Bridge:
+    """A many-to-many bridge: `bridge_table` joins `left_table` and `right_table` on its
+    two FK columns."""
+
+    bridge_table: str
+    left_table: str
+    left_column: str
+    right_table: str
+    right_column: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bridge_table": self.bridge_table,
+            "left_table": self.left_table,
+            "left_column": self.left_column,
+            "right_table": self.right_table,
+            "right_column": self.right_column,
+        }
+
+
+def discover_bridges(proposed_tables: list[Any], joins: list[Any]) -> list[Bridge]:
+    """Junction tables among `proposed_tables`: a trustworthy 2-column compound key whose
+    columns are trustworthy FKs to two different tables."""
+    fk_map = {(j.from_table, j.from_column): j.to_table
+              for j in joins if getattr(j, "is_trustworthy", False)}
+
+    out: list[Bridge] = []
+    for pt in proposed_tables:
+        k = pt.key
+        if k is None or not k.is_trustworthy or len(k.columns) != 2:
+            continue
+        c1, c2 = k.columns
+        t1 = fk_map.get((pt.table, c1))
+        t2 = fk_map.get((pt.table, c2))
+        if t1 and t2 and t1 != t2:
+            out.append(Bridge(bridge_table=pt.table, left_table=t1, left_column=c1,
+                              right_table=t2, right_column=c2))
+    out.sort(key=lambda b: (b.bridge_table, b.left_table, b.right_table))
+    return out

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/joins.py
@@ -93,6 +93,21 @@ def _distinct_nonnull(table: Any, column: str) -> set:
         return set()
 
 
+def _is_unique_column(table: Any, column: str) -> bool:
+    """True when `column`'s non-null values are all distinct (no duplicates) — the FK
+    side of a one-to-one relationship."""
+    from goldenmatch.core.frame import to_frame
+
+    try:
+        frame = to_frame(table)
+        if column not in frame.columns:
+            return False
+        vals = frame.column(column).drop_nulls().to_list()
+        return len(vals) == len(set(vals)) and len(vals) > 0
+    except Exception:  # noqa: BLE001 - a bad column never breaks the sweep
+        return False
+
+
 def _null_rate(table: Any, column: str) -> float:
     from goldenmatch.core.frame import to_frame
 
@@ -250,7 +265,8 @@ def discover_joins(
                             from_column=fk_col,
                             to_table=to_table,
                             to_column=key_col,
-                            relationship="many_to_one",
+                            relationship=("one_to_one" if _is_unique_column(source, fk_col)
+                                          else "many_to_one"),
                             certificate=cert,
                             signals=signals,
                             containment=containment,

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from goldenmatch.semantic.discovery.cardinality import Bridge, discover_bridges
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
 from goldenmatch.semantic.discovery.hierarchies import Hierarchy, discover_hierarchies
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
@@ -91,6 +92,7 @@ class ProposedModel:
     metrics: list[Metric] = field(default_factory=list)
     time_dimensions: list[TimeDimension] = field(default_factory=list)
     time_metrics: list[TimeMetric] = field(default_factory=list)
+    bridges: list[Bridge] = field(default_factory=list)
 
     @property
     def all_trustworthy(self) -> bool:
@@ -149,6 +151,7 @@ class ProposedModel:
             "metrics": [mt.to_dict() for mt in self.metrics],
             "time_dimensions": [td.to_dict() for td in self.time_dimensions],
             "time_metrics": [tm.to_dict() for tm in self.time_metrics],
+            "bridges": [b.to_dict() for b in self.bridges],
             "yaml": self.yaml,
         }
 
@@ -267,6 +270,7 @@ def discover_semantic_model(
         time_dimensions=[pt.time_dimension for pt in proposed_tables
                          if pt.time_dimension is not None],
         time_metrics=[tm for pt in proposed_tables for tm in pt.time_metrics],
+        bridges=discover_bridges(proposed_tables, joins),
     )
 
     # Optional, advisory, non-authoritative: annotate the finished model with business

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_cardinality.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_cardinality.py
@@ -1,0 +1,77 @@
+"""Cardinality (PR-14): one-to-one refinement + many-to-many bridges.
+
+Direct joins become `one_to_one` when the FK is unique on the from side; junction
+tables (a compound key of two FKs to two different tables) surface as m:n bridges.
+Deterministic, default-on. Driven on users/profiles (1:1) and orders/products/
+order_products (m:n) fixtures.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import discover_semantic_model
+from goldenmatch.semantic.discovery.joins import discover_joins
+from goldenmatch.semantic.discovery.keys import discover_keys
+
+
+def _one_to_one() -> dict[str, pa.Table]:
+    # each profile references a distinct user -> profiles.user_id is unique -> 1:1.
+    users = pa.table({"user_id": ["u1", "u2", "u3"], "name": ["A", "B", "C"]})
+    profiles = pa.table({"profile_id": ["p1", "p2", "p3"],
+                         "user_id": ["u1", "u2", "u3"], "bio": ["x", "y", "z"]})
+    return {"users": users, "profiles": profiles}
+
+
+def _many_to_many() -> dict[str, pa.Table]:
+    orders = pa.table({"order_id": ["o1", "o2"], "amount": [10.0, 20.0]})
+    products = pa.table({"product_id": ["pa", "pb"], "sku": ["s1", "s2"]})
+    # order_products bridges orders <-> products on the compound (order_id, product_id).
+    order_products = pa.table({
+        "order_id": ["o1", "o1", "o2"],
+        "product_id": ["pa", "pb", "pa"],
+    })
+    return {"orders": orders, "products": products, "order_products": order_products}
+
+
+# --- one-to-one refinement ------------------------------------------------------
+
+
+def test_unique_fk_join_is_one_to_one():
+    tables = _one_to_one()
+    keys = {n: discover_keys(t) for n, t in tables.items()}
+    joins = discover_joins(tables, keys)
+    j = next(j for j in joins if j.from_table == "profiles" and j.to_table == "users")
+    assert j.relationship == "one_to_one"
+
+
+def test_non_unique_fk_stays_many_to_one():
+    m = discover_semantic_model(_many_to_many())
+    # order_products.order_id -> orders is many-to-one (an order has many bridge rows).
+    j = next(j for j in m.joins
+             if j.from_table == "order_products" and j.to_table == "orders")
+    assert j.relationship == "many_to_one"
+
+
+# --- many-to-many bridges -------------------------------------------------------
+
+
+def test_discover_bridges_finds_the_junction():
+    from goldenmatch.semantic.discovery.cardinality import discover_bridges
+
+    tables = _many_to_many()
+    keys = {n: discover_keys(t) for n, t in tables.items()}
+    joins = discover_joins(tables, keys)
+    from goldenmatch.semantic.discovery.model import ProposedTable, _best_key
+    pts = [ProposedTable(table=n, entity_type=None, key=_best_key(keys[n])) for n in tables]
+
+    bridges = discover_bridges(pts, joins)
+    assert len(bridges) == 1
+    b = bridges[0]
+    assert b.bridge_table == "order_products"
+    assert {b.left_table, b.right_table} == {"orders", "products"}
+
+
+def test_bridge_flows_through_model_and_to_dict():
+    m = discover_semantic_model(_many_to_many())
+    assert any(b.bridge_table == "order_products" for b in m.bridges)
+    d = m.to_dict()
+    assert any(b["bridge_table"] == "order_products" for b in d["bridges"])


### PR DESCRIPTION
Fourth **frontier** slice — lift the "everything is many_to_one" limitation.

`discover_joins` sets `relationship="one_to_one"` when the FK is unique on the from side (flows into Cube/OSI emit). New `discover_bridges(proposed_tables, joins)` detects **m:n junction tables** — a trustworthy 2-column compound key (PR-10) whose columns are certified FKs (PR-3) to two different tables — as `Bridge(...)` on `ProposedModel.bridges` + `to_dict`. Deterministic, default-on.

Tests: `test_semantic_discovery_cardinality.py` (4). Full suite green (98).

Frontier: hierarchies ✅, metrics ✅, time ✅, **cardinality ✅**, next: SCD dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)