### PR TITLE
feat(ast-grep): single-kernel-collapse R5 gate + dedup goldenmatch's 2nd Levenshtein

### DIFF
--- a/.ast-grep/README.md
+++ b/.ast-grep/README.md
@@ -48,6 +48,7 @@ advisory (reported, non-blocking) so new rules can land gradually.
 |---|---|---|
 | `ts-no-empty-catch` | error | empty `catch {}` silently swallows errors — log or re-throw |
 | `ts-no-spread-math-min-max` | error | `Math.min/max(...array)` throws on >65K elements — the 11 real sites were fixed (this PR), so it's now a hard guard against reintroduction |
+| `ts-no-duplicate-kernel-math` | warning | a hand-rolled `levenshtein`/`jaro`/`soundex`/… outside the sanctioned pure-TS fallback modules is a second copy that drifts from the Rust `*-core` kernel and the Python port — import the existing export ([single-kernel-collapse R5](../context-network/architecture/single-kernel-collapse-roadmap.md)). The parity-gated fallbacks (`goldenmatch` `core/scorer.ts`, `core/transforms.ts`, `core/perceptualWasm.ts`) are ignored — they are the permanent edge-safe fallback surface, not drift. Currently **5 advisory findings** (goldencheck `fuzzy-values.ts`, goldenflow `phonetic.ts`, infermap `string-distance.ts` ×3) = the consolidation backlog; promote to `error` once they're gone |
 
 **Rust kernels** (`packages/rust/extensions/`):
 

--- a/.ast-grep/rule-tests/__snapshots__/ts-no-duplicate-kernel-math-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/ts-no-duplicate-kernel-math-snapshot.yml
@@ -1,0 +1,42 @@
+id: ts-no-duplicate-kernel-math
+snapshots:
+  'export function jaroWinkler(a: string, b: string): number { return 0; }':
+    labels:
+    - source: 'function jaroWinkler(a: string, b: string): number { return 0; }'
+      style: primary
+      start: 7
+      end: 71
+    - source: jaroWinkler
+      style: secondary
+      start: 16
+      end: 27
+  'export function levenshteinDistance(s1: string, s2: string): number { return 0; }':
+    labels:
+    - source: 'function levenshteinDistance(s1: string, s2: string): number { return 0; }'
+      style: primary
+      start: 7
+      end: 81
+    - source: levenshteinDistance
+      style: secondary
+      start: 16
+      end: 35
+  'function levenshtein(a: string, b: string): number { return 0; }':
+    labels:
+    - source: 'function levenshtein(a: string, b: string): number { return 0; }'
+      style: primary
+      start: 0
+      end: 64
+    - source: levenshtein
+      style: secondary
+      start: 9
+      end: 20
+  'function soundex(value: string): string { return value; }':
+    labels:
+    - source: 'function soundex(value: string): string { return value; }'
+      style: primary
+      start: 0
+      end: 57
+    - source: soundex
+      style: secondary
+      start: 9
+      end: 16

--- a/.ast-grep/rule-tests/ts-no-duplicate-kernel-math-test.yml
+++ b/.ast-grep/rule-tests/ts-no-duplicate-kernel-math-test.yml
@@ -1,0 +1,15 @@
+id: ts-no-duplicate-kernel-math
+valid:
+  # Importing the single-sourced primitive is the whole point of the rule.
+  - "import { levenshteinSimilarity } from './scorer.js';"
+  # Calling one is fine -- only DECLARING a second copy is flagged.
+  - "const d = levenshteinDistance(a, b);"
+  # Unrelated helpers must not trip the name regex.
+  - "function normalizeName(value: string): string { return value.trim(); }"
+  - "function levenshteinCacheKey(a: string, b: string): string { return a + b; }"
+invalid:
+  # A private DP copy of a kernel-backed primitive (the R5 target).
+  - "function levenshtein(a: string, b: string): number { return 0; }"
+  - "export function levenshteinDistance(s1: string, s2: string): number { return 0; }"
+  - "function soundex(value: string): string { return value; }"
+  - "export function jaroWinkler(a: string, b: string): number { return 0; }"

