### PR TITLE
test(ledger): ratchet pl.from_arrow re-entry (W2)

### DIFF
--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -32,3 +32,126 @@ def test_bridge_call_site_ledger():
         "Bridge ledger drift. If you ADDED a bridge: don't -- port via the "
         f"seam instead. If you RETIRED one: update the ledger. Found: {found}"
     )
+
+
+# ---------------------------------------------------------------------------
+# pl.from_arrow ratchet
+# ---------------------------------------------------------------------------
+#
+# `_as_polars_df` is not the only way back into polars -- `pl.from_arrow` is the
+# larger, previously UNWATCHED surface. #2462 shipped a silent arrow-lane bug
+# while the bridge ledger sat green, because the ledger only counted one idiom.
+#
+# RATCHET, not exact equality: 71 sites across 24 files would fail on every
+# unrelated refactor and get muted within a month. This may only go DOWN, and a
+# NEW file entering the list fails the build.
+#
+# A site that is CORRECT (polars-lane-only code, where converting to polars IS
+# the right behaviour) should carry an inline `# polars-lane: <reason>` pragma.
+# The counter SKIPS pragma'd lines, so declaring a site is how you remove it
+# from this number honestly -- which makes the number track UNDECLARED re-entry
+# rather than raw occurrences.
+EXPECTED_FROM_ARROW: dict[str, int] = {
+    "distributed/clustering.py": 17,
+    "core/cluster.py": 10,
+    "distributed/scoring.py": 6,
+    "backends/fs_out_of_core.py": 5,
+    "core/pairs.py": 4,
+    "core/golden.py": 3,
+    "core/pipeline.py": 3,
+    "distributed/golden.py": 3,
+    "core/blocker.py": 2,
+    "core/quality.py": 2,
+    "identity/block_index.py": 2,
+    "identity/fingerprint_batch.py": 2,
+    "_api.py": 1,
+    "backends/duckdb_backend.py": 1,
+    "core/_hashing.py": 1,
+    "core/autoconfig.py": 1,
+    "core/golden_fused.py": 1,
+    "core/ingest.py": 1,
+    "core/transform.py": 1,
+    "db/sync.py": 1,
+    "distributed/dataset.py": 1,
+    "mcp/server.py": 1,
+    "output/writer.py": 1,
+    "semantic/discovery/keys.py": 1,
+}
+
+# core/frame.py is excluded as a FORWARD-LOOKING guard, not to mask anything:
+# it currently has ZERO pl.from_arrow calls. It IS the seam, so if the
+# PolarsFrame backend ever needs the idiom that is its legitimate home and
+# should not read as debt. Re-verify the zero if you touch it.
+_SEAM_FILE = "core/frame.py"
+
+_FROM_ARROW = re.compile(r"pl\.from_arrow\(")
+_PRAGMA = re.compile(r"#\s*polars-lane:")
+
+
+def _count_from_arrow(text: str) -> int:
+    return sum(
+        1
+        for line in text.splitlines()
+        if _FROM_ARROW.search(line) and not _PRAGMA.search(line)
+    )
+
+
+def _scan_from_arrow() -> dict[str, int]:
+    found: dict[str, int] = {}
+    for py in PKG.rglob("*.py"):
+        rel = py.relative_to(PKG).as_posix()
+        if rel == _SEAM_FILE:
+            continue
+        n = _count_from_arrow(py.read_text(encoding="utf-8"))
+        if n > 0:
+            found[rel] = n
+    return found
+
+
+def test_from_arrow_no_new_files():
+    """A file that did not previously re-enter polars must not start."""
+    found = _scan_from_arrow()
+    new_files = sorted(set(found) - set(EXPECTED_FROM_ARROW))
+    assert not new_files, (
+        f"NEW file re-entering polars via pl.from_arrow: {new_files}. "
+        "Port via the seam, or mark the site `# polars-lane: <reason>` if it "
+        "is polars-lane-only code."
+    )
+
+
+def test_from_arrow_count_does_not_grow():
+    """Per-file counts may only go DOWN."""
+    found = _scan_from_arrow()
+    regressed = {
+        f: {"found": found[f], "allowed": EXPECTED_FROM_ARROW[f]}
+        for f in found
+        if f in EXPECTED_FROM_ARROW and found[f] > EXPECTED_FROM_ARROW[f]
+    }
+    assert not regressed, f"pl.from_arrow count went UP: {regressed}"
+
+
+def test_from_arrow_ledger_is_ratcheted_down():
+    """Retiring sites is a win -- but the ledger has to record it, or the
+    ratchet silently loosens and lets the count creep back up later."""
+    found = _scan_from_arrow()
+    improved = {
+        f: {"found": found.get(f, 0), "stale_expectation": EXPECTED_FROM_ARROW[f]}
+        for f in EXPECTED_FROM_ARROW
+        if found.get(f, 0) < EXPECTED_FROM_ARROW[f]
+    }
+    assert not improved, (
+        "You retired pl.from_arrow sites -- thank you. Now ratchet "
+        f"EXPECTED_FROM_ARROW DOWN to match: {improved}"
+    )
+
+
+def test_seam_file_still_has_no_from_arrow():
+    """The core/frame.py exclusion is forward-looking. If the seam grows
+    pl.from_arrow calls, that is a deliberate decision someone should make
+    explicitly rather than inherit from an exclusion written when it was zero."""
+    seam = PKG / _SEAM_FILE
+    n = _count_from_arrow(seam.read_text(encoding="utf-8"))
+    assert n == 0, (
+        f"{_SEAM_FILE} now has {n} pl.from_arrow call(s). That may be correct "
+        "for the PolarsFrame backend -- if so, pragma them and update this test."
+    )


