### PR TITLE
fix(goldengraph): unbreak the pipeline lane — `_HAS_FAISS` no longer exists

### DIFF
--- a/packages/python/goldengraph/tests/test_entity_index.py
+++ b/packages/python/goldengraph/tests/test_entity_index.py
@@ -1,7 +1,6 @@
 """SP1 EntityIndex: embed-once ANN retrieval over entity names (box-safe, numpy fallback)."""
 from __future__ import annotations
 
-import goldenmatch.core.ann_blocker as _ab
 import numpy as np
 import pytest
 from goldengraph.entity_index import EntityIndex
@@ -9,8 +8,17 @@ from goldengraph.entity_index import EntityIndex
 
 @pytest.fixture(autouse=True)
 def _force_numpy_fallback(monkeypatch):
-    # Hermetic: never depend on faiss being installed; numpy fallback gives the same neighbor set.
-    monkeypatch.setattr(_ab, "_HAS_FAISS", False)
+    """Pin the exact numpy ANN path so the expected neighbour sets are stable.
+
+    Uses goldenmatch's PUBLIC backend switch rather than patching a private
+    module attribute. The old form set ``ann_blocker._HAS_FAISS``, which stopped
+    existing when goldenmatch replaced its FAISS backend with native HNSW --
+    and because ``monkeypatch.setattr`` raises on a missing attribute, that
+    turned into a collection error across every test using this fixture.
+    ``GOLDENMATCH_ANN_BACKEND`` is documented and honoured unconditionally, so
+    it survives the next internal rename.
+    """
+    monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
 
 
 _VECS = {"apple": [1.0, 0.0, 0.0], "banana": [0.0, 1.0, 0.0], "cherry": [0.0, 0.0, 1.0]}

--- a/packages/python/goldengraph/tests/test_ingest_passages.py
+++ b/packages/python/goldengraph/tests/test_ingest_passages.py
@@ -3,7 +3,6 @@ CorpusBuild(schema, passages), and the GoldenGraph facade threads that PassageIn
 into ask() so mode="hybrid" works out of the box -- no hand-built retriever."""
 from __future__ import annotations
 
-import goldenmatch.core.ann_blocker as _ab
 import pytest
 from goldengraph.ingest import CorpusBuild, ingest_corpus
 from goldengraph.passage_index import PassageIndex
@@ -11,7 +10,17 @@ from goldengraph.passage_index import PassageIndex
 
 @pytest.fixture(autouse=True)
 def _force_numpy_fallback(monkeypatch):
-    monkeypatch.setattr(_ab, "_HAS_FAISS", False)
+    """Pin the exact numpy ANN path so the expected neighbour sets are stable.
+
+    Uses goldenmatch's PUBLIC backend switch rather than patching a private
+    module attribute. The old form set ``ann_blocker._HAS_FAISS``, which stopped
+    existing when goldenmatch replaced its FAISS backend with native HNSW --
+    and because ``monkeypatch.setattr`` raises on a missing attribute, that
+    turned into a collection error across every test using this fixture.
+    ``GOLDENMATCH_ANN_BACKEND`` is documented and honoured unconditionally, so
+    it survives the next internal rename.
+    """
+    monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
 
 
 class _StubLLM:

--- a/packages/python/goldengraph/tests/test_native_parity.py
+++ b/packages/python/goldengraph/tests/test_native_parity.py
@@ -60,7 +60,15 @@ def _load_native():
     except Exception:  # noqa: BLE001
         if require:
             raise
-        pytest.skip("goldengraph._native not built (set GOLDENGRAPH_NATIVE=1 to require)")
+        # allow_module_level is REQUIRED: this runs at import time (via the
+        # module-level `_NATIVE = _load_native()` below), and pytest turns a
+        # plain skip during collection into an ERROR that aborts the WHOLE
+        # session -- so an unbuilt engine took out every other goldengraph test
+        # instead of skipping this one module.
+        pytest.skip(
+            "goldengraph._native not built (set GOLDENGRAPH_NATIVE=1 to require)",
+            allow_module_level=True,
+        )
 
 
 _NATIVE = _load_native()

--- a/packages/python/goldengraph/tests/test_passage_index.py
+++ b/packages/python/goldengraph/tests/test_passage_index.py
@@ -4,7 +4,6 @@ texts per query, and -- unlike EntityIndex -- HOLD the embedder so `retrieve(que
 matches the `passages` protocol `ask` consumes."""
 from __future__ import annotations
 
