### PR TITLE
fix(spark): bound the scoring batch — unbounded groups OOM'd the executor heap

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/spark/batched.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/batched.py
@@ -32,6 +32,14 @@ this look natural and are both wrong:
 Neither mistake crashes. Both silently attach pair *i*'s score to pair *j*,
 which is the failure mode this project keeps finding -- so the safe construction
 is used even where the unsafe one would probably work.
+
+## And the batch has to be bounded
+
+A third mistake, which DOES crash, and did: grouping by partition alone. The
+group is materialised as an array in JVM heap, so its size is a memory
+commitment rather than a throughput knob. 1.9M candidate pairs over a handful of
+partitions gave `java.lang.OutOfMemoryError` (bench run 31625487603). See
+`batch_key`.
 """
 from __future__ import annotations
 
@@ -46,29 +54,52 @@ _ROWS = "__batch_rows__"
 _SCORES = "__batch_scores__"
 
 
-def batch_key(strategy: str = "partition") -> Any:
+#: Pairs per UDF call. Bounded, because the batch is materialised as an array
+#: in JVM heap -- see `batch_key`. 10,000 is what the Connect probe carried
+#: comfortably in one call (run 31611464914), and it is large enough that the
+#: per-call cost the batching exists to amortise is spread over ten thousand
+#: pairs.
+DEFAULT_BATCH_SIZE = 10_000
+
+
+def batch_key(strategy: str = "partition", batch_size: int = DEFAULT_BATCH_SIZE) -> Any:
     """The expression pairs are grouped by before scoring.
 
-    ``partition`` groups by ``spark_partition_id()``: one UDF call per Spark
-    partition, which is as large a batch as can be formed without a shuffle. The
-    batch is therefore whatever the upstream plan already co-located, and no data
-    moves to make it.
+    **The batch must be BOUNDED.** ``groupBy`` + ``collect_list`` materialises
+    each group as an array in JVM heap, so the group size is a memory
+    commitment, not a throughput knob. Grouping by ``spark_partition_id()``
+    alone -- one call per partition, "as large a batch as can be formed without
+    a shuffle" -- means the array is however many pairs the partition holds.
+    Measured: 1.9M candidate pairs over a handful of partitions gives
+    ``java.lang.OutOfMemoryError: Java heap space`` (bench run 31625487603).
+    That was not a slow path; it was no path.
 
-    Batch SIZE is deliberately not tuned here. It is a throughput question and
-    belongs with the measurement in J4; picking a number now would be picking it
-    without evidence.
+    So the key is ``(partition, chunk)``. ``monotonically_increasing_id()``
+    encodes the partition in its high bits and a row counter in its low bits, so
+    dividing it by ``batch_size`` yields chunks that are already
+    partition-scoped: rows of different partitions can never share a chunk id,
+    and within a partition consecutive rows fall into chunks of at most
+    ``batch_size``. No window, no shuffle, no second pass to number the rows.
+
+    The id is not contiguous across partitions, so chunk ids are sparse. That is
+    irrelevant -- they are group keys, never counters.
     """
-    # Validate BEFORE importing pyspark: rejecting an unknown strategy is not a
-    # Spark question, and requiring Spark to say so would make the error
+    # Validate BEFORE importing pyspark: rejecting bad arguments is not a Spark
+    # question, and requiring Spark to say so would make these errors
     # unreachable anywhere the tier is not installed.
     if strategy != "partition":
         raise ValueError(
-            f"unknown batch strategy {strategy!r}; only 'partition' exists. "
-            f"Batch sizing is a J4 (measurement) question, not a J1 one."
+            f"unknown batch strategy {strategy!r}; only 'partition' exists."
+        )
+    if batch_size <= 0:
+        raise ValueError(
+            f"batch_size must be positive; got {batch_size}. An unbounded batch "
+            f"is what OOM'd the executor heap -- the group is materialised as an "
+            f"array, so its size is a memory commitment."
         )
     from pyspark.sql import functions as F
 
-    return F.spark_partition_id()
+    return F.floor(F.monotonically_increasing_id() / F.lit(int(batch_size)))
 
 
 def score_pairs_batched(
@@ -80,6 +111,7 @@ def score_pairs_batched(
     scorer_id: int,
     udf_name: str,
     batch_strategy: str = "partition",
+    batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> Any:
     """Score ``(a, b)`` pairs through a batched array UDF; return
     ``(a, b, score)``.
