### PR TITLE
ci: lint scripts/, and add ColumnarResult.to_arrow()

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -38,6 +38,15 @@ claude_refs:
   - 'scripts/check_context_budget.py'
   - 'scripts/check_commit_msg.py'
   - 'scripts/test_context_and_commit_gates.py'
+# scripts/ is ~100 files including 24 check_*.py gates that ci-required depends
+# on, and NOTHING linted it: the python matrix runs `ruff check
+# packages/python/<pkg>`, which never reaches here. So the repo's own ruff config
+# (F/I/B/UP) was enforced everywhere except the directory enforcing everything
+# else. Found via a code-quality bot flagging an unused import CI could not have
+# caught (#2449).
+scripts_lint:
+  - 'scripts/**'
+  - 'pyproject.toml'
 python_root:
   - 'pyproject.toml'
   - 'uv.lock'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       # ci_workflow so widening it cannot change force_all's merge-queue meaning.
       any_workflow: ${{ steps.filter.outputs.any_workflow }}
       claude_refs: ${{ steps.filter.outputs.claude_refs }}
+      scripts_lint: ${{ steps.filter.outputs.scripts_lint }}
       # force_all: forces the full job matrix + the dynamic python matrix,
       # bypassing the path filters. True on (1) workflow_dispatch run_all=true,
       # and (2) a merge_group entry that edits ci.yml itself (so the filter
@@ -1073,6 +1074,31 @@ jobs:
         run: |
           pip install pytest
           python -m pytest scripts/test_downstream_symbols.py -q
+
+  # scripts/ holds the gates ci-required leans on, and was the one Python
+  # directory no lint ever reached -- the python matrix lints
+  # packages/python/<pkg> only.
+  scripts_lint:
+    needs: changes
+    if: needs.changes.outputs.scripts_lint == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      # `uv run ruff`, exactly as the package lanes invoke it, so BOTH the rule
+      # set (root pyproject [tool.ruff.lint]) and the ruff VERSION are shared.
+      # Pinning a version here instead looked tidier and was wrong: uvx ruff@0.9.2
+      # (the pre-commit pin) reports 24 findings the workspace ruff does not, so
+      # the job would have landed red against a scripts/ tree that is clean under
+      # the linter every other lane runs.
+      - name: Sync workspace (resolves the same ruff the package lanes use)
+        run: uv sync --no-install-workspace
+      - name: Ruff (scripts/)
+        run: uv run ruff check scripts/
 
   # Every repo path a CLAUDE.md names must exist. These files are loaded as
   # authoritative agent context, so a dead pointer does not merely fail to help --
@@ -4150,6 +4176,7 @@ jobs:
       - native_symbols
       - downstream_symbols
       - claude_refs
