### PR TITLE
bench(spark): measure the Rust kernel — the bench had it switched off

### DIFF
--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -54,7 +54,10 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - run: uv sync --all-packages --no-install-package goldenflow-native
+      # goldenmatch-native IS installed here: the whole point of the native
+      # arm is to run the Rust kernel, and excluding the wheel is how the
+      # first version of this bench reported pure-Python numbers.
       - name: Install the spark extra
         run: uv pip install -e 'packages/python/goldenmatch[spark]'
 
@@ -121,7 +124,18 @@ jobs:
           GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path row_python             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python             --native 0             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
+
+      # The arm that speaks to spec section 1. Without it the bench measures UDF
+      # plumbing with the kernel switched off and says nothing about "vectorized
+      # Rust beats Spark SQL per core".
+      - name: Bench row_python (NATIVE kernel)
+        if: inputs.mode != 'diag'
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+        run: |
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python             --native 1             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python_native.json
 
       - name: Bench batched_jvm
         if: inputs.mode != 'diag'
@@ -139,7 +153,7 @@ jobs:
       - name: Compare
         if: inputs.mode != 'diag'
         run: |
-          .venv/bin/python scripts/bench_spark_compare.py             bench-row_python.json bench-batched_jvm.json spark-scoring-bench.json
+          .venv/bin/python scripts/bench_spark_compare.py             bench-row_python.json bench-row_python_native.json \n            bench-batched_jvm.json spark-scoring-bench.json
 
       - name: Summary
         if: always()

--- a/scripts/bench_spark_compare.py
+++ b/scripts/bench_spark_compare.py
@@ -17,49 +17,67 @@ import sys
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
-    row_path, jvm_path, out_path = argv[0], argv[1], argv[2]
+    pure_path, native_path, jvm_path, out_path = argv[0], argv[1], argv[2], argv[3]
 
-    a = json.load(open(row_path, encoding="utf-8"))
-    b = json.load(open(jvm_path, encoding="utf-8"))
-    ra = a["timing"]["median_s"]
-    rb = b["timing"]["median_s"]
+    pure = json.load(open(pure_path, encoding="utf-8"))
+    native = json.load(open(native_path, encoding="utf-8"))
+    jvm = json.load(open(jvm_path, encoding="utf-8"))
 
-    print("=" * 68)
-    print(f"RESULT   rows={a['rows']:,}   candidate_pairs={a['candidate_pairs']:,}")
-    print("=" * 68)
-    for name, r in (("row_python", a["timing"]), ("batched_jvm", b["timing"])):
-        print(
-            f"  {name:14} median {r['median_s']:8.3f}s   "
-            f"(min {r['min_s']:.3f} max {r['max_s']:.3f})   "
-            f"rows_out={r['rows_out']:,}"
-        )
-
-    ratio = (ra / rb) if rb else None
-    print()
-    if ratio is None:
-        print("  INCONCLUSIVE: batched_jvm reported zero elapsed time.")
-    else:
-        print(f"  batched_jvm is {ratio:.2f}x the row_python path")
-        print()
-        if ratio < 1.2:
-            print("  The Python-worker hop is NOT where the time goes. J2's JNI")
-            print("  work should be re-justified on grounds other than throughput")
-            print("  -- the one-kernel and no-Python-on-executors arguments still")
-            print("  stand, the speed one does not.")
-        else:
-            print("  The Python-worker hop dominates. Removing the interpreter as")
-            print("  well as the hop (J2, JNI into score-cabi) is worth building.")
+    print("=" * 70)
+    print(f"RESULT   rows={pure['rows']:,}   "
+          f"candidate_pairs={pure['candidate_pairs']:,}")
+    print("=" * 70)
+    arms = [
+        ("row_python (pure)", pure),
+        ("row_python (NATIVE)", native),
+        ("batched_jvm (exact)", jvm),
+    ]
+    for name, a in arms:
+        r = a["timing"]
+        res = a.get("native_resolved")
+        tag = "" if res is None else f"  native_resolved={res}"
+        print(f"  {name:22} median {r['median_s']:8.3f}s   "
+              f"(min {r['min_s']:.3f} max {r['max_s']:.3f})   "
+              f"rows_out={r['rows_out']:,}{tag}")
 
     print()
