### PR TITLE
fix(quality): quality weighting is arrow-native, not polars-gated

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4243,6 +4243,7 @@
           "file": "packages/python/goldenmatch/goldenmatch/core/quality.py",
           "purpose": "GoldenCheck integration — enhanced data quality scanning before matching.",
           "defines": [
+            "_as_arrow_table",
             "_goldencheck_available",
             "_scan_and_fix",
             "_scan_findings",

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -4495,23 +4495,16 @@ def _run_dedupe_pipeline(
         # relevant universe; scoped so cell_quality is not paid over the whole
         # frame on every default dedupe.
         _member_ids = _golden_member_row_ids()
-        from goldenmatch.core.golden import _polars_importable as _pl_ok
-        if _member_ids and not _pl_ok():
-            # Zero-polars env: goldencheck's cell_quality is polars-backed;
-            # quality weighting fails OPEN (None = no weighting), the same
-            # contract as goldencheck-absent. Re-opens when goldencheck
-            # ships an arrow cell_quality.
-            _member_ids = []
         if _member_ids:
             from goldenmatch.core.quality import compute_quality_scores
             with stage("golden_quality_scores"):
-                # GOLDEN BRIDGE: compute_quality_scores is goldencheck-side
-                # polars; quality_weighting defaults True, so bridging (not
-                # declining) keeps the Frame lane live on default configs.
+                # Arrow-native, no bridge: goldencheck's cell_quality takes a
+                # pa.Table, so weighting runs on the seam frame directly and does
+                # NOT depend on the optional [polars] extra. It used to decline
+                # polars-free, which silently changed survivorship between
+                # `pip install goldenmatch` and `goldenmatch[polars]`.
                 quality_scores = compute_quality_scores(
-                    _as_polars_df(
-                        _collected_frame.filter_in("__row_id__", _member_ids).native
-                    )
+                    _collected_frame.filter_in("__row_id__", _member_ids).native
                 )
             if quality_scores:
                 logger.info(

--- a/packages/python/goldenmatch/goldenmatch/core/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from goldenmatch._polars_lazy import pl
 
@@ -85,8 +86,22 @@ def _goldencheck_available() -> bool:
         return False
 
 
+def _as_arrow_table(df: Any) -> Any:
+    """Coerce a frame to a ``pyarrow.Table`` without importing polars.
+
+    The arrow runtime hands us a ``pa.Table`` directly; a polars frame (or
+    anything else exposing ``to_arrow``) is coerced via its own method, so this
+    stays polars-free."""
+    import pyarrow as pa
+
+    if isinstance(df, pa.Table):
+        return df
+    _to_arrow = getattr(df, "to_arrow", None)
+    return _to_arrow() if callable(_to_arrow) else pa.table(df)
+
+
 def compute_quality_scores(
-    df: pl.DataFrame,
+    df: Any,
     row_id_col: str = "__row_id__",
 ) -> dict[tuple[int, str], float] | None:
     """Per-cell quality weights for quality-weighted survivorship, keyed by
@@ -101,8 +116,15 @@ def compute_quality_scores(
     behaviour/perf change -- weighting only kicks in when there are real issues.
 
     ``cell_quality`` returns positional row indices; we remap them to
-    ``row_id_col`` so the builders' ``(row_id, col)`` lookups line up."""
-    if not _goldencheck_available() or row_id_col not in df.columns:
+    ``row_id_col`` so the builders' ``(row_id, col)`` lookups line up.
+
+    Arrow-native: ``cell_quality`` itself takes a ``pa.Table``, so this runs
+    unchanged on a polars-free install (weighting must NOT depend on the
+    optional ``[polars]`` extra -- that silently changed survivorship)."""
+    if not _goldencheck_available():
+        return None
+    tbl = _as_arrow_table(df)
+    if row_id_col not in tbl.column_names:
         return None
     try:
         from goldencheck import cell_quality
@@ -110,14 +132,14 @@ def compute_quality_scores(
         return None  # older goldencheck without the per-cell API
 
     try:
-        positional = cell_quality(df)
+        positional = cell_quality(tbl)
     except Exception:  # noqa: BLE001 - never let DQ scoring break a dedupe run
         logger.debug("goldencheck.cell_quality failed; skipping quality weighting", exc_info=True)
         return None
     if not positional:
         return None
 
-    row_ids = df[row_id_col].to_list()
+    row_ids = tbl.column(row_id_col).to_pylist()
     scores: dict[tuple[int, str], float] = {}
     for (idx, col), weight in positional.items():
         if 0 <= idx < len(row_ids) and row_ids[idx] is not None:
@@ -125,7 +147,7 @@ def compute_quality_scores(
     return scores or None
 
 
-def blocking_risk(df: pl.DataFrame) -> dict[str, float] | None:
+def blocking_risk(df: Any) -> dict[str, float] | None:
     """Per-column "block-shatter risk" for quality-aware blocking.
 
     `risk[col]` is the fraction of rows whose value is an edit-distance variant
@@ -144,15 +166,10 @@ def blocking_risk(df: pl.DataFrame) -> dict[str, float] | None:
     except ImportError:
         return None
     # Arrow-native: GoldenMatch is polars-free, so operate on a pyarrow.Table.
-    # The arrow runtime hands us one directly; a polars frame (or anything with
-    # to_arrow) is coerced once. cell_quality is itself arrow-native.
+    # cell_quality is itself arrow-native.
     import pyarrow as pa
 
-    if isinstance(df, pa.Table):
-        tbl = df
-    else:
-        _to_arrow = getattr(df, "to_arrow", None)
-        tbl = _to_arrow() if callable(_to_arrow) else pa.table(df)
+    tbl = _as_arrow_table(df)
     n = tbl.num_rows
     if n == 0:
         return None

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 6,  # A1-A8 + A9-slice-1 retired; rebase onto deep-D2b removed the 2 frames-path sites
+    "core/pipeline.py": 5,  # A1-A8 + A9-slice-1 retired; rebase onto deep-D2b removed the 2 frames-path sites; golden_quality_scores retired (cell_quality is arrow-native)
 }
 
 

--- a/packages/python/goldenmatch/tests/test_quality_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_quality_no_polars.py
@@ -22,7 +22,14 @@ _PKG_ROOT = Path(__file__).parent.parent
 
 def _run_polars_blocked(body: str) -> subprocess.CompletedProcess:
     env = dict(os.environ)
-    env["PYTHONPATH"] = str(_PKG_ROOT)
+    # PREPEND, don't clobber: a worktree run sets PYTHONPATH so the sibling
+    # workspace packages (goldencheck) resolve from the worktree instead of the
+    # editable install pointing at another checkout. Overwriting it silently
+    # tested a stale goldencheck.
+    _existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{_PKG_ROOT}{os.pathsep}{_existing}" if _existing else str(_PKG_ROOT)
+    )
     env["POLARS_SKIP_CPU_CHECK"] = "1"
     prelude = (
         "import sys\n"
@@ -63,3 +70,107 @@ def test_quality_fix_degrades_to_scan_only_without_polars():
     proc = _run_polars_blocked(body)
     assert proc.returncode == 0, f"stdout={proc.stdout}\\nstderr={proc.stderr[-2500:]}"
     assert "QUALITY-NO-POLARS OK" in proc.stdout
+
+
+def test_compute_quality_scores_weights_cells_without_polars():
+    """SUBPROCESS, polars BLOCKED: quality-weighted survivorship must still get
+    its per-cell weights.
+
+    ``goldencheck.cell_quality`` is arrow-native (it takes a ``pa.Table`` and its
+    own docstring pins "stays polars-free"), so there is no reason for the
+    weighting to fail open when polars is absent. Regression guard: the pipeline
+    used to skip weighting entirely on a polars-free install, which silently
+    changed golden-record field selection between `pip install goldenmatch` and
+    `goldenmatch[polars]`.
+
+    Fixture honours goldencheck's fuzzy thresholds (>= 50 rows, >= 3 distinct):
+    "Californa" is a near-duplicate of the more frequent "California", so its row
+    is penalized and the weight comes back keyed by ``__row_id__`` (NOT the
+    positional index -- row_ids here are offset by 100 so a positional leak is
+    visible)."""
+    body = """
+        import sys
+        import pyarrow as pa
+        from goldenmatch.core.quality import compute_quality_scores
+
+        n_cal, n_tex, n_nev = 30, 20, 9
+        city = ["California"] * n_cal + ["Texas"] * n_tex + ["Nevada"] * n_nev + ["Californa"]
+        row_ids = [100 + i for i in range(len(city))]
+        tbl = pa.table({"__row_id__": pa.array(row_ids, type=pa.int64()), "city": city})
+
+        scores = compute_quality_scores(tbl)
+        assert scores is not None, "quality weighting failed open with polars absent"
+        typo_row_id = row_ids[-1]
+        assert (typo_row_id, "city") in scores, f"typo row not penalized; got {scores}"
+        assert scores[(typo_row_id, "city")] < 1.0
+        # Keys must be row_ids, not positional indices (positional would be 59).
+        assert (len(city) - 1, "city") not in scores, "scores keyed positionally, not by __row_id__"
+        assert "polars" not in sys.modules, "polars leaked in the quality path"
+        print("QUALITY-WEIGHTS-NO-POLARS OK")
+    """
+    proc = _run_polars_blocked(body)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\\nstderr={proc.stderr[-2500:]}"
+    assert "QUALITY-WEIGHTS-NO-POLARS OK" in proc.stdout
+
+
+def test_pipeline_engages_quality_weighting_without_polars():
+    """SUBPROCESS, polars BLOCKED, END-TO-END: a default-config dedupe must
+    actually CALL quality weighting, not silently skip it.
+
+    ENGAGE PROBE (green harness != lane exercised): the pipeline used to zero out
+    the member list when polars was absent, so ``compute_quality_scores`` was
+    never invoked and survivorship quietly took the unweighted path. Asserting
+    only on output would pass by luck on a tie-break; this spies the call.
+
+    60 rows = 30 exact-match pairs, so every row is a multi-member cluster member
+    and the scoped frame clears goldencheck's >= 50-row fuzzy threshold. One pair
+    disagrees on city ("California" vs the "Californa" typo), which is the signal
+    weighting exists to resolve."""
+    body = """
+        import sys
+        import pyarrow as pa
+        import goldenmatch.core.quality as Q
+
+        calls = []
+        _real = Q.compute_quality_scores
+
+        def _spy(df, *a, **kw):
+            out = _real(df, *a, **kw)
+            calls.append(out)
+            return out
+
+        Q.compute_quality_scores = _spy
+
+        import goldenmatch.core.pipeline as P
+        from goldenmatch.config.schemas import (
+            GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+            QualityConfig, TransformConfig,
+        )
+
+        names, cities = [], []
+        for i in range(30):
+            if i < 15:      city_a = city_b = "California"
+            elif i < 24:    city_a = city_b = "Texas"
+            elif i < 29:    city_a = city_b = "Nevada"
+            else:           city_a, city_b = "Californa", "California"  # typo first
+            names += [f"person{i}", f"person{i}"]
+            cities += [city_a, city_b]
+        tbl = pa.table({"name": names, "city": cities})
+
+        cfg = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="k", type="exact", fields=[MatchkeyField(field="name")],
+            )],
+            quality=QualityConfig(mode="disabled"),
+            transform=TransformConfig(mode="disabled"),
+        )
+        res = P.run_dedupe_df(tbl, cfg)
+
+        assert calls, "compute_quality_scores was NEVER called (weighting skipped polars-free)"
+        assert any(c for c in calls), f"weighting ran but produced no scores: {calls}"
+        assert "polars" not in sys.modules, "polars leaked in the dedupe path"
+        print("PIPELINE-WEIGHTING-NO-POLARS OK")
+    """
+    proc = _run_polars_blocked(body)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\\nstderr={proc.stderr[-2500:]}"
+    assert "PIPELINE-WEIGHTING-NO-POLARS OK" in proc.stdout

--- a/packages/python/goldenmatch/tests/test_quality_weighting.py
+++ b/packages/python/goldenmatch/tests/test_quality_weighting.py
@@ -125,7 +125,9 @@ def test_quality_scan_scoped_to_cluster_members(monkeypatch):
     orig = q.compute_quality_scores
 
     def _recording(df):
-        seen["height"] = df.height
+        # Representation-agnostic: the golden stage hands the seam frame over
+        # arrow-natively (pa.Table has num_rows, not polars' .height).
+        seen["height"] = getattr(df, "num_rows", None) or df.height
         return orig(df)
 
     monkeypatch.setattr(q, "compute_quality_scores", _recording)


### PR DESCRIPTION
## What

`compute_quality_scores` was polars-shaped (`df.columns`, `df[col].to_list()`) even though `goldencheck.cell_quality` has been **arrow-native since goldencheck 3.0** -- it takes a `pa.Table` and its own docstring pins *"stays polars-free"*. Two silent failures fell out of that.

### 1. Weighting silently disabled on the default install

`core/pipeline.py` declined weighting outright when polars was absent:

```python
if _member_ids and not _pl_ok():
    # Zero-polars env: goldencheck's cell_quality is polars-backed;
    # ... Re-opens when goldencheck ships an arrow cell_quality.
    _member_ids = []
```

Polars is an **optional extra** as of D6, and `quality_weighting` defaults `True`. So `pip install goldenmatch` and `pip install goldenmatch[polars]` produced **different golden records** -- silently, fail-open. The comment names its own re-open condition; goldencheck shipped the arrow `cell_quality` and nobody re-opened the gate.

### 2. Worse: dead on the arrow lane even *with* polars

The fused-golden short-circuit already passed the seam frame `.native` straight in. On the arrow lane that is a `pa.Table` -- and `"__row_id__" not in tbl.columns` is silently `True` for a `pa.Table` (`.columns` holds `ChunkedArray`s, not names):

```
>>> "__row_id__" not in pa.table({"__row_id__": [1,2]}).columns
True
```

So weighting returned `None` on **every arrow-lane run**, polars installed or not. No exception, no log.

## Fix

Port `compute_quality_scores` to the arrow shape -- the `blocking_risk` twin *in the same file* was already arrow-native (`"cell_quality is itself arrow-native"`) and is the template. Extract the shared `_as_arrow_table` coercion, drop both the `_pl_ok()` decline and the `_as_polars_df` bridge.

**Bridge ledger 6 -> 5.**

## Tests

All subprocess-based with `import polars` BLOCKED:

- **unit** -- weights come back keyed by `__row_id__`, not positional index (row_ids offset by 100 so a positional leak is visible)
- **e2e engage probe** -- asserts `compute_quality_scores` is actually *called* during a dedupe. Output-only assertions pass by luck on a tie-break; this pins the regression directly.
- fixture honours goldencheck's real thresholds (`_MIN_ROWS = 50`, `_MIN_DISTINCT = 3`). The pre-existing 5-row fixture in this file could never trigger a fuzzy penalty.

Also: `_run_polars_blocked` now **prepends** to `PYTHONPATH` instead of clobbering it, so worktree runs resolve the sibling goldencheck from the worktree rather than silently testing a stale editable install (that is how the stale-goldencheck skew hid here in the first place).

## Verification

- Touched suites green: `test_quality_no_polars` / `test_quality_weighting` / `test_quality_scan` / `test_quality_aware_blocking` / `test_bridge_ledger` / `test_zero_polars_gate` -- 24 passed.
- Broad golden/survivorship sweep (540 tests) run against **both this branch and a pristine `origin/main` worktree**: failure sets **byte-identical** (89 pre-existing `provenance=True` failures, a local native-gate artifact -- not introduced here).
- `test_quality_weighting.py` needed a one-line helper fix: its spy read `df.height`, a polars-ism, on what is now a `pa.Table`. The test's intent (scan scoped to cluster members) is representation-agnostic; the helper now reads `num_rows`.
- ruff clean on all touched files.

## Note

Found during a cross-package audit of the arrow seam. The `[quality]` extra still declares `goldencheck[polars]` justified by a comment naming `cell_quality` / `functional_dependencies` / `scan_dataframe` -- **all three are arrow-native now**; only `apply_fixes` genuinely needs polars. Left alone here to keep this PR to the defect; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