### PR TITLE
feat(semantic): model completeness / trust score (semantic-model discovery, Phase 16)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 452,
+      "module_count": 453,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7271,6 +7271,7 @@
           "purpose": "Semantic-model discovery (the generative half of the semantic wedge).",
           "imports": [
             "goldenmatch.semantic.discovery.cardinality",
+            "goldenmatch.semantic.discovery.completeness",
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.hierarchies",
             "goldenmatch.semantic.discovery.joins",
@@ -7290,6 +7291,17 @@
           "defines": [
             "Bridge",
             "discover_bridges"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.completeness",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/completeness.py",
+          "purpose": "Model completeness / trust score (PR-16).",
+          "defines": [
+            "Gap",
+            "ModelCompleteness",
+            "_has_sum_safe_measure",
+            "score_model"
           ]
         },
         {
@@ -7422,6 +7434,7 @@
           "imports": [
             "goldenmatch.semantic",
             "goldenmatch.semantic.discovery.cardinality",
+            "goldenmatch.semantic.discovery.completeness",
             "goldenmatch.semantic.discovery.emit",
             "goldenmatch.semantic.discovery.entities",
             "goldenmatch.semantic.discovery.hierarchies",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -80,6 +80,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   "frontier" slice (design:
   `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
   `tests/test_semantic_discovery_scd.py`.
+- **Semantic-model discovery — model completeness / trust score (Phase 16).** New
+  `goldenmatch/semantic/discovery/completeness.py`: `score_model(proposed_tables, joins)`
+  aggregates the existing discovery signals into a headline **grain-weighted** 0..1
+  `ModelCompleteness` score (grain coverage 0.5, connectivity 0.25, sum-safe-measure
+  coverage 0.25 — a certified grain is load-bearing, so it dominates) plus an explicit
+  `gaps` list (`Gap(table, kind, detail)` for `no_grain` / `no_measures` / `isolated`), so
+  "80% complete" always names the tables that are why it isn't 100%. On
+  `ProposedModel.completeness` + `to_dict`. Pure self-assessment; no new detection. New
+  exports `score_model` + `ModelCompleteness`. The sixth "frontier" slice (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`). Tests:
+  `tests/test_semantic_discovery_completeness.py`.
 
 ## [3.11.0] - 2026-08-03
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -54,6 +54,7 @@ from goldenmatch.semantic.discovery import (
     KeyCandidate,
     Measure,
     Metric,
+    ModelCompleteness,
     NameSuggestion,
     ProposedModel,
     ProposedTable,
@@ -74,6 +75,7 @@ from goldenmatch.semantic.discovery import (
     discover_time_dimension,
     discover_time_metrics,
     name_semantic_model,
+    score_model,
 )
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
@@ -173,6 +175,8 @@ __all__ = [
     # semantic-model discovery (Phase 2) — cross-table entity-type discovery
     "discover_bridges",
     "Bridge",
+    "score_model",
+    "ModelCompleteness",
     "discover_entity_types",
     "EntityType",
     # semantic-model discovery (Phase 3) — certified join / FK discovery across tables

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -20,6 +20,7 @@ Phase 7 (optional): `name_semantic_model` — advisory, self-verified LLM busine
 from __future__ import annotations
 
 from goldenmatch.semantic.discovery.cardinality import Bridge, discover_bridges
+from goldenmatch.semantic.discovery.completeness import ModelCompleteness, score_model
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
 from goldenmatch.semantic.discovery.hierarchies import Hierarchy, discover_hierarchies
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
@@ -52,6 +53,7 @@ from goldenmatch.semantic.discovery.time_intelligence import (
 
 __all__ = [
     "Bridge",
+    "ModelCompleteness",
     "Dimension",
     "EntityType",
     "Hierarchy",
@@ -68,6 +70,7 @@ __all__ = [
     "ProposedTable",
     "TableMeasures",
     "discover_bridges",
+    "score_model",
     "discover_entity_types",
     "discover_hierarchies",
     "discover_joins",

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/completeness.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/completeness.py
@@ -1,0 +1,93 @@
+"""Model completeness / trust score (PR-16).
+
+A headline, honest self-assessment of a discovered model: what fraction of tables have a
+certified grain, sum-safe measures, and a certified join — a grain-weighted 0..1 score —
+plus an explicit list of the gaps (so "80% complete" always comes with "these tables are
+why it isn't 100%"). Pure aggregation of the existing discovery signals.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# A certified grain is load-bearing (without it a table double-counts), so it dominates.
+_GRAIN_WEIGHT = 0.5
+_CONNECTIVITY_WEIGHT = 0.25
+_MEASURE_WEIGHT = 0.25
+
+
+@dataclass(frozen=True)
+class Gap:
+    """One thing a table lacks. `kind` is `no_grain` / `no_measures` / `isolated`."""
+
+    table: str
+    kind: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"table": self.table, "kind": self.kind, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class ModelCompleteness:
+    """A grain-weighted 0..1 completeness score for a discovered model + the gaps."""
+
+    score: float
+    n_tables: int
+    tables_with_grain: int
+    tables_with_measures: int
+    tables_connected: int
+    gaps: list[Gap] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "n_tables": self.n_tables,
+            "tables_with_grain": self.tables_with_grain,
+            "tables_with_measures": self.tables_with_measures,
+            "tables_connected": self.tables_connected,
+            "gaps": [g.to_dict() for g in self.gaps],
+        }
+
+
+def _has_sum_safe_measure(pt: Any) -> bool:
+    return any(getattr(m, "safe_to_sum", False) for m in getattr(pt, "measures", []))
+
+
+def score_model(proposed_tables: list[Any], joins: list[Any]) -> ModelCompleteness:
+    """Grain-weighted completeness score + gap list for the discovered model."""
+    n = len(proposed_tables)
+    if n == 0:
+        return ModelCompleteness(0.0, 0, 0, 0, 0, [])
+
+    connected = set()
+    for j in joins:
+        if getattr(j, "is_trustworthy", False):
+            connected.add(j.from_table)
+            connected.add(j.to_table)
+
+    with_grain = sum(1 for pt in proposed_tables if pt.grain_trustworthy)
+    with_measures = sum(1 for pt in proposed_tables if _has_sum_safe_measure(pt))
+    n_connected = sum(1 for pt in proposed_tables if pt.table in connected)
+
+    grain_frac = with_grain / n
+    measure_frac = with_measures / n
+    # A single table can't have joins, so connectivity is trivially satisfied there.
+    conn_frac = 1.0 if n <= 1 else n_connected / n
+    score = (_GRAIN_WEIGHT * grain_frac + _CONNECTIVITY_WEIGHT * conn_frac
+             + _MEASURE_WEIGHT * measure_frac)
+
+    gaps: list[Gap] = []
+    for pt in proposed_tables:
+        if not pt.grain_trustworthy:
+            gaps.append(Gap(pt.table, "no_grain",
+                            "no clean key — a metric on this grain double-counts"))
+        if not _has_sum_safe_measure(pt):
+            gaps.append(Gap(pt.table, "no_measures", "no sum-safe measure at this grain"))
+        if n > 1 and pt.table not in connected:
+            gaps.append(Gap(pt.table, "isolated", "no certified join to another table"))
+
+    return ModelCompleteness(
+        score=round(score, 6), n_tables=n, tables_with_grain=with_grain,
+        tables_with_measures=with_measures, tables_connected=n_connected, gaps=gaps,
+    )

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/model.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from goldenmatch.semantic.discovery.cardinality import Bridge, discover_bridges
+from goldenmatch.semantic.discovery.completeness import ModelCompleteness, score_model
 from goldenmatch.semantic.discovery.entities import EntityType, discover_entity_types
 from goldenmatch.semantic.discovery.hierarchies import Hierarchy, discover_hierarchies
 from goldenmatch.semantic.discovery.joins import JoinCandidate, discover_joins
@@ -96,6 +97,7 @@ class ProposedModel:
     time_metrics: list[TimeMetric] = field(default_factory=list)
     bridges: list[Bridge] = field(default_factory=list)
     scd_dimensions: list[SCDDimension] = field(default_factory=list)
+    completeness: ModelCompleteness | None = None
 
     @property
     def all_trustworthy(self) -> bool:
@@ -156,6 +158,7 @@ class ProposedModel:
             "time_metrics": [tm.to_dict() for tm in self.time_metrics],
             "bridges": [b.to_dict() for b in self.bridges],
             "scd_dimensions": [s.to_dict() for s in self.scd_dimensions],
+            "completeness": self.completeness.to_dict() if self.completeness else None,
             "yaml": self.yaml,
         }
 
@@ -278,6 +281,7 @@ def discover_semantic_model(
         time_metrics=[tm for pt in proposed_tables for tm in pt.time_metrics],
         bridges=discover_bridges(proposed_tables, joins),
         scd_dimensions=[pt.scd for pt in proposed_tables if pt.scd is not None],
+        completeness=score_model(proposed_tables, joins),
     )
 
     # Optional, advisory, non-authoritative: annotate the finished model with business

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_completeness.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_completeness.py
@@ -1,0 +1,62 @@
+"""Model completeness / trust score (PR-16).
+
+A headline self-assessment of the discovered model: what fraction of tables have a
+certified grain, sum-safe measures, and a certified join — a grain-weighted 0..1 score —
+plus an explicit list of the gaps. No new detection; it aggregates the existing signals.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import discover_semantic_model
+
+
+def _clean() -> dict[str, pa.Table]:
+    customers = pa.table({"customer_id": ["c1", "c2", "c3"], "region": ["w", "e", "w"]})
+    orders = pa.table({"order_id": ["o1", "o2", "o3"], "customer_id": ["c1", "c1", "c2"],
+                       "amount": [1.0, 2.0, 3.0]})
+    return {"customers": customers, "orders": orders}
+
+
+# --- scoring --------------------------------------------------------------------
+
+
+def test_clean_model_scores_high_and_lists_measure_gap():
+    m = discover_semantic_model(_clean())
+    c = m.completeness
+    assert c.n_tables == 2
+    assert c.tables_with_grain == 2
+    # both grains certified + connected via the FK join + orders has a sum-safe measure;
+    # customers has none -> grain 0.5*1 + conn 0.25*1 + measure 0.25*0.5 = 0.875.
+    assert abs(c.score - 0.875) < 1e-6
+    assert any(g.table == "customers" and g.kind == "no_measures" for g in c.gaps)
+
+
+def test_no_clean_key_is_a_named_gap_and_tanks_the_score():
+    # a duplicated row -> no unique key at any arity -> no certified grain.
+    keyless = pa.table({"a": ["x", "x", "y"], "b": ["1", "1", "2"]})
+    m = discover_semantic_model({"keyless": keyless})
+    c = m.completeness
+    assert c.tables_with_grain == 0
+    assert any(g.kind == "no_grain" for g in c.gaps)
+    # grain 0.5*0 + conn 0.25*1 (single table, trivially connected) + measure 0.25*0 = 0.25.
+    assert abs(c.score - 0.25) < 1e-6
+
+
+def test_isolated_table_is_flagged():
+    # two unrelated tables -> each is isolated (no certified join between them).
+    tables = {
+        "a": pa.table({"a_id": ["1", "2", "3"], "v": [1.0, 2.0, 3.0]}),
+        "b": pa.table({"b_id": ["x", "y", "z"], "w": [4.0, 5.0, 6.0]}),
+    }
+    m = discover_semantic_model(tables)
+    assert any(g.kind == "isolated" for g in m.completeness.gaps)
+
+
+# --- integration ----------------------------------------------------------------
+
+
+def test_completeness_in_to_dict():
+    d = discover_semantic_model(_clean()).to_dict()
+    assert "completeness" in d
+    assert d["completeness"]["tables_with_grain"] == 2
+    assert isinstance(d["completeness"]["gaps"], list)


### PR DESCRIPTION
Sixth **frontier** slice — a headline self-assessment. `score_model(proposed_tables, joins)` aggregates the existing signals into a **grain-weighted 0..1** score (grain 0.5, connectivity 0.25, sum-safe measures 0.25) plus an explicit `gaps` list (`no_grain` / `no_measures` / `isolated`), so "80% complete" always names the tables that are why. On `ProposedModel.completeness` + `to_dict`. Pure aggregation, no new detection.

Tests: `test_semantic_discovery_completeness.py` (4). Full suite green (86).

Frontier: hierarchies ✅, metrics ✅, time ✅, cardinality ✅, SCD ✅, **completeness ✅**, next: warehouse-scale derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)