### PR TITLE
feat(semantic): warehouse-scale derivation off information_schema (semantic-model discovery, Phase 17)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 453,
+      "module_count": 454,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7281,7 +7281,8 @@
             "goldenmatch.semantic.discovery.model",
             "goldenmatch.semantic.discovery.namer",
             "goldenmatch.semantic.discovery.scd",
-            "goldenmatch.semantic.discovery.time_intelligence"
+            "goldenmatch.semantic.discovery.time_intelligence",
+            "goldenmatch.semantic.discovery.warehouse"
           ]
         },
         {
@@ -7501,6 +7502,28 @@
             "_pick_time_column",
             "discover_time_dimension",
             "discover_time_metrics"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.warehouse",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/warehouse.py",
+          "purpose": "Warehouse-scale derivation off `information_schema` (PR-17).",
+          "defines": [
+            "CandidateColumn",
+            "CandidateFK",
+            "CandidateTable",
+            "CertifyStep",
+            "WarehouseManifest",
+            "_grouped",
+            "_ordered_cols",
+            "_rows",
+            "_truthy_no",
+            "discover_from_manifest",
+            "plan_certification",
+            "read_information_schema"
+          ],
+          "imports": [
+            "goldenmatch.semantic.discovery.model"
           ]
         },
         {

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -313,6 +313,30 @@ actually query. All are deterministic (no LLM) and default-on unless noted.
     valid_from, valid_to, current_flag, scd_type)` on `ProposedTable`/
     `ProposedModel.scd_dimensions` + `to_dict` + `meta.goldenmatch.scd`. Deterministic,
     default-on.
+16. **Model completeness / trust score.** New `discovery/completeness.py`:
+    `score_model(proposed_tables, joins)` aggregates the existing signals into a
+    headline **grain-weighted** 0..1 `ModelCompleteness` (grain coverage 0.5,
+    connectivity 0.25, sum-safe-measure coverage 0.25 — a certified grain is
+    load-bearing, so it dominates) plus an explicit `gaps` list (`no_grain` /
+    `no_measures` / `isolated`), so "80% complete" always names the tables that are why.
+    On `ProposedModel.completeness` + `to_dict`. Pure self-assessment; no new detection.
+    Deterministic, default-on.
+17. **Warehouse-scale derivation off `information_schema`.** New `discovery/warehouse.py`:
+    `read_information_schema(columns, table_constraints, key_column_usage, tables=None)`
+    reads the three ANSI `information_schema` relations (as pyarrow tables / row dicts —
+    no live DB connection, so it stays testable and credential-free) into a
+    `WarehouseManifest` of `CandidateTable(name, columns, declared_pk, declared_fks,
+    row_count)`. **The honest thesis marker:** every declared PK/FK is `certified=False`
+    — Snowflake/BigQuery/Redshift do NOT enforce PK/FK, so an `information_schema`
+    declaration is exactly the kind of guess this arc PROVES against data, never a
+    certificate. The manifest is a **planning artifact**, not a model:
+    `plan_certification(manifest)` ranks the tables worth pulling+certifying first
+    (has-declared-PK, then FK-referenced in-degree = spine/dimension tables, then smaller
+    row_count, then name) with per-table warnings that declared constraints are unproven.
+    A thin `discover_from_manifest(manifest, loader)` bridge (loader: `name -> table`)
+    pulls each candidate's data and runs the normal certified `discover_semantic_model`,
+    so nothing about the certification-first pipeline changes — `information_schema` just
+    tells you *which* tables to point it at at warehouse scale. Deterministic, default-on.
 
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Semantic-model discovery — warehouse-scale derivation off `information_schema`
+  (Phase 17).** New `goldenmatch.semantic.read_information_schema(columns,
+  table_constraints, key_column_usage, tables=None)` reads the three ANSI
+  `information_schema` relations (pyarrow tables or row dicts — no live DB connection, so
+  it stays testable and credential-free) into a `WarehouseManifest` of
+  `CandidateTable(name, columns, declared_pk, declared_fks, row_count)`. A warehouse has
+  hundreds of tables; `information_schema` tells you cheaply which ones exist and what
+  they declare, so you can point the certified pipeline at them without pulling every
+  table into memory. **Honest thesis marker:** Snowflake/BigQuery/Redshift do NOT enforce
+  PK/FK, so every declared PK/FK is left `certified=False` — a declaration is exactly the
+  kind of guess this arc PROVES against data, never a certificate. `plan_certification(
+  manifest)` ranks the tables worth pulling + certifying first (has-declared-PK, then
+  FK-referenced in-degree = spine/dimension tables, then smaller `row_count`, then name),
+  each `CertifyStep` naming why its declarations are unproven. `discover_from_manifest(
+  manifest, loader)` pulls each candidate's data (in plan order) and runs the normal
+  certified `discover_semantic_model` — the declared PK is used only to RANK; the grain,
+  joins, and measures are re-derived and proven from the loaded data, so a wrong
+  `information_schema` declaration can never leak into the model. Deterministic (no LLM),
+  **default-on**. The seventh "frontier" slice of the semantic-model discovery arc
+  (design: `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`, item
+  17). Tests: `tests/test_semantic_discovery_warehouse.py`.
 - **Semantic-model discovery — dimension hierarchies via FD (Phase 11).**
   `goldenmatch.semantic.discover_hierarchies(table, columns)` detects drill-down
   hierarchies (`country > state > city`) among a table's dimension columns by finding

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -47,6 +47,10 @@ from goldenmatch.semantic.cube import (
 )
 from goldenmatch.semantic.discovery import (
     Bridge,
+    CandidateColumn,
+    CandidateFK,
+    CandidateTable,
+    CertifyStep,
     Dimension,
     EntityType,
     Hierarchy,
@@ -62,9 +66,11 @@ from goldenmatch.semantic.discovery import (
     TableMeasures,
     TimeDimension,
     TimeMetric,
+    WarehouseManifest,
     apply_names,
     discover_bridges,
     discover_entity_types,
+    discover_from_manifest,
     discover_hierarchies,
     discover_joins,
     discover_keys,
@@ -75,6 +81,8 @@ from goldenmatch.semantic.discovery import (
     discover_time_dimension,
     discover_time_metrics,
     name_semantic_model,
+    plan_certification,
+    read_information_schema,
     score_model,
 )
 from goldenmatch.semantic.key_integrity import (
@@ -206,4 +214,13 @@ __all__ = [
     "NameSuggestion",
     "ProposedModel",
     "ProposedTable",
+    # semantic-model discovery (Phase 17) — warehouse-scale derivation off information_schema
+    "read_information_schema",
+    "plan_certification",
+    "discover_from_manifest",
+    "WarehouseManifest",
+    "CandidateTable",
+    "CandidateColumn",
+    "CandidateFK",
+    "CertifyStep",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -50,10 +50,25 @@ from goldenmatch.semantic.discovery.time_intelligence import (
     discover_time_dimension,
     discover_time_metrics,
 )
+from goldenmatch.semantic.discovery.warehouse import (
+    CandidateColumn,
+    CandidateFK,
+    CandidateTable,
+    CertifyStep,
+    WarehouseManifest,
+    discover_from_manifest,
+    plan_certification,
+    read_information_schema,
+)
 
 __all__ = [
     "Bridge",
+    "CandidateColumn",
+    "CandidateFK",
+    "CandidateTable",
+    "CertifyStep",
     "ModelCompleteness",
+    "WarehouseManifest",
     "Dimension",
     "EntityType",
     "Hierarchy",
@@ -81,6 +96,9 @@ __all__ = [
     "discover_time_dimension",
     "discover_time_metrics",
     "discover_semantic_model",
+    "discover_from_manifest",
+    "plan_certification",
+    "read_information_schema",
     "apply_names",
     "name_semantic_model",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/warehouse.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/warehouse.py
@@ -1,0 +1,294 @@
+"""Warehouse-scale derivation off `information_schema` (PR-17).
+
+A warehouse has hundreds of tables; you can't pull them all into memory just to learn
+where to start. `information_schema` gives a cheap CANDIDATE structure — columns, declared
+PK/FK — for free. But Snowflake/BigQuery/Redshift do NOT enforce PK/FK constraints, so a
+declaration is exactly the kind of guess this arc PROVES against data, never a certificate.
+
+So this module reads the three ANSI `information_schema` relations into a
+`WarehouseManifest` (a planning artifact, not a model), `plan_certification` ranks which
+tables to pull + certify first, and `discover_from_manifest` pulls the data and runs the
+normal certified `discover_semantic_model` — the declared PK is used only to RANK, the
+grain is still proven from data. No live DB connection: inputs are pyarrow tables or row
+dicts, so it stays testable and credential-free.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+_PK = "PRIMARY KEY"
+_FK = "FOREIGN KEY"
+
+
+def _rows(x: Any) -> list[dict[str, Any]]:
+    """Normalize a pyarrow Table / list-of-dicts / None into a list of row dicts."""
+    if x is None:
+        return []
+    to_pylist = getattr(x, "to_pylist", None)
+    if callable(to_pylist):
+        return list(to_pylist())
+    return list(x)
+
+
+def _truthy_no(val: Any) -> bool:
+    """`is_nullable` is the SQL string `'YES'`/`'NO'` (or a bool). True = nullable."""
+    if isinstance(val, bool):
+        return val
+    return str(val).strip().upper() not in {"NO", "FALSE", "0"}
+
+
+@dataclass(frozen=True)
+class CandidateColumn:
+    """One column as `information_schema.columns` declares it."""
+
+    name: str
+    data_type: str
+    nullable: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "data_type": self.data_type, "nullable": self.nullable}
+
+
+@dataclass(frozen=True)
+class CandidateFK:
+    """A DECLARED foreign key. `certified` is always False — it's a hypothesis until the
+    certifier proves the cardinality against data."""
+
+    columns: tuple[str, ...]
+    to_table: str
+    to_columns: tuple[str, ...]
+    certified: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "columns": list(self.columns),
+            "to_table": self.to_table,
+            "to_columns": list(self.to_columns),
+            "certified": self.certified,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateTable:
+    """One table's DECLARED shape. `declared_pk` is a grain hypothesis, not a certified
+    grain — the warehouse does not enforce it."""
+
+    name: str
+    columns: tuple[CandidateColumn, ...]
+    declared_pk: tuple[str, ...] = ()
+    declared_fks: tuple[CandidateFK, ...] = ()
+    row_count: int | None = None
+
+    @property
+    def has_declared_pk(self) -> bool:
+        return bool(self.declared_pk)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "columns": [c.to_dict() for c in self.columns],
+            "declared_pk": list(self.declared_pk),
+            "declared_fks": [fk.to_dict() for fk in self.declared_fks],
+            "row_count": self.row_count,
+        }
+
+
+@dataclass(frozen=True)
+class WarehouseManifest:
+    """The declared structure of a warehouse — a PLANNING artifact, not a semantic model.
+    Nothing here is certified; it tells you where to point the certified pipeline."""
+
+    tables: tuple[CandidateTable, ...] = ()
+
+    def table(self, name: str) -> CandidateTable | None:
+        return next((t for t in self.tables if t.name == name), None)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"tables": [t.to_dict() for t in self.tables]}
+
+
+@dataclass(frozen=True)
+class CertifyStep:
+    """One table in the certify plan: why it ranks here + why its declarations are unproven."""
+
+    table: str
+    reason: str
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"table": self.table, "reason": self.reason, "warnings": list(self.warnings)}
+
+
+def _grouped(rows: list[dict[str, Any]], key: str) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = {}
+    for r in rows:
+        out.setdefault(str(r.get(key)), []).append(r)
+    return out
+
+
+def _ordered_cols(rows: list[dict[str, Any]], col_key: str = "column_name") -> tuple[str, ...]:
+    """Columns of a constraint in declared order (`ordinal_position`, else input order)."""
+    ordered = sorted(rows, key=lambda r: r.get("ordinal_position") or 0)
+    return tuple(str(r[col_key]) for r in ordered)
+
+
+def read_information_schema(
+    columns: Any,
+    table_constraints: Any,
+    key_column_usage: Any,
+    tables: Any = None,
+) -> WarehouseManifest:
+    """Read the ANSI `information_schema` relations into a `WarehouseManifest`.
+
+    Args:
+        columns: `information_schema.columns` rows (`table_name`, `column_name`,
+            `data_type`, `ordinal_position`, `is_nullable`).
+        table_constraints: `information_schema.table_constraints` rows (`table_name`,
+            `constraint_name`, `constraint_type`).
+        key_column_usage: `information_schema.key_column_usage` rows (`table_name`,
+            `constraint_name`, `column_name`, `ordinal_position`, and for FKs
+            `referenced_table_name` / `referenced_column_name`).
+        tables: optional `information_schema.tables` rows (`table_name` + `row_count` /
+            `table_rows`) — used only for certify-plan ranking.
+
+    Returns:
+        A `WarehouseManifest`. Every declared PK/FK is left UNCERTIFIED — it's a
+        hypothesis the certified pipeline must prove against data.
+    """
+    col_rows = _rows(columns)
+    tc_rows = _rows(table_constraints)
+    kcu_rows = _rows(key_column_usage)
+    tbl_rows = _rows(tables)
+
+    cols_by_table = _grouped(col_rows, "table_name")
+    kcu_by_constraint = _grouped(kcu_rows, "constraint_name")
+
+    # constraint_name -> (table, type)
+    pk_constraints: dict[str, str] = {}   # table -> constraint_name
+    fk_constraints: list[tuple[str, str]] = []  # (table, constraint_name)
+    for r in tc_rows:
+        tbl, cname, ctype = str(r.get("table_name")), str(r.get("constraint_name")), \
+            str(r.get("constraint_type", "")).upper()
+        if ctype == _PK:
+            pk_constraints[tbl] = cname
+        elif ctype == _FK:
+            fk_constraints.append((tbl, cname))
+
+    fks_by_table: dict[str, list[CandidateFK]] = {}
+    for tbl, cname in fk_constraints:
+        usage = kcu_by_constraint.get(cname, [])
+        if not usage:
+            continue
+        ordered = sorted(usage, key=lambda r: r.get("ordinal_position") or 0)
+        local = tuple(str(r["column_name"]) for r in ordered)
+        to_table = str(ordered[0].get("referenced_table_name") or "")
+        to_cols = tuple(
+            str(r.get("referenced_column_name") or "") for r in ordered
+        )
+        if to_table:
+            fks_by_table.setdefault(tbl, []).append(
+                CandidateFK(columns=local, to_table=to_table, to_columns=to_cols)
+            )
+
+    row_counts: dict[str, int] = {}
+    for r in tbl_rows:
+        n = r.get("row_count", r.get("table_rows"))
+        if n is not None:
+            row_counts[str(r.get("table_name"))] = int(n)
+
+    out: list[CandidateTable] = []
+    for tbl in sorted(cols_by_table):
+        col_defs = sorted(cols_by_table[tbl], key=lambda r: r.get("ordinal_position") or 0)
+        cand_cols = tuple(
+            CandidateColumn(
+                name=str(r["column_name"]),
+                data_type=str(r.get("data_type", "")),
+                nullable=_truthy_no(r.get("is_nullable", True)),
+            )
+            for r in col_defs
+        )
+        pk_cname = pk_constraints.get(tbl)
+        declared_pk = _ordered_cols(kcu_by_constraint.get(pk_cname, [])) if pk_cname else ()
+        fks = tuple(sorted(fks_by_table.get(tbl, []),
+                           key=lambda fk: (fk.to_table, fk.columns)))
+        out.append(
+            CandidateTable(
+                name=tbl,
+                columns=cand_cols,
+                declared_pk=declared_pk,
+                declared_fks=fks,
+                row_count=row_counts.get(tbl),
+            )
+        )
+    return WarehouseManifest(tables=tuple(out))
+
+
+def plan_certification(manifest: WarehouseManifest) -> list[CertifyStep]:
+    """Rank the tables worth pulling + certifying first.
+
+    Order: has-declared-PK (a grain hypothesis to prove), then FK-referenced in-degree
+    (spine / dimension tables that many facts point at), then smaller row_count (certifies
+    faster), then name. Every step names WHY its declarations are unproven — the warehouse
+    doesn't enforce them, so `certify_key_integrity` / `certify_cube_joins` must.
+    """
+    in_degree: dict[str, int] = {}
+    for t in manifest.tables:
+        for fk in t.declared_fks:
+            in_degree[fk.to_table] = in_degree.get(fk.to_table, 0) + 1
+
+    def _sort_key(t: CandidateTable) -> tuple:
+        # larger is better for the first two -> negate; row_count asc with None last.
+        return (
+            0 if t.has_declared_pk else 1,
+            -in_degree.get(t.name, 0),
+            t.row_count if t.row_count is not None else float("inf"),
+            t.name,
+        )
+
+    steps: list[CertifyStep] = []
+    for t in sorted(manifest.tables, key=_sort_key):
+        deg = in_degree.get(t.name, 0)
+        reasons = []
+        if t.has_declared_pk:
+            reasons.append("has a declared primary key (grain hypothesis to prove)")
+        if deg:
+            reasons.append(f"referenced by {deg} declared FK(s) (spine/dimension)")
+        if t.row_count is not None:
+            reasons.append(f"~{t.row_count} rows")
+        reason = "; ".join(reasons) or "no declared constraints"
+
+        warnings: list[str] = []
+        if t.has_declared_pk:
+            warnings.append(
+                f"declared PRIMARY KEY {list(t.declared_pk)} is not enforced by the "
+                "warehouse — certify_key_integrity must prove it against data"
+            )
+        for fk in t.declared_fks:
+            warnings.append(
+                f"declared FOREIGN KEY {list(fk.columns)} -> {fk.to_table} is not "
+                "enforced — certify_cube_joins must prove the cardinality"
+            )
+        steps.append(CertifyStep(table=t.name, reason=reason, warnings=tuple(warnings)))
+    return steps
+
+
+def discover_from_manifest(
+    manifest: WarehouseManifest,
+    loader: Callable[[str], Any],
+    **kwargs: Any,
+) -> Any:
+    """Pull each candidate table's data (in certify-plan order) and run the normal
+    certified `discover_semantic_model`.
+
+    The declared PK/FK are used only to decide WHICH tables to pull and in what order —
+    the grain, joins, and measures are all re-derived and PROVEN from the loaded data, so
+    a wrong declaration in `information_schema` can never leak into the model. `loader`
+    maps a table name to any input the discovery pipeline accepts (e.g. a pyarrow Table).
+    """
+    from goldenmatch.semantic.discovery.model import discover_semantic_model
+
+    order = [step.table for step in plan_certification(manifest)]
+    data = {name: loader(name) for name in order}
+    return discover_semantic_model(data, **kwargs)

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_warehouse.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_warehouse.py
@@ -1,0 +1,141 @@
+"""Warehouse-scale derivation off information_schema (PR-17).
+
+A warehouse has hundreds of tables; you can't pull them all into memory just to learn
+where to start. `information_schema` gives you a cheap CANDIDATE structure — columns,
+declared PK/FK — but declared constraints are NOT enforced by Snowflake/BigQuery/Redshift,
+so they're a hypothesis to certify, never a certificate. This slice reads that metadata
+into a planning manifest and ranks which tables to pull + certify first; the actual grain
+is still PROVEN from data by the normal pipeline.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    WarehouseManifest,
+    discover_from_manifest,
+    plan_certification,
+    read_information_schema,
+)
+
+# --- fixtures: rows shaped like information_schema relations ----------------------
+
+
+def _columns() -> list[dict]:
+    return [
+        {"table_name": "customers", "column_name": "customer_id", "data_type": "varchar",
+         "ordinal_position": 1, "is_nullable": "NO"},
+        {"table_name": "customers", "column_name": "region", "data_type": "varchar",
+         "ordinal_position": 2, "is_nullable": "YES"},
+        {"table_name": "orders", "column_name": "order_id", "data_type": "varchar",
+         "ordinal_position": 1, "is_nullable": "NO"},
+        {"table_name": "orders", "column_name": "customer_id", "data_type": "varchar",
+         "ordinal_position": 2, "is_nullable": "YES"},
+        {"table_name": "orders", "column_name": "amount", "data_type": "double",
+         "ordinal_position": 3, "is_nullable": "YES"},
+    ]
+
+
+def _table_constraints() -> list[dict]:
+    return [
+        {"table_name": "customers", "constraint_name": "customers_pk",
+         "constraint_type": "PRIMARY KEY"},
+        {"table_name": "orders", "constraint_name": "orders_pk",
+         "constraint_type": "PRIMARY KEY"},
+        {"table_name": "orders", "constraint_name": "orders_customer_fk",
+         "constraint_type": "FOREIGN KEY"},
+    ]
+
+
+def _key_column_usage() -> list[dict]:
+    return [
+        {"table_name": "customers", "constraint_name": "customers_pk",
+         "column_name": "customer_id", "ordinal_position": 1},
+        {"table_name": "orders", "constraint_name": "orders_pk",
+         "column_name": "order_id", "ordinal_position": 1},
+        {"table_name": "orders", "constraint_name": "orders_customer_fk",
+         "column_name": "customer_id", "ordinal_position": 1,
+         "referenced_table_name": "customers", "referenced_column_name": "customer_id"},
+    ]
+
+
+# --- reading ---------------------------------------------------------------------
+
+
+def test_reads_columns_and_declared_pk_uncertified():
+    m = read_information_schema(_columns(), _table_constraints(), _key_column_usage())
+    assert isinstance(m, WarehouseManifest)
+    cust = next(t for t in m.tables if t.name == "customers")
+    assert [c.name for c in cust.columns] == ["customer_id", "region"]
+    assert cust.columns[0].data_type == "varchar"
+    assert cust.columns[1].nullable is True
+    assert cust.declared_pk == ("customer_id",)
+    assert cust.has_declared_pk is True
+
+
+def test_reads_declared_fk_with_referenced_table():
+    m = read_information_schema(_columns(), _table_constraints(), _key_column_usage())
+    orders = next(t for t in m.tables if t.name == "orders")
+    assert len(orders.declared_fks) == 1
+    fk = orders.declared_fks[0]
+    assert fk.columns == ("customer_id",)
+    assert fk.to_table == "customers"
+    assert fk.to_columns == ("customer_id",)
+    # information_schema declarations are hypotheses, never certificates.
+    assert fk.certified is False
+
+
+def test_accepts_pyarrow_tables_as_input():
+    cols = pa.Table.from_pylist(_columns())
+    tc = pa.Table.from_pylist(_table_constraints())
+    kcu = pa.Table.from_pylist(_key_column_usage())
+    m = read_information_schema(cols, tc, kcu)
+    assert {t.name for t in m.tables} == {"customers", "orders"}
+
+
+def test_row_count_from_tables_relation():
+    tables = [{"table_name": "customers", "row_count": 3},
+              {"table_name": "orders", "row_count": 9}]
+    m = read_information_schema(_columns(), _table_constraints(), _key_column_usage(),
+                               tables=tables)
+    assert next(t for t in m.tables if t.name == "customers").row_count == 3
+
+
+# --- planning --------------------------------------------------------------------
+
+
+def test_plan_ranks_fk_referenced_spine_first_and_warns_unproven():
+    m = read_information_schema(_columns(), _table_constraints(), _key_column_usage())
+    plan = plan_certification(m)
+    # customers is referenced by orders' FK (in-degree 1) -> it's the spine, certify first.
+    assert plan[0].table == "customers"
+    assert {s.table for s in plan} == {"customers", "orders"}
+    # every table with a declared PK must carry an "unproven / not enforced" warning.
+    for step in plan:
+        assert any("not enforced" in w for w in step.warnings)
+
+
+# --- the thesis: declarations are ranked on, never trusted ------------------------
+
+
+def test_discover_from_manifest_certifies_from_data_not_declaration():
+    # the warehouse DECLARES customer_id a PK, but the actual data violates it
+    # (duplicated customer_id) -> the certified pipeline must NOT trust the declaration.
+    m = read_information_schema(_columns(), _table_constraints(), _key_column_usage())
+    data = {
+        "customers": pa.table({"customer_id": ["c1", "c1", "c2"],  # dup -> not unique
+                               "region": ["w", "e", "w"]}),
+        "orders": pa.table({"order_id": ["o1", "o2", "o3"],
+                            "customer_id": ["c1", "c1", "c2"],
+                            "amount": [1.0, 2.0, 3.0]}),
+    }
+    model = discover_from_manifest(m, loader=lambda name: data[name])
+    cust = next(t for t in model.tables if t.table == "customers")
+    assert cust.grain_trustworthy is False  # proven from data, not the declared PK
+
+
+def test_manifest_to_dict_marks_declarations_uncertified():
+    m = read_information_schema(_columns(), _table_constraints(), _key_column_usage())
+    d = m.to_dict()
+    orders = next(t for t in d["tables"] if t["name"] == "orders")
+    assert orders["declared_fks"][0]["certified"] is False
+    assert orders["declared_pk"] == ["order_id"]


### PR DESCRIPTION
Seventh **frontier** slice, and the first that reaches *outside* in-memory data. A warehouse has hundreds of tables; `information_schema` tells you cheaply which exist and what they declare, so you can point the certified pipeline at the right ones without pulling everything into memory.

`read_information_schema(columns, table_constraints, key_column_usage, tables=None)` -> `WarehouseManifest` of `CandidateTable`. Inputs are pyarrow tables or row dicts, **no live DB connection** (testable, credential-free).

**Honest thesis marker:** Snowflake/BigQuery/Redshift do NOT enforce PK/FK, so every declared PK/FK is `certified=False` — a declaration is exactly the kind of guess this arc PROVES against data, never a certificate.

- `plan_certification(manifest)` ranks tables worth certifying first (has-declared-PK, FK-referenced in-degree = spine/dimension, smaller `row_count`, name) with per-step "not enforced" warnings.
- `discover_from_manifest(manifest, loader)` pulls each candidate's data in plan order and runs the normal certified `discover_semantic_model`. The declared PK ranks only; grain/joins/measures are **re-derived and proven from data** — a wrong declaration can't leak in (covered by a test that declares a PK the data violates).

Deterministic, default-on. Tests: `test_semantic_discovery_warehouse.py` (7). Suite green (89 + surface/parity 30).

Frontier: hierarchies ✅, metrics ✅, time ✅, cardinality ✅, SCD ✅, completeness ✅ (#2412), **warehouse ✅**, next: catalog reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)