### PR TITLE
docs(spec): decide the f32/f64 gate — Option A with two conditions

### DIFF
--- a/docs/superpowers/specs/2026-08-10-spark-native-execution-design.md
+++ b/docs/superpowers/specs/2026-08-10-spark-native-execution-design.md
@@ -165,13 +165,68 @@ seam is one Arrow FFI crossing per batch.
 
 ---
 
-## 6. OPEN DECISION — the f32/f64 gate
+## 6. DECIDED — the f32/f64 gate: **Option A**
+
+> **Decision (2026-08-11, delegated by Ben):** accept f32 with a stated
+> tolerance, subject to the two conditions below. Recorded here rather than left
+> open, so P3 has a settled premise.
 
 `sail_scoring` is `_FALLBACK_ONLY` because `score_field_pairwise` returns f32
 where the pure floor returns f64. Until this resolves, **the native kernel does
 not run under `auto`** and the goal of this spec is unmet by default.
 
-Three ways out:
+### Why A
+
+**The tolerance already exists and is already tested.**
+`tests/test_sail_scorer_native_parity.py` asserts
+`max(|native - pure|) < 1e-6` across every supported scorer, plus flag routing,
+identical-string, and length-mismatch cases. This is not accepting an unknown
+divergence; it is a bound that has been measured and pinned since the battery
+was written.
+
+**The code already states its own lift condition.** The `_FALLBACK_ONLY`
+rationale in `core/_native_loader.py` says sail_scoring *"stays Python under
+`auto` until its parity battery is green on the PUBLISHED wheel."* So the open
+question was never whether f32 is acceptable — it was whether that stated
+condition had been met. That is a task, not a philosophy.
+
+**f32 is the convention, not the exception.** `score_field_matrix` and the
+DataFusion FFI scorer already return f32. B breaks a repo-wide convention for one
+call site; C creates two return widths in one kernel family — the dual-lane shape
+the arrow migration spent months eliminating.
+
+**The divergence class is already accepted elsewhere.** The same rationale notes
+FS block scoring carries this exact class and is gated by its own
+`GOLDENMATCH_FS_NATIVE` env var rather than being permanently off.
+
+### The objection, addressed
+
+Accepting a divergence in a codebase that has just spent a long arc killing
+silent ones deserves scrutiny. The distinction is categorical: the #2462 bug
+(`"col" not in tbl.columns` silently returning `True`) was **undetectable,
+unbounded, and untested**. This is **bounded at 1e-6, asserted in CI, and written
+down**. A stated tolerance is an engineering decision; a silent one is a defect.
+
+### Conditions (both required before `sail_scoring` leaves `_FALLBACK_ONLY`)
+
+1. **The parity battery runs against the PUBLISHED wheel**, not an in-tree build.
+   This is the #688 lesson: an in-tree build masks symbol skew, and "we tested
+   it" is hollow if the artifact users install differs.
+2. **Add a threshold-boundary test.** The existing battery proves *score*
+   equality within 1e-6; it does **not** prove *decision* stability. The
+   user-visible risk is not score drift, it is a pair flipping across a threshold
+   and changing cluster membership. Score-tolerance != decision-stability, and
+   only the second is observable in output. This condition is not optional — A is
+   under-tested without it in precisely the dimension that matters.
+
+### What would reverse this
+
+If the boundary test shows cluster membership moving at realistic thresholds on
+real data — not a constructed adversarial case — then f32 buys throughput at the
+cost of reproducibility and **B becomes correct despite the convention break**.
+Re-open this section if that happens.
+
+### The options as evaluated
 
 | Option | Consequence |
 |---|---|
@@ -179,10 +234,9 @@ Three ways out:
 | **B. Return f64 from the kernel** | Removes the divergence entirely. Costs a kernel change and roughly 2x the FFI payload; the scorer convention elsewhere (`score_field_matrix`, the DataFusion FFI scorer) is f32, so this breaks a repo-wide convention for one call site. |
 | **C. f64 only on the Spark path** | Keeps the convention and removes the divergence where it matters. Two return widths in one kernel family — the dual-lane shape the arrow migration spent months removing. |
 
