### PR TITLE
fix(pipeline): bucket routing must not bypass the blocking-expressibility gate

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -3963,6 +3963,7 @@
             "_apply_postflight",
             "_arrow_lane_supported",
             "_as_polars_df",
+            "_bucket_can_express_blocking",
             "_build_em_blocks",
             "_cast_user_cols_to_str",
             "_collect_guard_columns",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -62,6 +62,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   default stays off until the benchmark says otherwise.
 
 ### Fixed
+- **Bucket routing no longer bypasses the blocking-expressibility gate (#2488).**
+  The bucket scorer derives FIELD-based block keys from `blocking.keys` /
+  `blocking.passes`; a guard kept strategies with no field keys (lsh / ann /
+  learned / canopy / sorted_neighborhood / token) on the legacy per-block path.
+  That guard sat *below* the `backend == "bucket"` short-circuit in
+  `_use_bucket_scorer`, and `ExecutionPlan.apply_to` writes `backend="bucket"`
+  onto the committed config -- so the guard was unreachable for exactly the
+  configs it protected. On a zero-config run the controller's sample pass routed
+  before the planner ran and scored the plan correctly on the legacy path, then
+  the final dedupe pass took bucket with the same plan, derived an empty block
+  key, and emitted zero pairs with no error and no warning: every record came
+  back a singleton. Measured on Amazon-Google (4589 records, 1300 truth pairs),
+  identical configs differing only in `backend`: 16,545 pairs / F1 0.0864 with
+  `backend` unset, 0 pairs / F1 0.0000 with `backend="bucket"`. The check now
+  runs first, as `_bucket_can_express_blocking`, so it holds however `backend`
+  was set. It also covers an allowlisted strategy carrying neither keys nor
+  passes (the degenerate `static keys=[] auto_suggest=True` config), since
+  auto-suggest chooses the real plan mid-pipeline and a routing decision taken
+  off the provisional plan can land on a strategy bucket cannot express; both
+  paths already yielded zero pairs for that shape, so only the routing changes.
+  An explicit `backend="bucket"` on a field-keyed plan is still honored at any
+  size.
 - **Every FS scoring path now resolves the link cutoff the same way.**
   `_fs_link_threshold` applies three steps in order -- configured
   `mk.link_threshold`, then the EM-calibrated per-dataset cutoff, then the

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -432,9 +432,44 @@ _BUCKET_DEFAULT_MAX_ROWS = 750_000  # == autoconfig_planner_rules.BUCKET_SUGGEST
 _BUCKET_DEFAULT_OPT_OUT = frozenset({"0", "off", "false", "no"})
 
 
+def _bucket_can_express_blocking(blocking: Any) -> bool:
+    """Whether the bucket scorer can reproduce this blocking plan's candidate set.
+
+    Bucket derives FIELD-based block keys from ``blocking.keys`` / ``blocking.passes``
+    in a single eager pass over the frame. Two shapes it cannot express:
+
+      * Strategies that generate candidates from signatures, embeddings or learned
+        predicates (lsh / ann / learned / canopy / sorted_neighborhood / token).
+        These carry no field keys at all -- ``BlockingConfig`` actively REJECTS
+        ``keys`` alongside them -- so bucket derives an empty key and scores an
+        empty candidate set.
+      * An allowlisted strategy that has no keys AND no passes yet, i.e. the
+        degenerate ``static keys=[] auto_suggest=True`` config. With auto-suggest
+        the real plan is chosen mid-pipeline, so a routing decision taken off the
+        provisional plan can land on a strategy bucket cannot express.
+
+    This is a CORRECTNESS gate, not a performance one, so it must hold however
+    ``backend`` came to be ``"bucket"`` -- set by the caller, or written onto the
+    committed config by the execution planner (``ExecutionPlan.apply_to``). #2488.
+    """
+    if blocking is None:
+        return True  # no blocking plan -> nothing for bucket to misread
+    if getattr(blocking, "strategy", None) not in (None, "static", "multi_pass"):
+        return False
+    return bool(getattr(blocking, "keys", None) or getattr(blocking, "passes", None))
+
+
 def _use_bucket_scorer(config: GoldenMatchConfig, collected_df: Any) -> bool:
     """Whether the fuzzy scoring stage should use the bucket scorer (default) vs
     the legacy per-block path. See the module note above the constants."""
+    # Correctness gate FIRST. #2488: the execution planner writes
+    # backend="bucket" onto the committed config, which used to short-circuit
+    # past the strategy check below -- so a token/lsh/... plan silently scored an
+    # empty candidate set (zero pairs, no error) on the final dedupe pass while
+    # the controller's own sample pass, routed before the planner ran, scored it
+    # correctly on the legacy path.
+    if not _bucket_can_express_blocking(getattr(config, "blocking", None)):
+        return False
     backend = getattr(config, "backend", None)
     if backend == "bucket":
         return True  # explicit choice -- honored at any size
@@ -449,16 +484,11 @@ def _use_bucket_scorer(config: GoldenMatchConfig, collected_df: Any) -> bool:
         config, "partitioned_block_scoring", False
     ):
         return False
