### PR TITLE
docs(p2): supersede ADR-0004 — the target is Apache Spark, not Sail

### DIFF
--- a/context-network/architecture/sail-tier.md
+++ b/context-network/architecture/sail-tier.md
@@ -1,10 +1,24 @@
-# Sail Tier (distributed, Sail-native — ADDITIVE to Ray)
+# Sail Tier (distributed) — RETARGETED 2026-08-11 to Apache Spark Connect
 
-> **Scope amended 2026-06-15 ([../decisions/0004-sail-tier-scope.md](../decisions/0004-sail-tier-scope.md)):**
-> Sail is an **additive** distributed substrate that can be supercharged, **NOT a Ray
-> replacement**. Ray clustering is effective and stays the default indefinitely. "Retires
-> Ray" / "deprecation window" language below is superseded — Sail adds a parallel opt-in
-> path; Ray is untouched.
+> **READ THIS FIRST.** This tier's target is now **Apache Spark**, not Sail. See
+> [`docs/superpowers/specs/2026-08-10-spark-native-execution-design.md`](../../docs/superpowers/specs/2026-08-10-spark-native-execution-design.md)
+> and Amendment 2 of [`../decisions/0004-sail-tier-scope.md`](../decisions/0004-sail-tier-scope.md).
+>
+> The goal is to run GoldenMatch's **native Rust kernels inside a Spark cluster the
+> customer already operates**, so a Splink-on-Spark team adopts GM with no new
+> infrastructure. The code below was always backend-agnostic —
+> `SparkSession.builder.remote(url)` with zero Sail-specific calls — which is why
+> retargeting cost days rather than a rewrite.
+>
+> Sail's remaining role is the no-cluster dev/CI server, and even that is
+> replaceable by `builder.remote("local[*]")`. Two capabilities decided it:
+> `addArtifacts` (ships deps to executors — makes the zero-install cutover real)
+> and `localCheckpoint` (fixes the WCC plan-growth wedge). Both exist on Apache
+> Spark; on Sail they are missing or unproven, and `pysail` additionally pins
+> `pyspark[connect]<4`.
+>
+> **Ray is untouched** and remains the distributed path for non-Spark users. The
+> old "Sail versus Ray" framing was the wrong axis entirely.
 
 The distributed sibling of the one-box DataFusion spine. Re-expresses the spine's
 relational plan against **Sail** (LakeSail — a Rust Spark drop-in built on DataFusion,

--- a/context-network/decisions/0004-sail-tier-scope.md
+++ b/context-network/decisions/0004-sail-tier-scope.md
@@ -1,9 +1,51 @@
-# 0004 — Sail tier scope: full, buildable, Sail-native, ADDITIVE to Ray (amended 2026-06-15)
+# 0004 — Sail tier scope (amended twice; SUPERSEDED 2026-08-11 by the Spark-native target)
 
-**Status:** accepted (2026-06-03, Ben) • **Amended** 2026-06-15 (Sail is additive, NOT a Ray
-replacement — see Amendment) • **Spec:** `docs/superpowers/specs/2026-06-03-sail-tier-design.md`
+**Status:** superseded (2026-08-11) • accepted 2026-06-03 • amended 2026-06-15
+• **Superseding spec:** `docs/superpowers/specs/2026-08-10-spark-native-execution-design.md`
+• **Original spec:** `docs/superpowers/specs/2026-06-03-sail-tier-design.md`
 
-## Amendment (2026-06-15, Ben) — Sail is additive; Ray stays
+## Amendment 2 (2026-08-11, Ben) — the axis was wrong; the target is Apache Spark
+
+Both this decision and its first amendment argue about **Sail versus Ray**. That is
+the wrong axis, and reframing it is what P0–P3 of the superseding spec acted on.
+
+**The goal is to run GoldenMatch's native Rust kernels inside a Spark cluster the
+customer already operates** — so a Splink-on-Spark team adopts GM with no new
+infrastructure. Against that goal:
+
+- **Ray never competed.** It is the distributed path for users who are not on
+  Spark. Nothing here retires or diminishes it.
+- **Sail was the test harness, not the product.** The tier is
+  `SparkSession.builder.remote(url)` with **zero** Sail-specific calls, so it
+  always spoke generic Spark Connect. Sail is one server implementation; Apache
+  Spark is another, and it is the one customers already run.
+- **The customer's cluster is the asset.** Handing them a new engine reinstates
+  the friction the whole exercise removes.
+
+### What the reframing produced, in evidence rather than argument
+
+| | |
+|---|---|
+| P0 (run 31496638072) | the tier runs on real Spark Connect with **no API gaps** — 36 tests pass unmodified. All 20 failures were one cause: the executor's Python worker could not import goldenmatch. |
+| P1 (run 31516855744) | `addArtifact` + `spark.sql.execution.pyspark.python` ships the client venv to executors: **20 failures → 2**, no cluster-side install. |
+| P2a | the residual 2 were a **tier defect**, not a runner artifact: the WCC loop never truncated its plan. Sail wedged (recompute); Spark OOM'd (broadcast). Same cause, and the diagnosis was already written in `_truncate_lineage`'s own docstring. |
+| P3 | the native scorer narrowed to f32 at the FFI boundary, which **changed match decisions** at round thresholds. Fixed at the source (f64 kernel, `goldenmatch-native 0.1.21`) and the gate lifted. |
+
+**The decisive practical difference:** `localCheckpoint` and `addArtifacts` both
+exist on Apache Spark and are missing or unproven on Sail. The first is what fixes
+the WCC wedge; the second is what makes the zero-install cutover true. Sail's
+`pysail` dependency also pins `pyspark[connect]<4`, capping the very users this
+targets.
+
+**Sail's remaining role** is the no-cluster dev/CI server — and even that is
+replaceable by `SparkSession.builder.remote("local[*]")`, at the cost of a JVM.
+
+Read everything below as historical record. The S1–S5 work was not wasted: it
+built a tier that turned out to be backend-agnostic, which is exactly why
+retargeting it cost days rather than a rewrite.
+
+
+## Amendment 1 (2026-06-15, Ben) — Sail is additive; Ray stays
 The original decision framed Sail as **replacing** the Ray distributed stack (a one-release
 deprecation window after S4). **That is revised:** Ray clustering is effective and stays the
 default distributed substrate indefinitely. Sail is an **additive** scale-out option that can


### PR DESCRIPTION
P2's **non-conflicting half**. Docs only.

The rename of `goldenmatch/sail/` waits for #2487 and #2491 to land — both touch files in that directory, and renaming now would turn their changes into modify/delete conflicts on *their* branches for no benefit.

## What was stale

ADR-0004 and `architecture/sail-tier.md` both still argue **"Sail versus Ray"**. That's the wrong axis. Ray never competed — it's the distributed path for users who aren't on Spark. The goal is running GM's native kernels inside a cluster the customer **already operates**.

## Amendment 2 records evidence, not argument

| phase | result |
|---|---|
| P0 | tier runs on real Spark Connect with **no API gaps** — 36 tests pass unmodified; all 20 failures were one cause (executor couldn't import goldenmatch) |
| P1 | `addArtifact` ships the client venv: **20 failures → 2**, no cluster-side install |
| P2a | the residual 2 were a **tier defect** — the WCC loop never truncated its plan. Sail wedged (recompute), Spark OOM'd (broadcast). Same cause, and the diagnosis was already in `_truncate_lineage`'s own docstring. |
| P3 | the scorer narrowed to f32 at the FFI boundary and **changed match decisions** at round thresholds; fixed at the source, gate lifted |

The decisive practical difference, now named in the ADR: **`localCheckpoint` and `addArtifacts` both exist on Apache Spark and are missing or unproven on Sail.** The first fixes the WCC wedge; the second makes the zero-install cutover true. `pysail` also pins `pyspark[connect]<4`, capping exactly the users this targets.

## Not a repudiation of S1–S5

Stated explicitly in the ADR: that work built a tier which turned out to be **backend-agnostic** — `SparkSession.builder.remote(url)` with zero Sail-specific calls — which is precisely why retargeting cost days rather than a rewrite.

Ray is untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