### PR TITLE
ci: put a ceiling on always-loaded context, and refuse CI-skip directives in commit messages

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -35,6 +35,9 @@ claude_refs:
   - 'packages/python/goldenmatch/docs/context/**'
   - 'scripts/check_claude_refs.py'
   - 'scripts/test_claude_refs.py'
+  - 'scripts/check_context_budget.py'
+  - 'scripts/check_commit_msg.py'
+  - 'scripts/test_context_and_commit_gates.py'
 python_root:
   - 'pyproject.toml'
   - 'uv.lock'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1090,10 +1090,14 @@ jobs:
           python-version: "3.13"
       - name: Every path a CLAUDE.md names exists
         run: python scripts/check_claude_refs.py
+      # The splits in #2445/#2446 were a one-time cut against a +208/-5-per-month
+      # habit. Without a ceiling they regrow.
+      - name: CLAUDE.md files are within their context budget
+        run: python scripts/check_context_budget.py --show
       - name: Gate unit tests
         run: |
           pip install pytest
-          python -m pytest scripts/test_claude_refs.py -q
+          python -m pytest scripts/test_claude_refs.py scripts/test_context_and_commit_gates.py -q
 
   native_symbols:
     needs: changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@
 # rule set, ruff-format) stay in CI so the commit hook never tempts anyone into
 # `git commit --no-verify`. The `ruff` hook below uses the SAME root
 # pyproject.toml [tool.ruff.lint] config CI enforces, so it can't diverge.
+# `commit-msg` is listed so a plain `pre-commit install` wires BOTH stages --
+# without it the CI-skip guard below silently never runs, which is precisely the
+# failure mode it exists to prevent.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.2
@@ -40,3 +45,17 @@ repos:
       # .github/workflows/secret-scan.yml) covers the broader token surface
       # such as the .mcpregistry_* bearer tokens.
       - id: detect-private-key
+
+  - repo: local
+    hooks:
+      # GitHub Actions skips a whole run when the commit message contains
+      # [skip ci] / [ci skip] / [no ci] / [skip actions] ANYWHERE, prose
+      # included. A skipped run leaves ci-required MISSING rather than failing,
+      # so the PR sits in the merge queue looking armed and never merges, with
+      # nothing red. CI cannot catch this -- there is no run to fail -- so it
+      # has to be refused before the commit exists. Bit #1620 and #2445.
+      - id: no-ci-skip-directive
+        name: commit message has no CI-skip directive
+        entry: python scripts/check_commit_msg.py
+        language: system
+        stages: [commit-msg]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,26 @@ section, apply the Tier-1 test: *would an agent do the wrong thing without this,
 on a change anywhere in the repo?* If the answer is "only when touching X", it
 belongs next to X or in `context-network/operations/`, with at most a one-line
 pointer here.
