### PR TITLE
docs(roadmap): reconcile stale plans + goldencheck-types README

### DIFF
--- a/context-network/architecture/single-kernel-collapse-roadmap.md
+++ b/context-network/architecture/single-kernel-collapse-roadmap.md
@@ -1,6 +1,13 @@
 # Single-Kernel-Collapse — Roadmap (R0–R5)
 
-**Status:** Spike • **Decision:** [../decisions/0016-single-kernel-collapse-spike.md](../decisions/0016-single-kernel-collapse-spike.md) • **Inventory:** [single-kernel-collapse-inventory.md](single-kernel-collapse-inventory.md)
+**Status:** R2–R4 substantially LANDED, **R5 remaining** (reconciled 2026-08-04) • **Decision:** [../decisions/0016-single-kernel-collapse-spike.md](../decisions/0016-single-kernel-collapse-spike.md) • **Inventory:** [single-kernel-collapse-inventory.md](single-kernel-collapse-inventory.md)
+
+> **Reconciliation note (2026-08-04):** far ahead of the per-stage text below. The own-string
+> primitives shipped and rapidfuzz was fully evicted suite-wide (#2159, #2218), as were
+> scipy/jellyfish/faiss/diptest/dateutil; the shared kernels were realized as their own published
+> products — **goldenfuzz**, **goldenphonetic**, **goldenhnsw**. R2 (scorers) and much of R3/R4 are
+> done; only **R5** (decommission dead duplicated math + the ast-grep gate forbidding algorithm math
+> outside `*-core`) genuinely remains. The stage text below is retained as the original plan of record.
 
 Staged plan for collapsing the suite's N duplicated algorithm implementations
 toward one shared Rust `*-core` kernel. **Additive until R5; one reversible flag

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -1,5 +1,12 @@
 # Roadmap — Arrow-native arc
 
+> **Reconciliation (2026-08-04):** this doc (last substantive update 2026-06-13) predates the
+> FS-scale (out-of-core / frame-residency, 50M on 64GB single-box) and own-primitives / rapidfuzz-
+> eviction arcs — treat the "Adjacent / follow-ups" items as historical and verify against current
+> state before acting. The one genuinely-open engine item is the **Sail binding 100M multi-node run
+> → flip the `mode` default** (W3), still infra-blocked on `SAIL_REMOTE`; FS single-node out-of-core
+> has reduced its urgency. Per the North Star, **W1 adoption/distribution** leads this engine work.
+
 > **Strategic note:** this is the *engine* roadmap — one workstream (W3) of the broader
 > [north-star-roadmap.md](north-star-roadmap.md), which sequences adoption / zero-config /
 > surface-parity / bus-factor work *ahead* of engine unification. The Arrow-native arc below

--- a/docs/superpowers/plans/2026-06-05-surface-gap-roadmap.md
+++ b/docs/superpowers/plans/2026-06-05-surface-gap-roadmap.md
@@ -1,5 +1,10 @@
 # GoldenMatch Surface-Gap Roadmap (CLI / TUI / Web / API)
 
+> **Reconciliation (2026-08-04):** COMPLETE. Every queued PR in the ledger below (#771–#782) merged,
+> and the AgentSession / A2A TypeScript port (Wave 5.5, deferred at the time) shipped via #989/#994/#995/#996.
+> The 2026-06-05 four-surface gaps are closed; only routine Wave 6.x polish (SCORERS/TRANSFORMS codegen
+> sync, docs-vs-CLI parity test) is worth a spot-check. Retained as the historical execution ledger.
+
 > **For agentic workers:** Each wave is independently shippable. Steps use checkbox (`- [ ]`) syntax. Use superpowers:executing-plans (or subagent-driven-development) per wave. `docs/superpowers/` is gitignored — do NOT `git add` this plan.
 
 **Goal:** Close every gap surfaced in the 2026-06-05 four-surface audit (CLI, TUI, Web/HTTP, programmatic API) for the `goldenmatch` product, including full Python↔TypeScript parity.

--- a/docs/superpowers/plans/2026-07-24-goldenmatch-pg-identity-audit-mediation-mdm.md
+++ b/docs/superpowers/plans/2026-07-24-goldenmatch-pg-identity-audit-mediation-mdm.md
@@ -1,8 +1,12 @@
 # goldenmatch-pg: identity audit + mediation + MDM SQL surface (post-#1913)
 
-**Status:** planned (not started). **Depends on:** #1913 (closed) — the in-DB
+**Status:** SHIPPED (#2094, `goldenmatch_pg` 0.16.0; crate now at 0.17.0). _Reconciled 2026-08-04._
+All 8 `gm_identity_{audit,audit_verify,audit_seal,resolve_conflict,claim,profile,stats,worklist}`
+functions are present in `packages/rust/extensions/postgres/sql/goldenmatch_pg--0.16.0.sql`
+(commit `4825c18f` "feat(pg): identity audit chain + steward mediation + MDM reads in SQL");
+the §9 checklist below is complete. **Depended on:** #1913 (closed) — the in-DB
 identity write path, GUC/DSN plumbing, dual `db_path`/in-DB store selection, and
-the `rust_pgrx` CI smoke it shipped are the foundation this reuses wholesale.
+the `rust_pgrx` CI smoke it shipped are the foundation this reused wholesale.
 
 ## 1. Context — what's already on the SQL surface vs. what's missing
 

--- a/docs/superpowers/specs/2026-06-19-six-vertical-roadmap.md
+++ b/docs/superpowers/specs/2026-06-19-six-vertical-roadmap.md
@@ -1,7 +1,7 @@
 # Six-vertical extension roadmap
 
 **Date:** 2026-06-19
-**Status:** Planning (tracked in GitHub milestones #1–#6)
+**Status:** Substantially delivered — reconciled 2026-08-04. M1 (agent-memory / AgentSession + durable store), M2 (dedup-scale: FS out-of-core + frame-residency), M4 (one-to-many screening, #1187), and M6 (CDP/MDM: incremental resolution, per-cell survivorship, stabilization, mediation, Customer 360) have all landed on `main`; M3/M5 track their GitHub milestones. Original planning content preserved below.
 **Scope:** Six adjacent "hot tech" verticals GoldenMatch can extend into beyond the existing knowledge-graph / identity work, each taken to a **production / compliance-grade** done bar.
 
 ## Why these six

--- a/packages/python/goldencheck-types/README.md
+++ b/packages/python/goldencheck-types/README.md
@@ -1,0 +1,47 @@
+# goldencheck-types
+
+Shared canonical field-type registry for the [Golden Suite](https://github.com/benseverndev-oss/goldenmatch) — a single source of truth for *"what does the field type `email` mean?"* (name hints, value signals, confidence thresholds) across every suite package and both languages.
+
+## What it is
+
+GoldenCheck profiles a dataset and emits **inferred field types**; downstream packages consume them:
+
+- **Producer:** `goldencheck` (data-quality profiling).
+- **Consumers:** `goldenpipe` (stage I/O contracts), `infermap` (target schema inference), and the TypeScript mirror `goldencheck-types` (cross-language, over a JSON wire).
+
+Keeping the type vocabulary in one small, dependency-light package lets the Python and TypeScript sides produce byte-identical types, and lets consumers depend on the vocabulary without pulling in the full profiler.
+
+## Install
+
+```bash
+pip install goldencheck-types
+```
+
+Only requires `pyyaml`.
+
+## Usage
+
+```python
+from goldencheck_types import load_field_types, FieldType, InferredSchema
+
+# Load the bundled canonical field types (16 domain packs: generic + 15 verticals)
+field_types = load_field_types()
+
+# Or inspect a single type
+email = field_types["email"]
+print(email.name_hints, email.confidence_threshold)
+```
+
+Public API (`goldencheck_types`): `SchemaVersion`, `FieldType`, `InferredSchema`, `load_field_types`, and the supporting Pydantic models in `types.py`.
+
+## Schema versioning
+
+Every emitted type carries a `schema_version`. Consumers **must** check it and refuse unknown versions rather than silently degrade. The version bumps when a required field is added to `FieldType`, an enum gains a value, or the `value_signals` wire shape changes.
+
+## Cross-language parity
+
+The TypeScript sibling at [`packages/typescript/goldencheck-types`](https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/typescript/goldencheck-types) ships the same `FieldType` / `InferredSchema` interfaces and the same bundled domain packs, synced byte-for-byte from one canonical source. This is the one Golden Suite package where the TypeScript side keeps `snake_case` field names, so the producer YAML and consumer JSON pass through unchanged.
+
+## License
+
+Apache-2.0. Part of the Golden Suite; see the [monorepo](https://github.com/benseverndev-oss/goldenmatch) for the full project.

--- a/packages/python/goldencheck-types/pyproject.toml
+++ b/packages/python/goldencheck-types/pyproject.toml
@@ -2,6 +2,7 @@
 name = "goldencheck-types"
 version = "0.2.0"
 description = "Shared canonical field types for the Golden Suite"
+readme = "README.md"
 requires-python = ">=3.11"
 dependencies = ["pyyaml>=6.0"]
 


### PR DESCRIPTION
## Summary

Phase 1 of a roadmap-reconcile + distribution sprint. This PR lands the **unambiguous, safe-in-repo** slice; the outward-facing distribution items are summarized below for a separate go-ahead.

### Roadmap reconciliation (docs → shipped reality, dated 2026-08-04)
Five planning docs had drifted behind what's on `main`:
- **pg-identity-audit-mediation-mdm plan** — `planned (not started)` → **SHIPPED** (#2094, `goldenmatch_pg` 0.16.0; crate now 0.17.0; all 8 `gm_identity_*` SQL fns present).
- **six-vertical roadmap** — `Planning` → **substantially delivered** (M1 agent-memory, M2 dedup-scale, M4 one-to-many screening #1187, M6 CDP/MDM all landed).
- **single-kernel-collapse roadmap** — `Spike / R1 next` → **R2–R4 landed, R5 remaining** (rapidfuzz + scipy/jellyfish/faiss/diptest/dateutil evicted; goldenfuzz/goldenphonetic/goldenhnsw shipped as products).
- **planning/roadmap.md** — reconciliation banner (engine doc trails the FS-scale + own-primitives arcs; Sail 100M multi-node run is the one open engine item; W1 adoption leads).
- **surface-gap roadmap** — marked **COMPLETE** (#771–#782 + the AgentSession/A2A TS port #989/#994/#995/#996 all merged).

### Distribution hygiene
- **goldencheck-types** was published (PyPI 0.2.0) with **no long-description**. Adds `README.md` and declares `readme = "README.md"` in pyproject so the next release ships it.

Docs/config only — no product code.

### Not in this PR (outward-facing / need sign-off)
Surfaced from the distribution inventory, deliberately excluded here: Smithery dashboard listings for `infermap` + `goldenanalysis`; a `goldengraph` PyPI publish decision; the `goldenmatch-kg` publish-vs-doc contradiction; and the adoption-content lane (Splink/Zingg comparison page, case study, awesome-list PRs, social-preview image). These are the subject of the sprint scoping I'm bringing to the maintainer separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_