@@ -109,7 +141,9 @@ def score_pairs_batched(
     # collect_lists in one aggregation are separate aggregate expressions with
     # no shared order guarantee, and they agree often enough to pass a test and
     # skew under a different plan.
-    grouped = joined.groupBy(batch_key(batch_strategy).alias("__batch__")).agg(
+    grouped = joined.groupBy(
+        batch_key(batch_strategy, batch_size).alias("__batch__")
+    ).agg(
         F.collect_list(F.struct("a", "b", "x", "y")).alias(_ROWS)
     )
 

--- a/packages/python/goldenmatch/tests/test_spark_batched_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_parity.py
@@ -199,3 +199,63 @@ def test_dedup_max_matches_the_row_shaped_contract(spark, registered):
 
     assert set(deduped) == set(raw), "dedup changed the pair set"
     assert deduped == raw, "no duplicate pairs here, so dedup must be a no-op"
+
+
+def test_many_pairs_do_not_exhaust_the_heap(spark, registered):
+    """The regression the bench found.
+
+    J1 keyed the batch on `spark_partition_id()` alone, so the group was however
+    many pairs a partition held and `collect_list` materialised all of them as
+    one array in JVM heap. 1.9M pairs gave
+    `java.lang.OutOfMemoryError: Java heap space` (bench run 31625487603) --
+    not a slow path, no path.
+
+    A small `batch_size` here forces MANY batches over a modest fixture, which is
+    the same shape as a large fixture with the default size and runs in seconds.
+    The assertion is that every pair still comes back correctly scored: bounding
+    the batch must not drop or duplicate rows.
+    """
+    from goldenmatch.spark.batched import score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+
+    df = spark.createDataFrame(_rows(20, 10), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+    want = _row_shaped(df, pairs)
+
+    scored = score_pairs_batched(
+        pairs, df, id_col=_ID, value_col="name",
+        scorer_id=scorer_id("exact"), udf_name=registered,
+        batch_size=7,  # deliberately tiny: forces many batches
+    )
+    got = {(int(r["a"]), int(r["b"])): r["score"] for r in scored.collect()}
+
+    assert len(got) == len(want), (
+        f"bounding the batch changed the row count: {len(got)} vs {len(want)}"
+    )
+    assert got == want, "scores changed when the batch was split"
+
+
+def test_batch_size_does_not_change_the_answer(spark, registered):
+    """Batch size is a memory/throughput choice and must be answer-invariant.
+
+    If it were not, the number would be a correctness parameter -- and nobody
+    would know which value was the correct one.
+    """
+    from goldenmatch.spark.batched import score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+
+    df = spark.createDataFrame(_rows(8, 8), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+
+    answers = []
+    for size in (3, 11, 10_000):
+        scored = score_pairs_batched(
+            pairs, df, id_col=_ID, value_col="name",
+            scorer_id=scorer_id("exact"), udf_name=registered, batch_size=size,
+        )
+        answers.append(
+            {(int(r["a"]), int(r["b"])): r["score"] for r in scored.collect()}
+        )
+    assert answers[0] == answers[1] == answers[2], (
+        "batch size changed the answer; it is a memory knob, not a semantic one"
+    )

--- a/packages/python/goldenmatch/tests/test_spark_batched_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_unit.py
@@ -19,16 +19,54 @@ from goldenmatch.spark import batched
 
 
 def test_only_the_partition_strategy_exists():
-    with pytest.raises(ValueError, match="J4"):
+    with pytest.raises(ValueError, match="only 'partition' exists"):
         batched.batch_key("by_block")
 
 
-def test_the_error_points_at_where_sizing_belongs():
-    """Batch sizing is a throughput question; answering it without measurement
-    is how a number gets baked in and never revisited."""
+def test_the_batch_must_be_bounded():
+    """The bug the bench found, pinned.
+
+    J1 shipped with the batch keyed on `spark_partition_id()` alone -- one call
+    per partition, described in its own docstring as "as large a batch as can be
+    formed without a shuffle". True, and exactly the problem: groupBy +
+    collect_list materialises the group as an array in JVM heap, so group size is
+    a MEMORY COMMITMENT, not a throughput knob. 1.9M candidate pairs gave
+    `java.lang.OutOfMemoryError: Java heap space` (bench run 31625487603).
+
+    Sizing was deferred as "a J4 measurement question". It is a
+    correctness-at-scale question, and a non-positive size is refused rather than
+    treated as "unlimited".
+    """
+    for bad in (0, -1, -10_000):
+        with pytest.raises(ValueError, match="must be positive"):
+            batched.batch_key("partition", bad)
+
+
+def test_the_refusal_explains_why_size_is_not_a_tuning_knob():
+    """A reader who sees the error must learn WHY, or they will raise the number
+    until it stops failing rather than understand what it costs."""
     with pytest.raises(ValueError) as err:
-        batched.batch_key("nope")
-    assert "measurement" in str(err.value)
+        batched.batch_key("partition", 0)
+    msg = str(err.value)
+    assert "memory" in msg and "array" in msg
+
+
+def test_the_default_batch_size_is_bounded_and_probe_backed():
+    """10,000 is not a guess: the Connect probe carried that many pairs in one
+    call (run 31611464914). Unbounded or trivially small are both wrong -- one
+    OOMs, the other reinstates the per-call overhead batching exists to remove.
+    """
+    assert 1_000 <= batched.DEFAULT_BATCH_SIZE <= 100_000
+
+
+def test_score_pairs_batched_exposes_the_size():
+    """A default that cannot be overridden is a constant with extra steps, and
+    the right value depends on row width and executor heap."""
+    import inspect
+
+    sig = inspect.signature(batched.score_pairs_batched)
+    assert "batch_size" in sig.parameters
+    assert sig.parameters["batch_size"].default == batched.DEFAULT_BATCH_SIZE
 
 
 # ── structural guards on the two silent-misalignment constructions ───


### PR DESCRIPTION
The J4 bench found it on its second run: 1.9M candidate pairs gave `java.lang.OutOfMemoryError: Java heap space` ([run 31625487603](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31625487603)). Not a slow path — no path.

## What I got wrong in J1

The batch was keyed on `spark_partition_id()` alone, which J1's own docstring called *"as large a batch as can be formed without a shuffle"*. True, and exactly the problem: `groupBy` + `collect_list` materialises each group as an **array in JVM heap**, so group size is a memory commitment, not a throughput knob.

I deferred sizing as "a J4 measurement question". It's a **correctness-at-scale** question, and deferring it shipped a path that can't run at the sizes it exists for.

## The fix

Key on `(partition, chunk)`. `monotonically_increasing_id()` encodes the partition in its high bits and a row counter in its low bits, so dividing by `batch_size` yields chunks that are **already partition-scoped** — rows from different partitions can never share a chunk id, and within a partition consecutive rows fall into chunks of at most `batch_size`. No window, no shuffle, no second pass to number rows.

Default 10,000 — not a guess: the Connect probe carried that many pairs in one call. Exposed as a parameter, since the right value depends on row width and executor heap.

## Tests

A non-positive size is refused rather than read as "unlimited", and the message explains **why** — a reader who only learns "invalid" raises the number until it stops failing instead of understanding what it costs.

Two lane tests:
- **Many small batches** over a modest fixture (same shape as a large fixture at the default size, but seconds not minutes) must return every pair correctly scored — bounding must not drop or duplicate rows.
- **Three different batch sizes must return the same answer.** If size changed the answer it would be a correctness parameter, and nobody would know which value was right.

## Next

Re-run `bench-spark-scoring` once this lands, and report the number — still the thing this arc has never produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