### PR TITLE
chore(scoreboard): weekly adoption snapshot

### DIFF
--- a/context-network/planning/scoreboard.jsonl
+++ b/context-network/planning/scoreboard.jsonl
@@ -1,1 +1,2 @@
 {"date": "2026-07-29", "stars": 126, "forks": 14, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 3511}
+{"date": "2026-08-10", "stars": 128, "forks": 13, "open_issues_nonmaintainer": 2, "pypi_30d": 96429, "npm_30d": 4949}

--- a/context-network/planning/scoreboard.md
+++ b/context-network/planning/scoreboard.md
@@ -5,15 +5,15 @@
 [north-star-roadmap.md](./north-star-roadmap.md): *is GoldenMatch becoming the
 tool developers reach for by default?* Trend > snapshot.
 
-**Latest: 2026-07-29** (vs previous snapshot)
+**Latest: 2026-08-10** (vs previous snapshot)
 
 | Signal | Now | WoW | North Star reading |
 |---|---|---|---|
-| GitHub stars | 126 | 126 | discovery momentum |
-| Forks | 14 | 14 | intent-to-use |
-| PyPI downloads (30d, suite) | — | — | actual reach |
-| npm downloads (30d, suite) | 3.5k | 3.5k | actual reach (TS) |
-| Open issues, non-maintainer | 1 | 1 | "someone reached for it"† |
+| GitHub stars | 128 | 128 (▲+2) | discovery momentum |
+| Forks | 13 | 13 (▼-1) | intent-to-use |
+| PyPI downloads (30d, suite) | 96.4k | 96.4k | actual reach |
+| npm downloads (30d, suite) | 4.9k | 4.9k (▲+1438) | actual reach (TS) |
+| Open issues, non-maintainer | 2 | 2 (▲+1) | "someone reached for it"† |
 
 † Raw count — still needs human triage to exclude badge-marketing bots
 (e.g. MCP-marketplace "live badge" issues). The roadmap's true gate is **≥1
@@ -23,6 +23,7 @@ GENUINE inbound issue from a stranger**; a bot filing a promo badge does not cou
 
 | Date | Stars | Forks | PyPI 30d | npm 30d | Ext. issues |
 |---|---|---|---|---|---|
+| 2026-08-10 | 128 | 13 | 96.4k | 4.9k | 2 |
 | 2026-07-29 | 126 | 14 | — | 3.5k | 1 |
 
 ## The gates (from the roadmap)


### PR DESCRIPTION
Weekly North Star adoption snapshot: stars, forks, PyPI/npm 30-day
downloads and non-maintainer inbound issues, appended to the trend.

Generated by `scripts/scoreboard.py` via `.github/workflows/scoreboard.yml`.
The `.md` is rewritten wholesale from the `.jsonl` each run; the new
data is the single appended row.
