### PR TITLE
fix(ci): unbreak bench-graphiti-smoke and make its failure legible

### DIFF
--- a/.github/workflows/bench-graphiti-smoke.yml
+++ b/.github/workflows/bench-graphiti-smoke.yml
@@ -57,7 +57,11 @@ jobs:
         # completed with exit code 5" -- no mention of the ImportError, so the
         # log gave no way to tell "dependency broken" from "job misconfigured".
         # Asserting the import here names the real cause on the failing step.
-        run: python -c "import graphiti_core; print('graphiti_core', graphiti_core.__version__)"
+        # importlib.metadata, NOT graphiti_core.__version__ -- the package does
+        # not define that attribute, and reaching for it turns a passing import
+        # into an AttributeError (which is exactly what the first cut of this
+        # step did).
+        run: python -c "import graphiti_core, importlib.metadata as m; print('graphiti_core', m.version('graphiti-core'))"
       - name: Graphiti adapter smoke (protocol + synthesis cost seam, DB-free)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:

--- a/.github/workflows/bench-graphiti-smoke.yml
+++ b/.github/workflows/bench-graphiti-smoke.yml
@@ -39,7 +39,25 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install graphiti-core + goldenmatch (isolated)
-        run: python -m pip install --upgrade pip pytest numpy graphiti-core goldenmatch
+        # httpx is listed explicitly because graphiti-core UNDER-DECLARES it:
+        # `graphiti_core/llm_client/client.py` imports httpx at module scope, but
+        # a fresh `pip install graphiti-core` (0.29.3) does not pull it, so the
+        # package fails to import. That broke this lane overnight between run
+        # #138 (Aug 11, green) and #139 (Aug 12, red) with no repo change --
+        # the install line is unpinned, so an upstream release lands here
+        # unannounced. Drop this once upstream declares the dependency.
+        run: python -m pip install --upgrade pip pytest numpy httpx graphiti-core goldenmatch
+      - name: Verify graphiti-core imports (this lane's premise)
+        # The smoke test guards itself with a module-level
+        # `pytest.importorskip("graphiti_core")` -- correct, because the same
+        # file runs in the general suite where graphiti is absent. But in THIS
+        # lane, which installs graphiti-core on purpose, a failed import is the
+        # defect, not a reason to skip. Skipping collected 0 tests, pytest
+        # returned exit code 5, and the lane went red saying only "Process
+        # completed with exit code 5" -- no mention of the ImportError, so the
+        # log gave no way to tell "dependency broken" from "job misconfigured".
+        # Asserting the import here names the real cause on the failing step.
+        run: python -c "import graphiti_core; print('graphiti_core', graphiti_core.__version__)"
       - name: Graphiti adapter smoke (protocol + synthesis cost seam, DB-free)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:


### PR DESCRIPTION
`main-health` red. One workflow file, two changes.

## The break

`bench-graphiti-smoke` went from [#138 green](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31533263242) (Aug 11) to [#139 red](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31566043433) (Aug 12) **with no repo change in between** — both `schedule`-triggered on `main`. The install line is unpinned, so an upstream release lands on this lane unannounced.

Reproduced in a clean venv:

```
$ pip install graphiti-core          # resolves 0.29.3
$ python -c "import graphiti_core"
  File ".../graphiti_core/llm_client/client.py", line 23, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```

`graphiti-core` **under-declares `httpx`** — it imports it at module scope but a fresh install does not pull it, so the package cannot be imported at all. Adding `httpx` to the install line fixes it (verified: `import OK` on 0.29.3). Listed explicitly with a note to drop it once upstream declares the dependency.

## Why it reported so badly — the part actually worth reviewing

This is the repo's recurring "a check exists and does not fire" class.

`test_qa_graphiti_smoke.py` opens with a module-level `pytest.importorskip("graphiti_core")`. That is **correct** where the file runs in the general suite, which has no graphiti. But in *this* lane, which installs `graphiti-core` on purpose, a failed import is the defect — not a reason to skip.

So the skip collected zero tests, pytest returned **exit code 5** (`no tests collected`), and the entire failure surfaced as:

```
collected 0 items / 1 skipped
##[error]Process completed with exit code 5
```

No mention of `httpx`. No import error. No way to tell a broken dependency from a misconfigured job without opening the test source. The lane was simultaneously **testing nothing and red**, which is the worst of both.

This PR adds an explicit import-verification step before pytest, so the `ImportError` lands on its own named step and says what actually broke. The `importorskip` stays — it is right for the general-suite case.

## Scope

- One file: `.github/workflows/bench-graphiti-smoke.yml` (+19/−1).
- No library code, no test changes, no behaviour change to any shipped package.
- `scripts/check_workflow_yaml.py`: 119 files scanned, all parse, no duplicate keys.

## Not in this PR

`publish-containers` [#1954](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31555425850) was the other red lane. It needed no code fix — one of eight matrix jobs died in `docker/metadata-action` with `self-signed certificate`, a TLS blip in the action's Node client. I re-ran the failed job and all 8 are green on attempt 2.

## Checklist

- [x] Verified the root cause by reproduction, not inference
- [x] Fix verified (`import graphiti_core` succeeds with `httpx` present)
- [x] `check_workflow_yaml.py` clean
- [ ] Tests — n/a, workflow-only
- [ ] Package `CHANGELOG.md` — n/a, CI lane only, no shipped behaviour
- [x] No secrets, tokens, or `.env` files committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_