### PR TITLE
fix(bench): ship the executor Python env — the row_python path needs P1

### DIFF
--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -67,9 +67,36 @@ jobs:
             "$JVM"/src/dev/goldensuite/spark/*.java
           jar --create --file "$JVM/build/goldenmatch-spark.jar" -C "$JVM/build/classes" .
 
+      # P1's executor environment. The row_python path forks a Python worker,
+      # which has NO access to the client's site-packages -- the first run of
+      # this bench died with `ModuleNotFoundError: No module named 'goldenmatch'`
+      # inside the worker, which is P0's original failure, rediscovered by
+      # forgetting the step that exists to fix it.
+      #
+      # Worth stating plainly because it is part of the result: the batched_jvm
+      # path needs NONE of this. Its scorer is already in the executor JVM, so
+      # there is no interpreter to feed and no environment to ship. That is a
+      # deployment difference the timings do not show.
+      - name: Build + pack a runtime venv for the executors (row_python only)
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/gmenv
+          /tmp/gmenv/bin/pip install --upgrade pip
+          # pandas is not a goldenmatch dependency but `pandas_udf` needs it in
+          # the WORKER. NOT -q: a silent pip failure ships an env that unpacks
+          # fine and imports nothing.
+          /tmp/gmenv/bin/pip install ./packages/python/goldenmatch pandas pyarrow
+          # cd out of the repo: its root directory is itself named `goldenmatch`,
+          # so a check run from here can import the source tree and pass while
+          # the env is empty.
+          (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch, pandas, pyarrow; print('shipped env imports OK')")
+          .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
+          ls -lh gm_env.tar.gz
+
       - name: Bench
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |

--- a/scripts/bench_spark_scoring.py
+++ b/scripts/bench_spark_scoring.py
@@ -133,6 +133,30 @@ def main(argv=None) -> int:
     remote = os.environ.get("GOLDENMATCH_SPARK_REMOTE", "local[*]")
     spark = SparkSession.builder.remote(remote).getOrCreate()
 
+    # P1's executor environment, needed by the ROW_PYTHON path only. Real Spark
+    # forks a Python worker with its own environment, so the client's
+    # site-packages are absent -- the first run of this bench died with
+    # `ModuleNotFoundError: No module named 'goldenmatch'` inside the worker,
+    # which is P0's original failure rediscovered by omitting the step that
+    # exists to fix it.
+    #
+    # Part of the result rather than a footnote: the batched_jvm path needs NONE
+    # of this. Its scorer is already in the executor JVM, so there is no
+    # interpreter to feed and no environment to ship -- a deployment difference
+    # the timings below do not capture.
+    pyenv = os.environ.get("GOLDENMATCH_SPARK_PYENV")
+    if pyenv:
+        from goldenmatch.spark.deps import ship_python_environment
+
+        ship_python_environment(spark, pyenv)
+        print(f"shipped executor env: {pyenv}", flush=True)
+    else:
+        print(
+            "WARNING: no GOLDENMATCH_SPARK_PYENV -- the row_python path will "
+            "fail on a real Spark backend",
+            flush=True,
+        )
+
     rows = _rows(args.rows, args.block_size)
     df = spark.createDataFrame(rows, _SCHEMA).cache()
     n_pairs = _candidate_pairs(df).count()


### PR DESCRIPTION
The first bench run died with `ModuleNotFoundError: No module named 'goldenmatch'` inside the Python worker — **P0's original failure**, rediscovered by writing a new harness and omitting the step that exists to fix it.

Both halves needed it: the workflow builds and packs the venv, and the script ships it. The `GOLDENMATCH_SPARK_PYENV` hook lived only in the *test* conftest, so setting the variable alone did nothing outside pytest.

Recorded in both places because **it is part of the result, not a footnote**: the `batched_jvm` path needs none of this. Its scorer is already in the executor JVM — no interpreter to feed, no environment to ship. That's a deployment difference the timings don't capture, and it holds whatever the ratio turns out to be.

The script now warns loudly when the variable is unset rather than failing deep inside a Spark stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