### PR TITLE
test(spark): backend-agnostic spark fixture + the P0 real-Spark Connect lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2985,6 +2985,57 @@ jobs:
         run: |
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_pipeline.py -v --timeout=300
 
+  # P0 (spec docs/superpowers/specs/2026-08-10-spark-native-execution-design.md):
+  # the SAME sail tests against APACHE SPARK's own Connect server, not Sail's.
+  # The tier is believed backend-agnostic -- goldenmatch/sail/session.py is
+  # `SparkSession.builder.remote(url)` and there is no Sail-specific call
+  # anywhere in the package -- and this lane is what turns that belief into a
+  # fact before P1-P6 are built on it.
+  #
+  # NOT in ci-required while P0 runs: a red here is a FINDING to enumerate, not
+  # a merge blocker. Promote to required once green (P2).
+  spark_connect:
+    needs: changes
+    if: needs.changes.outputs.sail == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      # Real Spark's Connect server is JVM-side (unlike Sail's Rust one).
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      # NO pysail. goldenmatch[sail] pins pyspark<4 BECAUSE of pysail, so install
+      # the client directly to get Spark 4, whose `local[*]` remote spawns
+      # Spark's own Connect server in-process (no container, no cluster).
+      - name: Install pyspark connect (no Sail)
+        run: uv pip install 'pyspark[connect]>=4'
+      # The load-bearing assertion. A lane that silently picked pysail up from
+      # the lockfile would prove nothing while looking green.
+      - name: Confirm Sail is absent
+        run: |
+          .venv/bin/python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('pysail') is None else 'pysail present; this lane must exercise real Spark')"
+      - name: Sail tests against Apache Spark Connect
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "local[*]"
+        run: |
+          .venv/bin/python -c "import pyspark; print('pyspark', pyspark.__version__)"
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_*.py -v --timeout=600 \
+            --junitxml=spark-connect-results.xml
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        if: always()
+        with:
+          name: spark-connect-p0-results
+          path: spark-connect-results.xml
+          if-no-files-found: warn
+
   # dbt-goldensuite — restored after #464 dropped the lane that pointed at the
   # since-deleted packages/dbt/goldencheck and never re-pointed it at the merged
   # package. Parses the macro package under an in-memory DuckDB profile and runs

--- a/docs/superpowers/specs/2026-08-10-spark-native-execution-design.md
+++ b/docs/superpowers/specs/2026-08-10-spark-native-execution-design.md
@@ -95,6 +95,65 @@ can be pointed at.
 
 ---
 
+## 2a. P0 RESULT — the tier runs on real Spark Connect (2026-08-11)
+
+Run [31496638072](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31496638072),
+`spark_connect` lane: pyspark 4 against Spark's own `local[*]` Connect server,
+pysail asserted absent.
+
+```
+20 failed, 36 passed, 8 skipped in 408.49s
+```
+
+The control passed: the `sail` lane (pysail) was **green** on the same commit, so
+the fixture extraction is behaviour-preserving and the delta is the backend.
+
+### The headline: no Spark Connect API gaps were found
+
+36 tests pass. Session creation, DataFrame ops, SQL, config validation, and the
+whole `test_sail_r3_feature_gate.py` surface all work unmodified against real
+Spark. **The "tier is backend-agnostic" inference is confirmed.** P1–P6 are not
+reshaped.
+
+### All 20 failures have ONE cause
+
+```
+ModuleNotFoundError: No module named 'goldenmatch'   (73x)
+ModuleNotFoundError: No module named 'pandas'        (13x)
+```
+
+raised inside the **Python UDF worker**. The correlation is exact: every failing
+test executes the pipeline (and therefore a `pandas_udf`); every passing test
+does not. Failures cluster in `clustering_parity`, `determinism`,
+`golden_parity`, `identity_incremental`, `score_parity`.
+
+**Classification: (c) environment — NOT (a) an API gap, NOT (b) a Sail-ism.**
+
+### What this proves, and it is the important part
+
+**The pysail lane structurally cannot catch this.** Sail's Connect server runs
+**in-process**, so its Python worker shares the client's interpreter and
+`import goldenmatch` simply works. Real Spark **forks a separate Python worker**
+with its own environment. Every "it works distributed" signal from S1–S5 CI was
+produced by a harness that could not exercise the executor dependency path at
+all. (The 2026-06-15 GKE run did exercise it — by baking the deps into the worker
+image.)
+
+So P1 is **not plumbing, it is the blocker**, and P0 has demonstrated that
+empirically rather than by argument. `addArtifacts` is precisely the mechanism
+these 20 failures need.
+
+### Consequences
+
+- **P1 is promoted** to the first real work item, with its exit criterion
+  unchanged and now clearly load-bearing: assert the kernel *loaded on an
+  executor*, do not infer it.
+- **The `spark_connect` lane must stay red until P1 lands.** That is the correct
+  state. It goes into `ci-required` at P2, once P1 makes it green.
+- No spec change is needed to §3–§9: the architecture survives the experiment.
+
+---
+
 ## 3. Decision: Apache Spark Connect is the target; Sail is removed
 
 **Sail's only remaining job is replaceable by Spark itself.**

