### PR TITLE
fix(block-analyzer): measure recall against the pairs the scorer would match

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2358,9 +2358,13 @@
           "defines": [
             "BlockingSuggestion",
             "_apply_candidate_transforms",
+            "_build_recall_target",
             "_mean_token_count",
+            "_retention",
             "_score_token_candidate",
             "_single_column_candidates",
+            "_target_pairs_from_matchkey",
+            "_target_pairs_from_similarity",
             "_token_candidates",
             "_token_candidates_enabled",
             "_token_index",
@@ -2377,6 +2381,7 @@
             "goldenmatch.config.schemas",
             "goldenmatch.core",
             "goldenmatch.core.frame",
+            "goldenmatch.core.scorer",
             "goldenmatch.core.token_blocker"
           ]
         },

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -62,6 +62,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   default stays off until the benchmark says otherwise.
 
 ### Fixed
+- **Blocking-candidate recall is measured against the pairs the scorer would
+  match, and for every candidate (#2513).** Three defects in `estimate_recall` /
+  `analyze_blocking`, all in how the recall number was produced and consumed.
+
+  1. *Wrong denominator.* Candidates were scored against pairs whose
+     Jaro-Winkler similarity on the highest-cardinality matchkey column was
+     `>= 0.7`. On Amazon-Google that population is 98.5% non-duplicates (2,355
+     sample pairs, 35 truly matching), so a candidate was judged largely on how
+     many NON-matches it co-blocked — a specificity penalty reported as recall,
+     and worst for the most discriminative candidate. `analyze_blocking` now
+     accepts the weighted `matchkey` the pipeline will score with and takes the
+     target set from `find_fuzzy_matches`, the one authoritative pair scorer.
+     Blocking is accountable for retaining what the scorer would match, so that
+     is the right denominator. Estimated vs true pair recall on Amazon-Google:
+     `tokens(title, df<=10)` 26.0% → 68.7% (true 65.9%), `df<=25` 46.1% → 87.3%
+     (87.6%), `df<=50` 73.6% → 96.8% (95.3%). Callers with only column names
+     (CLI / MCP / A2A) keep the old proxy, now documented as the weak fallback
+     it is.
+  2. *A sentinel used as a value.* Recall was measured only for the top 10 by
+     score; the rest were assigned `0.0` meaning "unmeasured" — then multiplied
+     into the rank, making them unselectable however good they were. On
+     Amazon-Google that zeroed `tokens(title, df<=100)`, the candidate with the
+     highest true pair recall of any generated (98.2%). Every candidate is
+     measured now, the placeholder is gone, and the two-tier sort that existed
+     to contain it collapses to one. A measurement failure fails open to `1.0`
+     (rank on score alone) rather than to `0.0`.
+  3. *Repeated work.* The sample is seeded, so all ten measured candidates saw
+     an identical pair population — and rebuilt it from scratch each time. The
+     target is now built once. `analyze_blocking` on Amazon-Google: **195.9s →
+     1.6s**, while measuring 53 candidates instead of 10.
+
+  Net effect on the shipped ranking: the top suggestion changes from
+  `tokens(title, df<=25)` to `tokens(title, df<=10)`, which measures F1 0.1697
+  end-to-end against 0.0864 for the previous pick.
 - **Bucket routing no longer bypasses the blocking-expressibility gate (#2488).**
   The bucket scorer derives FIELD-based block keys from `blocking.keys` /
   `blocking.passes`; a guard kept strategies with no field keys (lsh / ann /

--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -6,6 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 from itertools import combinations
+from typing import Any
 
 from goldenmatch._polars_lazy import pl
 
@@ -501,90 +502,161 @@ def check_coverage(candidate: dict, matchkey_columns: list[str]) -> bool:
 # ── Recall estimation ────────────────────────────────────────────────────────
 
 
-def estimate_recall(
-    df: pl.DataFrame,
-    candidate: dict,
-    matchkey_columns: list[str],
-    sample_size: int = 1000,
-) -> float:
-    """Estimate recall for a blocking candidate using pair sampling.
+def _target_pairs_from_matchkey(sample_frame: Any, matchkey: Any) -> set[tuple[int, int]]:
+    """Pairs the CONFIGURED matchkey would emit above its threshold (#2513).
 
-    Takes a random sample, finds fuzzy-similar pairs via JaroWinkler on the
-    highest-cardinality matchkey column, then checks what fraction would land
-    in the same block under this candidate.
+    This is the right denominator for blocking recall. Blocking's job is not to
+    find true duplicates -- that is the scorer's job -- it is to avoid losing
+    pairs the scorer would have matched. So "what fraction of the pairs the
+    matchkey emits does this candidate retain?" is the question, and anything
+    the scorer would reject anyway is not blocking's failure to retain.
+
+    Reuses ``find_fuzzy_matches``, the one authoritative pair scorer, rather
+    than rebuilding a second scoring path here (which would also have to
+    reimplement composite scorers like ``ensemble`` that the NxN matrix helper
+    does not expose).
+
+    Row ids are positional into ``sample_frame`` so callers can index parallel
+    per-row lists directly.
+    """
+    from goldenmatch.core.scorer import find_fuzzy_matches
+
+    height = sample_frame.height
+    block = sample_frame.native.with_columns(
+        pl.Series("__row_id__", list(range(height)), dtype=pl.Int64)
+    )
+    emitted = find_fuzzy_matches(block, matchkey)
+    return {(min(a, b), max(a, b)) for a, b, _ in emitted}
+
+
+def _target_pairs_from_similarity(
+    sample_frame: Any, matchkey_columns: list[str]
+) -> set[tuple[int, int]]:
+    """Fallback denominator when no weighted matchkey is available.
+
+    Character similarity on the highest-cardinality matchkey column. Retained
+    only for callers that have column names but no matchkey (CLI / MCP / A2A
+    entry points). It is a WEAK proxy -- on Amazon-Google, JW >= 0.7 selects
+    2,355 sample pairs of which 35 are true matches (1.5% precision), so a
+    candidate is judged largely on how many NON-matches it co-blocks. Prefer
+    passing a matchkey; see `_target_pairs_from_matchkey`.
     """
     from goldenmatch.core import strsim
 
-    n = len(df)
-    if n < 2:
-        return 0.0
-
-    from goldenmatch.core.frame import to_frame
-
-    actual_sample = min(sample_size, n)
-    sample_frame = to_frame(df).sample(actual_sample, seed=42)
-
-    # Pick highest-cardinality matchkey column
     valid_cols = [c for c in matchkey_columns if c in sample_frame.columns]
     if not valid_cols:
-        return 0.0
-
+        return set()
     best_col = max(valid_cols, key=lambda c: sample_frame.column(c).n_unique())
-
-    # Prepare string values for cdist
-    values = (
-        sample_frame.column(best_col)
-        .cast_str()
-        .fill_null("")
-        .to_list()
-    )
-    values = [str(v).lower().strip() for v in values]
-
-    # Compute pairwise JaroWinkler scores
+    values = [
+        str(v).lower().strip()
+        for v in sample_frame.column(best_col).cast_str().fill_null("").to_list()
+    ]
     scores = strsim.pure_field_matrix(values, "jaro_winkler")
+    height = sample_frame.height
+    return {
+        (i, j)
+        for i in range(height)
+        for j in range(i + 1, height)
+        if scores[i][j] >= 0.7
+    }
 
-    # Find pairs above threshold (upper triangle only)
-    threshold = 0.7
-    pairs_above = set()
-    for i in range(actual_sample):
-        for j in range(i + 1, actual_sample):
-            if scores[i][j] >= threshold:
-                pairs_above.add((i, j))
 
-    if not pairs_above:
-        return 1.0  # No pairs to miss
+def _build_recall_target(
+    df: pl.DataFrame,
+    matchkey_columns: list[str],
+    sample_size: int,
+    matchkey: Any = None,
+) -> tuple[Any, set[tuple[int, int]]]:
+    """The fixed sample and the pairs blocking must not lose, computed ONCE.
 
-    # Apply candidate transforms to sample and get block keys. The helper
-    # returns a seam Frame (not a raw frame), so read the column through the
-    # seam -- a raw `["__block_key__"]` subscript raises on the arrow-native
-    # lane ('PolarsFrame'/'ArrowFrame' object is not subscriptable).
+    Hoisted out of the per-candidate loop deliberately (#2513): the sample is
+    seeded, so every candidate saw an identical population and the analyzer
+    rebuilt it from scratch each time. On Amazon-Google that was ~19.6s of
+    O(n^2) work repeated for all ten measured candidates -- essentially the
+    whole 196s runtime of `analyze_blocking`.
+    """
+    from goldenmatch.core.frame import to_frame
+
+    actual_sample = min(sample_size, len(df))
+    sample_frame = to_frame(df).sample(actual_sample, seed=42)
+
+    if matchkey is not None:
+        try:
+            return sample_frame, _target_pairs_from_matchkey(sample_frame, matchkey)
+        except Exception:
+            logger.warning(
+                "Recall target: scoring the sample with matchkey %r failed; falling "
+                "back to the character-similarity proxy",
+                getattr(matchkey, "name", "?"), exc_info=True,
+            )
+    return sample_frame, _target_pairs_from_similarity(sample_frame, matchkey_columns)
+
+
+def _retention(
+    sample_frame: Any, candidate: dict, target_pairs: set[tuple[int, int]]
+) -> float:
+    """Fraction of ``target_pairs`` this candidate keeps in a shared block."""
+    from goldenmatch.core.frame import to_frame
+
+    if not target_pairs:
+        return 1.0  # nothing to lose
+
+    height = sample_frame.height
     if candidate.get("kind") == "token":
         # Token blocking is multi-key: a pair is retained when it shares AT
         # LEAST ONE surviving token, so membership is a set-intersection test
-        # rather than a key equality. Built on the sample, so the DF cap is
-        # resolved against the sample size the same way scoring did.
+        # rather than a key equality.
         index, _ = _token_index(sample_frame.native, candidate)
-        row_tokens: list[set[str]] = [set() for _ in range(actual_sample)]
+        row_tokens: list[set[str]] = [set() for _ in range(height)]
         for token, members in index.items():
             if len(members) < 2:
                 continue
             for r in members:
                 row_tokens[r].add(token)
-        pairs_in_same_block = sum(
-            1 for i, j in pairs_above if row_tokens[i] & row_tokens[j]
-        )
-        return pairs_in_same_block / len(pairs_above)
+        kept = sum(1 for i, j in target_pairs if row_tokens[i] & row_tokens[j])
+        return kept / len(target_pairs)
 
+    # `_apply_candidate_transforms` returns a seam Frame (not a raw frame), so
+    # read the column through the seam -- a raw `["__block_key__"]` subscript
+    # raises on the arrow-native lane ('PolarsFrame' object is not subscriptable).
     sample_with_key = _apply_candidate_transforms(sample_frame.native, candidate)
     block_keys = to_frame(sample_with_key).column("__block_key__").to_list()
-
-    # Check how many pairs share the same block key
-    pairs_in_same_block = sum(
-        1 for i, j in pairs_above
+    kept = sum(
+        1 for i, j in target_pairs
         if block_keys[i] is not None and block_keys[i] == block_keys[j]
     )
+    return kept / len(target_pairs)
 
-    return pairs_in_same_block / len(pairs_above)
+
+def estimate_recall(
+    df: pl.DataFrame,
+    candidate: dict,
+    matchkey_columns: list[str],
+    sample_size: int = 1000,
+    matchkey: Any = None,
+) -> float:
+    """Estimate what fraction of matchable pairs a blocking candidate retains.
+
+    Takes a seeded sample, builds the set of pairs blocking must not lose, then
+    checks how many of them this candidate co-blocks.
+
+    When ``matchkey`` is supplied the target set is the pairs that matchkey
+    actually emits -- the correct denominator, since blocking is accountable
+    for retaining what the scorer would match and nothing else. Without one it
+    falls back to a character-similarity proxy that is substantially weaker;
+    see `_target_pairs_from_similarity`.
+
+    Single-candidate entry point. `analyze_blocking` builds the target once and
+    calls `_retention` directly, so it does not pay for this per candidate.
+    """
+    if len(df) < 2:
+        return 0.0
+    sample_frame, target = _build_recall_target(
+        df, matchkey_columns, sample_size, matchkey
+    )
+    if not target and not matchkey_columns:
+        return 0.0
+    return _retention(sample_frame, candidate, target)
 
 
 # ── BlockingSuggestion ───────────────────────────────────────────────────────
@@ -623,8 +695,15 @@ def analyze_blocking(
     matchkey_columns: list[str],
     sample_size: int = 1000,
     target_block_size: int = 5000,
+    matchkey: Any = None,
 ) -> list[BlockingSuggestion]:
     """Analyze data and return ranked blocking strategy suggestions.
+
+    ``matchkey`` (optional, #2513) is the weighted matchkey the pipeline will
+    score with. Supplying it makes recall estimation measure the right thing --
+    what fraction of the pairs that matchkey emits each candidate retains --
+    instead of a character-similarity stand-in for "duplicate". Callers that
+    only have column names may omit it and get the weaker proxy.
 
     Pipeline:
     1. Generate candidates from matchkey_columns
@@ -664,23 +743,32 @@ def analyze_blocking(
     if not scored:
         return []
 
-    # Sort by score descending to pick top candidates for recall estimation
+    # Sort by score descending -- the tie-break for equal score*recall below.
     scored.sort(key=lambda x: x[1]["score"], reverse=True)
 
-    # Estimate recall for top 10
-    top_n = min(10, len(scored))
-    for i in range(top_n):
-        cand, metrics = scored[i]
+    # #2513: build the target pair set ONCE, then measure EVERY candidate
+    # against it. Previously only the top 10 by score were measured and the
+    # rest were assigned 0.0 as an "unmeasured" placeholder -- but 0.0 is also
+    # a real recall value, and it was multiplied into the rank, so an unmeasured
+    # candidate could never be selected however good it was. On Amazon-Google
+    # that zeroed `tokens(title, df<=100)`, which had the HIGHEST true pair
+    # recall of every candidate generated (98.2%).
+    sample_frame, target_pairs = _build_recall_target(
+        df, matchkey_columns, sample_size, matchkey
+    )
+    for cand, metrics in scored:
         try:
-            recall = estimate_recall(df, cand, matchkey_columns, sample_size=sample_size)
+            metrics["estimated_recall"] = _retention(sample_frame, cand, target_pairs)
         except Exception:
-            logger.warning(f"Recall estimation failed for {cand['description']}", exc_info=True)
-            recall = 0.0
-        metrics["estimated_recall"] = recall
-
-    # For the rest, set recall to 0.0
-    for i in range(top_n, len(scored)):
-        scored[i][1]["estimated_recall"] = 0.0
+            # Fail-open to 1.0, NOT 0.0: a measurement failure must not be
+            # indistinguishable from a measured "retains nothing", which is
+            # exactly the confusion the placeholder above caused. Leaving the
+            # candidate ranked on `score` alone is the neutral outcome.
+            logger.warning(
+                "Recall estimation failed for %s; ranking it on score alone",
+                cand["description"], exc_info=True,
+            )
+            metrics["estimated_recall"] = 1.0
 
     # Build suggestions with coverage-based ranking
     suggestions = []
@@ -700,27 +788,22 @@ def analyze_blocking(
             description=cand["description"],
         ))
 
-    # #2488: rank the MEASURED candidates by score x recall.
+    # #2488: rank by score x recall.
     #
     # `estimated_recall` was computed here and then thrown away -- the only
     # thing multiplying the score was `recall_bonus`, which is
     # `check_coverage`'s field-membership flag (are the key's columns matchkey
     # columns?) and has nothing to do with how many true pairs the key retains.
     # So the analyzer measured recall, logged it, and ranked as if it hadn't.
-    # On Amazon-Google every candidate estimates 0.05-0.07 recall and the top
-    # one was picked purely on selectivity.
     #
-    # Two tiers, deliberately: recall is only MEASURED for the top `top_n`, so
-    # multiplying it into every score would rank an unmeasured candidate
-    # (placeholder 0.0) as if it were known-useless, and would push measured
-    # candidates below unmeasured ones whenever recall < 1. `suggestions` is
-    # built in `scored` order and `scored` is sorted by raw score, so the first
-    # `top_n` are exactly the measured ones. They keep that block and are
-    # reordered within it; the unmeasured tail stays behind them in score order,
-    # exactly where it already was.
-    measured, unmeasured = suggestions[:top_n], suggestions[top_n:]
-    measured.sort(key=lambda s: (s.score * s.estimated_recall, s.score), reverse=True)
-    suggestions = measured + unmeasured
+    # #2513: this was a two-tier sort while recall was measured only for the top
+    # 10 -- the tail carried a 0.0 placeholder that would have zeroed its rank.
+    # Every candidate is measured now, so the tiers are gone and one sort covers
+    # the list. `score` stays as the tie-break, and it still carries the
+    # tractability half of the trade-off (a key that retains everything by
+    # putting everything in one block scores badly on comparison count), so
+    # ranking is not a race to maximise recall alone.
+    suggestions.sort(key=lambda s: (s.score * s.estimated_recall, s.score), reverse=True)
 
     if suggestions and suggestions[0].estimated_recall < _LOW_RECALL_WARN:
         # Not a hard reject. On a frame where EVERY candidate is below the floor

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1785,7 +1785,14 @@ def _run_auto_suggest(df: pl.DataFrame, config: GoldenMatchConfig) -> None:
     if not matchkey_columns:
         return
 
-    suggestions = analyze_blocking(df, matchkey_columns)
+    # #2513: hand the analyzer the matchkey the pipeline will actually score
+    # with, so recall is measured against the pairs that matchkey emits rather
+    # than a character-similarity stand-in for "duplicate". First weighted
+    # matchkey -- the fallback proxy still applies if there isn't one.
+    _scoring_mk = next(
+        (m for m in config.get_matchkeys() if m.type == "weighted"), None
+    )
+    suggestions = analyze_blocking(df, matchkey_columns, matchkey=_scoring_mk)
     if not suggestions:
         logger.info("Auto-suggest: no blocking suggestions found")
         return

--- a/packages/python/goldenmatch/tests/test_block_analyzer.py
+++ b/packages/python/goldenmatch/tests/test_block_analyzer.py
@@ -204,9 +204,13 @@ class TestAnalyzeBlocking:
         suggestions = analyze_blocking(df, ["last_name", "state", "zip"], sample_size=200)
         assert len(suggestions) > 0
         assert all(isinstance(s, BlockingSuggestion) for s in suggestions)
-        # Should be sorted by score (descending)
-        for i in range(len(suggestions) - 1):
-            assert suggestions[i].score >= suggestions[i + 1].score
+        # Sorted by score x estimated_recall descending, with raw score as the
+        # tie-break -- the ranking key #2488 introduced. (This asserted plain
+        # score order until #2513; that held only because recall was measured
+        # for the top 10 alone and the tail kept its score ordering, so a
+        # high-recall/low-score candidate never got to overtake.)
+        keys = [(s.score * s.estimated_recall, s.score) for s in suggestions]
+        assert keys == sorted(keys, reverse=True)
 
     def test_suggestion_fields(self):
         import random

--- a/packages/python/goldenmatch/tests/test_block_analyzer_recall_2488.py
+++ b/packages/python/goldenmatch/tests/test_block_analyzer_recall_2488.py
@@ -26,10 +26,12 @@ from goldenmatch.core.block_analyzer import (
     score_candidate,
 )
 
-#: `analyze_blocking` resolves `estimate_recall` from its own module at call
-#: time, so tests stub it there. Addressed by string rather than by importing
+#: `analyze_blocking` builds the recall target ONCE and then measures each
+#: candidate with `_retention` (#2513 -- it used to call `estimate_recall` per
+#: candidate, which rebuilt the same seeded pair population every time). Tests
+#: stub the per-candidate seam. Addressed by string rather than by importing
 #: the module a second time -- one import style per module in this file.
-_ESTIMATE_RECALL = "goldenmatch.core.block_analyzer.estimate_recall"
+_RETENTION = "goldenmatch.core.block_analyzer._retention"
 
 
 def _cand(fields, transforms, desc="c"):
@@ -101,8 +103,8 @@ class TestMeasuredRecallRanksTheSuggestions:
         # Make recall the only thing that differs meaningfully.
         recalls = {"a": 0.9, "b": 0.1}
         monkeypatch.setattr(
-            _ESTIMATE_RECALL,
-            lambda d, cand, cols, sample_size=1000: recalls.get(cand["key_fields"][0], 0.5),
+            _RETENTION,
+            lambda frame, cand, pairs: recalls.get(cand["key_fields"][0], 0.5),
         )
         sugs = analyze_blocking(df, ["a", "b"])
         assert sugs
@@ -112,32 +114,70 @@ class TestMeasuredRecallRanksTheSuggestions:
             "a high-recall candidate should outrank a low-recall one"
         )
 
-    def test_the_unmeasured_tail_stays_behind_the_measured_block(self, monkeypatch):
-        """Recall is only estimated for the top N. Multiplying a placeholder 0.0
-        into the tail would rank unmeasured candidates as known-useless, and
-        multiplying anywhere would push measured candidates below unmeasured
-        ones whenever recall < 1. Tiering avoids both."""
-        monkeypatch.setattr(_ESTIMATE_RECALL,
-                            lambda d, cand, cols, sample_size=1000: 0.4)
+    def test_every_candidate_is_measured(self, monkeypatch):
+        """#2513 replaced the two-tier sort. Recall used to be measured only for
+        the top 10 by score, with 0.0 standing in for "unmeasured" on the tail --
+        but 0.0 is also a real recall, and it was multiplied into the rank, so a
+        tail candidate could never be selected however good it was. Tiering kept
+        that placeholder from doing damage; measuring everything removes the
+        need for it. No suggestion may carry an unmeasured placeholder."""
+        seen: list[str] = []
+
+        def _spy(frame, cand, pairs):
+            seen.append(cand["description"])
+            return 0.4
+
+        monkeypatch.setattr(_RETENTION, _spy)
         df = pl.DataFrame({c: [f"{c}{i}" for i in range(40)] for c in "abcd"})
         sugs = analyze_blocking(df, list("abcd"))
-        measured = [s for s in sugs if s.estimated_recall > 0.0]
-        assert measured, "expected some candidates to have measured recall"
-        # every measured suggestion precedes every unmeasured one
-        last_measured = max(i for i, s in enumerate(sugs) if s.estimated_recall > 0.0)
-        first_unmeasured = min(
-            (i for i, s in enumerate(sugs) if s.estimated_recall == 0.0),
-            default=len(sugs),
+        assert len(sugs) > 10, "need more than one tier's worth to be meaningful"
+        assert len(seen) == len(sugs), (
+            f"measured {len(seen)} candidates but returned {len(sugs)} suggestions"
         )
-        assert last_measured < first_unmeasured
+        assert all(s.estimated_recall == 0.4 for s in sugs), (
+            "some suggestion carries a placeholder rather than its measured recall"
+        )
+
+    def test_a_low_score_candidate_can_win_on_recall(self, monkeypatch):
+        """THE #2513 REGRESSION. On Amazon-Google the candidate with the highest
+        true pair recall of any generated (`tokens(title, df<=100)`, 98.2%) fell
+        outside the top 10 by score, was assigned the 0.0 placeholder, and so
+        had rank value `score * 0 == 0` -- unselectable by construction."""
+        df = pl.DataFrame({c: [f"{c}{i % 20}" for i in range(40)] for c in "abcd"})
+        baseline = analyze_blocking(df, list("abcd"))
+        assert len(baseline) > 10
+        # Pick a candidate the score-ordered pass puts well into the tail.
+        tail_desc = baseline[-1].description
+
+        monkeypatch.setattr(
+            _RETENTION,
+            lambda frame, cand, pairs: 1.0 if cand["description"] == tail_desc else 0.01,
+        )
+        sugs = analyze_blocking(df, list("abcd"))
+        assert sugs[0].description == tail_desc, (
+            f"{tail_desc!r} has by far the best recall but ranked "
+            f"{[s.description for s in sugs].index(tail_desc)}"
+        )
+
+    def test_measurement_failure_does_not_read_as_zero_recall(self, monkeypatch):
+        """The same confusion in its other form: if measuring a candidate raises,
+        it must not be recorded as "retains nothing". Fail open and let `score`
+        rank it, rather than silently removing it from contention."""
+        def _boom(frame, cand, pairs):
+            raise RuntimeError("scorer exploded")
+
+        monkeypatch.setattr(_RETENTION, _boom)
+        df = pl.DataFrame({"a": [f"a{i % 10}" for i in range(30)]})
+        sugs = analyze_blocking(df, ["a"])
+        assert sugs, "a measurement failure must not empty the suggestion list"
+        assert all(s.estimated_recall == 1.0 for s in sugs)
 
     def test_low_recall_is_reported_not_silently_committed(self, monkeypatch, caplog):
         """On Amazon-Google EVERY candidate is below the floor. Hard-rejecting
         them all would leave degenerate blocking, and one mega-block is worse
         than a poor key -- so this warns rather than refuses, and the warning
         has to carry the number."""
-        monkeypatch.setattr(_ESTIMATE_RECALL,
-                            lambda d, cand, cols, sample_size=1000: 0.06)
+        monkeypatch.setattr(_RETENTION, lambda frame, cand, pairs: 0.06)
         df = pl.DataFrame({"a": [f"a{i}" for i in range(30)]})
         with caplog.at_level("WARNING"):
             sugs = analyze_blocking(df, ["a"])
@@ -146,8 +186,7 @@ class TestMeasuredRecallRanksTheSuggestions:
         assert "#2488" in caplog.text
 
     def test_no_warning_when_recall_is_healthy(self, monkeypatch, caplog):
-        monkeypatch.setattr(_ESTIMATE_RECALL,
-                            lambda d, cand, cols, sample_size=1000: 0.95)
+        monkeypatch.setattr(_RETENTION, lambda frame, cand, pairs: 0.95)
         df = pl.DataFrame({"a": [f"a{i}" for i in range(30)]})
         with caplog.at_level("WARNING"):
             analyze_blocking(df, ["a"])

--- a/packages/python/goldenmatch/tests/test_recall_target_2513.py
+++ b/packages/python/goldenmatch/tests/test_recall_target_2513.py
@@ -1,0 +1,229 @@
+"""`estimate_recall`'s denominator must be the pairs blocking is accountable for
+losing -- the ones the configured matchkey would emit (#2513).
+
+Blocking's job is not to find true duplicates; that is the scorer's job. It is
+to avoid losing pairs the scorer would have matched. The analyzer instead scored
+candidates against "pairs whose Jaro-Winkler similarity on the highest-cardinality
+matchkey column is >= 0.7", which on Amazon-Google is 98.5% non-duplicates (2,355
+sample pairs, 35 true). Candidates were therefore judged largely on how many
+NON-matches they co-blocked, and the more discriminative the candidate the worse
+it scored:
+
+    candidate                estimated   true pair recall
+    tokens(title, df<=10)        26.0%              65.9%
+    tokens(title, df<=25)        46.1%              87.6%
+    tokens(title, df<=50)        73.6%              95.3%
+    tokens(title, df<=100)        0.0% (*)          98.2%
+
+    (*) outside the top 10 by score, so never measured -- see
+        test_block_analyzer_recall_2488.py for that half.
+
+Scoring the sample with the real matchkey brings every one of those within ~3pp
+of truth, and costs less: 537 target pairs in 1.0s against 2,355 in 19.6s, and
+built once instead of once per candidate.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.block_analyzer import (
+    _build_recall_target,
+    _retention,
+    _target_pairs_from_matchkey,
+    analyze_blocking,
+    estimate_recall,
+)
+
+
+@pytest.fixture
+def df() -> pl.DataFrame:
+    """Three tight duplicate pairs plus four filler rows. The duplicates differ
+    enough that an exact key on the full string splits them; the filler rows
+    share no tokens with each other or with the pairs, so the scorer emits
+    exactly the three planted pairs and nothing else."""
+    return pl.DataFrame({
+        "name": [
+            "acme widget pro", "acme widget pro x",       # pair 0-1
+            "globex turbo drive", "globex turbo drives",  # pair 2-3
+            "initech stapler v2", "initech stapler v3",   # pair 4-5
+            "zebra", "quartz mining", "helicopter fuel", "opera house",
+        ],
+    })
+
+
+def _mk(threshold: float = 0.85) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="mk", type="weighted", threshold=threshold,
+        fields=[MatchkeyField(field="name", scorer="token_sort", weight=1.0,
+                              transforms=["lowercase", "strip"])],
+    )
+
+
+# ---- the target population ----
+
+
+def test_matchkey_target_is_the_pairs_the_scorer_emits(df: pl.DataFrame) -> None:
+    """Definitional: the denominator is what the configured matchkey matches,
+    not a stand-in for it."""
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    pairs = _target_pairs_from_matchkey(frame, _mk())
+    assert pairs, "the matchkey should emit the near-identical pairs"
+    # Every emitted pair is one of the three planted duplicates.
+    assert pairs <= {(0, 1), (2, 3), (4, 5)}
+
+
+def test_target_pairs_are_canonically_ordered(df: pl.DataFrame) -> None:
+    from goldenmatch.core.frame import to_frame
+
+    pairs = _target_pairs_from_matchkey(to_frame(df), _mk())
+    assert all(i < j for i, j in pairs)
+
+
+def test_a_stricter_threshold_yields_no_more_pairs(df: pl.DataFrame) -> None:
+    """Sanity on the wiring: the target really is threshold-driven, so raising
+    the matchkey's bar cannot admit pairs."""
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    loose = _target_pairs_from_matchkey(frame, _mk(threshold=0.5))
+    strict = _target_pairs_from_matchkey(frame, _mk(threshold=0.99))
+    assert strict <= loose
+
+
+def test_matchkey_is_preferred_over_the_similarity_proxy(df: pl.DataFrame) -> None:
+    """When a matchkey is available the target must come from it, not from the
+    fixed JW >= 0.7 proxy.
+
+    Shown with a strict matchkey, which admits fewer pairs than the proxy does.
+    The size gap on real free text is the actual defect and is far larger --
+    537 matchkey pairs against 2,355 proxy pairs on an Amazon-Google sample --
+    but a ten-row fixture of deliberately dissimilar strings cannot exhibit
+    that, so this asserts the wiring rather than the magnitude.
+    """
+    _, strict = _build_recall_target(df, ["name"], 1000, _mk(threshold=0.99))
+    _, proxy = _build_recall_target(df, ["name"], 1000, None)
+    assert len(strict) < len(proxy), (
+        "the target tracked the proxy instead of the supplied matchkey"
+    )
+
+
+def test_falls_back_to_the_proxy_when_scoring_raises(
+    df: pl.DataFrame, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fail open: a broken matchkey must degrade to the old proxy, not to an
+    empty target (which would read as "nothing to lose" -> recall 1.0 for
+    every candidate)."""
+    def _boom(frame: object, matchkey: object) -> set[tuple[int, int]]:
+        raise RuntimeError("scorer exploded")
+
+    monkeypatch.setattr(
+        "goldenmatch.core.block_analyzer._target_pairs_from_matchkey", _boom
+    )
+    with caplog.at_level("WARNING"):
+        _, pairs = _build_recall_target(df, ["name"], 1000, _mk())
+    assert pairs, "must fall back to the similarity proxy, not an empty target"
+    assert "falling back" in caplog.text
+
+
+def test_no_matchkey_columns_and_no_matchkey_gives_an_empty_target(df: pl.DataFrame) -> None:
+    _, pairs = _build_recall_target(df, ["nonexistent"], 1000, None)
+    assert pairs == set()
+
+
+# ---- retention against that population ----
+
+
+def test_a_key_that_co_blocks_the_target_pairs_scores_high(df: pl.DataFrame) -> None:
+    """`name[:6]` keeps all three planted pairs together."""
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    target = _target_pairs_from_matchkey(frame, _mk())
+    cand = {"key_fields": ["name"], "transforms": ["lowercase", "substring:0:6"],
+            "description": "name[:6]"}
+    assert _retention(frame, cand, target) == 1.0
+
+
+def test_a_key_that_splits_them_scores_low(df: pl.DataFrame) -> None:
+    """An exact key on the full string separates every planted pair, because
+    each differs by a character -- which is exactly why they needed fuzzy
+    scoring in the first place."""
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    target = _target_pairs_from_matchkey(frame, _mk())
+    cand = {"key_fields": ["name"], "transforms": ["lowercase"],
+            "description": "name"}
+    assert _retention(frame, cand, target) == 0.0
+
+
+def test_empty_target_is_full_retention_not_zero(df: pl.DataFrame) -> None:
+    """Nothing to lose is not the same as losing everything."""
+    from goldenmatch.core.frame import to_frame
+
+    cand = {"key_fields": ["name"], "transforms": ["lowercase"], "description": "name"}
+    assert _retention(to_frame(df), cand, set()) == 1.0
+
+
+# ---- the public entry point keeps working ----
+
+
+def test_estimate_recall_still_callable_without_a_matchkey(df: pl.DataFrame) -> None:
+    """CLI / MCP / A2A callers pass column names only."""
+    cand = {"key_fields": ["name"], "transforms": ["lowercase", "substring:0:6"],
+            "description": "name[:6]"}
+    r = estimate_recall(df, cand, ["name"])
+    assert 0.0 <= r <= 1.0
+
+
+def test_estimate_recall_accepts_a_matchkey(df: pl.DataFrame) -> None:
+    cand = {"key_fields": ["name"], "transforms": ["lowercase", "substring:0:6"],
+            "description": "name[:6]"}
+    assert estimate_recall(df, cand, ["name"], matchkey=_mk()) == 1.0
+
+
+def test_estimate_recall_on_a_degenerate_frame(df: pl.DataFrame) -> None:
+    cand = {"key_fields": ["name"], "transforms": ["lowercase"], "description": "name"}
+    assert estimate_recall(pl.DataFrame({"name": ["only"]}), cand, ["name"]) == 0.0
+
+
+# ---- the analyzer threads it through ----
+
+
+def test_analyze_blocking_accepts_and_uses_a_matchkey(df: pl.DataFrame, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = {}
+
+    real = _build_recall_target
+
+    def _spy(frame: pl.DataFrame, cols: list[str], sample_size: int,
+             matchkey: object = None) -> tuple[object, set[tuple[int, int]]]:
+        seen["matchkey"] = matchkey
+        return real(frame, cols, sample_size, matchkey)
+
+    monkeypatch.setattr("goldenmatch.core.block_analyzer._build_recall_target", _spy)
+    mk = _mk()
+    analyze_blocking(df, ["name"], matchkey=mk)
+    assert seen["matchkey"] is mk
+
+
+def test_the_target_is_built_once_not_per_candidate(df: pl.DataFrame, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hoist is load-bearing, not cosmetic: the sample is seeded, so every
+    candidate saw an identical population that was rebuilt from scratch each
+    time -- ~19.6s of O(n^2) work repeated ten times on Amazon-Google, which
+    was essentially the analyzer's whole 196s runtime."""
+    calls = []
+    real = _build_recall_target
+
+    def _count(frame: pl.DataFrame, cols: list[str], sample_size: int,
+               matchkey: object = None) -> tuple[object, set[tuple[int, int]]]:
+        calls.append(1)
+        return real(frame, cols, sample_size, matchkey)
+
+    monkeypatch.setattr("goldenmatch.core.block_analyzer._build_recall_target", _count)
+    sugs = analyze_blocking(df, ["name"], matchkey=_mk())
+    assert len(sugs) > 1, "need several candidates for the assertion to bite"
+    assert len(calls) == 1


### PR DESCRIPTION
## What and why

Closes #2513. Three defects in how `estimate_recall` produced its number and how `analyze_blocking` consumed it. All three are in the same family: a quantity that decides something is computed over the wrong population, or computed and then not consulted.

### 1. Wrong denominator

Candidates were scored against pairs whose Jaro-Winkler similarity on the highest-cardinality matchkey column was `>= 0.7`. On Amazon-Google that population is **98.5% non-duplicates** (2,355 sample pairs, 35 truly matching), so a candidate was judged largely on how many NON-matches it co-blocked — a specificity penalty reported as recall, worst for the most discriminative candidate.

Blocking's job is not to find true duplicates; that is the scorer's job. It is to avoid losing pairs the scorer *would* have matched. So `analyze_blocking` now takes the weighted matchkey the pipeline will score with and derives the target from `find_fuzzy_matches` — reusing the one authoritative pair scorer rather than building a second one (which would also have to reimplement composite scorers like `ensemble`, which the NxN matrix helper does not expose).

| candidate | estimated before | estimated after | true pair recall |
|---|---|---|---|
| `tokens(title, df<=10)` | 26.0% | **68.7%** | 65.9% |
| `tokens(title, df<=25)` | 46.1% | **87.3%** | 87.6% |
| `tokens(title, df<=50)` | 73.6% | **96.8%** | 95.3% |
| `tokens(title, df<=100)` | 0.0% ⁽*⁾ | **98.7%** | 98.2% |

### 2. A sentinel used as a value ⁽*⁾

Recall was measured for the top 10 by score only; the rest were assigned `0.0` meaning "unmeasured" — which was then *multiplied into the rank*, so those candidates scored exactly zero and could never be selected however good they were. That is the `df<=100` row above: the highest true pair recall of any candidate generated, unrankable by construction.

Every candidate is measured now, so the placeholder is gone and the two-tier sort that existed to contain it collapses to one. A measurement failure fails open to `1.0` (rank on score alone), never to `0.0` — the same confusion in its other form.

### 3. Repeated work

The sample is seeded, so every measured candidate saw an identical pair population and rebuilt it from scratch. Hoisting it out of the loop: `analyze_blocking` on Amazon-Google goes **195.9s → 1.6s**, while measuring 53 candidates instead of 10.

### Ranking outcome

Top suggestion moves from `tokens(title, df<=25)` to `tokens(title, df<=10)` — which measures **F1 0.1697** end-to-end against **0.0864** for the previous pick. `score` remains the other factor and still carries the tractability half of the trade-off, so this is not a race to maximise recall alone.

## Changes

- `analyze_blocking(..., matchkey=None)` — optional, threaded from `_run_auto_suggest` (first weighted matchkey).
- New internals: `_target_pairs_from_matchkey`, `_target_pairs_from_similarity` (the documented weak fallback), `_build_recall_target`, `_retention`.
- `estimate_recall` keeps its public signature; `matchkey` is an optional addition. CLI / MCP / A2A callers pass column names only and get the fallback.
- Fail-open on a matchkey scoring error: degrade to the proxy, not to an empty target (which would read as "nothing to lose" → recall 1.0 everywhere).
- New `tests/test_recall_target_2513.py` (14 tests).

## Testing

- `pytest tests/test_recall_target_2513.py` — 14 passed
- `pytest tests/ -k "block or analyze or recall or suggest or token or autoconfig"` — **1,969 passed**, 69 skipped, 2 xfailed, 1 failed
  - the one failure is `test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above`, which I confirmed fails identically on clean `main` with these changes stashed — pre-existing, unrelated to blocking, and one of the known local-only failures
- `pytest scripts/test_config_matrix.py test_agent_codemap.py test_docs_sections.py test_api_surface.py` — 64 passed (`test_agent_codemap` failed first; fixed by the regen in this PR)
- `pyright --pythonpath .venv/bin/python` on all changed files — 0 errors
- `ruff check` on all changed files — clean

## Two existing tests updated deliberately

Not loosened — the design they asserted is the design this PR removes:

- `test_the_unmeasured_tail_stays_behind_the_measured_block` → `test_every_candidate_is_measured`. Tiering existed only to stop the `0.0` placeholder doing damage; measuring everything removes the need for it. Added `test_a_low_score_candidate_can_win_on_recall` as the direct regression, plus `test_measurement_failure_does_not_read_as_zero_recall`.
- `test_returns_ranked_suggestions` asserted plain `score` ordering. The documented ranking key has been `score × estimated_recall` since #2488; the old assertion only held because recall was measured for the top 10 alone and the tail kept its score ordering, so a high-recall/low-score candidate never got to overtake. It now asserts the actual key.

These tests stub `_retention` rather than `estimate_recall`, since `analyze_blocking` no longer routes per-candidate through the latter — that is what the hoist means.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — **not run: `pre-commit` is not installed in this environment.** `ruff` (its main hook) passes on the changed files.
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated — n/a, no workflow or gotcha changed

## Not in this PR

The DF cap on token candidates is absolute, so `tokens(title, df<=10)` means something different on a 1,000-row sample than on the full frame. I expected to have to fix that too, but with the denominator corrected the sample-based estimate lands within ~3pp of full-frame truth across every cap, so it is not currently costing accuracy. Left alone rather than changed speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_