### PR TITLE
docs: add MCP Queen operational badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Golden Suite
 
+[![MCP Queen operational grade](https://mcpqueen.com/badge/io.github.benseverndev-oss/goldenmatch.svg)](https://mcpqueen.com/s/io.github.benseverndev-oss/goldenmatch)
+
 **Splink-beating entity resolution — Arrow-native, Rust-fast, zero-tuning — feeding a durable identity layer, so messy records from every source become stable golden entities with whole-record, Customer-360 provenance.**
 
 Zero-config matching that **beats expert-tuned Splink head-to-head on messy customer records**, in an **Arrow-native, Rust-authoritative** engine verified from a laptop CSV to a **100M-row dedupe in 9.2 minutes**. The identities it produces live in a **transaction-native control plane** — stable `entity_id`s, per-field provenance, merge/split, and a tamper-evident audit log — one call away as a Customer 360. It even **owns its primitives**: byte-identical, faster-than-`rapidfuzz` / `jellyfish` / FAISS Rust kernels, not rented dependencies.


### PR DESCRIPTION
Adds the live MCP Queen operational-grade badge to the README, following the existing badge request in #2246. The badge links to the current probe evidence and updates when that operational evidence changes. It describes observable MCP operations; it is not a security, privacy, data-quality, or compliance certification.