### PR TITLE
feat(spark): lift the sail_scoring native gate (P3 complete)

### DIFF
--- a/.github/workflows/pack-executor-env.yml
+++ b/.github/workflows/pack-executor-env.yml
@@ -84,9 +84,21 @@ jobs:
               if mod is not None:
                   has = hasattr(mod, "score_field_pairwise")
                   print("  PUBLISHED wheel carries score_field_pairwise:", has)
-                  if not has:
-                      print("  ^ P3 condition 1 NOT met: the published wheel predates the"
-                            " symbol; republish before lifting the gate (#688).")
+                  # BEHAVIOUR, not just presence. The symbol exists on the f32
+                  # <= 0.1.20 wheels too, so presence proves nothing: an f32
+                  # result changes match decisions at round thresholds. The gate
+                  # was lifted on 0.1.21's f64 kernel, so assert the width.
+                  if has:
+                      import pyarrow as _pa
+                      _r = mod.score_field_pairwise(
+                          _pa.array(["Jonathan"], type=_pa.large_string()),
+                          _pa.array(["Jonothan"], type=_pa.large_string()), 0)
+                      _w = getattr(getattr(_r, "dtype", None), "itemsize", 0)
+                      print(f"  PUBLISHED wheel score dtype itemsize: {_w} (need 8 = f64)")
+                      if _w < 8:
+                          raise SystemExit(
+                              "published goldenmatch-native returns narrow floats; "
+                              "sail_scoring is enabled and needs >=0.1.21's f64 kernel")
           except Exception as exc:  # noqa: BLE001
               print("  native kernel probe failed (not fatal):", exc)
           print("shipped env OK")

--- a/docs-site/goldenmatch/native.mdx
+++ b/docs-site/goldenmatch/native.mdx
@@ -42,8 +42,7 @@ Each component maps to the native kernel symbol(s) its `auto` call site invokes 
 | `pprl_bloom` | `bloom_clk_batch` |  |
 | `perceptual` | `perceptual_phash_image` |  |
 | `documents` | `documents_parse_message_text`, `documents_schema_validate`, `documents_extract_instruction`, `documents_normalize_record`, `documents_template`, `documents_template_list`, `documents_classify_prompt`, `documents_parse_classify`, `documents_parse_structured` |  |
-
-**Kept pure-Python under `auto` (GOLDENMATCH_NATIVE reference-mode):** `sail_scoring`. These carry (or could bind) a native symbol that is known to diverge from the pure-Python reference, so they stay on the fallback path until their parity battery is green — reachable only via `GOLDENMATCH_NATIVE=1`.
+| `sail_scoring` | `score_field_pairwise` |  |
 
 ## How parity stays honest
 

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -47,7 +47,6 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 **Fallback-only kernels** (a `-core` symbol the host references but the default does not run — `_FALLBACK_ONLY`):
 
 - `goldenflow`: `phone_validate`
-- `goldenmatch`: `sail_scoring`
 
 **Cross-language surface gaps** (declared Python-only / TS-only per surface — the same partition the [suite matrix](/suite-matrix) renders in full):
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7185,6 +7185,7 @@
           "defines": [
             "_native_scores",
             "_pure_scores",
+            "_warn_native_scorer_wheel_too_old_once",
             "make_scorer_udf",
             "score_batch"
           ],

--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -186,17 +186,31 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
                   "documents_template", "documents_template_list",
                   "documents_classify_prompt", "documents_parse_classify",
                   "documents_parse_structured"),
-    # "sail_scoring" is intentionally absent -> _FALLBACK_ONLY below.
+    # sail_scoring: LIFTED 2026-08-11 (spec 2026-08-10-spark-native-execution
+    # -design section 6). It was _FALLBACK_ONLY because score_field_pairwise
+    # narrowed to f32 and that cast changed MATCH DECISIONS at round thresholds
+    # (a pure 0.95 -> 0.949999988, so `>= 0.95` flipped on ordinary surname
+    # pairs). goldenmatch-native 0.1.21 returns f64 and the decision-stability
+    # battery is green.
+    #
+    # SYMBOL PRESENCE IS NOT ENOUGH HERE. `score_field_pairwise` exists on the
+    # f32 0.1.20 wheel too, so this entry cannot distinguish the two. The call
+    # site (`sail/scorers.py::_native_scores`) additionally verifies the returned
+    # DTYPE is f64 and falls back otherwise -- an older installed wheel must not
+    # silently reintroduce the flips.
+    "sail_scoring": ("score_field_pairwise",),
 }
 
 # Components with a native symbol that is KNOWN to diverge from the Python
