### PR TITLE
feat(goldenflow): accept a pyarrow Table/RecordBatch in transform() (#2447)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -10827,6 +10827,7 @@
             "_autoconfig_columns",
             "_cast_utf8",
             "_frame_level_blocked",
+            "_is_arrow_frame",
             "_numeric_inmem_ok",
             "_sample3",
             "_scalar_fn",

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`transform()` accepts a pyarrow `Table`/`RecordBatch` (#2447).** The engine was
+  already Polars-free and `transform("<path>.parquet")` already read that file WITH
+  pyarrow, but the `pa.Table` you got from reading the same file yourself was
+  rejected and redirected to `transform_df()` -- the one entry point that cannot
+  serve a Polars-free caller. An Arrow-native pipeline therefore got no
+  standardization at all. An Arrow frame IS a typed column dict, so `to_pydict()` is
+  the whole conversion and every downstream path is unchanged; like the `.parquet`
+  path and unlike `.csv`, the resulting dict is TYPED. Detection is attribute-based
+  (`to_pydict` + `column_names`) so it never imports pyarrow -- an optional extra
+  (`goldenflow[parquet]`) -- and cannot capture a `pl.DataFrame`, which exposes
+  `to_dict`/`columns`. `transform_df()` now raises a `TypeError` pointing at
+  `transform()` instead of dying on `ModuleNotFoundError: No module named 'polars'`
+  deep in the engine; that direction is deliberate, keeping ONE Polars-free door.
+
 ## 2.1.0 (2026-07-13)
 
 ### Owned auto-detect profile kernel

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -575,8 +575,12 @@ The columnar path (`engine/columnar.py`) is the DEFAULT for the public `transfor
 runs **Polars-free**: `import goldenflow` imports no Polars, all 113 transforms + CSV/
 Parquet/Excel/DB read + dict/file zero-config run without Polars. Only the 2.0 base-deps
 flip remains (drop `polars` from `[project.dependencies]` -> the `[polars]` extra).
-- **`transform(data, config)`** (Polars-free primary) takes a `dict[str, list]` or a path
-  (`.csv`/`.parquet`/`.xlsx`) -> `ColumnarResult`. Readers: `read_csv_columns` (stdlib
+- **`transform(data, config)`** (Polars-free primary) takes a `dict[str, list]`, a
+  pyarrow `Table`/`RecordBatch` (#2447 -- an arrow frame IS a typed column dict, so
+  `to_pydict()` is the whole conversion; detected by attribute so the check never
+  imports pyarrow, an optional extra here), or a path
+  (`.csv`/`.parquet`/`.xlsx`) -> `ColumnarResult`. `transform_df` REJECTS an arrow
+  frame with a pointer here rather than becoming a second Polars-free door. Readers: `read_csv_columns` (stdlib
   csv), `read_parquet_columns` (pyarrow `to_pydict`), `read_excel_columns` (openpyxl),
   `connectors.database.read_database_columns` (any DBAPI). `transform_df(pl.DataFrame)` is
   the Polars-backend adapter (tautologically needs Polars).

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -84,7 +84,24 @@ def transform_file(path, config=None, output_dir=None):
 
 
 def transform_df(df, config=None):
-    """Convenience function: transform a DataFrame."""
+    """Convenience function: transform a ``pl.DataFrame`` (needs ``goldenflow[polars]``).
+
+    An Arrow frame is redirected to :func:`transform`, which handles it Polars-free.
+    That direction is deliberate: `transform` is THE Polars-free door, and making
+    this a second one would duplicate the surface. Before the redirect an Arrow
+    caller got `ModuleNotFoundError: No module named 'polars'` from deep inside the
+    engine, which named the missing package but not the fact that a supported
+    Polars-free path existed two functions away (#2447).
+    """
+    from goldenflow.engine.columnar import _is_arrow_frame
+
+    if _is_arrow_frame(df):
+        raise TypeError(
+            "transform_df() is the polars engine; pass an arrow Table/RecordBatch "
+            "to transform() instead, which handles it polars-free and returns a "
+            "ColumnarResult (.columns dict + .manifest). transform_df() needs "
+            "goldenflow[polars] and a pl.DataFrame."
+        )
     engine = TransformEngine(config=config)
     return engine.transform_df(df)
 

--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -571,6 +571,17 @@ def read_excel_columns(path) -> dict[str, list]:
 _TYPED_READERS = {".parquet": read_parquet_columns, ".xlsx": read_excel_columns}
 
 
+def _is_arrow_frame(obj) -> bool:
+    """Whether `obj` quacks like a `pyarrow.Table` / `RecordBatch`.
+
+    Attribute-based rather than `isinstance`, so the check itself never imports
+    pyarrow -- it is an optional extra (`goldenflow[parquet]`), and a caller
+    passing a dict must not pay for it. `pl.DataFrame` exposes `to_dict` and
+    `columns`, not `to_pydict`/`column_names`, so it cannot be captured here.
+    """
+    return hasattr(obj, "to_pydict") and hasattr(obj, "column_names")
+
+
 def transform_columns_public(data, config):
     """Phase 4c/4e public core: transform a ``dict[str, list]`` frame OR a CSV path
     (str/``Path`` ending ``.csv``), returning a :class:`ColumnarResult` (Polars-free).
@@ -608,10 +619,30 @@ def transform_columns_public(data, config):
                 f"transform() reads .csv/.parquet/.xlsx paths Polars-free; "
                 f"{suffix or 'this'} needs transform_df() / read_file() with goldenflow[polars]."
             )
+    elif _is_arrow_frame(data):
+        # An Arrow table IS a typed column dict -- `to_pydict()` is the whole
+        # conversion, and everything below already works on that shape. Accepting
+        # it closes an odd asymmetry: `transform("<path>.parquet")` reads the file
+        # WITH pyarrow (the [parquet] extra) and transforms it Polars-free, but the
+        # `pa.Table` you get from reading that same file yourself was rejected and
+        # redirected to `transform_df()`, the one entry point that cannot serve a
+        # Polars-free caller (#2447).
+        #
+        # Duck-typed on purpose: detecting an Arrow frame must not import pyarrow,
+        # which is an OPTIONAL extra here. A caller holding a pa.Table necessarily
+        # has pyarrow, so `to_pydict()` is safe to call -- but a caller who does not
+        # must never pay an import for the check. `pl.DataFrame` has neither
+        # attribute (it uses `to_dict`/`columns`), so this cannot capture it.
+        #
+        # Dtype regime: like the .parquet path and unlike .csv, an Arrow frame
+        # carries real dtypes, so the resulting dict is TYPED -- no string-inference
+        # gap, and no coercion of "01234" to an int.
+        data = data.to_pydict()
     elif not isinstance(data, dict):
         raise TypeError(
-            "transform() takes a dict[str, list] of columns or a .csv path; pass a "
-            "pl.DataFrame to transform_df() instead."
+            "transform() takes a dict[str, list] of columns, a pyarrow Table/"
+            "RecordBatch, or a .csv/.parquet/.xlsx path; pass a pl.DataFrame to "
+            "transform_df() instead."
         )
 
     nm = native_module()

--- a/packages/python/goldenflow/tests/engine/test_columnar_arrow_input.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_arrow_input.py
@@ -1,0 +1,115 @@
+"""#2447: ``transform()`` accepts a pyarrow Table/RecordBatch Polars-free.
+
+The engine is Polars-free and `transform()` already runs a covered config over a
+``dict[str, list]``. It also reads ``transform("<path>.parquet")`` WITH pyarrow (the
+``[parquet]`` extra) and transforms it Polars-free. What it rejected was the
+``pa.Table`` you get from reading that same file yourself -- redirecting to
+``transform_df()``, the one entry point that cannot serve a Polars-free caller. So
+an Arrow-native pipeline got no standardization at all, and (per the report) full
+runs went out with transforms silently off.
+
+An Arrow frame IS a typed column dict, so `to_pydict()` is the whole conversion.
+The detection is attribute-based so it never imports pyarrow -- an optional extra
+here.
+"""
+from __future__ import annotations
+
+import goldenflow
+import pytest
+from goldenflow.engine.columnar import _is_arrow_frame
+
+pa = pytest.importorskip("pyarrow", reason="arrow input needs goldenflow[parquet]")
+
+
+# ── detection ────────────────────────────────────────────────────────────────
+
+
+def test_detects_table_and_record_batch():
+    assert _is_arrow_frame(pa.table({"c": ["x"]}))
+    assert _is_arrow_frame(pa.record_batch([pa.array(["x"])], names=["c"]))
+
+
+def test_does_not_capture_a_polars_frame():
+    """`pl.DataFrame` uses `to_dict`/`columns`, not `to_pydict`/`column_names`.
+    If this ever inverted, polars frames would silently take the arrow path."""
+    pl = pytest.importorskip("polars")
+    assert not _is_arrow_frame(pl.DataFrame({"c": ["x"]}))
+
+
+@pytest.mark.parametrize("obj", [{"c": ["x"]}, "data.csv", 42, None, ["x"]])
+def test_does_not_capture_other_inputs(obj):
+    assert not _is_arrow_frame(obj)
+
+
+def test_detection_does_not_import_pyarrow(monkeypatch):
+    """pyarrow is an OPTIONAL extra; a dict caller must not pay an import for the
+    check. Guards the reason this is duck-typed instead of `isinstance`."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _boom(name, *a, **k):
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise AssertionError("detection must not import pyarrow")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _boom)
+    assert not _is_arrow_frame({"c": ["x"]})
+    assert not _is_arrow_frame("data.csv")
+
+
+# ── the reported case ────────────────────────────────────────────────────────
+
+
+def test_arrow_table_transforms_with_a_full_manifest():
+    """The exact shape from #2447: the columnar API produced cleaned values and a
+    5-record manifest, while the same data as a pa.Table produced nothing."""
+    res = goldenflow.transform(pa.table({"city": ["  St. Louis  ", "cincinnati"]}))
+    assert res.columns == {"city": ["St. Louis", "cincinnati"]}
+    assert res.manifest.records, "arrow input must produce an audit manifest"
+    assert {r.transform for r in res.manifest.records} >= {"strip"}
+
+
+def test_arrow_matches_the_equivalent_dict_exactly():
+    """Arrow is a shape, not a semantic -- it must not change the result."""
+    cols = {"city": ["  St. Louis  ", "cincinnati", None], "n": ["1", "2", "3"]}
+    from_dict = goldenflow.transform(dict(cols))
+    from_arrow = goldenflow.transform(pa.table(cols))
+    assert from_arrow.columns == from_dict.columns
+    assert [(r.column, r.transform, r.affected_rows) for r in from_arrow.manifest.records] == \
+           [(r.column, r.transform, r.affected_rows) for r in from_dict.manifest.records]
+
+
+def test_record_batch_works_too():
+    rb = pa.record_batch([pa.array(["  x  "])], names=["c"])
+    assert goldenflow.transform(rb).columns == {"c": ["x"]}
+
+
+def test_nulls_survive_the_conversion():
+    res = goldenflow.transform(pa.table({"c": ["  a  ", None]}))
+    assert res.columns["c"] == ["a", None]
+
+
+def test_dict_input_is_unaffected():
+    assert goldenflow.transform({"city": ["  y  "]}).columns == {"city": ["y"]}
+
+
+# ── transform_df redirects rather than dying deep ────────────────────────────
+
+
+def test_transform_df_redirects_arrow_to_transform():
+    """Deliberately NOT a second polars-free door. Before this, an arrow caller got
+    `ModuleNotFoundError: No module named 'polars'` from inside the engine, which
+    named the missing package but not the supported path two functions away."""
+    with pytest.raises(TypeError) as ei:
+        goldenflow.transform_df(pa.table({"city": ["a"]}))
+    msg = str(ei.value)
+    assert "transform()" in msg
+    assert "polars-free" in msg
+
+
+def test_the_rejection_message_lists_arrow_as_accepted():
+    """An unsupported input should not send an arrow user to transform_df()."""
+    with pytest.raises(TypeError) as ei:
+        goldenflow.transform(42)
+    assert "RecordBatch" in str(ei.value)


### PR DESCRIPTION
Closes #2447.

## The gap, sharper than the issue states it

| call | before |
|---|---|
| `transform({"city": [...]})` | works, polars-free, native engine |
| `transform("data.parquet")` | works, polars-free — **reads it with pyarrow** |
| `transform(pa.Table)` | `TypeError` → "pass a pl.DataFrame to `transform_df()` instead" |
| `transform_df(pa.Table)` | `ModuleNotFoundError: No module named 'polars'` |

goldenflow would read a parquet file *using pyarrow* and transform it Polars-free, then reject the `pa.Table` you get from reading that same file yourself — redirecting you to the one entry point that **cannot** serve a Polars-free caller. So an Arrow-native pipeline got no standardization at all, and per the report, full runs went out with transforms silently off.

## Why this one is small, unlike #2442 / #2448

The opposite situation. There, the entry point was Arrow-shaped and everything behind it was polars, so an Arrow branch would only have moved the failure. **Here everything behind `transform()` is already polars-free** — native columnar engine, manifest, `ColumnarResult`. An Arrow frame *is* a typed column dict, so `to_pydict()` is the whole conversion and no downstream path changes.

Dtype regime lands right too: like `.parquet` and unlike `.csv`, the result is **typed** — no string-inference gap, no coercing `"01234"` to an int.

## Detection is attribute-based, on purpose

```python
def _is_arrow_frame(obj) -> bool:
    return hasattr(obj, "to_pydict") and hasattr(obj, "column_names")
```

`isinstance` would need `import pyarrow`, which is an **optional extra** here (`goldenflow[parquet]`) — a dict caller must not pay an import for the check. A caller holding a `pa.Table` necessarily has pyarrow, so `to_pydict()` is safe to call.

`pl.DataFrame` exposes `to_dict`/`columns`, not `to_pydict`/`column_names`, so it cannot be captured. There's a test pinning that, because an inversion would silently route polars frames down the Arrow path. Another test monkeypatches `__import__` to prove detection never imports pyarrow.

## `transform_df` redirects rather than becoming a second door

It now raises a `TypeError` pointing at `transform()`. That direction is deliberate: `transform` is already *the* polars-free door, and duplicating it would double the surface for no gain. The old failure named the missing package but not the supported path two functions away.

## Scope held narrow

`ColumnarResult.to_arrow()` — the mirror of the existing `to_polars()` — is **not** here. It's a separate public symbol and a separate decision; happy to add it as a follow-up if you want the symmetry.

No transform added, so `parity/goldenflow.yaml`'s `transforms` surface is untouched. Worth noting the asymmetry this does create: Python's `transform()` now accepts an input type the TS port doesn't. That's a deliberate call, not an oversight — flagging it since parity discipline is what makes those visible.

## Testing

**15 new tests** in `tests/engine/test_columnar_arrow_input.py`:

- the reported case end to end — cleaned values plus a populated manifest
- **arrow output byte-equal to the equivalent dict input**, columns *and* manifest records — arrow is a shape, not a semantic
- `RecordBatch`, null survival, dict input unaffected
- polars-frame non-capture, and the `__import__` guard
- `transform_df` redirect, and that the rejection message now lists arrow as accepted

Plus: **306 goldenflow engine/nopolars/parity tests pass**; `ruff` clean; `check_docs_consistency` / `check_claude_refs` / `check_context_budget` / `agent_codemap` all pass.

Two local failures I checked rather than waved off: `test_transformer.py`'s two cases fail on a **clean stash of main** too (missing `openai` optional dep in this sandbox), and `api_parity`'s TS emitter is documented CI-only.

## Checklist

- [x] Tests added/updated and passing locally
- [ ] `pre-commit run --all-files` — not run in this sandbox
- [x] Package `CHANGELOG.md` updated (added the `[Unreleased]` section — goldenflow had none)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated — the Polars-eviction section's `transform()` signature line was stale the moment this landed

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_