### PR TITLE
docs(goldenpipe): arrow-canonical decision — recommend NOT flipping (W3)

### DIFF
--- a/docs/design/2026-08-10-goldenpipe-arrow-canonical-decision.md
+++ b/docs/design/2026-08-10-goldenpipe-arrow-canonical-decision.md
@@ -1,0 +1,171 @@
+# GoldenPipe arrow-canonical: decision
+
+**Status:** decision requested (measurement done). **Created:** 2026-08-10.
+**Workstream:** W3 of `docs/superpowers/plans/2026-08-10-arrow-seam-hardening.md`.
+**Probe:** `packages/python/goldenpipe/benchmarks/adapter_conversion_probe.py`.
+
+## Recommendation
+
+**Option A — do nothing, and document the boundary as intentional.**
+
+The arrow seam is arrow-native inside goldenmatch / goldencheck / goldenflow and
+polars-canonical in goldenpipe. That is a real inconsistency. It is also, on the
+numbers below, the **faster** arrangement — flipping goldenpipe to arrow-canonical
+would make its one substantive conversion **~2.5x slower**, not faster.
+
+The consistency argument survives, but it now carries a measured price tag rather
+than being free tidying. That makes it a judgment call about what the suite is
+optimising for, which is why this document stops here instead of opening a PR.
+
+## What was already known
+
+Stage 0 (`2026-07-06-goldenpipe-stage0-findings.md`) measured the frame handoff:
+
+| | 2176 ms run | 4806 ms run |
+|---|---|---|
+| handoff: CSV re-read | 3.5 ms · 0.2% | 5.7 ms · 0.1% |
+| handoff: full-df Utf8 cast | 1.6 ms · 0.1% | 2.2 ms · 0.0% |
+| **handoff total** | **5.1 ms · 0.2%** | **7.9 ms · 0.2%** |
+
+Wall is ~99% per-stage kernel compute; `goldenmatch.dedupe` alone is ~75%.
+
+## What was NOT known, and now is
+
+Stage 0 measured the handoff, not the two conversion sites in
+`adapters/match.py`. Measuring those turned up a structural point that matters
+more than the timings.
+
+**The two sites are in DIFFERENT stages, and only one is on the default path:**
+
+| site | stage | scope |
+|---|---|---|
+| `ctx.df.cast({col: pl.Utf8 ...})` (`match.py:40`) | `DedupeStage` — **default** | ALL columns |
+| `{c: ctx.df[c].to_arrow() ...}` (`match.py:172`) | `FusedDedupeStage` — **opt-in** | key + score columns only |
+
+The plan framed both as "the adapter's per-column conversion". They are not one
+thing, and the arrow-facing one is the opt-in stage.
+
+### Measurements (median of 5, mixed-dtype frame: 3 string + 2 numeric)
+
+| | 100K | 1M |
+|---|---|---|
+| **A** per-column `.to_arrow()` (fused stage, 2 cols) | 0.76 ms | 7.56 ms |
+| **B** whole-frame `pl.Utf8` cast (classic stage) | 3.82 ms | 32.26 ms |
+| **C** arrow-native equivalent of B | 8.17 ms | 87.19 ms |
+| **B − C** (what flipping would save) | **−4.35 ms** | **−54.93 ms** |
+
+Negative means flipping **costs** wall.
+
+### Fairness check
+
+A whole-frame number could be an artifact of one library short-circuiting the
+already-`Utf8` columns. It is not:
+
+| | 100K | 1M |
+|---|---|---|
+| numeric→string cast, polars | 3.04 ms | 32.55 ms |
+| numeric→string cast, arrow | 7.66 ms | 83.18 ms |
+| **arrow slowdown on real work** | **2.52x** | **2.56x** |
+| no-op string cast, polars | 0.15 ms | 0.23 ms |
+| no-op string cast, arrow | 0.01 ms | 0.01 ms |
+
+Both libraries short-circuit the no-ops. The gap is real work: **pyarrow's
+numeric→string cast is ~2.5x slower than polars'**, consistently across sizes.
+
+### The point the numbers make
+
+The `pl.Utf8` cast is **not a polars tax**. It is a dtype normalization the
+pipeline needs regardless of substrate — an arrow-canonical goldenpipe still has
+to do it, just via `pc.cast`, ~2.5x slower. "Remove the conversion" was the wrong
+mental model: there is no conversion to remove, only a choice of which library
+performs an intrinsic cast.
+
+And A — the actual polars→arrow crossing — is **7.6 ms at 1M on the opt-in
+stage**, against a wall that is ~75% dedupe kernel. Both adapter docstrings claim
+polars→arrow shares column buffers; the measurement is consistent with that.
+
+### 10M
+
+Not run. The plan called for it on CI, but 100K→1M is linear and the slowdown
+ratio is stable (2.52x → 2.56x), so 10M would burn a `large-new-64GB` slot to
+confirm a sign that two sizes already agree on — for a change the numbers say not
+to make. Say the word if you want it anyway before deciding.
+
+## Options
+
+### A — Do nothing; document the boundary as intentional (RECOMMENDED)
+
+Add a note to `models/frame.py` recording that polars-canonical is deliberate,
+cross-referencing Stage 0 and this document, so the next person to notice the
+inconsistency finds the reasoning instead of re-litigating it.
+
+- **Cost:** ~0.
+- **Keeps:** two substrates in the suite; per-column `.to_arrow()` on the opt-in
+  fused stage (7.6 ms/1M).
+- **Why recommended:** the flip has no wall upside (Stage 0) and now a measured
+  wall *downside* (2.5x on the cast). Consistency alone does not justify making
+  the default path slower.
+
+### B — Additive `ArrowFrame` impl; adapters prefer arrow when the source is arrow
+
+The `Frame` protocol already has two backends (`LocalFrame`, `DuckDBFrame`), so a
+third is additive and `LocalFrame` stays polars-backed — Stage 0 untouched.
+
+- **Cost:** moderate, contained to the adapters.
+- **Buys:** removes the A crossing (7.6 ms/1M) on the opt-in stage.
+- **Does NOT remove** the B cast — that becomes C, i.e. ~2.5x slower.
+- **Verdict:** the plan pre-committed to recommending B if conversion exceeded
+  ~2% of wall. It does not, and the dominant term moves the wrong way. **Not
+  recommended on these numbers.**
+
+### C — Full flip: arrow-canonical `PipeContext`, `polars()` a compat shim
+
+- **Cost:** 41 call sites across 7 adapters, plus goldenanalysis and infermap,
+  which also hard-dep polars and sit in the same tier.
+- **Buys:** one substrate; drops the last hard polars dep in the orchestration
+  tier (install footprint, supply chain).
+- **Costs:** ~2.5x on every numeric→string cast on the default path.
+- **Verdict:** only coherent as a **product decision about the polars footprint
+  across goldenpipe + goldenanalysis + infermap together.** Flipping goldenpipe
+  alone leaves two of three tier-2 packages polars-canonical — inconsistency at
+  full price. Not an engineering call, and not one to make off this document.
+
+## If the answer is "consistency still matters"
+
+That is a legitimate position — the honest framing is that you would be buying
+a single substrate for roughly **+55 ms per 1M rows** on the default path, plus
+the 41-call-site change. Two things would make it a better trade:
+
+1. **Fix the cast, not the substrate.** The `pl.Utf8` whole-frame cast exists to
+   dodge schema-mismatch errors when mixed-dtype columns reach GoldenMatch. If
+   goldenmatch's ingest normalized dtypes itself, the adapter would not need the
+   cast at all, and B/C would stop mattering — which changes the arithmetic for
+   option C entirely.
+2. **Take the tier together.** goldenpipe + goldenanalysis + infermap in one
+   programme, so the footprint win is real rather than partial.
+
+Neither is in scope here.
+
+## Reproducing
+
+```bash
+cd packages/python/goldenpipe/benchmarks
+python adapter_conversion_probe.py --rows 1000000 --repeat 5
+```
+
+The probe greps `adapters/match.py` and **refuses to run** if the expressions it
+claims to measure have drifted from the shipped call sites — a probe that
+silently measures a paraphrase is worse than no probe. Verified: renaming the
+comprehension variable trips it and names the drifted snippet. It matches the
+expression as a substring, so it tolerates a trailing comment change and would
+not catch a semantically-equivalent rewrite that kept the same text — the
+granularity is "this expression still exists", not "this expression is still
+reached". Good enough to stop silent rot; not a substitute for reading the
+adapter.
+
+### Caveat on small inputs
+
+The 2.5x arrow slowdown holds at 100K and 1M. At ~1K rows both paths are
+sub-millisecond and the ratio inverts (arrow slightly faster) — noise-dominated
+and irrelevant to a decision about pipeline-scale work, but worth stating so the
+claim is not read as "arrow casts are always slower".

