### PR TITLE
refactor(scripts): resolve the unused-local findings per case, not by one rule

### DIFF
--- a/scripts/bench_native_kernels.py
+++ b/scripts/bench_native_kernels.py
@@ -153,7 +153,7 @@ def bench(n: int) -> None:
     native_call = t_tolist + t_full          # what score_buckets pays today (Vec kernel)
     arrow_ceiling = t_tolist + t_ingest      # theoretical max removable by zero-copy ABI
     arrow_path = t_arrow_build + t_arrow_call  # measured Arrow-native path
-    _py_total = t_tolist + t_pyloop  # kept: documents the pure-Python baseline
+    py_total = t_tolist + t_pyloop           # pure-Python baseline, end to end
 
     print(f"\n=== N={n:,} rows, {len(sizes):,} blocks, {n_pairs:,} candidate pairs ===")
     print(f"  T_tolist   (.to_list materialization) : {t_tolist*1e3:8.1f} ms")
@@ -166,6 +166,7 @@ def bench(n: int) -> None:
     print("  --")
     print(f"  Vec path total   (tolist+full)         : {native_call*1e3:8.1f} ms")
     print(f"  Arrow path total (arrowbuild+arrowcall): {arrow_path*1e3:8.1f} ms")
+    print(f"  Python path total (tolist+pyloop)      : {py_total*1e3:8.1f} ms")
     print(f"  ARROW SPEEDUP vs Vec kernel            : {native_call/arrow_path:8.2f}x"
           f"  ({100*(1-arrow_path/native_call):4.1f}% wall cut)")
     print(f"  Arrow upside ceiling (tolist+ingest)   : {arrow_ceiling*1e3:8.1f} ms"

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -598,9 +598,12 @@ def score_quality(
     bp = bp_acc / n_rows
     br = br_acc / n_rows
     bf1 = (2 * bp * br / (bp + br)) if (bp + br) else 0.0
-    # Cluster
-    _cfp_cnt = pred_multi_total - exact_cluster_matches  # computed, not yet reported
-    _cfn_cnt = gt_multi_total - exact_cluster_matches  # computed, not yet reported
+    # Cluster. NOTE the asymmetry with `pairwise` below: that block returns fp/fn,
+    # this one does not. The counts are `pred_multi_total - exact_cluster_matches`
+    # and `gt_multi_total - exact_cluster_matches` if they are ever wanted; they
+    # were computed here and dropped on the floor. Adding them to the returned dict
+    # is safe (qis_gate.py reads cluster via an explicit f1/p/r allowlist) but is an
+    # output change, so it is not being smuggled into a lint pass.
     cp = exact_cluster_matches / pred_multi_total if pred_multi_total else 0.0
     cr = exact_cluster_matches / gt_multi_total if gt_multi_total else 0.0
     cf1 = (2 * cp * cr / (cp + cr)) if (cp + cr) else 0.0

--- a/scripts/research/recall_certificate.py
+++ b/scripts/research/recall_certificate.py
@@ -122,7 +122,6 @@ def chao2(capture_counts: dict[tuple[int, int], int], K: int) -> float:
 
 def chao2_var(counts: dict, K: int) -> float:
     """Analytic variance of the Chao2 estimator (Chao 1987, incidence form)."""
-    _D = len(counts)  # richness, unused by this variance form
     Q1 = sum(1 for v in counts.values() if v == 1)
     Q2 = sum(1 for v in counts.values() if v == 2)
     c = (K - 1) / K if K > 1 else 1.0


### PR DESCRIPTION
Follow-up to #2455, addressing the four `github-code-quality` comments it drew. They couldn't be pushed onto that PR — it was already in the merge queue, which locks the head branch, and ejecting a green queued PR to land a non-urgent improvement was the wrong trade.

## The bot was right about the general point

`_`-prefixing a dead local silences the linter without deciding anything, and leaves a ghost that keeps getting flagged. I applied one blanket rule to four findings that turned out to be **three different situations**.

| location | resolution | reasoning |
|---|---|---|
| `bench_native_kernels.py` `_py_total` | **reported** | The block already prints the Vec path, Arrow path and ceiling totals. This wasn't junk, it was a *missing print*. Now `Python path total (tolist+pyloop)`. Output-only, in a benchmark script. |
| `research/recall_certificate.py` `_D` | **deleted** | `chao2_var` uses the Q1/Q2 incidence form, which doesn't take richness. My own comment said "unused by this variance form" — which should have told me there was no story to preserve. |
| `quality_invariant_scale.py` `_cfp_cnt` / `_cfn_cnt` | assignments dropped, **finding kept as a comment** | See below. |

## The QIS one is the interesting case

The variables were never the point. The finding is an **asymmetry in the returned dict**:

```python
"pairwise": {"f1", "p", "r", "tp", "fp", "fn"}   # reports fp/fn
"cluster":  {"f1", "p", "r", "exact", "gt_total", "pred_total"}   # does not
```

...while those two lines computed exactly the missing counts and dropped them. Deleting silently loses that; the comment keeps the formulas and the observation at the site, with no dead assignment.

**I deliberately did not add `fp`/`fn` to the returned dict**, though I checked and it's safe — `qis_gate.py:461` reads cluster through an explicit `("f1","p","r")` allowlist, so extra keys can't disturb the scorecard. It's still an output-schema change to a quality gate, and #2455 was a lint pass. That belongs in a change where someone is looking at the metrics, not smuggled in behind a linter fix. The comment says so, so the next person doesn't have to re-derive either the formulas or the safety analysis.

## Testing

- `ruff check scripts/` clean
- 110 gate tests pass (`config_matrix`, `agent_codemap`, `claude_refs`, `workflow_yaml`, `context_and_commit_gates`)
- `check_context_budget` passes
- All three files parse; the two edited scripts are unchanged in behaviour except the one added print

## Checklist

- [x] Tests added/updated and passing locally — no new tests; this is a refactor of dead code, covered by the existing gate suite
- [ ] `pre-commit run --all-files` — not run in this sandbox
- [ ] Package `CHANGELOG.md` — scripts only, no package behaviour
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` — no workflow or gotcha changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_