--- a/packages/python/goldenmatch/tests/conftest.py
+++ b/packages/python/goldenmatch/tests/conftest.py
@@ -205,3 +205,44 @@ def sample_parquet(tmp_path) -> Path:
     })
     pq.write_table(table, path)
     return path
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """A Spark Connect session, from whichever server the env selects.
+
+    Backend-agnostic ON PURPOSE (P0, spec
+    ``2026-08-10-spark-native-execution-design``). ``GOLDENMATCH_SPARK_REMOTE``:
+
+      unset             -> spawn a local pysail ``SparkConnectServer`` (prior behaviour)
+      ``"local[*]"``    -> Apache Spark's own local Connect server (pyspark >= 4)
+      ``"sc://host:p"`` -> an already-running Connect endpoint
+
+    Nine test files each carried a copy of this hardcoding
+    ``pysail.spark.SparkConnectServer``. That is *why* the tier had never been
+    run against real Spark: the tests could not express it. Every import is
+    inside the body, so a suite that never requests this fixture pays nothing.
+    """
+    import os
+
+    from pyspark.sql import SparkSession
+
+    remote = os.environ.get("GOLDENMATCH_SPARK_REMOTE")
+
+    if not remote:
+        pytest.importorskip("pysail")
+        from pysail.spark import SparkConnectServer
+
+        server = SparkConnectServer()
+        server.start()
+        _, port = server.listening_address
+        sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+        yield sess
+        sess.stop()
+        server.stop()
+        return
+
+    # Real Spark owns its own server lifecycle; nothing to stop but the session.
+    sess = SparkSession.builder.remote(remote).getOrCreate()
+    yield sess
+    sess.stop()

--- a/packages/python/goldenmatch/tests/test_sail_clustering_checkpoint.py
+++ b/packages/python/goldenmatch/tests/test_sail_clustering_checkpoint.py
@@ -7,22 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
-
-
-@pytest.fixture(scope="module")
-def spark():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def _partition(out_df):

--- a/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
@@ -6,22 +6,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
-
-
-@pytest.fixture(scope="module")
-def spark():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def _reference_partition(ids, edges):

--- a/packages/python/goldenmatch/tests/test_sail_connectivity.py
+++ b/packages/python/goldenmatch/tests/test_sail_connectivity.py
@@ -1,25 +1,14 @@
-"""S1 de-risk: prove the Sail (Spark Connect) harness runs in CI before any
-pipeline is built on it. Skips where the sail extra is absent; runs in the
-`sail` CI lane (goldenmatch[sail] installed)."""
+"""S1 de-risk: prove the Spark Connect harness runs in CI before any pipeline
+is built on it. Backend-agnostic (P0): the ``spark`` fixture picks pysail or a
+real Spark Connect server from ``GOLDENMATCH_SPARK_REMOTE``, so this same gate
+proves either one. Skips without a Spark client."""
 from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
 
 
-def test_sail_local_server_runs_trivial_query():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()  # background
-    try:
-        _, port = server.listening_address
-        spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-        rows = spark.sql("SELECT 1 + 1 AS two").collect()
-        assert rows[0]["two"] == 2
-        spark.stop()
-    finally:
-        server.stop()
+def test_spark_connect_runs_trivial_query(spark):
+    rows = spark.sql("SELECT 1 + 1 AS two").collect()
+    assert rows[0]["two"] == 2

--- a/packages/python/goldenmatch/tests/test_sail_determinism.py
+++ b/packages/python/goldenmatch/tests/test_sail_determinism.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
+
 pytest.importorskip("rapidfuzz")
 
 
@@ -39,20 +39,6 @@ _ROWS = [
     (4, "Brown", "20002"),
     (5, "Carter", "30003"),
 ]
-
-
-@pytest.fixture(scope="module")
-def spark():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def _reference_partition(ids, edges):

--- a/packages/python/goldenmatch/tests/test_sail_golden_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_golden_parity.py
@@ -8,22 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
-
-
-@pytest.fixture(scope="module")
-def spark():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 _VALUE_COLS = ["first_name", "email"]

--- a/packages/python/goldenmatch/tests/test_sail_identity_incremental.py
+++ b/packages/python/goldenmatch/tests/test_sail_identity_incremental.py
@@ -7,12 +7,15 @@ docs/superpowers/specs/2026-08-08-sail-identity-layer2-incremental-design.md.
 Two tiers, matching ``test_sail_identity_parity.py``:
   * PURE unit tests (the public import surface) run in the normal python lane.
   * SERVER tests use an in-process Sail Spark Connect server behind an
