### PR TITLE
test(gate): widen the zero-polars gate from 1 config to 8 (W1)

### DIFF
--- a/packages/python/goldenmatch/tests/_zero_polars_cases.py
+++ b/packages/python/goldenmatch/tests/_zero_polars_cases.py
@@ -1,0 +1,135 @@
+"""Config matrix for the D6 zero-polars gate.
+
+Importable WITHOUT pytest and WITHOUT the parent ``conftest.py`` (which imports
+polars), because the probe subprocess imports this module while polars imports
+are blocked at ``sys.meta_path``.
+
+Each case is a zero-arg callable that RUNS a dedupe and returns the result. A
+case owns its own ingest on purpose: ``exact`` goes through the CSV front
+(``run_dedupe``) so the arrow reader stays covered, while the rest hand an
+in-memory ``pa.Table`` to ``run_dedupe_df``. Returning a builder tuple instead
+would have quietly collapsed both entry points into one.
+
+Keep fixtures TINY -- the gate runs one subprocess per case per lane.
+"""
+from __future__ import annotations
+
+import pathlib
+import tempfile
+from typing import Any, Callable
+
+# Configs that legitimately CANNOT run polars-free today. Every entry needs a
+# reason. Adding one is a review conversation; removing one is a win.
+#
+# NOTE: a leak is not automatically a decline. Read the traceback first -- a
+# stray `isinstance(x, pl.DataFrame)` on a covered path is a BUG to fix, not a
+# dependency to declare. Only genuine polars-only features belong here.
+KNOWN_POLARS_DEPENDENT: dict[str, str] = {}
+
+
+def _people_table() -> Any:
+    """60 rows of duplicate pairs.
+
+    Clears goldencheck's fuzzy thresholds (``_MIN_ROWS=50``, ``_MIN_DISTINCT=3``)
+    so the quality-weighting cases get real signal -- the pre-existing 5-row
+    fixture in this suite could never trigger a penalty.
+
+    One pair disagrees on city ("Californa" vs "California") so survivorship has
+    something to resolve.
+    """
+    import pyarrow as pa
+
+    names: list[str] = []
+    cities: list[str] = []
+    emails: list[str] = []
+    for i in range(30):
+        if i < 15:
+            city_a = city_b = "California"
+        elif i < 24:
+            city_a = city_b = "Texas"
+        elif i < 29:
+            city_a = city_b = "Nevada"
+        else:
+            city_a, city_b = "Californa", "California"
+        names += [f"person{i}", f"person{i}"]
+        cities += [city_a, city_b]
+        emails += [f"p{i}@x.com", f"p{i}@x.com"]
+    return pa.table({"name": names, "city": cities, "email": emails})
+
+
+def _exact_matchkey(field: str = "name") -> Any:
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    return MatchkeyConfig(
+        name="k", type="exact", fields=[MatchkeyField(field=field)]
+    )
+
+
+def _prep_disabled() -> dict[str, Any]:
+    """quality + transform explicitly OFF (they default ON)."""
+    from goldenmatch.config.schemas import QualityConfig, TransformConfig
+
+    return {
+        "quality": QualityConfig(mode="disabled"),
+        "transform": TransformConfig(mode="disabled"),
+    }
+
+
+# --------------------------------------------------------------------------
+# Cases
+# --------------------------------------------------------------------------
+
+
+def case_exact() -> Any:
+    """The ORIGINAL probe case, preserved verbatim: CSV front + exact matchkey,
+    prep disabled. Keeps the arrow reader under the gate."""
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    import goldenmatch.core.pipeline as P
+
+    d = pathlib.Path(tempfile.mkdtemp())
+    csv = d / "people.csv"
+    csv.write_text(
+        "first,last,city\n"
+        "ann,smith,nyc\n"
+        "ann,smith,nyc\n"
+        "bob,jones,la\n"
+        "bobby,jones,la\n"
+        "cara,lee,sf\n",
+        encoding="utf-8",
+    )
+    cfg = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="k",
+                type="exact",
+                fields=[MatchkeyField(field="first"), MatchkeyField(field="last")],
+            )
+        ],
+        **_prep_disabled(),
+    )
+    res = P.run_dedupe([(str(csv), "people")], cfg)
+    assert res["golden"] is not None and res["golden"].num_rows >= 1
+    return res
+
+
+def case_default_prep() -> Any:
+    """Quality + transform at their DEFAULTS (both default-ON).
+
+    This is what a real `pip install goldenmatch` user gets, and the config the
+    original single-case probe never exercised.
+    """
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    import goldenmatch.core.pipeline as P
+
+    cfg = GoldenMatchConfig(matchkeys=[_exact_matchkey()])
+    return P.run_dedupe_df(_people_table(), cfg)
+
+
+CASES: dict[str, Callable[[], Any]] = {
+    "exact": case_exact,
+    "default_prep": case_default_prep,
+}

