### PR TITLE
fix(fs): resolve the link cutoff through one owner on every scoring path

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Fixed
+- **Every FS scoring path now resolves the link cutoff the same way.**
+  `_fs_link_threshold` applies three steps in order -- configured
+  `mk.link_threshold`, then the EM-calibrated per-dataset cutoff, then the
+  calibration-aware default -- and its docstring records that it was extracted
+  "so they cannot drift on how the cutoff is resolved" (#1804 item 4). Four
+  scorers used it; two did not. `fused_match._match_fused_fs` and
+  `probabilistic_fast._resolve_probabilistic_fast_path` hand-rolled only the
+  FIRST and THIRD steps, so whenever EM produced a calibrated cutoff -- what
+  `GOLDENMATCH_FS_CALIBRATE_THRESHOLD` exists to do, worth +0.49 F1 on dblp_acm
+  per that flag's own docstring -- those two routes silently ignored it and cut
+  at the fixed 0.50 while the scalar/vectorized/batched routes honoured it. The
+  same config on the same data cut differently depending on which scorer the
+  router happened to pick. Both now call the shared helper. With no calibrated
+  cutoff present the resolved value is unchanged, so this only moves runs that
+  were already asking for calibration (#2483).
+- **A `threshold` set on a probabilistic matchkey is reported instead of
+  silently ignored.** `threshold` is the weighted matchkey's cutoff; the
+  probabilistic scorers read `link_threshold`. Setting it did nothing and
+  *reading* it raised, so a user swept `threshold` from 0.90 to 0.99, got
+  byte-identical results, and reasonably concluded the cut did not matter on
+  their data -- it was measuring nothing. Config validation now emits a
+  `UserWarning` naming `link_threshold`. A warning rather than a rejection: a
+  stray key is a usage mistake, not a corrupt config (#2483).
 - **Blocking suggestions account for what a key can REACH, not just what it
   costs.** Two compounding defects in `core/block_analyzer.py`, both measured on
   the Amazon-Google benchmark frame (#2488). (1) `score_candidate` divided its

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
@@ -677,6 +678,24 @@ class MatchkeyConfig(BaseModel):
             ):
                 raise ValueError(
                     "review_threshold must be less than or equal to link_threshold."
+                )
+            if self.threshold is not None:
+                # #2483: `threshold` is the WEIGHTED matchkey's cutoff and is
+                # inert here -- the probabilistic scorers read `link_threshold`.
+                # Silently ignoring it is expensive: a user swept `threshold`
+                # 0.90-0.99, got byte-identical results, and concluded the cut
+                # did not matter on their data, when it was measuring nothing.
+                # Warn rather than raise -- rejecting would break configs that
+                # merely carry a stray key, and this is a usage mistake, not a
+                # corrupt config.
+                warnings.warn(
+                    f"MatchkeyConfig {self.name!r} (type='probabilistic') sets "
+                    f"'threshold'={self.threshold}, which is IGNORED. "
+                    "Probabilistic matchkeys cut on 'link_threshold' (and "
+                    "'review_threshold'); 'threshold' applies to weighted "
+                    "matchkeys only. Set 'link_threshold' instead. See #2483.",
+                    UserWarning,
+                    stacklevel=2,
                 )
             for f in self.fields:
                 if f.scorer is None:

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -419,7 +419,7 @@ def run_match_fused_fs_arrow(
         _ensure_fs_name_refdata,
         _field_values_from_list,
         _fs_calibration_mode,
-        compute_thresholds,
+        _fs_link_threshold,
         fs_weight_range,
         prior_weight,
     )
@@ -466,10 +466,16 @@ def run_match_fused_fs_arrow(
     # min/max sum would miss (which would mis-normalize every fused NE score).
     min_w, max_w = fs_weight_range(em_result, mk)
     weight_range = max_w - min_w
-    if mk.link_threshold is not None:
-        link_threshold = float(mk.link_threshold)
-    else:
-        link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
+    # #2483: resolve through the shared helper, not a hand-rolled two-step.
+    # `_fs_link_threshold` is the "so they cannot drift" extraction from #1804
+    # item 4 and applies THREE steps -- configured `mk.link_threshold`, then the
+    # EM-calibrated per-dataset cutoff, then the calibration-aware default. This
+    # path implemented only the first and third, so whenever EM produced a
+    # calibrated cutoff (GOLDENMATCH_FS_CALIBRATE_THRESHOLD) the fused route
+    # silently ignored it and used the fixed 0.50 while the scalar/vectorized/
+    # batched routes honoured it -- the same config cutting differently
+    # depending on which scorer the router happened to pick.
+    link_threshold = float(_fs_link_threshold(mk, em_result, calibrated))
     scorer_ids = [_FUSED_FS_SCORER_IDS[f.scorer] for f in mk.fields]
     levels = [int(f.levels) for f in mk.fields]
     partials = [float(f.partial_threshold) for f in mk.fields]

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -71,7 +71,11 @@ def _resolve_probabilistic_fast_path(
       - mk.negative_evidence is empty.
     """
     from goldenmatch.core.matchkey import _xform_sig
-    from goldenmatch.core.probabilistic import compute_thresholds, fs_weight_range
+    from goldenmatch.core.probabilistic import (
+        _fs_calibration_mode,
+        _fs_link_threshold,
+        fs_weight_range,
+    )
 
     if mk.type != "probabilistic":
         return None
@@ -112,12 +116,16 @@ def _resolve_probabilistic_fast_path(
             [float(w) for w in weights],
         ))
 
-    # Resolve threshold the same way the slow path does.
-    if mk.link_threshold is not None:
-        link_threshold = float(mk.link_threshold)
-    else:
-        link_threshold, _ = compute_thresholds(em_result)
-        link_threshold = float(link_threshold)
+    # Resolve threshold the same way the slow path does -- #2483: which means
+    # THROUGH `_fs_link_threshold`, not a hand-rolled copy of two of its three
+    # steps. The old code went configured -> default and skipped the
+    # EM-calibrated per-dataset cutoff in between, so this path disagreed with
+    # the scalar/vectorized/batched scorers whenever EM produced one.
+    # `calibrated` is derived exactly as `compute_thresholds` defaulted it here,
+    # so the no-calibrated-cutoff case stays byte-identical.
+    link_threshold = float(
+        _fs_link_threshold(mk, em_result, _fs_calibration_mode() == "posterior")
+    )
 
     # Centralized range (fs_weight_range) rather than a hand-rolled sum --
     # this fast path's per-pair loop doesn't score NE fields, but the

--- a/packages/python/goldenmatch/tests/test_fs_link_threshold_drift_2483.py
+++ b/packages/python/goldenmatch/tests/test_fs_link_threshold_drift_2483.py
@@ -1,0 +1,135 @@
+"""Every FS scoring path must resolve the link cutoff the same way.
+
+`_fs_link_threshold` applies three steps in order:
+
+    configured `mk.link_threshold`  ->  EM-calibrated per-dataset cutoff  ->  default
+
+Its docstring says it was "extracted verbatim from the scalar / vectorized /
+batched scorers (#1804 item 4) so they cannot drift on how the cutoff is
+resolved". Two paths then bypassed it and hand-rolled only the FIRST and THIRD
+steps: `fused_match._match_fused_fs` and
+`probabilistic_fast._resolve_probabilistic_fast_path`.
+
+So whenever EM produced a calibrated cutoff -- which is what
+`GOLDENMATCH_FS_CALIBRATE_THRESHOLD` exists to do, and is worth +0.49 F1 on
+dblp_acm per that flag's own docstring -- the answer depended on which scorer
+the router happened to pick. Same config, same data, different cut (#2483).
+
+These tests pin the CONTRACT (all six paths agree with the helper) rather than
+any particular number, so they keep holding if the default or the calibration
+strategy is retuned later.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig
+from goldenmatch.core.probabilistic import _fs_link_threshold
+
+
+class _EM:
+    """Minimal EMResult stand-in: only the attributes the resolver reads."""
+
+    def __init__(self, calibrated_link_threshold=None, proportion_matched=0.01):
+        if calibrated_link_threshold is not None:
+            self.calibrated_link_threshold = calibrated_link_threshold
+        self.proportion_matched = proportion_matched
+
+
+def _mk(**kw) -> MatchkeyConfig:
+    kw.setdefault("name", "p")
+    kw.setdefault("type", "probabilistic")
+    kw.setdefault("fields", [{"field": "a", "scorer": "exact"}])
+    return MatchkeyConfig(**kw)
+
+
+class TestResolverPrecedence:
+    def test_configured_wins_over_everything(self):
+        mk = _mk(link_threshold=0.77)
+        assert _fs_link_threshold(mk, _EM(calibrated_link_threshold=0.91), False) == 0.77
+
+    def test_calibrated_wins_over_the_default(self):
+        """The step both bypassing paths skipped."""
+        got = _fs_link_threshold(_mk(), _EM(calibrated_link_threshold=0.91), False)
+        assert got == 0.91
+
+    def test_default_when_neither_is_set(self):
+        got = _fs_link_threshold(_mk(), _EM(), False)
+        assert got == 0.50  # the documented fixed default for pre-blocked pairs
+
+
+class TestNoPathSkipsTheCalibratedCutoff:
+    """The regression: a path that resolves the cutoff must go through the
+    helper. Asserted structurally, because the alternative -- driving each
+    scorer end to end -- needs a native kernel and a fitted EM, and would test
+    the kernels rather than the resolution order that actually drifted."""
+
+    @pytest.mark.parametrize("module_path", [
+        "goldenmatch.core.fused_match",
+        "goldenmatch.core.probabilistic_fast",
+    ])
+    def test_path_imports_the_shared_resolver(self, module_path):
+        import importlib
+        import inspect
+
+        src = inspect.getsource(importlib.import_module(module_path))
+        assert "_fs_link_threshold" in src, (
+            f"{module_path} resolves a link threshold without the shared helper; "
+            "a hand-rolled copy is how the EM-calibrated cutoff got skipped (#2483)"
+        )
+
+    @pytest.mark.parametrize("module_path", [
+        "goldenmatch.core.fused_match",
+        "goldenmatch.core.probabilistic_fast",
+    ])
+    def test_path_no_longer_hand_rolls_the_two_step_form(self, module_path):
+        """Both bypassing paths had the same shape:
+
+            if mk.link_threshold is not None: ... else: compute_thresholds(...)
+
+        which is precedence step 1 then step 3, silently dropping step 2.
+        """
+        import importlib
+        import inspect
+
+        src = inspect.getsource(importlib.import_module(module_path))
+        assert "compute_thresholds(" not in src, (
+            f"{module_path} still calls compute_thresholds directly; that is the "
+            "two-step form that skips the EM-calibrated cutoff (#2483)"
+        )
+
+
+class TestInertThresholdIsReported:
+    """`threshold` is the WEIGHTED cutoff and does nothing on a probabilistic
+    matchkey. Silently ignoring it cost the #2483 reporter a sweep of 0.90-0.99
+    that returned byte-identical results, from which they reasonably concluded
+    the cut did not matter on their data."""
+
+    def test_threshold_on_a_probabilistic_matchkey_warns(self):
+        with pytest.warns(UserWarning, match="link_threshold"):
+            _mk(threshold=0.95)
+
+    def test_the_warning_names_the_field_to_use_instead(self):
+        with pytest.warns(UserWarning) as rec:
+            _mk(threshold=0.95)
+        msg = str(rec[0].message)
+        assert "IGNORED" in msg and "#2483" in msg
+
+    def test_it_warns_rather_than_rejecting(self):
+        """A stray key is a usage mistake, not a corrupt config -- raising would
+        break configs that merely carry one."""
+        with pytest.warns(UserWarning):
+            mk = _mk(threshold=0.95)
+        assert mk.type == "probabilistic"
+        assert mk.threshold == 0.95  # preserved, just not consulted
+
+    def test_link_threshold_alone_is_silent(self, recwarn):
+        _mk(link_threshold=0.95)
+        assert not [w for w in recwarn if "#2483" in str(w.message)]
+
+    def test_weighted_matchkeys_are_untouched(self, recwarn):
+        """`threshold` is REQUIRED there; warning would be nonsense."""
+        MatchkeyConfig(
+            name="w", type="weighted", threshold=0.9,
+            fields=[{"field": "a", "scorer": "jaro_winkler", "weight": 1.0}],
+        )
+        assert not [w for w in recwarn if "#2483" in str(w.message)]


### PR DESCRIPTION
Addresses #2483. **The reported suggestion 2 turned out not to be viable, and working out why surfaced the actual defect** — so the diagnosis here differs from the issue.

## What is actually wrong

`_fs_link_threshold(mk, em_result, calibrated)` applies three steps in order:

```
configured mk.link_threshold  ->  EM-calibrated per-dataset cutoff  ->  calibration-aware default
```

Its docstring records exactly why it exists:

> Extracted verbatim from the scalar / vectorized / batched scorers (#1804 item 4) **so they cannot drift on how the cutoff is resolved.**

Six FS paths resolve a cutoff. **Four use the helper. Two bypass it** and hand-roll steps 1 and 3, dropping the middle one:

| path | resolver |
|---|---|
| `probabilistic.py` ×4 (scalar / vectorized / batched) | `_fs_link_threshold` ✅ |
| `fused_match._match_fused_fs` | hand-rolled, **skips the calibrated cutoff** ❌ |
| `probabilistic_fast._resolve_probabilistic_fast_path` | hand-rolled, **skips the calibrated cutoff** ❌ |

Both had the same shape — `if mk.link_threshold is not None: ... else: compute_thresholds(...)` — which is step 1 then step 3.

So whenever EM produced a calibrated cutoff, those two routes silently ignored it and cut at the fixed **0.50**, while the other four honoured it. Same config, same data, **different cut depending on which scorer the router happened to pick.** Producing that cutoff is exactly what `GOLDENMATCH_FS_CALIBRATE_THRESHOLD` is for, and per that flag's own docstring it is worth **+0.49 F1 on dblp_acm** (0.3758 → 0.8611).

The anti-drift extraction already existed. Two call sites didn't use it.

## Why not the issue's suggestion 2

#2483 proposes passing `scored_weights` into `compute_thresholds` at the `fused_match` call site "since the scores are in hand at that point". They are not. On the fused path the threshold is computed **before** scoring and passed **into** the kernel, which scores and cuts in a single pass — there are no scores to percentile yet. Doing it would need a two-pass restructure (score, derive the cut, filter), which is a different and much larger change.

## Changes

- **`core/fused_match.py`** — resolves via `_fs_link_threshold`.
- **`core/probabilistic_fast.py`** — same. It had no `calibrated` in scope and relied on `compute_thresholds`'s internal default, so it derives the flag identically (`_fs_calibration_mode() == "posterior"`). **With no calibrated cutoff present the resolved value is unchanged**, so only runs already asking for calibration move.
- **`config/schemas.py`** — issue suggestion 4. A `threshold` set on a probabilistic matchkey is now reported instead of silently ignored. `threshold` is the *weighted* cutoff; the probabilistic scorers read `link_threshold`. Setting it did nothing and *reading* it raised, so the reporter swept 0.90→0.99, got byte-identical results, and reasonably concluded the cut did not matter on their data — it was measuring nothing. **Warns rather than rejects:** a stray key is a usage mistake, not a corrupt config, and raising would break configs that merely carry one.

## Testing

12 new tests in `tests/test_fs_link_threshold_drift_2483.py`, pinning the **contract** (all paths agree with the helper) rather than any particular number, so they survive a retune of the default or the calibration strategy.

**Verified non-vacuous** — with the fix reverted, **7 fail** (4 structural + 3 warning). The other 5 pass either way by design: they cover the pre-existing helper, which was always correct.

Regression slice `-k "probabilistic or fused or matchkey or schema or threshold or splink"` → **1382 passed, 53 skipped, 2 failed**. Both failures verified pre-existing on `main` with the three source files reverted:

- `test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above` — the long-standing one.
- `test_sail_scorer_native_parity.py::test_threshold_decisions_are_stable_between_native_and_pure[jaro_winkler]` — unrelated: f32/f64 kernel precision (`pure=0.950000000 native=0.949999988`), the republish blocker recorded in #2489 after the #2480 decision. Not touched by this change.

`ruff check` clean; codemap regenerated.

## Left undone deliberately

Issue suggestions **3** (have `auto_configure_probabilistic_df` write `link_threshold` explicitly) and **5** (expose the applied threshold on the result). Both reasonable, but 3 changes what a zero-config run does — the reporter flagged it as a design call themselves, and it is arguably subsumed now the precedence chain is honoured everywhere — and 5 is a public API addition. Decisions rather than bug fixes; happy to take either as a follow-up.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_