### PR TITLE
feat(spark): J1 — batch the scoring plan, gated on alignment

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 465,
+      "module_count": 466,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7702,6 +7702,16 @@
             "goldenmatch.core.autoconfig",
             "goldenmatch.core.autoconfig_controller",
             "goldenmatch.spark.config_pipeline"
+          ]
+        },
+        {
+          "module": "goldenmatch.spark.batched",
+          "file": "packages/python/goldenmatch/goldenmatch/spark/batched.py",
+          "purpose": "J1: reshape scoring from one call per PAIR to one call per BATCH.",
+          "defines": [
+            "batch_key",
+            "dedup_max",
+            "score_pairs_batched"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/spark/batched.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/batched.py
@@ -1,0 +1,148 @@
+"""J1: reshape scoring from one call per PAIR to one call per BATCH.
+
+Spark Connect only permits row-shaped UDFs -- the batch entry points
+(`ColumnarBatch`, `ArrowColumnVector`) sit behind Catalyst, which Connect does
+not expose. Catalyst calls a registered UDF once per row, so a native downcall
+per row would be dominated by call overhead and the kernel would never get to do
+any work. Grouping pairs into arrays amortises that: one call covers thousands
+of pairs.
+
+**This module contains no native code and no scoring.** It is the plan surgery
+alone, so that when JNI arrives in J2 a misaligned score cannot be blamed on the
+kernel. That separation is the entire point of doing J1 first.
+
+## The hazard, and why the construction looks the way it does
+
+A score must come back attached to the pair it belongs to. Two ways of building
+this look natural and are both wrong:
+
+1. **Several `collect_list`s in one aggregation.** ``collect_list(a)``,
+   ``collect_list(b)``, ``collect_list(val)`` are separate aggregate expressions
+   and Spark does not promise they observe rows in the same order. They usually
+   agree, which is worse than never agreeing: it passes in test and skews under
+   a different plan. So exactly ONE ``collect_list`` is taken here -- of a
+   struct -- and the per-field arrays are derived from it with ``transform``.
+   One list, one order, by construction.
+
+2. **Exploding the ids and the scores separately.** Two `explode`s over two
+   arrays are two independent generators; nothing pairs element *i* of one with
+   element *i* of the other. ``arrays_zip`` pairs them positionally first, and
+   the explode then walks a single array of already-paired structs.
+
+Neither mistake crashes. Both silently attach pair *i*'s score to pair *j*,
+which is the failure mode this project keeps finding -- so the safe construction
+is used even where the unsafe one would probably work.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Column holding the collected pairs of one batch.
+_ROWS = "__batch_rows__"
+#: Column holding the scores for that batch, positionally aligned with _ROWS.
+_SCORES = "__batch_scores__"
+
+
+def batch_key(strategy: str = "partition") -> Any:
+    """The expression pairs are grouped by before scoring.
+
+    ``partition`` groups by ``spark_partition_id()``: one UDF call per Spark
+    partition, which is as large a batch as can be formed without a shuffle. The
+    batch is therefore whatever the upstream plan already co-located, and no data
+    moves to make it.
+
+    Batch SIZE is deliberately not tuned here. It is a throughput question and
+    belongs with the measurement in J4; picking a number now would be picking it
+    without evidence.
+    """
+    # Validate BEFORE importing pyspark: rejecting an unknown strategy is not a
+    # Spark question, and requiring Spark to say so would make the error
+    # unreachable anywhere the tier is not installed.
+    if strategy != "partition":
+        raise ValueError(
+            f"unknown batch strategy {strategy!r}; only 'partition' exists. "
+            f"Batch sizing is a J4 (measurement) question, not a J1 one."
+        )
+    from pyspark.sql import functions as F
+
+    return F.spark_partition_id()
+
+
+def score_pairs_batched(
+    pairs_df: Any,
+    source_df: Any,
+    *,
+    id_col: str,
+    value_col: str,
+    scorer_id: int,
+    udf_name: str,
+    batch_strategy: str = "partition",
+) -> Any:
+    """Score ``(a, b)`` pairs through a batched array UDF; return
+    ``(a, b, score)``.
+
+    ``udf_name`` is the SQL name of an ``(int, array<string>, array<string>) ->
+    array<double>`` function -- what ``goldenmatch.spark.jvm.install`` registers.
+
+    The result is the same shape the row-shaped ``score_and_dedup`` produces, so
+    the two can be compared directly. That comparison is the J1 gate.
+    """
+    from pyspark.sql import functions as F
+
+    lhs, rhs = "__lhs__", "__rhs__"
+    joined = (
+        pairs_df.alias("__p__")
+        .join(source_df.alias(lhs), F.col(f"{lhs}.{id_col}") == F.col("__p__.a"))
+        .join(source_df.alias(rhs), F.col(f"{rhs}.{id_col}") == F.col("__p__.b"))
+        .select(
+            F.col("__p__.a").alias("a"),
+            F.col("__p__.b").alias("b"),
+            F.col(f"{lhs}.{value_col}").cast("string").alias("x"),
+            F.col(f"{rhs}.{value_col}").cast("string").alias("y"),
+        )
+    )
+
+    # ONE collect_list, of a struct. See the module docstring: several
+    # collect_lists in one aggregation are separate aggregate expressions with
+    # no shared order guarantee, and they agree often enough to pass a test and
+    # skew under a different plan.
+    grouped = joined.groupBy(batch_key(batch_strategy).alias("__batch__")).agg(
+        F.collect_list(F.struct("a", "b", "x", "y")).alias(_ROWS)
+    )
+
+    # Per-field arrays DERIVED from that single list, so they cannot disagree.
+    scored = grouped.select(
+        F.col(_ROWS),
+        F.call_udf(
+            udf_name,
+            F.lit(int(scorer_id)),
+            F.transform(F.col(_ROWS), lambda r: r["x"]),
+            F.transform(F.col(_ROWS), lambda r: r["y"]),
+        ).alias(_SCORES),
+    )
+
+    # arrays_zip pairs positionally BEFORE the explode, so one generator walks
+    # already-paired structs. Two explodes would be two independent generators.
+    exploded = scored.select(
+        F.explode(F.arrays_zip(F.col(_ROWS), F.col(_SCORES))).alias("__z__")
+    )
+    return exploded.select(
+        F.col(f"__z__.{_ROWS}.a").alias("a"),
+        F.col(f"__z__.{_ROWS}.b").alias("b"),
+        F.col(f"__z__.{_SCORES}").alias("score"),
+    )
+
+
+def dedup_max(scored_df: Any) -> Any:
+    """``max(score)`` per canonical pair -- the tier's existing MAX contract.
+
+    Separate from :func:`score_pairs_batched` so the batched path and the
+    row-shaped path can be compared BEFORE dedup as well as after: a
+    misalignment that dedup happens to mask would otherwise be invisible.
+    """
+    from pyspark.sql import functions as F
+
+    return scored_df.groupBy("a", "b").agg(F.max("score").alias("score"))

--- a/packages/python/goldenmatch/tests/test_spark_batched_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_parity.py
@@ -1,0 +1,201 @@
+"""J1 gate: the batched plan must produce exactly the row-shaped plan's answer.
+
+Runs in the Spark lanes; skips without a Spark Connect client or a built jar.
+
+J1 changes only the SHAPE of the plan -- group into arrays, score once, explode
+back. So the bar is not "sensible output", it is "identical output", and the
+comparison is against the row-shaped path computing the same thing.
+
+The scorer is `exact`, because that is all the J0 jar implements. That costs
+nothing here: alignment is scorer-independent, and a trivial scorer makes a
+misalignment MORE visible rather than less, since every expected value is 0.0 or
+1.0 and a swap shows up immediately.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pyspark")
+
+from goldenmatch.spark.jvm import (  # noqa: E402
+    JvmScorerUnavailable,
+    find_jar,
+    install,
+    scorer_id,
+)
+
+_ID = "__row_id__"
+_SCHEMA = f"{_ID} long, blk string, name string"
+
+
+@pytest.fixture(scope="module")
+def jar():
+    try:
+        return find_jar()
+    except JvmScorerUnavailable as exc:
+        pytest.skip(f"no JVM scorer jar built: {exc}")
+
+
+@pytest.fixture()
+def registered(spark, jar):
+    return install(spark, jar=jar)
+
+
+def _rows(n_blocks: int, per_block: int):
+    """Rows whose expected pairing is distinct per position.
+
+    Every record's `name` encodes its own id, and exactly one PARTNER per block
+    shares a name. So each pair has a knowable, non-uniform answer -- a
+    misalignment cannot hide behind a run of identical scores.
+    """
+    rows = []
+    rid = 0
+    for b in range(n_blocks):
+        for i in range(per_block):
+            # Two records per block share a name (i and i+1 when i is even).
+            name = f"n{b}_{i // 2}"
+            rows.append((rid, f"blk{b}", name))
+            rid += 1
+    return rows
+
+
+def _candidate_pairs(spark, df):
+    """Block self-join, a < b -- the same candidate set both paths score."""
+    from pyspark.sql import functions as F
+
+    a, b = df.alias("a"), df.alias("b")
+    return a.join(
+        b,
+        (F.col("a.blk") == F.col("b.blk"))
+        & (F.col(f"a.{_ID}") < F.col(f"b.{_ID}")),
+    ).select(F.col(f"a.{_ID}").alias("a"), F.col(f"b.{_ID}").alias("b"))
+
+
+def _row_shaped(df, pairs):
+    """The reference: score each pair individually, in Python, from collected
+    values. Deliberately NOT the Spark row UDF -- a reference sharing machinery
+    with the thing under test proves only that the machinery is consistent."""
+    vals = {r[_ID]: r["name"] for r in df.collect()}
+    out = {}
+    for r in pairs.collect():
+        a, b = int(r["a"]), int(r["b"])
+        x, y = vals[a], vals[b]
+        out[(a, b)] = None if x is None or y is None else (1.0 if x == y else 0.0)
+    return out
+
+
+def _batched(spark, df, pairs, udf_name):
+    from goldenmatch.spark.batched import score_pairs_batched
+
+    scored = score_pairs_batched(
+        pairs,
+        df,
+        id_col=_ID,
+        value_col="name",
+        scorer_id=scorer_id("exact"),
+        udf_name=udf_name,
+    )
+    return {
+        (int(r["a"]), int(r["b"])): r["score"] for r in scored.collect()
+    }
+
+
+def test_batched_matches_the_row_shaped_answer(spark, registered):
+    """The J1 gate. Same pairs, same scores, pair for pair."""
+    df = spark.createDataFrame(_rows(4, 6), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+
+    want = _row_shaped(df, pairs)
+    got = _batched(spark, df, pairs, registered)
+
+    assert set(got) == set(want), (
+        f"pair sets differ: only-batched={set(got) - set(want)}, "
+        f"only-reference={set(want) - set(got)}"
+    )
+    mismatched = {k: (got[k], want[k]) for k in want if got[k] != want[k]}
+    assert not mismatched, f"scores misaligned for {len(mismatched)} pair(s): {mismatched}"
+
+
+def test_every_score_lands_on_its_own_pair(spark, registered):
+    """States the alignment property directly rather than inferring it.
+
+    For each returned pair, recompute the expected score from that pair's OWN
+    values. A rotation, reversal, or cross-batch swap fails here even if the
+    multiset of scores is unchanged -- which is exactly what a misalignment
+    looks like.
+    """
+    df = spark.createDataFrame(_rows(5, 4), _SCHEMA)
+    vals = {r[_ID]: r["name"] for r in df.collect()}
+    pairs = _candidate_pairs(spark, df)
+    got = _batched(spark, df, pairs, registered)
+
+    for (a, b), score in got.items():
+        expected = 1.0 if vals[a] == vals[b] else 0.0
+        assert score == expected, (
+            f"pair ({a},{b}) has values {vals[a]!r}/{vals[b]!r} -> expected "
+            f"{expected}, got {score}"
+        )
+
+
+def test_the_multiset_check_would_not_have_caught_it(spark, registered):
+    """Guard on the TEST, not the code.
+
+    A misalignment preserves the multiset of scores, so a test comparing sorted
+    score lists would pass through it. This asserts the fixture actually has a
+    mix -- if every pair scored the same, the test above would be vacuous.
+    """
+    df = spark.createDataFrame(_rows(5, 4), _SCHEMA)
+    got = _batched(spark, df, _candidate_pairs(spark, df), registered)
+
+    distinct = set(got.values())
+    assert distinct == {0.0, 1.0}, (
+        f"fixture produced only {distinct}; with a single score value the "
+        f"alignment assertions cannot fail and prove nothing"
+    )
+
+
+def test_batching_spans_more_than_one_batch(spark, registered):
+    """If everything lands in one batch, cross-batch misalignment is untested.
+
+    Repartitioning forces several partitions, and `batch_key` groups by
+    partition -- so this is the case where a per-batch score array could be
+    attached to the wrong batch's rows.
+    """
+    df = spark.createDataFrame(_rows(6, 4), _SCHEMA)
+    pairs = _candidate_pairs(spark, df).repartition(4)
+
+    want = _row_shaped(df, pairs)
+    got = _batched(spark, df, pairs, registered)
+    assert got == want
+
+
+def test_nulls_survive_the_round_trip(spark, registered):
+    """A null value must come back null, not 1.0 and not dropped.
+
+    Two records missing the compared field share an absence, not a value -- the
+    substitution this project has already had to fix twice.
+    """
+    rows = [(0, "b", None), (1, "b", None), (2, "b", "x"), (3, "b", "x")]
+    df = spark.createDataFrame(rows, _SCHEMA)
+    got = _batched(spark, df, _candidate_pairs(spark, df), registered)
+
+    assert got[(0, 1)] is None, f"null-vs-null came back {got[(0, 1)]!r}"
+    assert got[(2, 3)] == 1.0
+    assert got[(0, 2)] is None
+
+
+def test_dedup_max_matches_the_row_shaped_contract(spark, registered):
+    """The MAX-per-canonical-pair contract, unchanged by the reshape."""
+    from goldenmatch.spark.batched import dedup_max, score_pairs_batched
+
+    df = spark.createDataFrame(_rows(3, 4), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+    scored = score_pairs_batched(
+        pairs, df, id_col=_ID, value_col="name",
+        scorer_id=scorer_id("exact"), udf_name=registered,
+    )
+    deduped = {(int(r["a"]), int(r["b"])): r["score"] for r in dedup_max(scored).collect()}
+    raw = {(int(r["a"]), int(r["b"])): r["score"] for r in scored.collect()}
+
+    assert set(deduped) == set(raw), "dedup changed the pair set"
+    assert deduped == raw, "no duplicate pairs here, so dedup must be a no-op"

--- a/packages/python/goldenmatch/tests/test_spark_batched_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_unit.py
@@ -1,0 +1,84 @@
+"""J1 unit tests: the batching contract, without Spark.
+
+Runs on every PR. What can be checked here is narrow -- the module builds Spark
+expressions, and expressions need Spark to mean anything -- so this pins the
+parts that are pure decisions, and the source itself for the two constructions
+whose absence would be a silent misalignment.
+
+Reading source in a test is normally a smell. It earns its place here because
+the alternative constructions do not fail: several `collect_list`s usually agree
+on order, and two `explode`s usually interleave correctly. A test that only runs
+the code would pass on the broken version, so the guard has to be structural.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from goldenmatch.spark import batched
+
+
+def test_only_the_partition_strategy_exists():
+    with pytest.raises(ValueError, match="J4"):
+        batched.batch_key("by_block")
+
+
+def test_the_error_points_at_where_sizing_belongs():
+    """Batch sizing is a throughput question; answering it without measurement
+    is how a number gets baked in and never revisited."""
+    with pytest.raises(ValueError) as err:
+        batched.batch_key("nope")
+    assert "measurement" in str(err.value)
+
+
+# ── structural guards on the two silent-misalignment constructions ───
+
+def test_exactly_one_collect_list_is_taken():
+    """Several `collect_list`s in one aggregation are separate aggregate
+    expressions with no shared order guarantee. They agree often enough to pass
+    a test and skew under a different plan, so the module must take ONE list of
+    structs and derive the per-field arrays from it.
+    """
+    src = inspect.getsource(batched.score_pairs_batched)
+    # Count CALLS, not the word: the surrounding comment explains the trap
+    # and mentions it several times.
+    assert src.count("F.collect_list(") == 1, (
+        "more than one collect_list: the per-field arrays can disagree on order "
+        "and scores will attach to the wrong pairs"
+    )
+    assert "F.struct(" in src, "the single collect_list must collect a struct"
+    assert "F.transform(" in src, (
+        "per-field arrays must be DERIVED from the collected list, not collected "
+        "separately"
+    )
+
+
+def test_arrays_are_zipped_before_exploding():
+    """Two `explode`s over two arrays are two independent generators; nothing
+    pairs element i of one with element i of the other. `arrays_zip` pairs them
+    positionally first, so a single generator walks already-paired structs."""
+    src = inspect.getsource(batched.score_pairs_batched)
+    assert "arrays_zip" in src, "scores must be zipped to their rows before explode"
+    assert src.count("F.explode(") == 1, (
+        "more than one explode: independent generators do not align"
+    )
+
+
+def test_dedup_is_separable_from_scoring():
+    """Kept apart so the two paths can be compared BEFORE dedup as well as
+    after -- a misalignment that dedup happens to mask would otherwise be
+    invisible."""
+    assert callable(batched.dedup_max)
+    assert "collect_list" not in inspect.getsource(batched.dedup_max)
+
+
+def test_the_module_carries_no_scoring_of_its_own():
+    """J1 is plan surgery. If scoring leaked in here, a misaligned result in J2
+    could be blamed on the kernel instead of the plan -- which is the entire
+    reason J1 exists before J2."""
+    src = inspect.getsource(batched)
+    for forbidden in ("jaro", "levenshtein", "token_sort", "strsim"):
+        assert forbidden not in src.lower(), (
+            f"{forbidden!r} appears in the batching module; scoring belongs to "
+            f"the kernel, not to the plan reshape"
+        )


### PR DESCRIPTION
Reshapes scoring from one call per **pair** to one call per **batch**: group pairs into arrays, score once, explode back.

Connect only permits row-shaped UDFs — the batch entry points sit behind Catalyst, which Connect doesn't expose — so without this a native downcall happens per row and is dominated by call overhead. The kernel would never get to do any work.

## No native code and no scoring in this module

J1 is the plan surgery **alone**, so that when JNI arrives in J2 a misaligned score can't be blamed on the kernel. A unit test enforces it by asserting no scorer name appears in the module.

## The hazard, and why the construction looks like this

A score has to come back attached to the pair it belongs to. Two natural ways to build this are both wrong, and **neither crashes**:

**1. Several `collect_list`s in one aggregation.** They're separate aggregate expressions and Spark doesn't promise they observe rows in the same order. They *usually* agree — which is worse than never agreeing, because it passes in test and skews under a different plan. So exactly **one** `collect_list` is taken, of a struct, and the per-field arrays are derived from it with `transform`.

**2. Exploding the ids and the scores separately.** Two explodes are two independent generators; nothing pairs element *i* of one with element *i* of the other. `arrays_zip` pairs them positionally first, so a single generator walks already-paired structs.

Both silently attach pair *i*'s score to pair *j*. The safe construction is used even where the unsafe one would probably work.

## Tests aimed at exactly that

The lane tests don't assert "sensible output" — they assert the **row-shaped answer, pair for pair**, against a reference computed in plain Python rather than through the same machinery.

- One recomputes each returned pair's expected score from **that pair's own values**, so a rotation or cross-batch swap fails even though the multiset of scores is unchanged — which is precisely what a misalignment looks like.
- One asserts the fixture contains a **mix** of scores, because with a single value the alignment assertions would be vacuous.
- One **repartitions** so more than one batch exists — cross-batch misalignment can't happen in a single batch.
- One pins that nulls survive the round trip as null, not `1.0`.

Two unit tests read the module source. Normally a smell; it earns its place because the alternative constructions don't fail, so a test that merely *runs* the code would pass on the broken version. The guard has to be structural.

## Scope

Batch **size** is deliberately not tuned — it's a throughput question that belongs with J4's measurement. `batch_key` rejects any other strategy and says so rather than baking in a number without evidence.

The scorer is `exact`, all the J0 jar implements. That costs nothing: alignment is scorer-independent, and a trivial scorer makes a misalignment *more* visible, since every expected value is 0.0 or 1.0.

## Next

**J2** — swap the pure-Java scorer for a JNI call into `score-cabi`. Parity then becomes a byte-identical claim against the Python path, which the existing ctypes harness already knows how to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
