### PR TITLE
diag(spark): bisect the batched plan to find where the heap goes

### DIFF
--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -27,6 +27,10 @@ on:
         description: "Timed runs per path; the median is reported"
         required: false
         default: "3"
+      mode:
+        description: "bench (compare paths) | diag (bisect the batched plan to find the OOM)"
+        required: false
+        default: "bench"
       runner:
         description: "Runner label"
         required: false
@@ -93,7 +97,18 @@ jobs:
           .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
           ls -lh gm_env.tar.gz
 
+      - name: Diagnose the batched plan (mode=diag)
+        if: inputs.mode == 'diag'
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+          GOLDENMATCH_NATIVE: "0"
+        run: |
+          .venv/bin/python scripts/diag_spark_batched_oom.py             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'
+
       - name: Bench
+        if: inputs.mode != 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
           GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"

--- a/scripts/diag_spark_batched_oom.py
+++ b/scripts/diag_spark_batched_oom.py
@@ -1,0 +1,188 @@
+"""Diagnose WHERE the batched Spark plan exhausts the heap.
+
+Three attempts to fix this by reasoning have failed:
+
+  1. "unbounded batches"      -> bounded to 10,000. Still OOM.
+  2. "pandas is heavy"        -> converted to arrow_udf. Still OOM.
+
+Both changes were independently right and neither addressed this. So this script
+stops guessing and BISECTS THE PLAN: it runs progressively more of the batched
+pipeline and reports the first stage that fails. The row-shaped path completes
+the same workload on the same box every time, so the failure is specific to this
+plan and one of these stages owns it.
+
+Each stage ends in `.count()` -- an action, so Spark actually executes it rather
+than building a lazy plan that never runs. Stages are cumulative: stage N+1 is
+stage N plus one operator, so the first failure names the operator.
+
+    1  candidates            block self-join only
+    2  + join to source      pair -> (a, b, x, y)
+    3  + groupBy/collect     the batch array, NO UDF        <- exonerates the UDF
+    4  + UDF                 scoring
+    5  + zip/explode         back to one row per pair
+
+If stage 3 fails, the UDF and the explode are innocent and the problem is
+grouping 1.9M rows into arrays at all. If stage 5 fails alone, `arrays_zip`
+building a second array of structs is the cost.
+
+`--rows` is swept so a constant-too-large is distinguishable from something
+quadratic: the pair count is quadratic in block size but linear in rows here.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import traceback
+
+_ID = "__row_id__"
+_SCHEMA = f"{_ID} long, blk string, name string"
+
+
+def _rows(n_rows: int, block_size: int):
+    return [
+        (i, f"blk{i // block_size}", f"v{i // block_size}_{(i % block_size) // 2}")
+        for i in range(n_rows)
+    ]
+
+
+def _candidates(df):
+    from pyspark.sql import functions as F
+
+    a, b = df.alias("a"), df.alias("b")
+    return a.join(
+        b,
+        (F.col("a.blk") == F.col("b.blk")) & (F.col(f"a.{_ID}") < F.col(f"b.{_ID}")),
+    ).select(F.col(f"a.{_ID}").alias("a"), F.col(f"b.{_ID}").alias("b"))
+
+
+def _joined(df, pairs):
+    from pyspark.sql import functions as F
+
+    lhs, rhs = "__lhs__", "__rhs__"
+    return (
+        pairs.alias("__p__")
+        .join(df.alias(lhs), F.col(f"{lhs}.{_ID}") == F.col("__p__.a"))
+        .join(df.alias(rhs), F.col(f"{rhs}.{_ID}") == F.col("__p__.b"))
+        .select(
+            F.col("__p__.a").alias("a"),
+            F.col("__p__.b").alias("b"),
+            F.col(f"{lhs}.name").cast("string").alias("x"),
+            F.col(f"{rhs}.name").cast("string").alias("y"),
+        )
+    )
+
+
+def _grouped(df, pairs, batch_size):
+    from goldenmatch.spark.batched import batch_key
+    from pyspark.sql import functions as F
+
+    return _joined(df, pairs).groupBy(
+        batch_key("partition", batch_size).alias("__batch__")
+    ).agg(F.collect_list(F.struct("a", "b", "x", "y")).alias("rows"))
+
+
+def _scored(df, pairs, batch_size, udf_name, scorer_id):
+    from pyspark.sql import functions as F
+
+    g = _grouped(df, pairs, batch_size)
+    return g.select(
+        F.col("rows"),
+        F.call_udf(
+            udf_name,
+            F.lit(int(scorer_id)),
+            F.transform(F.col("rows"), lambda r: r["x"]),
+            F.transform(F.col("rows"), lambda r: r["y"]),
+        ).alias("scores"),
+    )
+
+
+def _exploded(df, pairs, batch_size, udf_name, scorer_id):
+    from pyspark.sql import functions as F
+
+    s = _scored(df, pairs, batch_size, udf_name, scorer_id)
+    return s.select(F.explode(F.arrays_zip(F.col("rows"), F.col("scores"))).alias("z"))
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, default=200_000)
+    ap.add_argument("--block-size", type=int, default=20)
+    ap.add_argument("--batch-size", type=int, default=10_000)
+    args = ap.parse_args(argv)
+
+    from goldenmatch.spark.jvm import find_jar, install, scorer_id
+    from pyspark.sql import SparkSession
+
+    remote = os.environ.get("GOLDENMATCH_SPARK_REMOTE", "local[*]")
+    spark = SparkSession.builder.remote(remote).getOrCreate()
+    pyenv = os.environ.get("GOLDENMATCH_SPARK_PYENV")
+    if pyenv:
+        from goldenmatch.spark.deps import ship_python_environment
+
+        ship_python_environment(spark, pyenv)
+    udf_name = install(spark, jar=find_jar())
+
+    df = spark.createDataFrame(_rows(args.rows, args.block_size), _SCHEMA).cache()
+    pairs = _candidates(df)
+    sid = scorer_id("exact")
+
+    stages = [
+        ("1 candidates", lambda: pairs.count()),
+        ("2 + join to source", lambda: _joined(df, pairs).count()),
+        ("3 + groupBy/collect (NO UDF)",
+         lambda: _grouped(df, pairs, args.batch_size).count()),
+        ("4 + UDF",
+         lambda: _scored(df, pairs, args.batch_size, udf_name, sid).count()),
+        ("5 + zip/explode",
+         lambda: _exploded(df, pairs, args.batch_size, udf_name, sid).count()),
+    ]
+
+    print(f"\nrows={args.rows:,} block_size={args.block_size} "
+          f"batch_size={args.batch_size:,}", flush=True)
+    print("=" * 66, flush=True)
+    first_failure = None
+    for name, fn in stages:
+        t0 = time.perf_counter()
+        try:
+            n = fn()
+            print(f"  OK    {name:32} -> {n:>12,}  ({time.perf_counter()-t0:.1f}s)",
+                  flush=True)
+        except Exception as exc:  # noqa: BLE001 - the whole point is to report
+            kind = type(exc).__name__
+            oom = "OutOfMemory" in str(exc) or "OutOfMemory" in repr(exc)
+            print(f"  FAIL  {name:32} -> {kind}{' (OOM)' if oom else ''}", flush=True)
+            print(f"        {str(exc).strip().splitlines()[0][:160]}", flush=True)
+            first_failure = name
+            break
+
+    print("=" * 66)
+    if first_failure is None:
+        print("  Every stage completed. The plan is not the problem at this size;")
+        print("  raise --rows until it breaks, or the difference is elsewhere.")
+        return 0
+    print(f"  FIRST FAILING STAGE: {first_failure}")
+    print()
+    if first_failure.startswith("3"):
+        print("  The UDF and the explode are INNOCENT. Grouping the pairs into")
+        print("  arrays is itself what exhausts the heap -- the shuffle plus the")
+        print("  collected structs, before any scoring happens.")
+    elif first_failure.startswith("4"):
+        print("  Grouping is fine; the UDF call is where it goes. The derived")
+        print("  `transform` arrays duplicate every string in the batch.")
+    elif first_failure.startswith("5"):
+        print("  Scoring is fine; `arrays_zip` building a second array of structs")
+        print("  is the cost.")
+    else:
+        print("  The failure is UPSTREAM of the batching entirely -- shared with")
+        print("  the row-shaped path, so it is not what makes this plan special.")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001
+        traceback.print_exc()
+        sys.exit(2)


### PR DESCRIPTION
Three attempts to fix the batched-path OOM by reasoning have failed. Bounded batching and the arrow-native conversion were both independently right and **neither addressed it**. This stops guessing and measures which operator owns it.

Runs progressively more of the pipeline, each ending in `.count()` so Spark actually executes:

| stage | |
|---|---|
| 1 | candidates — block self-join only |
| 2 | + join to source |
| 3 | **+ groupBy/collect_list, NO UDF** |
| 4 | + UDF |
| 5 | + arrays_zip/explode |

Cumulative, so the **first failure names the operator**. Stage 3 is the one that matters: if it fails, the UDF and the explode are exonerated and grouping 1.9M rows into arrays is itself the cost — which no amount of work on the UDF would ever have fixed.

The script states what each outcome *means* rather than leaving it to inference, because the last three rounds were exactly that inference going wrong.

Added as a `mode` input on the existing bench workflow rather than a new lane — same environment, same jar build, same executor env, so a difference between the diagnostic and the failing bench can't be the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