+
+## The context budget is enforced (2026-08-09)
+
+`scripts/check_context_budget.py` caps every `CLAUDE.md` at a declared byte
+budget (`claude_refs` job, `ci-required`). The splits that cut always-loaded
+context 84% were a one-time cleanup against a standing habit — the root file had
+been running +208/−5 lines a month — so the ceiling is what stops the regrowth.
+It is a RATCHET: budgets sit just above current size, growth fails, shrinking is
+reported with a suggested tighter number and never fails. Raising a budget is
+allowed and sometimes right, but it is a visible line in the diff, which is the
+point. `--show` prints every file against its budget.
+
+## A commit message must not contain a CI-skip directive
+
+`[skip ci]` / `[ci skip]` / `[no ci]` / `[skip actions]` anywhere in a commit
+message — **including in prose** — makes GitHub Actions skip the whole run, which
+leaves `ci-required` MISSING rather than failing, so the PR sits in the merge
+queue looking armed and never merges with nothing red to show for it. The
+`no-ci-skip-directive` pre-commit hook (`commit-msg` stage) refuses it. CI cannot
+catch this — there is no run to fail — which is why it lives in a local hook.
+`default_install_hook_types` covers both stages, so a plain `pre-commit install`
+is enough. To write ABOUT the directive, break the literal ("the
+skip-CI-directive trap"); to skip CI deliberately, `git commit --no-verify`.

--- a/scripts/check_commit_msg.py
+++ b/scripts/check_commit_msg.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Reject a commit message containing a CI-skip directive.
+
+WHY THIS EXISTS
+---------------
+GitHub Actions skips a workflow when the HEAD commit message contains
+`[skip ci]`, `[ci skip]`, `[no ci]` or `[skip actions]` ANYWHERE -- including in
+descriptive prose. It does not have to be an instruction; it only has to be the
+substring.
+
+The consequence is silent and expensive. With no CI run on a PR head, the
+required `ci-required` check is MISSING rather than failing, and a missing
+required check is not `success` or `skipped` -- so the PR sits in the merge queue
+looking armed and never merges. Nothing turns red. You wait.
+
+This has now bitten twice. #1620: an empty commit pushed to RE-FIRE CI mentioned
+`[skip ci]` in its own message and skipped itself. #2445: the commit message said
+"the [skip ci] trap" while describing the trap, in a PR that was documenting the
+trap -- the whole ci.yml run was skipped and only 4 of 99 checks ran.
+
+CI cannot catch this. That is the point of putting it here: the run is skipped,
+so there is nothing to fail. It has to be refused before the commit exists.
+
+If you genuinely mean to skip CI, say so deliberately:
+
+    git commit --no-verify
+
+To write ABOUT the directive without triggering it, break the literal -- e.g.
+"the skip-CI-directive trap", or `[skip` + ` ci]` in separate backticks.
+
+Used as a pre-commit `commit-msg` hook; also runnable directly:
+
+    python scripts/check_commit_msg.py .git/COMMIT_EDITMSG
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+# The literals GitHub Actions matches. Case-insensitive, anywhere in the message.
+# NOTE the docstring above deliberately spells the directives out -- this file is
+# documentation, not a commit message, so running the checker against its own
+# source reports hits. That is correct behaviour, not a bug: the hook only ever
+# sees a commit-message file. Do not "fix" it by obfuscating the docstring; a
+# trap you cannot name in its own explanation is worse than the hits.
+_DIRECTIVES = ("skip ci", "ci skip", "no ci", "skip actions")
+_PATTERN = re.compile(
+    r"\[\s*(" + "|".join(d.replace(" ", r"\s+") for d in _DIRECTIVES) + r")\s*\]",
+    re.IGNORECASE,
+)
+
+
+def offending_lines(message: str) -> list[tuple[int, str, str]]:
+    """(lineno, matched text, the line) for every directive found."""
+    hits = []
+    for lineno, line in enumerate(message.splitlines(), 1):
+        # Comment lines are stripped by git before the message is stored.
+        if line.startswith("#"):
+            continue
+        for m in _PATTERN.finditer(line):
+            hits.append((lineno, m.group(0), line.strip()))
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        print(
+            "usage: check_commit_msg.py <path-to-commit-message-file>", file=sys.stderr
+        )
+        return 2
+
+    path = pathlib.Path(args[0])
+    try:
+        message = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"cannot read commit message file {path}: {exc}", file=sys.stderr)
+        return 2
+
+    hits = offending_lines(message)
+    if not hits:
+        return 0
+
+    print(
+        "\nCommit message contains a CI-skip directive:\n", file=sys.stderr
+    )
+    for lineno, matched, line in hits:
+        print(f"  line {lineno}: {matched}", file=sys.stderr)
+        print(f"    {line}", file=sys.stderr)
+    print(
+        "\nGitHub Actions matches these ANYWHERE in the message, including in prose,\n"
+        "and skips the whole run. A skipped run leaves `ci-required` MISSING rather\n"
+        "than failing, so the PR sits in the merge queue looking armed and never\n"
+        "merges -- with nothing red to tell you.\n"
+        "\n"
+        "If you are writing ABOUT the directive, break the literal (e.g.\n"
+        '"the skip-CI-directive trap"). If you really mean to skip CI, commit with\n'
+        "--no-verify.\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Cap the size of the CLAUDE.md files, which are loaded into every session.
+
+WHY THIS EXISTS
+---------------
+#2445 and #2446 cut the context loaded before any goldenmatch work from 259,621
+chars (~64,900 tokens) to 42,859 (~10,700) -- an 84% reduction. That was a
+one-time cleanup against a standing habit: in the 30 days before it, the root
+file alone took +208 / -5 lines. A 40:1 append ratio.
+
+Nothing in that cleanup stops the regrowth. Without a ceiling, the same work is
+due again in six months, and the reason is structural rather than careless: each
+individual addition is genuinely useful to the person adding it, and the cost is
+paid by everyone else, later, invisibly. A budget makes the tradeoff explicit at
+the moment it is taken -- you may add, but you must fold or move something first.
+
+RATCHET, NOT ASPIRATION
+-----------------------
+Budgets are set just above each file's CURRENT size, so this is non-breaking
+today and only ever bites on growth. When a file shrinks well below its budget
+the gate says so and suggests the tightened number; it does NOT fail, because a
+gate that punishes an improvement gets switched off.
+
+Raising a budget is legitimate -- some things genuinely belong in always-loaded
+context -- but it is a visible line in a diff, which is the entire point. Before
+raising one, apply the Tier-1 test: would an agent do the wrong thing without
+this, on a change ANYWHERE in this file's scope? If it is "only when touching X",
+it belongs next to X.
+
+FAIL (exit 1) on an over-budget file, or on a manifest entry naming a file that
+no longer exists. Exit 2 if the scan looks broken.
+
+Run from the repo root:  python scripts/check_context_budget.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Bytes. Set from the size at the time of writing plus modest headroom.
+# A file not listed here gets DEFAULT_BUDGET; crossing that means adding an
+# explicit entry, which is itself the decision this gate exists to surface.
+BUDGETS: dict[str, int] = {
+    # Loaded in EVERY session in every package -- the strictest budget in the repo.
+    "CLAUDE.md": 21_000,
+    "packages/python/CLAUDE.md": 3_000,
+    # Package-level files, loaded whenever that package is touched.
+    "packages/python/goldenmatch/CLAUDE.md": 24_500,
+    "packages/typescript/goldenmatch/CLAUDE.md": 65_000,
+    "packages/python/goldenflow/CLAUDE.md": 46_000,
+    "packages/rust/extensions/CLAUDE.md": 39_000,
+    "packages/python/goldengraph/CLAUDE.md": 36_000,
+    "packages/python/goldencheck/CLAUDE.md": 31_000,
+    "packages/python/goldenpipe/CLAUDE.md": 19_000,
+    "packages/python/infermap/CLAUDE.md": 9_000,
+}
+
+# Anything not named above. Nested subsystem files are all well under this.
+DEFAULT_BUDGET = 10_000
+
+# Report (do not fail) when a file has shrunk this far below its budget, so the
+# ratchet can be tightened in the PR that did the shrinking.
+SLACK_REPORT_THRESHOLD = 0.25
+
+MIN_EXPECTED_FILES = 10
+
+
+def claude_files() -> list[pathlib.Path]:
+    return sorted(
+        p
+        for p in ROOT.rglob("CLAUDE.md")
+        if "node_modules" not in p.parts and "_archive" not in p.parts
+    )
+
+
+def budget_for(rel: str) -> int:
+    return BUDGETS.get(rel, DEFAULT_BUDGET)
+
+
+def check() -> tuple[list[str], list[str], int]:
+    """Return (failures, notes, files_scanned)."""
+    failures: list[str] = []
+    notes: list[str] = []
+
+    files = claude_files()
+    for path in files:
+        rel = path.relative_to(ROOT).as_posix()
+        size = path.stat().st_size
+        budget = budget_for(rel)
+        if size > budget:
+            over = size - budget
+            explicit = rel in BUDGETS
+            failures.append(
+                f"::error file={rel}::{rel}: {size:,} bytes exceeds its "
+                f"{budget:,}-byte budget by {over:,}. Fold or move {over:,} bytes "
+                f"out (see context-network/operations/ and the package docs/context/ "
+                f"dirs for where extracted detail lives), or raise the budget in "
+                f"scripts/check_context_budget.py"
+                + ("" if explicit else " by adding an explicit entry")
+                + " and say why in the PR."
+            )
+        elif size < budget * (1 - SLACK_REPORT_THRESHOLD) and rel in BUDGETS:
+            suggested = ((size * 11 // 10) // 500 + 1) * 500
+            notes.append(
+                f"{rel}: {size:,} bytes against a {budget:,} budget -- consider "
+                f"tightening the ratchet to {suggested:,}"
+            )
+
+    for rel in BUDGETS:
+        if not (ROOT / rel).exists():
+            failures.append(
+                f"::error::{rel} has a budget entry but does not exist -- remove the "
+                f"stale entry from BUDGETS (a manifest that names missing files "
+                f"cannot be trusted to name the present ones)"
+            )
+
+    return failures, notes, len(files)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--show", action="store_true", help="print every file with its budget and headroom"
+    )
+    args = ap.parse_args(argv)
+
+    failures, notes, scanned = check()
+
+    if scanned < MIN_EXPECTED_FILES:
+        print(
+            f"::error::found only {scanned} CLAUDE.md file(s) -- below the "
+            f"{MIN_EXPECTED_FILES} floor, so the scan is broken, not clean",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.show:
+        for path in claude_files():
+            rel = path.relative_to(ROOT).as_posix()
+            size = path.stat().st_size
+            budget = budget_for(rel)
+            flag = "OVER" if size > budget else f"{100 * size // budget:>3}%"
+            print(f"  {flag}  {size:>7,} / {budget:>7,}  {rel}")
+
+    total = sum(p.stat().st_size for p in claude_files())
+    print(f"context budget: {scanned} CLAUDE.md file(s), {total:,} bytes total")
+
+    for note in notes:
+        print(f"  note: {note}")
+
+    if failures:
+        for f in failures:
+            print(f, file=sys.stderr)
+        print(
+            f"\n{len(failures)} budget violation(s). These files are loaded into every "
+            f"session in their scope, so bytes here are a tax on all of that work.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("  OK -- every CLAUDE.md is within budget.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_context_and_commit_gates.py
+++ b/scripts/test_context_and_commit_gates.py
@@ -1,0 +1,171 @@
+"""Unit tests for the context-budget gate and the commit-message gate.
+
+Both exist because a documented trap kept firing. The tests pin the behaviour
+that makes them worth having: the budget must bite on growth but never on an
+improvement, and the commit-message check must match the way GitHub Actions
+actually matches -- anywhere in the message, prose included.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_commit_msg as msg  # noqa: E402
+import check_context_budget as budget  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# context budget
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """A fake repo whose CLAUDE.md sizes the gate will measure."""
+    monkeypatch.setattr(budget, "ROOT", tmp_path)
+
+    def write(rel: str, size: int) -> Path:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x" * size, encoding="utf-8")
+        return p
+
+    return write
+
+
+def test_over_budget_fails(tree, monkeypatch):
+    monkeypatch.setattr(budget, "BUDGETS", {"CLAUDE.md": 100})
+    tree("CLAUDE.md", 500)
+    failures, _, _ = budget.check()
+    assert len(failures) == 1
+    assert "exceeds its 100-byte budget by 400" in failures[0]
+
+
+def test_within_budget_passes(tree, monkeypatch):
+    monkeypatch.setattr(budget, "BUDGETS", {"CLAUDE.md": 1000})
+    tree("CLAUDE.md", 900)
+    assert budget.check()[0] == []
+
+
+def test_exactly_at_budget_passes(tree, monkeypatch):
+    """The budget is a ceiling, not a strict inequality -- off-by-one matters."""
+    monkeypatch.setattr(budget, "BUDGETS", {"CLAUDE.md": 500})
+    tree("CLAUDE.md", 500)
+    assert budget.check()[0] == []
+
+
+def test_shrinking_is_reported_but_never_fails(tree, monkeypatch):
+    """A gate that punishes an improvement gets switched off."""
+    monkeypatch.setattr(budget, "BUDGETS", {"CLAUDE.md": 10_000})
+    tree("CLAUDE.md", 1_000)
+    failures, notes, _ = budget.check()
+    assert failures == []
+    assert len(notes) == 1
+    assert "tightening the ratchet" in notes[0]
+
+
+def test_unlisted_file_uses_the_default_budget(tree, monkeypatch):
+    monkeypatch.setattr(budget, "BUDGETS", {})
+    monkeypatch.setattr(budget, "DEFAULT_BUDGET", 200)
+    tree("packages/x/CLAUDE.md", 500)
+    failures, _, _ = budget.check()
+    assert len(failures) == 1
+    assert "by adding an explicit entry" in failures[0]
+
+
+def test_stale_budget_entry_fails(tree, monkeypatch):
+    """A manifest naming missing files can't be trusted to name the present ones."""
+    monkeypatch.setattr(budget, "BUDGETS", {"gone/CLAUDE.md": 1000})
+    tree("CLAUDE.md", 10)
+    failures, _, _ = budget.check()
+    assert any("has a budget entry but does not exist" in f for f in failures)
+
+
+def test_scan_floor_reports_broken_not_clean(tree, monkeypatch, capsys):
+    monkeypatch.setattr(budget, "BUDGETS", {})
+    tree("CLAUDE.md", 10)
+    assert budget.main([]) == 2
+    assert "the scan is broken" in capsys.readouterr().err
+
+
+def test_the_repo_as_it_stands_is_within_budget():
+    """End-to-end on the real tree -- the state the gate must hold."""
+    failures, _, scanned = budget.check()
+    assert scanned >= budget.MIN_EXPECTED_FILES, scanned
+    assert failures == [], failures
+
+
+def test_every_budget_entry_names_a_real_file():
+    missing = [rel for rel in budget.BUDGETS if not (budget.ROOT / rel).exists()]
+    assert not missing, missing
+
+
+# --------------------------------------------------------------------------
+# commit message
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "chore: x\n\n[skip ci]\n",
+        "chore: x\n\n[ci skip]\n",
+        "chore: x\n\n[no ci]\n",
+        "chore: x\n\n[skip actions]\n",
+        "chore: x\n\n[SKIP CI]\n",  # case-insensitive
+        "chore: x\n\n[ skip ci ]\n",  # padded
+        # The two that actually happened: the directive in DESCRIPTIVE prose.
+        "chore: re-trigger CI after the [skip ci] baseline\n",
+        "docs: explain the [skip ci] trap\n",
+    ],
+)
+def test_directives_are_rejected(tmp_path, body):
+    p = tmp_path / "COMMIT_EDITMSG"
+    p.write_text(body, encoding="utf-8")
+    assert msg.main([str(p)]) == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "feat: a normal message\n\nwith a body\n",
+        "docs: the skip-CI-directive trap\n",  # the documented workaround
+        "chore: skip ci without brackets is not a directive\n",
+        "chore: mentions [skipping] and [cider] but neither matches\n",
+    ],
+)
+def test_clean_messages_pass(tmp_path, body):
+    p = tmp_path / "COMMIT_EDITMSG"
+    p.write_text(body, encoding="utf-8")
+    assert msg.main([str(p)]) == 0
+
+
+def test_comment_lines_are_ignored(tmp_path):
+    """git strips `#` lines before storing, so they never reach Actions."""
+    p = tmp_path / "COMMIT_EDITMSG"
+    p.write_text("feat: x\n\n# [skip ci] would be stripped by git\n", encoding="utf-8")
+    assert msg.main([str(p)]) == 0
+
+
+def test_reports_line_number_and_match(tmp_path, capsys):
+    p = tmp_path / "COMMIT_EDITMSG"
+    p.write_text("feat: x\n\nbody\nthe [ci skip] mention\n", encoding="utf-8")
+    msg.main([str(p)])
+    err = capsys.readouterr().err
+    assert "line 4" in err
+    assert "[ci skip]" in err
+    assert "--no-verify" in err  # the deliberate-override escape hatch
+
+
+def test_missing_argument_is_a_usage_error(capsys):
+    assert msg.main([]) == 2
+
+
+def test_unreadable_file_is_an_error_not_a_pass(tmp_path):
+    assert msg.main([str(tmp_path / "nope")]) == 2

