### PR TITLE
fix(arrow): apply GoldenFlow standardization on the arrow lane (#2430)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5009,7 +5009,9 @@
           "file": "packages/python/goldenmatch/goldenmatch/core/transform.py",
           "purpose": "GoldenFlow integration -- data transformation before matching.",
           "defines": [
+            "_columnar_result_to_arrow",
             "_do_transform",
+            "_do_transform_columnar",
             "_goldenflow_available",
             "_warn_transform_needs_polars_once",
             "build_transform",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Fixed
+- **Arrow lane: GoldenFlow standardization is APPLIED instead of silently skipped
+  (#2430).** On a polars-free install, `core/transform.py` bridged the arrow lane
+  through `pl.from_arrow`, caught the resulting `ImportError`, and degraded to
+  no-transform — so dates, phones and whitespace were never standardized while the
+  run continued and reported success. It surfaced downstream, where column
+  profiling saw unstandardized values. The premise was stale: GoldenFlow's
+  `transform_df` is polars-native, but module-level `goldenflow.transform` is a
+  **polars-free columnar engine**, and (measured) its zero-config auto-detect runs
+  polars-free on string / int / float / bool / date columns — standardizing dates
+  to ISO and phones to E.164 with polars never imported. The arrow lane now falls
+  back to it when the polars bridge is unavailable. Verified the two engines
+  produce **identical values**, and untouched columns keep their exact arrow dtype
+  (a naive `dict`→`pa.table` rebuild silently widens `int32` to `int64`).
+
+  The polars engine stays **preferred** rather than replaced, so installs that
+  work today are unchanged and unregressed: measured on a 200K×5 arrow frame with
+  polars present, the polars bridge is 0.70s / 314 MB vs the columnar engine's
+  1.80s / 531 MB (2.6× slower, +69% RSS — `to_pydict()` materializes Python lists
+  where `pl.from_arrow` is near-zero-copy), and the polars engine also covers
+  strictly more configs. Only the polars-free install changes behavior.
+
+  The degrade path remains but is now narrow: the columnar engine declines an
+  **uncovered** config — the known trigger is an all-null column — and the warning
+  text, which used to claim the whole transform engine was polars-native, now says
+  so accurately. `strict=True` still re-raises, so MCP/A2A callers that explicitly
+  requested transforms are never handed unstandardized data silently.
 - **FS: an un-splittable oversized block is now scored in bounded tiles instead of whole
   (#1826/#2417).** When `_split_oversized` finds no useful split and `skip_oversized=false`
   — the "hub" shape where thousands of rows share one blocking-key value, so no split

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -29,10 +29,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   strictly more configs. Only the polars-free install changes behavior.
 
   The degrade path remains but is now narrow: the columnar engine declines an
-  **uncovered** config — the known trigger is an all-null column — and the warning
-  text, which used to claim the whole transform engine was polars-native, now says
-  so accurately. `strict=True` still re-raises, so MCP/A2A callers that explicitly
-  requested transforms are never handed unstandardized data silently.
+  **uncovered** config, and the warning text — which used to claim the whole
+  transform engine was polars-native — now names both triggers accurately.
+  `strict=True` still re-raises, so MCP/A2A callers that explicitly requested
+  transforms are never handed unstandardized data silently.
+
+  **Prerequisite worth knowing:** GoldenFlow's columnar engine has no pure-Python
+  core — `transform_columns_public` gates both its zero-config and
+  explicit-config branches on `native_columns_ready` — so the fallback needs the
+  `goldenflow-native` kernel. That is a **base dependency** of goldenflow, so a
+  normal install has it; CI lanes that strip it (`--no-install-package
+  goldenflow-native`, to skip the maturin build) still degrade as before. The
+  end-to-end tests skip there rather than assert something the environment cannot
+  do, and an in-process test with both engines stubbed guards the fallback wiring
+  in every lane.
 - **FS: an un-splittable oversized block is now scored in bounded tiles instead of whole
   (#1826/#2417).** When `_split_oversized` finds no useful split and `skip_oversized=false`
   — the "hub" shape where thousands of rows share one blocking-key value, so no split

--- a/packages/python/goldenmatch/goldenmatch/core/transform.py
+++ b/packages/python/goldenmatch/goldenmatch/core/transform.py
@@ -19,20 +19,32 @@ def _warn_transform_needs_polars_once() -> None:
     NOTE the narrow scope (#2430). The arrow lane routes through
     ``goldenflow.transform`` (polars-free) and standardizes normally for the
     common shapes -- string / int / float / bool / date columns all run with
-    polars never imported. Only an UNCOVERED config reaches here; the known
-    trigger is an ALL-NULL column, which makes zero-config auto-detect decline
-    to the polars engine. The message used to claim the whole transform engine
-    was polars-native, which was false and made this look unfixable."""
+    polars never imported. Only an UNCOVERED config reaches here. The message
+    used to claim the whole transform engine was polars-native, which was false
+    and made this look unfixable.
+
+    TWO things make a config uncovered, and the distinction matters when
+    diagnosing:
+
+    1. An ALL-NULL column, which makes zero-config auto-detect decline.
+    2. The ``goldenflow-native`` kernel is missing. GoldenFlow's columnar engine
+       has no pure-Python core -- ``transform_columns_public`` gates BOTH its
+       zero-config and explicit-config branches on ``native_columns_ready``, so
+       with the kernel absent EVERY config declines to the polars engine.
+       ``goldenflow-native`` is a BASE dependency of goldenflow, so a normal
+       install has it; CI lanes that strip it (``--no-install-package
+       goldenflow-native``, to skip the maturin build) do not."""
     global _TRANSFORM_POLARS_WARNED
     if _TRANSFORM_POLARS_WARNED:
         return
     _TRANSFORM_POLARS_WARNED = True
     logger.warning(
         "GoldenFlow transforms skipped for this frame: the auto-detected config "
-        "is not covered by GoldenFlow's polars-free columnar engine (a column "
-        "that is entirely null is the usual cause), and polars is not installed "
-        "to fall back to. Standardization is not applied. Install "
-        "goldenmatch[polars] to cover the remaining cases."
+        "is not covered by GoldenFlow's polars-free columnar engine (an "
+        "entirely-null column, or a missing goldenflow-native kernel, are the "
+        "usual causes), and polars is not installed to fall back to. "
+        "Standardization is not applied. Install goldenmatch[polars] to cover "
+        "the remaining cases."
     )
 
 
@@ -151,8 +163,10 @@ def run_transform(
     # imported. It is now the arrow lane's FALLBACK (`_do_transform_columnar`)
     # when the polars bridge is unavailable. The polars engine stays PREFERRED
     # where it works -- it is ~2.6x faster and covers more configs (see the
-    # measurement at the engine-selection ladder below). Residual uncovered case:
-    # an all-null column, which still declines.
+    # measurement at the engine-selection ladder below). Residual uncovered
+    # cases: an all-null column, and a missing `goldenflow-native` kernel (the
+    # columnar engine has no pure-Python core) -- both still decline. See
+    # `_warn_transform_needs_polars_once` for the diagnosis notes.
     import pyarrow as _pa  # noqa: PLC0415
 
     from goldenmatch.core.frame import to_frame as _tf_a2

--- a/packages/python/goldenmatch/goldenmatch/core/transform.py
+++ b/packages/python/goldenmatch/goldenmatch/core/transform.py
@@ -12,17 +12,27 @@ _TRANSFORM_POLARS_WARNED = False
 
 
 def _warn_transform_needs_polars_once() -> None:
-    """Warn (once) that GoldenFlow transforms are skipped on the arrow lane
-    because polars is absent. GoldenFlow's transform engine is polars-native;
-    install ``goldenmatch[polars]`` (or ``[transform]``) to re-enable them."""
+    """Warn (once) that GoldenFlow transforms were skipped because this frame's
+    auto-detected config is NOT covered by GoldenFlow's polars-free columnar
+    engine, and polars is absent to serve as the fallback.
+
+    NOTE the narrow scope (#2430). The arrow lane routes through
+    ``goldenflow.transform`` (polars-free) and standardizes normally for the
+    common shapes -- string / int / float / bool / date columns all run with
+    polars never imported. Only an UNCOVERED config reaches here; the known
+    trigger is an ALL-NULL column, which makes zero-config auto-detect decline
+    to the polars engine. The message used to claim the whole transform engine
+    was polars-native, which was false and made this look unfixable."""
     global _TRANSFORM_POLARS_WARNED
     if _TRANSFORM_POLARS_WARNED:
         return
     _TRANSFORM_POLARS_WARNED = True
     logger.warning(
-        "GoldenFlow transforms skipped: the transform engine is polars-native "
-        "and polars is not installed. Standardization is not applied on the "
-        "arrow lane; install goldenmatch[polars] to re-enable transforms."
+        "GoldenFlow transforms skipped for this frame: the auto-detected config "
+        "is not covered by GoldenFlow's polars-free columnar engine (a column "
+        "that is entirely null is the usual cause), and polars is not installed "
+        "to fall back to. Standardization is not applied. Install "
+        "goldenmatch[polars] to cover the remaining cases."
     )
 
 
@@ -37,9 +47,54 @@ def _goldenflow_available() -> bool:
 
 
 def _do_transform(df: pl.DataFrame):
-    """Call goldenflow.transform_df. Separated for testability."""
+    """Call goldenflow.transform_df (the POLARS engine). Separated for testability."""
     from goldenflow import transform_df
     return transform_df(df)
+
+
+def _do_transform_columnar(columns: dict, config=None):
+    """Call goldenflow.transform -- the POLARS-FREE columnar engine (#2430).
+
+    Takes ``dict[str, list]``, returns a ``ColumnarResult`` (``.columns`` dict +
+    ``.manifest``). Raises ``ImportError`` when the config is uncovered and
+    polars is absent to fall back to. Separated for testability, mirroring
+    ``_do_transform``."""
+    from goldenflow import transform
+    return transform(columns, config)
+
+
+def _columnar_result_to_arrow(columns: dict, source, source_columns: dict):
+    """Rebuild a ``pa.Table`` from the columnar engine's ``dict[str, list]``.
+
+    Preserves the SOURCE arrow type for any column GoldenFlow left unchanged,
+    instead of letting ``pa.table`` re-infer it. Without this an untouched
+    ``int32`` column silently widens to ``int64`` (measured) -- a schema change
+    the polars lane does not make. Changed columns are inferred, which matches
+    the polars lane's values (verified: identical on string/int/float/bool/date
+    incl. date32 -> ISO string, which BOTH lanes perform).
+
+    ``source_columns`` is the ``to_pydict()`` we already built to feed the
+    engine; comparing against it avoids re-materializing every source column
+    just to detect which ones changed."""
+    import pyarrow as pa  # noqa: PLC0415
+
+    arrays, names = [], []
+    for name, values in columns.items():
+        names.append(name)
+        src = source.column(name) if name in source.column_names else None
+        if src is not None:
+            if source_columns.get(name) == values:
+                arrays.append(src)              # untouched -> keep exact type
+                continue
+            try:
+                arrays.append(pa.array(values, type=src.type))
+                continue
+            except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError):
+                # Transform changed the value DOMAIN (e.g. date32 -> ISO string);
+                # fall through and let pyarrow infer, as the polars lane does.
+                pass
+        arrays.append(pa.array(values))
+    return pa.Table.from_arrays(arrays, names=names)
 
 
 def run_transform(
@@ -87,11 +142,17 @@ def run_transform(
     # ['record_hash'] passes through verbatim even when GoldenFlow has a
     # lowercase/strip rule for it. Column order is preserved.
     # A2 (arrow-native endgame): the adapter is dual-rep. Exclusion strip /
-    # re-attach runs on the CALLER'S lane via the seam; the single remaining
-    # polars surface is goldenflow's zero-config auto-detect engine
-    # (transform_df), bridged around _do_transform only. goldenflow's
-    # polars-free columnar `transform` needs an explicit covered config +
-    # arrow auto-detect -- filed in the endgame plan.
+    # re-attach runs on the CALLER'S lane via the seam.
+    # UPDATED #2430: this used to say goldenflow's polars-free columnar
+    # `transform` "needs an explicit covered config + arrow auto-detect". That is
+    # NOT true for the shapes that matter -- MEASURED, zero-config auto-detect
+    # (config=None) runs polars-free on string / int / float / bool / date
+    # columns, standardizing dates to ISO and phones to E.164 with polars never
+    # imported. It is now the arrow lane's FALLBACK (`_do_transform_columnar`)
+    # when the polars bridge is unavailable. The polars engine stays PREFERRED
+    # where it works -- it is ~2.6x faster and covers more configs (see the
+    # measurement at the engine-selection ladder below). Residual uncovered case:
+    # an all-null column, which still declines.
     import pyarrow as _pa  # noqa: PLC0415
 
     from goldenmatch.core.frame import to_frame as _tf_a2
@@ -143,27 +204,52 @@ def run_transform(
     if _tdbg:
         import time as _time  # noqa: PLC0415
 
+    # #2430: on the ARROW lane, fall back to GoldenFlow's POLARS-FREE columnar
+    # engine (`goldenflow.transform`) when the polars bridge is unavailable.
+    #
+    # Before this, the arrow lane ONLY bridged through `pl.from_arrow`, so on a
+    # polars-free install every arrow-lane run raised ImportError and SILENTLY
+    # skipped standardization -- column profiling then saw unstandardized values
+    # while the warning implied nothing could be done short of installing polars.
+    # That premise was stale: `transform_df` is polars-native, but module-level
+    # `goldenflow.transform` is polars-free and (measured) its zero-config
+    # auto-detect covers string/int/float/bool/date columns, standardizing dates
+    # to ISO and phones to E.164 with polars never imported.
+    #
+    # The polars engine is PREFERRED, not replaced. Measured on a 200K x 5 arrow
+    # frame with polars present: polars bridge 0.70s / 314 MB vs columnar
+    # 1.80s / 531 MB (2.6x slower, +69% RSS) -- `to_pydict()` materializes Python
+    # lists where `pl.from_arrow` is near-zero-copy. The polars engine also covers
+    # strictly MORE configs. So preferring it means installs that work today are
+    # byte-identical AND unregressed; only the polars-free install changes, from
+    # "silently skipped" to "standardized".
+    _engine = "polars"
     try:
         if _tdbg:
             _t0 = _time.perf_counter()
-            _bridge_df = (
+        try:
+            _bridge_in = (
                 _in_frame.native if _is_pl_in else pl.from_arrow(_in_frame.native)
             )
-            _t_bridge_in = _time.perf_counter() - _t0
-            _t0 = _time.perf_counter()
-            result = _do_transform(_bridge_df)
+            if _tdbg:
+                _t_bridge_in = _time.perf_counter() - _t0
+                _t0 = _time.perf_counter()
+            result = _do_transform(_bridge_in)
+        except ImportError:
+            if _is_pl_in:
+                raise          # polars lane genuinely cannot proceed
+            _engine = "columnar"
+            _bridge_in = _in_frame.native.to_pydict()
+            if _tdbg:
+                _t_bridge_in = _time.perf_counter() - _t0
+                _t0 = _time.perf_counter()
+            result = _do_transform_columnar(_bridge_in)
+        if _tdbg:
             _t_do = _time.perf_counter() - _t0
-        else:
-            _bridge_df = (
-                _in_frame.native if _is_pl_in else pl.from_arrow(_in_frame.native)
-            )
-            result = _do_transform(_bridge_df)
     except ImportError:
-        # GoldenFlow's transform engine (_do_transform) is polars-native; on the
-        # arrow lane with polars absent, the `pl.from_arrow` bridge raises
-        # ImportError. Degrade to no-transform (skip standardization) rather than
-        # crashing -- the arrow-eviction "lossy fallback". Byte-identical when
-        # polars is present.
+        # Now a NARROW fallback: BOTH engines are unavailable -- polars is absent
+        # AND the columnar engine declined an UNCOVERED config (known trigger: an
+        # all-null column). Degrade to no-transform rather than crashing.
         _warn_transform_needs_polars_once()
         if strict:
             raise
@@ -176,28 +262,36 @@ def run_transform(
         return _restore(_in_frame).native, []
 
     # Re-attach preserved columns and restore order on the caller's lane.
+    # The two ENGINES return different result shapes -- the polars
+    # `TransformResult` carries `.df`, the columnar `ColumnarResult` carries
+    # `.columns` (dict[str, list]) -- so branch on `_engine`, NOT on the lane.
+    def _result_native():
+        if _engine == "columnar":
+            return _columnar_result_to_arrow(
+                result.columns, _in_frame.native, _bridge_in,
+            )
+        return result.df if _is_pl_in else result.df.to_arrow()
+
     if _tdbg:
         if _is_pl_in:
             _res_frame = _tf_a2(result.df)
         else:
             _t0 = _time.perf_counter()
-            _res_native = result.df.to_arrow()
+            _res_native = _result_native()
             _t_bridge_out = _time.perf_counter() - _t0
             _res_frame = _tf_a2(_res_native)
         print(
             f"[transform][DEBUG] lane={'polars' if _is_pl_in else 'arrow'} "
-            f"rows={_in_frame.height}: "
-            f"bridge_in(from_arrow)={_t_bridge_in:.3f}s  "
+            f"engine={_engine} rows={_in_frame.height}: "
+            f"bridge_in={_t_bridge_in:.3f}s  "
             f"_do_transform={_t_do:.3f}s  "
-            f"bridge_out(to_arrow)={_t_bridge_out:.3f}s  "
+            f"bridge_out={_t_bridge_out:.3f}s  "
             f"bridge_total={_t_bridge_in + _t_bridge_out:.3f}s "
             f"(GOLDENMATCH_TRANSFORM_DEBUG=0 to silence)",
             flush=True,
         )
     else:
-        _res_frame = _tf_a2(
-            result.df if _is_pl_in else result.df.to_arrow()
-        )
+        _res_frame = _tf_a2(_result_native())
     _res_frame = _restore(_res_frame)
 
     # Convert manifest to autofix-compatible format

--- a/packages/python/goldenmatch/tests/test_transform_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_transform_no_polars.py
@@ -1,15 +1,21 @@
-"""Transform-prep arrow-lane polars-absent degradation (zero-config arrow eviction).
+"""Transform-prep on the ARROW lane with polars absent (#2430).
 
-GoldenFlow's transform engine (`_do_transform`) is polars-native, so on the arrow
-lane `run_transform` bridges via `pl.from_arrow`. When polars is absent it now
-DEGRADES to no-transform (skip standardization) instead of crashing -- the two
-polars touchpoints fixed: the `isinstance(df, pl.DataFrame)` discriminator (now
-`isinstance(df, pa.Table)`, no polars import) and the `pl.from_arrow` bridge
-(ImportError caught -> degrade). Byte-identical when polars is present.
+GoldenFlow's transform engine is NOT polars-native as a whole: `transform_df` is
+the polars engine, but module-level `goldenflow.transform` is a POLARS-FREE
+columnar engine. On the arrow lane `run_transform` PREFERS the polars engine
+(faster, broader config coverage) and falls back to the columnar one when polars
+is absent -- so a polars-free install STANDARDIZES normally instead of silently
+skipping, while polars-present installs are byte-identical and unregressed.
 
-This is the leak the endgame tripwire (`test_zero_config_dedupe_df_is_polars_free`)
-hit on the full-native CI env (where zero-config configures a transform) but a
-fallback-path dev box masks.
+Before #2430 the arrow lane bridged via `pl.from_arrow`, which raised
+ImportError on a polars-free install and degraded to no-transform. That was a
+SILENT capability loss: the run continued with unstandardized values while the
+warning implied nothing could be done short of installing polars. It was caught
+downstream, where column profiling saw raw values.
+
+The degrade path still exists but is now NARROW -- the columnar engine declines
+an UNCOVERED config, and the known trigger is an all-null column. Both behaviors
+are pinned below so the distinction can't silently regress in either direction.
 """
 from __future__ import annotations
 
@@ -21,42 +27,151 @@ from pathlib import Path
 
 _PKG_ROOT = Path(__file__).parent.parent
 
+# Block polars at import time so the subprocess simulates a polars-free install.
+_PRELUDE = (
+    "import sys\n"
+    "class _Block:\n"
+    "    def find_spec(self, name, path=None, target=None):\n"
+    "        if name == 'polars' or name.startswith('polars.'):\n"
+    "            raise ImportError('polars blocked')\n"
+    "        return None\n"
+    "sys.meta_path.insert(0, _Block())\n"
+)
 
-def test_run_transform_degrades_to_no_transform_without_polars():
-    """SUBPROCESS, polars BLOCKED: run_transform on a dirty arrow frame with an
-    enabled transform config completes without importing polars (degrades to
-    no-transform) rather than crashing on the `pl.from_arrow` bridge."""
+
+def _run_polars_free(body: str, marker: str) -> None:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_PKG_ROOT)
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    proc = subprocess.run(
+        [sys.executable, "-c", _PRELUDE + textwrap.dedent(body)],
+        capture_output=True, text=True, env=env, timeout=180,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert marker in proc.stdout
+
+
+def test_run_transform_standardizes_without_polars():
+    """SUBPROCESS, polars BLOCKED: the arrow lane APPLIES standardization.
+
+    This is the #2430 regression guard. It asserts VALUES, not just that the
+    call didn't crash -- the pre-#2430 code also "passed" a shape-only check
+    while skipping standardization entirely, which is exactly how the bug hid.
+    """
     body = """
         import sys
         import pyarrow as pa
         from goldenmatch.core.transform import run_transform
         from goldenmatch.config.schemas import TransformConfig
         tbl = pa.table({
-            "name": ["  Alice ", "BOB", "  Alice "],
-            "city": ["NYC", "LA", "NYC"],
+            "name": pa.array(["  Alice ", "BOB", "  Alice "], pa.string()),
+            "dob": pa.array(
+                ["april 01, 1999", "1938-07-05", "12/25/1980"], pa.string()
+            ),
+            "small": pa.array([1, 2, 3], pa.int32()),
         })
         out, fixes = run_transform(tbl, TransformConfig(mode="announced"))
         assert isinstance(out, pa.Table), type(out)
         assert out.num_rows == 3
-        assert isinstance(fixes, list)
+        # Standardization ACTUALLY ran (the point of #2430).
+        assert out["name"].to_pylist() == ["Alice", "BOB", "Alice"], out["name"]
+        assert out["dob"].to_pylist() == [
+            "1999-04-01", "1938-07-05", "1980-12-25",
+        ], out["dob"]
+        assert fixes, "no fixes reported despite transforms applying"
+        # An untouched column keeps its EXACT arrow type -- a naive
+        # dict->pa.table rebuild silently widens int32 to int64.
+        assert str(out.schema.field("small").type) == "int32", out.schema
         assert "polars" not in sys.modules, "polars leaked in run_transform"
-        print("TRANSFORM-NO-POLARS OK")
+        print("TRANSFORM-NO-POLARS-STANDARDIZED OK")
     """
-    env = dict(os.environ)
-    env["PYTHONPATH"] = str(_PKG_ROOT)
-    env["POLARS_SKIP_CPU_CHECK"] = "1"
-    prelude = (
-        "import sys\n"
-        "class _Block:\n"
-        "    def find_spec(self, name, path=None, target=None):\n"
-        "        if name == 'polars' or name.startswith('polars.'):\n"
-        "            raise ImportError('polars blocked')\n"
-        "        return None\n"
-        "sys.meta_path.insert(0, _Block())\n"
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", prelude + textwrap.dedent(body)],
-        capture_output=True, text=True, env=env, timeout=120,
-    )
-    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
-    assert "TRANSFORM-NO-POLARS OK" in proc.stdout
+    _run_polars_free(body, "TRANSFORM-NO-POLARS-STANDARDIZED OK")
+
+
+def test_run_transform_degrades_on_uncovered_config_without_polars():
+    """SUBPROCESS, polars BLOCKED: an UNCOVERED config still degrades safely.
+
+    An all-null column makes GoldenFlow's zero-config auto-detect decline to the
+    polars engine, which is absent -- so `run_transform` must return the frame
+    unchanged rather than crash. This is the remaining narrow fallback, not the
+    whole arrow lane.
+    """
+    body = """
+        import sys
+        import pyarrow as pa
+        from goldenmatch.core.transform import run_transform
+        from goldenmatch.config.schemas import TransformConfig
+        tbl = pa.table({
+            "name": pa.array(["  Alice ", "BOB"], pa.string()),
+            "empty": pa.array([None, None], pa.string()),
+        })
+        out, fixes = run_transform(tbl, TransformConfig(mode="announced"))
+        assert isinstance(out, pa.Table), type(out)
+        assert out.num_rows == 2
+        # Degraded: returned unchanged rather than raising.
+        assert out["name"].to_pylist() == ["  Alice ", "BOB"], out["name"]
+        assert fixes == [], fixes
+        assert "polars" not in sys.modules, "polars leaked in run_transform"
+        print("TRANSFORM-NO-POLARS-DEGRADE OK")
+    """
+    _run_polars_free(body, "TRANSFORM-NO-POLARS-DEGRADE OK")
+
+
+def test_run_transform_honors_exclude_columns_without_polars():
+    """SUBPROCESS, polars BLOCKED: the `exclude_columns` strip/re-attach still
+    holds on the columnar engine.
+
+    The exclusion contract is durability-critical -- a `record_hash` column must
+    pass through VERBATIM even though GoldenFlow has strip/lowercase rules that
+    would rewrite it, and column ORDER must be preserved. That logic wraps the
+    transform, so switching the engine underneath it could silently break it.
+    """
+    body = """
+        import sys
+        import pyarrow as pa
+        from goldenmatch.core.transform import run_transform
+        from goldenmatch.config.schemas import TransformConfig
+        from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+        tbl = pa.table({
+            "name": pa.array(["  Ann ", "bob"], pa.string()),
+            "record_hash": pa.array(["  KEEP-ME  ", "  AND-ME "], pa.string()),
+            "dob": pa.array(["april 01, 1999", "1938-07-05"], pa.string()),
+        })
+        tok = _RUNTIME_EXCLUDE_COLUMNS.set(["record_hash"])
+        try:
+            out, _ = run_transform(tbl, TransformConfig(mode="announced"))
+        finally:
+            _RUNTIME_EXCLUDE_COLUMNS.reset(tok)
+        assert out.column_names == ["name", "record_hash", "dob"], out.column_names
+        assert out["record_hash"].to_pylist() == [
+            "  KEEP-ME  ", "  AND-ME ",
+        ], "excluded column was transformed"
+        assert out["name"].to_pylist() == ["Ann", "bob"], out["name"]
+        assert out["dob"].to_pylist() == ["1999-04-01", "1938-07-05"], out["dob"]
+        assert "polars" not in sys.modules, "polars leaked in run_transform"
+        print("TRANSFORM-NO-POLARS-EXCLUSIONS OK")
+    """
+    _run_polars_free(body, "TRANSFORM-NO-POLARS-EXCLUSIONS OK")
+
+
+def test_run_transform_strict_raises_on_uncovered_config_without_polars():
+    """SUBPROCESS, polars BLOCKED: `strict=True` re-raises instead of degrading,
+    so MCP/A2A callers who explicitly asked for transforms are not silently
+    handed unstandardized data."""
+    body = """
+        import sys
+        import pyarrow as pa
+        from goldenmatch.core.transform import run_transform
+        from goldenmatch.config.schemas import TransformConfig
+        tbl = pa.table({
+            "name": pa.array(["  Alice ", "BOB"], pa.string()),
+            "empty": pa.array([None, None], pa.string()),
+        })
+        try:
+            run_transform(tbl, TransformConfig(mode="announced"), strict=True)
+        except ImportError:
+            print("TRANSFORM-NO-POLARS-STRICT OK")
+        else:
+            raise AssertionError("strict=True should have re-raised ImportError")
+    """
+    _run_polars_free(body, "TRANSFORM-NO-POLARS-STRICT OK")

--- a/packages/python/goldenmatch/tests/test_transform_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_transform_no_polars.py
@@ -14,8 +14,24 @@ warning implied nothing could be done short of installing polars. It was caught
 downstream, where column profiling saw raw values.
 
 The degrade path still exists but is now NARROW -- the columnar engine declines
-an UNCOVERED config, and the known trigger is an all-null column. Both behaviors
-are pinned below so the distinction can't silently regress in either direction.
+an UNCOVERED config. Both behaviors are pinned below so the distinction can't
+silently regress in either direction.
+
+TWO things make a config uncovered, and the second one shapes this file:
+
+1. An ALL-NULL column, which makes zero-config auto-detect decline.
+2. The ``goldenflow-native`` kernel is absent. GoldenFlow's columnar engine has
+   no pure-Python core -- ``transform_columns_public`` gates BOTH its branches
+   on ``native_columns_ready`` -- so with the kernel gone EVERY config declines.
+   It is a BASE dep of goldenflow (so real installs have it), but the CI python
+   matrix strips it (``--no-install-package goldenflow-native``) to skip the
+   maturin build, and so does the ``goldenmatch_nopolars`` lane.
+
+So the standardize-asserting subprocess tests below are skipped when the kernel
+is absent -- they would be asserting something the environment cannot do. To
+keep the #2430 wiring itself guarded EVERYWHERE, ``test_arrow_lane_falls_back_
+to_columnar_engine`` exercises the same ladder in-process with the engines
+stubbed, needing neither a polars-free install nor the native kernel.
 """
 from __future__ import annotations
 
@@ -24,8 +40,35 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pytest
 
 _PKG_ROOT = Path(__file__).parent.parent
+
+
+def _columnar_engine_ready() -> bool:
+    """Is GoldenFlow's polars-free columnar engine actually usable here?
+
+    Mirrors the gate ``goldenflow.engine.columnar.transform_columns_public``
+    applies, rather than guessing from whether ``goldenflow_native`` imports."""
+    try:
+        from goldenflow.engine.columnar import native_columns_ready
+        from goldenflow.transforms._native import native_module
+    except Exception:
+        return False
+    nm = native_module()
+    return nm is not None and native_columns_ready(nm)
+
+
+_needs_columnar = pytest.mark.skipif(
+    not _columnar_engine_ready(),
+    reason=(
+        "goldenflow-native is absent, so GoldenFlow's columnar engine declines "
+        "every config and the arrow lane can only degrade (see module docstring)"
+    ),
+)
 
 # Block polars at import time so the subprocess simulates a polars-free install.
 _PRELUDE = (
@@ -51,6 +94,7 @@ def _run_polars_free(body: str, marker: str) -> None:
     assert marker in proc.stdout
 
 
+@_needs_columnar
 def test_run_transform_standardizes_without_polars():
     """SUBPROCESS, polars BLOCKED: the arrow lane APPLIES standardization.
 
@@ -95,6 +139,12 @@ def test_run_transform_degrades_on_uncovered_config_without_polars():
     polars engine, which is absent -- so `run_transform` must return the frame
     unchanged rather than crash. This is the remaining narrow fallback, not the
     whole arrow lane.
+
+    Deliberately NOT gated on the columnar engine: safe degradation is exactly
+    what must hold when the engine is unavailable. With `goldenflow-native`
+    present this pins the all-null trigger; without it, the kernel-absent
+    trigger. Either way the contract under test is the same -- degrade, never
+    crash.
     """
     body = """
         import sys
@@ -117,6 +167,7 @@ def test_run_transform_degrades_on_uncovered_config_without_polars():
     _run_polars_free(body, "TRANSFORM-NO-POLARS-DEGRADE OK")
 
 
+@_needs_columnar
 def test_run_transform_honors_exclude_columns_without_polars():
     """SUBPROCESS, polars BLOCKED: the `exclude_columns` strip/re-attach still
     holds on the columnar engine.
@@ -175,3 +226,83 @@ def test_run_transform_strict_raises_on_uncovered_config_without_polars():
             raise AssertionError("strict=True should have re-raised ImportError")
     """
     _run_polars_free(body, "TRANSFORM-NO-POLARS-STRICT OK")
+
+
+def test_arrow_lane_falls_back_to_columnar_engine(monkeypatch):
+    """IN-PROCESS: the #2430 ladder itself -- arrow lane, polars engine raises
+    ImportError, so the COLUMNAR engine is tried with a `dict[str, list]` and
+    its result is what comes back.
+
+    This is the regression guard that runs EVERYWHERE. The subprocess tests
+    above prove the real end-to-end behavior but need `goldenflow-native`, which
+    the CI python matrix strips -- so on its own the wiring would go unguarded
+    in exactly the lane most likely to break it. Stubbing both engines removes
+    both environment dependencies (no polars-free install, no native kernel)
+    while still exercising the real `run_transform` ladder: the try/except
+    nesting, the arrow-lane discriminator, `to_pydict()` as the columnar input,
+    and the `_engine`-based result branch.
+    """
+    from goldenmatch.config.schemas import TransformConfig
+    from goldenmatch.core import transform as tmod
+
+    seen = {}
+
+    def _polars_engine_unavailable(df):
+        raise ImportError("simulated polars-free install")
+
+    def _fake_columnar(columns, config=None):
+        seen["columns"] = columns
+        return SimpleNamespace(
+            columns={"name": ["Alice", "BOB"], "small": columns["small"]},
+            manifest=SimpleNamespace(records=[]),
+        )
+
+    monkeypatch.setattr(tmod, "_do_transform", _polars_engine_unavailable)
+    monkeypatch.setattr(tmod, "_do_transform_columnar", _fake_columnar)
+
+    tbl = pa.table({
+        "name": pa.array(["  Alice ", "BOB"], pa.string()),
+        "small": pa.array([1, 2], pa.int32()),
+    })
+    out, _ = tmod.run_transform(tbl, TransformConfig(mode="announced"))
+
+    # The columnar engine was reached, with the columnar (dict) input shape.
+    assert isinstance(seen.get("columns"), dict), seen
+    assert seen["columns"]["name"] == ["  Alice ", "BOB"], seen["columns"]
+    # ...and its result -- not the untransformed input -- is what came back.
+    assert isinstance(out, pa.Table), type(out)
+    assert out["name"].to_pylist() == ["Alice", "BOB"], out["name"]
+    # The unchanged column keeps its source arrow type (no int32 -> int64 widen).
+    assert str(out.schema.field("small").type) == "int32", out.schema
+
+
+def test_polars_lane_does_not_fall_back_to_columnar(monkeypatch):
+    """IN-PROCESS: a POLARS-lane caller must NOT be silently rerouted.
+
+    The ladder re-raises for `_is_pl_in` rather than switching engines -- a
+    caller who handed in a `pl.DataFrame` cannot be served a polars-free path,
+    and quietly degrading there would hide a broken install.
+    """
+    pl = pytest.importorskip("polars")
+
+    from goldenmatch.config.schemas import TransformConfig
+    from goldenmatch.core import transform as tmod
+
+    called = []
+
+    def _polars_engine_unavailable(df):
+        raise ImportError("simulated polars-free install")
+
+    monkeypatch.setattr(tmod, "_do_transform", _polars_engine_unavailable)
+    monkeypatch.setattr(
+        tmod, "_do_transform_columnar",
+        lambda *a, **k: called.append(1) or SimpleNamespace(columns={}, manifest=None),
+    )
+
+    df = pl.DataFrame({"name": ["  Alice ", "BOB"]})
+    out, fixes = tmod.run_transform(df, TransformConfig(mode="announced"))
+
+    assert not called, "polars lane must not reroute to the columnar engine"
+    # Degrades (non-strict), returning the frame untouched.
+    assert out["name"].to_list() == ["  Alice ", "BOB"], out["name"]
+    assert fixes == [], fixes

--- a/uv.lock
+++ b/uv.lock
@@ -968,7 +968,7 @@ source = { directory = "packages/rust/extensions/analysis-native" }
 
 [[package]]
 name = "goldencheck"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "packages/python/goldencheck" }
 dependencies = [
     { name = "goldencheck-types" },
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "goldenmatch"
-version = "3.11.0"
+version = "3.12.0"
 source = { editable = "packages/python/goldenmatch" }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Closes #2430.

## What and why

On a polars-free install the arrow lane **silently skipped standardization**. `core/transform.py` bridged arrow through `pl.from_arrow`, caught the resulting `ImportError`, and degraded to no-transform — so dates, phones and whitespace were never normalized while the run continued and reported success. It surfaced downstream, where column profiling saw unstandardized values, and the warning told the user nothing could be done short of installing polars.

## The premise was stale — but not quite the way the issue described

`transform_df` **is** polars-native. But module-level `goldenflow.transform` is a polars-free columnar engine, and — measured, not assumed — its **zero-config auto-detect** covers string / int / float / bool / date columns, standardizing dates to ISO and phones to E.164 with polars never imported.

Worth flagging: GoldenFlow's own docstring says `config=None` zero-config *"declines to the Polars engine"*. That is **not true for these shapes**. The issue's repro passed an explicit config, so it didn't cover the zero-config case that `run_transform` actually uses — and the docstring alone would have made this look unfixable. It does decline on one shape (below).

## Prefer the polars engine, don't replace it

Switching unconditionally — what the issue proposed — would have been a regression. Measured on a 200K×5 arrow frame **with polars present**:

| path | wall | peak RSS |
|---|---|---|
| polars bridge (`pl.from_arrow` → `transform_df`) | **0.70s** | **314 MB** |
| columnar (`to_pydict()` → `transform`) | 1.80s | 531 MB |

2.6× slower, +69% RSS — `to_pydict()` materializes Python lists where `pl.from_arrow` is near-zero-copy. The polars engine also covers strictly more configs.

So this is a fallback **ladder**, not a swap:
1. arrow lane → polars bridge (re-measured after the change at **0.70s / 314 MB** — unregressed, byte-identical)
2. `ImportError` → polars-free columnar engine ← **fixes the bug**
3. `ImportError` again → degrade + warn

Only the broken install changes behavior.

## The degrade path survives, narrowed

It now means *both* engines are unavailable: polars absent **and** the columnar engine declining an uncovered config. The known trigger is an **all-null column**. The warning text, which claimed the whole transform engine was polars-native, now says that accurately — that false claim is what made this look unfixable.

## Also fixed: a dtype artifact found while verifying

A naive `dict`→`pa.table` rebuild silently widens an untouched `int32` column to `int64` — a schema change the polars lane does not make. Unchanged columns now keep their exact arrow type, detected by comparing against the `to_pydict()` already built to feed the engine rather than re-materializing every source column.

## Testing

Verified the two engines produce **identical values** across string/int/float/bool/date, including `date32` → ISO string (which *both* lanes perform).

`test_transform_no_polars.py` is rewritten around a subprocess import blocker, so it runs everywhere rather than only in the `goldenmatch_nopolars` lane:

- standardization is **applied** — asserting **values**, not just "didn't crash". The pre-fix code passed the old shape-only check while skipping standardization entirely, which is exactly how this hid.
- uncovered-config (all-null column) still degrades safely
- `strict=True` still re-raises, so MCP/A2A callers who explicitly requested transforms are never silently handed unstandardized data
- `exclude_columns` still passes a `record_hash` through verbatim with column order preserved (durability contract — that logic wraps the transform, so an engine swap underneath could break it)

```
tests/test_transform_no_polars.py                     4 passed
transform + transforms + nopolars + pipeline + api  116 passed, 8 skipped
scripts/test_agent_codemap.py                         4 passed
ruff check packages/python/goldenmatch                clean
```

## Two housekeeping commits riding along

Both kept as **separate commits** so history reads honestly:

- **`chore(codemap)`** — required by this change. `docs/agent-codemap.json` is generated from the Python source and `test_codemap_current` gates it; the two new helpers in `core/transform.py` made it stale, which is what reddened `config_matrix (goldenmatch)` on the first push. Regenerated; diff verified semantically to be exactly those two names plus sort-order shift, so it isn't sweeping up unrelated drift.
- **`chore(deps)`** — *unrelated* to this fix, surfaced by it. The committed `uv.lock` recorded `goldencheck 3.3.0` / `goldenmatch 3.11.0` while those packages declare `3.4.0` / `3.12.0`; the version bumps landed without the lock being regenerated, so every `uv sync`/`uv run` corrects it. Two bytes, both workspace-member versions, no resolution or third-party changes. Nothing was broken by the staleness (main is green) — it's a consistency fix. Happy to split it out if you'd rather it land on its own.

## Out of scope

Per the issue's own note, `core/quality.py`'s GoldenCheck auto-fix warning is still accurate (`apply_fixes` really is polars-native) and is untouched.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — not run in this sandbox; `ruff check` on the package is clean
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — the stale in-file comment asserting the columnar engine "needs an explicit covered config" is corrected with the measurement