### PR TITLE
fix(dedupe): domain extraction before matchkeys on the arrow lane + arrow-port domain.py

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2976,7 +2976,6 @@
             "normalize_model"
           ],
           "imports": [
-            "goldenmatch._polars_lazy",
             "goldenmatch.core.complexity_profile",
             "goldenmatch.core.frame",
             "goldenmatch.core.profile_emitter"
@@ -6882,6 +6881,7 @@
           "purpose": "Reference data — bundled OSS lookups that lift engine accuracy.",
           "imports": [
             "goldenmatch.core.acronym",
+            "goldenmatch.plugins.registry",
             "goldenmatch.refdata.addresses",
             "goldenmatch.refdata.business",
             "goldenmatch.refdata.business_aliases",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -11,19 +11,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   (`KeyError: 'Field "__model__" does not exist in schema'`).** Bisected from
   the weekly `benchmarks` Abt-Buy failure to the polars->arrow `dedupe_df`
   eviction: two separate defects, both only reachable once a polars input
-  started taking the arrow lane. (1) STAGE ORDER — the dedupe pipeline's arrow
+  started taking the arrow lane. (1) STAGE ORDER -- the dedupe pipeline's arrow
   lane derived matchkeys BEFORE running domain extraction, but domain
   extraction is what materializes the `__brand__` / `__model__` /
   `__title_key__` columns auto-config's matchkeys reference, so
   `derive_matchkey` reached a column that did not exist yet. The classic lane
   and the match pipeline's arrow lane already ran domain extraction first; the
   dedupe arrow lane now matches them. (2) THREE UN-PORTED `df.columns` READS in
-  `core/domain.py` — `pa.Table.columns` is a list of ChunkedArrays, not names,
+  `core/domain.py` -- `pa.Table.columns` is a list of ChunkedArrays, not names,
   so `_emit_domain_profile` raised `'ChunkedArray' object has no attribute
   'startswith'` (only under a profile capture, which is why the existing
   arrow-lane tests missed it and the auto-config controller always hit it), and
   the guards in `_detect_product_subdomain` and `_extract_biblio_features_df`
-  SILENTLY answered False for every membership test — pinning subdomain
+  SILENTLY answered False for every membership test -- pinning subdomain
   detection to its "electronics" fallback and skipping bibliographic extraction
   entirely, with no error either time. All frame access in that module now goes
   through the seam. Net effect on the benchmark input: the auto-config

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,42 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Fixed
+- **Zero-config dedupe of product data no longer crashes on the arrow lane
+  (`KeyError: 'Field "__model__" does not exist in schema'`).** Bisected from
+  the weekly `benchmarks` Abt-Buy failure to the polars->arrow `dedupe_df`
+  eviction: two separate defects, both only reachable once a polars input
+  started taking the arrow lane. (1) STAGE ORDER — the dedupe pipeline's arrow
+  lane derived matchkeys BEFORE running domain extraction, but domain
+  extraction is what materializes the `__brand__` / `__model__` /
+  `__title_key__` columns auto-config's matchkeys reference, so
+  `derive_matchkey` reached a column that did not exist yet. The classic lane
+  and the match pipeline's arrow lane already ran domain extraction first; the
+  dedupe arrow lane now matches them. (2) THREE UN-PORTED `df.columns` READS in
+  `core/domain.py` — `pa.Table.columns` is a list of ChunkedArrays, not names,
+  so `_emit_domain_profile` raised `'ChunkedArray' object has no attribute
+  'startswith'` (only under a profile capture, which is why the existing
+  arrow-lane tests missed it and the auto-config controller always hit it), and
+  the guards in `_detect_product_subdomain` and `_extract_biblio_features_df`
+  SILENTLY answered False for every membership test — pinning subdomain
+  detection to its "electronics" fallback and skipping bibliographic extraction
+  entirely, with no error either time. All frame access in that module now goes
+  through the seam. Net effect on the benchmark input: the auto-config
+  controller goes from every iteration erroring (fallback to v0 + RED sentinel)
+  to running normally, byte-identical clusters to the classic lane.
+- **`PluginRegistry.reset()` no longer strips the plugins goldenmatch itself
+  ships.** refdata registers its scorers + transforms as an import-time side
+  effect; `reset()` drops the singleton, but a module body cannot run twice
+  (`sys.modules` holds it), so every bundled plugin was gone for the rest of
+  the process and the next `has_transform("refdata_business_canonical")` read
+  False with nothing to point at. `PluginRegistry.add_bootstrap` records those
+  idempotent registrations and replays them onto the fresh singleton, so a
+  reset now clears USER registrations only. Found via the
+  `test_alias_transforms_registered` xdist flake: the test-side workaround for
+  it re-registered a hand-maintained module list that had drifted --
+  `business_aliases` and `core.acronym` were never added to it -- so the
+  failure appeared only when a resetting test happened to precede a refdata one
+  in the same worker. That workaround is deleted; the library no longer needs
+  it.
 - **The suggest/review path now fails at the boundary with a message that names
   the requirement (#2442).** `review_config` / `suggest_from_result` normalise
   `__row_id__` with the polars-only `with_row_index`, so an Arrow caller got

--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -12,15 +12,23 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from goldenmatch.core.complexity_profile import DomainProfile as PublicDomainProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
 
 logger = logging.getLogger(__name__)
 
 
-def _tf_dom(df):
+# A6 dual-rep: every frame that reaches this module is a seam frame, a polars
+# DataFrame (classic lane) or a pa.Table (arrow lane). Route ALL frame access
+# through `_tf_dom` -- `pa.Table.columns` is a list of ChunkedArrays, not names,
+# so a bare `df.columns` either raises (`.startswith` on a ChunkedArray) or,
+# worse, silently answers False for every `col in df.columns` membership test.
+_Frameish = Any
+
+
+def _tf_dom(df: _Frameish):
     from goldenmatch.core.frame import to_frame
 
     return to_frame(df)
@@ -421,11 +429,11 @@ def extract_biblio_features(text: str) -> dict[str, str | None]:
 # ── DataFrame-Level Extraction ────────────────────────────────────────────
 
 
-def _emit_domain_profile(domain: DomainProfile, df_after: pl.DataFrame, low_conf_ids) -> None:
+def _emit_domain_profile(domain: DomainProfile, df_after: _Frameish, low_conf_ids) -> None:
     """Emit PublicDomainProfile. No-op when null emitter."""
     if not _emitter_stack.get():
         return
-    derived = [c for c in df_after.columns if c.startswith("__")]
+    derived = [c for c in _tf_dom(df_after).columns if c.startswith("__")]
     current_emitter().set_domain(PublicDomainProfile(
         detected_domain=getattr(domain, "name", None),
         confidence=float(getattr(domain, "confidence", 0.0)),
@@ -435,10 +443,10 @@ def _emit_domain_profile(domain: DomainProfile, df_after: pl.DataFrame, low_conf
 
 
 def extract_features(
-    df: pl.DataFrame,
+    df: _Frameish,
     domain: DomainProfile,
     confidence_threshold: float = 0.3,
-) -> tuple[pl.DataFrame, list[int]]:
+) -> tuple[_Frameish, list[int]]:
     """Extract structured features from text columns, adding derived columns.
 
     Args:
@@ -474,19 +482,17 @@ def extract_features(
     return result_df, low_conf
 
 
-def _detect_product_subdomain(df: pl.DataFrame, domain: DomainProfile) -> str:
+def _detect_product_subdomain(df: _Frameish, domain: DomainProfile) -> str:
     """Auto-detect whether product data is electronics or software.
 
     Samples text columns and counts software-specific signals vs
     electronics-specific signals.
     """
+    _f = _tf_dom(df)
     text_col = domain.text_columns[0] if domain.text_columns else None
-    if not text_col or text_col not in df.columns:
+    if not text_col or text_col not in _f.columns:
         return "electronics"
 
-    from goldenmatch.core.frame import to_frame as _tf_a6
-
-    _f = _tf_a6(df)
     sample = _f.head(min(200, _f.height))
     sw_signals = 0
     hw_signals = 0
@@ -511,10 +517,10 @@ def _detect_product_subdomain(df: pl.DataFrame, domain: DomainProfile) -> str:
 
 
 def _extract_software_features_df(
-    df: pl.DataFrame,
+    df: _Frameish,
     domain: DomainProfile,
     confidence_threshold: float,
-) -> tuple[pl.DataFrame, list[int]]:
+) -> tuple[_Frameish, list[int]]:
     """Extract software product features into derived columns."""
     text_col = domain.text_columns[0]
 
@@ -568,10 +574,10 @@ def _extract_software_features_df(
 
 
 def _extract_product_features_df(
-    df: pl.DataFrame,
+    df: _Frameish,
     domain: DomainProfile,
     confidence_threshold: float,
-) -> tuple[pl.DataFrame, list[int]]:
+) -> tuple[_Frameish, list[int]]:
     """Extract product features into derived columns."""
     text_col = domain.text_columns[0]  # primary text column
 
@@ -632,13 +638,13 @@ def _extract_product_features_df(
 
 
 def _extract_biblio_features_df(
-    df: pl.DataFrame,
+    df: _Frameish,
     domain: DomainProfile,
     confidence_threshold: float,
-) -> tuple[pl.DataFrame, list[int]]:
+) -> tuple[_Frameish, list[int]]:
     """Extract bibliographic features."""
     text_col = domain.text_columns[0] if domain.text_columns else "title"
-    if text_col not in df.columns:
+    if text_col not in _tf_dom(df).columns:
         return df, []
 
     title_keys = []

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3147,6 +3147,27 @@ def _run_dedupe_pipeline(
                         _col, _frame.derive_standardized_column(_col, _std_names)
                     )
 
+        # Domain extraction MUST precede compute_matchkeys: it is what
+        # materializes the `__brand__` / `__model__` / `__title_key__` columns
+        # that auto-config's matchkeys reference, so deriving matchkeys first
+        # sends `derive_matchkey` at a column that does not exist yet
+        # (KeyError: 'Field "__model__" does not exist in schema' -- the
+        # benchmarks Abt-Buy failure). This is the order the classic lane and
+        # the match pipeline's arrow lane already use; keep the three in sync.
+        if config.domain and config.domain.enabled:
+            # A6: domain extraction is seam-driven dual-rep -- lane preserved.
+            with stage("domain_extraction"):
+                _frame = _tf_lane(_apply_domain_extraction(_frame.native, config))
+
+        # ── Learning Memory: pre-scoring learner overlay (parity with the classic
+        # branch's memory_pre_overlay at ~3220). Operates on `matchkeys` +
+        # `memory_store` (opened once above the lane split), not the frame, so it
+        # sits here on the arrow lane before precompute. memory_post is already
+        # shared (below the lane merge), so this closes the last memory gap on the
+        # arrow lane -- arrow-lane migration phase 2.
+        with stage("memory_pre_overlay"):
+            _apply_memory_pre(memory_store, config, matchkeys)
+
         if "compute_matchkeys" not in _eager_stages_done:
             with stage("compute_matchkeys"):
                 for _mk in matchkeys:
@@ -3162,20 +3183,6 @@ def _run_dedupe_pipeline(
                             ]
                         ),
                     )
-
-        if config.domain and config.domain.enabled:
-            # A6: domain extraction is seam-driven dual-rep -- lane preserved.
-            with stage("domain_extraction"):
-                _frame = _tf_lane(_apply_domain_extraction(_frame.native, config))
-
-        # ── Learning Memory: pre-scoring learner overlay (parity with the classic
-        # branch's memory_pre_overlay at ~3220). Operates on `matchkeys` +
-        # `memory_store` (opened once above the lane split), not the frame, so it
-        # sits here on the arrow lane before precompute. memory_post is already
-        # shared (below the lane merge), so this closes the last memory gap on the
-        # arrow lane -- arrow-lane migration phase 2.
-        with stage("memory_pre_overlay"):
-            _apply_memory_pre(memory_store, config, matchkeys)
 
         with stage("precompute_matchkey_transforms"):
             collected_frame = precompute_matchkey_transforms_frame(_frame, matchkeys)

--- a/packages/python/goldenmatch/goldenmatch/plugins/registry.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/registry.py
@@ -6,6 +6,8 @@ from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from goldenmatch.plugins.base import ScorerPlugin, TransformPlugin
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,16 @@ class PluginRegistry:
 
     _instance: PluginRegistry | None = None
     _discovered: bool = False
+    # Bundled registrations that ran as an import-time side effect (refdata's
+    # scorers + transforms). `reset()` drops the singleton but cannot re-run a
+    # module body -- `sys.modules` already holds it -- so without replay those
+    # plugins were gone for the REST OF THE PROCESS, and the next
+    # `has_transform("refdata_business_canonical")` read False with nothing to
+    # point at. Under xdist that is invisible until a resetting test happens to
+    # land in the same worker ahead of a refdata one, which is why it presented
+    # as shard-membership flake rather than a bug.
+    _bootstraps: list[Callable[[], None]] = []
+    _bootstrapping: bool = False
 
     def __init__(self) -> None:
         self._scorers: dict[str, object] = {}
@@ -32,15 +44,43 @@ class PluginRegistry:
         self._golden_strategies: dict[str, object] = {}
 
     @classmethod
+    def add_bootstrap(cls, fn: Callable[[], None]) -> None:
+        """Record an idempotent registration to replay onto a fresh singleton.
+
+        Callers register their plugins as they always did and then hand the
+        same callable here; nothing new is imported, so this only restores
+        state a `reset()` destroyed.
+        """
+        if fn not in cls._bootstraps:
+            cls._bootstraps.append(fn)
+
+    @classmethod
     def instance(cls) -> PluginRegistry:
         """Get or create the singleton registry."""
         if cls._instance is None:
             cls._instance = cls()
+            # Set _instance FIRST: the bootstraps call instance() themselves,
+            # and must land on the one being built rather than recursing.
+            if not cls._bootstrapping:
+                cls._bootstrapping = True
+                try:
+                    for fn in cls._bootstraps:
+                        try:
+                            fn()
+                        except Exception as e:  # pragma: no cover -- shipped-code bug
+                            logger.warning("Failed to replay plugin bootstrap: %s", e)
+                finally:
+                    cls._bootstrapping = False
         return cls._instance
 
     @classmethod
     def reset(cls) -> None:
-        """Reset the singleton (for testing)."""
+        """Reset the singleton (for testing).
+
+        Bundled bootstraps are replayed on the next `instance()`, so a reset
+        clears user/test registrations without silently stripping the plugins
+        goldenmatch itself ships.
+        """
         cls._instance = None
         cls._discovered = False
 

--- a/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
@@ -57,6 +57,7 @@ Provenance + license for every bundled dataset:
 from __future__ import annotations
 
 from goldenmatch.core.acronym import register_transforms as _register_acronym_transforms
+from goldenmatch.plugins.registry import PluginRegistry as _PluginRegistry
 from goldenmatch.refdata.addresses import is_available as addresses_available
 from goldenmatch.refdata.addresses import (
     known_tokens as address_tokens,
@@ -93,12 +94,23 @@ from goldenmatch.refdata.surnames import (
 )
 
 # Register the bundled scorers + transforms on import. Idempotent.
-register_scorers()
-_register_business_transforms()
-_register_business_alias_transforms()
-_register_address_transforms()
-_register_industry_transforms()
-_register_acronym_transforms()
+# Each is ALSO handed to PluginRegistry.add_bootstrap so a `PluginRegistry.reset()`
+# does not strip them for the rest of the process: a reset drops the singleton,
+# but this module body cannot run twice (sys.modules holds it), so without the
+# replay the refdata plugins would be permanently gone.
+_BUNDLED_REGISTRATIONS = (
+    register_scorers,
+    _register_business_transforms,
+    _register_business_alias_transforms,
+    _register_address_transforms,
+    _register_industry_transforms,
+    _register_acronym_transforms,
+)
+
+for _register in _BUNDLED_REGISTRATIONS:
+    _register()
+    _PluginRegistry.add_bootstrap(_register)
+del _register
 
 __all__ = [
     "address_tokens",

--- a/packages/python/goldenmatch/tests/conftest.py
+++ b/packages/python/goldenmatch/tests/conftest.py
@@ -129,35 +129,20 @@ def _disable_autoconfig_memory(monkeypatch):
         pass
 
 
-@pytest.fixture(autouse=True)
-def _ensure_refdata_plugins_registered():
-    """Re-register refdata plugins before every test.
-
-    Per the xdist gotcha in CLAUDE.md: workers don't share state, and
-    ``test_plugins.py``'s ``reset_registry`` fixture wipes the singleton
-    within a worker. The ``import goldenmatch.refdata`` side-effect
-    registration only fires once per worker process, so refdata tests
-    scheduled after a plugin-test reset would see an empty registry.
-
-    Each ``register_*`` function is idempotent. Skips silently if a
-    refdata submodule isn't importable (slim installs).
-    """
-    try:
-        import goldenmatch.refdata  # noqa: F401  triggers registration
-        from goldenmatch.refdata.scorer import register_scorers
-        register_scorers()
-    except ImportError:
-        return
-    for module_path in (
-        "goldenmatch.refdata.business",
-        "goldenmatch.refdata.addresses",
-        "goldenmatch.refdata.industries",
-    ):
-        try:
-            mod = __import__(module_path, fromlist=["register_transforms"])
-            mod.register_transforms()
-        except (ImportError, AttributeError):
-            continue
+# The autouse `_ensure_refdata_plugins_registered` fixture that used to live
+# here is gone: `PluginRegistry.reset()` now replays the bundled registrations
+# onto the fresh singleton (`PluginRegistry.add_bootstrap`, wired in
+# `goldenmatch/refdata/__init__.py`), so the library no longer loses its own
+# plugins to a reset and the test harness has nothing to paper over.
+#
+# Keeping it would have been worse than redundant. It re-registered a
+# HAND-MAINTAINED list -- business, addresses, industries, scorer -- that had
+# drifted: `business_aliases` and `core.acronym` were never added. So
+# `refdata_business_canonical` alone stayed unregistered after any resetting
+# test, and `test_business_aliases.py::test_alias_transforms_registered` failed
+# if and only if xdist put a resetting test ahead of it in the same worker.
+# That is the "shard-isolation-fragile" flake class the CI --deselect list
+# documents; a fix-list that must be kept in sync by hand is the mechanism.
 
 
 @pytest.fixture

--- a/packages/python/goldenmatch/tests/test_business_aliases.py
+++ b/packages/python/goldenmatch/tests/test_business_aliases.py
@@ -19,3 +19,22 @@ def test_alias_transforms_registered():
     gn = reg.get_transform("refdata_given_name_canonical")
     assert are_equivalent("Bob", "Robert")                 # precondition from the data
     assert gn.transform("Bob") == gn.transform("Robert")   # same set -> same canonical
+
+
+def test_bundled_transforms_survive_a_registry_reset():
+    """`PluginRegistry.reset()` must not permanently strip the bundled plugins.
+
+    refdata registers its scorers/transforms as an import-time side effect, and
+    a module body cannot run twice -- so before the bootstrap replay, ANY test
+    that reset the singleton left `refdata_business_canonical` unregistered for
+    the rest of the process. Under xdist that surfaced only when a resetting
+    test happened to precede this file in the same worker, so it read as
+    shard-membership flake instead of the state bug it is.
+    """
+    import goldenmatch.refdata  # noqa: F401  -- the import-time registration
+
+    assert PluginRegistry.instance().has_transform("refdata_business_canonical")
+    PluginRegistry.reset()
+    reg = PluginRegistry.instance()
+    assert reg.has_transform("refdata_business_canonical")
+    assert reg.has_transform("refdata_given_name_canonical")

--- a/packages/python/goldenmatch/tests/test_domain_extraction_arrow.py
+++ b/packages/python/goldenmatch/tests/test_domain_extraction_arrow.py
@@ -7,11 +7,32 @@ arrow-native lane.
 `TypeError: unexpected argument type Expr` -- crashing domain extraction on
 product/bibliographic data whenever an LLM key was present. The fix coerces to
 polars for that LLM-gated block; this test locks it.
+
+The rest of the file locks the SECOND round of the same class, found by
+bisecting the `benchmarks` Abt-Buy failure to #2250 (the polars->arrow
+`dedupe_df` eviction). Two distinct defects, both only reachable once a polars
+input started taking the arrow lane:
+
+1. Stage ORDER -- the dedupe pipeline's arrow lane derived matchkeys BEFORE
+   running domain extraction, so a matchkey over `__model__` hit
+   `KeyError: 'Field "__model__" does not exist in schema'`.
+2. Three un-ported `df.columns` reads in `core/domain.py`. `pa.Table.columns`
+   is a list of ChunkedArrays, not names, so one raised
+   (`'ChunkedArray' object has no attribute 'startswith'`) and two SILENTLY
+   answered False for every membership test -- disabling product-subdomain
+   detection and bibliographic extraction on the arrow lane with no error.
 """
 from __future__ import annotations
 
+import polars as pl
 import pyarrow as pa
-from goldenmatch.config.schemas import DomainConfig, GoldenMatchConfig
+import pytest
+from goldenmatch.config.schemas import (
+    DomainConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
 from goldenmatch.core import llm_extract as LE
 from goldenmatch.core.pipeline import _apply_domain_extraction
 
@@ -53,3 +74,173 @@ def test_domain_extraction_arrow_no_llm_key_is_safe(monkeypatch):
     ))
     out = _apply_domain_extraction(_product_table(), cfg)
     assert out is not None
+
+
+def _software_titles() -> list[str]:
+    """Software-shaped text: software words, no electronics model numbers.
+
+    `_detect_product_subdomain` scores `software` on these; the electronics
+    signals (a `LETTERS+DIGITS` model number, or spec words) are deliberately
+    absent so the two lanes have an unambiguous right answer to agree on.
+    """
+    return [
+        "Microsoft Office Home and Student License Download",
+        "Adobe Acrobat Standard Edition Upgrade",
+        "Norton Antivirus Subscription Software",
+    ]
+
+
+def _biblio_profile():
+    from goldenmatch.core.domain import DomainProfile as InternalProfile
+
+    return InternalProfile(name="bibliographic", confidence=0.9, text_columns=["title"])
+
+
+def test_domain_extraction_emits_profile_on_arrow_table():
+    """`_emit_domain_profile` reads column NAMES; on a pa.Table they are arrays.
+
+    The emitter is a no-op unless a capture is active, which is why the two
+    tests above never reached this line -- the auto-config controller runs the
+    pipeline under `profile_capture`, so in production it always did.
+    Pre-fix: `AttributeError: 'pyarrow.lib.ChunkedArray' object has no
+    attribute 'startswith'`.
+    """
+    from goldenmatch.core.profile_emitter import profile_capture
+
+    cfg = GoldenMatchConfig(domain=DomainConfig(
+        enabled=True, mode="auto", llm_validation=False,
+    ))
+    with profile_capture() as e:
+        out = _apply_domain_extraction(_product_table(), cfg)
+
+    assert out is not None
+    assert e.domain is not None
+    # The derived-column list is the payload that needed real column names.
+    assert "__model__" in e.domain.derived_columns
+    assert "__brand__" in e.domain.derived_columns
+
+
+def test_product_subdomain_detection_agrees_across_lanes():
+    """`text_col not in df.columns` is False for EVERY column on a pa.Table.
+
+    Pre-fix that short-circuited `_detect_product_subdomain` to its
+    "electronics" fallback on the arrow lane -- a silent wrong answer, not a
+    crash, so software data was extracted with the electronics extractor.
+    """
+    from goldenmatch.core.domain import DomainProfile as InternalProfile
+    from goldenmatch.core.domain import _detect_product_subdomain
+
+    titles = _software_titles()
+    polars_answer = _detect_product_subdomain(
+        pl.DataFrame({"title": titles}),
+        InternalProfile(name="product", confidence=0.9, text_columns=["title"]),
+    )
+    arrow_answer = _detect_product_subdomain(
+        pa.table({"title": titles}),
+        InternalProfile(name="product", confidence=0.9, text_columns=["title"]),
+    )
+    assert polars_answer == "software"
+    assert arrow_answer == polars_answer
+
+
+def test_biblio_extraction_adds_title_key_on_arrow_table():
+    """Same membership bug at the biblio extractor's guard.
+
+    Pre-fix `_extract_biblio_features_df` returned the frame UNCHANGED on the
+    arrow lane -- no `__title_key__`, no error, so a matchkey over it would
+    then fail far away from the cause.
+    """
+    from goldenmatch.core.domain import extract_features
+    from goldenmatch.core.frame import to_frame
+
+    titles = ["The Anatomy of a Large-Scale Hypertextual Web Search Engine",
+              "Authoritative Sources in a Hyperlinked Environment"]
+    out, _low_conf = extract_features(pa.table({"title": titles}), _biblio_profile())
+
+    assert "__title_key__" in to_frame(out).columns
+    assert to_frame(out).height == 2
+
+
+# ── Stage order: domain extraction must precede matchkey derivation ──────────
+
+def _domain_matchkey_config() -> GoldenMatchConfig:
+    """Explicit config whose only matchkey is over a DERIVED domain column.
+
+    This is the shape auto-config produces on product data, reduced to the one
+    thing that matters: the matchkey cannot be derived until domain extraction
+    has materialized `__model__`.
+    """
+    return GoldenMatchConfig(
+        domain=DomainConfig(enabled=True, mode="auto", llm_validation=False),
+        matchkeys=[MatchkeyConfig(
+            name="model_exact", type="exact",
+            fields=[MatchkeyField(field="__model__")],
+        )],
+    )
+
+
+def _product_frame() -> pl.DataFrame:
+    return pl.DataFrame({
+        "title": [
+            "Sony STR-DA3600ES receiver", "Sony STR-DA3600ES 7.2 receiver",
+            "Canon EOS 60D camera", "Canon EOS 60D DSLR",
+            "Bose QC15 headphones", "Bose QC15 noise cancelling",
+        ],
+        "description": ["av receiver", "av receiver", "camera", "camera",
+                        "audio", "audio"],
+    })
+
+
+def test_arrow_lane_matchkey_over_derived_domain_column():
+    """The benchmarks Abt-Buy failure, reduced.
+
+    A polars input evicts to the arrow lane (#2250). Pre-fix that lane derived
+    matchkeys BEFORE domain extraction, so this raised
+    `KeyError: 'Field "__model__" does not exist in schema'`.
+    """
+    import goldenmatch as gm
+
+    res = gm.dedupe_df(_product_frame(), config=_domain_matchkey_config())
+    assert res is not None
+    assert len(getattr(res, "clusters", None) or {}) > 0
+
+
+def test_arrow_lane_runs_domain_extraction_before_matchkeys():
+    """Pin the ORDER itself, not just the absence of the crash.
+
+    The classic lane and the match pipeline's arrow lane both run
+    domain_extraction -> memory_pre_overlay -> compute_matchkeys; the dedupe
+    arrow lane must too, or the next derived-column matchkey re-breaks it.
+    """
+    import goldenmatch as gm
+    from goldenmatch.core.bench import bench_capture
+
+    with bench_capture() as rec:
+        gm.dedupe_df(_product_frame(), config=_domain_matchkey_config())
+
+    stages = list(rec.timings)
+    assert "domain_extraction" in stages
+    assert "compute_matchkeys" in stages
+    assert stages.index("domain_extraction") < stages.index("compute_matchkeys")
+
+
+@pytest.mark.parametrize("lane", ["arrow", "classic"])
+def test_derived_column_matchkey_parity_across_lanes(monkeypatch, lane):
+    """Both lanes produce the same clusters for a derived-column matchkey.
+
+    `GOLDENMATCH_FRAME_LANE=0` is the documented revert switch to the classic
+    shim; it was the only working path for this config before the fix.
+    """
+    import goldenmatch as gm
+
+    if lane == "classic":
+        monkeypatch.setenv("GOLDENMATCH_FRAME_LANE", "0")
+    else:
+        monkeypatch.delenv("GOLDENMATCH_FRAME_LANE", raising=False)
+
+    res = gm.dedupe_df(_product_frame(), config=_domain_matchkey_config())
+    sizes = sorted(
+        len(c["members"] if isinstance(c, dict) else c.members)
+        for c in (getattr(res, "clusters", None) or {}).values()
+    )
+    assert sizes == [1, 1, 2, 2]

--- a/packages/python/goldenmatch/tests/test_plugins.py
+++ b/packages/python/goldenmatch/tests/test_plugins.py
@@ -37,15 +37,21 @@ class TestPluginRegistry:
         r2 = PluginRegistry.instance()
         assert r1 is not r2
 
-    def test_list_empty(self):
+    def test_fresh_registry_has_only_bundled_plugins(self):
+        """A fresh singleton carries the bundled refdata plugins, nothing else.
+
+        This asserted `== {..: [], ..}` while `reset()` silently stripped the
+        bundled registrations for the rest of the process (a module body cannot
+        re-run). Now they are replayed onto the new singleton, so "fresh" means
+        "no USER registrations", not "empty" -- and the connector /
+        golden_strategy groups, which have no bundled entries, still are.
+        """
         r = PluginRegistry.instance()
         plugins = r.list_plugins()
-        assert plugins == {
-            "scorer": [],
-            "transform": [],
-            "connector": [],
-            "golden_strategy": [],
-        }
+        assert plugins["connector"] == []
+        assert plugins["golden_strategy"] == []
+        assert "refdata_business_canonical" in plugins["transform"]
+        assert "my_scorer" not in plugins["scorer"]
 
     def test_register_scorer(self):
         class MyScorer:

--- a/scripts/bench_native_kernels.py
+++ b/scripts/bench_native_kernels.py
@@ -153,7 +153,7 @@ def bench(n: int) -> None:
     native_call = t_tolist + t_full          # what score_buckets pays today (Vec kernel)
     arrow_ceiling = t_tolist + t_ingest      # theoretical max removable by zero-copy ABI
     arrow_path = t_arrow_build + t_arrow_call  # measured Arrow-native path
-    _py_total = t_tolist + t_pyloop  # kept: documents the pure-Python baseline
+    py_total = t_tolist + t_pyloop           # pure-Python baseline, end to end
 
     print(f"\n=== N={n:,} rows, {len(sizes):,} blocks, {n_pairs:,} candidate pairs ===")
     print(f"  T_tolist   (.to_list materialization) : {t_tolist*1e3:8.1f} ms")
@@ -166,6 +166,7 @@ def bench(n: int) -> None:
     print("  --")
     print(f"  Vec path total   (tolist+full)         : {native_call*1e3:8.1f} ms")
     print(f"  Arrow path total (arrowbuild+arrowcall): {arrow_path*1e3:8.1f} ms")
+    print(f"  Python path total (tolist+pyloop)      : {py_total*1e3:8.1f} ms")
     print(f"  ARROW SPEEDUP vs Vec kernel            : {native_call/arrow_path:8.2f}x"
           f"  ({100*(1-arrow_path/native_call):4.1f}% wall cut)")
     print(f"  Arrow upside ceiling (tolist+ingest)   : {arrow_ceiling*1e3:8.1f} ms"

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -598,9 +598,12 @@ def score_quality(
     bp = bp_acc / n_rows
     br = br_acc / n_rows
     bf1 = (2 * bp * br / (bp + br)) if (bp + br) else 0.0
-    # Cluster
-    _cfp_cnt = pred_multi_total - exact_cluster_matches  # computed, not yet reported
-    _cfn_cnt = gt_multi_total - exact_cluster_matches  # computed, not yet reported
+    # Cluster. NOTE the asymmetry with `pairwise` below: that block returns fp/fn,
+    # this one does not. The counts are `pred_multi_total - exact_cluster_matches`
+    # and `gt_multi_total - exact_cluster_matches` if they are ever wanted; they
+    # were computed here and dropped on the floor. Adding them to the returned dict
+    # is safe (qis_gate.py reads cluster via an explicit f1/p/r allowlist) but is an
+    # output change, so it is not being smuggled into a lint pass.
     cp = exact_cluster_matches / pred_multi_total if pred_multi_total else 0.0
     cr = exact_cluster_matches / gt_multi_total if gt_multi_total else 0.0
     cf1 = (2 * cp * cr / (cp + cr)) if (cp + cr) else 0.0

--- a/scripts/research/recall_certificate.py
+++ b/scripts/research/recall_certificate.py
@@ -122,7 +122,6 @@ def chao2(capture_counts: dict[tuple[int, int], int], K: int) -> float:
 
 def chao2_var(counts: dict, K: int) -> float:
     """Analytic variance of the Chao2 estimator (Chao 1987, incidence form)."""
-    _D = len(counts)  # richness, unused by this variance form
     Q1 = sum(1 for v in counts.values() if v == 1)
     Q2 = sum(1 for v in counts.values() if v == 2)
     c = (K - 1) / K if K > 1 else 1.0


### PR DESCRIPTION
## What and why

Fixes the `benchmarks` lane failing on `main` (#2457): `KeyError: 'Field "__model__" does not exist in schema'` on the Abt-Buy two-source zero-config path.

Bisected, and it needs two answers, because "what turned the lane red" and "what is broken" are different commits.

**Why the lane went red between #94 and #95: `8db33ebc` (#2386) - and it is not a regression.** `benchmarks` is weekly. Run #94 (Aug 3, `afe986ff`) passed; #95 (Aug 10, `e736ff12`) failed. But #94 never ran the failing case: its log has no `Abt-Buy` line at all, only `DBLP-ACM ... Skipping` / `NCVR ... skipping` / `Febrl3: f1=0.9912`. #2386 merged at 13:22 UTC on Aug 3, after #94 started at 09:58 UTC, and is the only commit in the 64-commit window touching `run_benchmarks.py` / `leipzig_eval.py` / `benchmarks.yml` - it is the commit that added the two-source Leipzig product lane. No `benchmarks` run has ever exercised that path successfully.

**Why the path is broken: `72e3756d` (#2250), Jul 29** - "route polars `dedupe_df` input through the arrow Frame lane". Bisected with the real Abt-Buy CSVs (200 rows per source, prepped exactly as `run_two_source_dedupe_zeroconfig` does), which reproduces the CI error verbatim in ~10s. Both endpoints re-verified cleanly and sequentially afterwards: parent `aa12a5bd` completes with 298 clusters, `72e3756d` raises. At current `main`, `GOLDENMATCH_FRAME_LANE=0` - the classic-lane escape hatch that same commit added - still passes, which confirms the mechanism.

## Changes

Two layers, both only reachable once a polars input started taking the arrow lane.

- **`core/pipeline.py` - stage order.** The dedupe pipeline's arrow lane derived matchkeys BEFORE running domain extraction. Domain extraction is what materializes the `__brand__` / `__model__` / `__title_key__` columns that auto-config's matchkeys reference, so `derive_matchkey` reached a column that did not exist yet. The classic lane (`domain_extraction` -> `memory_pre_overlay` -> `compute_matchkeys`) and the match pipeline's arrow lane already had this right; the dedupe arrow lane now matches them.
- **`core/domain.py` - three un-ported `df.columns` reads.** `pa.Table.columns` is a list of ChunkedArrays, not names.
  - `_emit_domain_profile` raised `'ChunkedArray' object has no attribute 'startswith'`. It is a no-op unless a profile capture is active, which is exactly why the existing arrow-lane tests missed it and the auto-config controller always hit it.
  - `_detect_product_subdomain` and `_extract_biblio_features_df` were worse: `col in df.columns` is `False` for EVERY column on a `pa.Table`, so both guards short-circuited. Subdomain detection was pinned to its "electronics" fallback and bibliographic extraction was skipped outright, with no error either time.
  - All frame access in the module now goes through the seam, and the annotations say `_Frameish` instead of claiming `pl.DataFrame` - the wrong annotation is what invited this.
- **`plugins/registry.py` + `refdata/__init__.py` - a flake the new tests exposed**, fixed per the standing flaky-test-first rule rather than deferred. `PluginRegistry.reset()` dropped the singleton, but refdata registers its scorers/transforms as an import-time side effect and a module body cannot run twice (`sys.modules` holds it), so a reset stripped the bundled plugins for the rest of the process. `PluginRegistry.add_bootstrap` records those idempotent registrations and replays them onto the fresh singleton; a reset now clears user registrations only. This is a library bug, not just a test bug - any caller of `reset()` silently lost the shipped transforms.
- **`tests/conftest.py` - the workaround for that flake is deleted.** It re-registered a hand-maintained module list - business, addresses, industries, scorer - that had DRIFTED: `business_aliases` and `core.acronym` were never added to it. That is why exactly one transform (`refdata_business_canonical`) went missing, and only when xdist happened to put a resetting test ahead of a refdata one in the same worker. A fix-list that must be kept in sync by hand is the mechanism behind the "shard-isolation-fragile" class the CI `--deselect` list documents.

Net effect on the benchmark input: the auto-config controller goes from every iteration erroring (`n_errored=4`, fallback to v0 + RED sentinel) to running normally, with clusters byte-identical to the classic lane.

## Testing

- `pytest tests/test_domain_extraction_arrow.py` - 9 passed. 7 are new, and **each was verified to fail without the layer it pins**: reverting `domain.py` alone fails 3 (emit-profile, subdomain-parity, biblio-title-key), reverting `pipeline.py` alone fails the other 3 (matchkey-over-derived-column, stage-order, arrow/classic parity). One test pins the ORDER itself via `bench_capture()`, not just the absence of the crash, so the next derived-column matchkey cannot silently re-break it.
- `pytest tests/test_business_aliases.py tests/test_plugins.py tests/plugins ...` (all registry-touching files) - 266 passed. Adds a deterministic reset-survival test, so the ordering dependency no longer decides the outcome. `test_list_empty` is renamed and rewritten: it asserted a fresh registry is literally empty, which was only true because of the bug.
- Full goldenmatch suite, `-n auto`, CI's `--ignore` list, `GOLDENMATCH_NATIVE=0`: **9057 passed, 30 failed** against a **pristine-tree baseline of the identical invocation: 9049 passed, 30 failed**. Set-diffed - zero new failures, zero fixed-by-accident. The 30 are environmental in this container (no `datafusion`, no `PIL`/documents extra, no native kernels, no embeddings).
- End to end on the real dataset: `dedupe_df` over the Abt-Buy two-source frame now completes instead of raising, with the same 298 clusters and the same `BUDGET_TIME` stop reason as the classic lane (arrow iter-0 171s vs classic 147s - same order, and the slowness is pre-existing product-domain behaviour, not introduced here).
- `ruff check packages/python/goldenmatch` clean; `check_context_budget` / `check_claude_refs` / `check_docs_consistency` / `check_docs_staleness` / `test_config_matrix` (50) / `test_agent_codemap` pass. `docs/agent-codemap.json` regenerated.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets) - **not run: `pre-commit` is not installed in this container.** `ruff check` was run directly and is clean.
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed - no workflow or gotcha changed

## Follow-up, not in this PR

The three `--deselect`ed `test_memory_*` tests in `ci.yml` are documented as the same shard-isolation class ("a test co-located in the shard clobbers a core transform/scorer registration"). The root cause of that class is fixed here, so they are a candidate for re-enabling - but the note says it is not reproducible off-CI, and it did not reproduce locally either way, so proving it needs a CI run rather than a local one. Left alone deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_