### PR TITLE
feat(semantic): catalog reconciliation (semantic-model discovery, Phase 18)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 454,
+      "module_count": 455,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7280,6 +7280,7 @@
             "goldenmatch.semantic.discovery.metrics",
             "goldenmatch.semantic.discovery.model",
             "goldenmatch.semantic.discovery.namer",
+            "goldenmatch.semantic.discovery.reconcile",
             "goldenmatch.semantic.discovery.scd",
             "goldenmatch.semantic.discovery.time_intelligence",
             "goldenmatch.semantic.discovery.warehouse"
@@ -7476,6 +7477,19 @@
           "imports": [
             "goldenmatch.core.llm_labeler",
             "goldenmatch.semantic.discovery.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.reconcile",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/reconcile.py",
+          "purpose": "Catalog reconciliation (PR-18).",
+          "defines": [
+            "Reconciliation",
+            "TableDiff",
+            "_CatalogTable",
+            "_normalize_catalog",
+            "_normalize_one",
+            "reconcile_model"
           ]
         },
         {

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -337,6 +337,23 @@ actually query. All are deterministic (no LLM) and default-on unless noted.
     pulls each candidate's data and runs the normal certified `discover_semantic_model`,
     so nothing about the certification-first pipeline changes — `information_schema` just
     tells you *which* tables to point it at at warehouse scale. Deterministic, default-on.
+18. **Catalog reconciliation.** New `discovery/reconcile.py`:
+    `reconcile_model(proposed, existing)` diffs a discovered `ProposedModel` against an
+    **already-parsed** existing catalog (a list of MetricFlow `DeclaredKeySpec` or Cube
+    `Cube` — reusing the existing `parse_semantic_models` / `parse_cube_models` readers,
+    so no new format code). Both sides normalize to a common `(name, key, measures)` shape
+    and produce a `Reconciliation` of typed `TableDiff`s: `only_in_model` /
+    `only_in_catalog` (tables), `grain_drift` (the table exists in both but the discovered
+    certified grain ≠ the catalog's declared key), and `measure_only_in_model` /
+    `measure_only_in_catalog`. **The differentiator over a text diff:** the discovered
+    side is CERTIFIED, so a `grain_drift` where the discovered grain is trustworthy and
+    the catalog's declared key is *not* the certified grain is marked `proven=True` — a
+    provable defect in the catalog ("your model declares `order_id` the key; we proved the
+    grain is `order_id + line_no`, so every SUM at that grain double-counts"), not a
+    stylistic difference. `Reconciliation.in_sync` is the headline. On its own module +
+    `to_dict`; deterministic, default-on. **Scope cut (logged):** v1 covers tables, grain,
+    and measures; cross-dialect *join*-edge reconciliation and a **LookML** reader (no
+    parser exists yet) are follow-ons — not silently omitted, explicitly deferred.
 
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Semantic-model discovery — catalog reconciliation (Phase 18).** New
+  `goldenmatch.semantic.reconcile_model(proposed, existing)` diffs a discovered (certified)
+  `ProposedModel` against an already-parsed existing catalog — a list of MetricFlow
+  `DeclaredKeySpec` (from `parse_semantic_models`) or Cube `Cube` (from
+  `parse_cube_models`), reusing the existing readers so there's no new format code. Both
+  sides normalize to a neutral `(name, key, measures)` shape and produce a
+  `Reconciliation` of typed `TableDiff`s: `only_in_model` / `only_in_catalog` (tables),
+  `grain_drift` (in both, but discovered certified grain ≠ declared key), and
+  `measure_only_in_model` / `measure_only_in_catalog`. **The differentiator over a text
+  diff:** the discovered side is CERTIFIED, so a `grain_drift` where the discovered grain
+  is trustworthy and the catalog's declared key isn't it is marked `proven=True` — a
+  provable double-counting defect in the catalog ("your model declares `order_id` the key;
+  we proved the grain is `order_id + line_no`"), not a stylistic difference.
+  `Reconciliation.in_sync` is the headline; `to_dict` for the serialized view.
+  Deterministic (no LLM), **default-on**. Scope cut (logged, not silently omitted): v1
+  covers tables, grain, and measures; cross-dialect join-edge reconciliation and a LookML
+  reader (no parser exists yet) are explicit follow-ons. The eighth "frontier" slice of the
+  semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`, item 18). Tests:
+  `tests/test_semantic_discovery_reconcile.py`.
 - **Semantic-model discovery — warehouse-scale derivation off `information_schema`
   (Phase 17).** New `goldenmatch.semantic.read_information_schema(columns,
   table_constraints, key_column_usage, tables=None)` reads the three ANSI

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -62,7 +62,9 @@ from goldenmatch.semantic.discovery import (
     NameSuggestion,
     ProposedModel,
     ProposedTable,
+    Reconciliation,
     SCDDimension,
+    TableDiff,
     TableMeasures,
     TimeDimension,
     TimeMetric,
@@ -83,6 +85,7 @@ from goldenmatch.semantic.discovery import (
     name_semantic_model,
     plan_certification,
     read_information_schema,
+    reconcile_model,
     score_model,
 )
 from goldenmatch.semantic.key_integrity import (
@@ -223,4 +226,8 @@ __all__ = [
     "CandidateColumn",
     "CandidateFK",
     "CertifyStep",
+    # semantic-model discovery (Phase 18) — catalog reconciliation
+    "reconcile_model",
+    "Reconciliation",
+    "TableDiff",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -43,6 +43,11 @@ from goldenmatch.semantic.discovery.namer import (
     apply_names,
     name_semantic_model,
 )
+from goldenmatch.semantic.discovery.reconcile import (
+    Reconciliation,
+    TableDiff,
+    reconcile_model,
+)
 from goldenmatch.semantic.discovery.scd import SCDDimension, discover_scd
 from goldenmatch.semantic.discovery.time_intelligence import (
     TimeDimension,
@@ -68,6 +73,8 @@ __all__ = [
     "CandidateTable",
     "CertifyStep",
     "ModelCompleteness",
+    "Reconciliation",
+    "TableDiff",
     "WarehouseManifest",
     "Dimension",
     "EntityType",
@@ -99,6 +106,7 @@ __all__ = [
     "discover_from_manifest",
     "plan_certification",
     "read_information_schema",
+    "reconcile_model",
     "apply_names",
     "name_semantic_model",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/reconcile.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/reconcile.py
@@ -1,0 +1,154 @@
+"""Catalog reconciliation (PR-18).
+
+Diff a discovered (certified) `ProposedModel` against an EXISTING catalog — a list of
+parsed MetricFlow `DeclaredKeySpec` or Cube `Cube` objects (reuse `parse_semantic_models`
+/ `parse_cube_models`; no new format code).
+
+The differentiator over a plain text diff: the discovered side is PROVEN. So when the
+discovered grain is certified trustworthy and disagrees with the catalog's declared key,
+that `grain_drift` is a **provable defect** in the catalog — every SUM at the declared
+grain double-counts — not a stylistic difference. `proven=True` marks exactly those.
+
+Scope (logged, not silently omitted): v1 covers tables, grain, and measures.
+Cross-dialect *join*-edge reconciliation and a LookML reader (no parser exists yet) are
+explicit follow-ons.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class _CatalogTable:
+    """A dialect-neutral view of one existing-catalog table."""
+
+    name: str
+    key: tuple[str, ...]
+    measures: frozenset[str]
+
+
+@dataclass(frozen=True)
+class TableDiff:
+    """One reconciliation finding. `kind` is one of `only_in_model` / `only_in_catalog` /
+    `grain_drift` / `measure_only_in_model` / `measure_only_in_catalog`. `proven` is True
+    only when the discovered side's certification makes the finding authoritative (a
+    certified grain that the catalog's declared key contradicts)."""
+
+    table: str
+    kind: str
+    detail: str
+    proven: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"table": self.table, "kind": self.kind, "detail": self.detail,
+                "proven": self.proven}
+
+
+@dataclass(frozen=True)
+class Reconciliation:
+    """The diff between a discovered model and an existing catalog."""
+
+    matched_tables: tuple[str, ...]
+    diffs: tuple[TableDiff, ...]
+    n_tables_model: int
+    n_tables_catalog: int
+
+    @property
+    def in_sync(self) -> bool:
+        return not self.diffs
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "in_sync": self.in_sync,
+            "matched_tables": list(self.matched_tables),
+            "diffs": [d.to_dict() for d in self.diffs],
+            "n_tables_model": self.n_tables_model,
+            "n_tables_catalog": self.n_tables_catalog,
+        }
+
+
+def _normalize_one(obj: Any) -> _CatalogTable:
+    """Normalize a single parsed catalog entry (MetricFlow `DeclaredKeySpec` or Cube
+    `Cube`) into the neutral shape. Duck-typed so we don't import the dialect classes."""
+    # MetricFlow DeclaredKeySpec: .model / .key / .measures (list[str]).
+    if hasattr(obj, "model") and hasattr(obj, "key"):
+        return _CatalogTable(
+            name=str(obj.model),
+            key=tuple(obj.key or ()),
+            measures=frozenset(str(m) for m in getattr(obj, "measures", []) or []),
+        )
+    # Cube: .name / .primary_key (property) / .measures (list[CubeMeasure] with .name).
+    if hasattr(obj, "name") and hasattr(obj, "primary_key"):
+        measures = frozenset(
+            str(getattr(m, "name", m)) for m in getattr(obj, "measures", []) or []
+        )
+        return _CatalogTable(name=str(obj.name), key=tuple(obj.primary_key or ()),
+                             measures=measures)
+    raise TypeError(
+        f"unsupported catalog entry {type(obj).__name__!r}; expected a parsed MetricFlow "
+        "DeclaredKeySpec or Cube (use parse_semantic_models / parse_cube_models)"
+    )
+
+
+def _normalize_catalog(existing: Any) -> dict[str, _CatalogTable]:
+    entries = list(existing) if not isinstance(existing, (str, bytes)) else []
+    return {ct.name: ct for ct in (_normalize_one(o) for o in entries)}
+
+
+def reconcile_model(proposed: Any, existing: Any) -> Reconciliation:
+    """Reconcile a discovered `ProposedModel` against a parsed existing catalog.
+
+    Args:
+        proposed: a `ProposedModel` from `discover_semantic_model`.
+        existing: the parsed catalog — a list of MetricFlow `DeclaredKeySpec` (from
+            `parse_semantic_models`) or Cube `Cube` (from `parse_cube_models`).
+
+    Returns:
+        A `Reconciliation`. A `grain_drift` where the discovered grain is certified
+        trustworthy and disagrees with the catalog's declared key is marked
+        `proven=True` — a provable double-counting defect in the catalog.
+    """
+    catalog = _normalize_catalog(existing)
+    model_tables = {pt.table: pt for pt in proposed.tables}
+
+    diffs: list[TableDiff] = []
+    matched: list[str] = []
+
+    for name in sorted(model_tables.keys() - catalog.keys()):
+        diffs.append(TableDiff(name, "only_in_model",
+                               "discovered but absent from the catalog"))
+    for name in sorted(catalog.keys() - model_tables.keys()):
+        diffs.append(TableDiff(name, "only_in_catalog",
+                               "declared in the catalog but not discovered"))
+
+    for name in sorted(model_tables.keys() & catalog.keys()):
+        pt = model_tables[name]
+        ct = catalog[name]
+        matched.append(name)
+
+        model_grain = tuple(pt.grain)
+        if set(model_grain) != set(ct.key):
+            # certified grain vs declared key: PROVEN when our grain is trustworthy.
+            proven = bool(pt.grain_trustworthy)
+            diffs.append(TableDiff(
+                name, "grain_drift",
+                f"discovered grain {list(model_grain)} != catalog key {list(ct.key)}"
+                + (" (certified — the catalog key double-counts)" if proven else ""),
+                proven=proven,
+            ))
+
+        model_measures = {m.column for m in pt.measures}
+        for col in sorted(model_measures - ct.measures):
+            diffs.append(TableDiff(name, "measure_only_in_model",
+                                   f"measure {col!r} discovered but not in the catalog"))
+        for col in sorted(ct.measures - model_measures):
+            diffs.append(TableDiff(name, "measure_only_in_catalog",
+                                   f"measure {col!r} in the catalog but not discovered"))
+
+    return Reconciliation(
+        matched_tables=tuple(matched),
+        diffs=tuple(diffs),
+        n_tables_model=len(model_tables),
+        n_tables_catalog=len(catalog),
+    )

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_reconcile.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_reconcile.py
@@ -1,0 +1,132 @@
+"""Catalog reconciliation (PR-18).
+
+Diff a discovered (certified) `ProposedModel` against an existing catalog — a parsed
+MetricFlow or Cube model. The point isn't a text diff: the discovered side is PROVEN, so a
+grain that disagrees with the catalog's declared key, when our grain is certified, is a
+provable defect in the catalog (double-counting), not a stylistic difference.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.semantic import (
+    Reconciliation,
+    discover_semantic_model,
+    parse_cube_models,
+    parse_semantic_models,
+    reconcile_model,
+)
+
+
+def _clean() -> dict[str, pa.Table]:
+    customers = pa.table({"customer_id": ["c1", "c2", "c3"], "region": ["w", "e", "w"]})
+    orders = pa.table({"order_id": ["o1", "o2", "o3"], "customer_id": ["c1", "c1", "c2"],
+                       "amount": [1.0, 2.0, 3.0]})
+    return {"customers": customers, "orders": orders}
+
+
+# --- table presence --------------------------------------------------------------
+
+
+def test_table_only_in_model_is_reported():
+    proposed = discover_semantic_model(_clean())
+    # catalog only knows about customers -> orders is only_in_model.
+    catalog = parse_semantic_models({
+        "semantic_models": [
+            {"name": "customers", "entities": [{"name": "customer_id", "type": "primary"}]},
+        ]
+    })
+    rec = reconcile_model(proposed, catalog)
+    assert isinstance(rec, Reconciliation)
+    assert rec.in_sync is False
+    assert any(d.table == "orders" and d.kind == "only_in_model" for d in rec.diffs)
+
+
+def test_table_only_in_catalog_is_reported():
+    proposed = discover_semantic_model(_clean())
+    catalog = parse_semantic_models({
+        "semantic_models": [
+            {"name": "customers", "entities": [{"name": "customer_id", "type": "primary"}]},
+            {"name": "orders", "entities": [{"name": "order_id", "type": "primary"}]},
+            {"name": "ghost", "entities": [{"name": "ghost_id", "type": "primary"}]},
+        ]
+    })
+    rec = reconcile_model(proposed, catalog)
+    assert any(d.table == "ghost" and d.kind == "only_in_catalog" for d in rec.diffs)
+
+
+# --- the money finding: proven grain drift ---------------------------------------
+
+
+def test_grain_drift_against_certified_grain_is_proven():
+    # orders' real grain is (order_id) and it's certified unique; the catalog wrongly
+    # declares customer_id the key -> a PROVEN grain defect, not a style diff.
+    proposed = discover_semantic_model(_clean())
+    catalog = parse_semantic_models({
+        "semantic_models": [
+            {"name": "customers", "entities": [{"name": "customer_id", "type": "primary"}]},
+            {"name": "orders", "entities": [{"name": "customer_id", "type": "primary"}]},
+        ]
+    })
+    rec = reconcile_model(proposed, catalog)
+    drift = next(d for d in rec.diffs if d.table == "orders" and d.kind == "grain_drift")
+    assert drift.proven is True
+    assert "order_id" in drift.detail and "customer_id" in drift.detail
+
+
+def test_matching_grain_is_in_sync_for_that_table():
+    proposed = discover_semantic_model(_clean())
+    catalog = parse_semantic_models({
+        "semantic_models": [
+            {"name": "customers", "entities": [{"name": "customer_id", "type": "primary"}]},
+            {"name": "orders", "entities": [{"name": "order_id", "type": "primary"}]},
+        ]
+    })
+    rec = reconcile_model(proposed, catalog)
+    assert "customers" in rec.matched_tables
+    assert not any(d.table == "customers" and d.kind == "grain_drift" for d in rec.diffs)
+
+
+# --- measures --------------------------------------------------------------------
+
+
+def test_measure_only_in_model_is_reported():
+    proposed = discover_semantic_model(_clean())
+    # catalog declares orders with the right key but no `amount` measure.
+    catalog = parse_semantic_models({
+        "semantic_models": [
+            {"name": "customers", "entities": [{"name": "customer_id", "type": "primary"}]},
+            {"name": "orders", "entities": [{"name": "order_id", "type": "primary"}]},
+        ]
+    })
+    rec = reconcile_model(proposed, catalog)
+    assert any(d.table == "orders" and d.kind == "measure_only_in_model"
+               and "amount" in d.detail for d in rec.diffs)
+
+
+# --- Cube dialect + serialization ------------------------------------------------
+
+
+def test_reconciles_against_cube_catalog():
+    proposed = discover_semantic_model(_clean(), dialect="cube")
+    cube = parse_cube_models({
+        "cubes": [
+            {"name": "customers",
+             "dimensions": [{"name": "customer_id", "primary_key": True}]},
+        ]
+    })
+    rec = reconcile_model(proposed, cube)
+    assert any(d.table == "orders" and d.kind == "only_in_model" for d in rec.diffs)
+
+
+def test_to_dict_shape():
+    proposed = discover_semantic_model(_clean())
+    catalog = parse_semantic_models({
+        "semantic_models": [
+            {"name": "customers", "entities": [{"name": "customer_id", "type": "primary"}]},
+            {"name": "orders", "entities": [{"name": "order_id", "type": "primary"}]},
+        ]
+    })
+    d = reconcile_model(proposed, catalog).to_dict()
+    assert set(d) >= {"in_sync", "matched_tables", "diffs", "n_tables_model",
+                      "n_tables_catalog"}
+    assert isinstance(d["diffs"], list)


### PR DESCRIPTION
Eighth **frontier** slice. `reconcile_model(proposed, existing)` diffs a discovered (certified) `ProposedModel` against an already-parsed existing catalog — a list of MetricFlow `DeclaredKeySpec` (`parse_semantic_models`) or Cube `Cube` (`parse_cube_models`), **reusing the existing readers** so there's no new format code.

Both sides normalize to a neutral `(name, key, measures)` shape → `Reconciliation` of typed `TableDiff`s: `only_in_model` / `only_in_catalog` / `grain_drift` / `measure_only_in_model` / `measure_only_in_catalog`. `in_sync` is the headline.

**Differentiator over a text diff:** the discovered side is CERTIFIED, so a `grain_drift` where the discovered grain is trustworthy and the catalog's declared key isn't it is `proven=True` — a provable double-counting defect in the catalog ("your model declares `customer_id` the key; we proved the grain is `order_id`"), not a stylistic difference. Covered by a test that feeds a wrong-keyed catalog and asserts `proven`.

**Scope cut (logged, not silently omitted):** v1 covers tables, grain, and measures; cross-dialect join-edge reconciliation and a **LookML** reader (no parser exists yet) are explicit follow-ons.

Deterministic, default-on. Tests: `test_semantic_discovery_reconcile.py` (7, incl a Cube-catalog case). Suite green (130 incl surface/parity).

Frontier: hierarchies ✅, metrics ✅, time ✅, cardinality ✅, SCD ✅, completeness ✅, warehouse ✅, **reconciliation ✅**, last: real-LLM namer validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)