--- a/scripts/test_context_and_commit_gates.py
+++ b/scripts/test_context_and_commit_gates.py
@@ -9,7 +9,6 @@ actually matches -- anywhere in the message, prose included.
 from __future__ import annotations
 
 import sys
-import textwrap
 from pathlib import Path
 
 import pytest
@@ -18,7 +17,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import check_commit_msg as msg  # noqa: E402
 import check_context_budget as budget  # noqa: E402
-
 
 # --------------------------------------------------------------------------
 # context budget


### PR DESCRIPTION
Two follow-ups to #2445 / #2446, both the same shape: **a cleanup that doesn't defend itself gets undone.**

## 1. `scripts/check_context_budget.py`

The splits cut always-loaded context from 259,621 chars (~64,900 tokens) to 42,859 (~10,700). That was one-time work against a standing habit — the root file had been running **+208 / −5 lines a month**. Nothing in the cleanup stops regrowth, and the reason it regrows is structural rather than careless: each addition is genuinely useful to whoever adds it, and the cost is paid by everyone else, later, invisibly.

**It's a ratchet, not an aspiration.** Budgets sit just above current size, so this is non-breaking today and only bites on growth. Shrinking is *reported* with a suggested tighter number and never fails — a gate that punishes an improvement gets switched off. Raising a budget stays legitimate; it's just a visible line in a diff, which is the entire mechanism. A stale entry naming a deleted file **fails**, same no-silent-skip discipline as the other gates.