-import goldenmatch.core.ann_blocker as _ab
 import numpy as np
 import pytest
 from goldengraph.passage_index import PassageIndex
@@ -12,8 +11,17 @@ from goldengraph.passage_index import PassageIndex
 
 @pytest.fixture(autouse=True)
 def _force_numpy_fallback(monkeypatch):
-    # Hermetic: never depend on faiss being installed; numpy fallback gives the same neighbor set.
-    monkeypatch.setattr(_ab, "_HAS_FAISS", False)
+    """Pin the exact numpy ANN path so the expected neighbour sets are stable.
+
+    Uses goldenmatch's PUBLIC backend switch rather than patching a private
+    module attribute. The old form set ``ann_blocker._HAS_FAISS``, which stopped
+    existing when goldenmatch replaced its FAISS backend with native HNSW --
+    and because ``monkeypatch.setattr`` raises on a missing attribute, that
+    turned into a collection error across every test using this fixture.
+    ``GOLDENMATCH_ANN_BACKEND`` is documented and honoured unconditionally, so
+    it survives the next internal rename.
+    """
+    monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
 
 
 _VECS = {"apple": [1.0, 0.0, 0.0], "banana": [0.0, 1.0, 0.0], "cherry": [0.0, 0.0, 1.0]}


### PR DESCRIPTION
`goldengraph-pipeline` has been red on `main` since 2026-08-03 — 12 consecutive runs, all one cause.

## What's actually wrong

```
AttributeError: module 'goldenmatch.core.ann_blocker' has no attribute '_HAS_FAISS'
```

Three test fixtures force the exact numpy ANN path with `monkeypatch.setattr(ann_blocker, "_HAS_FAISS", False)`. goldenmatch replaced its FAISS backend with native HNSW, so that attribute is gone — and `monkeypatch.setattr` raises on a missing attribute by design (that safety net is the only reason this surfaced at all). The fixtures are `autouse`, so all **20** tests using them error at setup.

This is cross-package coupling to a private attribute. goldengraph installs goldenmatch from **monorepo source** (deliberately — the lane exists to test against current `main`), so a goldenmatch-side rename lands here the moment it merges.

## The fix

Use the public switch the private attribute was standing in for:

```python
monkeypatch.setenv("GOLDENMATCH_ANN_BACKEND", "numpy")
```

`_resolve_backend` honours `numpy` unconditionally, it's documented, and it survives the next internal rename. It's also what the fixtures already said they meant — their comments read *"hermetic: never depend on faiss being installed; numpy fallback gives the same neighbor set."*

## A latent defect that made this much worse

`test_native_parity.py` calls `pytest.skip()` at **import** time (via a module-level `_NATIVE = _load_native()`) without `allow_module_level=True`. pytest turns a plain skip during collection into an **error that aborts the entire session** — so a merely-unbuilt native engine took out every other goldengraph test instead of skipping one module.

That's fixed here too. It matters beyond tidiness: it's why my first diagnosis of this outage was **wrong**. Reproducing locally without the native wheel, I saw only that collection error and reported it as the root cause. It wasn't — it was masking the real one. Anyone debugging this lane locally would have hit the same wall.

## Verification

Reproduced CI's environment properly — monorepo goldenmatch installed editable **plus** a locally built `goldengraph-native` wheel — so the numbers reconcile exactly against the failing run:

| | passed | skipped | errors |
|---|---|---|---|
| before | 399 | 6 | **20** |
| after | **419** | 6 | **0** |

399 + 20 = 419. Every previously-erroring test now runs and passes; nothing was skipped away.

## Why nobody noticed for five days

`goldengraph-pipeline` is push-triggered and not in `ci-required`, so `main-health` — which watches *scheduled* lanes — never surfaces it, and no PR gates on it. It only became visible because a PR touched `goldengraph-native/**` and fired the lane.

Worth considering separately: either add this lane to `main-health`'s watch list, or make the goldengraph tests stop reaching into goldenmatch's private module attributes at all (this PR removes the last three such reaches).

## Checklist

- [x] Tests added/updated and passing locally — the fix *is* in tests; verified 419/0 in a CI-equivalent env
- [ ] `pre-commit run --all-files` — not run in this sandbox; `ruff` clean on all four touched files
- [ ] Package `CHANGELOG.md` — test-only fix, no runtime behaviour change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated — n/a; the reasoning is in the fixture docstrings, where the next person will hit it

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_