### PR DESCRIPTION
W2 of the arrow seam hardening plan (#2463). Test-only — no production code changes. Independent of #2464 (W1).

## Why

`_as_polars_df` was never the only way back into polars. #2462 shipped a silent arrow-lane bug while the bridge ledger sat **green**, because the ledger counts one idiom (5 sites) and ignores the larger surface: **71 `pl.from_arrow` calls across 24 files**, entirely unwatched.

Top offenders: `distributed/clustering.py` 17, `core/cluster.py` 10, `distributed/scoring.py` 6, `backends/fs_out_of_core.py` 5, `core/pairs.py` 4.

## Ratchet, not exact equality

Exact equality works for 5 sites. For 71 across 24 files it would fail on every unrelated refactor and get muted within a month. Three arms instead:

- **no new files** — a file that didn't re-enter polars must not start
- **counts may only go down** — per-file
- **retiring a site requires ratcheting the ledger** — otherwise the bound silently loosens and lets the count creep back later

## The `# polars-lane:` pragma

Not every `pl.from_arrow` is debt. Some sit in polars-lane-only code where converting *is* the correct behaviour, and counting those makes the number meaningless. The counter skips lines carrying `# polars-lane: <reason>`, so:

- the number tracks **undeclared** re-entry, not raw occurrences
- declaring a site costs a written justification at the call site
- retiring debt honestly and declaring it correct both move the number down, and both leave a reviewable trace

## Proven to bite

A ledger that cannot fail is decoration, so all four mechanisms were broken on purpose and reverted:

| | scenario | result |
|---|---|---|
| A | count goes up in a listed file | **FAIL** |
| B | new unlisted file (`core/scorer.py`) starts | **FAIL**, names the file |
| C | site retired, ledger left stale | **FAIL** |
| D | same line as B, plus the pragma | **PASS** |

Worktree verified clean afterwards.

## Seam exclusion

`core/frame.py` is excluded as a **forward-looking** guard — it has **zero** `pl.from_arrow` today (I initially wrote the opposite in the plan and corrected it). It gets its own test, so the seam growing these calls becomes an explicit decision rather than something inherited from an exclusion written when the count was zero.

## Not done, per plan

**Task 6 — classifying the 71 real sites — is deliberately not in this PR.** The ratchet is valuable the moment it lands; classification needs per-site reading and is ongoing hygiene. `distributed/clustering.py` (17) and `core/cluster.py` (10) are the place to start. I did not guess at which sites are legitimate.

## Merge note

Touches `test_bridge_ledger.py`, which #2462 also edits (`EXPECTED_BRIDGE_CALLS` 6 → 5). Different lines — this PR only adds below — so it should auto-merge, but land #2462 first if the queue disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