Current state (`--show`):

```
 90%   19,013 /  21,000  CLAUDE.md
 90%   22,165 /  24,500  packages/python/goldenmatch/CLAUDE.md
 96%   62,908 /  65,000  packages/typescript/goldenmatch/CLAUDE.md
 97%   44,676 /  46,000  packages/python/goldenflow/CLAUDE.md
 96%   37,527 /  39,000  packages/rust/extensions/CLAUDE.md
 96%   34,766 /  36,000  packages/python/goldengraph/CLAUDE.md
```

The three biggest untouched package files are now pinned where they are. They're the obvious candidates for the next split, and the budget is what will make that visible when someone tries to grow them.

## 2. The `commit-msg` hook

GitHub Actions skips a run when the message contains a skip-CI directive **anywhere, prose included**. A skipped run leaves `ci-required` MISSING rather than failing, so the PR sits in the merge queue looking armed and never merges, with nothing red to explain it.

This has now bitten three times:

| | what happened |
|---|---|
| #1620 | an empty commit pushed to *re-fire* CI mentioned the directive and skipped itself |
| #2445 | my commit message described the trap using the literal — 4 of 99 checks ran |
| **this PR** | **my first commit message did it again, describing #2445.** The new hook rejected it before push |

That third one is the argument for the hook. I was maximally aware of this failure mode — I'd written the paragraph about it minutes earlier — and still walked into it, because the failure is invisible at commit time.