--- a/packages/python/goldenmatch/tests/_zero_polars_cases.py
+++ b/packages/python/goldenmatch/tests/_zero_polars_cases.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import pathlib
 import tempfile
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 # Configs that legitimately CANNOT run polars-free today. Every entry needs a
 # reason. Adding one is a review conversation; removing one is a win.
@@ -83,12 +84,12 @@ def _prep_disabled() -> dict[str, Any]:
 def case_exact() -> Any:
     """The ORIGINAL probe case, preserved verbatim: CSV front + exact matchkey,
     prep disabled. Keeps the arrow reader under the gate."""
+    import goldenmatch.core.pipeline as P
     from goldenmatch.config.schemas import (
         GoldenMatchConfig,
         MatchkeyConfig,
         MatchkeyField,
     )
-    import goldenmatch.core.pipeline as P
 
     d = pathlib.Path(tempfile.mkdtemp())
     csv = d / "people.csv"
@@ -122,14 +123,107 @@ def case_default_prep() -> Any:
     This is what a real `pip install goldenmatch` user gets, and the config the
     original single-case probe never exercised.
     """
-    from goldenmatch.config.schemas import GoldenMatchConfig
     import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import GoldenMatchConfig
 
     cfg = GoldenMatchConfig(matchkeys=[_exact_matchkey()])
+    return P.run_dedupe_df(_people_table(), cfg)
+
+
+def case_weighted_fuzzy() -> Any:
+    """Weighted matchkey with fuzzy per-field scorers.
+
+    There is no "fuzzy" matchkey TYPE (the literal is exact/weighted/
+    probabilistic); fuzzy comparison rides on ``weighted`` via per-field
+    ``scorer``. This is the scorer path where the #2250 lane divergence lived.
+    """
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    cfg = GoldenMatchConfig(
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["city"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="k",
+                type="weighted",
+                threshold=0.85,
+                fields=[
+                    MatchkeyField(field="name", scorer="jaro_winkler", weight=0.7),
+                    MatchkeyField(field="city", scorer="jaro_winkler", weight=0.3),
+                ],
+            )
+        ],
+        **_prep_disabled(),
+    )
+    return P.run_dedupe_df(_people_table(), cfg)
+
+
+def case_probabilistic() -> Any:
+    """Fellegi-Sunter matchkey -- the EM/FS path."""
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    cfg = GoldenMatchConfig(
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["city"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="k",
+                type="probabilistic",
+                fields=[
+                    MatchkeyField(field="name", scorer="jaro_winkler"),
+                    MatchkeyField(field="city", scorer="jaro_winkler"),
+                ],
+            )
+        ],
+        **_prep_disabled(),
+    )
+    return P.run_dedupe_df(_people_table(), cfg)
+
+
+def case_quality_weighting() -> Any:
+    """quality_weighting=True over the dirty-city fixture.
+
+    Regression pin for #2462: weighting used to be silently skipped polars-free
+    (and dead on the arrow lane even WITH polars, because
+    ``"col" not in pa_table.columns`` is silently True).
+    """
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import GoldenMatchConfig, GoldenRulesConfig
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[_exact_matchkey()],
+        golden_rules=GoldenRulesConfig(default_strategy="most_complete", quality_weighting=True),
+        **_prep_disabled(),
+    )
+    return P.run_dedupe_df(_people_table(), cfg)
+
+
+def case_zero_config() -> Any:
+    """No matchkeys -- auto-config picks. The most-used entry point."""
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    cfg = GoldenMatchConfig(matchkeys=[], **_prep_disabled())
     return P.run_dedupe_df(_people_table(), cfg)
 
 
 CASES: dict[str, Callable[[], Any]] = {
     "exact": case_exact,
     "default_prep": case_default_prep,
+    "weighted_fuzzy": case_weighted_fuzzy,
+    "probabilistic": case_probabilistic,
+    "quality_weighting": case_quality_weighting,
+    "zero_config": case_zero_config,
 }

--- a/packages/python/goldenmatch/tests/_zero_polars_cases.py
+++ b/packages/python/goldenmatch/tests/_zero_polars_cases.py
@@ -219,6 +219,71 @@ def case_zero_config() -> Any:
     return P.run_dedupe_df(_people_table(), cfg)
 
 
+def case_golden_strategies() -> Any:
+    """NON-default survivorship: per-field ``most_recent`` + ``longest_value``.
+
+    The default is ``most_complete``; the fused golden kernel declines some
+    strategies and falls back to the demux, so this covers a different golden
+    route than the other cases.
+    """
+    import goldenmatch.core.pipeline as P
+    import pyarrow as pa
+    from goldenmatch.config.schemas import (
+        GoldenFieldRule,
+        GoldenMatchConfig,
+        GoldenRulesConfig,
+    )
+
+    tbl = _people_table()
+    # Recency column so `most_recent` has something to order by.
+    seen = pa.array([1_600_000_000 + i for i in range(tbl.num_rows)], type=pa.int64())
+    tbl = tbl.append_column("seen_at", seen)
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[_exact_matchkey()],
+        golden_rules=GoldenRulesConfig(
+            default_strategy="most_complete",
+            fields={
+                "city": GoldenFieldRule(strategy="most_recent", date_column="seen_at"),
+                "email": GoldenFieldRule(strategy="longest_value"),
+            },
+        ),
+        **_prep_disabled(),
+    )
+    return P.run_dedupe_df(tbl, cfg)
+
+
+def case_bucket_partitioned() -> Any:
+    """``partitioned_block_scoring`` -- the bucketed-materialize scale path.
+
+    One of the two flows `_arrow_lane_supported` historically declined, and the
+    one whose assignment-table build was polars-native.
+    """
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    cfg = GoldenMatchConfig(
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["city"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="k",
+                type="weighted",
+                threshold=0.85,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            )
+        ],
+        partitioned_block_scoring=True,
+        **_prep_disabled(),
+    )
+    return P.run_dedupe_df(_people_table(), cfg)
+
+
 CASES: dict[str, Callable[[], Any]] = {
     "exact": case_exact,
     "default_prep": case_default_prep,
@@ -226,4 +291,6 @@ CASES: dict[str, Callable[[], Any]] = {
     "probabilistic": case_probabilistic,
     "quality_weighting": case_quality_weighting,
     "zero_config": case_zero_config,
+    "golden_strategies": case_golden_strategies,
+    "bucket_partitioned": case_bucket_partitioned,
 }

--- a/packages/python/goldenmatch/tests/_zero_polars_probe.py
+++ b/packages/python/goldenmatch/tests/_zero_polars_probe.py
@@ -6,7 +6,6 @@ landed in sys.modules.
 import os
 import pathlib
 import sys
-import tempfile
 
 
 # Simulate the D6 end-state: polars is NOT INSTALLED. Any import attempt
@@ -33,40 +32,20 @@ os.environ["GOLDENMATCH_FRAME"] = "arrow"
 os.environ["GOLDENMATCH_NATIVE"] = os.environ.get("GOLDENMATCH_NATIVE_GATE", "0")
 os.environ["POLARS_SKIP_CPU_CHECK"] = "1"
 
-d = pathlib.Path(tempfile.mkdtemp())
-csv = d / "people.csv"
-csv.write_text(
-    "first,last,city\n"
-    "ann,smith,nyc\n"
-    "ann,smith,nyc\n"
-    "bob,jones,la\n"
-    "bobby,jones,la\n"
-    "cara,lee,sf\n",
-    encoding="utf-8",
-)
+# The case module must be importable from this file's own directory -- the gate
+# puts the tests dir on PYTHONPATH, but a direct `python tests/_zero_polars_probe.py`
+# run should work too.
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
-import goldenmatch.core.pipeline as P  # noqa: E402
-from goldenmatch.config.schemas import (  # noqa: E402
-    GoldenMatchConfig,
-    MatchkeyConfig,
-    MatchkeyField,
-    QualityConfig,
-    TransformConfig,
-)
+from _zero_polars_cases import CASES  # noqa: E402
 
-cfg = GoldenMatchConfig(
-    matchkeys=[
-        MatchkeyConfig(
-            name="k",
-            type="exact",
-            fields=[MatchkeyField(field="first"), MatchkeyField(field="last")],
-        )
-    ],
-    quality=QualityConfig(mode="disabled"),
-    transform=TransformConfig(mode="disabled"),
-)
-res = P.run_dedupe([(str(csv), "people")], cfg)
-assert res["golden"] is not None and res["golden"].num_rows >= 1
+case_name = sys.argv[1] if len(sys.argv) > 1 else "exact"
+if case_name not in CASES:
+    raise SystemExit(f"unknown case {case_name!r}; known: {sorted(CASES)}")
 
-assert "polars" not in sys.modules
+res = CASES[case_name]()
+assert res is not None, f"case {case_name!r} returned no result"
+
+_leaked = sorted(m for m in sys.modules if m == "polars" or m.startswith("polars."))
+assert not _leaked, f"case {case_name!r} imported polars: {_leaked}"
 print("ZERO-POLARS OK")

--- a/packages/python/goldenmatch/tests/test_zero_polars_gate.py
+++ b/packages/python/goldenmatch/tests/test_zero_polars_gate.py
@@ -19,20 +19,50 @@ _PROBE = Path(__file__).parent / "_zero_polars_probe.py"
 import pytest
 
 
+sys.path.insert(0, str(Path(__file__).parent))
+from _zero_polars_cases import CASES, KNOWN_POLARS_DEPENDENT  # noqa: E402
+
+
+@pytest.mark.parametrize("case_name", sorted(CASES))
 @pytest.mark.parametrize("native", ["0", "1"], ids=["pure", "native"])
-def test_arrow_lane_exact_dedupe_imports_zero_polars(native):
-    # BOTH lanes: the default install is native-ON -- the native kernel
-    # branches have their own polars touchpoints (a raw isinstance in the
-    # bucket fast worker escaped the pure-lane-only gate).
+def test_zero_polars_across_config_matrix(case_name, native):
+    """Every COVERED config runs polars-free on BOTH lanes.
+
+    One subprocess PER CASE so a leak is attributed to the exact config that
+    caused it -- a single shared process would only say "something leaked".
+
+    BOTH lanes: the default install is native-ON, and the native kernel branches
+    have their own polars touchpoints (a raw isinstance in the bucket fast worker
+    escaped the pure-lane-only gate).
+    """
+    if case_name in KNOWN_POLARS_DEPENDENT:
+        pytest.skip(f"declared polars-dependent: {KNOWN_POLARS_DEPENDENT[case_name]}")
+
+    tests_dir = Path(__file__).parent
     env = dict(os.environ)
-    env["PYTHONPATH"] = str(Path(__file__).parent.parent)
+    # PREPEND, don't clobber: a worktree run needs the sibling workspace packages
+    # (goldencheck) to resolve from the worktree, not from an editable install
+    # pointing at another checkout.
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in [str(tests_dir.parent), str(tests_dir), env.get("PYTHONPATH", "")] if p
+    )
     env["GOLDENMATCH_NATIVE_GATE"] = native
     proc = subprocess.run(
-        [sys.executable, str(_PROBE)],
+        [sys.executable, str(_PROBE), case_name],
         capture_output=True, text=True, env=env, timeout=300,
     )
-    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2000:]}"
+    assert proc.returncode == 0, (
+        f"case={case_name} lane={native}\n"
+        f"stdout={proc.stdout}\nstderr={proc.stderr[-2000:]}"
+    )
     assert "ZERO-POLARS OK" in proc.stdout
+
+
+def test_decline_ledger_entries_are_real_cases():
+    """A decline must name a case that EXISTS, else the ledger rots into a list
+    of excuses for configs nobody runs."""
+    unknown = set(KNOWN_POLARS_DEPENDENT) - set(CASES)
+    assert not unknown, f"declined cases not in the matrix: {sorted(unknown)}"
 
 
 def test_cli_import_zero_polars():

--- a/packages/python/goldenmatch/tests/test_zero_polars_gate.py
+++ b/packages/python/goldenmatch/tests/test_zero_polars_gate.py
@@ -18,7 +18,6 @@ _PROBE = Path(__file__).parent / "_zero_polars_probe.py"
 
 import pytest
 
-
 sys.path.insert(0, str(Path(__file__).parent))
 from _zero_polars_cases import CASES, KNOWN_POLARS_DEPENDENT  # noqa: E402
 


### PR DESCRIPTION
W1 of the arrow seam hardening plan (#2463). Test-only — no production code changes.

## Why

#2462 shipped with `goldenmatch_nopolars` **green and ci-required**. The gate proved exactly one config: 5 rows, one `exact` matchkey, `quality=disabled`, `transform=disabled`. Every default-config path was outside it.

## What

The probe now takes a case name; the gate parametrizes over a matrix, **one subprocess per case** so a leak is attributed to the exact config that caused it rather than "something leaked".

| case | covers |
|---|---|
| `exact` | the ORIGINAL case, preserved verbatim (CSV front via `run_dedupe`) |
| `default_prep` | quality + transform at their DEFAULTS — what `pip install goldenmatch` actually gets |
| `weighted_fuzzy` | weighted matchkey + per-field fuzzy scorers (the #2250 scorer path) |
| `probabilistic` | Fellegi-Sunter / EM |
| `quality_weighting` | regression pin for #2462 |
| `zero_config` | no matchkeys, auto-config picks |
| `golden_strategies` | non-default survivorship (`most_recent` + `longest_value`) |
| `bucket_partitioned` | `partitioned_block_scoring` |

**All 8 pass polars-free on both lanes.** So the arrow lane is genuinely broader than the old probe proved — that is now pinned rather than assumed. 18 tests, 16.2s, well inside budget.

## The decline ledger

`KNOWN_POLARS_DEPENDENT` ships **empty**. Nothing across the 8 needed declaring. It exists so that a future genuine polars dependency becomes a declared, reviewable line instead of an untested gap — with an explicit note that a leak is *not* automatically a decline: read the traceback, because a stray `isinstance(x, pl.DataFrame)` on a covered path is a bug to fix.

The only degradation observed was goldencheck's polars-native `apply_fixes` on `default_prep`, which **warns loudly** and is already covered by `test_quality_no_polars.py`. Worth contrasting with #2462: that one failed silently.

## Proof the gate bites

A deliberate `import polars` case exits 1 — the `meta_path` blocker turns any leak into a hard failure, so a leak cannot pass quietly. Verified, then reverted. A gate that cannot fail is decoration.

## Plan corrections found in execution

- **`case_exact` kept the CSV front.** The plan's draft switched it to `run_dedupe_df`, which would have silently dropped arrow-reader ingest coverage. Cases now own their own run instead of returning a `(table, config)` tuple, so both entry points stay covered.
- **There is no `fuzzy` matchkey type** — the literal is exact/weighted/probabilistic; fuzzy rides on `weighted` via per-field `scorer`.
- **Config shapes:** weighted/probabilistic require a `blocking` config; `GoldenRulesConfig` requires `default_strategy`; `most_recent` takes `date_column`, not `timestamp_field`. The first drafts failed on pydantic validation, not polars — a red here only means something once the config actually constructs.

Also fixes the harness to **prepend** rather than clobber `PYTHONPATH`, so worktree runs resolve the sibling goldencheck from the worktree instead of a stale editable install (exactly the skew that hid #2462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