### PR TITLE
ci(codeql): align init/analyze to autobuild 4.37.3 SHA (fix main red)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v3
         with:
           languages: ${{ matrix.language }}
           # Config file scopes the scan to shipping source (paths-ignore for
@@ -66,7 +66,7 @@ jobs:
         uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v3
         with:
           category: "/language:${{ matrix.language }}"
           # Also write the SARIF locally so it can be archived as a build


### PR DESCRIPTION
## Summary

`main` has been red since commit `9150366b8` (the merge of dependabot #2319, *"Bump github/codeql-action/autobuild from 4.36.2 to 4.37.3"*). The **CodeQL** workflow's two matrix jobs (`python`, `javascript-typescript`) both fail with:

```
CodeQL job status was configuration error.
```

`ci.yml` (the merge gate) is green throughout — this is a separate, non-required workflow, so it reddened `main` without blocking the queue.

## Root cause

CodeQL requires its `init` / `autobuild` / `analyze` action steps to all be pinned to the **same release**. Dependabot #2319 bumped only `autobuild` to 4.37.3 (`e4fba868`), leaving `init` and `analyze` at 4.36.2 (`8aad20d1`). The mixed-version bundle is a configuration error, which is exactly what both jobs hit — on every commit since the bump.

## Fix

Align `init` and `analyze` forward to the same 4.37.3 SHA as `autobuild`, keeping the security bump rather than reverting it. All three steps now pin `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`.

One-line effective change (`.github/workflows/codeql.yml`); no product code touched. `scorecard.yml`'s standalone `upload-sarif` is a different workflow and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_