### PR TITLE
fix(bench): measure each arm in its own process — the benchmark was measuring itself

### DIFF
--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -107,7 +107,23 @@ jobs:
         run: |
           .venv/bin/python scripts/diag_spark_batched_oom.py             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'
 
-      - name: Bench
+      # ONE ARM PER PROCESS. Both used to run in one script against one
+      # `local[*]` session, where the driver and executor SHARE A JVM -- so the
+      # second arm started with the first's cached DataFrame and shuffles still
+      # resident, and OOM'd. Three rounds of CI went into "fixing" a batched path
+      # that a plan bisect then ran end to end in 21s (run 31649168548): the
+      # benchmark was measuring itself. Separate processes share nothing, and it
+      # is the only fair shape anyway -- whichever arm ran second was penalised.
+      - name: Bench row_python
+        if: inputs.mode != 'diag'
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_NATIVE: "0"
+        run: |
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
+
+      - name: Bench batched_jvm
         if: inputs.mode != 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
@@ -115,11 +131,15 @@ jobs:
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py \
-            --rows '${{ inputs.rows }}' \
-            --block-size '${{ inputs.block_size }}' \
-            --repeats '${{ inputs.repeats }}' \
-            --out spark-scoring-bench.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path batched_jvm             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-batched_jvm.json
+
+      # A SCRIPT, not inline Python: an embedded multi-line program inside a
+      # YAML `run:` block must survive block-scalar parsing too, and this repo
+      # has now broken that twice.
+      - name: Compare
+        if: inputs.mode != 'diag'
+        run: |
+          .venv/bin/python scripts/bench_spark_compare.py             bench-row_python.json bench-batched_jvm.json spark-scoring-bench.json
 
       - name: Summary
         if: always()

