### PR TITLE
chore(ledger): classify 8 pl.from_arrow sites as correct; ratchet 71 → 63

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/duckdb_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/duckdb_backend.py
@@ -52,7 +52,7 @@ class DuckDBBackend:
         """
         sql = query or f"SELECT * FROM {table}"
         arrow_table = self._conn.execute(sql).to_arrow_table()
-        df = pl.from_arrow(arrow_table)
+        df = pl.from_arrow(arrow_table)  # polars-lane: this method's declared contract returns a polars LazyFrame
         logger.info("DuckDB: read %d rows from %s", df.height, table if not query else "query")
         return df.lazy()
 

--- a/packages/python/goldenmatch/goldenmatch/core/_hashing.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_hashing.py
@@ -184,4 +184,4 @@ def record_fingerprints_batch_arrow(records_df):  # pl.DataFrame -> list[str]
     # to a Python list[str] via Polars (handles the Arrow -> Python
     # decoding without per-row overhead beyond the final list build).
     import polars as _pl
-    return _pl.from_arrow(arrow_out).to_list()
+    return _pl.from_arrow(arrow_out).to_list()  # polars-lane: this branch only runs when the INPUT was polars; the arrow input takes to_pylist() above

--- a/packages/python/goldenmatch/goldenmatch/core/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality.py
@@ -57,12 +57,12 @@ def _scan_findings(df, domain: str | None):
             # Installed goldencheck predates its Arrow Flip (scan_dataframe
             # is polars-only there): bridge and retry. Floor bumps to
             # goldencheck>=3.0 remove this at D6.
-            findings, _ = scan_dataframe(pl.from_arrow(df), domain=domain)
+            findings, _ = scan_dataframe(pl.from_arrow(df), domain=domain)  # polars-lane: legacy goldencheck (<3.0) scan_dataframe is polars-only; removed at the >=3.0 floor bump
         return apply_confidence_downgrade(findings, llm_boost=False)
 
     from goldencheck.engine.scanner import scan_file
     if not isinstance(df, pl.DataFrame):  # legacy goldencheck: polars csv path
-        df = pl.from_arrow(df)  # type: ignore[assignment]
+        df = pl.from_arrow(df)  # type: ignore[assignment]  # polars-lane: legacy goldencheck scan_file csv path is polars-only
     with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
         df.write_csv(tmp.name)
         tmp_path = Path(tmp.name)

--- a/packages/python/goldenmatch/goldenmatch/core/transform.py
+++ b/packages/python/goldenmatch/goldenmatch/core/transform.py
@@ -243,7 +243,7 @@ def run_transform(
             _t0 = _time.perf_counter()
         try:
             _bridge_in = (
-                _in_frame.native if _is_pl_in else pl.from_arrow(_in_frame.native)
+                _in_frame.native if _is_pl_in else pl.from_arrow(_in_frame.native)  # polars-lane: polars engine PREFERRED (measured 2.6x faster / -69% RSS vs columnar, covers more configs); polars-free installs take the columnar fallback below
             )
             if _tdbg:
                 _t_bridge_in = _time.perf_counter() - _t0

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -374,7 +374,7 @@ def _full_scan_pipeline(
     # v3.0.0: result.golden is a pa.Table. The DB write-back path
     # (write_golden_records / writer.py) uses polars semantics (.filter,
     # pl.col, column indexing), so materialize back to polars at this seam.
-    golden_df = pl.from_arrow(result.golden) if result.golden is not None else None
+    golden_df = pl.from_arrow(result.golden) if result.golden is not None else None  # polars-lane: the DB write-back consumer (writer.write_golden_records) uses polars semantics
     all_pairs = list(result.scored_pairs)
     logger.info(
         "Pipeline: dedupe_df returned %d scored pairs, %d clusters",

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1672,7 +1672,7 @@ def _tool_match_record(record: dict, threshold: float | None, top_k: int) -> dic
     match_data = rs.data
     if isinstance(match_data, pa.Table):
         import polars as pl
-        match_data = pl.from_arrow(match_data)
+        match_data = pl.from_arrow(match_data)  # polars-lane: core.match_one is declared `df: pl.DataFrame`
 
     for mk in matchkeys:
         if mk.type != "weighted":

--- a/packages/python/goldenmatch/goldenmatch/output/writer.py
+++ b/packages/python/goldenmatch/goldenmatch/output/writer.py
@@ -36,7 +36,7 @@ def write_output(
         pq.write_table(df, path)
         return path
     if not is_pl:
-        df = pl.from_arrow(df)
+        df = pl.from_arrow(df)  # polars-lane: csv/xlsx byte-formatting (quoting, null spelling, xlsx engine) is the PINNED output contract; parquet already returned arrow-native above
 
     if fmt == "csv":
         df.write_csv(path)

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -51,6 +51,12 @@ def test_bridge_call_site_ledger():
 # The counter SKIPS pragma'd lines, so declaring a site is how you remove it
 # from this number honestly -- which makes the number track UNDECLARED re-entry
 # rather than raw occurrences.
+# Task 6 pass 1 (2026-08-10): 71 -> 63. Eight sites across seven files were
+# READ and declared correct via `# polars-lane:` (legacy-goldencheck compat,
+# the measured polars transform engine, polars-declared consumers, and the
+# pinned csv/xlsx output contract), so those files left this dict entirely.
+# The remaining 63 are REAL debt -- see the PR for why clustering/cluster are
+# not a mechanical swap.
 EXPECTED_FROM_ARROW: dict[str, int] = {
     "distributed/clustering.py": 17,
     "core/cluster.py": 10,
@@ -61,20 +67,13 @@ EXPECTED_FROM_ARROW: dict[str, int] = {
     "core/pipeline.py": 3,
     "distributed/golden.py": 3,
     "core/blocker.py": 2,
-    "core/quality.py": 2,
     "identity/block_index.py": 2,
     "identity/fingerprint_batch.py": 2,
     "_api.py": 1,
-    "backends/duckdb_backend.py": 1,
-    "core/_hashing.py": 1,
     "core/autoconfig.py": 1,
     "core/golden_fused.py": 1,
     "core/ingest.py": 1,
-    "core/transform.py": 1,
-    "db/sync.py": 1,
     "distributed/dataset.py": 1,
-    "mcp/server.py": 1,
-    "output/writer.py": 1,
     "semantic/discovery/keys.py": 1,
 }
 


### PR DESCRIPTION
W2 Task 6, pass 1 — the classification deferred out of #2465.

Every site below was **read before being declared**. The `# polars-lane:` pragma is a justification, not a mute button, so each carries the reason inline.

## Declared correct — 8 sites / 7 files, out of the ledger

| site | why converting to polars is right |
|---|---|
| `core/quality.py` ×2 | legacy goldencheck (<3.0): `scan_dataframe`/`scan_file` are polars-only there. Version-gated; dies at the `>=3.0` floor bump. |
| `core/transform.py` | polars engine **preferred and measured** — 2.6× faster, −69% RSS vs the columnar path, covers more configs. Polars-free installs already take the columnar fallback. Best-justified site in the package. |
| `mcp/server.py` | `core.match_one` is declared `df: pl.DataFrame`. |
| `db/sync.py` | the DB write-back consumer uses polars semantics. |
| `output/writer.py` | csv/xlsx byte-formatting is the **pinned output contract**; parquet already returns arrow-native above this line. |
| `backends/duckdb_backend.py` | the method's declared contract *returns* polars. |
| `core/_hashing.py` | that branch only runs when the **input** was polars — arrow input already takes `to_pylist()` above it. |

## Left counted as debt — the more interesting half

`distributed/clustering.py` (17) and `core/cluster.py` (10) are **not** polars-lane code. They're Ray `map_batches(batch_format="pyarrow")` UDFs: arrow in → `pl.from_arrow` → work → `.to_arrow()` out. Arrow→polars→arrow round-trips, per batch, per task, inside an arrow pipeline. Exactly what the ledger exists to count.

Several already import the seam's `to_frame`, which **accepts a `pa.Table` natively** — so `pl.from_arrow(batch)` followed by `to_frame(df)` builds a `PolarsFrame` where `to_frame(batch)` would give an `ArrowFrame` for free.

Tempting to swap. I didn't: the `W4e-2`/`W4e-3` comments pin the polars **backend** deliberately for byte-identity in the distributed lane, and `empty_frame(..., backend="polars")` is explicit about it. Porting needs distributed parity verification, not a find-and-replace — and shipping a scale-path change verified only on small local fixtures is the trap this whole programme came out of.

`core/ingest.py` (1) is self-declared legacy debt with W2e already named as its removal point.

## The ratchet proved itself on real work

Not a synthetic test this time: retiring the 8 sites made `test_from_arrow_ledger_is_ratcheted_down` **fail and name all seven files** that had dropped to zero. That's the mechanism doing its job in normal use.

## Verification

- 63 sites across 17 files; 8 pragmas present in source
- zero-polars gate (the new 8-case matrix from #2464) green
- `test_transform_no_polars` strict-mode failure is **pre-existing** — reproduced with `origin/main`'s `transform.py` substituted in, so it isn't the pragma
- ruff clean on all 8 touched files

## Remaining

63 sites, dominated by `distributed/clustering.py` (17), `core/cluster.py` (10), `distributed/scoring.py` (6), `backends/fs_out_of_core.py` (5). The two big ones are a real porting task with a distributed-parity gate, not classification work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