--- a/.ast-grep/rules/ts-no-duplicate-kernel-math.yml
+++ b/.ast-grep/rules/ts-no-duplicate-kernel-math.yml
@@ -1,0 +1,39 @@
+id: ts-no-duplicate-kernel-math
+language: typescript
+severity: warning
+message: >-
+  Hand-rolled implementation of a kernel-backed string algorithm outside the
+  sanctioned pure-TS fallback modules. These primitives are single-sourced from
+  the Rust `*-core` kernels (goldenmatch-score-core / goldenfuzz / goldenphonetic)
+  and mirrored by ONE conformance-tested pure-TS fallback; a second local copy
+  silently drifts from the kernel and from the Python port. Import the existing
+  export instead of re-implementing it.
+note: >-
+  Single-kernel-collapse R5 (context-network/architecture/single-kernel-collapse-roadmap.md).
+  Sanctioned pure-TS fallbacks are ignored below (goldenmatch core/scorer.ts,
+  core/transforms.ts, core/perceptualWasm.ts) -- those ARE the permanent
+  edge-safe fallback surface and are parity-gated against the kernel. Everything
+  else should import from them (or from the package's own scorer) rather than
+  keep a private DP loop. Severity is `warning` while the remaining
+  cross-package duplicates are consolidated; promote to `error` once
+  `ast-grep scan` reports none.
+files:
+  - "packages/typescript/**/src/**/*.ts"
+ignores:
+  # The sanctioned, parity-gated pure-TS fallback surface (kill-constraint 1:
+  # "Pure-TS stays the permanent fallback" -- these are deliberate, not drift).
+  - "packages/typescript/goldenmatch/src/core/scorer.ts"
+  - "packages/typescript/goldenmatch/src/core/transforms.ts"
+  - "packages/typescript/goldenmatch/src/core/perceptualWasm.ts"
+  # Tests legitimately re-implement reference math to check the real impl.
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/tests/**"
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    # Exact names only. A loose `<name><Suffix>?` regex over-matched helpers like
+    # `levenshteinCacheKey` (caught by this rule's own test case), so the set is
+    # enumerated: the primitive plus its conventional Distance/Similarity forms.
+    regex: "^(levenshtein|levenshteinDistance|levenshteinSimilarity|damerauLevenshtein|damerauLevenshteinDistance|damerauLevenshteinSimilarity|jaro|jaroSimilarity|jaroWinkler|jaroWinklerSimilarity|soundex|metaphone|doubleMetaphone|hamming|hammingDistance|diceCoefficient|jaccardSimilarity)$"

--- a/context-network/architecture/single-kernel-collapse-roadmap.md
+++ b/context-network/architecture/single-kernel-collapse-roadmap.md
@@ -54,6 +54,36 @@ forbidding algorithm math outside `*-core` (e.g. a hand-rolled levenshtein DP lo
 in `scorer.ts`). This is the only DELETING stage; it lands only after every prior
 stage's flag has been default-on and stable for a full release cycle.
 
+> **R5 status (2026-08-07): the GATE has landed; the DELETION half is mostly a
+> no-op by design.** Two findings from doing the work:
+>
+> 1. **"Delete the duplicated math" cannot mean deleting the pure ports.** Hard
+>    constraint 1 above makes pure-TS the *permanent* fallback (cross-target WASM
+>    is still unverified), and the architecture frame classifies pure-Python /
+>    pure-TS as conformance-tested **fallbacks**, not dead code. So `scorer.ts`'s
+>    `levenshtein`/`jaro`/… are deliberate and STAY. The only genuinely dead math
+>    is a *second* copy of a primitive that already has a sanctioned home.
+> 2. **The gate is the durable deliverable.** `ts-no-duplicate-kernel-math`
+>    (`.ast-grep/rules/`) flags a hand-rolled kernel-backed primitive declared
+>    outside the sanctioned fallback modules, which are allow-listed. It ships
+>    **warning**-severity (per the repo's gradual-landing convention) because its
+>    current findings ARE the consolidation backlog: goldencheck
+>    `fuzzy-values.ts`, goldenflow `phonetic.ts`, infermap `string-distance.ts`
+>    (×3). Promote to **error** once those are consolidated — that is the
+>    remaining R5 work, and it is cross-package (each needs a dependency
+>    decision), not a mechanical delete.
+>
+> Also done: the one *intra*-package duplicate was removed — goldenmatch
+> `core/indicators.ts` carried its own Levenshtein DP used solely by
+> `tokenSortRatio`; it now calls the exported `levenshteinSimilarity` from
+> `core/scorer.ts` (same package, no new dep). That copy was UTF-16 code-unit
+> based while the scorer's is codepoint-aware (`Array.from`), so the dedup also
+> fixes a latent non-BMP divergence from the Python/Rust reference.
+>
+> Note the preconditions in the stage text are still only partly met (kill-criteria
+> 1c/2/3 below remain PENDING), which is exactly why nothing default-flipped and
+> nothing in the fallback surface was deleted here.
+
 ## The two hard constraints
 
 1. **TS edge-safety.** `src/core/**` must stay edge-safe (no `node:*`), and WASM

--- a/packages/typescript/goldenmatch/src/core/indicators.ts
+++ b/packages/typescript/goldenmatch/src/core/indicators.ts
@@ -18,6 +18,7 @@ import type {
   SparsityVerdict,
   CollisionSignal,
 } from "./complexityProfile.js";
+import { levenshteinSimilarity } from "./scorer.js";
 
 // ---------------------------------------------------------------------------
 // Wall-clock budgets (seconds) — match Python constants.
@@ -375,29 +376,13 @@ export function computeIdentityCollisionSignal(
 function tokenSortRatio(a: string, b: string): number {
   const ta = a.toLowerCase().trim().split(/\s+/).filter(Boolean).sort().join(" ");
   const tb = b.toLowerCase().trim().split(/\s+/).filter(Boolean).sort().join(" ");
-  if (ta === tb) return 1.0;
-  if (ta.length === 0 && tb.length === 0) return 1.0;
-  const dist = levenshtein(ta, tb);
-  const maxLen = Math.max(ta.length, tb.length);
-  return maxLen === 0 ? 1.0 : 1.0 - dist / maxLen;
-}
-
-function levenshtein(a: string, b: string): number {
-  if (a === b) return 0;
-  if (a.length === 0) return b.length;
-  if (b.length === 0) return a.length;
-  const prev = new Array<number>(b.length + 1);
-  const curr = new Array<number>(b.length + 1);
-  for (let j = 0; j <= b.length; j++) prev[j] = j;
-  for (let i = 1; i <= a.length; i++) {
-    curr[0] = i;
-    for (let j = 1; j <= b.length; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      curr[j] = Math.min(curr[j - 1]! + 1, prev[j]! + 1, prev[j - 1]! + cost);
-    }
-    for (let j = 0; j <= b.length; j++) prev[j] = curr[j]!;
-  }
-  return prev[b.length]!;
+  // Single-sourced from the scorer's Levenshtein (R5 dedup): this module used to
+  // carry its own DP copy. `levenshteinSimilarity` is the same 1 - dist/maxLen
+  // formula, and is the conformance-tested pure-TS fallback for the score-core
+  // kernel -- so this can no longer drift from the scorer. It is also
+  // codepoint-aware (`Array.from`) where the old local copy counted UTF-16 code
+  // units, which matches the Python/Rust reference on non-BMP input.
+  return levenshteinSimilarity(ta, tb);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Takes on **single-kernel-collapse R5** — *"remove the now-dead duplicated math and add an ast-grep CI gate forbidding algorithm math outside `*-core`"*. Doing the work surfaced two findings that reshape the stage.

### 1. The DELETION half is mostly a no-op **by design**
Hard constraint 1 in the roadmap makes **pure-TS the permanent fallback** (cross-target WASM is still unverified), and the architecture frame classifies pure ports as *conformance-tested fallbacks, not co-equal sources of truth*. So `scorer.ts`'s `levenshtein`/`jaro`/… are **deliberate and stay** — deleting them would break the documented edge-safe fallback surface. The only genuinely dead math is a **second copy** of a primitive that already has a sanctioned home.

### 2. The GATE is the durable deliverable
The ast-grep infrastructure already existed (`sgconfig.yml`, `.ast-grep/{rules,rule-tests}`, a CI workflow) — **only this rule was missing.**

Adds **`ts-no-duplicate-kernel-math`**: flags a hand-rolled kernel-backed primitive (`levenshtein`/`damerau`/`jaro`/`jaroWinkler`/`soundex`/`metaphone`/`hamming`/`dice`/`jaccard`) *declared* outside the sanctioned pure-TS fallback modules, which are allow-listed (`core/scorer.ts`, `core/transforms.ts`, `core/perceptualWasm.ts`) along with tests.

Ships **`warning`**-severity per the repo's gradual-landing convention, because its findings *are* the consolidation backlog:

| Package | Site |
|---|---|
| goldencheck | `core/profilers/fuzzy-values.ts` |
| goldenflow | `core/transforms/phonetic.ts` |
| infermap | `core/util/string-distance.ts` (×3) |

`ast-grep scan` still exits **0**, so this lands non-blocking. Promote to `error` once those are consolidated — that's the remaining R5 work, and it's cross-package (each needs a dependency decision), not a mechanical delete.

### Also: the one real deletion
`goldenmatch/core/indicators.ts` carried its **own Levenshtein DP**, used solely by `tokenSortRatio` — a second copy inside the same package as `scorer.ts`. It now calls the exported `levenshteinSimilarity` (same package, no new dep). The local copy was **UTF-16 code-unit** based while the scorer's is **codepoint-aware** (`Array.from`), so the dedup also fixes a latent non-BMP divergence from the Python/Rust reference. `indicators.ts` is consequently no longer flagged.

### Notes
- The rule's **own test caught a real false positive** during development (a loose `<name><Suffix>?` regex matched `levenshteinCacheKey`), so the name set is enumerated exactly.
- Preconditions in the R5 stage text are still only partly met (kill-criteria 1c/2/3 remain PENDING) — which is exactly why **nothing default-flipped and nothing in the fallback surface was deleted**. The roadmap is updated to record this.

**Verified:** `ast-grep test` 13/13 · `ast-grep scan` exit 0 · goldenmatch TS `tsc --noEmit` clean + **3,671 tests pass** · `docs_consistency` all-PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_