--- a/scripts/bench_spark_compare.py
+++ b/scripts/bench_spark_compare.py
@@ -1,0 +1,67 @@
+"""Combine the two independently-measured bench arms into one comparison.
+
+A separate script rather than inline Python in the workflow: an embedded
+multi-line program inside a YAML `run:` block has to survive block-scalar
+parsing as well as Python's, and this repo has now broken that twice.
+
+Each arm is measured in its own PROCESS (see bench_spark_scoring.py) because
+`local[*]` shares one JVM between driver and executor -- so running both in one
+session left the second arm starting on the first's residue, and it OOM'd. This
+script only reads their JSON.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    row_path, jvm_path, out_path = argv[0], argv[1], argv[2]
+
+    a = json.load(open(row_path, encoding="utf-8"))
+    b = json.load(open(jvm_path, encoding="utf-8"))
+    ra = a["timing"]["median_s"]
+    rb = b["timing"]["median_s"]
+
+    print("=" * 68)
+    print(f"RESULT   rows={a['rows']:,}   candidate_pairs={a['candidate_pairs']:,}")
+    print("=" * 68)
+    for name, r in (("row_python", a["timing"]), ("batched_jvm", b["timing"])):
+        print(
+            f"  {name:14} median {r['median_s']:8.3f}s   "
+            f"(min {r['min_s']:.3f} max {r['max_s']:.3f})   "
+            f"rows_out={r['rows_out']:,}"
+        )
+
+    ratio = (ra / rb) if rb else None
+    print()
+    if ratio is None:
+        print("  INCONCLUSIVE: batched_jvm reported zero elapsed time.")
+    else:
+        print(f"  batched_jvm is {ratio:.2f}x the row_python path")
+        print()
+        if ratio < 1.2:
+            print("  The Python-worker hop is NOT where the time goes. J2's JNI")
+            print("  work should be re-justified on grounds other than throughput")
+            print("  -- the one-kernel and no-Python-on-executors arguments still")
+            print("  stand, the speed one does not.")
+        else:
+            print("  The Python-worker hop dominates. Removing the interpreter as")
+            print("  well as the hop (J2, JNI into score-cabi) is worth building.")
+
+    print()
+    print("  CAVEAT, load-bearing: batched_jvm scores `exact` while row_python")
+    print("  scores jaro_winkler, because the J0 jar carries no algorithms of its")
+    print("  own. This measures the CALLING MECHANISM, not the kernels -- and it")
+    print("  flatters batched_jvm LEAST, since `exact` does almost no work and")
+    print("  leaves per-call overhead as the whole signal. Like-for-like needs J2.")
+
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump({"row_python": a, "batched_jvm": b, "ratio": ratio}, fh, indent=2)
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_spark_scoring.py
+++ b/scripts/bench_spark_scoring.py
@@ -27,6 +27,20 @@ better to know that before writing it.
 `exact` being cheap makes the comparison HARSHER on the JVM path, not kinder:
 with almost no work per pair, per-call overhead is the whole signal.
 
+## One arm per PROCESS, and why
+
+Both arms used to run in one script against one `local[*]` session, where the
+DRIVER AND EXECUTOR SHARE A JVM. The second arm therefore started with whatever
+the first had left resident -- a cached DataFrame plus three 1.9M-row shuffles --
+and OOM'd. Three rounds of CI went into "fixing" a batched path that a plan
+bisect later ran end to end in 21 seconds (run 31649168548): the benchmark was
+measuring itself.
+
+So each arm now runs in its own process, invoked separately, and the results are
+combined afterwards. Nothing survives between them. It is also the only fair
+shape for a comparison: whichever arm ran second was being systematically
+penalised.
+
 ## Reading the result
 
 A ratio near 1.0 means the Python-worker hop is not where the time goes, and the
@@ -125,6 +139,13 @@ def main(argv=None) -> int:
     ap.add_argument("--block-size", type=int, default=20)
     ap.add_argument("--repeats", type=int, default=3)
     ap.add_argument("--out", default="spark-scoring-bench.json")
+    ap.add_argument(
+        "--path",
+        choices=["row_python", "batched_jvm"],
+        required=True,
+        help="ONE arm per process -- see the module docstring. Running both in "
+             "one session let the first arm's residue OOM the second.",
+    )
     args = ap.parse_args(argv)
 
     from goldenmatch.spark.jvm import JvmScorerUnavailable, find_jar, install
@@ -171,56 +192,29 @@ def main(argv=None) -> int:
         "candidate_pairs": n_pairs,
         "repeats": args.repeats,
         "remote": remote,
-        "paths": {},
+        "path": args.path,
     }
 
-    print("\n[1/2] row_python (pandas_udf -> forked Python worker)", flush=True)
-    results["paths"]["row_python"] = _time(
-        lambda: _row_python(spark, df), repeats=args.repeats
-    )
-
-    try:
-        udf_name = install(spark, jar=find_jar())
-    except JvmScorerUnavailable as exc:
-        print(f"::error::no JVM scorer jar: {exc}")
-        return 2
-
-    print("\n[2/2] batched_jvm (array UDF, in the executor JVM)", flush=True)
-    results["paths"]["batched_jvm"] = _time(
-        lambda: _batched_jvm(spark, df, udf_name), repeats=args.repeats
-    )
-
-    rp = results["paths"]["row_python"]["median_s"]
-    bj = results["paths"]["batched_jvm"]["median_s"]
-    results["speedup_row_python_over_batched_jvm"] = round(rp / bj, 3) if bj else None
-
-    print("\n" + "=" * 68)
-    print("RESULT")
-    print("=" * 68)
-    for name, r in results["paths"].items():
-        print(
-            f"  {name:14} median {r['median_s']:8.3f}s   "
-            f"(min {r['min_s']:.3f} max {r['max_s']:.3f})  rows_out={r['rows_out']:,}"
-        )
-    ratio = results["speedup_row_python_over_batched_jvm"]
-    print(f"\n  batched_jvm is {ratio}x the row_python path")
-    print()
-    if ratio is None:
-        print("  INCONCLUSIVE.")
-    elif ratio < 1.2:
-        print("  The Python-worker hop is NOT where the time goes. J2's JNI work")
-        print("  should be re-justified on grounds other than throughput -- the")
-        print("  one-kernel argument still stands, the speed one does not.")
+    if args.path == "row_python":
+        print("[row_python] arrow_udf -> forked Python worker", flush=True)
+        results["timing"] = _time(lambda: _row_python(spark, df),
+                                  repeats=args.repeats)
     else:
-        print("  The Python-worker hop dominates. Removing it is worth doing, and")
-        print("  J2 (JNI into score-cabi) is the way to remove the interpreter as")
-        print("  well as the hop.")
-    print()
-    print("  CAVEAT, and it is load-bearing: the JVM path scores `exact` while")
-    print("  the Python path scores jaro_winkler. This measures the CALLING")
-    print("  MECHANISM, not the kernels -- and it flatters the Python path least,")
-    print("  since `exact` does almost no work and leaves per-call overhead as the")
-    print("  whole signal. A like-for-like kernel comparison needs J2.")
+        try:
+            udf_name = install(spark, jar=find_jar())
+        except JvmScorerUnavailable as exc:
+            print(f"::error::no JVM scorer jar: {exc}")
+            return 2
+        print("[batched_jvm] array UDF, in the executor JVM", flush=True)
+        results["timing"] = _time(lambda: _batched_jvm(spark, df, udf_name),
+                                  repeats=args.repeats)
+
+    r = results["timing"]
+    print(
+        f"  {args.path:14} median {r['median_s']:8.3f}s  "
+        f"(min {r['min_s']:.3f} max {r['max_s']:.3f})  rows_out={r['rows_out']:,}",
+        flush=True,
+    )
 
     with open(args.out, "w", encoding="utf-8") as fh:
         json.dump(results, fh, indent=2)

--- a/scripts/diag_spark_batched_oom.py
+++ b/scripts/diag_spark_batched_oom.py
@@ -105,6 +105,18 @@ def _exploded(df, pairs, batch_size, udf_name, scorer_id):
     return s.select(F.explode(F.arrays_zip(F.col("rows"), F.col("scores"))).alias("z"))
 
 
+def _deduped(df, pairs, batch_size, udf_name, scorer_id):
+    from pyspark.sql import functions as F
+
+    e = _exploded(df, pairs, batch_size, udf_name, scorer_id)
+    flat = e.select(
+        F.col("z.rows.a").alias("a"),
+        F.col("z.rows.b").alias("b"),
+        F.col("z.scores").alias("score"),
+    )
+    return flat.groupBy("a", "b").agg(F.max("score").alias("score"))
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--rows", type=int, default=200_000)
@@ -137,6 +149,12 @@ def main(argv=None) -> int:
          lambda: _scored(df, pairs, args.batch_size, udf_name, sid).count()),
         ("5 + zip/explode",
          lambda: _exploded(df, pairs, args.batch_size, udf_name, sid).count()),
+        # The bench does this and the earlier bisect did not, so it was the one
+        # untested difference between a plan that completes and a bench that
+        # OOMs. Testing it here rules it in or out independently of the harness
+        # isolation fix, rather than fixing two things and learning nothing.
+        ("6 + dedup_max (groupBy a,b)",
+         lambda: _deduped(df, pairs, args.batch_size, udf_name, sid).count()),
     ]
 
     print(f"\nrows={args.rows:,} block_size={args.block_size} "
@@ -171,6 +189,10 @@ def main(argv=None) -> int:
     elif first_failure.startswith("4"):
         print("  Grouping is fine; the UDF call is where it goes. The derived")
         print("  `transform` arrays duplicate every string in the batch.")
+    elif first_failure.startswith("6"):
+        print("  The batched plan is fine; the MAX dedup over 1.9M exploded rows")
+        print("  is the cost. That is shared with the row-shaped path, which does")
+        print("  the same groupBy -- so it is not what makes this plan special.")
     elif first_failure.startswith("5"):
         print("  Scoring is fine; `arrays_zip` building a second array of structs")
         print("  is the cost.")


### PR DESCRIPTION
The plan bisect settled it ([run 31649168548](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31649168548)): the batched pipeline runs **the exact workload the bench OOMs on**, end to end, in 21 seconds.

```
OK  1 candidates                  ->  1,900,000  (6.7s)
OK  2 + join to source            ->  1,900,000  (2.6s)
OK  3 + groupBy/collect (NO UDF)  ->        206  (3.2s)
OK  4 + UDF                       ->        206  (3.0s)
OK  5 + zip/explode               ->  1,900,000  (5.5s)
```

So the OOM was never in the plan. Both arms ran in **one script against one `local[*]` session**, where the driver and executor share a JVM — so the second arm started with the first's cached DataFrame and three 1.9M-row shuffles still resident. Whichever arm ran second was penalised, and the batched one ran second.

**Three rounds of CI went into "fixing" that** — bounded batching, then the arrow-native conversion. Both were real improvements worth keeping. Neither was the cause, and I asserted each as though it were.

## What changes

Each arm runs in its **own process**, invoked separately, results combined afterwards. Nothing survives between them. It's the only fair shape for a comparison, not just a fix.

The compare step is a **script**, not inline Python: an embedded multi-line program inside a YAML `run:` block must survive block-scalar parsing too, and this repo has now broken that twice — once in the probe, once here.

The bisect also gains **stage 6 (`dedup_max`)** — the one operator the bench did and the earlier bisect didn't. That rules it in or out independently, rather than changing two things and learning nothing from either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