-**Recommendation: A**, with the tolerance written down and a threshold-boundary
-test. This session's work was largely about *silent* divergence; a stated,
-tested tolerance is a different thing from an unnoticed one. **This is Ben's
-call and should be settled before Phase 3.**
+**Selected: A** (see the decision block above). B and C remain recorded so a
+future reader can see what was weighed, and B is the documented fallback if the
+boundary test in condition 2 comes back bad.
 
 ---
 
@@ -221,13 +275,25 @@ lift `pyspark[connect]<4`; delete `_truncate_lineage` once P0 confirms real
 Spark's `localCheckpoint`; retire `deploy/sail-gke/` from the product docs;
 amend ADR-0004.
 
-### P3 — Resolve the f32 gate, take `sail_scoring` out of `_FALLBACK_ONLY`
+### P3 — Take `sail_scoring` out of `_FALLBACK_ONLY`
 
-Per §6. **Blocked on Ben's decision.**
+§6 is **decided (Option A)**; this phase executes its two conditions. No longer
+blocked.
 
-**Exit:** native runs under `auto` on Spark, with a parity battery on the
-**published** wheel (per the loader's own rule, and the #688 symbol-skew
-lesson).
+1. Add the threshold-boundary test (§6 condition 2): assert **cluster membership**
+   is stable across the native/pure boundary at realistic thresholds, not merely
+   that scores agree within 1e-6. This is the test that does not exist yet.
+2. Run the parity battery against the **PUBLISHED** wheel, not an in-tree build
+   (§6 condition 1, the #688 lesson).
+3. Only then remove `"sail_scoring"` from `_FALLBACK_ONLY` in
+   `core/_native_loader.py` and update its rationale comment to record that the
+   stated lift condition was met, with the tolerance named.
+
+**Exit:** native runs under `auto` on Spark; both conditions demonstrably met.
+
+**Abort criterion:** if step 1 shows membership moving on real data, stop and
+switch to §6 option B (f64 kernel). Do NOT widen the tolerance to make the test
+pass — that converts a stated tolerance back into a silent one.
 
 ### P4 — Config-driven execution + `backend="spark"`
 


### PR DESCRIPTION
Ben delegated the call. Recording it so P3 has a settled premise instead of an open question.

## Decision: accept f32 with a stated tolerance

The evidence made this less of a judgment call than it looked.

**The tolerance already exists and is already tested.** `tests/test_sail_scorer_native_parity.py` asserts `max(|native − pure|) < 1e-6` across every supported scorer, plus flag routing, identical-string, and length-mismatch cases. This isn't accepting an unknown divergence — it's a measured, pinned bound.

**The code states its own lift condition.** `_FALLBACK_ONLY`'s rationale says sail_scoring *"stays Python under `auto` until its parity battery is green on the PUBLISHED wheel."* So the open question was never whether f32 is acceptable — it was whether that condition had been met. A task, not a philosophy.

**f32 is the convention.** `score_field_matrix` and the DataFusion FFI scorer already return it. Option B breaks a repo-wide convention for one call site; option C creates two return widths in one kernel family — the dual-lane shape the arrow migration spent months removing.

**The class is already accepted elsewhere.** FS block scoring carries this exact divergence and is gated by its own env var rather than being permanently off.

## The objection, addressed in the spec

Accepting a divergence right after an arc spent killing silent ones deserves scrutiny. The distinction is categorical: #2462 was **undetectable, unbounded, untested**. This is **bounded at 1e-6, asserted in CI, written down**. A stated tolerance is an engineering decision; a silent one is a defect.

## Two conditions, both required before the gate lifts

1. **The parity battery runs against the PUBLISHED wheel**, not an in-tree build — the #688 lesson, since an in-tree build masks symbol skew.
2. **A threshold-boundary test is added.** The existing battery proves *score* equality within 1e-6 but **not decision stability**. The user-visible risk isn't score drift — it's a pair flipping a threshold and changing cluster membership. Not optional: without it, A is under-tested in exactly the dimension that matters.

## Reversal criterion

If the boundary test shows membership moving on **real** data (not a constructed adversarial case), then f32 buys throughput at the cost of reproducibility and **B becomes correct** despite the convention break.

P3 now carries an explicit abort criterion, and forbids widening the tolerance to make the test pass — that would convert a stated tolerance straight back into a silent one.

P3 is rewritten to execute the two conditions and is no longer blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