### PR TITLE
feat(semantic): real-LLM namer validation / eval harness (semantic-model discovery, Phase 19)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 455,
+      "module_count": 456,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7280,6 +7280,7 @@
             "goldenmatch.semantic.discovery.metrics",
             "goldenmatch.semantic.discovery.model",
             "goldenmatch.semantic.discovery.namer",
+            "goldenmatch.semantic.discovery.namer_eval",
             "goldenmatch.semantic.discovery.reconcile",
             "goldenmatch.semantic.discovery.scd",
             "goldenmatch.semantic.discovery.time_intelligence",
@@ -7477,6 +7478,22 @@
           "imports": [
             "goldenmatch.core.llm_labeler",
             "goldenmatch.semantic.discovery.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.discovery.namer_eval",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/discovery/namer_eval.py",
+          "purpose": "Namer quality eval harness (PR-19).",
+          "defines": [
+            "NamerQuality",
+            "TargetResult",
+            "_accepted",
+            "_norm",
+            "run_namer_eval",
+            "score_naming"
+          ],
+          "imports": [
+            "goldenmatch.semantic.discovery.namer"
           ]
         },
         {

--- a/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md
@@ -355,6 +355,19 @@ actually query. All are deterministic (no LLM) and default-on unless noted.
     and measures; cross-dialect *join*-edge reconciliation and a **LookML** reader (no
     parser exists yet) are follow-ons — not silently omitted, explicitly deferred.
 
+19. **Real-LLM namer validation (eval harness).** New `discovery/namer_eval.py`:
+    `score_naming(suggestions, gold)` is a pure, deterministic scorer of the advisory
+    namer's (PR-7) output against a labeled `{target: accepted_name(s)}` gold map —
+    `NamerQuality(coverage, accuracy, precision, verified_accuracy, results)` where a name
+    matches after normalization (lowercase, alnum-only; NOT a stemmer — plural/alias
+    variants must be listed as explicit gold aliases). `run_namer_eval(model, tables,
+    gold, *, backend)` is a thin wrapper that names then scores. The scorer is
+    backend-agnostic: CI exercises it with hand-built suggestions and a dict-driven fake
+    backend (deterministic, no API calls); the real provider (`load_namer_backend`) is
+    **opt-in** behind `GOLDENMATCH_NAMER_EVAL_LIVE` (a skipped live test), so the harness
+    never spends live calls in CI. This closes the arc: slices 11-18 are deterministic
+    features; slice 19 is the *measurement* for the one non-deterministic part.
+
 Each PR is independently useful (PR-1 alone gives "certified key discovery per
 table"). The certifier is exercised from PR-1, so the "pre-graded" property holds at
 every step.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Semantic-model discovery — real-LLM namer validation / eval harness (Phase 19).** New
+  `goldenmatch.semantic.score_naming(suggestions, gold)` is a pure, deterministic scorer of
+  the advisory namer's (Phase 7) output against a labeled `{target: accepted_name(s)}` gold
+  map — a `NamerQuality(coverage, accuracy, precision, verified_accuracy, results)` where a
+  name matches after normalization (lowercase, alphanumeric-only; deliberately NOT a
+  stemmer, so plural/alias variants are listed as explicit gold aliases rather than
+  silently conflated). `run_namer_eval(model, tables, gold, *, backend)` names then scores
+  in one call. The scorer is backend-agnostic: CI exercises it with hand-built suggestions
+  and a dict-driven fake backend (no API calls, fully deterministic), while the real
+  provider (`load_namer_backend`) is **opt-in** behind `GOLDENMATCH_NAMER_EVAL_LIVE` (a
+  skipped live test), so the harness never spends live calls in CI. This closes the
+  "frontier" arc: slices 11-18 added deterministic features; slice 19 is the *measurement*
+  for the one non-deterministic part (the LLM namer). New exports `score_naming`,
+  `run_namer_eval`, `NamerQuality`, `TargetResult`. The ninth and final "frontier" slice of
+  the semantic-model discovery arc (design:
+  `docs/superpowers/specs/2026-08-03-semantic-model-discovery-design.md`, item 19). Tests:
+  `tests/test_semantic_discovery_namer_eval.py`.
 - **Semantic-model discovery — catalog reconciliation (Phase 18).** New
   `goldenmatch.semantic.reconcile_model(proposed, existing)` diffs a discovered (certified)
   `ProposedModel` against an already-parsed existing catalog — a list of MetricFlow

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -59,6 +59,7 @@ from goldenmatch.semantic.discovery import (
     Measure,
     Metric,
     ModelCompleteness,
+    NamerQuality,
     NameSuggestion,
     ProposedModel,
     ProposedTable,
@@ -66,6 +67,7 @@ from goldenmatch.semantic.discovery import (
     SCDDimension,
     TableDiff,
     TableMeasures,
+    TargetResult,
     TimeDimension,
     TimeMetric,
     WarehouseManifest,
@@ -86,7 +88,9 @@ from goldenmatch.semantic.discovery import (
     plan_certification,
     read_information_schema,
     reconcile_model,
+    run_namer_eval,
     score_model,
+    score_naming,
 )
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
@@ -230,4 +234,9 @@ __all__ = [
     "reconcile_model",
     "Reconciliation",
     "TableDiff",
+    # semantic-model discovery (Phase 19) — namer quality eval harness
+    "score_naming",
+    "run_namer_eval",
+    "NamerQuality",
+    "TargetResult",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/__init__.py
@@ -43,6 +43,12 @@ from goldenmatch.semantic.discovery.namer import (
     apply_names,
     name_semantic_model,
 )
+from goldenmatch.semantic.discovery.namer_eval import (
+    NamerQuality,
+    TargetResult,
+    run_namer_eval,
+    score_naming,
+)
 from goldenmatch.semantic.discovery.reconcile import (
     Reconciliation,
     TableDiff,
@@ -88,6 +94,8 @@ __all__ = [
     "TimeMetric",
     "NameSuggestion",
     "NamerBackend",
+    "NamerQuality",
+    "TargetResult",
     "ProposedModel",
     "ProposedTable",
     "TableMeasures",
@@ -107,6 +115,8 @@ __all__ = [
     "plan_certification",
     "read_information_schema",
     "reconcile_model",
+    "run_namer_eval",
+    "score_naming",
     "apply_names",
     "name_semantic_model",
 ]

--- a/packages/python/goldenmatch/goldenmatch/semantic/discovery/namer_eval.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/discovery/namer_eval.py
@@ -1,0 +1,142 @@
+"""Namer quality eval harness (PR-19).
+
+The namer (PR-7) is the one non-deterministic, LLM-driven part of discovery. This module
+measures how good its names are against a labeled gold set: `score_naming(suggestions,
+gold)` is a pure, deterministic scorer, and `run_namer_eval(model, tables, gold, *,
+backend)` is a thin wrapper that names the model then scores it.
+
+The scorer is backend-agnostic, so the real provider (via `load_namer_backend`) is opt-in
+for a live run and CI exercises the harness with a fake backend — no API calls, fully
+deterministic.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+def _norm(name: str) -> str:
+    """Normalize for comparison: lowercase, strip everything but alphanumerics. So
+    'Total Revenue' == 'total-revenue!'. Deliberately NOT a stemmer — singular/plural
+    variants must be listed as explicit gold aliases, not silently conflated."""
+    return re.sub(r"[^a-z0-9]", "", str(name).lower())
+
+
+def _accepted(gold_value: Any) -> set[str]:
+    if isinstance(gold_value, (set, list, tuple)):
+        return {_norm(v) for v in gold_value}
+    return {_norm(gold_value)}
+
+
+@dataclass(frozen=True)
+class TargetResult:
+    """The eval outcome for one gold target."""
+
+    target: str
+    gold: tuple[str, ...]
+    suggested: str | None
+    matched: bool
+    verified: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target,
+            "gold": list(self.gold),
+            "suggested": self.suggested,
+            "matched": self.matched,
+            "verified": self.verified,
+        }
+
+
+@dataclass(frozen=True)
+class NamerQuality:
+    """Naming quality over a labeled gold set.
+
+    - `coverage`: fraction of gold targets the namer suggested *any* name for.
+    - `accuracy`: fraction of gold targets named *correctly* (of all targets).
+    - `precision`: fraction of *suggested* names that were correct.
+    - `verified_accuracy`: correct AND passed self-critique, of all targets.
+    """
+
+    n_targets: int
+    n_suggested: int
+    n_correct: int
+    n_verified_correct: int
+    coverage: float
+    accuracy: float
+    precision: float
+    verified_accuracy: float
+    results: tuple[TargetResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_targets": self.n_targets,
+            "n_suggested": self.n_suggested,
+            "n_correct": self.n_correct,
+            "n_verified_correct": self.n_verified_correct,
+            "coverage": self.coverage,
+            "accuracy": self.accuracy,
+            "precision": self.precision,
+            "verified_accuracy": self.verified_accuracy,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+def score_naming(suggestions: list[Any], gold: dict[str, Any]) -> NamerQuality:
+    """Score a list of `NameSuggestion` against a gold `{target: accepted_name(s)}` map.
+
+    Only gold targets are scored — extra suggestions the gold set doesn't cover are
+    ignored (the gold set defines the evaluation surface).
+    """
+    by_target: dict[str, Any] = {s.target: s for s in suggestions}
+
+    results: list[TargetResult] = []
+    n_suggested = n_correct = n_verified_correct = 0
+    for target in sorted(gold):
+        accepted = _accepted(gold[target])
+        sug = by_target.get(target)
+        suggested_name = sug.suggested_name if sug is not None else None
+        verified = bool(sug.verified) if sug is not None else False
+        matched = suggested_name is not None and _norm(suggested_name) in accepted
+        if sug is not None:
+            n_suggested += 1
+        if matched:
+            n_correct += 1
+            if verified:
+                n_verified_correct += 1
+        gold_display = tuple(sorted(gold[target])) if isinstance(
+            gold[target], (set, list, tuple)) else (str(gold[target]),)
+        results.append(TargetResult(target, gold_display, suggested_name, matched, verified))
+
+    n = len(gold)
+    return NamerQuality(
+        n_targets=n,
+        n_suggested=n_suggested,
+        n_correct=n_correct,
+        n_verified_correct=n_verified_correct,
+        coverage=(n_suggested / n) if n else 0.0,
+        accuracy=(n_correct / n) if n else 0.0,
+        precision=(n_correct / n_suggested) if n_suggested else 0.0,
+        verified_accuracy=(n_verified_correct / n) if n else 0.0,
+        results=tuple(results),
+    )
+
+
+def run_namer_eval(
+    model: Any,
+    tables: dict[str, Any],
+    gold: dict[str, Any],
+    *,
+    backend: Any,
+) -> NamerQuality:
+    """Name `model` with `backend`, then score the result against `gold`.
+
+    `backend` is any `NamerBackend` — a fake for CI, or `load_namer_backend()` for a live
+    provider run (opt-in). Naming never mutates the certified structure; this only reads
+    `name_semantic_model`'s advisory output.
+    """
+    from goldenmatch.semantic.discovery.namer import name_semantic_model
+
+    suggestions = name_semantic_model(model, tables, backend=backend)
+    return score_naming(suggestions, gold)

--- a/packages/python/goldenmatch/tests/test_semantic_discovery_namer_eval.py
+++ b/packages/python/goldenmatch/tests/test_semantic_discovery_namer_eval.py
@@ -1,0 +1,148 @@
+"""Namer quality eval harness (PR-19) — the ninth (last) frontier slice.
+
+Slices 11-18 were deterministic, no-LLM. The namer (PR-7) is the opposite: it calls a real
+LLM. This slice measures how good those names are against a labeled gold set — a
+deterministic scorer (`score_naming`) unit-tested with hand-built suggestions and a
+dict-driven fake backend, plus a thin `run_namer_eval` wrapper. The real provider is opt-in
+behind `GOLDENMATCH_NAMER_EVAL_LIVE` (see the skipped live test), so CI never spends API
+calls.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pyarrow as pa
+import pytest
+from goldenmatch.semantic import (
+    NamerQuality,
+    NameSuggestion,
+    discover_semantic_model,
+    run_namer_eval,
+    score_naming,
+)
+
+
+def _tables() -> dict[str, pa.Table]:
+    customers = pa.table({"customer_id": ["c1", "c2", "c3"], "region": ["w", "e", "w"]})
+    orders = pa.table({"order_id": ["o1", "o2", "o3"], "customer_id": ["c1", "c1", "c2"],
+                       "amount": [1.0, 2.0, 3.0]})
+    return {"customers": customers, "orders": orders}
+
+
+def _sug(target: str, name: str, *, verified: bool = True) -> NameSuggestion:
+    return NameSuggestion(target=target, kind="measure", suggested_name=name,
+                          confidence=0.9, verified=verified, evidence="x")
+
+
+# --- pure scorer -----------------------------------------------------------------
+
+
+def test_perfect_naming_scores_one():
+    gold = {"measure:orders.amount": "Total Revenue", "dimension:customers.region": "Region"}
+    suggestions = [_sug("measure:orders.amount", "Total Revenue"),
+                   _sug("dimension:customers.region", "Region")]
+    q = score_naming(suggestions, gold)
+    assert isinstance(q, NamerQuality)
+    assert q.n_targets == 2
+    assert q.coverage == 1.0
+    assert q.accuracy == 1.0
+    assert q.precision == 1.0
+
+
+def test_normalization_ignores_case_and_punctuation():
+    gold = {"measure:orders.amount": "Total Revenue"}
+    q = score_naming([_sug("measure:orders.amount", "total-revenue!")], gold)
+    assert q.accuracy == 1.0
+
+
+def test_wrong_name_lowers_accuracy_and_precision():
+    gold = {"measure:orders.amount": "Total Revenue", "dimension:customers.region": "Region"}
+    suggestions = [_sug("measure:orders.amount", "Total Revenue"),
+                   _sug("dimension:customers.region", "Zip Code")]  # wrong
+    q = score_naming(suggestions, gold)
+    assert q.accuracy == 0.5
+    assert q.precision == 0.5  # 1 correct of 2 suggested
+
+
+def test_missing_suggestion_lowers_coverage_not_precision():
+    gold = {"measure:orders.amount": "Total Revenue", "dimension:customers.region": "Region"}
+    q = score_naming([_sug("measure:orders.amount", "Total Revenue")], gold)  # region absent
+    assert q.coverage == 0.5
+    assert q.accuracy == 0.5
+    assert q.precision == 1.0  # everything it DID suggest was right
+
+
+def test_gold_accepts_aliases():
+    gold = {"measure:orders.amount": {"Total Revenue", "Revenue", "Sales"}}
+    q = score_naming([_sug("measure:orders.amount", "Sales")], gold)
+    assert q.accuracy == 1.0
+
+
+def test_verified_accuracy_excludes_unverified_hits():
+    gold = {"measure:orders.amount": "Total Revenue"}
+    q = score_naming([_sug("measure:orders.amount", "Total Revenue", verified=False)], gold)
+    assert q.accuracy == 1.0            # the name is right
+    assert q.verified_accuracy == 0.0   # but it never passed self-critique
+
+
+def test_to_dict_shape_and_per_target_results():
+    gold = {"measure:orders.amount": "Total Revenue"}
+    d = score_naming([_sug("measure:orders.amount", "Total Revenue")], gold).to_dict()
+    assert set(d) >= {"n_targets", "coverage", "accuracy", "precision",
+                      "verified_accuracy", "results"}
+    r = d["results"][0]
+    assert set(r) >= {"target", "gold", "suggested", "matched", "verified"}
+
+
+# --- end-to-end runner with the deterministic fake backend -----------------------
+
+
+class _FakeBackend:
+    """Answers exactly the targets a prompt lists, per the namer's JSON contract."""
+
+    _NAMES = {
+        "measure:orders.amount": "Total Revenue",
+        "dimension:customers.region": "Region",
+    }
+
+    def propose(self, prompt: str) -> str:
+        from goldenmatch.semantic.discovery.namer import _targets_in_prompt
+
+        targets = _targets_in_prompt(prompt)
+        if "VERIFY" in prompt.upper():
+            return json.dumps({"verdicts": [
+                {"target": t, "supported": True, "confidence": 0.9} for t in targets
+            ]})
+        return json.dumps({"names": [
+            {"target": t, "name": self._NAMES.get(t, t.split(":")[-1]), "evidence": "fix"}
+            for t in targets
+        ]})
+
+
+def test_run_namer_eval_end_to_end_is_deterministic():
+    tables = _tables()
+    model = discover_semantic_model(tables)
+    gold = {"measure:orders.amount": "Total Revenue",
+            "dimension:customers.region": "Region"}
+    q = run_namer_eval(model, tables, gold, backend=_FakeBackend())
+    assert q.accuracy == 1.0
+    assert q.coverage == 1.0
+
+
+# --- live provider path: opt-in only, never spends API calls in CI ----------------
+
+
+@pytest.mark.skipif(not os.getenv("GOLDENMATCH_NAMER_EVAL_LIVE"),
+                    reason="live LLM eval is opt-in (set GOLDENMATCH_NAMER_EVAL_LIVE=1)")
+def test_run_namer_eval_live_provider():
+    from goldenmatch.semantic.discovery.namer import load_namer_backend
+
+    backend = load_namer_backend()
+    if backend is None:
+        pytest.skip("no namer provider/key resolved")
+    tables = _tables()
+    model = discover_semantic_model(tables)
+    gold = {"measure:orders.amount": {"Total Revenue", "Revenue", "Total Amount"}}
+    q = run_namer_eval(model, tables, gold, backend=backend)
+    assert q.coverage > 0.0


### PR DESCRIPTION
Ninth and **final** frontier slice — closes the arc. Slices 11-18 were deterministic features; this one is the *measurement* for the single non-deterministic part, the advisory LLM namer (Phase 7).

`score_naming(suggestions, gold)` — pure, deterministic scorer of namer output against a labeled `{target: accepted_name(s)}` gold map → `NamerQuality(coverage, accuracy, precision, verified_accuracy, results)`. Match is normalized (lowercase, alnum-only); it's deliberately **not** a stemmer, so plural/alias variants are listed as explicit gold aliases rather than silently conflated. `run_namer_eval(model, tables, gold, *, backend)` names then scores.

**Never spends live calls in CI:** the scorer is backend-agnostic, CI drives it with hand-built suggestions + a dict-driven fake backend (deterministic), and the real provider (`load_namer_backend`) is opt-in behind `GOLDENMATCH_NAMER_EVAL_LIVE` (a skipped live test).

New exports `score_naming` / `run_namer_eval` / `NamerQuality` / `TargetResult`. Tests: `test_semantic_discovery_namer_eval.py` (8 + 1 live-skip). Suite green (138 incl surface/parity).

**Frontier arc complete — 9/9:** hierarchies ✅, metrics ✅, time ✅, cardinality ✅, SCD ✅, completeness ✅, warehouse ✅, reconciliation ✅, **namer eval ✅**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)