-# reference and must NOT auto-run native even under reference-mode:
-#   - sail_scoring: score_field_pairwise returns f32 vs the pure f64 floor
-#     (boundary-nondeterminism, same class as FS). Stays Python under ``auto``
-#     until its parity battery is green on the PUBLISHED wheel. Previously "off by
-#     accident" (unmapped); now off ON PURPOSE.
+# reference and must NOT auto-run native even under reference-mode.
+#
+# EMPTY as of 2026-08-11: sail_scoring was the only entry and its divergence was
+# removed at the source (f64 kernel, goldenmatch-native 0.1.21) rather than
+# tolerated. Keep the mechanism -- a future kernel that provably diverges belongs
+# here rather than being quietly enabled.
+#
 # (FS block scoring is gated separately via GOLDENMATCH_FS_NATIVE, not here.)
-_FALLBACK_ONLY: frozenset[str] = frozenset({"sail_scoring"})
+_FALLBACK_ONLY: frozenset[str] = frozenset()
 
 
 def _has_symbol(component: str) -> bool:

--- a/packages/python/goldenmatch/goldenmatch/sail/scorers.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/scorers.py
@@ -26,7 +26,10 @@ A tolerance is fine for a score you report and not for one you THRESHOLD. See
 spec 2026-08-10-spark-native-execution-design section 6."""
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # SQL-callable names (match the matchkey scorer names the spine supports).
 _SUPPORTED = ("jaro_winkler", "levenshtein", "token_sort")
@@ -38,6 +41,30 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     "levenshtein": 1,
     "token_sort": 2,
 }
+
+
+_NATIVE_SCORER_F32_WARNED = False
+
+
+def _warn_native_scorer_wheel_too_old_once(dtype: Any) -> None:
+    """Warn once when the installed native wheel returns narrow floats.
+
+    goldenmatch-native < 0.1.21 narrowed `score_field_pairwise` to f32, which
+    changes match decisions at round thresholds. We fall back to the pure floor
+    (correct, slower) rather than take the faster wrong answer -- but silence
+    here would look exactly like "native is not installed", so say it once.
+    """
+    global _NATIVE_SCORER_F32_WARNED
+    if _NATIVE_SCORER_F32_WARNED:
+        return
+    _NATIVE_SCORER_F32_WARNED = True
+    logger.warning(
+        "goldenmatch-native returns %s from score_field_pairwise; native Spark "
+        "scoring is DISABLED for this session because narrow floats change match "
+        "decisions at round thresholds. Upgrade to goldenmatch-native>=0.1.21 "
+        "for the f64 kernel.",
+        dtype,
+    )
 
 
 def _pure_scores(scorer_name: str, a: Any, b: Any) -> list[float]:
@@ -85,10 +112,22 @@ def _native_scores(scorer_name: str, a: Any, b: Any) -> Any | None:
 
         aa = pa.array(list(a), type=pa.large_string())
         bb = pa.array(list(b), type=pa.large_string())
-        return native.score_field_pairwise(aa, bb, scorer_id)
+        out = native.score_field_pairwise(aa, bb, scorer_id)
     except Exception:
         # Any FFI / pyarrow hiccup falls through to the pure floor.
         return None
+
+    # BEHAVIOUR guard, not a symbol guard. `score_field_pairwise` exists on the
+    # f32 goldenmatch-native <= 0.1.20 wheels as well, so the loader's
+    # symbol-presence check cannot tell them apart -- and an f32 result changes
+    # MATCH DECISIONS at round thresholds (a pure 0.95 arrives as 0.949999988,
+    # so `>= 0.95` flips; measured on ordinary surname pairs). An older installed
+    # wheel must degrade to the pure floor rather than silently reintroduce that.
+    dtype = getattr(out, "dtype", None)
+    if dtype is not None and getattr(dtype, "itemsize", 0) < 8:
+        _warn_native_scorer_wheel_too_old_once(dtype)
+        return None
+    return out
 
 
 def score_batch(scorer_name: str, a: Any, b: Any) -> Any:

--- a/packages/python/goldenmatch/tests/test_native_loader_reference.py
+++ b/packages/python/goldenmatch/tests/test_native_loader_reference.py
@@ -76,16 +76,32 @@ def test_simhash_shares_the_sketch_kernel(monkeypatch) -> None:
     assert nl.native_enabled("sketch") is True
 
 
-def test_sail_scoring_stays_fallback_even_with_symbol(monkeypatch) -> None:
-    """sail_scoring is f32-vs-f64 divergent -> _FALLBACK_ONLY: never native under
-    auto even when the kernel symbol is present."""
+def test_sail_scoring_is_native_capable_when_the_symbol_is_present(monkeypatch) -> None:
+    """sail_scoring LEFT _FALLBACK_ONLY (2026-08-11).
+
+    It was fallback-only because score_field_pairwise narrowed to f32, which
+    changed match decisions at round thresholds. goldenmatch-native 0.1.21
+    returns f64, so the divergence was removed at the source rather than
+    tolerated, and the loader now treats it like any other component.
+
+    NOTE the loader gate is SYMBOL presence, and the symbol exists on the old f32
+    wheels too -- so this alone is not sufficient. The width check lives at the
+    call site and is pinned by tests/test_sail_native_wheel_guard.py.
+    """
 
     class FakeNative:
         score_field_pairwise = staticmethod(lambda *a, **k: None)
 
     monkeypatch.setattr(nl, "_native", FakeNative)
     monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
-    assert nl.native_enabled("sail_scoring") is False
+    assert nl.native_enabled("sail_scoring") is True
+
+
+def test_fallback_only_is_empty_but_the_mechanism_survives() -> None:
+    """Nothing is fallback-only today. The set must remain the place a proven
+    divergence goes, so a future one is DECLARED rather than quietly enabled."""
+    assert nl._FALLBACK_ONLY == frozenset()
+    assert isinstance(nl._FALLBACK_ONLY, frozenset)
 
 
 def test_env_zero_forces_fallback(monkeypatch) -> None:

--- a/packages/python/goldenmatch/tests/test_sail_native_wheel_guard.py
+++ b/packages/python/goldenmatch/tests/test_sail_native_wheel_guard.py
@@ -1,0 +1,97 @@
+"""P3: an OLD native wheel must not silently reintroduce the f32 decision flips.
+
+`sail_scoring` left `_FALLBACK_ONLY` once goldenmatch-native 0.1.21 shipped the
+f64 kernel. But the loader gates on SYMBOL PRESENCE, and
+``score_field_pairwise`` exists on the f32 <= 0.1.20 wheels too -- so the loader
+alone cannot tell them apart. The call site checks the returned DTYPE instead.
+
+Without that guard, a user on an older installed wheel gets native f32 scoring
+under ``auto`` and the exact flips section 6 was written to prevent
+(a pure 0.95 arriving as 0.949999988, so ``>= 0.95`` turns over).
+
+No native kernel or Spark needed: the wheel is faked.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from goldenmatch.sail import scorers
+
+_A = ["Jonathan", "Anderson"]
+_B = ["Jonothan", "Andersen"]
+
+
+class _FakeWheel:
+    """Stands in for goldenmatch-native, returning a chosen float width."""
+
+    def __init__(self, dtype):
+        self._dtype = dtype
+        self.calls = 0
+
+    def score_field_pairwise(self, a, b, scorer_id):  # noqa: ARG002
+        self.calls += 1
+        return np.array([0.95, 0.95], dtype=self._dtype)
+
+
+def _install(monkeypatch, wheel):
+    monkeypatch.setattr(scorers, "logger", scorers.logger)
+    monkeypatch.setattr(scorers, "_NATIVE_SCORER_F32_WARNED", False, raising=False)
+    import goldenmatch.core._native_loader as loader
+
+    monkeypatch.setattr(loader, "native_module", lambda: wheel)
+    monkeypatch.setattr(loader, "native_enabled", lambda *a, **k: True)
+
+
+def test_f32_wheel_is_refused_and_falls_back(monkeypatch):
+    """The old wheel's answer is DISCARDED, not used."""
+    wheel = _FakeWheel(np.float32)
+    _install(monkeypatch, wheel)
+
+    out = scorers._native_scores("jaro_winkler", _A, _B)
+
+    assert wheel.calls == 1, "the kernel should be called before the width is known"
+    assert out is None, (
+        "an f32 wheel must fall back to the pure floor; returning its result "
+        "reintroduces the threshold flips that reversed spec section 6"
+    )
+
+
+def test_f64_wheel_is_used(monkeypatch):
+    """And the guard must not reject the CORRECT wheel -- a guard that refuses
+    everything would 'pass' while disabling the feature entirely."""
+    wheel = _FakeWheel(np.float64)
+    _install(monkeypatch, wheel)
+
+    out = scorers._native_scores("jaro_winkler", _A, _B)
+
+    assert out is not None, "the f64 wheel must be used"
+    assert np.asarray(out).dtype == np.float64
+
+
+def test_score_batch_still_returns_correct_values_on_an_old_wheel(monkeypatch):
+    """End to end: an f32 wheel degrades to the pure floor, so callers still get
+    CORRECT scores -- just without the native speedup."""
+    _install(monkeypatch, _FakeWheel(np.float32))
+
+    got = np.asarray(scorers.score_batch("jaro_winkler", _A, _B), dtype=np.float64)
+    want = np.asarray(scorers._pure_scores("jaro_winkler", _A, _B), dtype=np.float64)
+
+    assert np.array_equal(got, want), "fallback must equal the pure floor exactly"
+
+
+def test_sail_scoring_is_no_longer_fallback_only():
+    """The gate is lifted, and the mechanism is retained for future divergences."""
+    from goldenmatch.core._native_loader import _COMPONENT_SYMBOLS, _FALLBACK_ONLY
+
+    assert "sail_scoring" not in _FALLBACK_ONLY
+    assert "sail_scoring" in _COMPONENT_SYMBOLS
+    assert "score_field_pairwise" in _COMPONENT_SYMBOLS["sail_scoring"]
+
+
+@pytest.mark.parametrize("width", [np.float16, np.float32])
+def test_any_narrow_float_is_refused(width, monkeypatch):
+    """Guard on width, not on an f32 literal -- a future wheel returning f16
+    would be just as wrong."""
+    _install(monkeypatch, _FakeWheel(width))
+    assert scorers._native_scores("jaro_winkler", _A, _B) is None

