### PR TITLE
fix(spark): the tier is arrow-native — remove pandas from every UDF and executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3091,19 +3091,32 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/gmenv
           /tmp/gmenv/bin/pip install --upgrade pip
-          # goldenmatch does NOT depend on pandas, but `pandas_udf` needs it in
-          # the WORKER -- that is why P0 logged `No module named 'pandas'` 13
-          # times alongside the goldenmatch ones. pyarrow is goldenmatch's own
-          # dep but is named here so the worker contract is explicit rather than
-          # transitive. NOT -q: a silent pip failure is how you ship an env that
-          # unpacks fine and imports nothing.
-          /tmp/gmenv/bin/pip install ./packages/python/goldenmatch pandas pyarrow
+          # NO PANDAS. The tier's UDFs are `arrow_udf` over `pa.Array`, so the
+          # executor needs pyarrow (goldenmatch's own hard dependency) and
+          # nothing else. Shipping pandas was an UNDECLARED runtime dependency
+          # of a package that does not depend on it -- in a repo that evicted
+          # polars and made pyarrow the hard dep. pyarrow is named explicitly so
+          # the worker contract is stated rather than transitive. NOT -q: a
+          # silent pip failure is how you ship an env that unpacks fine and
+          # imports nothing.
+          /tmp/gmenv/bin/pip install ./packages/python/goldenmatch pyarrow
           echo "--- shipped env contents ---"
           /tmp/gmenv/bin/pip list | grep -iE "goldenmatch|goldenphonetic|pandas|pyarrow"
           # cd out of the repo: its ROOT DIRECTORY is itself named `goldenmatch`,
           # so a check run from there can import the source tree instead of the
           # installed package and pass while the env is empty.