+      - scripts_lint
       - config_matrix
       - er_matcher
     if: always()

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- **`ColumnarResult.to_arrow()`** — the mirror of the existing `to_polars()`,
+  completing the round trip opened by `transform(pa.Table)`: an arrow caller hands
+  data in and gets it back in the same shape instead of unpacking a dict by hand.
+  Deferred import like `to_polars`, so the Polars-free dict path still never
+  requires pyarrow; calling the method is the opt-in.
 - **`transform()` accepts a pyarrow `Table`/`RecordBatch` (#2447).** The engine was
   already Polars-free and `transform("<path>.parquet")` already read that file WITH
   pyarrow, but the `pa.Table` you got from reading the same file yourself was

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -580,7 +580,8 @@ flip remains (drop `polars` from `[project.dependencies]` -> the `[polars]` extr
   `to_pydict()` is the whole conversion; detected by attribute so the check never
   imports pyarrow, an optional extra here), or a path
   (`.csv`/`.parquet`/`.xlsx`) -> `ColumnarResult`. `transform_df` REJECTS an arrow
-  frame with a pointer here rather than becoming a second Polars-free door. Readers: `read_csv_columns` (stdlib
+  frame with a pointer here rather than becoming a second Polars-free door.
+  `ColumnarResult.to_arrow()` mirrors `to_polars()` (both deferred-import). Readers: `read_csv_columns` (stdlib
   csv), `read_parquet_columns` (pyarrow `to_pydict`), `read_excel_columns` (openpyxl),
   `connectors.database.read_database_columns` (any DBAPI). `transform_df(pl.DataFrame)` is
   the Polars-backend adapter (tautologically needs Polars).

--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -59,6 +59,21 @@ class ColumnarResult:
 
         return pl.DataFrame(self.columns)
 
+    def to_arrow(self):
+        """Bridge to a ``pyarrow.Table`` (imports pyarrow — opt-in).
+
+        The mirror of :meth:`to_polars`, completing the round trip opened by
+        `transform(pa.Table)` (#2447): an arrow caller can now hand data in and get
+        it back in the same shape rather than unpacking a dict by hand.
+
+        Deferred import, like `to_polars`: pyarrow is an optional extra
+        (``goldenflow[parquet]``) and the Polars-free dict path must never require
+        it. Calling this method is the opt-in.
+        """
+        import pyarrow as pa
+
+        return pa.table(self.columns)
+
 
 def columnar_engine_selected() -> bool:
     """True when ``GOLDENFLOW_ENGINE=columnar`` opts into the Polars-free path."""

--- a/packages/python/goldenflow/tests/engine/test_columnar_arrow_input.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_arrow_input.py
@@ -113,3 +113,48 @@ def test_the_rejection_message_lists_arrow_as_accepted():
     with pytest.raises(TypeError) as ei:
         goldenflow.transform(42)
     assert "RecordBatch" in str(ei.value)
+
+
+# ── to_arrow(): the mirror of to_polars(), closing the round trip ────────────
+
+
+def test_to_arrow_round_trips_an_arrow_input():
+    res = goldenflow.transform(pa.table({"city": ["  St. Louis  ", "cincinnati"]}))
+    out = res.to_arrow()
+    assert isinstance(out, pa.Table)
+    assert out.to_pydict() == {"city": ["St. Louis", "cincinnati"]}
+
+
+def test_to_arrow_works_from_a_dict_input_too():
+    """The bridge is on the RESULT, so it does not care how the data arrived."""
+    out = goldenflow.transform({"c": ["  x  "]}).to_arrow()
+    assert out.to_pydict() == {"c": ["x"]}
+
+
+def test_to_arrow_preserves_nulls():
+    out = goldenflow.transform(pa.table({"c": ["  a  ", None]})).to_arrow()
+    assert out.to_pydict() == {"c": ["a", None]}
+
+
+def test_to_arrow_agrees_with_to_polars():
+    """Two bridges over one dict must not disagree about the data."""
+    pl = pytest.importorskip("polars")
+    res = goldenflow.transform({"c": ["  a  ", None], "n": ["1", "2"]})
+    assert res.to_arrow().to_pydict() == res.to_polars().to_dict(as_series=False)
+    assert isinstance(res.to_polars(), pl.DataFrame)
+
+
+def test_to_arrow_is_not_called_on_the_default_path(monkeypatch):
+    """pyarrow is an optional extra; a dict caller who never asks for arrow must
+    not trigger the import. Guards the deferred-import contract."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _boom(name, *a, **k):
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise AssertionError("transform() must not import pyarrow on the dict path")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _boom)
+    assert goldenflow.transform({"c": ["  x  "]}).columns == {"c": ["x"]}

--- a/scripts/_pin_actions.py
+++ b/scripts/_pin_actions.py
@@ -8,6 +8,7 @@ Discarded after the scorecard hardening PR lands — kept only so the
 mapping is reproducible if Dependabot ever needs a fresh round of pins.
 """
 from __future__ import annotations
+
 import re
 from pathlib import Path
 

--- a/scripts/bench_embedding_providers.py
+++ b/scripts/bench_embedding_providers.py
@@ -33,9 +33,8 @@ from pathlib import Path
 # Make `dqbench_adapters.*` and the sibling bench script importable.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import polars as pl
-
 import goldenmatch
+import polars as pl
 from goldenmatch.config.schemas import (
     BlockingConfig,
     BlockingKeyConfig,

--- a/scripts/bench_er_headtohead/run_converted_splink.py
+++ b/scripts/bench_er_headtohead/run_converted_splink.py
@@ -188,9 +188,8 @@ def main() -> int:
     evaluate_mod = _import_sibling("evaluate")
 
     import splink.comparison_library as cl
-    from splink import DuckDBAPI, Linker, SettingsCreator, block_on
-
     from goldenmatch.config.from_splink import from_splink
+    from splink import DuckDBAPI, Linker, SettingsCreator, block_on
 
     s = {
         "DuckDBAPI": DuckDBAPI,

--- a/scripts/bench_er_headtohead/run_gm_converted.py
+++ b/scripts/bench_er_headtohead/run_gm_converted.py
@@ -121,7 +121,6 @@ def main() -> None:
 
     try:
         import pyarrow.parquet as pq
-
         from goldenmatch.config.from_splink import SplinkConversionError, from_splink
         from goldenmatch.core.bench import bench_capture
 

--- a/scripts/bench_er_headtohead/shapes.py
+++ b/scripts/bench_er_headtohead/shapes.py
@@ -12,8 +12,8 @@ guard test (``test_shapes_import_does_not_drag_goldenmatch``) enforces this.
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 # Named generator constants (also imported by generate_fixture for pool sizing).
 N_VENUE = 3_500

--- a/scripts/bench_er_headtohead/test_scale_envelope.py
+++ b/scripts/bench_er_headtohead/test_scale_envelope.py
@@ -98,8 +98,9 @@ def test_generate_biblio_titles_actually_vary(tmp_path):
     gen = _load("generate_fixture")
     out, truth = tmp_path / "b.parquet", tmp_path / "b.truth.parquet"
     gen.generate(3000, 0.3, out, truth, 42, 1000, shape="biblio")
-    import pyarrow.parquet as pq
     from collections import defaultdict
+
+    import pyarrow.parquet as pq
 
     t = pq.read_table(out)
     truth_t = pq.read_table(truth)
@@ -149,8 +150,9 @@ def test_generate_product_titles_actually_vary(tmp_path):
     gen = _load("generate_fixture")
     out, truth = tmp_path / "p.parquet", tmp_path / "p.truth.parquet"
     gen.generate(3000, 0.3, out, truth, 42, 1000, shape="product")
-    import pyarrow.parquet as pq
     from collections import defaultdict
+
+    import pyarrow.parquet as pq
 
     t = pq.read_table(out)
     truth_t = pq.read_table(truth)

--- a/scripts/bench_native_bucket.py
+++ b/scripts/bench_native_bucket.py
@@ -71,8 +71,8 @@ def _pairset_digest(pairs: list[tuple[int, int, float]]) -> tuple[int, str]:
 def _run_one(native: str, prepared, blocking, mk, n_buckets: int) -> dict[str, Any]:
     """Run score_buckets once under the given GOLDENMATCH_NATIVE value."""
     from goldenmatch.backends.score_buckets import score_buckets
-    from goldenmatch.core.bench import bench_capture
     from goldenmatch.core._native_loader import native_enabled
+    from goldenmatch.core.bench import bench_capture
 
     os.environ["GOLDENMATCH_NATIVE"] = native
     label = "native" if native == "1" else "python"
@@ -132,7 +132,10 @@ def main() -> int:
 
     import polars as pl
     from goldenmatch.config.schemas import (
-        BlockingConfig, BlockingKeyConfig, MatchkeyConfig, MatchkeyField,
+        BlockingConfig,
+        BlockingKeyConfig,
+        MatchkeyConfig,
+        MatchkeyField,
     )
     from goldenmatch.core.matchkey import precompute_matchkey_transforms
 

--- a/scripts/bench_native_kernels.py
+++ b/scripts/bench_native_kernels.py
@@ -26,9 +26,8 @@ import statistics
 import sys
 import time
 
-import polars as pl
-
 import goldenmatch._native as native
+import polars as pl
 
 # jaro_winkler=0, token_sort=2 (see backends/score_buckets._NATIVE_SCORER_IDS)
 SCORER_IDS = [0, 2]
@@ -154,7 +153,7 @@ def bench(n: int) -> None:
     native_call = t_tolist + t_full          # what score_buckets pays today (Vec kernel)
     arrow_ceiling = t_tolist + t_ingest      # theoretical max removable by zero-copy ABI
     arrow_path = t_arrow_build + t_arrow_call  # measured Arrow-native path
-    py_total = t_tolist + t_pyloop
+    _py_total = t_tolist + t_pyloop  # kept: documents the pure-Python baseline
 
     print(f"\n=== N={n:,} rows, {len(sizes):,} blocks, {n_pairs:,} candidate pairs ===")
     print(f"  T_tolist   (.to_list materialization) : {t_tolist*1e3:8.1f} ms")
@@ -164,7 +163,7 @@ def bench(n: int) -> None:
     print(f"  T_pyloop   (pure-Python per-pair loop) : {t_pyloop*1e3:8.1f} ms")
     print(f"  T_arrowbuild (.to_arrow zero-copy)     : {t_arrow_build*1e3:8.1f} ms")
     print(f"  T_arrowcall  (arrow kernel: ingest+comp): {t_arrow_call*1e3:8.1f} ms")
-    print(f"  --")
+    print("  --")
     print(f"  Vec path total   (tolist+full)         : {native_call*1e3:8.1f} ms")
     print(f"  Arrow path total (arrowbuild+arrowcall): {arrow_path*1e3:8.1f} ms")
     print(f"  ARROW SPEEDUP vs Vec kernel            : {native_call/arrow_path:8.2f}x"

--- a/scripts/check_api_parity.py
+++ b/scripts/check_api_parity.py
@@ -326,7 +326,9 @@ def _dump_yaml(manifest) -> str:
 def _run_emitter(cmd: list[str]) -> dict:
     """Run an emitter subprocess; return its parsed JSON descriptor.
     Exit code 3 from an emitter = environment gap (missing extra) -> re-raise as SystemExit(3)."""
-    import json, subprocess, sys
+    import json
+    import subprocess
+    import sys
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode == 3:
         sys.stderr.write(proc.stderr)
@@ -338,7 +340,9 @@ def _run_emitter(cmd: list[str]) -> dict:
 
 
 def main(argv=None):
-    import argparse, pathlib, sys
+    import argparse
+    import pathlib
+    import sys
     ap = argparse.ArgumentParser()
     ap.add_argument("package")
     ap.add_argument("--init", action="store_true", help="write a bootstrap manifest from both descriptors")

--- a/scripts/check_docs_sections.py
+++ b/scripts/check_docs_sections.py
@@ -78,7 +78,7 @@ REFERENCE_ORDER = ("config-matrix", "recipes", "cli", "native", "performance", "
 # (v2.0, GPT-4o) are allowed structurally and need not be listed.
 PROPER_NOUNS = frozenset({
     "goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis",
-    "goldenpipe", "infermap", "goldenschema", "goldengraph", "golden", "suite",
+    "infermap", "goldenschema", "goldengraph", "golden", "suite",
     "python", "typescript", "javascript", "node", "rust", "arrow", "polars",
     "duckdb", "postgresql", "postgres", "sqlite", "ray", "bloom", "claude",
     "gpt", "openai", "anthropic", "docker", "dbt", "neo4j", "llamaindex",

--- a/scripts/check_main_health.py
+++ b/scripts/check_main_health.py
@@ -35,7 +35,7 @@ import argparse
 import json
 import subprocess
 import sys
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 # Trigger events we IGNORE when judging main health. A `workflow_dispatch` run is
 # a human manually kicking a lane (a one-off bench, a retro-publish); its failure
@@ -54,7 +54,7 @@ TRACKER_MARKER = "<!-- main-health-tracker -->"
 TRACKER_LABEL = "main-health"
 
 
-def classify(conclusion: Optional[str]) -> str:
+def classify(conclusion: str | None) -> str:
     """Map a run conclusion to 'red' | 'ok'. Unknown conclusions are red (fail loud)."""
     if conclusion in RED_CONCLUSIONS:
         return "red"
@@ -65,7 +65,7 @@ def classify(conclusion: Optional[str]) -> str:
     return "red"
 
 
-def select_main_run(runs: list[dict]) -> Optional[dict]:
+def select_main_run(runs: list[dict]) -> dict | None:
     """From completed main runs (GitHub returns them newest-first), the latest one
     triggered by an AUTOMATIC event. Manual ``workflow_dispatch`` runs are skipped
     so a stale one-off dispatch failure can't masquerade as a broken main lane.
@@ -120,7 +120,7 @@ def list_active_workflows(repo: str) -> list[dict]:
     return out
 
 
-def latest_main_run(repo: str, workflow_id: int) -> Optional[dict]:
+def latest_main_run(repo: str, workflow_id: int) -> dict | None:
     """Latest COMPLETED, AUTOMATIC run of this workflow on main, or None.
 
     Fetches several recent completed main runs (newest-first) and returns the
@@ -158,7 +158,7 @@ def collect_main_runs(repo: str) -> list[dict]:
 # --------------------------------------------------------------- surfaces (issue)
 
 
-def find_tracker_issue(repo: str) -> Optional[dict]:
+def find_tracker_issue(repo: str) -> dict | None:
     data = _gh_api(
         f"repos/{repo}/issues?state=open&labels={TRACKER_LABEL}&per_page=20"
     )
@@ -255,7 +255,7 @@ def write_step_summary(records: list[dict], reds: list[dict]) -> None:
         fh.write("\n".join(lines) + "\n")
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--repo", default="benseverndev-oss/goldenmatch")
     ap.add_argument(

--- a/scripts/check_ts_parity_freshness.py
+++ b/scripts/check_ts_parity_freshness.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 # 4-decimal scorer-parity contract (tests/parity/scorer-ground-truth.test.ts

--- a/scripts/config_matrix/manifest.py
+++ b/scripts/config_matrix/manifest.py
@@ -24,7 +24,6 @@ import importlib.util
 import inspect
 import json
 import tomllib
-import typing
 from pathlib import Path
 
 from pydantic_core import PydanticUndefined

--- a/scripts/dqbench_adapters/febrl3.py
+++ b/scripts/dqbench_adapters/febrl3.py
@@ -11,8 +11,8 @@ positional → rec_id before set-comparing.
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 import polars as pl
 

--- a/scripts/emit_python_surface.py
+++ b/scripts/emit_python_surface.py
@@ -9,6 +9,7 @@ gives the real names a user types (hyphenation like `mcp-serve`, and sub-app gro
 unlike registered_commands whose .name can be None. Only the CLI module path differs per package.
 """
 from __future__ import annotations
+
 import importlib
 import json
 import sys

--- a/scripts/eval_benchmark.py
+++ b/scripts/eval_benchmark.py
@@ -20,12 +20,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    import pandas as pd
 
 # ── Scoring (mirrors scripts/eval_er_evaluation.py, factored for reuse) ─────
 
@@ -44,8 +45,8 @@ def _resolve_metric(ee, candidates: list[str]):
 
 
 def score_predictions(
-    pred: "pd.Series",
-    ref: "pd.Series",
+    pred: pd.Series,
+    ref: pd.Series,
     label: str,
 ) -> dict[str, Any]:
     """Run er-evaluation metrics on aligned (predictions, reference) Series.
@@ -54,8 +55,8 @@ def score_predictions(
     ``scripts/eval_er_evaluation.py`` so downstream tooling can consume
     either output identically.
     """
-    import pandas as pd
     import er_evaluation as ee  # pyright: ignore[reportMissingImports]
+    import pandas as pd
 
     # Align on intersection of indices; record_ids must appear in both.
     aligned = pd.concat([pred.rename("prediction"), ref.rename("reference")],
@@ -136,7 +137,7 @@ def score_predictions(
 
 # ── Per-benchmark loaders ──────────────────────────────────────────────────
 
-def _clusters_to_series(clusters: dict[int, dict], all_ids: list[int]) -> "pd.Series":
+def _clusters_to_series(clusters: dict[int, dict], all_ids: list[int]) -> pd.Series:
     """Map every member -> cluster_id. Unassigned ids get unique singleton ids."""
     import pandas as pd
     out: dict[int, int] = {}
@@ -157,7 +158,7 @@ def _clusters_to_series(clusters: dict[int, dict], all_ids: list[int]) -> "pd.Se
 def _gt_pairs_to_series(
     pairs: set[tuple[Any, Any]],
     all_ids: list[Any],
-) -> "pd.Series":
+) -> pd.Series:
     """Collapse ground-truth pair set into clusters via union-find, emit Series.
 
     Records not appearing in any pair become singleton clusters with unique ids.
@@ -197,11 +198,10 @@ def _gt_pairs_to_series(
     return s
 
 
-def load_febrl3() -> tuple["pd.Series", "pd.Series", float, dict[str, Any]]:
+def load_febrl3() -> tuple[pd.Series, pd.Series, float, dict[str, Any]]:
     """Run gm.dedupe_df on Febrl3, return (predictions, reference, wall_s, extras)."""
-    import polars as pl
-    import pandas as pd
     import goldenmatch as gm
+    import polars as pl
     from recordlinkage.datasets import load_febrl3 as _load
     df_pd, gt_pairs = _load(return_links=True)
     df_pd = df_pd.reset_index()
@@ -239,7 +239,7 @@ def load_febrl3() -> tuple["pd.Series", "pd.Series", float, dict[str, Any]]:
     return predictions, reference, wall_s, extras
 
 
-def load_dblp_acm(datasets_dir: Path) -> tuple["pd.Series", "pd.Series", float, dict[str, Any]]:
+def load_dblp_acm(datasets_dir: Path) -> tuple[pd.Series, pd.Series, float, dict[str, Any]]:
     """Run gm.match_df on DBLP-ACM, return predictions/reference/wall.
 
     Cross-source match. Both predictions and reference live in the
@@ -251,8 +251,8 @@ def load_dblp_acm(datasets_dir: Path) -> tuple["pd.Series", "pd.Series", float, 
       ``__target_row_id__``, ``__ref_row_id__``, ``__match_score__``,
       ``target_<col>...``, ``ref_<col>...``.
     """
-    import polars as pl
     import goldenmatch as gm
+    import polars as pl
 
     a_path = datasets_dir / "DBLP-ACM" / "DBLP2.csv"
     b_path = datasets_dir / "DBLP-ACM" / "ACM.csv"
@@ -273,7 +273,7 @@ def load_dblp_acm(datasets_dir: Path) -> tuple["pd.Series", "pd.Series", float, 
 
     matched = getattr(result, "matched", None)
     if matched is None or (hasattr(matched, "height") and matched.height == 0):
-        print(f"[dblp-acm] MatchResult.matched is empty")
+        print("[dblp-acm] MatchResult.matched is empty")
         matched_pairs_combined: set[tuple[int, int]] = set()
     else:
         print(f"[dblp-acm] MatchResult.matched columns: {matched.columns}")
@@ -346,15 +346,15 @@ def load_dblp_acm(datasets_dir: Path) -> tuple["pd.Series", "pd.Series", float, 
     return predictions, reference, wall_s, extras
 
 
-def load_ncvr(datasets_dir: Path) -> tuple["pd.Series", "pd.Series", float, dict[str, Any]]:
+def load_ncvr(datasets_dir: Path) -> tuple[pd.Series, pd.Series, float, dict[str, Any]]:
     """Run gm.dedupe_df on the NCVR 10K sample.
 
     Ground truth: per CLAUDE.md, NCVR's ``ncid`` column is the natural key
     that survives across registrations. Rows with the same ``ncid`` are
     the same voter (re-registrations after a move, etc.).
     """
-    import polars as pl
     import goldenmatch as gm
+    import polars as pl
     sample = datasets_dir / "NCVR" / "ncvoter_sample_10k.txt"
     if not sample.exists():
         sys.exit(f"NCVR sample missing: {sample}")

--- a/scripts/eval_er_evaluation.py
+++ b/scripts/eval_er_evaluation.py
@@ -30,10 +30,13 @@ import json
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
-def _build_prediction_series(clusters: dict[int, dict]) -> "pd.Series":
+def _build_prediction_series(clusters: dict[int, dict]) -> pd.Series:
     """Map row_id -> cluster_id as a pandas Series.
 
     ``clusters`` is GoldenMatch's standard shape: ``dict[cluster_id, {"members": [row_id, ...], ...}]``.
@@ -51,7 +54,7 @@ def _build_prediction_series(clusters: dict[int, dict]) -> "pd.Series":
     return s
 
 
-def _build_reference_series(gt_path: Path) -> "pd.Series":
+def _build_reference_series(gt_path: Path) -> pd.Series:
     """Load ground truth ``id,cluster_id`` CSV into a pandas Series.
 
     Mirrors ``scripts/scale_audit_5m.py::_pairs_from_ground_truth``: the
@@ -110,10 +113,10 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
 
     # Import after argparse so --help works without the heavy deps.
-    import polars as pl
-    import pandas as pd
-    import goldenmatch as gm
     import er_evaluation as ee  # pyright: ignore[reportMissingImports]
+    import goldenmatch as gm
+    import pandas as pd
+    import polars as pl
     ee_version = getattr(ee, "__version__", "unknown")
 
     print(f"er_evaluation version: {ee_version}")
@@ -279,7 +282,7 @@ def main() -> None:
 
     if args.summary_md is not None:
         with args.summary_md.open("a", encoding="utf-8") as f:
-            f.write(f"# eval-er-evaluation\n\n")
+            f.write("# eval-er-evaluation\n\n")
             f.write(f"- fixture: `{args.fixture}` ({df.height:,} rows)\n")
             f.write(f"- dedupe wall: **{wall_s:.1f}s**\n")
             f.write(f"- predicted clusters: {len(result.clusters):,}\n")

--- a/scripts/investigate_autoconfig_2m.py
+++ b/scripts/investigate_autoconfig_2m.py
@@ -43,7 +43,7 @@ def ensure_fixture(rows: int, dupe_rate: float = 0.15) -> Path:
 
 
 def dump_config(label: str, rows: int) -> None:
-    from goldenmatch.core.autoconfig import auto_configure_df, _LAST_CONTROLLER_RUN
+    from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN, auto_configure_df
 
     fp = ensure_fixture(rows)
     df = pl.read_csv(fp, encoding="utf8-lossy", ignore_errors=True)

--- a/scripts/qis_gate.py
+++ b/scripts/qis_gate.py
@@ -51,7 +51,6 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_BASELINE = REPO / "scripts" / "baselines" / "qis_scorecard.json"
@@ -133,11 +132,11 @@ class GateResult:
 
 
 def evaluate_gate(
-    rung_f1: dict[int, Optional[float]],
-    baseline: Optional[dict[str, float]],
+    rung_f1: dict[int, float | None],
+    baseline: dict[str, float] | None,
     *,
-    rung_refused: Optional[dict[int, bool]] = None,
-    rung_unmeasurable_reason: Optional[dict[int, Optional[str]]] = None,
+    rung_refused: dict[int, bool] | None = None,
+    rung_unmeasurable_reason: dict[int, str | None] | None = None,
     scale_tol: float = DEFAULT_SCALE_TOL,
     delta_tol: float = DEFAULT_DELTA_TOL,
     abs_floor: float = DEFAULT_ABS_FLOOR,
@@ -290,7 +289,7 @@ def _estimate_candidate_pairs(cfg, df) -> float:
         return 0.0
 
 
-def load_baseline(path: Path) -> Optional[dict]:
+def load_baseline(path: Path) -> dict | None:
     if not path.exists():
         return None
     with open(path, encoding="utf-8") as fh:
@@ -325,8 +324,8 @@ def measure_rungs(rungs: list[int], *, seed: int, shape: str, corruption: str) -
     UNMEASURABLE (``f1=None``); ``evaluate_gate`` then flags it honestly instead of
     fabricating a 0.0 -- never a false green."""
     sys.path.insert(0, str(REPO / "scripts"))
-    import quality_invariant_scale as qis  # noqa: E402
     import goldenmatch  # noqa: E402
+    import quality_invariant_scale as qis  # noqa: E402
     from goldenmatch.core.autoconfig_controller import ControllerNotConfidentError  # noqa: E402
 
     def _score(result) -> dict:
@@ -374,7 +373,7 @@ def measure_rungs(rungs: list[int], *, seed: int, shape: str, corruption: str) -
             return False
         return _pair_explosion(cfg, df)
 
-    def _measure_red(df) -> tuple[Optional[dict], Optional[str]]:
+    def _measure_red(df) -> tuple[dict | None, str | None]:
         """Score the committed RED config via the allow_red_config force-run.
         Returns ``(metrics, None)`` when measured, ``(None, "pair_explosion")`` when
         the committed config's ESTIMATED candidate pairs exceed ``MEASURE_MAX_PAIRS``
@@ -520,7 +519,7 @@ def write_step_summary(result: GateResult, records: dict[int, dict]) -> None:
         fh.write("\n".join(lines) + "\n")
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--tier", choices=sorted(TIERS), default="ci",
                     help="which row-count matrix to run (ci: <=1M, heavy: 5M)")

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -599,8 +599,8 @@ def score_quality(
     br = br_acc / n_rows
     bf1 = (2 * bp * br / (bp + br)) if (bp + br) else 0.0
     # Cluster
-    cfp_cnt = pred_multi_total - exact_cluster_matches
-    cfn_cnt = gt_multi_total - exact_cluster_matches
+    _cfp_cnt = pred_multi_total - exact_cluster_matches  # computed, not yet reported
+    _cfn_cnt = gt_multi_total - exact_cluster_matches  # computed, not yet reported
     cp = exact_cluster_matches / pred_multi_total if pred_multi_total else 0.0
     cr = exact_cluster_matches / gt_multi_total if gt_multi_total else 0.0
     cf1 = (2 * cp * cr / (cp + cr)) if (cp + cr) else 0.0
@@ -1031,7 +1031,6 @@ def _run_phase5_and_collect(
     so it can be oracle-scored (golden records are one row per cluster and can't be).
     """
     import ray  # lazy: the [ray] extra is cluster-only
-
     from goldenmatch.distributed.pipeline import run_dedupe_pipeline_distributed
 
     # Phase-5 contract: a GLOBAL __row_id__. Member ids ARE the row index, so the

--- a/scripts/research/amortized_partition_er.py
+++ b/scripts/research/amortized_partition_er.py
@@ -66,7 +66,7 @@ except Exception:  # pragma: no cover
 # --------------------------------------------------------------------------- #
 @dataclass
 class SimDataset:
-    fields: "torch.Tensor"   # [N, F] record field vectors
+    fields: torch.Tensor   # [N, F] record field vectors
     labels: list[int]        # gold entity id per record (len N)
 
 
@@ -158,7 +158,7 @@ if _HAVE_TORCH:
             U_b = U.unsqueeze(0).expand(feats.size(0), d)
             return self.score(torch.cat([feats, U_b], -1)).squeeze(-1)     # [K+1]
 
-        def nll_and_aux(self, sim: "SimDataset"):
+        def nll_and_aux(self, sim: SimDataset):
             """Teacher-forced NLL of the gold partition + masked-field recon aux."""
             e = self.encode(sim.fields)                  # [N, d]
             n = e.size(0)
@@ -210,7 +210,7 @@ if _HAVE_TORCH:
             return nll / n, aux
 
         @torch.no_grad()
-        def decode(self, sim: "SimDataset"):
+        def decode(self, sim: SimDataset):
             """Greedy MAP-ish partition + per-step confidence (for calibration)."""
             e = self.encode(sim.fields)
             n = e.size(0)
@@ -255,7 +255,7 @@ if _HAVE_TORCH:
             return assign, confidences, corrects
 
         @torch.no_grad()
-        def sample_partition(self, sim: "SimDataset", temp: float = 1.0) -> list[int]:
+        def sample_partition(self, sim: SimDataset, temp: float = 1.0) -> list[int]:
             """Draw ONE partition sample from q(partition | X): sequential
             assignment, sampling each step from softmax(logits / temp) instead of
             argmax. A pool of these is the Monte-Carlo posterior used by step 3.
@@ -311,7 +311,7 @@ def pairwise_f1(assign: list[int], labels: list[int]) -> float:
     return (2 * p * r / (p + r)) if (p + r) else 0.0
 
 
-def cc_threshold_baseline(sim: "SimDataset", thresh: float) -> list[int]:
+def cc_threshold_baseline(sim: SimDataset, thresh: float) -> list[int]:
     """Connected components of records within L2 `thresh` — the classic
     threshold+transitive-closure ER baseline."""
     x = sim.fields

--- a/scripts/research/landscape_er.py
+++ b/scripts/research/landscape_er.py
@@ -46,9 +46,9 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
+import richer_simulator as RR  # noqa: E402
 from amortized_partition_er import pairwise_f1  # noqa: E402
 from real_schema_encoder import _load_real  # noqa: E402
-import richer_simulator as RR  # noqa: E402
 
 
 # --------------------------------------------------------------------------- #
@@ -60,7 +60,6 @@ import richer_simulator as RR  # noqa: E402
 # and the scan predicted is where the ridge-raising mechanism should matter.
 # --------------------------------------------------------------------------- #
 def simulate_conflict(n_entities: int, rng, bridge_rate: float = 0.6):
-    import random
     sizes = RR._sample_cluster_sizes(n_entities, rng)
     # placeholder pool: distinctive multi-token phrases, each shared by a few
     # unrelated entities (moderate frequency -> survives IDF -> a real bridge).
@@ -456,8 +455,8 @@ def main() -> int:
         verdict = (f"landscape LOSES to discrete by {f_land - f_disc:+.3f} F1 — the "
                    "mechanism hurts. Drop it.")
     print(f"   {verdict}")
-    print(f"   (both optimise the SAME cost ledger; lower bits = better-optimised, "
-          f"not necessarily higher F1.)\n")
+    print("   (both optimise the SAME cost ledger; lower bits = better-optimised, "
+          "not necessarily higher F1.)\n")
     return 0
 
 

--- a/scripts/research/phase0_goldenmatch_recall.py
+++ b/scripts/research/phase0_goldenmatch_recall.py
@@ -128,14 +128,14 @@ def main() -> int:
 
     print(f"\n  union: found(D)={D}  true-in-union(tp)={tp}  precision={precision:.3f}")
     print(f"  capture overlap (true pairs, decorrelation): {overlap:.2f}")
-    print(f"  capture-count histogram: "
+    print("  capture-count histogram: "
           + " ".join(f"{k}:{sum(1 for v in counts.values() if v==k)}" for k in range(1, K + 1)))
-    print(f"\n  RECALL of the K-system union:")
+    print("\n  RECALL of the K-system union:")
     print(f"    naive Chao2 (FP-contaminated): {naive_recall:.3f}")
     if fpr['recall'] == fpr['recall']:
         print(f"    FP-aware (ignores singleton cell): {fpr['recall']:.3f}  (p={fpr['p']:.3f})")
     else:
-        print(f"    FP-aware: n/a (need f2 and f3 cells)")
+        print("    FP-aware: n/a (need f2 and f3 cells)")
     print(f"    TRUE recall (gold):                {true_recall:.3f}")
 
     print("\n  PHASE-0 VERDICT:")

--- a/scripts/research/real_schema_encoder.py
+++ b/scripts/research/real_schema_encoder.py
@@ -66,13 +66,13 @@ def _record_ids(field_values: list[str]) -> list[int]:
 
 @dataclass
 class SchemaDataset:
-    input_ids: "torch.Tensor"   # 1D Long, all records' trigram buckets concatenated
-    offsets: "torch.Tensor"     # 1D Long, start index per record
+    input_ids: torch.Tensor   # 1D Long, all records' trigram buckets concatenated
+    offsets: torch.Tensor     # 1D Long, start index per record
     labels: list[int]           # gold entity id per record
     n: int
 
 
-def to_dataset(records: list[list[str]], labels: list[int]) -> "SchemaDataset":
+def to_dataset(records: list[list[str]], labels: list[int]) -> SchemaDataset:
     flat, offsets = [], []
     for fv in records:
         offsets.append(len(flat))
@@ -149,7 +149,7 @@ if _HAVE_TORCH:
             self.recon = _mlp(d, 96, fdim)       # mate-context -> own bag emb (#3)
             self.d = d
 
-        def encode(self, ds: "SchemaDataset"):
+        def encode(self, ds: SchemaDataset):
             bag = self.bag(ds.input_ids, ds.offsets)   # [N, fdim]
             return self.enc(bag), bag                  # e [N,d], bag [N,fdim]
 
@@ -174,7 +174,7 @@ if _HAVE_TORCH:
             U_b = U.unsqueeze(0).expand(feats.size(0), d)
             return self.score(torch.cat([feats, U_b], -1)).squeeze(-1)
 
-        def nll_and_aux(self, ds: "SchemaDataset"):
+        def nll_and_aux(self, ds: SchemaDataset):
             e, bag = self.encode(ds)
             n = e.size(0)
             order = torch.randperm(n)
@@ -218,7 +218,7 @@ if _HAVE_TORCH:
             return nll / n, aux
 
         @torch.no_grad()
-        def decode(self, ds: "SchemaDataset"):
+        def decode(self, ds: SchemaDataset):
             e, _ = self.encode(ds)
             n = e.size(0)
             total = e.sum(0)

--- a/scripts/research/recall_certificate.py
+++ b/scripts/research/recall_certificate.py
@@ -44,7 +44,6 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from landscape_er import build_affinity, default_theta  # noqa: E402
 from real_schema_encoder import _load_real  # noqa: E402
 
 
@@ -123,7 +122,7 @@ def chao2(capture_counts: dict[tuple[int, int], int], K: int) -> float:
 
 def chao2_var(counts: dict, K: int) -> float:
     """Analytic variance of the Chao2 estimator (Chao 1987, incidence form)."""
-    D = len(counts)
+    _D = len(counts)  # richness, unused by this variance form
     Q1 = sum(1 for v in counts.values() if v == 1)
     Q2 = sum(1 for v in counts.values() if v == 2)
     c = (K - 1) / K if K > 1 else 1.0
@@ -464,13 +463,13 @@ def main() -> int:
     if r['N_ll'] == r['N_ll']:    # not nan
         print(f"    log-linear (indep) N_hat = {r['N_ll']:.0f}")
     else:
-        print(f"    log-linear (indep) N_hat = n/a (needs K>=3 non-empty groups)")
+        print("    log-linear (indep) N_hat = n/a (needs K>=3 non-empty groups)")
     print(f"  precision (sampled, n={args.precision_sample}): "
           f"p_hat={r['p_hat']:.3f}  Wilson CI [{r['p_lo']:.3f}, {r['p_hi']:.3f}]  "
           f"(true={r['true_precision']:.3f})")
     print(f"  matcher overlap (indep diagnostic): {r['mean_overlap']:.2f}\n")
     fpr = r['fpr']
-    print(f"  RECALL — naive (Chao2 on raw union, FP-contaminated):")
+    print("  RECALL — naive (Chao2 on raw union, FP-contaminated):")
     print(f"      point={r['recall_point']:.3f}  95% CI [{r['recall_lo']:.3f}, {r['recall_hi']:.3f}]")
     print(f"  RECALL — FP-aware (higher-order cells, p={fpr['p']:.3f}, ignores f1):")
     cons = fpr.get('recall_cons', float('nan'))
@@ -479,9 +478,9 @@ def main() -> int:
         if cons == cons:
             print(f"      >>> HETEROGENEITY-ROBUST conservative bound (safety): recall >= {cons:.3f}")
         else:
-            print(f"      conservative bound n/a (need f2 and f3 cells)")
+            print("      conservative bound n/a (need f2 and f3 cells)")
     else:
-        print(f"      n/a (need >=2 multi-capture cells; raise K / add modalities)")
+        print("      n/a (need >=2 multi-capture cells; raise K / add modalities)")
     print(f"  RECALL — AUDIT-calibrated (~{r['n_aud']}/stratum labels, measures miss mass):")
     print(f"      point={r['recall_audit']:.3f}  "
           f"sub-threshold stratum |B|={r['sub_size']} true-rate={r['pB']:.3f}")

--- a/scripts/research/recon_er_experiment.py
+++ b/scripts/research/recon_er_experiment.py
@@ -47,9 +47,9 @@ import argparse
 import math
 import random
 import sys
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable
 
 # Make `dqbench_adapters.*` importable when run from the repo root (mirrors the
 # sys.path dance in scripts/run_benchmarks.py — scripts/ is not a package).

--- a/scripts/score_distributed_assignments.py
+++ b/scripts/score_distributed_assignments.py
@@ -90,7 +90,7 @@ def main() -> int:
         "multi_member_predicted": pred_multi_total,
         "multi_member_gt": gt_multi_total,
     }
-    print("\n=== DISTRIBUTED %d-ROW QUALITY (from assignments) ===" % n_rows)
+    print(f"\n=== DISTRIBUTED {n_rows}-ROW QUALITY (from assignments) ===")
     print(f"pairwise: f1={pf1:.4f}  p={pp:.4f}  r={pr:.4f}")
     print(f"b_cubed:  f1={bf1:.4f}  p={bp:.4f}  r={br:.4f}")
     print(f"cluster:  f1={cf1:.4f}  p={cp:.4f}  r={cr:.4f}  exact={exact_cluster_matches:,}")

--- a/scripts/test_config_matrix.py
+++ b/scripts/test_config_matrix.py
@@ -8,7 +8,6 @@ Regenerate a stale page with: python scripts/gen_config_matrix.py --write <pkg>
 from __future__ import annotations
 
 import pytest
-
 from config_matrix import REGISTRY
 from config_matrix.coverage import coverage
 from config_matrix.crossref import stale_env_refs, undocumented_vocab, vocab_column_gaps
@@ -50,8 +49,8 @@ def test_goldencheck_check_types_catalog_matches_source():
     # `check="..."` literals the code actually emits, so it can't drift into a lie.
     import re
 
-    from goldencheck.models.finding import CHECK_TYPES
     from config_matrix.render import ROOT
+    from goldencheck.models.finding import CHECK_TYPES
 
     src = ROOT / "packages" / "python" / "goldencheck" / "goldencheck"
     scanned: set[str] = set()
@@ -71,8 +70,8 @@ def test_goldenpipe_builtin_stages_match_pyproject():
     # drift from what a fresh install actually registers.
     import tomllib
 
-    from goldenpipe.engine.registry import BUILTIN_STAGES
     from config_matrix.render import ROOT
+    from goldenpipe.engine.registry import BUILTIN_STAGES
 
     pp = tomllib.loads(
         (ROOT / "packages" / "python" / "goldenpipe" / "pyproject.toml").read_text(encoding="utf-8")

--- a/scripts/verify_disagree.py
+++ b/scripts/verify_disagree.py
@@ -39,11 +39,10 @@ def _worker(mode: str, backend: str, inp: str, out: str) -> None:
     """Run one dedupe under the pinned mode/backend and write partitions."""
     import pyarrow as pa
     import pyarrow.parquet as pq
-
     from goldenmatch import dedupe_df
     from goldenmatch.core._native_loader import native_module
-    from goldenmatch.core.probabilistic import fs_missing_mode
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from goldenmatch.core.probabilistic import fs_missing_mode
 
     df = pq.read_table(inp)
     cfg = auto_configure_probabilistic_df(df)

--- a/uv.lock
+++ b/uv.lock
@@ -894,7 +894,7 @@ wheels = [
 
 [[package]]
 name = "goldenanalysis"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/python/goldenanalysis" }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
The two follow-ups I flagged and deliberately kept out of earlier PRs.

## 1. `scripts/` was never linted

The python matrix runs `ruff check packages/python/<pkg>`, so `scripts/` — ~100 files including the **24 `check_*.py` gates `ci-required` leans on** — was the one Python directory no lint ever reached. The repo's ruff config was enforced everywhere except the directory doing the enforcing.

Surfaced on #2449, when a code-quality bot flagged an unused import that CI structurally could not have caught.

**104 findings, all annotation hygiene, no runtime bugs.** 93 auto-fixed. The remainder needed judgment:

| rule | n | resolution |
|---|---|---|
| `F821` undefined `pd` | 12 | `"pd.Series"` string annotations with pandas imported inside functions. Under `from __future__ import annotations` they're never evaluated — nothing was broken. Fixed with `TYPE_CHECKING` imports, not `noqa`. |
| `F841` dead locals | 4 | **Underscore-prefixed, not deleted** — see below |
| `UP031` percent-format | 1 | converted to f-string |

On the `F841`s: `cfp_cnt` / `cfn_cnt` in `quality_invariant_scale.py` compute cluster false-positive/negative counts that are then never reported. That reads like an **unfinished reporting line**, not junk. Deleting them would satisfy the linter and destroy the evidence; underscoring keeps the computation, changes no behaviour, and leaves the next reader something to act on.

New `scripts_lint` job in `ci-required`, filtered on `scripts/**`.

### One thing I got wrong and caught before pushing

I first pinned `uvx ruff@0.9.2` to match the pre-commit pin — it looked tidier. Checked it before committing:

```
$ uvx ruff@0.9.2 check scripts/
Found 24 errors.
```

So that job would have landed **red** against a tree that is clean under the linter every other lane runs. It now uses `uv run ruff`, exactly as the package lanes invoke it, so both the rule set *and* the version are shared and cannot diverge.

Separately: the pre-commit pin being three majors behind the workspace ruff is a real pre-existing inconsistency. Not touching it here — it's its own decision, and it would silently change what `pre-commit run --all-files` reports for everyone.

## 2. `ColumnarResult.to_arrow()`

Mirrors the existing `to_polars()`, completing the round trip opened by `transform(pa.Table)` in #2447 — an Arrow caller hands data in and gets it back in the same shape instead of unpacking a dict by hand.

Deferred import like its sibling, so the Polars-free dict path still never requires pyarrow. A test monkeypatches `__import__` to prove the default path stays clean, and another asserts `to_arrow()` and `to_polars()` agree on the same result — two bridges over one dict must not disagree about the data.

## Testing

- **143 gate tests** (CI's explicit-filename invocation) pass — the auto-fixes touched the gates themselves, so this is the load-bearing check
- every gate still *runs*: `check_claude_refs`, `check_context_budget`, `check_workflow_yaml`, `check_filter_coverage`, `check_docs_consistency`, `check_docs_links`
- **311 goldenflow** engine/nopolars tests; 20 in the arrow file
- `ruff check scripts/` and `ruff check packages/python/goldenflow/` clean
- agent-codemap regenerated (caught me twice already, so it's reflexive now)

Unchanged from clean main: `test_transformer.py`'s 2 failures (missing `openai` optional dep), and `scripts/` whole-directory pytest collection erroring on duplicate basenames — both verified against a clean stash.

## Checklist

- [x] Tests added/updated and passing locally
- [ ] `pre-commit run --all-files` — not run in this sandbox (and see the version note above)
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_