**CI structurally cannot catch this**: there's no run to fail. So it's a `commit-msg` pre-commit hook, and `.pre-commit-config.yaml` now declares `default_install_hook_types` so a plain `pre-commit install` wires both stages — without that the guard would silently never run, which is precisely the failure mode it exists to prevent. `git commit --no-verify` remains the deliberate override.

One deliberate oddity: the checker reports hits when run against **its own source**, because the docstring spells the directives out. That's correct — the hook only ever sees a commit-message file — and there's a comment saying not to "fix" it by obfuscating the explanation. A trap you can't name in its own documentation is worse than the hits.

## Testing

- **25 new unit tests**, including both real incident messages, the documented workaround phrasing, and near-misses (`[skipping]`, `[cider]`, unbracketed prose) that must **not** trip
- Budget tests cover the ratchet directions explicitly: over-budget fails, exactly-at-budget passes, shrinking reports-but-never-fails, stale entry fails, empty scan reports broken
- **56 tests green** across all four doc/CI gates
- `check_claude_refs` / `check_context_budget` / `check_workflow_yaml` / `check_filter_coverage` all pass
- The final commit message on this PR was checked against the new hook before pushing

## Checklist

- [x] Tests added/updated and passing locally
- [ ] `pre-commit run --all-files` — not run in this sandbox
- [ ] Package `CHANGELOG.md` — CI-only, no runtime behaviour
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_