-          (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch, goldenmatch.core.strsim, pandas, pyarrow; print('shipped env imports OK')")
+          (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch, goldenmatch.core.strsim, pyarrow; print('shipped env imports OK')")
+          # The gate: pandas must NOT be in the shipped environment. Without
+          # this the dependency creeps back the first time someone reaches for
+          # `pandas_udf`, and nothing would notice -- the env would simply grow.
+          # One-line python on purpose: a multi-line script inside `run:` has to
+          # survive YAML block parsing too, and the first attempt at this did not.
+          if /tmp/gmenv/bin/python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('pandas') is None else 1)"; then
+            echo "shipped env is pandas-free"
+          else
+            echo "::error::pandas is in the shipped executor env; the tier is arrow-native (arrow_udf over pa.Array) and must not need it"
+            exit 1
+          fi
           # venv-pack comes from the [spark] extra installed above -- NOT a
           # separate `uv pip install` as before. Shipping executor deps is the
           # whole reason the extra carries it, so resolving it from the extra is

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 466,
+      "module_count": 467,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7690,6 +7690,16 @@
           ]
         },
         {
+          "module": "goldenmatch.spark._arrow",
+          "file": "packages/python/goldenmatch/goldenmatch/spark/_arrow.py",
+          "purpose": "Arrow-native UDF plumbing for the Spark tier.",
+          "defines": [
+            "arrow_udf",
+            "from_pylist",
+            "to_pylist"
+          ]
+        },
+        {
           "module": "goldenmatch.spark.autoconfig",
           "file": "packages/python/goldenmatch/goldenmatch/spark/autoconfig.py",
           "purpose": "P6: zero-config on Spark.",
@@ -7752,6 +7762,7 @@
           "imports": [
             "goldenmatch.config.schemas",
             "goldenmatch.core.probabilistic",
+            "goldenmatch.spark._arrow",
             "goldenmatch.spark.autoconfig",
             "goldenmatch.spark.clustering",
             "goldenmatch.spark.golden",
@@ -7782,7 +7793,8 @@
           ],
           "imports": [
             "goldenmatch.config.schemas",
-            "goldenmatch.core.golden"
+            "goldenmatch.core.golden",
+            "goldenmatch.spark._arrow"
           ]
         },
         {
@@ -7811,7 +7823,8 @@
           "imports": [
             "goldenmatch.core._hashing",
             "goldenmatch.identity.fingerprint_batch",
-            "goldenmatch.identity.store"
+            "goldenmatch.identity.store",
+            "goldenmatch.spark._arrow"
           ]
         },
         {
@@ -7869,7 +7882,7 @@
         {
           "module": "goldenmatch.spark.scorers",
           "file": "packages/python/goldenmatch/goldenmatch/spark/scorers.py",
-          "purpose": "Scorers as Spark pandas UDFs for the Sail tier (Spark Connect).",
+          "purpose": "Scorers as Spark ARROW UDFs for the Spark tier (Spark Connect).",
           "defines": [
             "_native_scores",
             "_pure_scores",
@@ -7879,7 +7892,8 @@
           ],
           "imports": [
             "goldenmatch.core",
-            "goldenmatch.core._native_loader"
+            "goldenmatch.core._native_loader",
+            "goldenmatch.spark._arrow"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/spark/_arrow.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/_arrow.py
@@ -1,0 +1,77 @@
+"""Arrow-native UDF plumbing for the Spark tier.
+
+The tier used ``pandas_udf`` everywhere, which made **pandas a runtime
+requirement on every executor** -- in a repo that evicted polars, made pyarrow
+the hard dependency, and does not declare pandas as a dependency at all. The
+executor environment P1 ships had to `pip install pandas` explicitly to make the
+tier work, which is an undeclared dependency documented rather than fixed.
+
+Spark has first-class Arrow UDFs, so there was never a need:
+
+    @arrow_udf("string")
+    def f(s: pa.Array) -> pa.Array: ...
+
+Same shape as ``pandas_udf``, ``pa.Array`` instead of ``pd.Series``, and pyarrow
+is already a hard dependency.
+
+Two things fall out of the change beyond dropping a dependency:
+
+- **Nulls stop being NaN.** A pandas Series of an all-null string batch infers
+  float64, so iterating yielded NaN floats -- and NaN is TRUTHY, so `x or ""`
+  did not rescue it and the float reached the scorer as
+  `TypeError: 'float' object is not subscriptable`. A `pa.Array` carries a
+  validity bitmap; `to_pylist()` gives `None`. The bug class disappears rather
+  than being defended against.
+- **The batch is already the shape the kernel wants.** `pa.Array` for a string
+  column IS the offsets+data layout `score-cabi` takes, so the Python path can
+  hand buffers to Rust with no conversion.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def arrow_udf(return_type: str) -> Any:
+    """``pyspark.sql.functions.arrow_udf``, resolved with a legible failure.
+
+    Raises rather than falling back to ``pandas_udf``: a silent fallback would
+    reinstate the pandas requirement on executors, which is the whole thing
+    being removed. Better to fail at registration, on the driver, with a message
+    naming the Spark version needed, than to work by quietly shipping pandas.
+    """
+    from pyspark.sql import functions as F
+
+    fn = getattr(F, "arrow_udf", None)
+    if fn is None:
+        import pyspark
+
+        raise RuntimeError(
+            f"pyspark {pyspark.__version__} has no `arrow_udf`. The Spark tier "
+            f"is Arrow-native and deliberately does NOT fall back to "
+            f"`pandas_udf`, because that would put pandas back on every "
+            f"executor -- an undeclared dependency this package does not have. "
+            f"Upgrade pyspark, or run this workload on the one-box path."
+        )
+    return fn(return_type)
+
+
+def to_pylist(arr: Any) -> list:
+    """Values of a ``pa.Array`` as Python objects, nulls as ``None``.
+
+    A one-line helper so call sites read the same everywhere and nobody
+    reintroduces ``.tolist()`` (the pandas spelling) by muscle memory.
+    """
+    return arr.to_pylist()
+
+
+def from_pylist(values: list, type_: str = "string") -> Any:
+    """A ``pa.Array`` from Python values, for returning out of an arrow_udf.
+
+    ``type_`` mirrors the UDF's declared return type; passing it explicitly
+    stops pyarrow inferring, which on an all-null batch would produce a null-typed
+    array that Spark cannot match to the declared schema.
+    """
+    import pyarrow as pa
+
+    dtype = {"string": pa.string(), "double": pa.float64()}[type_]
+    return pa.array(values, type=dtype)

--- a/packages/python/goldenmatch/goldenmatch/spark/batched.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/batched.py
@@ -32,6 +32,14 @@ this look natural and are both wrong:
 Neither mistake crashes. Both silently attach pair *i*'s score to pair *j*,
 which is the failure mode this project keeps finding -- so the safe construction
 is used even where the unsafe one would probably work.
+
+## And the batch has to be bounded
+
+A third mistake, which DOES crash, and did: grouping by partition alone. The
+group is materialised as an array in JVM heap, so its size is a memory
+commitment rather than a throughput knob. 1.9M candidate pairs over a handful of
+partitions gave `java.lang.OutOfMemoryError` (bench run 31625487603). See
+`batch_key`.
 """
 from __future__ import annotations
 
@@ -46,29 +54,52 @@ _ROWS = "__batch_rows__"
 _SCORES = "__batch_scores__"
 
 
-def batch_key(strategy: str = "partition") -> Any:
+#: Pairs per UDF call. Bounded, because the batch is materialised as an array
+#: in JVM heap -- see `batch_key`. 10,000 is what the Connect probe carried
+#: comfortably in one call (run 31611464914), and it is large enough that the
+#: per-call cost the batching exists to amortise is spread over ten thousand
+#: pairs.
+DEFAULT_BATCH_SIZE = 10_000
+
+
+def batch_key(strategy: str = "partition", batch_size: int = DEFAULT_BATCH_SIZE) -> Any:
     """The expression pairs are grouped by before scoring.
 
-    ``partition`` groups by ``spark_partition_id()``: one UDF call per Spark
-    partition, which is as large a batch as can be formed without a shuffle. The
-    batch is therefore whatever the upstream plan already co-located, and no data
-    moves to make it.
+    **The batch must be BOUNDED.** ``groupBy`` + ``collect_list`` materialises
+    each group as an array in JVM heap, so the group size is a memory
+    commitment, not a throughput knob. Grouping by ``spark_partition_id()``
+    alone -- one call per partition, "as large a batch as can be formed without
+    a shuffle" -- means the array is however many pairs the partition holds.
+    Measured: 1.9M candidate pairs over a handful of partitions gives
+    ``java.lang.OutOfMemoryError: Java heap space`` (bench run 31625487603).
+    That was not a slow path; it was no path.
 
-    Batch SIZE is deliberately not tuned here. It is a throughput question and
-    belongs with the measurement in J4; picking a number now would be picking it
-    without evidence.
+    So the key is ``(partition, chunk)``. ``monotonically_increasing_id()``
+    encodes the partition in its high bits and a row counter in its low bits, so
+    dividing it by ``batch_size`` yields chunks that are already
+    partition-scoped: rows of different partitions can never share a chunk id,
+    and within a partition consecutive rows fall into chunks of at most
+    ``batch_size``. No window, no shuffle, no second pass to number the rows.
+
+    The id is not contiguous across partitions, so chunk ids are sparse. That is
+    irrelevant -- they are group keys, never counters.
     """
-    # Validate BEFORE importing pyspark: rejecting an unknown strategy is not a
-    # Spark question, and requiring Spark to say so would make the error
+    # Validate BEFORE importing pyspark: rejecting bad arguments is not a Spark
+    # question, and requiring Spark to say so would make these errors
     # unreachable anywhere the tier is not installed.
     if strategy != "partition":
         raise ValueError(
-            f"unknown batch strategy {strategy!r}; only 'partition' exists. "
-            f"Batch sizing is a J4 (measurement) question, not a J1 one."
+            f"unknown batch strategy {strategy!r}; only 'partition' exists."
+        )
+    if batch_size <= 0:
+        raise ValueError(
+            f"batch_size must be positive; got {batch_size}. An unbounded batch "
+            f"is what OOM'd the executor heap -- the group is materialised as an "
+            f"array, so its size is a memory commitment."
         )
     from pyspark.sql import functions as F
 
-    return F.spark_partition_id()
+    return F.floor(F.monotonically_increasing_id() / F.lit(int(batch_size)))
 
 
 def score_pairs_batched(
@@ -80,6 +111,7 @@ def score_pairs_batched(
     scorer_id: int,
     udf_name: str,
     batch_strategy: str = "partition",
+    batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> Any:
     """Score ``(a, b)`` pairs through a batched array UDF; return
     ``(a, b, score)``.
@@ -109,7 +141,9 @@ def score_pairs_batched(
     # collect_lists in one aggregation are separate aggregate expressions with
     # no shared order guarantee, and they agree often enough to pass a test and
     # skew under a different plan.
-    grouped = joined.groupBy(batch_key(batch_strategy).alias("__batch__")).agg(
+    grouped = joined.groupBy(
+        batch_key(batch_strategy, batch_size).alias("__batch__")
+    ).agg(
         F.collect_list(F.struct("a", "b", "x", "y")).alias(_ROWS)
     )
 

--- a/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
@@ -354,20 +354,18 @@ def _field_score_parts(field: Any, a_prefix: str, b_prefix: str) -> tuple[Any, A
 
 def _transformed(col: Any, chain: list[str]) -> Any:
     """Apply a one-box transform chain to a column via ``apply_transforms``."""
-    from pyspark.sql.functions import pandas_udf
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
-    @pandas_udf("string")
+    @arrow_udf("string")
     def _udf(c):
-        import pandas as pd
-
         from goldenmatch.utils.transforms import apply_transforms
 
-        return pd.Series(
+        return from_pylist(
             [
                 None if v is None else apply_transforms(str(v), chain)
-                for v in c.tolist()
+                for v in to_pylist(c)
             ],
-            dtype="object",
+            "string",
         )
 
     return _udf(col.cast("string"))

--- a/packages/python/goldenmatch/goldenmatch/spark/deps.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/deps.py
@@ -42,7 +42,8 @@ def ship_python_environment(
     speed. Build it on the target platform (CI is the obvious place).
 
     **What must be in it.** ``goldenmatch`` plus **pandas** and **pyarrow**.
-    goldenmatch does not depend on pandas, but ``pandas_udf`` requires it in the
+    goldenmatch does not depend on pandas, and the tier no longer needs it: its
+    UDFs are ``arrow_udf`` over ``pa.Array``. Shipping it was required while the
     worker -- installing goldenmatch alone ships an archive that unpacks cleanly
     and cannot run a single UDF. rapidfuzz is NOT needed: the scorer floor is
     goldenmatch's own ``core.strsim``, and rapidfuzz is a dev-only extra.
@@ -103,7 +104,10 @@ def executor_probe(spark: Any) -> dict[str, Any]:
                 # The scorer floor is goldenmatch's OWN strsim, not rapidfuzz --
                 # rapidfuzz is a dev-only extra and must NOT be shipped.
                 "strsim": _importable("goldenmatch.core.strsim"),
-                "pandas": _importable("pandas"),
+                # Reported, not required. The tier moved off pandas_udf, so a shipped env
+        # without pandas is CORRECT -- this stays only so a probe of an older
+        # env still says what is there.
+        "pandas": _importable("pandas"),
                 "pyarrow": _importable("pyarrow"),
                 "native_kernel": native,
                 "executable": _sys.executable,

--- a/packages/python/goldenmatch/goldenmatch/spark/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/golden.py
@@ -3,10 +3,10 @@
 Joins the S2 ``assignments`` (cluster_id, member_id) to the source records,
 filters to multi-member clusters, then for each field collects the cluster's
 values (``collect_list``) and merges them with the ONE-BOX
-``core.golden.merge_field`` primitive via a scalar pandas UDF -- reusing the
+``core.golden.merge_field`` primitive via a scalar arrow UDF -- reusing the
 exact survivorship logic guarantees semantic parity; Sail distributes the
 group-and-merge. Pure-relational (collect_list + scalar UDF), building on S1's
-proven pandas_udf mechanism (not grouped-map applyInPandas).
+proven arrow_udf mechanism (not grouped-map applyInArrow).
 
 S3 scope: the uniform, order-INDEPENDENT case (default ``most_complete`` over
 multi-member clusters). Order-dependent strategies (most_recent/source_priority),
@@ -18,26 +18,24 @@ from typing import Any
 
 
 def make_merge_udf(strategy: str) -> Any:
-    """A scalar pandas UDF mapping an array-of-values column (one cluster's
+    """A scalar arrow UDF mapping an array-of-values column (one cluster's
     collected field values) to the survivor value via ``merge_field``."""
-    from pyspark.sql.functions import pandas_udf
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
-    @pandas_udf("string")
-    def _udf(col):  # col: pandas Series; each element is the collected list
-        import pandas as pd
-
+    @arrow_udf("string")
+    def _udf(col):  # col: pa.Array; each element is the collected list
         from goldenmatch.config.schemas import GoldenFieldRule
         from goldenmatch.core.golden import merge_field
 
         rule = GoldenFieldRule(strategy=strategy)
         out = []
-        for vals in col:
+        for vals in to_pylist(col):
             # ``vals`` arrives as a python list OR a numpy ndarray (Spark array
             # column); list(...) handles both -- do NOT assume a python list.
             values = list(vals) if vals is not None else []
             merged, _conf, _src = merge_field(values, rule)
             out.append(None if merged is None else str(merged))
-        return pd.Series(out)
+        return from_pylist(out, "string")
 
     return _udf
 

--- a/packages/python/goldenmatch/goldenmatch/spark/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/identity.py
@@ -2,7 +2,7 @@
 
 Re-expresses Layer 1 of one-box ``identity.resolve.resolve_clusters`` (create +
 ``same_as`` edges — entity-independent + content-deterministic) as relational
-Spark ops + scalar pandas-UDFs. The stateful incremental layer (absorb/merge
+Spark ops + scalar arrow-UDFs. The stateful incremental layer (absorb/merge
 against an existing store) is DEFERRED, honest-null: it stays driver-side, as
 the Ray path left it. Spec: docs/superpowers/specs/2026-06-10-sail-tier-stage
 -s5-identity-design.md.
@@ -95,10 +95,11 @@ def derive_record_ids(
 ) -> Any:
     """Add a ``record_id`` column to ``source_df``. PK path is a pure column
     expression; the no-PK h1 path runs ``record_id_for_row`` in a struct
-    pandas_udf over the payload columns (parity with one-box by construction).
+    arrow_udf over the payload columns (parity with one-box by construction).
     """
     from pyspark.sql import functions as F
-    from pyspark.sql.types import StringType
+
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
     has_source = source_col in source_df.columns
     src_expr = F.col(source_col) if has_source else F.lit("dataframe")
@@ -116,20 +117,23 @@ def derive_record_ids(
     # when __source__ is absent (matches one-box row.get default).
     udf_cols = payload_cols + ([source_col] if has_source else [])
 
-    @F.pandas_udf(StringType())
-    def _rid(*cols):
-        import pandas as pd
-
-        frame = pd.concat(cols, axis=1)
-        frame.columns = udf_cols
+    # ONE struct argument rather than a variadic UDF. The pandas version took
+    # *cols and rebuilt a frame with `pd.concat`; arrow_udf's variadic form is
+    # not part of the documented contract, and a struct is both supported and
+    # self-describing -- `to_pylist()` yields one dict per row with the field
+    # names already attached, so no column-name reassembly is needed.
+    @arrow_udf("string")
+    def _rid(rows):
         out = []
-        for _, row in frame.iterrows():
+        for row in to_pylist(rows):
             payload = {c: row[c] for c in payload_cols}
             source = str(row[source_col]) if has_source else "dataframe"
             out.append(record_id_for_row(payload, source, None))
-        return pd.Series(out)
+        return from_pylist(out, "string")
 
-    return source_df.withColumn("record_id", _rid(*[F.col(c) for c in udf_cols]))
+    return source_df.withColumn(
+        "record_id", _rid(F.struct(*[F.col(c) for c in udf_cols]))
+    )
 
 
 def mint_entity_ids(assignments_with_recid: Any) -> Any:
@@ -139,7 +143,8 @@ def mint_entity_ids(assignments_with_recid: Any) -> Any:
     one-box scheme).
     """
     from pyspark.sql import functions as F
-    from pyspark.sql.types import StringType
+
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
     grouped = assignments_with_recid.groupBy("cluster_id").agg(
         F.collect_list("record_id").alias("__rids__")
@@ -148,18 +153,16 @@ def mint_entity_ids(assignments_with_recid: Any) -> Any:
     if _id_scheme() == "uuid7":
         from goldenmatch.identity.store import new_entity_id
 
-        @F.pandas_udf(StringType())
+        @arrow_udf("string")
         def _eid(col):
-            import pandas as pd
-
-            return pd.Series([new_entity_id() for _ in col])
+            return from_pylist([new_entity_id() for _ in to_pylist(col)], "string")
     else:
 
-        @F.pandas_udf(StringType())
+        @arrow_udf("string")
         def _eid(col):
-            import pandas as pd
-
-            return pd.Series([entity_id_for_members(list(v)) for v in col])
+            return from_pylist(
+                [entity_id_for_members(list(v)) for v in to_pylist(col)], "string"
+            )
 
     return grouped.withColumn("entity_id", _eid(F.col("__rids__"))).select(
         "cluster_id", "entity_id"
@@ -225,26 +228,26 @@ def build_identity_nodes(
     polish, not needed for the create-path graph.)
     """
     from pyspark.sql import functions as F
-    from pyspark.sql.types import StringType
+
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
     # entity -> golden JSON for multi-member clusters.
     gcols = [c for c in golden_df.columns if c != "cluster_id"]
 
-    @F.pandas_udf(StringType())
-    def _as_json(*cols):
-        import pandas as pd
-
-        frame = pd.concat(cols, axis=1)
-        frame.columns = gcols
+    # One struct argument, as in `_rid`. `pd.isna` is gone with it: a pa.Array
+    # carries a validity bitmap, so `to_pylist()` yields None for a null and
+    # there is no NaN to test for.
+    @arrow_udf("string")
+    def _as_json(rows):
         out = []
-        for _, row in frame.iterrows():
-            rec = {c: (None if pd.isna(row[c]) else row[c]) for c in gcols}
+        for row in to_pylist(rows):
+            rec = {c: row[c] for c in gcols}
             out.append(json.dumps(rec, default=str))
-        return pd.Series(out)
+        return from_pylist(out, "string")
 
     golden_json = (
         golden_df.join(entity_ids, on="cluster_id", how="inner")
-        .withColumn("golden_record", _as_json(*[F.col(c) for c in gcols]))
+        .withColumn("golden_record", _as_json(F.struct(*[F.col(c) for c in gcols])))
         .select("entity_id", "golden_record")
     )
 
@@ -505,26 +508,26 @@ def _golden_record_json(entity_ids: Any, golden_df: Any) -> Any:
     projection ``build_identity_nodes`` does inline, factored out so the create
     and incremental node builders cannot drift)."""
     from pyspark.sql import functions as F
-    from pyspark.sql.types import StringType
+
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
     gcols = [c for c in golden_df.columns if c != "cluster_id"]
 
-    @F.pandas_udf(StringType())
-    def _as_json(*cols):
-        import pandas as pd
-
-        frame = pd.concat(cols, axis=1)
-        frame.columns = gcols
+    # One struct argument, as in `_rid`. `pd.isna` is gone with it: a pa.Array
+    # carries a validity bitmap, so `to_pylist()` yields None for a null and
+    # there is no NaN to test for.
+    @arrow_udf("string")
+    def _as_json(rows):
         out = []
-        for _, row in frame.iterrows():
-            rec = {c: (None if pd.isna(row[c]) else row[c]) for c in gcols}
+        for row in to_pylist(rows):
+            rec = {c: row[c] for c in gcols}
             out.append(json.dumps(rec, default=str))
-        return pd.Series(out)
+        return from_pylist(out, "string")
 
     return (
         golden_df.join(entity_ids.select("cluster_id", "entity_id"), on="cluster_id",
                        how="inner")
-        .withColumn("golden_record", _as_json(*[F.col(c) for c in gcols]))
+        .withColumn("golden_record", _as_json(F.struct(*[F.col(c) for c in gcols])))
         .select("entity_id", "golden_record")
     )
 

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -1,6 +1,6 @@
 """J0: ship the JVM scorer jar to a Spark session and register it.
 
-The tier scores by forking a Python worker per batch (`pandas_udf`): an Arrow IPC
+The tier scores by forking a Python worker per batch (`arrow_udf`): an Arrow IPC
 hop plus an interpreter, and the sole reason P1 ships a Python environment to
 executors at all. Executors are JVMs and can call the Rust kernel directly. This
 module is the client half of that -- deliver the jar, register the UDF.
@@ -57,7 +57,7 @@ SCORER_IDS: dict[str, int] = {
 class JvmScorerUnavailable(RuntimeError):
     """The jar could not be found, shipped, or registered.
 
-    Its own type so callers can fall back to the `pandas_udf` path rather than
+    Its own type so callers can fall back to the in-Python UDF path rather than
     catching a bare Exception. A distributed run must not fail because one
     executor could not load a library -- correctness first, speed second.
     """

--- a/packages/python/goldenmatch/goldenmatch/spark/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/pipeline.py
@@ -1,6 +1,6 @@
 """End-to-end Sail pipeline: load -> block -> score -> dedup -> WCC -> golden,
 all distributed on Sail (Spark Connect). The bench entrypoint (S4). Blocking is
-a single pre-existing column (S1 scope); the scorer is the rapidfuzz pandas UDF;
+a single pre-existing column (S1 scope); the scorer is the arrow UDF;
 WCC defaults to the chain-robust pointer-jumping algorithm (scale).
 
 R3 (coverage / feature-gate honesty): unsupported config fails LOUDLY up front

--- a/packages/python/goldenmatch/goldenmatch/spark/scorers.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/scorers.py
@@ -1,4 +1,4 @@
-"""Scorers as Spark pandas UDFs for the Sail tier (Spark Connect).
+"""Scorers as Spark ARROW UDFs for the Spark tier (Spark Connect).
 
 Two backends, identical [0, 1] semantics:
 
@@ -147,38 +147,22 @@ def score_batch(scorer_name: str, a: Any, b: Any) -> Any:
 
 
 def make_scorer_udf(scorer_name: str) -> Any:
-    """Return a Spark ``pandas_udf`` (double) scoring two string columns in
-    [0, 1] -- native Arrow kernel when enabled, pure rapidfuzz otherwise."""
+    """Return a Spark ``arrow_udf`` (double) scoring two string columns in
+    [0, 1] -- native Arrow kernel when enabled, pure floor otherwise."""
     if scorer_name not in _SUPPORTED:
         raise NotImplementedError(
             f"Sail supports scorers {_SUPPORTED}; got {scorer_name!r}."
         )
-    from pyspark.sql.functions import pandas_udf
+    from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
-    @pandas_udf("double")
-    def _udf(a, b):  # a, b: pandas Series[str]
-        import numpy as np
-        import pandas as pd
-
-        # NaN -> None BEFORE scoring. A string column whose batch is ENTIRELY
-        # null arrives as float64, so iterating it yields NaN floats rather than
-        # None -- and `x or ""` does not rescue that, because NaN is TRUTHY. The
-        # float reached the scorer and raised
-        # `TypeError: 'float' object is not subscriptable`, crashing the whole
-        # job rather than returning a wrong number. Any block where every record
-        # is missing the scored field hit it.
-        #
-        # Normalizing here rather than in `score_batch` keeps the pandas-shaped
-        # problem at the pandas-shaped boundary; `score_batch` takes plain
-        # iterables and should not have to know about NaN.
-        def _clean(s):
-            return [
-                None if (v is None or (isinstance(v, float) and np.isnan(v)))
-                else v
-                for v in s.tolist()
-            ]
-
-        scores = score_batch(scorer_name, _clean(a), _clean(b))
-        return pd.Series(np.asarray(scores, dtype="float64"), index=a.index)
+    @arrow_udf("double")
+    def _udf(a, b):  # a, b: pa.Array[string]
+        # `to_pylist` yields None for nulls, from the validity bitmap. The
+        # pandas version had to defend against NaN here: an all-null batch
+        # inferred float64, and NaN is TRUTHY, so `x or ""` let a float reach
+        # the scorer as `TypeError: 'float' object is not subscriptable`. Arrow
+        # removes the bug class rather than guarding it.
+        scores = score_batch(scorer_name, to_pylist(a), to_pylist(b))
+        return from_pylist([float(s) for s in scores], "double")
 
     return _udf

--- a/packages/python/goldenmatch/goldenmatch/spark/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/scoring.py
@@ -1,5 +1,5 @@
 """S1 score+dedup on Sail (Spark Connect): a block self-join scored by a
-rapidfuzz pandas UDF, threshold-filtered, then deduped via GROUP BY max.
+scorer arrow UDF, threshold-filtered, then deduped via GROUP BY max.
 Returns the RAW above-threshold canonical (a < b) pair set.
 
 This is the same relational shape as the one-box spine's score+dedup, re-

--- a/packages/python/goldenmatch/tests/test_spark_batched_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_parity.py
@@ -199,3 +199,63 @@ def test_dedup_max_matches_the_row_shaped_contract(spark, registered):
 
     assert set(deduped) == set(raw), "dedup changed the pair set"
     assert deduped == raw, "no duplicate pairs here, so dedup must be a no-op"
+
+
+def test_many_pairs_do_not_exhaust_the_heap(spark, registered):
+    """The regression the bench found.
+
+    J1 keyed the batch on `spark_partition_id()` alone, so the group was however
+    many pairs a partition held and `collect_list` materialised all of them as
+    one array in JVM heap. 1.9M pairs gave
+    `java.lang.OutOfMemoryError: Java heap space` (bench run 31625487603) --
+    not a slow path, no path.
+
+    A small `batch_size` here forces MANY batches over a modest fixture, which is
+    the same shape as a large fixture with the default size and runs in seconds.
+    The assertion is that every pair still comes back correctly scored: bounding
+    the batch must not drop or duplicate rows.
+    """
+    from goldenmatch.spark.batched import score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+
+    df = spark.createDataFrame(_rows(20, 10), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+    want = _row_shaped(df, pairs)
+
+    scored = score_pairs_batched(
+        pairs, df, id_col=_ID, value_col="name",
+        scorer_id=scorer_id("exact"), udf_name=registered,
+        batch_size=7,  # deliberately tiny: forces many batches
+    )
+    got = {(int(r["a"]), int(r["b"])): r["score"] for r in scored.collect()}
+
+    assert len(got) == len(want), (
+        f"bounding the batch changed the row count: {len(got)} vs {len(want)}"
+    )
+    assert got == want, "scores changed when the batch was split"
+
+
+def test_batch_size_does_not_change_the_answer(spark, registered):
+    """Batch size is a memory/throughput choice and must be answer-invariant.
+
+    If it were not, the number would be a correctness parameter -- and nobody
+    would know which value was the correct one.
+    """
+    from goldenmatch.spark.batched import score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+
+    df = spark.createDataFrame(_rows(8, 8), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+
+    answers = []
+    for size in (3, 11, 10_000):
+        scored = score_pairs_batched(
+            pairs, df, id_col=_ID, value_col="name",
+            scorer_id=scorer_id("exact"), udf_name=registered, batch_size=size,
+        )
+        answers.append(
+            {(int(r["a"]), int(r["b"])): r["score"] for r in scored.collect()}
+        )
+    assert answers[0] == answers[1] == answers[2], (
+        "batch size changed the answer; it is a memory knob, not a semantic one"
+    )

--- a/packages/python/goldenmatch/tests/test_spark_batched_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_unit.py
@@ -19,16 +19,54 @@ from goldenmatch.spark import batched
 
 
 def test_only_the_partition_strategy_exists():
-    with pytest.raises(ValueError, match="J4"):
+    with pytest.raises(ValueError, match="only 'partition' exists"):
         batched.batch_key("by_block")
 
 
-def test_the_error_points_at_where_sizing_belongs():
-    """Batch sizing is a throughput question; answering it without measurement
-    is how a number gets baked in and never revisited."""
+def test_the_batch_must_be_bounded():
+    """The bug the bench found, pinned.
+
+    J1 shipped with the batch keyed on `spark_partition_id()` alone -- one call
+    per partition, described in its own docstring as "as large a batch as can be
+    formed without a shuffle". True, and exactly the problem: groupBy +
+    collect_list materialises the group as an array in JVM heap, so group size is
+    a MEMORY COMMITMENT, not a throughput knob. 1.9M candidate pairs gave
+    `java.lang.OutOfMemoryError: Java heap space` (bench run 31625487603).
+
+    Sizing was deferred as "a J4 measurement question". It is a
+    correctness-at-scale question, and a non-positive size is refused rather than
+    treated as "unlimited".
+    """
+    for bad in (0, -1, -10_000):
+        with pytest.raises(ValueError, match="must be positive"):
+            batched.batch_key("partition", bad)
+
+
+def test_the_refusal_explains_why_size_is_not_a_tuning_knob():
+    """A reader who sees the error must learn WHY, or they will raise the number
+    until it stops failing rather than understand what it costs."""
     with pytest.raises(ValueError) as err:
-        batched.batch_key("nope")
-    assert "measurement" in str(err.value)
+        batched.batch_key("partition", 0)
+    msg = str(err.value)
+    assert "memory" in msg and "array" in msg
+
+
+def test_the_default_batch_size_is_bounded_and_probe_backed():
+    """10,000 is not a guess: the Connect probe carried that many pairs in one
+    call (run 31611464914). Unbounded or trivially small are both wrong -- one
+    OOMs, the other reinstates the per-call overhead batching exists to remove.
+    """
+    assert 1_000 <= batched.DEFAULT_BATCH_SIZE <= 100_000
+
+
+def test_score_pairs_batched_exposes_the_size():
+    """A default that cannot be overridden is a constant with extra steps, and
+    the right value depends on row width and executor heap."""
+    import inspect
+
+    sig = inspect.signature(batched.score_pairs_batched)
+    assert "batch_size" in sig.parameters
+    assert sig.parameters["batch_size"].default == batched.DEFAULT_BATCH_SIZE
 
 
 # ── structural guards on the two silent-misalignment constructions ───

--- a/packages/python/goldenmatch/tests/test_spark_executor_deps.py
+++ b/packages/python/goldenmatch/tests/test_spark_executor_deps.py
@@ -1,7 +1,7 @@
 """P1: the executor's Python worker can import goldenmatch, because the client
 shipped it at session time.
 
-Without this every ``pandas_udf`` dies with ``ModuleNotFoundError`` -- which is
+Without this every UDF dies with ``ModuleNotFoundError`` -- which is
 exactly what P0 measured (run 31496638072: 20 failures, one cause). These tests
 run ON THE EXECUTOR; asking the driver would prove nothing, because the driver
 is where the client venv already lives.
@@ -41,8 +41,23 @@ def test_executor_can_import_goldenmatch(spark):
     # extra -- asserting it here would force shipping a dependency the product
     # deliberately removed (it was replaced by owned bit-parallel strsim).
     assert report["strsim"] is True, f"goldenmatch.core.strsim missing: {report}"
-    assert report["pandas"] is True, (
-        f"pandas missing on the executor -- pandas_udf cannot run: {report}"
+    # pandas must be ABSENT, and this assertion used to say the opposite.
+    #
+    # It was right when the tier's UDFs were `pandas_udf`: the worker genuinely
+    # could not run without it. The tier is now `arrow_udf` over `pa.Array`, so
+    # pandas on the executor would mean an undeclared dependency had crept back
+    # into the shipped environment -- of a package that does not depend on it, in
+    # a repo that evicted polars and made pyarrow the hard dep.
+    #
+    # Inverting a passing assertion is worth doing carefully, so note what still
+    # proves the env is real: `goldenmatch` and `strsim` above, and `pyarrow`
+    # below. An empty environment would fail those, not pass this.
+    assert report["pandas"] is False, (
+        f"pandas is present on the executor; the tier is arrow-native and the "
+        f"shipped env must not carry it: {report}"
+    )
+    assert report["pyarrow"] is True, (
+        f"pyarrow missing on the executor -- arrow_udf cannot run: {report}"
     )
 
 

--- a/packages/python/goldenmatch/tests/test_spark_no_pandas.py
+++ b/packages/python/goldenmatch/tests/test_spark_no_pandas.py
@@ -1,0 +1,98 @@
+"""The Spark tier must not depend on pandas.
+
+This repo evicted polars, made pyarrow the hard dependency, and does not declare
+pandas anywhere. The Spark tier nevertheless used `pandas_udf` throughout, which
+made pandas a RUNTIME REQUIREMENT ON EVERY EXECUTOR -- and the environment P1
+ships had to `pip install pandas` explicitly to make the tier work. An undeclared
+dependency, documented rather than fixed.
+
+Spark has first-class Arrow UDFs (`arrow_udf`, `mapInArrow`, `applyInArrow`), so
+there was never a need for the pandas API.
+
+These tests are the ratchet. Without them the dependency returns the first time
+somebody reaches for `pandas_udf` out of habit, and nothing notices -- the
+shipped environment simply grows.
+
+No Spark needed: this reads the tier's source.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+_SPARK_PKG = (
+    pathlib.Path(__file__).resolve().parents[1] / "goldenmatch" / "spark"
+)
+
+#: Source files of the tier. `_arrow.py` is included -- it is the module that
+#: REPLACED pandas and must not smuggle it back in a fallback.
+_MODULES = sorted(p for p in _SPARK_PKG.glob("*.py"))
+
+
+def _code_lines(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Lines with comments stripped, so prose ABOUT pandas does not trip the
+    gate. The history of this change is worth recording in comments; what must
+    not come back is the dependency."""
+    out = []
+    for i, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.split("#", 1)[0]
+        out.append((i, line))
+    return out
+
+
+def test_the_tier_has_source_files():
+    """A glob that matched nothing would make every test below vacuous."""
+    assert len(_MODULES) >= 8, f"only found {len(_MODULES)} modules in {_SPARK_PKG}"
+
+
+@pytest.mark.parametrize("path", _MODULES, ids=lambda p: p.name)
+def test_no_pandas_udf(path):
+    """`pandas_udf` is the API that drags pandas onto executors."""
+    # `pandas_udf(` -- a CALL or decorator, not the bare word. `_arrow.py`'s
+    # docstring names the API it replaced, and that record is worth keeping;
+    # what must not come back is the usage.
+    hits = [(i, ln.strip()) for i, ln in _code_lines(path) if "pandas_udf(" in ln]
+    assert not hits, (
+        f"{path.name} uses pandas_udf at {hits}. Use `arrow_udf` from "
+        f"goldenmatch.spark._arrow: same shape, pa.Array instead of pd.Series, "
+        f"and pyarrow is already a hard dependency."
+    )
+
+
+@pytest.mark.parametrize("path", _MODULES, ids=lambda p: p.name)
+def test_no_pandas_import(path):
+    """Importing pandas anywhere in the tier puts it back in the shipped env."""
+    hits = [
+        (i, ln.strip())
+        for i, ln in _code_lines(path)
+        if "import pandas" in ln or "import pandas as pd" in ln
+    ]
+    assert not hits, f"{path.name} imports pandas at {hits}"
+
+
+def test_the_arrow_helper_does_not_fall_back_to_pandas():
+    """A fallback would be worse than the original problem: it would work in
+    test and quietly reinstate the dependency in production. `arrow_udf` must
+    RAISE when pyspark cannot provide it."""
+    src = (_SPARK_PKG / "_arrow.py").read_text(encoding="utf-8")
+    code = "\n".join(ln.split("#", 1)[0] for ln in src.splitlines())
+    assert "pandas_udf(" not in code, "_arrow.py falls back to pandas_udf"
+    assert "raise RuntimeError" in code, (
+        "_arrow.py must raise when arrow_udf is unavailable, not degrade"
+    )
+
+
+def test_pandas_is_not_a_declared_dependency():
+    """The premise of all of the above. If pandas were ever added to the
+    package's dependencies this gate would be arguing against the project's own
+    manifest, and someone should reconsider deliberately rather than by import.
+    """
+    pyproject = (
+        pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    ).read_text(encoding="utf-8")
+    lines = [
+        ln for ln in pyproject.splitlines()
+        if "pandas" in ln and not ln.strip().startswith("#")
+    ]
+    assert not lines, f"pandas appears in pyproject.toml: {lines}"


### PR DESCRIPTION
**pandas was a runtime requirement on every executor** of a package that doesn't declare it as a dependency, in a repo that evicted polars and made pyarrow the hard dep. The environment P1 ships had to `pip install pandas` explicitly, and the comment I wrote there documented the problem instead of fixing it:

> *"goldenmatch does NOT depend on pandas, but `pandas_udf` needs it in the WORKER"*

Spark has first-class Arrow UDFs, so there was never a need. All **8 UDFs** across `scorers` / `golden` / `identity` / `config_pipeline` move to `arrow_udf` over `pa.Array` — same shape, and pyarrow is already a hard dependency.

The pattern came from the June Sail work. **I added two more in `config_pipeline.py` during P4**, by matching the surrounding code — the wrong instinct when the surrounding code is the defect. I also swept the arrow seam at the start of this session and never looked at the tier's UDF layer.

## What falls out beyond dropping a dependency

**Nulls stop being NaN.** A pandas Series of an all-null string batch infers float64, so iterating yielded NaN — and NaN is *truthy*, so `x or ""` didn't rescue it and a float reached the scorer as `TypeError: 'float' object is not subscriptable`. That was a real crash I fixed defensively three commits ago. A `pa.Array` carries a validity bitmap and `to_pylist()` gives `None`, so the **bug class is gone rather than guarded**. `pd.isna` disappears from `identity.py` for the same reason.

**The batch is already the shape the kernel wants.** A `pa.Array` for a string column *is* the offsets+data layout `score-cabi` takes — so the Python path can hand buffers to Rust with no conversion. I said that was out of reach.

**Two variadic `*cols` + `pd.concat` UDFs became one struct argument.** `arrow_udf`'s variadic form isn't in the documented contract, and a struct is self-describing: `to_pylist()` yields a dict per row with field names attached.

**`_arrow.arrow_udf` raises** when pyspark can't provide it rather than falling back to `pandas_udf`. A fallback would be worse than the original problem — it would pass in test and quietly reinstate the dependency in production.

## The ratchet

- `pip install ... pandas` is gone from the shipped executor env, and the build now **fails if pandas is importable there**.
- `tests/test_spark_no_pandas.py`: no `pandas_udf(`, no `import pandas`, in any tier module; the arrow helper must not fall back; pandas must not appear in `pyproject.toml`.

It matches **usage** rather than the word, so the comments recording this history survive.

Without the ratchet the dependency returns the first time somebody reaches for `pandas_udf` out of habit, and nothing notices — the env simply grows.

## Note

This branch also carries the bounded-batch commit from #2507 (already merged); only the arrow-native change is new here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