-    ``importorskip``, so they SKIP without the [sail] extra and run in the
+    ``importorskip`` on ``pyspark``, so they SKIP without a Spark client and run in the
     `sail` CI lane.
 """
 from __future__ import annotations
 
 import pytest
+
+pytest.importorskip("pyspark")
+
 
 RUN = {
     "run_name": "run-2",
@@ -69,22 +72,6 @@ def test_incremental_signature_is_additive():
 # --------------------------------------------------------------------------
 # Tier 2: server tests.
 # --------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def spark():
-    pytest.importorskip("pysail")
-    pytest.importorskip("pyspark")
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def _source(spark, rows):

--- a/packages/python/goldenmatch/tests/test_sail_identity_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_identity_parity.py
@@ -6,7 +6,7 @@ Two test tiers:
     need no Sail server -- they run anywhere (incl. the normal python lane).
   * SERVER tests (the builders, the 3-part parity gate, determinism) use an
     in-process Sail Spark Connect server; the ``spark`` fixture ``importorskip``s
-    ``pysail``/``pyspark`` so they SKIP without the [sail] extra and run in the
+    ``pyspark`` so they SKIP without a Spark client and run in the
     `sail` CI lane.
 
 Parity gate (entity-id-INDEPENDENT, since one-box mints UUIDv7 while S5 mints
@@ -19,6 +19,9 @@ from __future__ import annotations
 from collections import defaultdict
 
 import pytest
+
+pytest.importorskip("pyspark")
+
 from goldenmatch.sail.identity import entity_id_for_members, record_id_for_row
 
 # --------------------------------------------------------------------------
@@ -58,22 +61,6 @@ def test_entity_id_distinct_for_distinct_members():
 # --------------------------------------------------------------------------
 # Tier 2: server-backed tests (in-process Sail Spark Connect server).
 # --------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def spark():
-    pytest.importorskip("pysail")
-    pytest.importorskip("pyspark")
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def test_derive_record_ids_pk(spark):

--- a/packages/python/goldenmatch/tests/test_sail_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_sail_pipeline.py
@@ -5,22 +5,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
-
-
-@pytest.fixture(scope="module")
-def spark():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def test_run_sail_pipeline_end_to_end(spark):

--- a/packages/python/goldenmatch/tests/test_sail_score_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_score_parity.py
@@ -5,23 +5,9 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pysail")
 pytest.importorskip("pyspark")
+
 pytest.importorskip("polars")
-
-
-@pytest.fixture(scope="module")
-def spark():
-    from pysail.spark import SparkConnectServer
-    from pyspark.sql import SparkSession
-
-    server = SparkConnectServer()
-    server.start()
-    _, port = server.listening_address
-    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
-    yield sess
-    sess.stop()
-    server.stop()
 
 
 def _fixture_rows():


### PR DESCRIPTION
Executes **P0** of the Spark-native execution spec (#2476), per plan #2477. Tests and CI only — **no engine code changed.**

## The obstacle

The `spark` fixture was duplicated across **nine** test files, each hardcoding `pysail.spark.SparkConnectServer`. That's why the tier had never been run against real Spark: **the tests couldn't express it.**

## The finding the plan missed — and it would have made the new lane a lie

Those files also carried **module-level `pytest.importorskip("pysail")`**. On a lane where pysail is deliberately absent, every test would **skip**, and the lane would report green while proving nothing.

Same shape as the zero-polars gate trap, one level down. The pysail guard is now the *fixture's* business; each file keeps a `pyspark` guard instead.

## Deviation from the plan, on evidence

The plan put the fixture in a separate `tests/conftest_spark.py` imported by each file, to keep a pyspark import out of the root conftest. **That produced 41 ruff errors** — `F811` in every file whose tests take `spark` as a parameter.

The concern behind it turned out void: the root conftest holds only stdlib + pytest, and this fixture's imports are **all inside the body**, so a suite that never requests it pays nothing at collection. Fixture now lives in `tests/conftest.py`. No cross-file imports, no `noqa` noise.

## Other things that surfaced

- Two files (`identity_parity`, `identity_incremental`) kept their guards *inside* the fixture rather than at module level. An assertion caught it mid-run rather than silently emitting files with no pyspark guard at all. Stale docstrings corrected.
- `test_sail_connectivity.py` built its server inline in the test body rather than as a fixture. Rewritten to use the shared one, so the S1 harness gate now proves whichever backend the env selects.

## The lane

Installs `pyspark[connect]>=4` and **not** pysail, then **asserts pysail is absent** — a lane that silently picked it up from the lockfile would prove nothing. Runs the same tests with `GOLDENMATCH_SPARK_REMOTE=local[*]`: Spark's own in-process Connect server, no container, no cluster. (`goldenmatch[sail]` pins `pyspark<4` *because of* pysail, so the client is installed directly.)

Deliberately `continue-on-error` and **not** in `ci-required`. While P0 runs, **a red is a finding to enumerate, not a merge blocker** — promote at P2. Verified programmatically: present, `continue-on-error: true`, absent from `ci-required`.

## Verification

Local checks are collection + `py_compile` + ruff only (all clean; the wider suite still collects, confirming the global conftest change is inert). Running this needs pyspark and a JVM, which OOMs the dev box — **CI is the harness**, which is the whole point of the lane.

**What to look at when it runs:** the `spark_connect` job's result is the P0 deliverable. Each deviation gets classified (a) Spark Connect API gap → reshapes the spec, (b) accidental Sail-ism → P2 fix, (c) test-harness assumption → noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