--- a/packages/python/goldenpipe/benchmarks/adapter_conversion_probe.py
+++ b/packages/python/goldenpipe/benchmarks/adapter_conversion_probe.py
@@ -1,0 +1,159 @@
+"""W3 Task 7: measure the goldenpipe adapter's polars<->arrow conversion cost.
+
+Stage 0 (`docs/design/2026-07-06-goldenpipe-stage0-findings.md`) measured the
+FRAME HANDOFF at 5.1ms / 0.2% of a 2176ms wall. It did NOT measure the two
+conversion sites in `adapters/match.py`, which is the number the arrow-canonical
+decision hinges on.
+
+MEASURES THE SHIPPED BASIS, not a lookalike: `_assert_shipped()` greps the real
+adapter source and refuses to run if the expressions below have drifted from the
+call sites they claim to represent. A probe that silently measures a paraphrase
+is worse than no probe.
+
+Three timings per size:
+
+  A  per-column `.to_arrow()`   -- FusedDedupeStage.run (OPT-IN stage, key+score
+                                   columns only). Claimed zero-copy.
+  B  whole-frame `pl.Utf8` cast -- DedupeStage.run (classic stage, ALL columns).
+  C  arrow-native equivalent of B (`pc.cast` per column, rebuild table)
+     -- the control. B is a dtype normalization, NOT a polars tax: an
+     arrow-canonical pipeline still has to do it. C shows what flipping would
+     actually save (B - C), which may be nothing or negative.
+
+Usage:
+    python adapter_conversion_probe.py [--rows 100000] [--repeat 5]
+
+Run 100K/1M locally; send 10M to CI (`large-new-64GB`) -- see
+feedback_no_local_scale_benchmarks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+import polars as pl
+import pyarrow as pa
+import pyarrow.compute as pc
+
+_ADAPTER = (
+    Path(__file__).resolve().parents[1] / "goldenpipe" / "adapters" / "match.py"
+)
+
+# The exact expressions this probe claims to represent, as they appear in the
+# shipped adapter. If a refactor moves them, the probe must fail loudly rather
+# than keep reporting a number for code that no longer exists.
+_SHIPPED_SNIPPETS = {
+    "B_utf8_cast": "ctx.df = ctx.df.cast({col: pl.Utf8 for col in ctx.df.columns})",
+    "A_per_column_to_arrow": "columns = {c: ctx.df[c].to_arrow() for c in needed}",
+}
+
+
+def _assert_shipped() -> None:
+    src = _ADAPTER.read_text(encoding="utf-8")
+    missing = [k for k, snip in _SHIPPED_SNIPPETS.items() if snip not in src]
+    if missing:
+        raise SystemExit(
+            f"probe drift: {missing} no longer found verbatim in {_ADAPTER}. "
+            "Re-read the adapter and update _SHIPPED_SNIPPETS before trusting "
+            "any number from this probe."
+        )
+
+
+def _frame(rows: int) -> pl.DataFrame:
+    """Mixed-dtype frame -- the Utf8 cast exists precisely because dtypes are
+    mixed (birth_year i64 vs str), so an all-string frame would understate it."""
+    return pl.DataFrame(
+        {
+            "name": [f"person{i % 50000}" for i in range(rows)],
+            "city": [("California", "Texas", "Nevada")[i % 3] for i in range(rows)],
+            "email": [f"p{i % 50000}@x.com" for i in range(rows)],
+            "birth_year": [1950 + (i % 60) for i in range(rows)],   # i64
+            "score": [float(i % 997) / 7.0 for i in range(rows)],   # f64
+        }
+    )
+
+
+def _median_ms(fn, repeat: int) -> float:
+    samples = []
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        out = fn()
+        samples.append((time.perf_counter() - t0) * 1000.0)
+        del out
+    return statistics.median(samples)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, default=100_000)
+    ap.add_argument("--repeat", type=int, default=5)
+    args = ap.parse_args()
+
+    _assert_shipped()
+
+    df = _frame(args.rows)
+    # FusedDedupeStage converts ONLY key + score columns, not the whole frame.
+    needed = ["city", "name"]
+
+    a = _median_ms(lambda: {c: df[c].to_arrow() for c in needed}, args.repeat)
+    b = _median_ms(
+        lambda: df.cast({col: pl.Utf8 for col in df.columns}), args.repeat
+    )
+
+    tbl = df.to_arrow()
+    c = _median_ms(
+        lambda: pa.table(
+            {n: pc.cast(tbl.column(n), pa.large_string()) for n in tbl.column_names}
+        ),
+        args.repeat,
+    )
+
+    # FAIRNESS SPLIT. A whole-frame number could be an artifact of one library
+    # short-circuiting the already-correct-dtype columns. Split the cast into
+    # the columns that need real work (numeric -> string) and the ones that do
+    # not, so the comparison cannot hide behind a no-op.
+    numeric = [n for n in df.columns if df[n].dtype != pl.Utf8]
+    stringy = [n for n in df.columns if df[n].dtype == pl.Utf8]
+
+    b_num = _median_ms(lambda: df.cast({n: pl.Utf8 for n in numeric}), args.repeat)
+    c_num = _median_ms(
+        lambda: pa.table(
+            {n: pc.cast(tbl.column(n), pa.large_string()) for n in numeric}
+        ),
+        args.repeat,
+    )
+    b_str = _median_ms(lambda: df.cast({n: pl.Utf8 for n in stringy}), args.repeat)
+    c_str = _median_ms(
+        lambda: pa.table(
+            {n: pc.cast(tbl.column(n), pa.large_string()) for n in stringy}
+        ),
+        args.repeat,
+    )
+
+    out = {
+        "rows": args.rows,
+        "repeat": args.repeat,
+        "A_per_column_to_arrow_ms": round(a, 4),
+        "B_polars_utf8_cast_ms": round(b, 4),
+        "C_arrow_cast_equivalent_ms": round(c, 4),
+        "B_minus_C_ms": round(b - c, 4),
+        "fairness": {
+            "numeric_cast_polars_ms": round(b_num, 4),
+            "numeric_cast_arrow_ms": round(c_num, 4),
+            "numeric_arrow_slowdown_x": round(c_num / b_num, 2) if b_num else None,
+            "noop_string_cast_polars_ms": round(b_str, 4),
+            "noop_string_cast_arrow_ms": round(c_str, 4),
+            "note": (
+                "Both libraries short-circuit the no-op string casts, so the "
+                "whole-frame gap is real work, not a short-circuit artifact."
+            ),
+        },
+    }
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
W3 of the arrow seam hardening plan (#2463). Measurement + decision doc. **No engine changes, and deliberately no implementation PR** — this ends at a go/no-go for you.

## Recommendation: Option A — do nothing

The plan pre-committed to recommending **Option B** if the adapter conversion exceeded ~2% of wall. It doesn't — and measuring changed the question rather than answering it.

## Two things the measurement turned up

**1. The two sites are in different stages.** The plan (mine) treated them as one thing. They aren't:

| site | stage | scope |
|---|---|---|
| `ctx.df.cast({col: pl.Utf8 ...})` | `DedupeStage` — **default** | ALL columns |
| `{c: ctx.df[c].to_arrow() ...}` | `FusedDedupeStage` — **opt-in** | key + score cols only |

The arrow-facing one is the opt-in stage.

**2. The cast is not a polars tax.** It's dtype normalization an arrow-canonical pipeline *still has to do* — via `pc.cast`, ~2.5× slower. "Remove the conversion" was the wrong mental model: there is no conversion to remove, only a choice of which library performs an intrinsic cast.

## Numbers (median of 5, mixed-dtype frame)

| | 100K | 1M |
|---|---|---|
| **A** per-column `.to_arrow()` (opt-in stage) | 0.76 ms | 7.56 ms |
| **B** polars `Utf8` cast (default stage) | 3.82 ms | 32.26 ms |
| **C** arrow-native equivalent of B | 8.17 ms | 87.19 ms |
| **B − C** = what flipping would save | **−4.35 ms** | **−54.93 ms** |

Negative means flipping **costs** wall. Combined with Stage 0's handoff at 0.2%, the flip has no upside and a measured downside.

### Fairness-checked

A whole-frame number could be an artifact of one library short-circuiting already-`Utf8` columns. It isn't — **both** short-circuit the no-ops (0.23 ms vs 0.01 ms at 1M). The gap is real work: arrow's numeric→string cast is **2.52× slower at 100K, 2.56× at 1M** — stable across sizes.

## What I didn't run

**10M.** The plan called for it on CI. It's linear to 1M with a stable ratio, so it would burn a `large-new-64GB` slot to confirm a sign two sizes already agree on, for a change the numbers say not to make. Flagging rather than skipping silently — say the word and I'll run it.

## Probe integrity

It measures the **shipped** basis: greps `adapters/match.py` and refuses to run if the expressions drifted. Verified by renaming the comprehension variable → refuses and names the snippet. First attempt at that verification *didn't* bite (I'd appended a trailing comment, so the substring still matched); the doc states the guard's real granularity — "this expression still exists", not "this expression is still reached".

Also documented: at ~1K rows the ratio inverts (both sub-ms, noise-dominated), so the claim isn't read as "arrow casts are always slower".

## If consistency still wins

That's a legitimate position, and the doc frames it honestly rather than closing it off: you'd be buying a single substrate for roughly **+55 ms per 1M rows** on the default path plus 41 call sites. Two things would make it a better trade:

1. **Fix the cast, not the substrate** — the `pl.Utf8` cast exists to dodge schema-mismatch errors when mixed-dtype columns reach GoldenMatch. If goldenmatch's ingest normalized dtypes itself, the adapter wouldn't need it and B/C stop mattering entirely.
2. **Take the tier together** — goldenpipe + goldenanalysis + infermap in one programme. Flipping goldenpipe alone leaves two of three tier-2 packages polars-canonical: inconsistency at full price.

Neither is in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