-    # Bucket derives FIELD-based block keys (blocking.passes/keys). lsh / ann /
-    # learned / canopy / sorted_neighborhood generate candidates from signatures /
-    # embeddings / learned predicates that bucket does not replicate -> it would
-    # split near-dups the legacy path merges. Keep those on legacy (tracked gap:
-    # test_bucket_legacy_parity_matrix). static / multi_pass are validated identical.
-    _blk = getattr(config, "blocking", None)
-    if _blk is not None and getattr(_blk, "strategy", None) not in (
-        None, "static", "multi_pass",
-    ):
-        return False
+    # (The strategy/keys gate that used to live here now runs at the top of this
+    # function as `_bucket_can_express_blocking` -- see #2488. Keeping it below the
+    # `backend == "bucket"` short-circuit made it unreachable for exactly the
+    # configs it existed to protect. Parity gap still tracked by
+    # test_bucket_legacy_parity_matrix; static / multi_pass validated identical.)
     # Controller profiling: keep the legacy per-block path so auto-config reads the
     # SAME block-size distribution signals it always has (bucket emits different
     # profile stages -> would shift the controller's refit decisions / oscillate).

--- a/packages/python/goldenmatch/tests/test_bucket_routing_guard_2488.py
+++ b/packages/python/goldenmatch/tests/test_bucket_routing_guard_2488.py
@@ -1,0 +1,122 @@
+"""The bucket scorer's blocking-expressibility gate is a CORRECTNESS gate and
+must hold however ``backend`` became ``"bucket"`` (#2488).
+
+The bug: ``_use_bucket_scorer`` returned True on ``backend == "bucket"`` before
+reaching the strategy allowlist that exists to keep non-field-keyed strategies
+off the bucket path. ``ExecutionPlan.apply_to`` writes ``backend="bucket"`` onto
+the committed config, so on a zero-config run the FINAL dedupe pass took bucket
+with a ``token`` plan, derived an empty block key, and emitted zero pairs -- with
+no error -- while the controller's own sample pass (routed before the planner
+ran) had scored the same plan correctly on the legacy path.
+
+Measured on Amazon-Google before the fix: identical configs differing only in
+``backend`` gave 16,545 pairs (unset) vs 0 pairs (``"bucket"``).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    LSHKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    TokenBlockingConfig,
+)
+from goldenmatch.core.pipeline import _bucket_can_express_blocking, _use_bucket_scorer
+
+
+@pytest.fixture
+def df() -> pl.DataFrame:
+    return pl.DataFrame({
+        "record_id": [f"r{i}" for i in range(6)],
+        "title": ["alpha widget", "alpha widget", "beta gadget",
+                  "beta gadget", "gamma thing", "gamma thing"],
+    })
+
+
+def _cfg(blocking: BlockingConfig | None, backend: str | None = None) -> GoldenMatchConfig:
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="mk", type="weighted", threshold=0.8,
+            fields=[MatchkeyField(field="title", scorer="token_sort", weight=1.0)],
+        )],
+        blocking=blocking,
+    )
+    if backend is not None:
+        cfg.backend = backend
+    return cfg
+
+
+# ---- _bucket_can_express_blocking: the predicate itself ----
+
+
+def test_field_keyed_plans_are_expressible():
+    cfg = BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["title"])])
+    assert _bucket_can_express_blocking(cfg)
+
+
+def test_missing_blocking_is_expressible():
+    """No blocking plan -> nothing for bucket to misread."""
+    assert _bucket_can_express_blocking(None)
+
+
+@pytest.mark.parametrize("blocking", [
+    BlockingConfig(strategy="token", token=TokenBlockingConfig(column="title")),
+    BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(column="title", threshold=0.5)),
+    BlockingConfig(strategy="learned"),
+])
+def test_signature_generated_plans_are_not_expressible(blocking: BlockingConfig) -> None:
+    """These carry no field keys -- the schema REJECTS `keys` alongside them --
+    so bucket would derive an empty key and score an empty candidate set."""
+    assert blocking.keys == []
+    assert not _bucket_can_express_blocking(blocking)
+
+
+def test_degenerate_keyless_static_is_not_expressible():
+    """`_degenerate_blocking_config()`'s shape. With auto_suggest the real plan
+    is chosen mid-pipeline, so routing off this provisional plan can land on a
+    strategy bucket cannot express."""
+    cfg = BlockingConfig(strategy="static", keys=[], auto_suggest=True)
+    assert not _bucket_can_express_blocking(cfg)
+
+
+# ---- the regression: backend="bucket" must not bypass the gate ----
+
+
+@pytest.mark.parametrize("backend", [None, "bucket"])
+def test_token_plan_never_routes_to_bucket(df: pl.DataFrame, backend: str | None) -> None:
+    """THE REGRESSION. Before the fix this returned True for backend='bucket',
+    sending a token plan to a scorer that cannot express it."""
+    cfg = _cfg(BlockingConfig(strategy="token",
+                              token=TokenBlockingConfig(column="title")), backend)
+    assert _use_bucket_scorer(cfg, df) is False
+
+
+@pytest.mark.parametrize("backend", [None, "bucket"])
+def test_lsh_plan_never_routes_to_bucket(df: pl.DataFrame, backend: str | None) -> None:
+    cfg = _cfg(BlockingConfig(strategy="lsh",
+                              lsh=LSHKeyConfig(column="title", threshold=0.5)), backend)
+    assert _use_bucket_scorer(cfg, df) is False
+
+
+def test_explicit_bucket_still_honored_for_expressible_plans(df: pl.DataFrame) -> None:
+    """The gate must not break the feature it guards: an explicit
+    backend='bucket' on a field-keyed plan is still honored at any size."""
+    cfg = _cfg(BlockingConfig(strategy="static",
+                              keys=[BlockingKeyConfig(fields=["title"])]), "bucket")
+    assert _use_bucket_scorer(cfg, df) is True
+
+
+def test_planner_written_backend_cannot_bypass_the_gate(df: pl.DataFrame) -> None:
+    """ExecutionPlan.apply_to is how `backend` became "bucket" in the wild --
+    the gate must not care which writer set it."""
+    from goldenmatch.core.execution_plan import ExecutionPlan
+
+    cfg = _cfg(BlockingConfig(strategy="token",
+                              token=TokenBlockingConfig(column="title")))
+    ExecutionPlan(backend="bucket").apply_to(cfg)
+    assert cfg.backend == "bucket"          # the planner really did write it
+    assert _use_bucket_scorer(cfg, df) is False


### PR DESCRIPTION
## What and why

Root cause of the #2488 zero-config collapse on Amazon-Google: the final dedupe pass silently emitted **zero pairs**, so every record came back a singleton (F1 0.0000).

`_use_bucket_scorer` returns `True` on `backend == "bucket"` (pipeline.py:439), *above* the strategy allowlist at line 458 that exists to keep non-field-keyed blocking strategies (lsh / ann / learned / canopy / sorted_neighborhood / token) off the bucket path. `ExecutionPlan.apply_to` writes `backend="bucket"` onto the committed config, so the guard was unreachable for exactly the configs it was written to protect.

The two-pass shape is what made it invisible. The controller's own sample pass routes *before* the planner runs, so it took the legacy path and scored the plan correctly; the final pass then took bucket with the same plan, derived an empty block key, and returned nothing. Traced on a real zero-config run:

```
[2] USE-BUCKET   returned=False  strategy='token'   <- sample pass, legacy
[3] BUILD-BLOCKS strategy='token' -> 2625 blocks
[4] METRICS      {'fuzzy_pair_count': 11856, 'block_count': 2625}

[7] USE-BUCKET   returned=True   strategy='token'   <- final pass, SAME config
[8] METRICS      {'fuzzy_pair_count': 0, 'block_count': 0}
```

11,856 pairs computed, then discarded. No error, no warning.

Minimal reproduction on Amazon-Google (4,589 records, 1,300 labelled pairs), identical configs differing only in `backend`:

| config | candidate pairs | F1 |
|---|---|---|
| `token`, `backend` unset | 16,545 | 0.0864 |
| `token`, `backend="bucket"` | **0** | **0.0000** |

After the fix both arms give 16,545 pairs / F1 0.0864.

## Changes

- Hoist the check to the top of `_use_bucket_scorer` as a named predicate, `_bucket_can_express_blocking`, so it holds however `backend` came to be `"bucket"` — caller-set or planner-written. This is a correctness gate, not a performance one.
- Close the neighbouring case as well as the reported one: an allowlisted strategy carrying neither `keys` nor `passes` (the degenerate `static keys=[] auto_suggest=True` config) is likewise not expressible, because auto-suggest picks the real plan mid-pipeline and a routing decision taken off the provisional plan can land on a strategy bucket cannot express. Output is unchanged for that shape — both paths already yielded zero pairs — only the routing is.
- An explicit `backend="bucket"` on a field-keyed plan is still honoured at any size, covered by a test so the gate cannot regress into blocking the feature it guards.
- New `tests/test_bucket_routing_guard_2488.py` (12 tests), CHANGELOG entry, `docs/agent-codemap.json` regen (the new module-level function makes it stale).

## Testing

- `pytest tests/test_bucket_routing_guard_2488.py` — 12 passed
- `pytest tests/ -k "bucket or blocking or block_analyzer or token"` — **851 passed**, 52 skipped, 2 xfailed
- `pytest scripts/test_config_matrix.py test_agent_codemap.py test_docs_sections.py test_api_surface.py` — 64 passed (`test_agent_codemap` failed first; fixed by the regen above)
- `pyright --pythonpath .venv/bin/python` on both changed files — 0 errors
- `ruff check` on both changed files — clean
- End-to-end reproduction re-run after the fix: both `backend` arms now identical at 16,545 pairs / F1 0.0864

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — **not run: `pre-commit` is not installed in this environment.** `ruff` (its main hook) passes on the changed files.
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated — n/a, no workflow or gotcha changed

## Not in this PR

Two things surfaced while tracing this, both measured, neither fixed here:

1. **`estimate_recall`'s denominator is ~98.5% non-duplicates.** It scores candidates against pairs that Jaro-Winkler ≥ 0.7 calls similar; on this dataset that proxy has 1.49% precision against the labelled pairs (2,355 proxy pairs, 35 true). So a candidate is penalised for correctly *declining* to co-block non-matches — a specificity penalty reported as recall. Measured estimate vs true pair recall: `tokens(title, df<=10)` 26.0% vs **65.9%**; `df<=25` 46.1% vs **87.6%**; `df<=50` 73.6% vs **95.3%**. Since the estimate multiplies the ranking score (`block_analyzer.py:722`), discriminative candidates are systematically demoted. Needs a design decision on the proxy, not a quick patch — filing separately.
2. **`score_field("", "", "token_sort")` returns 1.0** — two empty strings are a perfect match. Inactive on this dataset, but a latent false-positive hazard for any derived column whose extractor can return `""` on both sides.

Refs #2488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_