### PR TITLE
fix(spark): truncate the WCC plan every round (P2a)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7086,6 +7086,7 @@
           "purpose": "Weakly-connected components on Sail (Spark Connect) -- the Union-Find",
           "defines": [
             "_truncate_lineage",
+            "_truncate_plan",
             "connected_components",
             "connected_components_scale"
           ]

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -14,6 +14,32 @@ from __future__ import annotations
 from typing import Any
 
 
+def _truncate_plan(df: Any) -> Any:
+    """Reset a DataFrame's query plan in place, cheaply. Returns ``df`` unchanged
+    on any backend that cannot.
+
+    Iterative joins against a frame's own derivatives grow the plan without
+    bound. ``localCheckpoint`` cuts it: in-memory, no shared storage, no config.
+    Where it is unavailable (notably Sail -- lakehq/sail#482 lists
+    persist/localCheckpoint/checkpoint as planned, and ``cache`` is a no-op) this
+    is a NO-OP by design: callers that need a hard barrier there pass a
+    ``checkpoint_dir`` and get the parquet round-trip instead
+    (``_truncate_lineage``).
+
+    Never raises. A backend without the primitive must still produce correct
+    output -- just slower, which is the documented Sail posture.
+    """
+    for attempt in ("localCheckpoint", "checkpoint"):
+        fn = getattr(df, attempt, None)
+        if fn is None:
+            continue
+        try:
+            return fn(eager=True)
+        except Exception:  # noqa: BLE001 - unsupported/unimplemented -> next
+            continue
+    return df
+
+
 def connected_components(
     pairs_df: Any,
     ids_df: Any,
@@ -50,9 +76,29 @@ def connected_components(
     )
 
     # Iterate to fixpoint. Bounded by component diameter; at S2 fixture scale
-    # this is 2-3 rounds. The convergence count is a driver scalar (cheap).
-    # NOTE for S4: cache/checkpoint `labels` each round + swap in large-star/
-    # small-star -- label-prop's O(diameter) won't bind at 100M chains.
+    # this is 2-3 rounds.
+    #
+    # P2a: `labels` MUST have its lineage truncated each round. Every round joins
+    # `labels` against derivatives of itself (nbr_min, then the convergence
+    # compare), so the plan grows ~2 joins per round, and the `changed` count is
+    # an ACTION that re-materializes the whole accumulated plan -- O(rounds^2)
+    # work, plus a plan the optimizer mis-estimates.
+    #
+    # This bit on BOTH backends, differently, which is what makes it the loop's
+    # fault rather than an engine's:
+    #   * Sail: no lineage primitive at all (cache is a no-op, localCheckpoint
+    #     unimplemented, lakehq/sail#482) -> recompute wedge at ~12K rows.
+    #   * real Spark: the deep self-similar plan gets mis-costed and the
+    #     optimizer builds a broadcast that exhausts the JVM heap
+    #     ("Not enough memory to build and broadcast the table").
+    # `autoBroadcastJoinThreshold=-1` only swaps one symptom for the other; the
+    # fix is to stop growing the plan.
+    #
+    # `connected_components_scale` already had this via a parquet barrier
+    # (_truncate_lineage) but it was opt-in and never applied HERE.
+    # `localCheckpoint()` is strictly better where available: in-memory, no
+    # shared storage, no config -- and it is precisely the primitive Sail lacked,
+    # so this is a concrete payoff of targeting real Spark.
     #
     # Spark Connect discipline: every join is on a SHARED COLUMN NAME (auto-
     # coalesced, no duplicate-column ambiguity), and the other side is RENAMED
@@ -90,7 +136,8 @@ def connected_components(
             .limit(1)
             .count()
         )
-        labels = new_labels
+        # Truncate BEFORE the next round consumes it (see the note above).
+        labels = _truncate_plan(new_labels)
         if changed == 0:
             break
 
@@ -223,6 +270,11 @@ def connected_components_scale(
         if changed == 0:
             break
         # Truncate the accumulated pointer-jump lineage on continuing rounds.
+        # P2a: the cheap in-memory cut runs ALWAYS (no config, no storage). The
+        # parquet barrier stays opt-in for backends without the primitive and for
+        # a HARD barrier at 100M, where an in-memory checkpoint can still be
+        # evicted and recomputed.
+        labels = _truncate_plan(labels)
         if checkpoint_dir and checkpoint_interval and (round_idx + 1) % checkpoint_interval == 0:
             labels = _truncate_lineage(labels, checkpoint_dir, f"wcc_round_{round_idx + 1}")
 

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -30,10 +30,16 @@ def _truncate_plan(df: Any) -> Any:
     output -- just slower, which is the documented Sail posture.
     """
     for attempt in ("localCheckpoint", "checkpoint"):
-        fn = getattr(df, attempt, None)
-        if fn is None:
-            continue
+        # getattr is INSIDE the try on purpose. pyspark's Spark Connect
+        # DataFrame raises PySparkNotImplementedError from __getattr__ for
+        # unsupported methods -- `checkpoint` and `localCheckpoint` are both on
+        # that list under pyspark 3.5 Connect (which is what the pysail lane
+        # runs). That is NOT AttributeError, so `getattr(df, name, None)` does
+        # not swallow it and the default is never reached.
         try:
+            fn = getattr(df, attempt, None)
+            if fn is None:
+                continue
             return fn(eager=True)
         except Exception:  # noqa: BLE001 - unsupported/unimplemented -> next
             continue

--- a/packages/python/goldenmatch/tests/test_sail_truncate_plan.py
+++ b/packages/python/goldenmatch/tests/test_sail_truncate_plan.py
@@ -1,0 +1,47 @@
+"""P2a: `_truncate_plan` unit tests. NO pyspark needed.
+
+Deliberately not in test_sail_clustering_parity.py -- that file is gated on
+`importorskip("pyspark")`, and a regression test for a pure-Python helper should
+not be invisible in every lane without a Spark install. The bug these pin broke
+every WCC test on pysail and would have been caught earlier had it run here.
+"""
+from __future__ import annotations
+
+
+def test_truncate_plan_is_a_noop_when_the_backend_lacks_the_primitive():
+    """P2a regression: `_truncate_plan` must survive a backend that raises from
+    ATTRIBUTE ACCESS, not just from the call.
+
+    pyspark's Spark Connect DataFrame raises PySparkNotImplementedError out of
+    __getattr__ for unsupported methods (`checkpoint` and `localCheckpoint` are
+    both on that list under pyspark 3.5 Connect). That is not AttributeError, so
+    `getattr(df, name, None)` does NOT return the default -- the first version of
+    this helper put getattr outside the try and broke every WCC test on pysail.
+    """
+    from goldenmatch.sail.clustering import _truncate_plan
+
+    class _RaisesOnAttributeAccess:
+        def __getattr__(self, name):
+            if name in ("checkpoint", "localCheckpoint"):
+                raise NotImplementedError(f"[NOT_IMPLEMENTED] {name}() is not implemented.")
+            raise AttributeError(name)
+
+    df = _RaisesOnAttributeAccess()
+    assert _truncate_plan(df) is df, "must return the frame unchanged, not raise"
+
+
+def test_truncate_plan_uses_local_checkpoint_when_available():
+    """And when the primitive IS there, it must actually be used -- a helper that
+    silently no-ops everywhere would 'fix' nothing while looking correct."""
+    from goldenmatch.sail.clustering import _truncate_plan
+
+    sentinel = object()
+    calls: list[str] = []
+
+    class _Supports:
+        def localCheckpoint(self, eager=False):  # noqa: N802 - pyspark's spelling
+            calls.append(f"localCheckpoint(eager={eager})")
+            return sentinel
+
+    assert _truncate_plan(_Supports()) is sentinel
+    assert calls == ["localCheckpoint(eager=True)"], calls


### PR DESCRIPTION
Resolves the 2 residual failures from P1 (#2481). **It's a tier defect, not a CI-runner artifact** — and the diagnosis was already written in the same file.

## What the loop does

`connected_components` joins `labels` against derivatives of **itself** twice per round — `nbr_min`, then the convergence compare — and never truncates. The plan grows ~2 joins per round, and the `changed` count is an **action** that re-materialises the whole accumulated plan each round. O(rounds²) work over a plan the optimizer increasingly mis-costs.

## Why that makes it the loop's fault

The same defect appears on **both** backends, expressed differently:

| backend | symptom |
|---|---|
| Sail | no lineage primitive at all (`cache` is a no-op; persist/localCheckpoint/checkpoint planned — [#482](https://github.com/lakehq/sail/issues/482)) → recompute wedge at ~12K rows |
| real Spark | deep self-similar plan → mis-costed broadcast → `OutOfMemoryError: Java heap space` |

`autoBroadcastJoinThreshold=-1` only swaps one symptom for the other. Not doing that.

## The proof it was already known

`_truncate_lineage` exists in this file, and its docstring says:

> *"Each pointer-jump round joins labels against derivatives of itself, so the query plan grows unbounded across rounds; at 100M the optimizer chokes / the run hangs."*

It was applied to `connected_components_scale` **only**, and **opt-in**. `connected_components` — the one every S2 test and the pipeline use — never got it.

## The fix

`_truncate_plan()` — `localCheckpoint` with a `checkpoint` fallback — every round, in **both** functions. In-memory, no shared storage, no config.

It's a **no-op where the primitive is missing** (Sail), so that backend keeps its documented correct-but-slower posture rather than regressing. And it's a concrete payoff of targeting real Spark: `localCheckpoint` is exactly the primitive Sail lacks.

The parquet barrier stays opt-in in the scale variant — at 100M an in-memory checkpoint can still be evicted and recomputed, so a hard barrier is still worth having.

## Verification

Expected: the two tests `xfail`'d on #2481 should **xpass** (non-strict, so that isn't a failure). Confirm on the `spark_connect` lane before removing the markers — I haven't removed them here, since #2481 hasn't landed and I'd rather see the lane than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