--- a/packages/python/goldenmatch/tests/test_sail_native_wheel_guard.py
+++ b/packages/python/goldenmatch/tests/test_sail_native_wheel_guard.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-
 from goldenmatch.sail import scorers
 
 _A = ["Jonathan", "Anderson"]


### PR DESCRIPTION
`goldenmatch-native 0.1.21` is **published and verified on PyPI** (6 artifacts, all platforms) with the f64 `score_field_pairwise`. Both §6 conditions are met, so `sail_scoring` leaves `_FALLBACK_ONLY` and native Spark scoring runs under `auto`.

## Why this isn't a one-line change

The loader gates on **symbol presence** — and `score_field_pairwise` exists on the f32 `<= 0.1.20` wheels too. Symbol presence **cannot tell them apart**.

Lifting the gate on that alone would give every user with an older installed wheel native **f32** scoring, and with it the exact decision flips §6 exists to prevent: a pure `0.95` arriving as `0.949999988`, so `>= 0.95` turns over on ordinary surname pairs.

So the call site adds a **behaviour guard**: check the returned dtype width, fall back to the pure floor on anything narrower than f64, and emit a **one-time warning** — silence there would be indistinguishable from "native isn't installed". Guarded on *width*, not an f32 literal, so a future f16 wheel is refused too.

## Verified the guard actually guards

Removing it fails **4 of the 6** new tests; restoring it passes all 6. The suite also pins the opposite direction — an f64 wheel must be **used** — because a guard that refuses everything would "pass" while silently disabling the feature.

## Other changes

**`_FALLBACK_ONLY` is now empty**, with the mechanism deliberately retained and a note: a future proven divergence belongs there rather than being quietly enabled.

**An existing test asserted the old contract** (`sail_scoring` stays fallback even with the symbol). Updated rather than deleted — it now records why the gate lifted, and that the loader's symbol check isn't sufficient alone.

**`pack-executor-env`'s condition-1 check upgraded** from "carries the symbol" to "returns f64": it calls the published kernel and asserts `itemsize == 8`. The symbol was never what changed, so a symbol check would have passed on the f32 wheel and proved nothing.

## P3 is complete

Decided → reversed by its own condition → fixed at the source → published → verified → gate lifted, with a guard for anyone who hasn't upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