### PR TITLE
fix(autoconfig): grow the learned-blocking sample as sqrt(rows)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1889,6 +1889,7 @@
             "_is_strong_identifier_union",
             "_is_text_corpus",
             "_learned_block_cap",
+            "_learned_sample_size",
             "_legacy_auto_configure_v0",
             "_llm_classify_columns",
             "_llm_suggest_blocking_keys",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Fixed
+- **The learned-blocking trainer no longer loses its training signal as the
+  dataset grows.** `learned_sample_size` was `min(total_rows // 4, 5000)` --
+  pinned at 5,000 rows from 50K upward however large the frame got. The learner
+  trains on the true pairs found INSIDE that sample, and the number of pairs with
+  both members sampled decays as `s^2 / n`. Measured on the QIS realistic shape,
+  ground-truth pairs inside a 5,000-row sample: 86 at 500K, 47 at 1M, 25 at 2M,
+  14 at 4M -- the signal halves every time the data doubles. At 5M the learner saw
+  13 true pairs against 56 at 1M. The sample now grows as `sqrt(rows)`, which
+  holds `s^2/n` constant; at 5M that is 11,180 rows and restores the trainer to 46
+  true pairs. Anchored at 1M so this is a pure extension: every frame at or below
+  1M keeps its previous sample size byte-for-byte, and only larger frames change.
+  Bounded at 50,000 rows, since the sample run is superlinear in sample size.
+
+  **This is necessary but NOT sufficient for the 5M slowdown, and is not claimed
+  as a fix for it.** With the training signal restored, the learner still emits
+  160 blocks of ~31K rows at 5M. Rule SELECTION is scored on the sample too, and
+  block SIZE is exactly what a sample cannot show: a bounded-cardinality predicate
+  like `first_name:first_3` has ~850 blocks of 13 rows in an 11K sample and ~899
+  blocks of 5,562 rows on the full 5M frame -- about 19.5 billion candidate pairs,
+  reported to the selector as `recall=1.000, reduction=1.000`. That is a separate
+  defect in the same family and is tracked on its own.
 - **Zero-config no longer discards a real identity column as a "surrogate key"
   purely because the dataset got bigger.** The `#876` surrogate-key guard asks
   "does every record carry its own value for this column?", and answered it from

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3378,6 +3378,53 @@ def _compute_max_safe_block(height: int, native_scoring: bool) -> int:
     return max(1000, min(ceiling, height // 40))
 
 
+# Learned-blocking training sample. `learned_sample_size` used to be
+# `min(total_rows // 4, 5000)` -- pinned at 5,000 rows from 50K rows upward, no
+# matter how big the frame got.
+#
+# The learner trains on the TRUE PAIRS it finds inside that sample, and the
+# number of pairs whose BOTH members land in a fixed-size sample decays as
+# `s^2 / n`. Measured on the QIS realistic shape, ground-truth pairs contained
+# in a 5,000-row sample:
+#
+#     n = 500K -> 86     n = 1M -> 47     n = 2M -> 25     n = 4M -> 14
+#
+# i.e. the training signal HALVES every time the data doubles. In CI at 5M the
+# learner saw 13 true pairs (against 56 at 1M), learned rules too coarse to
+# separate anything, and emitted 160 blocks of ~31K rows instead of 791 blocks
+# of ~1.3K -- roughly 78 BILLION candidate pairs against 0.6B at 1M. Five times
+# the data, ~124x the pair work; the 5M rung ran 93 minutes without finishing.
+#
+# Holding the signal constant means growing the sample as sqrt(n): pairs scale
+# as `s^2/n`, so `s ∝ sqrt(n)` keeps `s^2/n` flat. Verified against the same
+# measurement -- an 11,180-row sample at 4M recovers 61 pairs, against 14 at
+# 5,000.
+#
+# ANCHORED so this is a pure extension of today's behaviour: below the anchor
+# the floor wins, reproducing `min(total_rows // 4, 5000)` exactly, so every
+# frame under 1M keeps its current sample byte-for-byte and only >1M changes.
+# The ceiling bounds training cost (the sample run is superlinear in `s`); past
+# roughly 100M rows the signal starts decaying again, which is a known limit of
+# this shape of fix rather than something it silently papers over.
+_LEARNED_SAMPLE_FLOOR = 5_000          # the historical fixed value
+_LEARNED_SAMPLE_ANCHOR_ROWS = 1_000_000  # frame size at which the floor is exactly right
+_LEARNED_SAMPLE_CEILING = 50_000       # bound on training cost
+
+
+def _learned_sample_size(total_rows: int) -> int:
+    """Training-sample size for learned blocking, grown as sqrt(rows).
+
+    Keeps the number of true pairs the learner trains on roughly CONSTANT with
+    scale instead of letting it decay as 1/n. Returns the pre-existing
+    ``min(total_rows // 4, 5000)`` for any frame at or below the anchor.
+    """
+    scaled = _LEARNED_SAMPLE_FLOOR * math.sqrt(total_rows / _LEARNED_SAMPLE_ANCHOR_ROWS)
+    target = min(max(_LEARNED_SAMPLE_FLOOR, int(scaled)), _LEARNED_SAMPLE_CEILING)
+    # `total_rows // 4` is the original held-out-data guard: never train on more
+    # than a quarter of the frame, so predicates generalize instead of memorizing.
+    return min(total_rows // 4, target)
+
+
 def _learned_block_cap(total_rows: int, current_cap: int, native_scoring: bool) -> int:
     """Runtime oversized-DROP cap for learned blocking.
 
@@ -5123,7 +5170,7 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
             )
         else:
             blocking.strategy = "learned"
-            blocking.learned_sample_size = min(total_rows // 4, 5000)
+            blocking.learned_sample_size = _learned_sample_size(total_rows)
             blocking.learned_min_recall = 0.95
             blocking.skip_oversized = True
             # skip_oversized DROPS whole blocks above max_block_size, so the cap

--- a/packages/python/goldenmatch/tests/test_autoconfig_learned_sample_scale.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_learned_sample_scale.py
@@ -1,0 +1,91 @@
+"""The learned-blocking trainer must not lose its training signal as data grows.
+
+`learned_sample_size` was `min(total_rows // 4, 5000)` -- pinned at 5,000 rows
+from 50K upward however big the frame got. The learner trains on the TRUE PAIRS
+found inside that sample, and the count of pairs with BOTH members sampled decays
+as `s^2 / n`. Measured on the QIS realistic shape, ground-truth pairs inside a
+5,000-row sample:
+
+    n = 500K -> 86     n = 1M -> 47     n = 2M -> 25     n = 4M -> 14
+
+The signal HALVES every time the data doubles. In CI at 5M the learner saw 13
+true pairs (56 at 1M) and emitted 160 blocks of ~31K rows instead of 791 of
+~1.3K -- ~78B candidate pairs against 0.6B, and the 5M rung ran 93 minutes
+without finishing.
+
+Growing the sample as sqrt(n) holds `s^2/n` constant. Verified end to end: at 5M
+the trainer goes from 13 true pairs to 46, against 56 at 1M.
+
+SCOPE NOTE, deliberately pinned below. This is anchored at 1M so it is a pure
+extension: every frame at or below the anchor keeps its previous sample size
+byte-for-byte, which is why no existing baseline moves. It is also NOT sufficient
+on its own -- rule SELECTION is still scored on the sample, where a bounded-
+cardinality predicate like `first_name:first_3` shows 13-row blocks that become
+5,562-row blocks on the full frame. That is a separate defect.
+"""
+from __future__ import annotations
+
+import math
+
+from goldenmatch.core.autoconfig import (
+    _LEARNED_SAMPLE_CEILING,
+    _LEARNED_SAMPLE_FLOOR,
+    _learned_sample_size,
+)
+
+
+def _previous_behaviour(total_rows: int) -> int:
+    """What shipped before: a flat 5,000-row cap."""
+    return min(total_rows // 4, 5000)
+
+
+class TestUnchangedAtOrBelowTheAnchor:
+    """The blast radius is bounded to frames LARGER than 1M, by construction."""
+
+    def test_matches_previous_behaviour_up_to_1m(self):
+        for n in (50_000, 100_000, 200_000, 500_000, 999_999, 1_000_000):
+            assert _learned_sample_size(n) == _previous_behaviour(n), f"changed at n={n}"
+
+    def test_small_frames_keep_the_quarter_guard(self):
+        """Below 20K rows the held-out guard binds, not the floor."""
+        assert _learned_sample_size(12_000) == 3_000
+        assert _learned_sample_size(4_000) == 1_000
+
+
+class TestGrowsWithScale:
+    def test_sample_grows_above_the_anchor(self):
+        """THE regression: a fixed sample is what let the signal decay."""
+        assert _learned_sample_size(5_000_000) > _previous_behaviour(5_000_000)
+
+    def test_growth_is_sqrt_so_the_pair_yield_stays_flat(self):
+        """Pairs in a sample scale as s^2/n, so s must scale as sqrt(n) to hold
+        s^2/n constant. Check the invariant directly rather than the formula."""
+        anchor_n, anchor_s = 1_000_000, _learned_sample_size(1_000_000)
+        anchor_yield = anchor_s**2 / anchor_n
+        for n in (2_000_000, 5_000_000, 16_000_000):
+            got = _learned_sample_size(n) ** 2 / n
+            # Integer truncation only, so a tight tolerance is right here.
+            assert math.isclose(got, anchor_yield, rel_tol=0.01), (
+                f"pair yield drifted at n={n}: {got:.0f} vs {anchor_yield:.0f}"
+            )
+
+    def test_five_million_lands_where_the_measurement_says(self):
+        """5M is the rung that failed; 11,180 is what restored 46 true pairs."""
+        assert _learned_sample_size(5_000_000) == 11_180
+
+
+class TestBounds:
+    def test_never_below_the_historical_floor(self):
+        """Shrinking the sample would be a silent quality regression."""
+        for n in (50_000, 250_000, 1_000_000, 10_000_000):
+            assert _learned_sample_size(n) >= min(n // 4, _LEARNED_SAMPLE_FLOOR)
+
+    def test_ceiling_bounds_training_cost(self):
+        """The sample run is superlinear in s, so this cannot grow forever."""
+        assert _learned_sample_size(10_000_000_000) == _LEARNED_SAMPLE_CEILING
+
+    def test_never_trains_on_more_than_a_quarter_of_the_frame(self):
+        """The held-out guard must survive the scaling -- predicates have to
+        generalize, not memorize."""
+        for n in (50_000, 1_000_000, 5_000_000, 100_000_000):
+            assert _learned_sample_size(n) <= n // 4


### PR DESCRIPTION
## What and why

Follow-up to #2466. That fix stopped the 5M rung OOMing (66.0 GB climbing to zero → **17.6 GB flat with 47 GB free**). It then still failed to finish — 93 minutes, RSS pinned flat, cancelled. Flat memory while grinding is a **compute** problem, not a memory one.

`learned_sample_size` was `min(total_rows // 4, 5000)` — pinned at 5,000 rows from 50K upward however large the frame got. The learner trains on the true pairs found *inside* that sample, and the count of pairs with **both** members sampled decays as `s² / n`. Measured on the QIS realistic shape, ground-truth pairs inside a 5,000-row sample:

| n | 500K | 1M | 2M | 4M |
|---|---|---|---|---|
| true pairs in sample | 86 | 47 | 25 | 14 |

**The training signal halves every time the data doubles.** At 5M the learner saw **13** true pairs against 56 at 1M, learned rules too coarse to separate anything, and emitted 160 blocks of ~31K rows instead of 791 of ~1.3K — roughly **78 billion** candidate pairs against 0.6B at 1M. Five times the data, ~124× the pair work.

This is the third instance of one root cause, after #2466's surrogate-key guard: **a fixed-size sample used to estimate a property that scales with frame size.**

## Changes

- `_learned_sample_size(total_rows)` grows the sample as `sqrt(rows)`, which holds `s²/n` constant. At 5M that is 11,180 rows and takes the trainer from **13 true pairs back to 46** (1M sees 56).
- **Anchored at 1M, so the blast radius is bounded by construction**: below the anchor the floor wins and reproduces `min(total_rows // 4, 5000)` exactly. Every frame at or under 1M keeps its sample byte-for-byte and no existing baseline moves — including the entire QIS ci tier, which tops out at 1M.
- Ceiling at 50,000, because the sample run is superlinear in sample size. Past ~100M the signal begins decaying again; that is a stated limit of this shape of fix, not something it quietly papers over.
- `_learned_block_cap`'s growth was left alone deliberately — it is a documented raise-only fix for a *different* scale bug (#1784/#1837, oversized blocks silently dropped costing recall), not part of this one.

## This is necessary but NOT sufficient — and is not claimed as a fix for the 5M runtime

With the signal restored, the learner **still** emits 160 blocks at 5M. Rule *selection* is also scored on the sample, and block **size** is precisely what a sample cannot show. Bounded-cardinality predicates keep their block *count* and grow their block *size* with n:

| predicate | sample blocks / size | full-frame blocks / size | full-frame pairs |
|---|---|---|---|
| `first_name:first_3` | 850 / **13** | 899 / **5,562** | 19.5B |
| `last_name:first_3` | 576 / **19** | 576 / **8,681** | 21.7B |
| `id:first_3` | 90 / 124 | 100 / **50,000** | 250B |

`first_name:first_3` is reported to the selector as `recall=1.000, reduction=1.000` on an 11K sample and is ~19.5 billion candidate pairs on the full frame. `blocker.py:1385` learns and scores rules on `sample_df`, then `apply_learned_blocks` applies them to the full frame.

Same family, one layer up. The fix has the same shape as the two before it — project block size to full-frame scale before accepting a rule, using the predicate's true distinct-key count (one hash aggregate) rather than the sample's. Not attempted here; it is a larger change to rule selection and deserves its own PR.

## Testing

- **8 new tests. The 4 growth/ceiling ones verified to FAIL against the previous flat cap**; the other 4 pin the unchanged-below-1M behaviour, so the bounded blast radius is itself under test.
- **Full goldenmatch suite: 6 failed / 9150 passed — the same six pre-existing failures as the pristine-tree baseline** taken with the identical command earlier in this work (6 failed / 9116 passed on a clean tree). Baselined, not asserted.
- `ruff` clean · codemap regenerated · context-budget · docs-consistency.
- End-to-end at 5M: `sample_size=11180`, `Learning blocking rules from 46 true pairs` (was 13).

`pre-commit` is not installed in this environment, so I ran the gate scripts it wraps individually rather than claim a clean `pre-commit run --all-files`.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — not installed here; ran `ruff` + codemap/budget/docs checks individually
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_