### PR TITLE
chore(release): 2026-08 GoldenModel frontier cut (goldenmatch 3.12.0 + goldencheck 3.4.0 + 5 npm + golden-suite 0.4.0)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,11 +27,11 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.11.0` | `1.27.0` | `goldenmatch` | 95 | ✓ | ✓ | wheel · Postgres · DuckDB |
-| [GoldenCheck](#goldencheck) | `3.3.0` | `0.7.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
-| [GoldenFlow](#goldenflow) | `2.1.0` | `0.18.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
-| [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.1` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
-| [GoldenAnalysis](#goldenanalysis) | `0.4.0` | `0.3.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
+| [GoldenMatch](#goldenmatch) | `3.12.0` | `1.28.0` | `goldenmatch` | 95 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenCheck](#goldencheck) | `3.4.0` | `0.8.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
+| [GoldenFlow](#goldenflow) | `2.1.0` | `0.19.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
+| [GoldenPipe](#goldenpipe) | `1.4.0` | `0.4.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
+| [GoldenAnalysis](#goldenanalysis) | `0.4.0` | `0.4.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
 | [InferMap](#infermap) | `0.6.0` | `0.7.0` | `infermap` | 4 | — | — | wheel |
 {/* api-surface-matrix:generated:end */}
 

--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.4.0] - 2026-08-04
+
+- Floor bumps for the 2026-08 GoldenModel frontier cut: `goldenmatch[polars]>=3.12` (was
+  `>=3.11`) — the nine "frontier" semantic-model discovery slices (dimension hierarchies,
+  metrics, time intelligence, cardinality/bridges, SCD, model completeness/trust score,
+  warehouse-scale derivation off `information_schema`, catalog reconciliation, and the
+  namer quality-eval harness); `goldencheck[polars]>=3.4` (was `>=3.3`, lockstep). Native
+  floors unchanged.
+
 ## [0.3.6] - 2026-08-03
 
 - Floor bumps for the 2026-08 suite release: `goldenmatch[polars]>=3.11` (was

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.3.6"
+__version__ = "0.4.0"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.3.6"
+version = "0.4.0"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,8 +37,8 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.11",        # entity resolution: dedupe, match, golden records (>=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
-    "goldencheck[polars]>=3.3",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
+    "goldenmatch[polars]>=3.12",        # entity resolution: dedupe, match, golden records (>=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldencheck[polars]>=3.4",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.4",              # read-only cross-cutting metrics + reporting

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GoldenCheck will be documented in this file.
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-08-04
+
+- Lockstep suite release (2026-08 GoldenModel frontier cut). No functional changes to
+  GoldenCheck; version kept in sync with the goldenmatch 3.12.0 / golden-suite 0.4.0 cut.
+
 ## [3.3.0] - 2026-08-03
 
 ### Changed

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.3.0"
+version = "3.4.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data \u2014 scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.12.0] - 2026-08-04
+
 ### Added
 - **Semantic-model discovery — real-LLM namer validation / eval harness (Phase 19).** New
   `goldenmatch.semantic.score_naming(suggestions, gold)` is a pure, deterministic scorer of

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.11.0"
+__version__ = "3.12.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.11.0"
+version = "3.12.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/typescript/goldenanalysis/package.json
+++ b/packages/typescript/goldenanalysis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenanalysis",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Read-only cross-cutting analysis, metrics, and reporting for the Golden Suite. TypeScript port of the goldenanalysis Python library.",
   "keywords": [
     "analysis",

--- a/packages/typescript/goldenanalysis/src/index.ts
+++ b/packages/typescript/goldenanalysis/src/index.ts
@@ -10,6 +10,6 @@
  *   console.log(toMarkdown(report));
  */
 
-export const VERSION = "0.3.0";
+export const VERSION = "0.4.0";
 
 export * from "./core/index.js";

--- a/packages/typescript/goldenanalysis/src/node/mcp/server.ts
+++ b/packages/typescript/goldenanalysis/src/node/mcp/server.ts
@@ -231,7 +231,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldenanalysis", version: "0.3.0" },
+            serverInfo: { name: "goldenanalysis", version: "0.4.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenanalysis/tests/unit/smoke.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/smoke.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "../../src/index.js";
 
 describe("smoke", () => {
   it("exports a version", () => {
-    expect(VERSION).toBe("0.3.0");
+    expect(VERSION).toBe("0.4.0");
   });
 });

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Data validation that discovers rules from your data. TypeScript port of the goldencheck Python library.",
   "keywords": [
     "data-validation",

--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -27,7 +27,7 @@ export const program = new Command();
 program
   .name("goldencheck-js")
   .description("Data validation that discovers rules from your data")
-  .version("0.7.0");
+  .version("0.8.0");
 
 // --- scan ---
 program

--- a/packages/typescript/goldencheck/src/core/engine/notifier.ts
+++ b/packages/typescript/goldencheck/src/core/engine/notifier.ts
@@ -91,7 +91,7 @@ export async function sendWebhook(
 
   const payload = {
     tool: "goldencheck-js",
-    version: "0.7.0",
+    version: "0.8.0",
     trigger,
     file,
     health_grade: grade,

--- a/packages/typescript/goldencheck/src/node/a2a/server.ts
+++ b/packages/typescript/goldencheck/src/node/a2a/server.ts
@@ -29,7 +29,7 @@ import { ReviewQueue, type ReviewItem } from "../../core/agent/review-queue.js";
 
 export const AGENT_CARD = {
   name: "goldencheck-agent",
-  version: "0.7.0",
+  version: "0.8.0",
   description: "Data validation agent that discovers rules from your data.",
   skills: [
     { id: "scan", description: "Scan a data file for quality issues" },

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -375,7 +375,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldencheck", version: "0.7.0" },
+            serverInfo: { name: "goldencheck", version: "0.8.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/cli.ts
+++ b/packages/typescript/goldenflow/src/cli.ts
@@ -20,7 +20,7 @@ import { listRuns } from "./node/history.js";
 // Ensure all transforms are registered
 import "./core/transforms/index.js";
 
-const VERSION = "0.18.0";
+const VERSION = "0.19.0";
 
 export const program = new Command()
   .name("goldenflow-js")

--- a/packages/typescript/goldenflow/src/node/a2a/server.ts
+++ b/packages/typescript/goldenflow/src/node/a2a/server.ts
@@ -46,7 +46,7 @@ export const AGENT_CARD: {
   name: "GoldenFlow",
   description:
     "Data transformation -- standardize, clean, and normalize data with auto-detection and domain-aware transforms",
-  version: "0.18.0",
+  version: "0.19.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8150",
   skills: [

--- a/packages/typescript/goldenflow/src/node/api/server.ts
+++ b/packages/typescript/goldenflow/src/node/api/server.ts
@@ -23,7 +23,7 @@ function sanitizePath(raw: string): string {
   return resolved;
 }
 
-const VERSION = "0.18.0";
+const VERSION = "0.19.0";
 
 /** Strip stack / errno / syscall fields from objects + Error instances so
  *  unauthenticated callers don't see internal paths / library versions. */

--- a/packages/typescript/goldenflow/src/node/mcp/server.ts
+++ b/packages/typescript/goldenflow/src/node/mcp/server.ts
@@ -348,7 +348,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldenflow", version: "0.18.0" },
+            serverInfo: { name: "goldenflow", version: "0.19.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-08-04
+
+- Lockstep suite release (2026-08 GoldenModel frontier cut). No functional changes to
+  goldenmatch-js; version kept in sync with the goldenmatch 3.12.0 / golden-suite 0.4.0 cut.
+
 ## [1.27.0] - 2026-08-03
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.27.0",
+  version: "1.28.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1222,7 +1222,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.27.0",
+          version: "1.28.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1714,7 +1714,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.27.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.28.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenpipe/package.json
+++ b/packages/typescript/goldenpipe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenpipe",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Golden Suite orchestrator — chains GoldenCheck, GoldenFlow, and GoldenMatch into one adaptive pipeline. TypeScript port of the goldenpipe Python library.",
   "keywords": [
     "pipeline",

--- a/packages/typescript/goldenpipe/src/cli.ts
+++ b/packages/typescript/goldenpipe/src/cli.ts
@@ -22,7 +22,7 @@ import { startMcpServer } from "./node/mcp/server.js";
 import { startA2aServer } from "./node/a2a/server.js";
 import { runServer as runApiServer } from "./node/api/server.js";
 
-const VERSION = "0.3.1";
+const VERSION = "0.4.0";
 
 function printResult(result: PipeResult, verbose: boolean): void {
   process.stdout.write(`GoldenPipe: ${result.source}\n`);

--- a/packages/typescript/goldenpipe/src/node/a2a/server.ts
+++ b/packages/typescript/goldenpipe/src/node/a2a/server.ts
@@ -45,7 +45,7 @@ export const AGENT_CARD: {
 } = {
   name: "GoldenPipe",
   description: "Pluggable pipeline framework for data quality workflows",
-  version: "0.3.1",
+  version: "0.4.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8250",
   skills: [

--- a/packages/typescript/goldenpipe/src/node/api/server.ts
+++ b/packages/typescript/goldenpipe/src/node/api/server.ts
@@ -24,7 +24,7 @@ import { resolve, isAbsolute, relative, sep } from "node:path";
 import { handleTool } from "../mcp/server.js";
 import { run } from "../run.js";
 
-const VERSION = "0.3.1";
+const VERSION = "0.4.0";
 
 /** Resolve a path relative to cwd and reject traversal outside it. */
 function sanitizePath(raw: string): string {

--- a/packages/typescript/goldenpipe/src/node/mcp/server.ts
+++ b/packages/typescript/goldenpipe/src/node/mcp/server.ts
@@ -214,7 +214,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenpipe", version: "0.3.1" },
+              serverInfo: { name: "goldenpipe", version: "0.4.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });


### PR DESCRIPTION
Publishes the nine **frontier** semantic-model discovery slices that merged after the 3.11.0 cut. `main` was carrying them under the same `3.11.0` as the published wheel; this bumps so they can ship.

**Substantive change:** goldenmatch `3.11.0 -> 3.12.0` — frontier slices 11-19 (dimension hierarchies, metrics, time intelligence, cardinality/bridges, SCD, model completeness/trust score, warehouse-scale derivation off `information_schema`, catalog reconciliation, namer quality-eval harness).

**Lockstep (no functional change):**
- goldencheck `3.3.0 -> 3.4.0`
- golden-suite `0.3.6 -> 0.4.0` (floors: `goldenmatch>=3.12`, `goldencheck>=3.4`)
- 5 npm minor: goldenanalysis `0.4.0`, goldencheck `0.8.0`, goldenflow `0.19.0`, goldenmatch `1.28.0`, goldenpipe `0.4.0`

All version-bearing files bumped in lockstep (pyproject, `__init__`, server.json, TS `package.json` + embedded source literals). **version_consistency gate green (34 packages).** Mirrors the 2026-08-03 suite cut (#2402).

Publish (post-merge): tag + `workflow_dispatch` per package; no `gh release create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)