-    print("  CAVEAT, load-bearing: batched_jvm scores `exact` while row_python")
-    print("  scores jaro_winkler, because the J0 jar carries no algorithms of its")
-    print("  own. This measures the CALLING MECHANISM, not the kernels -- and it")
-    print("  flatters batched_jvm LEAST, since `exact` does almost no work and")
-    print("  leaves per-call overhead as the whole signal. Like-for-like needs J2.")
+    # THE claim in spec section 1, finally measured: what does the Rust kernel
+    # buy over the pure floor, holding everything else identical?
+    rp, rn = pure["timing"]["median_s"], native["timing"]["median_s"]
+    if not native.get("native_resolved"):
+        print("  WARNING: the native arm did NOT resolve to the Rust kernel.")
+        print("  The wheel is missing from the driver or, more likely, from the")
+        print("  SHIPPED EXECUTOR ENV -- the UDF runs there. Treat the two")
+        print("  row_python numbers as the same measurement taken twice.")
+    elif rn:
+        print(f"  Rust kernel vs pure floor: {rp / rn:.2f}x")
+        print("  (same UDF, same plan, same worker -- only the kernel differs,")
+        print("   so this is the section-1 differentiator on its own.)")
+
+    rj = jvm["timing"]["median_s"]
+    if rj:
+        print(f"  batched_jvm vs pure row_python: {rp / rj:.2f}x")
+    print()
+    print("  CAVEAT, load-bearing: batched_jvm scores `exact` while both")
+    print("  row_python arms score jaro_winkler, because the J0 jar carries no")
+    print("  algorithms of its own. The JVM comparison is CALLING MECHANISM only")
+    print("  and flatters the JVM arm; like-for-like needs J2. The pure-vs-native")
+    print("  comparison above has no such caveat -- it is the same code path")
+    print("  twice with one flag changed.")
 
     with open(out_path, "w", encoding="utf-8") as fh:
-        json.dump({"row_python": a, "batched_jvm": b, "ratio": ratio}, fh, indent=2)
-    print(f"\nwrote {out_path}")
+        json.dump(
+            {
+                "row_python_pure": pure,
+                "row_python_native": native,
+                "batched_jvm": jvm,
+                "native_speedup": (rp / rn) if rn else None,
+                "jvm_vs_pure": (rp / rj) if rj else None,
+            },
+            fh,
+            indent=2,
+        )
+    print("wrote " + out_path)
     return 0
 
 

--- a/scripts/bench_spark_scoring.py
+++ b/scripts/bench_spark_scoring.py
@@ -140,6 +140,14 @@ def main(argv=None) -> int:
     ap.add_argument("--repeats", type=int, default=3)
     ap.add_argument("--out", default="spark-scoring-bench.json")
     ap.add_argument(
+        "--native",
+        choices=["0", "1"],
+        default="0",
+        help="GOLDENMATCH_NATIVE for this arm. The Rust kernel runs ON THE "
+             "EXECUTOR, so the shipped env must also carry the wheel -- setting "
+             "this on the driver alone changes nothing.",
+    )
+    ap.add_argument(
         "--path",
         choices=["row_python", "batched_jvm"],
         required=True,
@@ -147,6 +155,11 @@ def main(argv=None) -> int:
              "one session let the first arm's residue OOM the second.",
     )
     args = ap.parse_args(argv)
+
+    # Set BEFORE goldenmatch.spark.scorers is imported anywhere: the loader
+    # reads the flag when it resolves the component, and an import that already
+    # happened would have resolved it under the old value.
+    os.environ["GOLDENMATCH_NATIVE"] = args.native
 
     from goldenmatch.spark.jvm import JvmScorerUnavailable, find_jar, install
     from pyspark.sql import SparkSession
@@ -193,6 +206,7 @@ def main(argv=None) -> int:
         "repeats": args.repeats,
         "remote": remote,
         "path": args.path,
+        "native": args.native,
     }
 
     if args.path == "row_python":
@@ -208,6 +222,20 @@ def main(argv=None) -> int:
         print("[batched_jvm] array UDF, in the executor JVM", flush=True)
         results["timing"] = _time(lambda: _batched_jvm(spark, df, udf_name),
                                   repeats=args.repeats)
+
+    # Report what the kernel ACTUALLY resolved to, not what was asked for. A
+    # missing wheel silently yields the pure floor, and a bench that reports the
+    # requested flag rather than the resolved one would label pure-Python
+    # numbers as native -- which is exactly how this harness misreported its
+    # first result.
+    try:
+        from goldenmatch.core._native_loader import native_enabled
+
+        results["native_resolved"] = bool(native_enabled("sail_scoring"))
+    except Exception:  # noqa: BLE001
+        results["native_resolved"] = False
+    print(f"  native requested={args.native} resolved={results['native_resolved']}",
+          flush=True)
 
     r = results["timing"]
     print(


### PR DESCRIPTION
The bench set `GOLDENMATCH_NATIVE=0` **and** excluded `goldenmatch-native` from the install, so **both arms ran with the Rust kernel disabled**: `row_python` took the pure-Python `core.strsim` floor, `batched_jvm` did Java string equality.

The kernel never ran. I then reported **1.938s** as *"the number this arc has never had"* while the thing the arc is about was switched off.

Spec §1 claims *"vectorized Rust executing over Arrow batches beats Spark SQL per core"*. The bench as written **could not measure that at all**.

## What changes

A third arm: `row_python` with the native kernel **on**. Same UDF, same plan, same worker — only the kernel differs, so the pure-vs-native ratio **is** the §1 differentiator on its own, with none of the caveats the JVM comparison carries.

The wheel is installed on the driver **and into the shipped executor env** (`goldenmatch[native]`). That second one is the trap: the scorer UDF runs on the *executor*, so `GOLDENMATCH_NATIVE=1` on the driver alone changes nothing and the worker still takes the pure floor.

The bench now reports what the kernel **resolved** to (`native_enabled`), not what was requested, and the comparison **warns loudly** when a native arm didn't resolve. A missing wheel silently yields the pure floor — precisely how this harness mislabelled its first result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