### PR TITLE
feat(spark): J2 -- run the Rust kernel inside the executor JVM (JNI)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -902,6 +902,17 @@ spark:
   # lane, so a Java edit that never triggered that lane would ship untested --
   # the same staleness the P2 rename introduced, one language over.
   - 'packages/jvm/**'
+  # J2: the jar carries the Rust kernel, reached through score-jni -> score-cabi
+  # -> score-core. The lane BUILDS all three, and the cross-language parity gate
+  # (test_spark_jvm_native_parity.py) is the only place a divergence between the
+  # JVM's score and Python's would surface. A kernel edit that skipped this lane
+  # would ship a jar nothing had compared against.
+  - 'packages/rust/extensions/score-jni/**'
+  - 'packages/rust/extensions/score-cabi/**'
+  - 'packages/rust/extensions/score-core/**'
+  # The tier's own Python scorer is the ORACLE that gate compares against, so a
+  # change to it moves the reference the JVM is measured by.
+  - 'packages/python/goldenmatch/goldenmatch/core/strsim.py'
 action:
   - 'packages/actions/**'
 dbt:

--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -35,6 +35,14 @@ on:
         description: "Runner label"
         required: false
         default: "large-new-64GB"
+      driver_memory:
+        description: >-
+          Heap for the local[*] JVM, which IS the executor. Set EQUALLY for both
+          arms. The batched path materialises each group as an array in JVM heap,
+          so an unset ceiling (Spark's 1g default) measures a configuration
+          rather than a design -- and that is what OOM'd the JVM arm.
+        required: false
+        default: "12g"
 
 permissions:
   contents: read
@@ -64,15 +72,33 @@ jobs:
       # Same build the spark_connect lane does, and for the same reason:
       # `--release 17` so the jar runs on Spark's oldest supported JDK rather
       # than only on whatever the runner happens to have.
+      # J2: the kernel's JNI door, built BEFORE the jar because it ships inside
+      # it. Without this step the jar loads, falls back to J0's `exact`-only
+      # scorer, and this bench silently measures the wrong thing against a
+      # native row_python arm. The arm asserts on it too -- belt and braces,
+      # because a silent fallback here produces a NUMBER, and a number is
+      # believed.
+      - name: Build the native scorer library (JNI)
+        run: |
+          set -euo pipefail
+          cargo build --release \
+            --manifest-path packages/rust/extensions/score-jni/Cargo.toml
+          ls -lh packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so
+
       - name: Build the JVM scorer jar
         run: |
           set -euo pipefail
           SPARK_JARS="$(.venv/bin/python -c 'import pyspark, os; print(os.path.join(os.path.dirname(pyspark.__file__), "jars"))')"
           JVM=packages/jvm/goldenmatch-spark
-          mkdir -p "$JVM/build/classes"
-          javac --release 17 -cp "$SPARK_JARS/*" -d "$JVM/build/classes" \
+          mkdir -p "$JVM/build/classes/native/linux-x86-64"
+          javac --release 17 -encoding UTF-8 -cp "$SPARK_JARS/*" -d "$JVM/build/classes" \
             "$JVM"/src/dev/goldensuite/spark/*.java
+          cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
+            "$JVM/build/classes/native/linux-x86-64/"
           jar --create --file "$JVM/build/goldenmatch-spark.jar" -C "$JVM/build/classes" .
+          jar --list --file "$JVM/build/goldenmatch-spark.jar" \
+            | grep -qx "native/linux-x86-64/libgoldenmatch_score_jni.so" \
+            || { echo "::error::the native library is not in the jar; the JVM arm would bench the J0 fallback"; exit 1; }
 
       # P1's executor environment. The row_python path forks a Python worker,
       # which has NO access to the client's site-packages -- the first run of
@@ -89,14 +115,26 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/gmenv
           /tmp/gmenv/bin/pip install --upgrade pip
-          # pandas is not a goldenmatch dependency but `pandas_udf` needs it in
-          # the WORKER. NOT -q: a silent pip failure ships an env that unpacks
-          # fine and imports nothing.
-          /tmp/gmenv/bin/pip install ./packages/python/goldenmatch pandas pyarrow
+          # NO PANDAS. The tier's UDFs are `arrow_udf` over `pa.Array` now, so
+          # the worker needs pyarrow (goldenmatch's own hard dependency) and
+          # nothing else. This step still installed pandas after the tier stopped
+          # using it -- which would have made the row_python arm carry a
+          # dependency the shipped path does not have. NOT -q: a silent pip
+          # failure ships an env that unpacks fine and imports nothing.
+          #
+          /tmp/gmenv/bin/pip install ./packages/python/goldenmatch pyarrow
           # cd out of the repo: its root directory is itself named `goldenmatch`,
           # so a check run from here can import the source tree and pass while
           # the env is empty.
-          (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch, pandas, pyarrow; print('shipped env imports OK')")
+          (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch, pyarrow; print('shipped env imports OK')")
+          # ASSERT the Rust kernel reached the WORKER. `goldenmatch` depends on
+          # goldenmatch-native, so it arrives transitively -- but the native
+          # row_python arm is only native if the worker has it, and setting
+          # GOLDENMATCH_NATIVE on the driver alone changes nothing. Verified
+          # rather than assumed, because the arm's whole purpose evaporates
+          # silently if this is ever untrue.
+          (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch_native, goldenmatch_native._native; print('worker HAS the Rust kernel')") \
+            || { echo "::error::the shipped executor env has no goldenmatch-native; the NATIVE row_python arm would score with the pure floor and be labelled native"; exit 1; }
           .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
           ls -lh gm_env.tar.gz
 
@@ -104,6 +142,7 @@ jobs:
         if: inputs.mode == 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
           GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
@@ -121,10 +160,11 @@ jobs:
         if: inputs.mode != 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
           GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path row_python             --native 0             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 0             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
 
       # The arm that speaks to spec section 1. Without it the bench measures UDF
       # plumbing with the kernel switched off and says nothing about "vectorized
@@ -133,19 +173,21 @@ jobs:
         if: inputs.mode != 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
           GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path row_python             --native 1             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python_native.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 1             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python_native.json
 
       - name: Bench batched_jvm
         if: inputs.mode != 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
           GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path batched_jvm             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-batched_jvm.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path batched_jvm --scorer jaro_winkler --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-batched_jvm.json
 
       # A SCRIPT, not inline Python: an embedded multi-line program inside a
       # YAML `run:` block must survive block-scalar parsing too, and this repo
@@ -153,7 +195,7 @@ jobs:
       - name: Compare
         if: inputs.mode != 'diag'
         run: |
-          .venv/bin/python scripts/bench_spark_compare.py             bench-row_python.json bench-row_python_native.json \n            bench-batched_jvm.json spark-scoring-bench.json
+          .venv/bin/python scripts/bench_spark_compare.py             bench-row_python.json bench-row_python_native.json bench-batched_jvm.json spark-scoring-bench.json
 
       - name: Summary
         if: always()

--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -147,7 +147,7 @@ jobs:
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/diag_spark_batched_oom.py             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'
+          .venv/bin/python scripts/diag_spark_batched_oom.py --scorer jaro_winkler --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'
 
       # ONE ARM PER PROCESS. Both used to run in one script against one
       # `local[*]` session, where the driver and executor SHARE A JVM -- so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2977,8 +2977,86 @@ jobs:
   # kernel, which this lane deliberately does not install. That f32/f64 decision
   # guard is gated by native_wheel_drift, not here -- this lane is NOT a gate on
   # the native scorer, and promoting it does not make it one.
-  spark_connect:
+  # J3: the aarch64 half of the jar, built and SELF-TESTED on real ARM hardware.
+  #
+  # The jar carries the Rust kernel as a resource per platform, and CI built
+  # linux-x86-64 only. A Graviton cluster -- which is most of the cheap capacity
+  # on AWS now, and increasingly the default -- would have found no resource for
+  # `linux-aarch64`, fallen back to the `exact`-only J0 scorer, and kept running.
+  # Slower and narrower, silently, on the exact deployment the JVM path exists to
+  # serve. That is the silent-fallback class this repo keeps paying for.
+  #
+  # NATIVE, not cross-compiled. Cross-compiling and checking the ELF header
+  # proves the file is aarch64-shaped; it does not prove the kernel RUNS there.
+  # This repo has a live example of a binary that built and loaded fine and then
+  # parked on a futex for 190s on one specific CPU (#688). So the library is
+  # built on an ARM runner and NativeSelfTest is executed on it -- 10,000 pairs
+  # across the JNI boundary, on the architecture in question.
+  #
+  # The artifact this job tests is the artifact `spark_connect` puts in the jar.
+  # Rebuilding it there would reintroduce the way "the tested jar" and "the
+  # shipped jar" can differ, which is the reason the jar is built inside the lane
+  # that tests it in the first place.
+  #
+  # No pyspark, no uv sync: NativeSelfTest exercises the Spark-FREE classes, so
+  # this job needs a JDK, cargo and nothing else.
+  spark_jvm_aarch64:
     needs: changes
+    if: needs.changes.outputs.spark == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Build the native scorer library for aarch64
+        run: |
+          set -euo pipefail
+          cargo build --release \
+            --manifest-path packages/rust/extensions/score-jni/Cargo.toml
+          SO=packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so
+          file "$SO"
+          # Assert the machine type rather than trusting the runner label. A
+          # mislabelled runner would otherwise ship an x86 library under the
+          # aarch64 resource path -- which fails at dlopen on every ARM executor,
+          # and falls back silently.
+          readelf -h "$SO" | grep -q "AArch64" \
+            || { echo "::error::$SO is not an AArch64 object"; exit 1; }
+          nm -D --defined-only "$SO" | grep -qE "Java_dev_goldensuite_spark_NativeScorer_scorePairwiseUtf8$" \
+            || { echo "::error::the JNI entry points are not exported"; exit 1; }
+      # The whole point: RUN it here. Spark-free classes only -- the two UDF
+      # classes need a Spark classpath and nothing in this job touches Spark.
+      - name: Native scorer self-test ON aarch64
+        run: |
+          set -euo pipefail
+          JVM=packages/jvm/goldenmatch-spark
+          mkdir -p "$JVM/build/classes/native/linux-aarch64" "$JVM/build/test-classes"
+          javac --release 17 -encoding UTF-8 -d "$JVM/build/classes" \
+            "$JVM"/src/dev/goldensuite/spark/GoldenScorer.java \
+            "$JVM"/src/dev/goldensuite/spark/ExactScorer.java \
+            "$JVM"/src/dev/goldensuite/spark/SeqCoercion.java \
+            "$JVM"/src/dev/goldensuite/spark/Utf8Batch.java \
+            "$JVM"/src/dev/goldensuite/spark/NativeLibrary.java \
+            "$JVM"/src/dev/goldensuite/spark/NativeScorer.java \
+            "$JVM"/src/dev/goldensuite/spark/ScorerSelection.java
+          cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
+            "$JVM/build/classes/native/linux-aarch64/"
+          javac --release 17 -encoding UTF-8 -d "$JVM/build/test-classes" \
+            -cp "$JVM/build/classes" \
+            "$JVM"/test/dev/goldensuite/spark/NativeSelfTest.java
+          java -cp "$JVM/build/classes:$JVM/build/test-classes" \
+            dev.goldensuite.spark.NativeSelfTest
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: goldenmatch-score-jni-linux-aarch64
+          path: packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so
+          if-no-files-found: error
+          retention-days: 1
+
+  spark_connect:
+    needs: [changes, spark_jvm_aarch64]
     if: needs.changes.outputs.spark == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -3081,9 +3159,10 @@ jobs:
       # library the operator has to place on every executor would just replace
       # the packed-virtualenv apparatus this arc exists to remove.
       #
-      # `linux-x86-64` only, because that is what a Spark executor runs. The
-      # loader resolves other os/arch names already, so adding one is a build
-      # change and not a code change (J3).
+      # This step builds `linux-x86-64` -- the runner's own architecture.
+      # `linux-aarch64` is built AND self-tested on real ARM hardware by
+      # `spark_jvm_aarch64` and downloaded below, so the binary that was tested
+      # is the binary that ships (J3).
       - name: Build the native scorer library (JNI)
         run: |
           set -euo pipefail
@@ -3095,12 +3174,22 @@ jobs:
           # load and then fail on first call, inside an executor.
           nm -D --defined-only "$SO" | grep -E "Java_dev_goldensuite_spark_NativeScorer_(abiVersion|scorerIdCount|scorePairwiseUtf8)$" \
             || { echo "::error::the JNI entry points are not exported from $SO"; exit 1; }
-      - name: Build the JVM scorer jar
+      # J3: the aarch64 library, built AND self-tested on real ARM hardware by
+      # `spark_jvm_aarch64`. Downloaded rather than cross-compiled here, so the
+      # binary that was tested is the binary that ships -- rebuilding it would
+      # reintroduce exactly the "tested jar vs shipped jar" gap this lane's
+      # single-job jar build exists to close.
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: goldenmatch-score-jni-linux-aarch64
+          path: /tmp/jni-aarch64
+      - name: Build the JVM scorer jar (x86-64 + aarch64)
         run: |
           set -euo pipefail
           SPARK_JARS="$(.venv/bin/python -c 'import pyspark, os; print(os.path.join(os.path.dirname(pyspark.__file__), "jars"))')"
           JVM=packages/jvm/goldenmatch-spark
-          mkdir -p "$JVM/build/classes/native/linux-x86-64"
+          mkdir -p "$JVM/build/classes/native/linux-x86-64" \
+                   "$JVM/build/classes/native/linux-aarch64"
           # -encoding UTF-8: the sources carry multi-byte literals (the parity
           # fixtures) and javac otherwise reads them in the platform default,
           # which is not UTF-8 everywhere.
@@ -3108,15 +3197,28 @@ jobs:
             "$JVM"/src/dev/goldensuite/spark/*.java
           cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
             "$JVM/build/classes/native/linux-x86-64/"
+          cp /tmp/jni-aarch64/libgoldenmatch_score_jni.so \
+            "$JVM/build/classes/native/linux-aarch64/"
+          # Assert each library IS the architecture its resource path claims.
+          # Swapping them yields a jar that loads on neither -- dlopen fails on
+          # every executor and both platforms fall back silently.
+          readelf -h "$JVM/build/classes/native/linux-x86-64/libgoldenmatch_score_jni.so" \
+            | grep -q "X86-64" || { echo "::error::the linux-x86-64 resource is not an x86-64 object"; exit 1; }
+          readelf -h "$JVM/build/classes/native/linux-aarch64/libgoldenmatch_score_jni.so" \
+            | grep -q "AArch64" || { echo "::error::the linux-aarch64 resource is not an AArch64 object"; exit 1; }
           jar --create --file "$JVM/build/goldenmatch-spark.jar" -C "$JVM/build/classes" .
           echo "--- jar contents ---"
           jar --list --file "$JVM/build/goldenmatch-spark.jar"
-          # The jar without the library still RUNS -- it falls back to the
-          # `exact`-only scorer so a job survives -- which is exactly why its
-          # absence has to be an error here rather than a surprise later.
-          jar --list --file "$JVM/build/goldenmatch-spark.jar" \
-            | grep -qx "native/linux-x86-64/libgoldenmatch_score_jni.so" \
-            || { echo "::error::the native library is not in the jar; the tier would silently fall back to the J0 scorer"; exit 1; }
+          # The jar without a library still RUNS -- it falls back to the
+          # `exact`-only scorer so a job survives -- which is exactly why an
+          # absence has to be an error here rather than a surprise on somebody's
+          # cluster. BOTH arches: a Graviton fleet finding no aarch64 resource is
+          # precisely the failure this ships to prevent.
+          for arch in linux-x86-64 linux-aarch64; do
+            jar --list --file "$JVM/build/goldenmatch-spark.jar" \
+              | grep -qx "native/$arch/libgoldenmatch_score_jni.so" \
+              || { echo "::error::no $arch library in the jar; that platform would silently fall back to the J0 scorer"; exit 1; }
+          done
       # The Spark-free half of the jar, gated before anything ships it. No JUnit:
       # a test framework would mean a dependency resolver, and this package has
       # no build system on purpose (one small jar does not justify a fourth
@@ -4397,6 +4499,11 @@ jobs:
       # nothing about goldenmatch). `spark_connect` is the lane that speaks to
       # the product goal, and it has been green on three consecutive main runs.
       - spark_connect
+      # J3: listed DIRECTLY, not left to `spark_connect`'s `needs`. This summary
+      # treats `skipped` as a pass, and a job whose dependency FAILED is skipped
+      # -- so a broken aarch64 build would skip spark_connect and sail through
+      # here reporting nothing wrong. The jar it produces is half of what ships.
+      - spark_jvm_aarch64
       - pyright
       - version_consistency
       - readme_callouts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3050,6 +3050,7 @@ jobs:
             "$JVM"/src/dev/goldensuite/spark/NativeLibrary.java \
             "$JVM"/src/dev/goldensuite/spark/NativeScorer.java \
             "$JVM"/src/dev/goldensuite/spark/NativeFingerprint.java \
+            "$JVM"/src/dev/goldensuite/spark/NativeTransform.java \
             "$JVM"/src/dev/goldensuite/spark/ScorerSelection.java
           cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
             "$JVM/build/classes/native/linux-aarch64/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3040,6 +3040,7 @@ jobs:
             "$JVM"/src/dev/goldensuite/spark/Utf8Batch.java \
             "$JVM"/src/dev/goldensuite/spark/NativeLibrary.java \
             "$JVM"/src/dev/goldensuite/spark/NativeScorer.java \
+            "$JVM"/src/dev/goldensuite/spark/NativeFingerprint.java \
             "$JVM"/src/dev/goldensuite/spark/ScorerSelection.java
           cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
             "$JVM/build/classes/native/linux-aarch64/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1882,6 +1882,15 @@ jobs:
       # failure (a symbol that does not export, a link error) would pass the
       # tests and ship a library no host can load.
       - run: cargo build --release --manifest-path score-cabi/Cargo.toml
+      # score-jni: the JNI binding over score-cabi, so a Spark executor JVM calls
+      # the kernel directly instead of forking a Python worker per batch. Its own
+      # [workspace] again, so its own lines. Gated HERE as well as in the
+      # spark_connect lane because that lane is path-filtered: a change to
+      # score-core or score-cabi that broke this binding would otherwise not be
+      # compiled by anything until someone touched a Spark file.
+      - run: cargo test --manifest-path score-jni/Cargo.toml
+      - run: cargo clippy --manifest-path score-jni/Cargo.toml --all-targets -- -D warnings
+      - run: cargo build --release --manifest-path score-jni/Cargo.toml
       # fs-core (2026-07-17) is the pyo3-free single source of truth for the
       # Fellegi-Sunter block-scoring math (name/ensemble/tf scorers + normalize),
       # its own [workspace] path-dep of `native`. Exercised indirectly by the
@@ -3066,17 +3075,48 @@ jobs:
       # `--release 17` matters: Spark supports Java 17, 21 and 25, and the
       # runner's JDK is only one of them. Compiling without it would produce a
       # jar that runs here and fails on a 17 executor with UnsupportedClassVersionError.
+      # J2: the Rust kernel's JNI door, built BEFORE the jar because it ships
+      # INSIDE it. Riding in the jar is what keeps `addArtifact` sufficient --
+      # one file, nothing installed on the cluster, no `java.library.path`. A
+      # library the operator has to place on every executor would just replace
+      # the packed-virtualenv apparatus this arc exists to remove.
+      #
+      # `linux-x86-64` only, because that is what a Spark executor runs. The
+      # loader resolves other os/arch names already, so adding one is a build
+      # change and not a code change (J3).
+      - name: Build the native scorer library (JNI)
+        run: |
+          set -euo pipefail
+          cargo build --release \
+            --manifest-path packages/rust/extensions/score-jni/Cargo.toml
+          SO=packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so
+          ls -lh "$SO"
+          # The kernel really is in there -- a library missing the symbol would
+          # load and then fail on first call, inside an executor.
+          nm -D --defined-only "$SO" | grep -E "Java_dev_goldensuite_spark_NativeScorer_(abiVersion|scorerIdCount|scorePairwiseUtf8)$" \
+            || { echo "::error::the JNI entry points are not exported from $SO"; exit 1; }
       - name: Build the JVM scorer jar
         run: |
           set -euo pipefail
           SPARK_JARS="$(.venv/bin/python -c 'import pyspark, os; print(os.path.join(os.path.dirname(pyspark.__file__), "jars"))')"
           JVM=packages/jvm/goldenmatch-spark
-          mkdir -p "$JVM/build/classes"
-          javac --release 17 -cp "$SPARK_JARS/*" -d "$JVM/build/classes" \
+          mkdir -p "$JVM/build/classes/native/linux-x86-64"
+          # -encoding UTF-8: the sources carry multi-byte literals (the parity
+          # fixtures) and javac otherwise reads them in the platform default,
+          # which is not UTF-8 everywhere.
+          javac --release 17 -encoding UTF-8 -cp "$SPARK_JARS/*" -d "$JVM/build/classes" \
             "$JVM"/src/dev/goldensuite/spark/*.java
+          cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
+            "$JVM/build/classes/native/linux-x86-64/"
           jar --create --file "$JVM/build/goldenmatch-spark.jar" -C "$JVM/build/classes" .
           echo "--- jar contents ---"
           jar --list --file "$JVM/build/goldenmatch-spark.jar"
+          # The jar without the library still RUNS -- it falls back to the
+          # `exact`-only scorer so a job survives -- which is exactly why its
+          # absence has to be an error here rather than a surprise later.
+          jar --list --file "$JVM/build/goldenmatch-spark.jar" \
+            | grep -qx "native/linux-x86-64/libgoldenmatch_score_jni.so" \
+            || { echo "::error::the native library is not in the jar; the tier would silently fall back to the J0 scorer"; exit 1; }
       # The Spark-free half of the jar, gated before anything ships it. No JUnit:
       # a test framework would mean a dependency resolver, and this package has
       # no build system on purpose (one small jar does not justify a fourth
@@ -3085,10 +3125,24 @@ jobs:
         run: |
           set -euo pipefail
           JVM=packages/jvm/goldenmatch-spark
-          javac --release 17 -d "$JVM/build/test-classes" -cp "$JVM/build/classes" \
+          javac --release 17 -encoding UTF-8 -d "$JVM/build/test-classes" -cp "$JVM/build/classes" \
             "$JVM"/test/dev/goldensuite/spark/*.java
           java -cp "$JVM/build/classes:$JVM/build/test-classes" \
             dev.goldensuite.spark.SelfTest
+      # J2's end-to-end gate with no Spark in the picture: extract the library
+      # from the classpath, dlopen it, cross the JNI boundary, score 10,000
+      # pairs. Separate from the step above because it REQUIRES the library --
+      # SelfTest must stay runnable with nothing built, and a test that learns to
+      # skip is how a lane goes green while testing nothing.
+      #
+      # It refuses to skip: CI built that library one step ago, so "not loadable"
+      # here means the build produced something the JVM cannot use.
+      - name: JVM native scorer self-test (JNI into score-cabi)
+        run: |
+          set -euo pipefail
+          JVM=packages/jvm/goldenmatch-spark
+          java -cp "$JVM/build/classes:$JVM/build/test-classes" \
+            dev.goldensuite.spark.NativeSelfTest
       - name: Tier tests against Apache Spark Connect
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1895,6 +1895,14 @@ jobs:
       # packed virtualenv to lowercase a column. Its unit tests pin the parity
       # decisions (Python counts U+001C..U+001F as whitespace and Rust does not;
       # slicing is by code point; honorifics include POST-nominals).
+      # survivorship-core (2026-08-13): the pyo3-free golden-record merge.
+      # Written because `merge_field` existed in Rust only inside native/, which
+      # is pyo3+pyarrow AND is the fused columnar INDICES kernel, not this. Its
+      # unit tests pin the TIE-BREAKS -- Python keeps the first maximum and
+      # Rust's max_by_key keeps the last, and a tie resolved the other way is a
+      # different golden record with no error attached.
+      - run: cargo test --manifest-path survivorship-core/Cargo.toml
+      - run: cargo clippy --manifest-path survivorship-core/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path transforms-core/Cargo.toml
       - run: cargo clippy --manifest-path transforms-core/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path score-jni/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3143,6 +3143,60 @@ jobs:
           JVM=packages/jvm/goldenmatch-spark
           java -cp "$JVM/build/classes:$JVM/build/test-classes" \
             dev.goldensuite.spark.NativeSelfTest
+      # The J-arc's actual justification, measured rather than argued.
+      #
+      # Throughput was measured and the JVM path LOST (2.4x slower than the
+      # Python-worker path -- run 31656227516). What is left is deployment: a jar
+      # that `addArtifact` delivers, against a virtualenv that must be built for
+      # the executor platform and shipped. "No Python on the executors."
+      #
+      # That claim is unproven and, read against the source, only partly true:
+      # J2 moved SCORING into the JVM, but normalization, survivorship and the
+      # identity graph still define Python UDFs. Clustering defines none.
+      #
+      # Omitting the executor env cannot test this. Under `local[*]` the Python
+      # worker forks from the DRIVER's interpreter, which HAS goldenmatch -- so
+      # everything would pass and report that nothing needs Python on executors,
+      # which is false. So an env is shipped and it is deliberately EMPTY: any
+      # operation needing a Python worker now fails with ModuleNotFoundError
+      # exactly as it would on a cluster with no cluster-side install.
+      #
+      # continue-on-error: this is an INVENTORY, not a gate. Its failures are
+      # facts about the tier, and a red build would say "something broke" when
+      # what it found is where the work still is.
+      - name: Build a deliberately EMPTY executor env
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/bare-env
+          # No goldenmatch, no pyarrow, nothing. Assert the emptiness -- an env
+          # that accidentally carried goldenmatch would make the inventory
+          # report jar-only support the tier does not have.
+          if /tmp/bare-env/bin/python -c "import goldenmatch" 2>/dev/null; then
+            echo "::error::the bare env can import goldenmatch; the inventory would be meaningless"
+            exit 1
+          fi
+          .venv/bin/venv-pack -p /tmp/bare-env -o bare_env.tar.gz --force
+          ls -lh bare_env.tar.gz
+      - name: Inventory -- what runs with NO Python on the executors
+        continue-on-error: true
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "local[*]"
+          GOLDENMATCH_SPARK_PYENV: "bare_env.tar.gz"
+          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+        run: |
+          .venv/bin/python scripts/spark_jar_only_inventory.py \
+            --out spark-jar-only-inventory.json
+      - name: Inventory summary
+        if: always()
+        run: |
+          if [ -f spark-jar-only-inventory.json ]; then
+            {
+              echo '## Spark: what runs with no Python on the executors'
+              echo '```json'
+              cat spark-jar-only-inventory.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Tier tests against Apache Spark Connect
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3059,6 +3059,7 @@ jobs:
             "$JVM"/src/dev/goldensuite/spark/NativeScorer.java \
             "$JVM"/src/dev/goldensuite/spark/NativeFingerprint.java \
             "$JVM"/src/dev/goldensuite/spark/NativeTransform.java \
+            "$JVM"/src/dev/goldensuite/spark/NativeSurvivorship.java \
             "$JVM"/src/dev/goldensuite/spark/ScorerSelection.java
           cp packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so \
             "$JVM/build/classes/native/linux-aarch64/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1888,6 +1888,15 @@ jobs:
       # spark_connect lane because that lane is path-filtered: a change to
       # score-core or score-cabi that broke this binding would otherwise not be
       # compiled by anything until someone touched a Spark file.
+      # transforms-core (2026-08-13): the pyo3-free transform chain. Written
+      # because there was NO Rust implementation -- verified against origin/main,
+      # not one file under packages/rust/ mentioned apply_transform or any
+      # sibling -- so normalization was Python-only and a Spark cluster needed a
+      # packed virtualenv to lowercase a column. Its unit tests pin the parity
+      # decisions (Python counts U+001C..U+001F as whitespace and Rust does not;
+      # slicing is by code point; honorifics include POST-nominals).
+      - run: cargo test --manifest-path transforms-core/Cargo.toml
+      - run: cargo clippy --manifest-path transforms-core/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path score-jni/Cargo.toml
       - run: cargo clippy --manifest-path score-jni/Cargo.toml --all-targets -- -D warnings
       - run: cargo build --release --manifest-path score-jni/Cargo.toml

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4783,7 +4783,8 @@
             "partial_ratio",
             "pure_field_matrix",
             "ratio",
-            "token_sort_ratio"
+            "token_sort_ratio",
+            "token_sort_similarity"
           ]
         },
         {
@@ -7831,10 +7832,11 @@
         {
           "module": "goldenmatch.spark.jvm",
           "file": "packages/python/goldenmatch/goldenmatch/spark/jvm.py",
-          "purpose": "J0: ship the JVM scorer jar to a Spark session and register it.",
+          "purpose": "Ship the JVM scorer jar to a Spark session and register it (J0), now backed",
           "defines": [
             "JvmScorerUnavailable",
             "find_jar",
+            "implementation",
             "install",
             "scorer_id"
           ]

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7768,6 +7768,7 @@
             "goldenmatch.spark.autoconfig",
             "goldenmatch.spark.clustering",
             "goldenmatch.spark.golden",
+            "goldenmatch.spark.jvm",
             "goldenmatch.spark.probabilistic",
             "goldenmatch.spark.scorers",
             "goldenmatch.utils.transforms"
@@ -7791,12 +7792,14 @@
           "purpose": "Golden-record survivorship on Sail (Spark Connect), distributed.",
           "defines": [
             "build_golden",
-            "make_merge_udf"
+            "make_merge_udf",
+            "merge_expr"
           ],
           "imports": [
             "goldenmatch.config.schemas",
             "goldenmatch.core.golden",
-            "goldenmatch.spark._arrow"
+            "goldenmatch.spark._arrow",
+            "goldenmatch.spark.jvm"
           ]
         },
         {
@@ -7807,6 +7810,7 @@
             "IdentityGraphFrames",
             "_golden_record_json",
             "_id_scheme",
+            "_jvm_fingerprint_types_ok",
             "build_identity_events",
             "build_identity_graph",
             "build_identity_graph_incremental",
@@ -7835,10 +7839,14 @@
           "purpose": "Ship the JVM scorer jar to a Spark session and register it (J0), now backed",
           "defines": [
             "JvmScorerUnavailable",
+            "_is_int",
             "find_jar",
             "implementation",
             "install",
-            "scorer_id"
+            "jvm_supports_strategy",
+            "jvm_supports_transform",
+            "scorer_id",
+            "unsupported_transforms"
           ]
         },
         {

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -9920,6 +9920,14 @@
       "path": "packages/rust/extensions/suggest-wasm"
     },
     {
+      "name": "goldenmatch-survivorship-core",
+      "path": "packages/rust/extensions/survivorship-core"
+    },
+    {
+      "name": "goldenmatch-transforms-core",
+      "path": "packages/rust/extensions/transforms-core"
+    },
+    {
       "name": "goldenmatch_pg",
       "path": "packages/rust/extensions/postgres"
     },

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -9900,6 +9900,10 @@
       "path": "packages/rust/extensions/score-core"
     },
     {
+      "name": "goldenmatch-score-jni",
+      "path": "packages/rust/extensions/score-jni"
+    },
+    {
       "name": "goldenmatch-score-wasm",
       "path": "packages/rust/extensions/score-wasm"
     },

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenFingerprintUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenFingerprintUdf.java
@@ -1,0 +1,24 @@
+package dev.goldensuite.spark;
+
+import org.apache.spark.sql.api.java.UDF1;
+
+/** SQL surface for {@link NativeFingerprint}: JSON object in, 64 hex chars out.
+ *
+ * <p>Registered as {@code golden_fingerprint} and called on
+ * {@code to_json(struct(...))}, so Spark builds the JSON in the engine and no
+ * Python worker is involved at any point.
+ *
+ * <p>Thin on purpose, exactly like {@link GoldenScoreUdf}: everything with a
+ * decision in it lives in Spark-free classes that are unit-testable without a
+ * Spark classpath.
+ */
+public final class GoldenFingerprintUdf implements UDF1<String, String> {
+
+  /** @param json a JSON object, typically from {@code to_json(struct(...))}
+   *  @return 64 lowercase hex chars, or {@code null} if the input was null or
+   *      could not be read as a JSON object */
+  @Override
+  public String call(String json) {
+    return NativeFingerprint.of(json);
+  }
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreImplUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreImplUdf.java
@@ -26,12 +26,16 @@ import org.apache.spark.sql.api.java.UDF1;
 public final class GoldenScoreImplUdf implements UDF1<Integer, String> {
 
   /** @param ignored a column reference, present only to defeat constant folding
-   *  @return {@code "<ImplementationName>|<diagnostics>"} -- one string because
-   *      a UDF returns one value, and the two are useless apart: the name says
-   *      what ran, the diagnostics say why */
+   *  @return {@code "<name>|<diagnostics>|<runtime>"} -- one string because a
+   *      UDF returns one value, and the three are useless apart: the name says
+   *      what ran, the diagnostics say why, and the runtime says on what. The
+   *      last is not decoration: the batched scoring path materialises groups in
+   *      JVM heap, so a result is uninterpretable without knowing the heap
+   *      ceiling, and a Connect client has no other way to ask. */
   @Override
   public String call(Integer ignored) {
     return GoldenScoreUdf.implementationName() + "|"
-        + GoldenScoreUdf.implementationDiagnostics();
+        + GoldenScoreUdf.implementationDiagnostics() + "|"
+        + ScorerSelection.runtimeInfo();
   }
 }

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreImplUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreImplUdf.java
@@ -1,0 +1,37 @@
+package dev.goldensuite.spark;
+
+import org.apache.spark.sql.api.java.UDF1;
+
+/** Reports which scorer the EXECUTOR actually resolved, and why.
+ *
+ * <p>The jar falls back to {@link ExactScorer} when the native library will not
+ * load, which keeps a distributed job alive but would otherwise be invisible:
+ * the query still returns numbers, just narrower ones from a different code
+ * path. This repo has lost real time to exactly that shape of failure (a
+ * published wheel silently taking a fallback branch while every version string
+ * looked right), so the resolution is queryable and the Spark lane asserts on it.
+ *
+ * <h2>Why it takes an argument it ignores</h2>
+ *
+ * A zero-argument deterministic UDF is <b>foldable</b> -- {@code Expression
+ * .foldable} is {@code children.forall(_.foldable)}, which is vacuously true
+ * with no children -- so Catalyst's constant folding would evaluate it on the
+ * <b>driver</b> at planning time and never run it on an executor at all. That
+ * would answer the wrong question perfectly: the driver's classloader is not the
+ * one that has to find the library.
+ *
+ * <p>So it takes a column. The argument's value is unused; its presence is what
+ * makes the call non-foldable and forces it out to where the answer matters.
+ */
+public final class GoldenScoreImplUdf implements UDF1<Integer, String> {
+
+  /** @param ignored a column reference, present only to defeat constant folding
+   *  @return {@code "<ImplementationName>|<diagnostics>"} -- one string because
+   *      a UDF returns one value, and the two are useless apart: the name says
+   *      what ran, the diagnostics say why */
+  @Override
+  public String call(Integer ignored) {
+    return GoldenScoreUdf.implementationName() + "|"
+        + GoldenScoreUdf.implementationDiagnostics();
+  }
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreUdf.java
@@ -31,16 +31,24 @@ import org.apache.spark.sql.api.java.UDF3;
  */
 public final class GoldenScoreUdf implements UDF3<Integer, Object, Object, List<Double>> {
 
-  /** J0 carries no algorithms of its own. J2 swaps this for a JNI-backed
-   * implementation and the refusals in {@link ExactScorer} go away. */
-  private static final GoldenScorer SCORER = new ExactScorer();
-
   /** Names the implementation actually in use, so a caller can tell a J0 jar
-   * from a J2 one without reading version strings. Callable from SQL once
-   * registered, which is how the Python side asserts the jar it shipped is the
-   * jar that loaded. */
+   * from a J2 one without reading version strings. Callable from SQL via
+   * {@link GoldenScoreImplUdf}, which is how the Python side asserts the jar it
+   * shipped is the jar that loaded -- and, since a UDF runs on an EXECUTOR, that
+   * the library loaded there rather than merely on the driver.
+   *
+   * <p>Delegates to {@link ScorerSelection} rather than holding its own static:
+   * two sources for "which scorer is running" could disagree, and the one Spark
+   * calls would not be the one the tests read. */
   public static String implementationName() {
-    return SCORER.getClass().getSimpleName();
+    return ScorerSelection.implementationName();
+  }
+
+  /** Why the native library did or did not load, verbatim. Paired with
+   * {@link #implementationName()} so a fallback reports its own cause instead of
+   * leaving it in an executor log nobody collects. */
+  public static String implementationDiagnostics() {
+    return ScorerSelection.diagnostics();
   }
 
   @Override
@@ -53,7 +61,7 @@ public final class GoldenScoreUdf implements UDF3<Integer, Object, Object, List<
     if (as == null || bs == null) {
       return null;
     }
-    Double[] scores = SCORER.score(scorerId, as, bs);
+    Double[] scores = ScorerSelection.scorer().score(scorerId, as, bs);
     // A fixed-size list from Arrays.asList is fine as a UDF return; Spark reads
     // it and does not mutate. Copying it would allocate a second list per batch
     // for no benefit.

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenSurvivorshipUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenSurvivorshipUdf.java
@@ -1,0 +1,25 @@
+package dev.goldensuite.spark;
+
+import org.apache.spark.sql.api.java.UDF2;
+
+/** SQL surface for {@link NativeSurvivorship}: a cluster's collected values plus
+ * a strategy, one survivor out.
+ *
+ * <p>Registered as {@code golden_survivorship} and called on a
+ * {@code collect_list} of the field. The first argument is {@code Object} for
+ * the same reason {@link GoldenScoreUdf}'s is: Spark's Java type for an
+ * {@code array<string>} column is version-dependent, and declaring
+ * {@code java.util.List} throws {@code ClassCastException} against the Scala
+ * {@code Seq} it actually passes. {@link SeqCoercion} handles it.
+ */
+public final class GoldenSurvivorshipUdf implements UDF2<Object, String, String> {
+
+  @Override
+  public String call(Object values, String strategy) {
+    String[] vs = SeqCoercion.toStringArray(values);
+    if (vs == null) {
+      return null;
+    }
+    return NativeSurvivorship.merge(vs, strategy);
+  }
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenTransformUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenTransformUdf.java
@@ -1,0 +1,23 @@
+package dev.goldensuite.spark;
+
+import org.apache.spark.sql.api.java.UDF2;
+
+/** SQL surface for {@link NativeTransform}: value + chain in, normalized value
+ * out.
+ *
+ * <p>Registered as {@code golden_transform} and called as
+ * {@code golden_transform(col, 'lowercase,strip')}. The chain is a second
+ * COLUMN rather than baked into the class because {@code registerJavaFunction}
+ * takes no constructor arguments -- one registration therefore serves every
+ * chain in the query, exactly as the scorer's id argument serves every scorer.
+ */
+public final class GoldenTransformUdf implements UDF2<String, String, String> {
+
+  /** @param value the value to normalize
+   *  @param chain comma-separated transform names
+   *  @return the normalized value, or {@code null} for a MISSING result */
+  @Override
+  public String call(String value, String chain) {
+    return NativeTransform.apply(value, chain);
+  }
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeFingerprint.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeFingerprint.java
@@ -1,0 +1,70 @@
+package dev.goldensuite.spark;
+
+/** Record fingerprints from the executor JVM, via the same Rust kernel Python
+ * uses.
+ *
+ * <h2>Why this is here</h2>
+ *
+ * The jar-only inventory measured what a Spark cluster can run with no Python on
+ * its executors, and found 3 of 7: pure Spark SQL, clustering, and J2's scoring.
+ * The identity graph was not among them -- ``identity.py`` defines five
+ * ``arrow_udf``s, and the first of them derives every record's fingerprint. So a
+ * cluster still had to be handed a packed virtualenv to compute an ID.
+ *
+ * <p>It did not need a new algorithm to fix. ``fingerprint-core`` is already
+ * pyo3-free and already exposes ``fingerprint_json``, written -- in its own
+ * manifest's words -- for "non-Python callers (pgrx / DuckDB / C ABI)". This is
+ * one more such caller.
+ *
+ * <h2>A JSON string, not Arrow buffers</h2>
+ *
+ * Deliberately unlike {@link NativeScorer}. Scoring is quadratic in block size,
+ * so its per-call cost had to be amortised across a batch of pairs; that is the
+ * entire reason {@link Utf8Batch} exists. Fingerprinting is once per RECORD --
+ * linear, and orders of magnitude fewer calls -- and Spark can build the JSON in
+ * the engine with {@code to_json(struct(*))}, no Python anywhere. Inventing an
+ * Arrow protocol here would add a marshaling layer to save a cost nobody is
+ * paying.
+ *
+ * <h2>Null means refused, not "empty record"</h2>
+ *
+ * The native side returns null for invalid JSON, a non-object, or an
+ * unsupported value, rather than throwing: a pending JNI exception that a caller
+ * forgets to check detonates somewhere unrelated. An empty object is a VALID
+ * record with a real fingerprint, so null cannot be confused with it.
+ */
+public final class NativeFingerprint {
+
+  private NativeFingerprint() {}
+
+  /** Fingerprint a JSON object, or {@code null} if it cannot be read.
+   *
+   * <p>Drops {@code __}-prefixed keys, matching
+   * {@code core._hashing.record_fingerprint} -- the drop happens inside the
+   * shared kernel, so the two cannot disagree about which fields count.
+   *
+   * @throws IllegalStateException if the native library is unavailable. Unlike
+   *     the scorer there is no fallback: a WRONG fingerprint silently splits or
+   *     merges identities, so refusing is the only safe failure.
+   */
+  public static String of(String json) {
+    if (json == null) {
+      return null;
+    }
+    if (!NativeLibrary.ensureLoaded()) {
+      throw new IllegalStateException(
+          "the native library is not loaded, so record fingerprints cannot be "
+              + "computed in the JVM: " + NativeLibrary.diagnostics()
+              + ". There is deliberately no fallback -- a fingerprint computed a "
+              + "second way would silently split or merge identities.");
+    }
+    return fingerprintJson(json);
+  }
+
+  /** Whether fingerprints can be computed here at all. */
+  public static boolean available() {
+    return NativeLibrary.ensureLoaded();
+  }
+
+  static native String fingerprintJson(String json);
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeLibrary.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeLibrary.java
@@ -133,9 +133,17 @@ public final class NativeLibrary {
    * {@code /native/linux-x86-64/libgoldenmatch_score_jni.so}.
    *
    * <p>Package-private and deterministic so a test can assert the mapping
-   * without a library present. The jar built in CI carries linux-x86-64 only,
-   * because that is what a Spark executor runs; the other names resolve so that
-   * adding an arch is a build change and not a code change.
+   * without a library present -- and {@code SelfTest} asserts it for platforms
+   * it is NOT running on, because otherwise the aarch64 mapping would only ever
+   * be checked on aarch64, which is precisely the platform nobody was testing
+   * when the jar shipped x86-only.
+   *
+   * <p>The CI jar carries <b>linux-x86-64 and linux-aarch64</b>. Both, because
+   * a Graviton fleet is most of the cheap capacity on AWS now: an ARM executor
+   * finding no resource does not fail, it falls back to the {@code exact}-only
+   * scorer and runs slower and narrower without saying so. The darwin and
+   * windows names resolve for in-tree developer builds; adding a platform to
+   * the jar is a build change, not a code change.
    */
   static String resourcePath() {
     return "/native/" + platform() + "/" + fileName();

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeLibrary.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeLibrary.java
@@ -1,0 +1,210 @@
+package dev.goldensuite.spark;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+
+/** Finds and loads {@code libgoldenmatch_score_jni}, the Rust kernel's JNI door.
+ *
+ * <h2>Why extraction, and not {@code System.loadLibrary}</h2>
+ *
+ * {@code loadLibrary} searches {@code java.library.path}, which means somebody
+ * has to have put a {@code .so} on every executor and set a JVM flag. That is
+ * precisely the "install something on the cluster" cost this whole arc exists to
+ * remove -- the Python tier's answer was to ship a packed virtualenv, and
+ * replacing one deployment apparatus with another would be no progress at all.
+ *
+ * <p>So the library rides <b>inside the jar</b> as a resource and is extracted
+ * to a temp file on first use. {@code spark.addArtifact(jar)} then delivers
+ * everything: one file, nothing installed, no flags. {@code loadLibrary} is
+ * still tried last, for a host that genuinely prefers to manage it.
+ *
+ * <h2>Resolution order</h2>
+ *
+ * <ol>
+ *   <li>{@code goldenmatch.score.jni.lib} system property, or the
+ *       {@code GOLDENMATCH_SCORE_JNI_LIB} environment variable -- an explicit
+ *       path. This is what CI uses to test a freshly-built library before a jar
+ *       exists, and what a customer with their own build uses.</li>
+ *   <li>The jar resource for this platform (see {@link #resourcePath}).</li>
+ *   <li>{@code System.loadLibrary}.</li>
+ * </ol>
+ *
+ * <h2>Failure is recorded, never thrown</h2>
+ *
+ * A distributed run must not die because one executor could not load a library;
+ * the caller falls back. But a silent fallback is how you ship a path that
+ * "works" and is quietly slower or narrower than intended -- this repo has
+ * already lost time to a published wheel silently taking a fallback branch. So
+ * the reason is kept in {@link #diagnostics()} and surfaced through a UDF, and
+ * the Spark lane asserts on it rather than trusting that native was reached.
+ */
+public final class NativeLibrary {
+
+  private NativeLibrary() {}
+
+  /** Base name, matching {@code [lib].name} in score-jni's Cargo.toml. */
+  static final String BASE = "goldenmatch_score_jni";
+
+  /** Explicit-path overrides, checked before the bundled resource. */
+  static final String PROPERTY = "goldenmatch.score.jni.lib";
+  static final String ENV = "GOLDENMATCH_SCORE_JNI_LIB";
+
+  private static boolean attempted;
+  private static boolean loaded;
+  private static String diagnostics = "not attempted";
+
+  /** Load the library if it is not already loaded. Idempotent, and never throws.
+   *
+   * @return true if the library is usable
+   */
+  public static synchronized boolean ensureLoaded() {
+    if (attempted) {
+      return loaded;
+    }
+    attempted = true;
+    StringBuilder tried = new StringBuilder();
+
+    String explicit = System.getProperty(PROPERTY);
+    if (explicit == null || explicit.isEmpty()) {
+      explicit = System.getenv(ENV);
+    }
+    if (explicit != null && !explicit.isEmpty()) {
+      try {
+        System.load(Path.of(explicit).toAbsolutePath().toString());
+        loaded = true;
+        diagnostics = "loaded from " + explicit + " (explicit override)";
+        return true;
+      } catch (Throwable t) {
+        tried.append("explicit ").append(explicit).append(": ").append(brief(t)).append("; ");
+      }
+    }
+
+    String resource = resourcePath();
+    try {
+      Path extracted = extract(resource);
+      System.load(extracted.toString());
+      loaded = true;
+      diagnostics = "loaded from jar resource " + resource + " extracted to " + extracted;
+      return true;
+    } catch (Throwable t) {
+      tried.append("resource ").append(resource).append(": ").append(brief(t)).append("; ");
+    }
+
+    try {
+      System.loadLibrary(BASE);
+      loaded = true;
+      diagnostics = "loaded via java.library.path";
+      return true;
+    } catch (Throwable t) {
+      tried.append("loadLibrary ").append(BASE).append(": ").append(brief(t));
+    }
+
+    loaded = false;
+    diagnostics = "NOT LOADED -- " + tried;
+    return false;
+  }
+
+  /** Why the library did or did not load. Never null; carries the whole chain of
+   * attempts on failure so a cluster problem is diagnosable from one string in a
+   * query result rather than from executor logs nobody collected. */
+  public static synchronized String diagnostics() {
+    return diagnostics;
+  }
+
+  /** Record that a library which LOADED cannot be used -- an ABI skew, or
+   * symbols that are not the ones this jar expects.
+   *
+   * <p>A separate state from "did not load" on purpose. The two produce the same
+   * fallback but have completely different fixes (ship the library vs. rebuild
+   * the pair together), and a diagnostic that conflates them sends whoever reads
+   * it looking in the wrong place.
+   */
+  static synchronized void recordUnusable(String reason) {
+    loaded = false;
+    diagnostics = "LOADED BUT UNUSABLE -- " + reason;
+  }
+
+  /** The classpath resource holding the library for the running platform, e.g.
+   * {@code /native/linux-x86-64/libgoldenmatch_score_jni.so}.
+   *
+   * <p>Package-private and deterministic so a test can assert the mapping
+   * without a library present. The jar built in CI carries linux-x86-64 only,
+   * because that is what a Spark executor runs; the other names resolve so that
+   * adding an arch is a build change and not a code change.
+   */
+  static String resourcePath() {
+    return "/native/" + platform() + "/" + fileName();
+  }
+
+  /** {@code os-arch}, in the naming this project's jar layout uses. */
+  static String platform() {
+    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
+
+    String osKey;
+    if (os.contains("linux")) {
+      osKey = "linux";
+    } else if (os.contains("mac") || os.contains("darwin")) {
+      osKey = "darwin";
+    } else if (os.contains("win")) {
+      osKey = "windows";
+    } else {
+      osKey = "unknown";
+    }
+
+    String archKey;
+    if (arch.equals("amd64") || arch.equals("x86_64")) {
+      archKey = "x86-64";
+    } else if (arch.equals("aarch64") || arch.equals("arm64")) {
+      archKey = "aarch64";
+    } else {
+      archKey = arch.isEmpty() ? "unknown" : arch;
+    }
+    return osKey + "-" + archKey;
+  }
+
+  /** Platform library file name for {@link #BASE}. */
+  static String fileName() {
+    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    if (os.contains("win")) {
+      return BASE + ".dll";
+    }
+    if (os.contains("mac") || os.contains("darwin")) {
+      return "lib" + BASE + ".dylib";
+    }
+    return "lib" + BASE + ".so";
+  }
+
+  /** Copy a classpath resource to a temp file and return its path.
+   *
+   * <p>{@code System.load} needs a real filesystem path -- it cannot read out of
+   * a jar. The file is marked delete-on-exit rather than deleted eagerly: a
+   * loaded library must stay on disk for the life of the JVM, and an executor
+   * JVM outlives any single task.
+   */
+  private static Path extract(String resource) throws IOException {
+    try (InputStream in = NativeLibrary.class.getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IOException("not on the classpath");
+      }
+      Path dir = Files.createTempDirectory("goldenmatch-jni-");
+      Path target = dir.resolve(fileName());
+      try (OutputStream out = Files.newOutputStream(target)) {
+        in.transferTo(out);
+      }
+      target.toFile().deleteOnExit();
+      dir.toFile().deleteOnExit();
+      return target;
+    }
+  }
+
+  private static String brief(Throwable t) {
+    String m = t.getMessage();
+    return t.getClass().getSimpleName() + (m == null ? "" : ": " + m);
+  }
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeScorer.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeScorer.java
@@ -1,0 +1,180 @@
+package dev.goldensuite.spark;
+
+/** J2: the Rust kernel, called from inside the executor JVM.
+ *
+ * <h2>What this replaces</h2>
+ *
+ * {@link ExactScorer} carried one scorer because J0 deliberately shipped no
+ * algorithms: a Java jaro-winkler would have been a fourth implementation of a
+ * kernel that already exists once in Rust, and this project's position is that a
+ * score should have one source of truth. This class keeps that position and
+ * removes the restriction by <i>calling</i> the kernel instead of copying it --
+ * the same {@code score_one} that {@code native} (pyo3), {@code datafusion-udf},
+ * {@code score-wasm} and {@code score-cabi} all wrap.
+ *
+ * <h2>What it does NOT change</h2>
+ *
+ * Null policy stays here, in the host. {@code score-cabi} has no validity
+ * bitmap by design, and {@link Utf8Batch} keeps the presence mask, so an
+ * unobserved pair returns {@code null} rather than being scored against an
+ * empty string. Null slots are still handed to the kernel (as zero-length
+ * slices) and their results discarded -- wasted work, chosen over an index
+ * remapping that could silently attach a score to the wrong pair.
+ *
+ * <h2>Skew is refused, not absorbed</h2>
+ *
+ * The library reports its ABI version and how many scorer ids it dispatches,
+ * and both are checked before this class will run anything. A caller and a
+ * kernel that disagree do not fail loudly on their own: an unknown id falls to
+ * {@code score_one}'s catch-all and returns a confident {@code 0.0}. This repo
+ * has already paid for a version skew that produced plausible numbers, so the
+ * gate is at load time.
+ */
+public final class NativeScorer implements GoldenScorer {
+
+  /** The ABI this class was written against. Bumped in lockstep with
+   * {@code goldenmatch_score_abi_version} in score-cabi. */
+  static final int EXPECTED_ABI = 1;
+
+  private final int scorerIdCount;
+
+  private NativeScorer(int scorerIdCount) {
+    this.scorerIdCount = scorerIdCount;
+  }
+
+  /** Load the library, verify it, and return a usable scorer -- or {@code null}
+   * if any of that fails.
+   *
+   * <p>Null rather than an exception because the caller's correct response is to
+   * fall back, not to abort a distributed job. The reason is left in
+   * {@link NativeLibrary#diagnostics()}, which the Spark lane asserts on so a
+   * fallback cannot pass for a native run.
+   */
+  public static NativeScorer createOrNull() {
+    if (!NativeLibrary.ensureLoaded()) {
+      return null;
+    }
+    try {
+      int abi = abiVersion();
+      if (abi != EXPECTED_ABI) {
+        NativeLibrary.recordUnusable(
+            "ABI mismatch: library reports " + abi + ", this jar expects "
+                + EXPECTED_ABI + ". Rebuild the jar and the library together.");
+        return null;
+      }
+      int count = scorerIdCount();
+      if (count <= 0) {
+        NativeLibrary.recordUnusable("library reports " + count + " scorer ids");
+        return null;
+      }
+      return new NativeScorer(count);
+    } catch (Throwable t) {
+      // UnsatisfiedLinkError if the symbols are absent -- a library that loaded
+      // but is not the one we think it is.
+      NativeLibrary.recordUnusable(
+          "loaded but unusable: " + t.getClass().getSimpleName() + ": " + t.getMessage());
+      return null;
+    }
+  }
+
+  /** How many scorer ids the loaded kernel dispatches. */
+  public int scorerIds() {
+    return scorerIdCount;
+  }
+
+  @Override
+  public boolean supports(int scorerId) {
+    return scorerId >= 0 && scorerId < scorerIdCount;
+  }
+
+  @Override
+  public Double[] score(int scorerId, String[] a, String[] b) {
+    if (a == null || b == null) {
+      throw new IllegalArgumentException("null input array");
+    }
+    if (a.length != b.length) {
+      throw new IllegalArgumentException(
+          "array length mismatch: " + a.length + " vs " + b.length);
+    }
+    if (!supports(scorerId)) {
+      throw new UnsupportedOperationException(
+          "scorer id " + scorerId + " is outside the loaded kernel's 0.."
+              + (scorerIdCount - 1) + ". An id the kernel does not know would be"
+              + " scored by its catch-all arm as 0.0, so it is refused here.");
+    }
+
+    Utf8Batch left = Utf8Batch.encode(a);
+    Utf8Batch right = Utf8Batch.encode(b);
+    double[] raw = new double[a.length];
+    int rc = scorePairwiseUtf8(
+        scorerId, left.offsets, left.data, right.offsets, right.data, a.length, raw);
+    if (rc != 0) {
+      throw new IllegalStateException(
+          "native scoring failed with code " + rc + " (" + describe(rc) + ")"
+              + " for scorer " + scorerId + " over " + a.length + " pairs");
+    }
+
+    Double[] out = new Double[a.length];
+    for (int i = 0; i < out.length; i++) {
+      // Reinstate absence. The kernel scored the null slots as empty-vs-empty
+      // and those numbers are meaningless -- keeping them is how null-vs-null
+      // becomes a perfect 1.0.
+      out[i] = (left.present[i] && right.present[i]) ? Double.valueOf(raw[i]) : null;
+    }
+    return out;
+  }
+
+  /** Error codes from the native layer, kept in one place on this side too.
+   *
+   * <p>Mirrors {@code score_jni::describe}. The duplication is deliberate: the
+   * message has to be readable from a Java stack trace with no Rust in sight,
+   * and a code the JVM cannot name is a code nobody diagnoses.
+   */
+  static String describe(int code) {
+    switch (code) {
+      case 0:
+        return "ok";
+      case -1:
+        return "a required buffer pointer was NULL";
+      case -2:
+        return "batch length was negative or unrepresentable";
+      case -3:
+        return "offsets were decreasing, negative, or ran past the data buffer";
+      case -4:
+        return "a slice was not valid UTF-8";
+      case -10:
+        return "an array was too short for the batch length";
+      case -11:
+        return "scorer id outside 0..=255";
+      case -12:
+        return "a JNI array could not be pinned";
+      default:
+        return "unknown error code";
+    }
+  }
+
+  // ── native entry points (score-jni/src/lib.rs) ──────────────────────
+  //
+  // Declaring these does NOT trigger loading; an absent library surfaces as
+  // UnsatisfiedLinkError on the first CALL, which is why createOrNull() gates
+  // every use behind NativeLibrary.ensureLoaded().
+
+  static native int abiVersion();
+
+  static native int scorerIdCount();
+
+  /** Score {@code n} pairs from Arrow-layout buffers into {@code out}.
+   *
+   * @return 0, or a negative code -- see {@link #describe}. Errors are codes
+   *     rather than exceptions because a pending JNI exception that a caller
+   *     forgets to check detonates somewhere unrelated.
+   */
+  static native int scorePairwiseUtf8(
+      int scorerId,
+      int[] aOffsets,
+      byte[] aData,
+      int[] bOffsets,
+      byte[] bData,
+      int n,
+      double[] out);
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeSurvivorship.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeSurvivorship.java
@@ -1,0 +1,68 @@
+package dev.goldensuite.spark;
+
+/** Golden-record survivorship in the executor JVM.
+ *
+ * <p>There was no pyo3-free Rust implementation until {@code
+ * survivorship-core}: {@code merge_field} existed in Rust only inside the pyo3
+ * {@code native} crate, and even there as the fused columnar INDICES kernel
+ * rather than this per-cluster value merge. So survivorship was Python-only and
+ * {@code spark/golden.py} had to be an {@code arrow_udf}.
+ *
+ * <h2>Values reuse {@link Utf8Batch}</h2>
+ *
+ * Rather than a {@code String[]} and a {@code GetStringUTFChars} per element.
+ * The Arrow marshaling is already written, already tested, and already handles
+ * the multi-byte case a per-element loop gets wrong. The presence mask matters
+ * on its own: a null MEMBER is not an empty value, and survivorship ignores
+ * absent members rather than letting them vote for {@code ""}.
+ *
+ * <h2>Strategies are gated, not discovered</h2>
+ *
+ * {@code source_priority} and {@code most_recent} need a sources or dates list
+ * that the Spark path does not pass -- Python RAISES for them, and so does the
+ * kernel. {@code custom:*} is arbitrary Python. {@link #supports} lets a caller
+ * refuse at plan time with the strategy named.
+ *
+ * <p>The refusals are the point: a survivor chosen by a different rule is a
+ * <b>wrong golden record that looks right</b> -- no exception, no null, just a
+ * plausible value nothing downstream can flag.
+ */
+public final class NativeSurvivorship {
+
+  private NativeSurvivorship() {}
+
+  /** The surviving value for one cluster, or {@code null} when there is none.
+   *
+   * @param values one entry per cluster member; nulls are absent members
+   * @param strategy a survivorship strategy name
+   * @throws IllegalStateException if the native library is unavailable -- no
+   *     fallback, because a golden record built a second way is wrong in a way
+   *     that raises nothing
+   */
+  public static String merge(String[] values, String strategy) {
+    if (values == null || strategy == null) {
+      return null;
+    }
+    if (!NativeLibrary.ensureLoaded()) {
+      throw new IllegalStateException(
+          "the native library is not loaded, so survivorship cannot run in the "
+              + "JVM: " + NativeLibrary.diagnostics() + ". There is deliberately "
+              + "no fallback -- a survivor chosen a second way is a wrong golden "
+              + "record that looks right.");
+    }
+    Utf8Batch b = Utf8Batch.encode(values);
+    return mergeField(b.offsets, b.data, b.present, b.length, strategy);
+  }
+
+  /** Whether the loaded kernel can run {@code strategy}. */
+  public static boolean supports(String strategy) {
+    return strategy != null
+        && NativeLibrary.ensureLoaded()
+        && supportsStrategy(strategy);
+  }
+
+  static native String mergeField(
+      int[] offsets, byte[] data, boolean[] present, int n, String strategy);
+
+  static native boolean supportsStrategy(String strategy);
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeTransform.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/NativeTransform.java
@@ -1,0 +1,63 @@
+package dev.goldensuite.spark;
+
+/** The transform chain (normalization) in the executor JVM.
+ *
+ * <p>Normalization was Python-only: there was no Rust implementation at all
+ * until {@code transforms-core}, which is why {@code config_pipeline._transformed}
+ * is an {@code arrow_udf} and why a Spark cluster needed a packed virtualenv to
+ * lowercase a column. This is the JVM half of closing that.
+ *
+ * <h2>The chain is one comma-separated string</h2>
+ *
+ * Transform names contain {@code :} ({@code substring:0:3}) but never
+ * {@code ,}. A {@code String[]} would cost a JNI transition per element to
+ * deliver a value that is identical on every row of the query.
+ *
+ * <h2>Gate the chain, do not discover it</h2>
+ *
+ * {@code bloom_filter} (HMAC-keyed PPRL) and plugin transforms are Python-only
+ * by design. {@link #supportsChain} exists so a caller refuses at PLAN time with
+ * the offending name in hand; finding out mid-job, after the plan is already
+ * distributed, is strictly worse.
+ *
+ * <h2>Null means MISSING</h2>
+ *
+ * Not "empty". {@code strip_honorifics} on an honorific-only name legitimately
+ * yields nothing, and Fellegi-Sunter reads an empty string as an agreement on
+ * nothing rather than an absence of evidence -- so the distinction is
+ * load-bearing all the way down.
+ */
+public final class NativeTransform {
+
+  private NativeTransform() {}
+
+  /** Apply {@code chain} to {@code value}; {@code null} if either is null or the
+   * result is a missing value.
+   *
+   * @throws IllegalStateException if the native library is unavailable. No
+   *     fallback: a value normalized a second way lands in a DIFFERENT BLOCK, so
+   *     the pair is never compared and nothing downstream reports a problem.
+   */
+  public static String apply(String value, String chain) {
+    if (value == null || chain == null) {
+      return null;
+    }
+    if (!NativeLibrary.ensureLoaded()) {
+      throw new IllegalStateException(
+          "the native library is not loaded, so transforms cannot run in the "
+              + "JVM: " + NativeLibrary.diagnostics() + ". There is deliberately "
+              + "no fallback -- normalization feeds BLOCKING, and a value "
+              + "normalized differently is simply never compared.");
+    }
+    return applyChain(value, chain);
+  }
+
+  /** Whether every transform in {@code chain} can run here. */
+  public static boolean supports(String chain) {
+    return chain != null && NativeLibrary.ensureLoaded() && supportsChain(chain);
+  }
+
+  static native String applyChain(String value, String chain);
+
+  static native boolean supportsChain(String chain);
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/ScorerSelection.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/ScorerSelection.java
@@ -58,4 +58,33 @@ public final class ScorerSelection {
   public static String diagnostics() {
     return NativeLibrary.diagnostics();
   }
+
+  /** The JVM this scorer is running in: version, heap ceiling, CPU count.
+   *
+   * <h2>Why a scorer reports heap</h2>
+   *
+   * Because nothing else can, and the number decides how results are read. The
+   * batched path materialises each group as an array in JVM heap, so its memory
+   * ceiling is a property of the executor, not of the algorithm -- and a
+   * benchmark that OOMs at an unknown heap size has measured a configuration
+   * rather than a design.
+   *
+   * <p>That is not hypothetical here: the batched arm of this arc's benchmark
+   * died with {@code java.lang.OutOfMemoryError: Java heap space} while the
+   * row-shaped arm completed the same workload on the same box, and nobody knew
+   * what heap either had. A Spark Connect client cannot ask -- there is no
+   * {@code SparkContext} to interrogate -- but a UDF is already running in the
+   * JVM that has the answer.
+   *
+   * <p>{@code maxMemory()} is the ceiling the JVM will grow to (i.e. {@code -Xmx}),
+   * which is the number that matters; {@code totalMemory()} is only what it has
+   * committed so far and would read as a much smaller, misleading limit.
+   */
+  public static String runtimeInfo() {
+    Runtime rt = Runtime.getRuntime();
+    long maxMb = rt.maxMemory() / (1024L * 1024L);
+    return "java=" + System.getProperty("java.version", "?")
+        + " heap_max=" + maxMb + "MB"
+        + " cpus=" + rt.availableProcessors();
+  }
 }

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/ScorerSelection.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/ScorerSelection.java
@@ -1,0 +1,61 @@
+package dev.goldensuite.spark;
+
+/** Decides which {@link GoldenScorer} this JVM runs, once.
+ *
+ * <h2>Why this is its own class</h2>
+ *
+ * It is Spark-free, and the decision it makes is the one most worth testing:
+ * whether the native kernel was reached or the jar quietly fell back. Leaving it
+ * inside {@link GoldenScoreUdf} would put it behind a Spark classpath, so the
+ * only way to test it would be to spin up a session -- and the piece that must
+ * never go untested would be the piece hardest to test. Every other class here
+ * with a decision in it ({@link SeqCoercion}, {@link Utf8Batch},
+ * {@link NativeScorer}) is Spark-free for the same reason.
+ *
+ * <h2>Resolved once, per JVM</h2>
+ *
+ * A {@code static} because the alternative is re-attempting a filesystem
+ * extraction and a {@code dlopen} on every batch. On a Spark cluster that means
+ * once per executor JVM, which is exactly the granularity that matters: the
+ * driver loading the library successfully says nothing about whether an executor
+ * can.
+ *
+ * <h2>The fallback is deliberate, and it announces itself</h2>
+ *
+ * When the native library will not load, this returns {@link ExactScorer} rather
+ * than throwing. A distributed job must not die because one executor could not
+ * load a shared library -- correctness and availability first.
+ *
+ * <p>But a fallback nobody can see is worse than no fallback: the query still
+ * returns numbers, from a narrower path, and every version string still looks
+ * right. This repo has already lost real time to that exact shape. So
+ * {@link #implementationName()} and {@link #diagnostics()} are queryable through
+ * {@link GoldenScoreImplUdf}, and the Spark lane asserts on them.
+ */
+public final class ScorerSelection {
+
+  private ScorerSelection() {}
+
+  private static final GoldenScorer SCORER = select();
+
+  private static GoldenScorer select() {
+    GoldenScorer kernel = NativeScorer.createOrNull();
+    return kernel != null ? kernel : new ExactScorer();
+  }
+
+  /** The scorer this JVM uses. Never null. */
+  public static GoldenScorer scorer() {
+    return SCORER;
+  }
+
+  /** Simple class name of the scorer in use -- {@code NativeScorer} when the
+   * kernel loaded, {@code ExactScorer} when it did not. */
+  public static String implementationName() {
+    return SCORER.getClass().getSimpleName();
+  }
+
+  /** Why the native library did or did not load, verbatim. */
+  public static String diagnostics() {
+    return NativeLibrary.diagnostics();
+  }
+}

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/Utf8Batch.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/Utf8Batch.java
@@ -1,0 +1,120 @@
+package dev.goldensuite.spark;
+
+import java.nio.charset.StandardCharsets;
+
+/** A batch of strings flattened into Arrow's string layout, for the native call.
+ *
+ * <h2>Why flatten at all</h2>
+ *
+ * The obvious JNI signature passes {@code String[]} and calls
+ * {@code GetStringUTFChars} on each element -- a JNI transition and usually a
+ * copy <b>per string</b>. At this arc's batch size (10,000 pairs) that is 20,000
+ * JNI calls to avoid one, which undoes the reason the plan was reshaped into
+ * batches in the first place.
+ *
+ * <p>So the batch is packed here into the layout {@code score-cabi} already
+ * takes: an {@code int[]} of {@code n + 1} byte offsets plus a {@code byte[]} of
+ * packed UTF-8. The native side then pins five primitive arrays -- a fixed cost
+ * per <i>batch</i>, not per pair.
+ *
+ * <h2>Nulls live in the mask, not the data</h2>
+ *
+ * Arrow's string layout has nowhere to put "absent": a null and an empty string
+ * are both a zero-length slice. So {@link #present} carries that distinction and
+ * the caller reinstates it after scoring.
+ *
+ * <p>This matters more than it looks. Letting a missing value read as
+ * {@code ""} makes null-vs-null score a perfect 1.0, and two records whose only
+ * shared evidence is a shared <i>absence</i> then merge at every threshold. That
+ * is not hypothetical -- it is a bug this tier already shipped and fixed.
+ *
+ * <h2>Spark-free</h2>
+ *
+ * No Spark type appears here, so the piece most likely to be subtly wrong is
+ * unit-testable with no Spark on the classpath. Every failure mode in an encoder
+ * produces a <i>number</i> rather than an exception, and a wrong similarity
+ * score looks exactly like a right one.
+ */
+public final class Utf8Batch {
+
+  /** Byte offsets, {@code length + 1} entries, non-decreasing, ending at
+   * {@code data.length}. Slot {@code i} is
+   * {@code data[offsets[i] .. offsets[i + 1])}. */
+  public final int[] offsets;
+
+  /** Packed UTF-8 for every slot, concatenated. */
+  public final byte[] data;
+
+  /** {@code false} where the input value was null. A zero-length slice alone
+   * cannot say whether the value was absent or empty. */
+  public final boolean[] present;
+
+  /** Number of slots. */
+  public final int length;
+
+  private Utf8Batch(int[] offsets, byte[] data, boolean[] present, int length) {
+    this.offsets = offsets;
+    this.data = data;
+    this.present = present;
+    this.length = length;
+  }
+
+  /** Pack {@code values} into Arrow's string layout.
+   *
+   * <p>Two passes: encode each value once into a per-slot array, then copy into
+   * one buffer of the exact total size. The alternative -- a growing buffer --
+   * would reallocate and copy repeatedly for a batch whose size is known after
+   * the first pass.
+   *
+   * @param values may contain nulls; must not be null itself
+   * @throws IllegalArgumentException if the packed data would exceed
+   *     {@link Integer#MAX_VALUE} bytes, which the {@code int} offsets cannot
+   *     address -- refused rather than silently overflowing into negative
+   *     offsets that {@code score-cabi} would reject with an opaque code from
+   *     inside an executor
+   */
+  public static Utf8Batch encode(String[] values) {
+    if (values == null) {
+      throw new IllegalArgumentException("values must not be null");
+    }
+    int n = values.length;
+    byte[][] encoded = new byte[n][];
+    boolean[] present = new boolean[n];
+    long total = 0L;
+    for (int i = 0; i < n; i++) {
+      String v = values[i];
+      if (v == null) {
+        // Null slot: zero-length slice, present[i] stays false. It is still
+        // SCORED by the kernel (empty vs empty) and the result is discarded by
+        // the caller. Compacting nulls out would save that work at the cost of
+        // an index remapping -- the one place in this path where an off-by-one
+        // would silently attach a score to the wrong pair.
+        encoded[i] = EMPTY;
+        continue;
+      }
+      present[i] = true;
+      byte[] b = v.getBytes(StandardCharsets.UTF_8);
+      encoded[i] = b;
+      total += b.length;
+    }
+    if (total > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          "batch packs to " + total + " bytes, which int offsets cannot address;"
+              + " reduce the batch size (see batched.DEFAULT_BATCH_SIZE)");
+    }
+
+    int[] offsets = new int[n + 1];
+    byte[] data = new byte[(int) total];
+    int at = 0;
+    for (int i = 0; i < n; i++) {
+      offsets[i] = at;
+      byte[] b = encoded[i];
+      System.arraycopy(b, 0, data, at, b.length);
+      at += b.length;
+    }
+    offsets[n] = at;
+    return new Utf8Batch(offsets, data, present, n);
+  }
+
+  private static final byte[] EMPTY = new byte[0];
+}

--- a/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/NativeSelfTest.java
+++ b/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/NativeSelfTest.java
@@ -52,6 +52,7 @@ public final class NativeSelfTest {
     unknownScorerIdsAreRefused(scorer);
     mismatchedLengthsAreRefused(scorer);
     aLargeBatchSurvivesInOneCall(scorer);
+    recordFingerprintsRunHereToo();
 
     if (failures > 0) {
       System.err.println("\n" + failures + " assertion(s) FAILED");
@@ -201,6 +202,55 @@ public final class NativeSelfTest {
     } else {
       fail("large batch", "length " + got.length + ", " + matches + " matches, want "
           + want);
+    }
+  }
+
+  static void recordFingerprintsRunHereToo() {
+    // The identity graph's kernel, in the same library. Pinned vectors rather
+    // than a computed oracle -- there is no second implementation on this side
+    // to compare against, and these exact values are pinned in
+    // fingerprint-core's own tests AND verified against Python's
+    // record_fingerprint, so agreeing with them is agreeing with both.
+    //
+    // On aarch64 this is the only thing that checks the fingerprint kernel at
+    // all: SHA-256 has no architecture-specific paths in this build, but that
+    // is a claim worth one assertion rather than an assumption.
+    eqStr("empty record",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        NativeFingerprint.of("{}"));
+    eqStr("a real record",
+        "a052f98b58d306db41c5672d7f5c5950895db304d2b4c4008ce1b4f649500b72",
+        NativeFingerprint.of(
+            "{\"name\":\"jonathan smith\",\"city\":\"boston\",\"n\":42}"));
+    // Field ORDER must not matter -- the kernel sorts. A fingerprint that
+    // depended on column order would split identities across two DataFrames
+    // holding the same data.
+    eqStr("field order is irrelevant",
+        NativeFingerprint.of("{\"a\":1,\"b\":2}"),
+        NativeFingerprint.of("{\"b\":2,\"a\":1}"));
+    // `__`-prefixed keys are dropped INSIDE the kernel, so both surfaces agree
+    // on which fields count without either having to remember to strip them.
+    eqStr("__ keys are dropped",
+        NativeFingerprint.of("{\"a\":1}"),
+        NativeFingerprint.of("{\"a\":1,\"__row_id__\":7}"));
+    // Unreadable input is REFUSED, not hashed into something plausible.
+    if (NativeFingerprint.of("not json") == null) {
+      pass("invalid JSON refused");
+    } else {
+      fail("invalid JSON", "expected null, got a fingerprint");
+    }
+    if (NativeFingerprint.of(null) == null) {
+      pass("null input yields null");
+    } else {
+      fail("null input", "expected null");
+    }
+  }
+
+  static void eqStr(String what, String want, String got) {
+    if (want != null && want.equals(got)) {
+      pass(what);
+    } else {
+      fail(what, "want " + want + ", got " + got);
     }
   }
 

--- a/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/NativeSelfTest.java
+++ b/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/NativeSelfTest.java
@@ -1,0 +1,227 @@
+package dev.goldensuite.spark;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** End-to-end gate for the JNI path, with no Spark anywhere.
+ *
+ * <p>Separate from {@link SelfTest} because it REQUIRES the native library:
+ * SelfTest must stay runnable on any JDK with nothing built, and folding these
+ * in would either make it fail without a library or teach it to skip -- and a
+ * test that skips silently is how a lane goes green while testing nothing.
+ *
+ * <p>This one refuses to skip. If the library is not loadable it FAILS, because
+ * CI runs it immediately after building that library: "not loadable" there means
+ * the build produced something the JVM cannot use, which is the single most
+ * likely way this whole approach breaks.
+ *
+ * <h2>What it can and cannot check</h2>
+ *
+ * It cannot check that jaro-winkler is <i>correct</i> -- there is no oracle on
+ * this side, and inventing one would mean writing the Java implementation this
+ * arc exists to avoid. Cross-language equality against the Python/Rust scorer is
+ * checked where an oracle exists: {@code test_spark_jvm_native_parity.py}.
+ *
+ * <p>What it checks here are the properties that hold for any correct kernel and
+ * catch every marshaling bug: identity scores 1.0, alignment survives a batch,
+ * multi-byte values are not truncated, absence is not evidence, and a bad
+ * request is refused rather than scored.
+ */
+public final class NativeSelfTest {
+
+  private static int failures = 0;
+
+  public static void main(String[] args) {
+    NativeScorer scorer = NativeScorer.createOrNull();
+    System.out.println("  library: " + NativeLibrary.diagnostics());
+    if (scorer == null) {
+      System.err.println(
+          "\nFAIL: the native library did not load. CI builds it in the step"
+              + " before this one, so this means the build produced something the"
+              + " JVM cannot use. Resource path sought: "
+              + NativeLibrary.resourcePath());
+      System.exit(1);
+    }
+
+    theJarSelectsTheNativeScorer();
+    identicalStringsScoreOne(scorer);
+    scoresStayAlignedAcrossABatch(scorer);
+    multiByteValuesAreNotTruncated(scorer);
+    absenceIsNotEvidence(scorer);
+    everyScorerTheSparkTierUsesRuns(scorer);
+    unknownScorerIdsAreRefused(scorer);
+    mismatchedLengthsAreRefused(scorer);
+    aLargeBatchSurvivesInOneCall(scorer);
+
+    if (failures > 0) {
+      System.err.println("\n" + failures + " assertion(s) FAILED");
+      System.exit(1);
+    }
+    System.out.println("\nall native self-tests passed");
+  }
+
+  /** The load-bearing one. Everything below could pass while the UDF Spark
+   * actually calls had silently fallen back to ExactScorer. */
+  static void theJarSelectsTheNativeScorer() {
+    // ScorerSelection, not GoldenScoreUdf: the UDF only delegates here, and this
+    // class is Spark-free so the assertion runs with no Spark classpath. The
+    // delegation is what makes that equivalent -- there is one static, not two.
+    String impl = ScorerSelection.implementationName();
+    if ("NativeScorer".equals(impl)) {
+      pass("the jar resolved NativeScorer");
+    } else {
+      fail("selected implementation", "want NativeScorer, got " + impl + " -- "
+          + ScorerSelection.diagnostics());
+    }
+  }
+
+  static void identicalStringsScoreOne(NativeScorer s) {
+    // True of every scorer in the tier's set, and the cheapest possible check
+    // that the buffers arrived intact: a marshaling bug makes a string unequal
+    // to itself.
+    String[] v = {"jonathan", "smith", "acme corporation"};
+    for (int id : new int[] {GoldenScorer.JARO_WINKLER, GoldenScorer.LEVENSHTEIN,
+        GoldenScorer.TOKEN_SORT, GoldenScorer.EXACT}) {
+      Double[] got = s.score(id, v, v);
+      boolean ok = true;
+      for (Double d : got) {
+        ok = ok && d != null && d == 1.0d;
+      }
+      if (ok) {
+        pass("scorer " + id + ": identical strings score 1.0");
+      } else {
+        fail("scorer " + id + " identity", Arrays.toString(got));
+      }
+    }
+  }
+
+  static void scoresStayAlignedAcrossABatch(NativeScorer s) {
+    // The failure this whole batching design is most exposed to: a score coming
+    // back attached to the wrong pair. Constructed so misalignment cannot hide
+    // -- exact matches interleaved with certain non-matches, so any shift shows.
+    String[] a = {"aa", "bb", "cc", "dd", "ee", "ff"};
+    String[] b = {"aa", "zz", "cc", "zz", "ee", "zz"};
+    Double[] got = s.score(GoldenScorer.EXACT, a, b);
+    eq("batch alignment", Arrays.asList(1.0d, 0.0d, 1.0d, 0.0d, 1.0d, 0.0d),
+        Arrays.asList(got));
+  }
+
+  static void multiByteValuesAreNotTruncated(NativeScorer s) {
+    // Offsets are BYTE offsets. An encoder that writes char counts cuts "Zoë"
+    // short and the value stops matching itself -- and every multi-byte value
+    // AFTER it in the batch is misread too, because the offsets have drifted.
+    String[] a = {"Zoë", "日本語", "plain", "café"};
+    Double[] got = s.score(GoldenScorer.EXACT, a, a);
+    eq("multi-byte identity", Arrays.asList(1.0d, 1.0d, 1.0d, 1.0d), Arrays.asList(got));
+
+    // And a multi-byte value must not read as equal to its ASCII-folded form.
+    Double[] differ = s.score(GoldenScorer.EXACT, new String[] {"café"},
+        new String[] {"cafe"});
+    eq("multi-byte inequality", Arrays.asList(0.0d), Arrays.asList(differ));
+  }
+
+  static void absenceIsNotEvidence(NativeScorer s) {
+    // null-vs-null must be null, NOT 1.0. The kernel has no validity bitmap by
+    // design, so this is entirely the host's presence mask doing its job -- and
+    // the failure it prevents (records merging on a shared absence) is one this
+    // tier already shipped once.
+    Double[] got = s.score(GoldenScorer.JARO_WINKLER,
+        new String[] {null, "smith", null, "a"},
+        new String[] {null, null, "jones", "a"});
+    eq("absence", Arrays.asList(null, null, null, 1.0d), Arrays.asList(got));
+  }
+
+  static void everyScorerTheSparkTierUsesRuns(NativeScorer s) {
+    // J0 could run one scorer. The point of J2 is that the restriction is gone,
+    // so assert the tier's whole set actually executes rather than assuming the
+    // dispatch reaches them.
+    String[] a = {"jonathan smith"};
+    String[] b = {"smith jonathon"};
+    for (int id : new int[] {GoldenScorer.JARO_WINKLER, GoldenScorer.LEVENSHTEIN,
+        GoldenScorer.TOKEN_SORT, GoldenScorer.EXACT}) {
+      Double[] got = s.score(id, a, b);
+      if (got.length == 1 && got[0] != null && got[0] >= 0.0d && got[0] <= 1.0d) {
+        pass("scorer " + id + " runs (" + got[0] + ")");
+      } else {
+        fail("scorer " + id + " runs", Arrays.toString(got));
+      }
+    }
+    if (!s.supports(GoldenScorer.JARO_WINKLER)) {
+      fail("supports jaro_winkler", "the kernel is loaded but says it cannot");
+    } else {
+      pass("supports() reports the kernel's own id range (" + s.scorerIds() + " ids)");
+    }
+  }
+
+  static void unknownScorerIdsAreRefused(NativeScorer s) {
+    // score_one's catch-all returns 0.0 for an id it does not know, which is a
+    // confident wrong answer rather than an error. The host must not let one
+    // through.
+    for (int id : new int[] {-1, s.scorerIds(), s.scorerIds() + 100, 9999}) {
+      try {
+        s.score(id, new String[] {"a"}, new String[] {"a"});
+        fail("refuse scorer " + id, "expected UnsupportedOperationException");
+      } catch (UnsupportedOperationException e) {
+        pass("scorer id " + id + " refused");
+      }
+    }
+  }
+
+  static void mismatchedLengthsAreRefused(NativeScorer s) {
+    try {
+      s.score(GoldenScorer.EXACT, new String[] {"a"}, new String[] {"a", "b"});
+      fail("length mismatch", "expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      pass("length mismatch refused");
+    }
+  }
+
+  static void aLargeBatchSurvivesInOneCall(NativeScorer s) {
+    // The batch size the tier actually uses (batched.DEFAULT_BATCH_SIZE). The
+    // whole approach rests on one downcall carrying this many pairs, and the
+    // arrays it pins are proportionally large; a size limit would surface here
+    // rather than in an executor.
+    final int n = 10_000;
+    String[] a = new String[n];
+    String[] b = new String[n];
+    for (int i = 0; i < n; i++) {
+      a[i] = "value-" + i;
+      b[i] = (i % 3 == 0) ? a[i] : "other-" + i;
+    }
+    Double[] got = s.score(GoldenScorer.EXACT, a, b);
+    int matches = 0;
+    for (int i = 0; i < n; i++) {
+      if (got[i] != null && got[i] == 1.0d) {
+        matches++;
+      }
+    }
+    int want = (n + 2) / 3;
+    if (got.length == n && matches == want) {
+      pass("10,000 pairs in one call (" + matches + " exact matches)");
+    } else {
+      fail("large batch", "length " + got.length + ", " + matches + " matches, want "
+          + want);
+    }
+  }
+
+  // ── tiny assertion helpers ─────────────────────────────────────────
+
+  static void eq(String what, List<?> want, List<?> got) {
+    if (want.equals(got)) {
+      pass(what);
+    } else {
+      fail(what, "want " + want + ", got " + got);
+    }
+  }
+
+  static void pass(String what) {
+    System.out.println("  ok   " + what);
+  }
+
+  static void fail(String what, String detail) {
+    failures++;
+    System.out.println("  FAIL " + what + ": " + detail);
+  }
+
+  private NativeSelfTest() {}
+}

--- a/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/SelfTest.java
+++ b/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/SelfTest.java
@@ -33,6 +33,7 @@ public final class SelfTest {
     utf8DistinguishesNullFromEmptyString();
     utf8OffsetsAreNonDecreasingAndEndAtDataLength();
     utf8RoundTripsEveryValue();
+    theResourcePathMatchesWhatTheBuildStages();
 
     if (failures > 0) {
       System.err.println("\n" + failures + " assertion(s) FAILED");
@@ -237,7 +238,69 @@ public final class SelfTest {
     eq("round trip", Arrays.asList(in), got);
   }
 
+  // ── NativeLibrary resource resolution (J3) ─────────────────────────
+
+  static void theResourcePathMatchesWhatTheBuildStages() {
+    // The loader computes a resource path from os.name/os.arch; CI stages files
+    // at literal paths. Nothing connects the two but this assertion, and a
+    // mismatch does not crash -- the resource is simply not found, the jar
+    // falls back to the `exact`-only scorer, and a cluster runs slower and
+    // narrower without saying so. That is the failure mode J3 exists to
+    // prevent, so the two spellings are pinned against each other here.
+    //
+    // The names are asserted for the platforms CI BUILDS, independently of the
+    // platform this test runs on -- otherwise the aarch64 mapping would only
+    // ever be checked on aarch64, which is exactly the platform nobody was
+    // testing when the jar shipped x86-only.
+    eqStr("x86-64 linux resource",
+        "/native/linux-x86-64/libgoldenmatch_score_jni.so",
+        resourceFor("Linux", "amd64"));
+    eqStr("aarch64 linux resource",
+        "/native/linux-aarch64/libgoldenmatch_score_jni.so",
+        resourceFor("Linux", "aarch64"));
+    // A Graviton JVM may report either spelling depending on vendor.
+    eqStr("arm64 is the same as aarch64",
+        "/native/linux-aarch64/libgoldenmatch_score_jni.so",
+        resourceFor("Linux", "arm64"));
+    // x86_64 is what some JVMs report instead of amd64.
+    eqStr("x86_64 is the same as amd64",
+        "/native/linux-x86-64/libgoldenmatch_score_jni.so",
+        resourceFor("Linux", "x86_64"));
+    // Not built by CI, but the mapping must still be stable -- these are the
+    // paths an in-tree developer build stages to.
+    eqStr("macOS arm resource",
+        "/native/darwin-aarch64/libgoldenmatch_score_jni.dylib",
+        resourceFor("Mac OS X", "aarch64"));
+    eqStr("windows resource",
+        "/native/windows-x86-64/goldenmatch_score_jni.dll",
+        resourceFor("Windows 11", "amd64"));
+  }
+
+  /** {@link NativeLibrary#resourcePath()} as it would resolve on another
+   * platform. The properties are restored afterwards so this cannot leak into a
+   * later test -- and into the LOADER, which reads the same properties. */
+  static String resourceFor(String osName, String osArch) {
+    String oldOs = System.getProperty("os.name");
+    String oldArch = System.getProperty("os.arch");
+    try {
+      System.setProperty("os.name", osName);
+      System.setProperty("os.arch", osArch);
+      return NativeLibrary.resourcePath();
+    } finally {
+      System.setProperty("os.name", oldOs);
+      System.setProperty("os.arch", oldArch);
+    }
+  }
+
   // ── tiny assertion helpers ─────────────────────────────────────────
+
+  static void eqStr(String what, String want, String got) {
+    if (want.equals(got)) {
+      pass(what);
+    } else {
+      fail(what, "want " + want + ", got " + got);
+    }
+  }
 
   static void eq(String what, int want, int got) {
     if (want == got) {

--- a/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/SelfTest.java
+++ b/packages/jvm/goldenmatch-spark/test/dev/goldensuite/spark/SelfTest.java
@@ -28,6 +28,11 @@ public final class SelfTest {
     exactReturnsNullForAnUnobservedPair();
     exactRefusesEveryOtherScorer();
     exactRefusesMismatchedLengths();
+    utf8EncodesOffsetsAsByteOffsetsNotCharOffsets();
+    utf8EncodesAnEmptyBatch();
+    utf8DistinguishesNullFromEmptyString();
+    utf8OffsetsAreNonDecreasingAndEndAtDataLength();
+    utf8RoundTripsEveryValue();
 
     if (failures > 0) {
       System.err.println("\n" + failures + " assertion(s) FAILED");
@@ -160,7 +165,104 @@ public final class SelfTest {
     }
   }
 
+  // ── Utf8Batch ──────────────────────────────────────────────────────
+  //
+  // The J2 marshaling layer, and the piece most likely to be silently wrong:
+  // every failure mode here produces a NUMBER rather than an exception, and a
+  // wrong similarity score looks exactly like a right one.
+
+  static void utf8EncodesOffsetsAsByteOffsetsNotCharOffsets() {
+    // The classic Arrow marshaling bug. "Zoë" is 3 chars and 4 UTF-8 bytes; an
+    // encoder that writes char counts truncates the value and scores garbage
+    // against a correctly-encoded counterpart.
+    Utf8Batch b = Utf8Batch.encode(new String[] {"Zoë", "ab"});
+    eqInts("byte offsets", new int[] {0, 4, 6}, b.offsets);
+    eq("byte count", 6, b.data.length);
+  }
+
+  static void utf8EncodesAnEmptyBatch() {
+    // An empty batch is a real case (a group can filter to nothing), and the
+    // offsets array must still be n+1 = 1 element or the kernel reads past it.
+    Utf8Batch b = Utf8Batch.encode(new String[] {});
+    eqInts("empty batch offsets", new int[] {0}, b.offsets);
+    eq("empty batch data", 0, b.data.length);
+    eq("empty batch length", 0, b.length);
+  }
+
+  static void utf8DistinguishesNullFromEmptyString() {
+    // Both encode to a zero-length slice -- there is nowhere else for a null to
+    // go in Arrow's layout -- so the PRESENCE MASK is the only thing that keeps
+    // them apart. If it did not, a missing value would score as an empty string
+    // and null-vs-null would come back a perfect 1.0: the exact substitution
+    // that merged records whose only shared evidence was a shared absence.
+    Utf8Batch b = Utf8Batch.encode(new String[] {null, "", "x"});
+    eqInts("null and empty both empty slices", new int[] {0, 0, 0, 1}, b.offsets);
+    eqBools("presence mask", new boolean[] {false, true, true}, b.present);
+  }
+
+  static void utf8OffsetsAreNonDecreasingAndEndAtDataLength() {
+    // score-cabi REFUSES decreasing offsets or offsets past the buffer, so a
+    // violation here is a hard error rather than a wrong score -- but it would
+    // surface as an opaque -3 from inside an executor. Catch it at the source.
+    Utf8Batch b = Utf8Batch.encode(new String[] {"alpha", null, "", "béta", "c"});
+    boolean ok = b.offsets.length == b.length + 1
+        && b.offsets[0] == 0
+        && b.offsets[b.length] == b.data.length;
+    for (int i = 0; ok && i < b.length; i++) {
+      ok = b.offsets[i] <= b.offsets[i + 1];
+    }
+    if (ok) {
+      pass("offsets non-decreasing and terminated at data.length");
+    } else {
+      fail("offsets invariant", Arrays.toString(b.offsets) + " over " + b.data.length
+          + " bytes");
+    }
+  }
+
+  static void utf8RoundTripsEveryValue() {
+    // The end-to-end property: whatever went in must be readable back out of
+    // the slices, byte for byte. Anything weaker passes while the encoder is
+    // off by one and only shows up as a slightly wrong similarity.
+    String[] in = {"alpha", null, "", "béta", "日本語", "z"};
+    Utf8Batch b = Utf8Batch.encode(in);
+    List<String> got = new ArrayList<>();
+    for (int i = 0; i < b.length; i++) {
+      if (!b.present[i]) {
+        got.add(null);
+        continue;
+      }
+      got.add(new String(b.data, b.offsets[i], b.offsets[i + 1] - b.offsets[i],
+          java.nio.charset.StandardCharsets.UTF_8));
+    }
+    eq("round trip", Arrays.asList(in), got);
+  }
+
   // ── tiny assertion helpers ─────────────────────────────────────────
+
+  static void eq(String what, int want, int got) {
+    if (want == got) {
+      pass(what);
+    } else {
+      fail(what, "want " + want + ", got " + got);
+    }
+  }
+
+  static void eqInts(String what, int[] want, int[] got) {
+    if (Arrays.equals(want, got)) {
+      pass(what);
+    } else {
+      fail(what, "want " + Arrays.toString(want) + ", got " + Arrays.toString(got));
+    }
+  }
+
+  static void eqBools(String what, boolean[] want, boolean[] got) {
+    if (Arrays.equals(want, got)) {
+      pass(what);
+    } else {
+      fail(what, "want " + Arrays.toString(want) + ", got " + Arrays.toString(got));
+    }
+  }
+
 
   static void eq(String what, List<?> want, List<?> got) {
     if (want.equals(got)) {

--- a/packages/python/goldenmatch/goldenmatch/core/strsim.py
+++ b/packages/python/goldenmatch/goldenmatch/core/strsim.py
@@ -34,6 +34,7 @@ __all__ = [
     "levenshtein_normalized_similarity",
     "indel_normalized_similarity",
     "ratio",
+    "token_sort_similarity",
     "token_sort_ratio",
     "partial_ratio",
     "damerau_levenshtein_distance",
@@ -255,14 +256,45 @@ def ratio(s1: str, s2: str) -> float:
     return indel_normalized_similarity(s1, s2) * 100.0
 
 
+def token_sort_similarity(s1: str, s2: str) -> float:
+    """Token-sort similarity on ``[0, 1]``.
+
+    == ``score_one(2, s1, s2)`` in score-core, which is
+    ``indel_ratio(token_sort_string(a), token_sort_string(b))``. Rust's
+    ``split_whitespace`` + ``sort_unstable`` + ``join(" ")`` is this function's
+    ``" ".join(sorted(s.split()))``: same tokens, and UTF-8 byte order is
+    code-point order, so the sorts agree.
+
+    Exists because callers that want ``[0, 1]`` were reaching for
+    :func:`token_sort_ratio` and dividing by 100 -- and ``(x * 100) / 100`` is
+    not ``x`` in binary floating point. That cost one ULP against the kernel, for
+    nothing. Consumers on the ``[0, 1]`` scale should call this; the 0-100
+    :func:`token_sort_ratio` stays exactly as it was for rapidfuzz parity.
+
+    .. note::
+       ``token_sort_ratio(...) / 100.0`` is still written at roughly eight other
+       call sites (``core.scorer``, ``core.boost``, ``core.explainer``,
+       ``backends.score_buckets``, ``native``, ``backends.datafusion_backend``).
+       They carry the same one-ULP deviation from ``score_one``. Moving them is a
+       repo-wide change to scores that are THRESHOLDED, with pinned expectations
+       across several suites, so it is deliberately NOT bundled with the J2 work
+       that found it -- it wants its own change and its own gate run.
+    """
+    a = " ".join(sorted(s1.split()))
+    b = " ".join(sorted(s2.split()))
+    return indel_normalized_similarity(a, b)
+
+
 def token_sort_ratio(s1: str, s2: str) -> float:
     """== rapidfuzz ``fuzz.token_sort_ratio`` (0-100 scale): Indel ratio over
     whitespace-split, code-point-sorted, space-joined tokens. No case
     normalization (rapidfuzz's default processor here is a no-op), so
-    ``Foo``/``foo`` scores 66.67, matching the crate."""
-    a = " ".join(sorted(s1.split()))
-    b = " ".join(sorted(s2.split()))
-    return indel_normalized_similarity(a, b) * 100.0
+    ``Foo``/``foo`` scores 66.67, matching the crate.
+
+    The scaled form of :func:`token_sort_similarity`, not a second
+    implementation -- byte-identical to what it computed before that function was
+    split out (same expression, same order of operations)."""
+    return token_sort_similarity(s1, s2) * 100.0
 
 
 def partial_ratio(s1: str, s2: str) -> float:

--- a/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
@@ -352,8 +352,38 @@ def _field_score_parts(field: Any, a_prefix: str, b_prefix: str) -> tuple[Any, A
     )
 
 
-def _transformed(col: Any, chain: list[str]) -> Any:
-    """Apply a one-box transform chain to a column via ``apply_transforms``."""
+def _transformed(
+    col: Any, chain: list[str], transform_udf: str | None = None
+) -> Any:
+    """Apply a one-box transform chain to a column via ``apply_transforms``.
+
+    ``transform_udf`` is the SQL name of the jar's ``golden_transform``. When
+    given, the chain runs ENTIRELY IN THE EXECUTOR JVM over the same pyo3-free
+    ``transforms-core`` Python uses, so no Python worker is involved and no
+    executor virtualenv is needed.
+
+    The chain is validated on the DRIVER first. ``bloom_filter`` and plugin
+    transforms are Python-only by design, and a chain containing one is
+    refused here -- at plan time, naming the transform -- rather than
+    returning nulls from every row of an already-distributed job.
+    """
+    if transform_udf is not None:
+        from pyspark.sql import functions as F
+
+        from goldenmatch.spark.jvm import unsupported_transforms
+
+        bad = unsupported_transforms(chain)
+        if bad:
+            raise ValueError(
+                f"the JVM transform path cannot run {bad}. `bloom_filter` is "
+                f"HMAC-keyed PPRL and plugin transforms are arbitrary Python; "
+                f"both are Python-only by design. Drop them from the chain, "
+                f"or omit transform_udf and ship a Python environment."
+            )
+        return F.call_udf(
+            transform_udf, col.cast("string"), F.lit(",".join(chain))
+        )
+
     from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
     @arrow_udf("string")

--- a/packages/python/goldenmatch/goldenmatch/spark/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/golden.py
@@ -17,6 +17,38 @@ from __future__ import annotations
 from typing import Any
 
 
+def merge_expr(col: Any, strategy: str, survivorship_udf: str) -> Any:
+    """Survivorship in the EXECUTOR JVM, over the same pyo3-free
+    ``survivorship-core`` the Python path uses.
+
+    ``col`` is one cluster's collected field values (a ``collect_list``).
+
+    The strategy is validated on the DRIVER first. ``source_priority`` needs a
+    sources list and ``most_recent`` needs dates -- neither of which this call
+    site passes, so Python RAISES for them and the kernel refuses. ``custom:*``
+    is arbitrary Python. Refusing at plan time with the strategy named beats
+    emitting a plausible wrong survivor from every cluster, because a golden
+    record chosen by a different rule raises nothing and looks right.
+    """
+    from pyspark.sql import functions as F
+
+    from goldenmatch.spark.jvm import (
+        JVM_SURVIVORSHIP_STRATEGIES,
+        jvm_supports_strategy,
+    )
+
+    if not jvm_supports_strategy(strategy):
+        raise ValueError(
+            f"the JVM survivorship path cannot run strategy {strategy!r}. "
+            f"`source_priority` needs a sources list and `most_recent` needs "
+            f"dates, neither of which this call site passes -- Python raises for "
+            f"them too. `custom:` strategies are arbitrary Python. Available: "
+            f"{sorted(JVM_SURVIVORSHIP_STRATEGIES)}. Omit survivorship_udf to "
+            f"use the Python path with an executor environment."
+        )
+    return F.call_udf(survivorship_udf, col, F.lit(strategy))
+
+
 def make_merge_udf(strategy: str) -> Any:
     """A scalar arrow UDF mapping an array-of-values column (one cluster's
     collected field values) to the survivor value via ``merge_field``."""

--- a/packages/python/goldenmatch/goldenmatch/spark/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/identity.py
@@ -86,16 +86,68 @@ def _id_scheme() -> str:
 # --- Spark frame builders (lazy pyspark imports) ---
 
 
+#: Spark types whose `to_json` encoding is proven to fingerprint identically to
+#: the Python path. Deliberately narrow -- see `_jvm_fingerprint_types_ok`.
+_JVM_FINGERPRINT_TYPES = frozenset(
+    {"string", "boolean", "byte", "short", "integer", "long", "null"}
+)
+
+
+def _jvm_fingerprint_types_ok(source_df: Any, payload_cols: list[str]) -> list[str]:
+    """Payload columns whose type is NOT proven safe for the JVM path.
+
+    The JVM path fingerprints ``to_json(struct(...))``; the Python path
+    fingerprints a dict that has been through ``_canonical_payload``. Those agree
+    for strings, integers, booleans and nulls, and are NOT proven to agree for:
+
+    - **floats** -- Python hands the kernel a float value; Spark hands it a JSON
+      literal, and the two only fingerprint alike if every float renders
+      identically. Round-tripping through text is exactly where that breaks.
+    - **non-finite floats** -- ``_canonical_payload`` turns them into the STRINGS
+      ``"nan"``/``"inf"``/``"-inf"``. Spark's ``to_json`` emits bare ``NaN`` /
+      ``Infinity`` tokens, which are not even valid JSON.
+    - **dates and timestamps** -- Python calls ``.isoformat()``; Spark applies its
+      own session-dependent format. Same instant, different bytes, different id.
+    - **binary, arrays, maps, structs** -- ``_canonical_payload`` reduces these
+      with ``str()``, which is a Python repr and has no JSON analogue.
+
+    A wrong fingerprint does not fail; it silently splits one identity into two
+    or merges two into one. So an unproven type is REFUSED rather than guessed
+    at, and the message names the columns so the caller can cast them or keep
+    the Python path for this dataset.
+    """
+    bad = []
+    for f in source_df.schema.fields:
+        if f.name not in payload_cols:
+            continue
+        if f.dataType.typeName().lower() not in _JVM_FINGERPRINT_TYPES:
+            bad.append(f"{f.name}:{f.dataType.simpleString()}")
+    return bad
+
+
 def derive_record_ids(
     source_df: Any,
     *,
     source_col: str = "__source__",
     source_pk_col: str | None = None,
     id_col: str = "__row_id__",
+    fingerprint_udf: str | None = None,
 ) -> Any:
     """Add a ``record_id`` column to ``source_df``. PK path is a pure column
     expression; the no-PK h1 path runs ``record_id_for_row`` in a struct
     arrow_udf over the payload columns (parity with one-box by construction).
+
+    ``fingerprint_udf`` is the SQL name of the jar's ``golden_fingerprint``
+    (see :func:`goldenmatch.spark.jvm.install`). When given, the no-PK path is
+    computed **entirely in the executor JVM** -- Spark builds the JSON with
+    ``to_json(struct(...))`` and the same Rust ``fingerprint-core`` that Python
+    uses hashes it -- so no Python worker is involved and no executor virtualenv
+    is needed. The jar-only inventory measures exactly this.
+
+    Passed explicitly rather than auto-detected, matching
+    :func:`goldenmatch.spark.batched.score_pairs_batched`: whether a run needs
+    Python on its executors is a deployment decision, and a path that silently
+    switched itself would make identities depend on which jar happened to load.
     """
     from pyspark.sql import functions as F
 
@@ -116,6 +168,29 @@ def derive_record_ids(
     # no-PK h1 id matches one-box per-row. Falls back to "dataframe" per row
     # when __source__ is absent (matches one-box row.get default).
     udf_cols = payload_cols + ([source_col] if has_source else [])
+
+    if fingerprint_udf is not None:
+        bad = _jvm_fingerprint_types_ok(source_df, payload_cols)
+        if bad:
+            raise ValueError(
+                f"the JVM fingerprint path cannot be used for {source_df} because "
+                f"these columns have types whose JSON encoding is not proven to "
+                f"fingerprint identically to the Python path: {', '.join(bad)}. "
+                f"A differing fingerprint does not fail -- it silently splits one "
+                f"identity in two -- so it is refused. Cast them to string, or "
+                f"omit fingerprint_udf and ship a Python environment for this "
+                f"dataset. Proven-safe types: {sorted(_JVM_FINGERPRINT_TYPES)}."
+            )
+        # `__`-prefixed keys are dropped INSIDE fingerprint-core, so the struct
+        # is built from payload_cols only and the two surfaces cannot disagree
+        # about which fields count. `to_json` runs in the engine: no Python.
+        h1 = F.call_udf(
+            fingerprint_udf, F.to_json(F.struct(*[F.col(c) for c in payload_cols]))
+        )
+        return source_df.withColumn(
+            "record_id",
+            F.concat(src_expr, F.lit(":h1:"), F.substring(h1, 1, 12)),
+        )
 
     # ONE struct argument rather than a variadic UDF. The pandas version took
     # *cols and rebuilt a frame with `pd.concat`; arrow_udf's variadic form is

--- a/packages/python/goldenmatch/goldenmatch/spark/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/identity.py
@@ -184,8 +184,22 @@ def derive_record_ids(
         # `__`-prefixed keys are dropped INSIDE fingerprint-core, so the struct
         # is built from payload_cols only and the two surfaces cannot disagree
         # about which fields count. `to_json` runs in the engine: no Python.
+        # `ignoreNullFields=false` is LOAD-BEARING. Spark's `to_json` omits null
+        # fields by default, so a row with a missing value produced JSON without
+        # that key at all -- while the Python path hands the kernel a dict that
+        # still carries `city: None`. Different fields in, different fingerprint
+        # out, and the two ids simply disagree.
+        #
+        # Caught by `test_derive_record_ids_matches_the_python_path`, which is
+        # exactly the row it was written for: name="" / city=None. The type gate
+        # above cannot see this -- every column was a proven-safe type; the
+        # divergence was in the ENCODING, not the types.
         h1 = F.call_udf(
-            fingerprint_udf, F.to_json(F.struct(*[F.col(c) for c in payload_cols]))
+            fingerprint_udf,
+            F.to_json(
+                F.struct(*[F.col(c) for c in payload_cols]),
+                {"ignoreNullFields": "false"},
+            ),
         )
         return source_df.withColumn(
             "record_id",

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -1,4 +1,5 @@
-"""J0: ship the JVM scorer jar to a Spark session and register it.
+"""Ship the JVM scorer jar to a Spark session and register it (J0), now backed
+by the Rust kernel over JNI (J2).
 
 The tier scores by forking a Python worker per batch (`arrow_udf`): an Arrow IPC
 hop plus an interpreter, and the sole reason P1 ships a Python environment to
@@ -11,16 +12,19 @@ an array-shaped UDF carries 10,000 pairs in one call. That last one is what make
 the approach worth anything: Connect only permits row-shaped UDFs, so without
 batching every pair would cost a downcall into native code.
 
-**J0 carries no scoring algorithms.** The jar implements `exact` only, and
-refuses every other scorer loudly. A Java jaro-winkler would be a fourth
-implementation of a kernel that already exists once in Rust, which is the thing
-this whole arc argues against; `exact` escapes that because string equality is
-identical by inspection in any language. The kernel arrives in J2 via JNI into
-`score-cabi`.
+**The jar carries no scoring algorithms of its own -- it calls the Rust one.**
+J0 shipped `exact` only and refused everything else, deliberately: a Java
+jaro-winkler would have been a fourth implementation of a kernel that already
+exists once in Rust, which is the thing this whole arc argues against. J2 lifts
+the restriction the right way round, by reaching the kernel rather than copying
+it -- `NativeScorer` -> JNI -> `score-cabi` -> `score_one`, the same dispatcher
+behind pyo3 `native`, `datafusion-udf` and `score-wasm`.
 
-So nothing routes through here yet by default. J0's job is to prove the plumbing
-with no native call in the picture, so that when the plan reshape lands in J1 a
-misalignment cannot be confused with a kernel bug.
+The library rides inside the jar and is extracted per JVM, so `addArtifact`
+delivers everything: one file, nothing installed on the cluster, no
+`java.library.path` flags. When it will not load the jar falls back to the
+`exact`-only scorer so a distributed job survives -- and :func:`implementation`
+exists so that fallback can never pass for a native run.
 """
 from __future__ import annotations
 
@@ -37,7 +41,17 @@ JAR_ENV = "GOLDENMATCH_SPARK_JAR"
 #: The SQL name the batch scorer registers under.
 UDF_NAME = "golden_score_batch"
 
+#: The SQL name of the probe reporting which scorer an EXECUTOR resolved.
+IMPL_UDF_NAME = "golden_score_impl"
+
 _UDF_CLASS = "dev.goldensuite.spark.GoldenScoreUdf"
+_IMPL_UDF_CLASS = "dev.goldensuite.spark.GoldenScoreImplUdf"
+
+#: What ``implementation()`` reports when the Rust kernel loaded.
+NATIVE_IMPL = "NativeScorer"
+
+#: ...and when it did not, and the jar fell back to `exact`-only.
+FALLBACK_IMPL = "ExactScorer"
 
 #: Where the build puts the jar, relative to the repo root.
 _BUILT_JAR = Path("packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar")
@@ -114,18 +128,51 @@ def install(spark: object, *, jar: str | os.PathLike[str] | None = None,
             f"session, so check the session was built with `.remote(...)`."
         ) from exc
 
-    try:
-        spark.udf.registerJavaFunction(  # type: ignore[attr-defined]
-            name, _UDF_CLASS, "array<double>"
-        )
-    except Exception as exc:  # noqa: BLE001
-        raise JvmScorerUnavailable(
-            f"could not register {_UDF_CLASS} as {name!r}: "
-            f"{type(exc).__name__}: {exc}"
-        ) from exc
+    for sql_name, cls, ret in (
+        (name, _UDF_CLASS, "array<double>"),
+        # Registered alongside, not on demand: the probe has to be available
+        # BEFORE anything is scored, or the first thing a caller can check is
+        # whether the results they already trusted came from the kernel.
+        (IMPL_UDF_NAME, _IMPL_UDF_CLASS, "string"),
+    ):
+        try:
+            spark.udf.registerJavaFunction(sql_name, cls, ret)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001
+            raise JvmScorerUnavailable(
+                f"could not register {cls} as {sql_name!r}: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
 
     logger.info("Spark JVM scorer: shipped %s and registered %r", path, name)
     return name
+
+
+def implementation(spark: object) -> tuple[str, str]:
+    """Ask an **executor** which scorer it resolved, and why.
+
+    Returns ``(implementation_name, diagnostics)`` -- see :data:`NATIVE_IMPL` and
+    :data:`FALLBACK_IMPL`.
+
+    The jar falls back to the `exact`-only scorer when the native library will
+    not load, which keeps a distributed job alive but is otherwise invisible: the
+    query still returns numbers, from a narrower path, and every version string
+    still looks right. This project has already lost time to that shape of
+    failure, so the resolution is queryable and the lane asserts on it.
+
+    **The answer must come from an executor, not the driver.** A driver that
+    loads the library says nothing about a cluster whose executors cannot -- and
+    a zero-argument deterministic UDF would be constant-folded onto the driver at
+    planning time, answering the wrong question perfectly. Hence the probe takes
+    a column and this passes it one.
+    """
+    from pyspark.sql import functions as F
+
+    df = spark.range(1)  # type: ignore[attr-defined]
+    raw = df.select(
+        F.call_udf(IMPL_UDF_NAME, F.col("id").cast("int")).alias("impl")
+    ).collect()[0]["impl"]
+    name, _, diagnostics = str(raw).partition("|")
+    return name, diagnostics
 
 
 def scorer_id(name: str) -> int:

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -51,6 +51,50 @@ _UDF_CLASS = "dev.goldensuite.spark.GoldenScoreUdf"
 _IMPL_UDF_CLASS = "dev.goldensuite.spark.GoldenScoreImplUdf"
 _FINGERPRINT_UDF_CLASS = "dev.goldensuite.spark.GoldenFingerprintUdf"
 
+#: The SQL name of the transform chain (normalization).
+TRANSFORM_UDF_NAME = "golden_transform"
+
+_TRANSFORM_UDF_CLASS = "dev.goldensuite.spark.GoldenTransformUdf"
+
+#: Transforms the JVM can run, mirroring ``transforms_core::supports``.
+#:
+#: The RUST side is authoritative -- it is what actually runs -- and this set
+#: exists so a chain is refused on the DRIVER, at plan time, with the offending
+#: name in hand. Discovering it mid-job, after the plan is distributed, is
+#: strictly worse. ``bloom_filter`` (HMAC-keyed PPRL) and plugin transforms are
+#: absent on purpose, not pending.
+JVM_TRANSFORMS = frozenset({
+    "lowercase", "uppercase", "strip", "strip_all", "soundex", "metaphone",
+    "digits_only", "alpha_only", "normalize_whitespace", "token_sort",
+    "first_token", "last_token", "strip_honorifics",
+})
+
+
+def _is_int(s: str) -> bool:
+    try:
+        int(s)
+    except ValueError:
+        return False
+    return True
+
+
+def jvm_supports_transform(name: str) -> bool:
+    """Whether the JVM can run one transform. Mirrors ``transforms_core::supports``."""
+    if name in JVM_TRANSFORMS:
+        return True
+    parts = name.split(":")
+    if name.startswith("substring:"):
+        return len(parts) == 3 and all(_is_int(p) for p in parts[1:])
+    if name.startswith("qgram:"):
+        return len(parts) == 2 and _is_int(parts[1]) and int(parts[1]) > 0
+    return False
+
+
+def unsupported_transforms(chain: list[str]) -> list[str]:
+    """The transforms in ``chain`` the JVM cannot run. Empty means the whole
+    chain normalizes with no Python on the executors."""
+    return [t for t in chain if not jvm_supports_transform(t)]
+
 #: What ``implementation()`` reports when the Rust kernel loaded.
 NATIVE_IMPL = "NativeScorer"
 
@@ -143,6 +187,10 @@ def install(spark: object, *, jar: str | os.PathLike[str] | None = None,
         # every capability the jar has -- a caller should not have to know which
         # kernels exist to get them.
         (FINGERPRINT_UDF_NAME, _FINGERPRINT_UDF_CLASS, "string"),
+        # The transform chain. Normalization was Python-only until
+        # `transforms-core`; this is what lets a cluster normalize a
+        # column without an executor virtualenv.
+        (TRANSFORM_UDF_NAME, _TRANSFORM_UDF_CLASS, "string"),
     ):
         try:
             spark.udf.registerJavaFunction(sql_name, cls, ret)  # type: ignore[attr-defined]

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -56,6 +56,30 @@ TRANSFORM_UDF_NAME = "golden_transform"
 
 _TRANSFORM_UDF_CLASS = "dev.goldensuite.spark.GoldenTransformUdf"
 
+#: The SQL name of the golden-record survivorship kernel.
+SURVIVORSHIP_UDF_NAME = "golden_survivorship"
+
+_SURVIVORSHIP_UDF_CLASS = "dev.goldensuite.spark.GoldenSurvivorshipUdf"
+
+#: Survivorship strategies the JVM can run, mirroring
+#: ``survivorship_core::SUPPORTED``.
+#:
+#: The Spark call site passes values and a strategy and nothing else, so
+#: ``source_priority`` (needs sources) and ``most_recent`` (needs dates) are
+#: absent -- Python RAISES for them on that call, and so does the kernel.
+#: ``custom:*`` is arbitrary Python. All three are refused on the DRIVER so a
+#: job fails at plan time with the strategy named, rather than emitting a
+#: plausible wrong survivor from every cluster.
+JVM_SURVIVORSHIP_STRATEGIES = frozenset({
+    "most_complete", "majority_vote", "first_non_null", "longest_value",
+    "unanimous_or_null", "confidence_majority",
+})
+
+
+def jvm_supports_strategy(strategy: str) -> bool:
+    """Whether the JVM can run one survivorship strategy."""
+    return strategy in JVM_SURVIVORSHIP_STRATEGIES
+
 #: Transforms the JVM can run, mirroring ``transforms_core::supports``.
 #:
 #: The RUST side is authoritative -- it is what actually runs -- and this set
@@ -191,6 +215,9 @@ def install(spark: object, *, jar: str | os.PathLike[str] | None = None,
         # `transforms-core`; this is what lets a cluster normalize a
         # column without an executor virtualenv.
         (TRANSFORM_UDF_NAME, _TRANSFORM_UDF_CLASS, "string"),
+        # Golden-record survivorship, the last of the four kernels the jar
+        # carries.
+        (SURVIVORSHIP_UDF_NAME, _SURVIVORSHIP_UDF_CLASS, "string"),
     ):
         try:
             spark.udf.registerJavaFunction(sql_name, cls, ret)  # type: ignore[attr-defined]

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -44,8 +44,12 @@ UDF_NAME = "golden_score_batch"
 #: The SQL name of the probe reporting which scorer an EXECUTOR resolved.
 IMPL_UDF_NAME = "golden_score_impl"
 
+#: The SQL name of the record-fingerprint kernel (identity graph).
+FINGERPRINT_UDF_NAME = "golden_fingerprint"
+
 _UDF_CLASS = "dev.goldensuite.spark.GoldenScoreUdf"
 _IMPL_UDF_CLASS = "dev.goldensuite.spark.GoldenScoreImplUdf"
+_FINGERPRINT_UDF_CLASS = "dev.goldensuite.spark.GoldenFingerprintUdf"
 
 #: What ``implementation()`` reports when the Rust kernel loaded.
 NATIVE_IMPL = "NativeScorer"
@@ -134,6 +138,11 @@ def install(spark: object, *, jar: str | os.PathLike[str] | None = None,
         # BEFORE anything is scored, or the first thing a caller can check is
         # whether the results they already trusted came from the kernel.
         (IMPL_UDF_NAME, _IMPL_UDF_CLASS, "string"),
+        # The identity graph's fingerprint, over the SAME `fingerprint-core`
+        # Python uses. Registered here so one `install` call gives a session
+        # every capability the jar has -- a caller should not have to know which
+        # kernels exist to get them.
+        (FINGERPRINT_UDF_NAME, _FINGERPRINT_UDF_CLASS, "string"),
     ):
         try:
             spark.udf.registerJavaFunction(sql_name, cls, ret)  # type: ignore[attr-defined]

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -147,11 +147,18 @@ def install(spark: object, *, jar: str | os.PathLike[str] | None = None,
     return name
 
 
-def implementation(spark: object) -> tuple[str, str]:
-    """Ask an **executor** which scorer it resolved, and why.
+def implementation(spark: object) -> tuple[str, str, str]:
+    """Ask an **executor** which scorer it resolved, why, and on what.
 
-    Returns ``(implementation_name, diagnostics)`` -- see :data:`NATIVE_IMPL` and
-    :data:`FALLBACK_IMPL`.
+    Returns ``(implementation_name, diagnostics, runtime)`` -- see
+    :data:`NATIVE_IMPL` and :data:`FALLBACK_IMPL`. ``runtime`` carries the
+    executor JVM's version, **heap ceiling** and CPU count.
+
+    The heap is there because the batched scoring path materialises each group as
+    an array in JVM heap, so its ceiling is a property of the executor rather
+    than of the algorithm -- and a Connect client has no ``SparkContext`` to ask.
+    A benchmark that OOMs at an unknown heap size has measured a configuration,
+    not a design; this arc has already produced one.
 
     The jar falls back to the `exact`-only scorer when the native library will
     not load, which keeps a distributed job alive but is otherwise invisible: the
@@ -171,8 +178,11 @@ def implementation(spark: object) -> tuple[str, str]:
     raw = df.select(
         F.call_udf(IMPL_UDF_NAME, F.col("id").cast("int")).alias("impl")
     ).collect()[0]["impl"]
-    name, _, diagnostics = str(raw).partition("|")
-    return name, diagnostics
+    # Fixed-width split, padded: an older jar returns two fields, and unpacking
+    # that into three would raise a ValueError that reads as "the probe is
+    # broken" rather than "the jar predates the runtime field".
+    parts = (str(raw).split("|", 2) + ["", ""])[:3]
+    return parts[0], parts[1], parts[2]
 
 
 def scorer_id(name: str) -> int:

--- a/packages/python/goldenmatch/goldenmatch/spark/scorers.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/scorers.py
@@ -80,9 +80,19 @@ def _pure_scores(scorer_name: str, a: Any, b: Any) -> list[float]:
         def score(x: Any, y: Any) -> float:
             return strsim.levenshtein_normalized_similarity(x or "", y or "")
     elif scorer_name == "token_sort":
-        # repo convention: normalize the 0-100 ratio scorer to [0, 1].
+        # The [0, 1] scorer DIRECTLY, not `token_sort_ratio(...) / 100`. That
+        # round trip is not lossless -- `(x * 100) / 100` differs from `x` in the
+        # last bit -- so the floor used to disagree with `score_one` (and so with
+        # the native kernel, the DataFusion UDF, the WASM scorer and the JVM one)
+        # by one ULP on ordinary inputs. Measured while building the J2 JNI
+        # parity gate: 0.923076923076923 here against 0.9230769230769231 from the
+        # kernel, for a pair whose exact answer is 12/13.
+        #
+        # One ULP is ignorable for a score you REPORT. This tier THRESHOLDS
+        # these, and the argument is the one this module's own docstring makes
+        # about f32 narrowing -- same argument, smaller number.
         def score(x: Any, y: Any) -> float:
-            return strsim.token_sort_ratio(x or "", y or "") / 100.0
+            return strsim.token_sort_similarity(x or "", y or "")
     else:
         raise NotImplementedError(
             f"Sail supports scorers {_SUPPORTED}; got {scorer_name!r}."

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -120,13 +120,18 @@ def test_the_executor_resolved_the_native_scorer(spark, registered):
     from an EXECUTOR -- a driver that loads the library says nothing about a
     cluster whose executors cannot.
     """
-    name, diagnostics = implementation(spark)
+    name, diagnostics, runtime = implementation(spark)
+    print(f"\n  executor: {name} | {runtime}\n  {diagnostics}")
     assert name == NATIVE_IMPL, (
         f"the executor resolved {name!r}, not {NATIVE_IMPL!r}. Diagnostics: "
         f"{diagnostics}. A {FALLBACK_IMPL} here means the native library did not "
         f"load, and every parity assertion below would be testing the J0 jar."
     )
     assert diagnostics, "the probe returned no diagnostics"
+    # The heap ceiling decides how a batched-path result is read -- that path
+    # materialises groups in JVM heap -- and a Connect client cannot ask any
+    # other way.
+    assert "heap_max=" in runtime, f"no heap ceiling reported: {runtime!r}"
 
 
 @pytest.mark.parametrize("scorer", SCORERS)

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -1,0 +1,226 @@
+"""J2 lane gate: a score from a Spark executor's JVM equals the Python one.
+
+This is the claim the whole arc rests on. Every binding in this repo -- pyo3
+``native``, ``datafusion-udf``, ``score-wasm``, ``score-cabi`` and now
+``score-jni`` -- wraps the SAME ``score_one``, so a score is identical across
+surfaces *by construction* rather than by several implementations being kept in
+step. A test is what turns that from an intention into a property.
+
+Equality here is **exact**, not approximate. Both sides run the same Rust
+function over the same bytes; anything but bit-identical means the marshaling
+changed the input, and a tolerance would hide precisely the class of bug this
+exists to catch (a truncated multi-byte value, a slice off by one, a batch that
+drifted out of alignment). Those produce *plausible* scores, which is what makes
+them dangerous.
+
+The oracle is ``score-wasm``-free plain Python/Rust on the client side; where the
+client has the compiled kernel installed the two are the same code, and where it
+does not the pure-Python fallback is still the number this package promises its
+users. Either way the JVM must agree with it.
+
+Skips where no Spark Connect client or no built jar is present; the
+``spark_connect`` lane provides both.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pyspark")
+
+from goldenmatch.spark.jvm import (  # noqa: E402
+    FALLBACK_IMPL,
+    NATIVE_IMPL,
+    JvmScorerUnavailable,
+    find_jar,
+    implementation,
+    install,
+    scorer_id,
+)
+
+#: Chosen to exercise the ways marshaling breaks rather than to be pretty:
+#: near-misses (where a truncation still scores high and looks fine), multi-byte
+#: values, empty strings, values whose byte length differs from their char
+#: length, and one pair that must score exactly 1.0 and exactly 0.0.
+PAIRS: list[tuple[str, str]] = [
+    ("jonathan smith", "jonathon smyth"),
+    ("Acme Corporation", "Acme Corp"),
+    ("identical", "identical"),
+    ("totally", "different"),
+    ("", ""),
+    ("", "nonempty"),
+    ("café", "cafe"),
+    ("Zoë Müller", "Zoe Muller"),
+    ("日本語テキスト", "日本語テスト"),
+    ("O'Brien", "OBrien"),
+    ("  leading", "leading"),
+    ("MIXED case", "mixed CASE"),
+]
+
+#: The scorers the Spark tier's config surface permits. `exact` included on
+#: purpose: J0 could only run that one, so it is the control -- if it diverged,
+#: the problem would be the plumbing rather than the kernel.
+SCORERS = ["jaro_winkler", "levenshtein", "token_sort", "exact"]
+
+
+@pytest.fixture(scope="module")
+def jar():
+    try:
+        return find_jar()
+    except JvmScorerUnavailable as exc:
+        pytest.skip(f"no JVM scorer jar built: {exc}")
+
+
+@pytest.fixture()
+def registered(spark, jar):
+    return install(spark, jar=jar)
+
+
+def _python_scores(scorer: str, pairs: list[tuple[str, str]]) -> list[float]:
+    """The client-side answer, through the SHIPPED scorer.
+
+    ``goldenmatch.spark.scorers.score_batch`` is the function the tier's own
+    Python UDF calls, so this compares the JVM against what a user actually gets
+    today -- not against a lookalike assembled out of ``strsim`` primitives that
+    happens to agree. (Building the oracle by hand is how you end up measuring
+    something adjacent to the shipped path and calling it parity.)
+
+    ``exact`` is not one of ``score_batch``'s scorers -- it is string equality,
+    which is why J0 could implement it in Java without forking the kernel -- so
+    it is defined here directly, matching ``score_one``'s id 3.
+    """
+    if scorer == "exact":
+        return [1.0 if a == b else 0.0 for a, b in pairs]
+
+    from goldenmatch.spark.scorers import score_batch
+
+    xs = [a for a, _ in pairs]
+    ys = [b for _, b in pairs]
+    return [float(v) for v in score_batch(scorer, xs, ys)]
+
+
+def _jvm_scores(spark, udf, scorer: str, pairs: list[tuple[str, str]]) -> list[float]:
+    """The executor-side answer, through the registered batch UDF."""
+    from pyspark.sql import functions as F
+
+    xs = [a for a, _ in pairs]
+    ys = [b for _, b in pairs]
+    df = spark.createDataFrame([(xs, ys)], ["xs", "ys"])
+    got = df.select(
+        F.call_udf(udf, F.lit(scorer_id(scorer)), F.col("xs"), F.col("ys")).alias("s")
+    ).collect()[0]["s"]
+    return [float(v) for v in got]
+
+
+def test_the_executor_resolved_the_native_scorer(spark, registered):
+    """Everything below would pass against the `exact`-only fallback.
+
+    So this runs first and is the load-bearing assertion of the file: the jar
+    falls back when the library will not load, which keeps a job alive and would
+    otherwise leave this whole suite green while testing J0. The probe answers
+    from an EXECUTOR -- a driver that loads the library says nothing about a
+    cluster whose executors cannot.
+    """
+    name, diagnostics = implementation(spark)
+    assert name == NATIVE_IMPL, (
+        f"the executor resolved {name!r}, not {NATIVE_IMPL!r}. Diagnostics: "
+        f"{diagnostics}. A {FALLBACK_IMPL} here means the native library did not "
+        f"load, and every parity assertion below would be testing the J0 jar."
+    )
+    assert diagnostics, "the probe returned no diagnostics"
+
+
+@pytest.mark.parametrize("scorer", SCORERS)
+def test_jvm_scores_match_python_exactly(spark, registered, scorer):
+    """The parity claim, one scorer at a time.
+
+    Exact equality: both sides are the same Rust function over the same bytes.
+    """
+    want = _python_scores(scorer, PAIRS)
+    got = _jvm_scores(spark, registered, scorer, PAIRS)
+
+    assert len(got) == len(want)
+    mismatches = [
+        (PAIRS[i], want[i], got[i]) for i in range(len(want)) if got[i] != want[i]
+    ]
+    assert not mismatches, (
+        f"{scorer}: JVM and Python disagree on {len(mismatches)} pair(s). "
+        f"Both call score_one over the same bytes, so a difference is the "
+        f"marshaling, not the algorithm: {mismatches}"
+    )
+
+
+def test_a_scorer_j0_could_not_run_now_runs(spark, registered):
+    """J2's actual deliverable, stated as a test.
+
+    J0's jar refused every id but `exact`. If this passes, the kernel arrived --
+    and it is asserted against the Python answer rather than a hardcoded
+    constant, so it cannot pass by agreeing with a number somebody typed.
+    """
+    pair = [("jonathan", "jonothan")]
+    got = _jvm_scores(spark, registered, "jaro_winkler", pair)[0]
+    want = _python_scores("jaro_winkler", pair)[0]
+    assert got == want
+    # And it is really doing the work, not returning an `exact` 0.0 by accident.
+    assert 0.0 < got < 1.0, f"expected a partial similarity, got {got}"
+
+
+def test_multibyte_values_survive_the_boundary(spark, registered):
+    """The marshaling bug that produces plausible numbers instead of failures.
+
+    Offsets are BYTE offsets. Treating them as character indices truncates every
+    multi-byte value AND shifts every value after it, so the batch scores
+    confidently and wrongly. Identity is the sharpest probe: a truncated string
+    stops matching itself.
+    """
+    values = ["Zoë", "日本語", "naïve café", "plain", "🎯 emoji"]
+    pairs = [(v, v) for v in values]
+    got = _jvm_scores(spark, registered, "exact", pairs)
+    assert got == [1.0] * len(values), (
+        f"a value stopped matching itself across the JNI boundary: "
+        f"{list(zip(values, got))}"
+    )
+
+
+def test_nulls_are_not_scored_as_empty_strings(spark, registered):
+    """Absence of evidence must not read as evidence.
+
+    ``score-cabi`` carries no validity bitmap by design -- null policy belongs to
+    the host -- so this is the JVM side's presence mask doing its job. Getting it
+    wrong makes null-vs-null a perfect 1.0, and two records whose only shared
+    evidence is a shared absence then merge at every threshold. That is a bug
+    this tier already shipped once.
+    """
+    from pyspark.sql import functions as F
+
+    xs = [None, "smith", None, "same"]
+    ys = [None, None, "jones", "same"]
+    df = spark.createDataFrame([(xs, ys)], ["xs", "ys"])
+    got = df.select(
+        F.call_udf(
+            registered, F.lit(scorer_id("jaro_winkler")), F.col("xs"), F.col("ys")
+        ).alias("s")
+    ).collect()[0]["s"]
+    assert list(got) == [None, None, None, 1.0]
+
+
+def test_a_ten_thousand_pair_batch_crosses_in_one_call(spark, registered):
+    """The property that makes going native worth anything.
+
+    Connect only permits row-shaped UDFs, so without batching every pair would
+    cost a downcall. This is `batched.DEFAULT_BATCH_SIZE`, and the arrays the
+    JNI layer pins are proportionally large -- a size limit would surface here
+    rather than in a customer's executor.
+    """
+    n = 10_000
+    xs = [f"value-{i}" for i in range(n)]
+    ys = [xs[i] if i % 3 == 0 else f"other-{i}" for i in range(n)]
+    df = spark.createDataFrame([(xs, ys)], ["xs", "ys"])
+    from pyspark.sql import functions as F
+
+    got = df.select(
+        F.call_udf(
+            registered, F.lit(scorer_id("exact")), F.col("xs"), F.col("ys")
+        ).alias("s")
+    ).collect()[0]["s"]
+    assert len(got) == n
+    assert sum(1 for v in got if v == 1.0) == len(range(0, n, 3))

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -313,3 +313,96 @@ def test_unproven_column_types_are_refused_not_guessed(spark, registered):
         derive_record_ids(
             df, id_col="__row_id__", fingerprint_udf=FINGERPRINT_UDF_NAME
         )
+
+
+# ── survivorship (golden records) ────────────────────────────────────
+
+#: Clusters chosen for TIE-BREAKS, which is where this port could silently
+#: diverge: Python's `Counter.most_common` keeps insertion order and `max()`
+#: keeps the FIRST maximum, while Rust's `max_by_key` keeps the LAST. A tie
+#: resolved the other way is a different golden record with no error attached.
+SURVIVORSHIP_CLUSTERS: list[list[str | None]] = [
+    ["a", "b"],
+    ["b", "a", "a"],
+    ["a", "a", "b", "b"],
+    [None, "x", "y"],
+    [None, None],
+    ["a", None, "a"],
+    ["ab", "abcd"],
+    ["ab", "cd"],
+    ["café", "abcde"],
+    ["", "x"],
+    ["same", "same", "same"],
+    ["日本語", "ab"],
+]
+
+#: Every strategy the Spark call site can reach. `source_priority` and
+#: `most_recent` are absent because Python RAISES for them without a sources or
+#: dates list, which this call site does not pass.
+SURVIVORSHIP_STRATEGIES = [
+    "most_complete", "majority_vote", "first_non_null", "longest_value",
+    "unanimous_or_null", "confidence_majority",
+]
+
+
+@pytest.mark.parametrize("strategy", SURVIVORSHIP_STRATEGIES)
+def test_jvm_survivorship_matches_python_exactly(spark, registered, strategy):
+    """The survivor chosen in the JVM must be the one Python chooses.
+
+    ``survivorship-core`` had a committed differential dump from the day it was
+    written, but that harness is MANUAL -- it needs cargo and a person to run
+    it. Nothing in the suite re-checked it, so the port could drift from
+    ``merge_field`` and CI would stay green. This is the automatic half.
+
+    Exact equality, and no tolerance is meaningful here anyway: the result is a
+    value, not a number. A survivor chosen by a different tie-break is a wrong
+    golden record that raises nothing and looks right.
+    """
+    from goldenmatch.config.schemas import GoldenFieldRule
+    from goldenmatch.core.golden import merge_field
+    from goldenmatch.spark.golden import merge_expr
+    from goldenmatch.spark.jvm import SURVIVORSHIP_UDF_NAME
+    from pyspark.sql import functions as F
+
+    rows = [(i, list(vals)) for i, vals in enumerate(SURVIVORSHIP_CLUSTERS)]
+    df = spark.createDataFrame(rows, "cid long, vals array<string>")
+    got = {
+        r["cid"]: r["v"]
+        for r in df.select(
+            "cid",
+            merge_expr(F.col("vals"), strategy, SURVIVORSHIP_UDF_NAME).alias("v"),
+        ).collect()
+    }
+    want = {
+        i: (lambda m: None if m is None else str(m))(
+            merge_field(list(vals), GoldenFieldRule(strategy=strategy))[0]
+        )
+        for i, vals in enumerate(SURVIVORSHIP_CLUSTERS)
+    }
+    mismatches = {
+        i: (SURVIVORSHIP_CLUSTERS[i], want[i], got.get(i))
+        for i in want
+        if got.get(i) != want[i]
+    }
+    assert not mismatches, (
+        f"{strategy}: JVM and Python chose different survivors. Both call the "
+        f"same merge semantics, so a difference is a TIE-BREAK divergence: "
+        f"{mismatches}"
+    )
+
+
+def test_strategies_python_refuses_are_refused_here_too(spark, registered):
+    """The refusals are the load-bearing part.
+
+    ``source_priority`` needs a sources list and ``most_recent`` needs dates --
+    neither of which the Spark call site passes, so Python raises. The JVM path
+    must refuse them at PLAN time rather than emitting a plausible survivor from
+    every cluster, and it must name the strategy so the failure is actionable.
+    """
+    from goldenmatch.spark.golden import merge_expr
+    from goldenmatch.spark.jvm import SURVIVORSHIP_UDF_NAME
+    from pyspark.sql import functions as F
+
+    for strategy in ("source_priority", "most_recent", "custom:whatever"):
+        with pytest.raises(ValueError, match=strategy.split(":")[0]):
+            merge_expr(F.col("vals"), strategy, SURVIVORSHIP_UDF_NAME)

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -229,3 +229,87 @@ def test_a_ten_thousand_pair_batch_crosses_in_one_call(spark, registered):
     ).collect()[0]["s"]
     assert len(got) == n
     assert sum(1 for v in got if v == 1.0) == len(range(0, n, 3))
+
+
+# ── record fingerprints (identity graph) ─────────────────────────────
+
+def test_jvm_fingerprints_match_python_exactly(spark, registered):
+    """The identity graph's ids, computed with no Python on the executor.
+
+    Same `fingerprint-core` on both sides, so equality is exact. It has to be:
+    a fingerprint that differs by one byte does not fail, it silently splits one
+    identity into two -- there is no threshold to absorb it and no test that
+    would notice downstream.
+    """
+    from goldenmatch.core._hashing import record_fingerprint
+    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME
+    from pyspark.sql import functions as F
+
+    rows = [
+        ("jonathan smith", "boston", 42),
+        ("", "", 0),
+        ("Zoë Müller", "münchen", -1),
+        ("O'Brien", "st. john's", 999999),
+        ("日本語", "東京", 7),
+    ]
+    df = spark.createDataFrame(rows, "name string, city string, n long")
+    got = [
+        r[0]
+        for r in df.select(
+            F.call_udf(
+                FINGERPRINT_UDF_NAME, F.to_json(F.struct("name", "city", "n"))
+            )
+        ).collect()
+    ]
+    want = [record_fingerprint({"name": a, "city": b, "n": c}) for a, b, c in rows]
+    assert got == want, (
+        f"JVM and Python fingerprints disagree. Both call fingerprint-core, so "
+        f"a difference is the JSON encoding, not the hash: "
+        f"{[(i, w, g) for i, (w, g) in enumerate(zip(want, got)) if w != g]}"
+    )
+
+
+def test_derive_record_ids_matches_the_python_path(spark, registered):
+    """The whole function, JVM path against Python path, on one DataFrame."""
+    from goldenmatch.spark.identity import derive_record_ids
+    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME
+    from pyspark.sql import functions as F
+
+    df = spark.createDataFrame(
+        [("a", "x", 1), ("b", "y", 2), ("", None, 3)],
+        "name string, city string, n long",
+    ).withColumn("__source__", F.lit("probe"))
+
+    py = {
+        r["name"]: r["record_id"]
+        for r in derive_record_ids(df, id_col="__row_id__").collect()
+    }
+    jvm = {
+        r["name"]: r["record_id"]
+        for r in derive_record_ids(
+            df, id_col="__row_id__", fingerprint_udf=FINGERPRINT_UDF_NAME
+        ).collect()
+    }
+    assert jvm == py, f"record_id differs between the two paths: {py} vs {jvm}"
+    assert all(v.startswith("probe:h1:") for v in jvm.values()), jvm
+
+
+def test_unproven_column_types_are_refused_not_guessed(spark, registered):
+    """A float column must be REFUSED by the JVM path, not silently fingerprinted.
+
+    Python hands the kernel a float value; Spark hands it a JSON literal, and the
+    two only agree if every float renders identically. Guessing produces ids that
+    are wrong in a way nothing downstream can detect, so the path refuses and
+    names the column.
+    """
+    from goldenmatch.spark.identity import derive_record_ids
+    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME
+    from pyspark.sql import functions as F
+
+    df = spark.createDataFrame(
+        [("a", 1.5)], "name string, score double"
+    ).withColumn("__source__", F.lit("probe"))
+    with pytest.raises(ValueError, match="score:double"):
+        derive_record_ids(
+            df, id_col="__row_id__", fingerprint_udf=FINGERPRINT_UDF_NAME
+        )

--- a/packages/python/goldenmatch/tests/test_spark_jvm_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_parity.py
@@ -7,10 +7,18 @@ This is the half the unit tests cannot reach: `addArtifact` against a real
 session, `registerJavaFunction` against a real catalog, and the array marshaling
 that the probe measured but this code now depends on.
 
-J0 deliberately proves the PLUMBING with no native call in the picture. The jar
-implements `exact` only -- string equality, identical by inspection in any
-language -- so nothing here can be a kernel divergence. When the plan reshape
-lands in J1, a misaligned score cannot be blamed on the scorer.
+J0 deliberately proved the PLUMBING with no native call in the picture: the jar
+implemented `exact` only -- string equality, identical by inspection in any
+language -- so nothing here could be a kernel divergence, and a misalignment
+found by J1's plan reshape could not be blamed on the scorer.
+
+That separation has done its job and this file stays on the plumbing side of it.
+J2 put the Rust kernel behind the same UDF (JNI -> `score-cabi` -> `score_one`),
+but whether the JVM's number EQUALS Python's is a different question with a
+different oracle, and it lives in `test_spark_jvm_native_parity.py`. Here the
+questions are still: does the jar ship, does the UDF register, does a batch come
+back aligned, and does a bad request fail loudly instead of returning a plausible
+number.
 """
 from __future__ import annotations
 
@@ -110,16 +118,44 @@ def test_a_large_batch_survives(spark, registered):
     assert all(v == 1.0 for v in got)
 
 
-def test_an_unsupported_scorer_fails_loudly(spark, registered):
-    """J0 carries no scoring algorithms. A Java jaro-winkler would be a fourth
-    implementation of a kernel that exists once in Rust; the jar refuses instead,
-    and the refusal must survive the Spark boundary rather than becoming a
-    plausible number."""
+def test_a_scorer_j0_refused_now_runs(spark, registered):
+    """J0 refused every scorer but `exact`, on purpose: a Java jaro-winkler would
+    have been a fourth implementation of a kernel that exists once in Rust.
+
+    This test used to assert that refusal, and asserting it now would pin the jar
+    to the limitation J2 exists to remove -- so it is inverted rather than
+    deleted. The refusal is gone because the kernel ARRIVED (JNI ->
+    ``score-cabi`` -> ``score_one``), not because the restriction was relaxed;
+    the jar still carries no algorithms of its own.
+
+    Exact agreement with the Python answer is
+    ``test_spark_jvm_native_parity.py``'s job. What matters here is only that the
+    call crosses the boundary and comes back with real work done.
+    """
+    df = spark.createDataFrame([(["jonathan"], ["jonothan"])], ["xs", "ys"])
+    got = df.selectExpr(
+        f"{registered}({scorer_id('jaro_winkler')}, xs, ys) AS s"
+    ).collect()[0]["s"]
+    assert len(got) == 1
+    # A partial similarity: not `exact`'s 0.0, and not a trivially perfect 1.0.
+    assert 0.0 < got[0] < 1.0, (
+        f"expected a real jaro-winkler score, got {got[0]}. A 0.0 here would "
+        f"mean the id fell through to the kernel's catch-all arm."
+    )
+
+
+def test_an_id_the_kernel_does_not_know_is_still_refused(spark, registered):
+    """The refusal that must NOT go away.
+
+    ``score_one``'s catch-all returns 0.0 for an unknown id -- a confident wrong
+    answer rather than an error. J2 widened what the jar accepts to the loaded
+    kernel's own id range; anything outside it still has to fail loudly, and the
+    failure has to survive the Spark boundary rather than arriving as a plausible
+    number.
+    """
     df = spark.createDataFrame([(["a"], ["b"])], ["xs", "ys"])
     with pytest.raises(Exception) as err:  # noqa: PT011 - Spark wraps the cause
-        df.selectExpr(
-            f"{registered}({scorer_id('jaro_winkler')}, xs, ys) AS s"
-        ).collect()
-    assert "score-cabi" in str(err.value) or "ExactScorer" in str(err.value), (
+        df.selectExpr(f"{registered}(9999, xs, ys) AS s").collect()
+    assert "9999" in str(err.value), (
         f"the refusal did not survive the boundary: {err.value}"
     )

--- a/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
@@ -15,6 +15,7 @@ from goldenmatch.spark.jvm import (
     FINGERPRINT_UDF_NAME,
     IMPL_UDF_NAME,
     SCORER_IDS,
+    TRANSFORM_UDF_NAME,
     UDF_NAME,
     JvmScorerUnavailable,
     find_jar,
@@ -106,6 +107,29 @@ def test_install_ships_then_registers(jar):
             "dev.goldensuite.spark.GoldenFingerprintUdf",
             "string",
         ),
+        (TRANSFORM_UDF_NAME, "dev.goldensuite.spark.GoldenTransformUdf", "string"),
+    ]
+
+
+def test_the_jvm_transform_set_refuses_what_is_python_only():
+    """`bloom_filter` and plugin transforms are Python-only BY DESIGN.
+
+    They are refused on the driver so a chain fails at plan time with the name
+    in hand, rather than returning nulls from every row of a job that is already
+    distributed. Absent on purpose, not pending.
+    """
+    from goldenmatch.spark.jvm import jvm_supports_transform, unsupported_transforms
+
+    for name in ("lowercase", "soundex", "substring:0:3", "qgram:2"):
+        assert jvm_supports_transform(name), name
+    for name in ("bloom_filter", "bloom_filter:high", "legal_form_strip"):
+        assert not jvm_supports_transform(name), name
+    # A malformed parameterised spec must not read as supported and then
+    # silently become a no-op on the executor.
+    for name in ("substring:", "substring:a:b", "qgram:x", "qgram:0"):
+        assert not jvm_supports_transform(name), name
+    assert unsupported_transforms(["lowercase", "bloom_filter", "strip"]) == [
+        "bloom_filter"
     ]
 
 

--- a/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import pytest
 from goldenmatch.spark.jvm import (
+    FINGERPRINT_UDF_NAME,
     IMPL_UDF_NAME,
     SCORER_IDS,
     UDF_NAME,
@@ -100,7 +101,27 @@ def test_install_ships_then_registers(jar):
     assert spark.registered == [
         (UDF_NAME, "dev.goldensuite.spark.GoldenScoreUdf", "array<double>"),
         (IMPL_UDF_NAME, "dev.goldensuite.spark.GoldenScoreImplUdf", "string"),
+        (
+            FINGERPRINT_UDF_NAME,
+            "dev.goldensuite.spark.GoldenFingerprintUdf",
+            "string",
+        ),
     ]
+
+
+def test_every_kernel_the_jar_carries_is_registered_by_install(jar):
+    """One `install` call gives a session everything the jar can do.
+
+    A caller should not have to know which kernels exist to get them -- and a
+    capability that has to be registered separately is one that silently is not
+    there, which for the fingerprint means falling back to a Python worker on a
+    cluster that was supposed to need none.
+    """
+    spark = _FakeSession()
+    install(spark, jar=jar)
+    names = [r[0] for r in spark.registered]
+    for expected in (UDF_NAME, IMPL_UDF_NAME, FINGERPRINT_UDF_NAME):
+        assert expected in names, f"{expected} not registered; got {names}"
 
 
 def test_the_implementation_probe_registers_alongside_the_scorer(jar):

--- a/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import pytest
 from goldenmatch.spark.jvm import (
+    IMPL_UDF_NAME,
     SCORER_IDS,
     UDF_NAME,
     JvmScorerUnavailable,
@@ -97,8 +98,28 @@ def test_install_ships_then_registers(jar):
     assert name == UDF_NAME
     assert spark.artifacts == [str(jar)]
     assert spark.registered == [
-        (UDF_NAME, "dev.goldensuite.spark.GoldenScoreUdf", "array<double>")
+        (UDF_NAME, "dev.goldensuite.spark.GoldenScoreUdf", "array<double>"),
+        (IMPL_UDF_NAME, "dev.goldensuite.spark.GoldenScoreImplUdf", "string"),
     ]
+
+
+def test_the_implementation_probe_registers_alongside_the_scorer(jar):
+    """J2's jar falls back to the `exact`-only scorer when the native library
+    will not load. That keeps a distributed job alive and is otherwise
+    invisible -- the query still returns numbers, from a narrower path.
+
+    So the probe that reports which scorer an executor resolved must be
+    registered by `install`, not on demand. Registering it later would mean the
+    first thing a caller can check is whether the results they already trusted
+    came from the kernel.
+    """
+    spark = _FakeSession()
+    install(spark, jar=jar)
+    names = [r[0] for r in spark.registered]
+    assert IMPL_UDF_NAME in names, (
+        f"the implementation probe did not register; a silent fallback to the "
+        f"J0 scorer would be undetectable. Registered: {names}"
+    )
 
 
 def test_the_return_type_is_an_array(jar):
@@ -157,3 +178,59 @@ def test_an_unknown_scorer_is_refused_not_defaulted():
     silently wrong number rather than a failure."""
     with pytest.raises(ValueError, match="unknown scorer"):
         scorer_id("definitely_not_a_scorer")
+
+
+# ── the pure floor must equal the kernel exactly (J2) ────────────────
+#
+# The JVM path computes `score_one` -- the same dispatcher behind pyo3 `native`,
+# `datafusion-udf` and `score-wasm`. So "the JVM agrees with Python" is only a
+# meaningful claim if the tier's own Python scorer agrees with `score_one` too.
+# Measured while building J2's parity gate, it did not: `token_sort` came back
+# 0.923076923076923 from the pure floor and 0.9230769230769231 from the kernel.
+#
+# Cause: the floor called the 0-100 `token_sort_ratio` and divided by 100, and
+# `(x * 100) / 100` is not `x` in binary floating point. One ULP, and entirely
+# self-inflicted -- there was no reason to scale up and back down.
+#
+# One ULP sounds ignorable, and for a score you REPORT it is. This tier does not
+# report these; it thresholds them. `scorers.py`'s own module docstring makes the
+# argument, about f32: "a tolerance is fine for a score you report and not for
+# one you THRESHOLD". Same argument, smaller number.
+#
+# No Spark, no jar, no native wheel needed -- this is arithmetic.
+
+def test_the_pure_floor_does_not_round_trip_token_sort_through_0_100():
+    """The specific defect: scale up to 0-100, divide back, lose a bit."""
+    from goldenmatch.core import strsim
+    from goldenmatch.spark.scorers import _pure_scores
+
+    # 6 shared tokens of 13 total characters -> exactly 12/13.
+    a, b = ["日本語テキスト"], ["日本語テスト"]
+    got = _pure_scores("token_sort", a, b)[0]
+
+    xs = " ".join(sorted(a[0].split()))
+    ys = " ".join(sorted(b[0].split()))
+    want = strsim.indel_normalized_similarity(xs, ys)
+
+    assert got == want, (
+        f"the floor returned {got!r}, the unscaled similarity is {want!r}. "
+        f"A 0-100 round trip is the only difference, and it costs a bit that "
+        f"the kernel does not lose."
+    )
+    # And the round trip is demonstrably lossy, so the test above is not vacuous.
+    assert strsim.token_sort_ratio(xs, ys) / 100.0 != want
+
+
+def test_token_sort_similarity_and_ratio_stay_in_lockstep():
+    """The 0-100 scorer keeps its rapidfuzz parity: it is the [0, 1] value
+    scaled, not a second implementation."""
+    from goldenmatch.core import strsim
+
+    for a, b in [
+        ("alice smith", "smith alice"),
+        ("日本語テキスト", "日本語テスト"),
+        ("", ""),
+        ("one", "one two three"),
+        ("Foo", "foo"),
+    ]:
+        assert strsim.token_sort_ratio(a, b) == strsim.token_sort_similarity(a, b) * 100.0

--- a/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
@@ -15,6 +15,7 @@ from goldenmatch.spark.jvm import (
     FINGERPRINT_UDF_NAME,
     IMPL_UDF_NAME,
     SCORER_IDS,
+    SURVIVORSHIP_UDF_NAME,
     TRANSFORM_UDF_NAME,
     UDF_NAME,
     JvmScorerUnavailable,
@@ -108,6 +109,11 @@ def test_install_ships_then_registers(jar):
             "string",
         ),
         (TRANSFORM_UDF_NAME, "dev.goldensuite.spark.GoldenTransformUdf", "string"),
+        (
+            SURVIVORSHIP_UDF_NAME,
+            "dev.goldensuite.spark.GoldenSurvivorshipUdf",
+            "string",
+        ),
     ]
 
 

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -9920,6 +9920,14 @@
       "path": "packages/rust/extensions/suggest-wasm"
     },
     {
+      "name": "goldenmatch-survivorship-core",
+      "path": "packages/rust/extensions/survivorship-core"
+    },
+    {
+      "name": "goldenmatch-transforms-core",
+      "path": "packages/rust/extensions/transforms-core"
+    },
+    {
       "name": "goldenmatch_pg",
       "path": "packages/rust/extensions/postgres"
     },

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -9900,6 +9900,10 @@
       "path": "packages/rust/extensions/score-core"
     },
     {
+      "name": "goldenmatch-score-jni",
+      "path": "packages/rust/extensions/score-jni"
+    },
+    {
       "name": "goldenmatch-score-wasm",
       "path": "packages/rust/extensions/score-wasm"
     },

--- a/packages/rust/extensions/score-jni/.gitignore
+++ b/packages/rust/extensions/score-jni/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/packages/rust/extensions/score-jni/Cargo.toml
+++ b/packages/rust/extensions/score-jni/Cargo.toml
@@ -1,0 +1,54 @@
+# score-jni -- the JNI binding over `score-cabi`, so a Spark executor JVM calls
+# the canonical Rust scorers directly.
+#
+# # Why this exists on top of score-cabi rather than instead of it
+#
+# `score-cabi` already exposes the kernel over a C ABI in Arrow's string layout.
+# A JVM cannot call a plain C function without a `Java_*`-named entry point
+# unless it uses Panama (FFM), which was only finalized in JDK 22 -- and Spark
+# supports JDK 17, 21 and 25. So a cluster on 17 or 21 has no FFM, and JNI is
+# the only door.
+#
+# This crate is that door and nothing else: it pins the JVM's primitive arrays,
+# hands their addresses to `goldenmatch_score_pairwise_utf8`, and returns its
+# code. It re-implements no marshaling and no scoring -- score-cabi already
+# validates offsets and UTF-8, and score-core already owns `score_one`. Every
+# binding in this repo (pyo3 `native`, `datafusion-udf`, `score-wasm`,
+# `score-cabi`) wraps that same core, which is what makes a score identical
+# across surfaces by construction rather than by four implementations being kept
+# in step. This adds a fifth host, not a fifth implementation.
+#
+# # One .so, both ABIs
+#
+# Linking score-cabi as an rlib into this cdylib re-exports its `#[no_mangle]`
+# C symbols alongside the JNI ones, so the same shared library serves a JNI host
+# today and an FFM host later with no second build. That is deliberate.
+#
+# Standalone workspace -- same isolation rationale as score-cabi,
+# goldengraph-cabi and goldenprofile-cabi.
+[workspace]
+
+[package]
+name = "goldenmatch-score-jni"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "JNI binding over goldenmatch-score-cabi: batch string scoring inside a JVM (Spark executors) with no Python worker"
+
+[lib]
+name = "goldenmatch_score_jni"
+# cdylib only. Nothing links this as a Rust library -- its entire purpose is to
+# be `System.load`ed by a JVM. `rlib` is added back only under test.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# The C ABI this crate marshals into. Path dep on the sibling binding, NOT on
+# score-core: routing through score-cabi means its offset/UTF-8 validation is
+# the one implementation, so a malformed batch is refused identically whether it
+# arrives from C or from the JVM.
+goldenmatch-score-cabi = { path = "../score-cabi" }
+# jni-rs: the de-facto binding. Chosen over hand-writing the JNINativeInterface
+# function-table offsets because getting those wrong is a segfault inside an
+# executor, not a compile error.
+jni = "0.21"

--- a/packages/rust/extensions/score-jni/Cargo.toml
+++ b/packages/rust/extensions/score-jni/Cargo.toml
@@ -48,6 +48,13 @@ crate-type = ["cdylib", "rlib"]
 # the one implementation, so a malformed batch is refused identically whether it
 # arrives from C or from the JVM.
 goldenmatch-score-cabi = { path = "../score-cabi" }
+# Record fingerprints, for the identity graph. A SECOND kernel in this one
+# library on purpose: the jar carries exactly one `.so` per platform, extracted
+# and dlopen'd once per executor JVM, so a second library would mean a second
+# extraction and a second load for no benefit. `fingerprint-core` is pyo3-free
+# and its `fingerprint_json` was written for exactly this -- "non-Python callers
+# (pgrx / DuckDB / C ABI)", per its own manifest.
+goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
 # jni-rs: the de-facto binding. Chosen over hand-writing the JNINativeInterface
 # function-table offsets because getting those wrong is a segfault inside an
 # executor, not a compile error.

--- a/packages/rust/extensions/score-jni/Cargo.toml
+++ b/packages/rust/extensions/score-jni/Cargo.toml
@@ -58,6 +58,8 @@ goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
 # The transform chain (normalization). Third kernel in the same library -- one
 # `.so` per platform, one extraction, one dlopen per executor JVM.
 goldenmatch-transforms-core = { path = "../transforms-core" }
+# Golden-record survivorship. Fourth kernel in the same library.
+goldenmatch-survivorship-core = { path = "../survivorship-core" }
 # jni-rs: the de-facto binding. Chosen over hand-writing the JNINativeInterface
 # function-table offsets because getting those wrong is a segfault inside an
 # executor, not a compile error.

--- a/packages/rust/extensions/score-jni/Cargo.toml
+++ b/packages/rust/extensions/score-jni/Cargo.toml
@@ -55,6 +55,9 @@ goldenmatch-score-cabi = { path = "../score-cabi" }
 # and its `fingerprint_json` was written for exactly this -- "non-Python callers
 # (pgrx / DuckDB / C ABI)", per its own manifest.
 goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
+# The transform chain (normalization). Third kernel in the same library -- one
+# `.so` per platform, one extraction, one dlopen per executor JVM.
+goldenmatch-transforms-core = { path = "../transforms-core" }
 # jni-rs: the de-facto binding. Chosen over hand-writing the JNINativeInterface
 # function-table offsets because getting those wrong is a segfault inside an
 # executor, not a compile error.

--- a/packages/rust/extensions/score-jni/src/lib.rs
+++ b/packages/rust/extensions/score-jni/src/lib.rs
@@ -184,68 +184,6 @@ pub extern "system" fn Java_dev_goldensuite_spark_NativeScorer_scorePairwiseUtf8
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The JNI entry points need a JVM, so what is testable here is the code
-    /// table and the fact that this crate reports the SAME kernel identity as
-    /// the C ABI it wraps. A skew between them would mean the load-time gate is
-    /// checking one library and the scoring is done by another.
-    #[test]
-    fn abi_identity_matches_the_c_abi_it_wraps() {
-        assert_eq!(goldenmatch_score_cabi::goldenmatch_score_abi_version(), 1);
-        assert_eq!(
-            goldenmatch_score_cabi::goldenmatch_score_scorer_id_count(),
-            15
-        );
-    }
-
-    #[test]
-    fn every_code_this_layer_can_return_has_a_description() {
-        for code in [
-            0,
-            -1,
-            -2,
-            -3,
-            -4,
-            error::BAD_ARRAY_LENGTH,
-            error::SCORER_ID_OUT_OF_RANGE,
-            error::JNI_ERROR,
-        ] {
-            assert_ne!(
-                describe(code),
-                "unknown error code",
-                "code {code} has no description; a real failure would be \
-                 diagnosed as 'unknown'"
-            );
-        }
-        assert_eq!(describe(-99), "unknown error code");
-    }
-
-    /// The codes this layer adds must not collide with score-cabi's, because
-    /// they are returned through the same `int` and read from one table.
-    #[test]
-    fn added_codes_do_not_collide_with_the_c_abi_codes() {
-        let cabi = [
-            goldenmatch_score_cabi::error::NULL_POINTER,
-            goldenmatch_score_cabi::error::BAD_LENGTH,
-            goldenmatch_score_cabi::error::BAD_OFFSETS,
-            goldenmatch_score_cabi::error::INVALID_UTF8,
-        ];
-        for added in [
-            error::BAD_ARRAY_LENGTH,
-            error::SCORER_ID_OUT_OF_RANGE,
-            error::JNI_ERROR,
-        ] {
-            assert!(
-                !cabi.contains(&added),
-                "code {added} is already a score-cabi code"
-            );
-        }
-    }
-}
-
 // ── record fingerprints (identity graph) ────────────────────────────
 //
 // A second kernel in the same library. The jar carries one `.so` per platform,
@@ -461,4 +399,66 @@ pub extern "system" fn Java_dev_goldensuite_spark_NativeSurvivorship_supportsStr
         return 0;
     };
     u8::from(goldenmatch_survivorship_core::supports(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The JNI entry points need a JVM, so what is testable here is the code
+    /// table and the fact that this crate reports the SAME kernel identity as
+    /// the C ABI it wraps. A skew between them would mean the load-time gate is
+    /// checking one library and the scoring is done by another.
+    #[test]
+    fn abi_identity_matches_the_c_abi_it_wraps() {
+        assert_eq!(goldenmatch_score_cabi::goldenmatch_score_abi_version(), 1);
+        assert_eq!(
+            goldenmatch_score_cabi::goldenmatch_score_scorer_id_count(),
+            15
+        );
+    }
+
+    #[test]
+    fn every_code_this_layer_can_return_has_a_description() {
+        for code in [
+            0,
+            -1,
+            -2,
+            -3,
+            -4,
+            error::BAD_ARRAY_LENGTH,
+            error::SCORER_ID_OUT_OF_RANGE,
+            error::JNI_ERROR,
+        ] {
+            assert_ne!(
+                describe(code),
+                "unknown error code",
+                "code {code} has no description; a real failure would be \
+                 diagnosed as 'unknown'"
+            );
+        }
+        assert_eq!(describe(-99), "unknown error code");
+    }
+
+    /// The codes this layer adds must not collide with score-cabi's, because
+    /// they are returned through the same `int` and read from one table.
+    #[test]
+    fn added_codes_do_not_collide_with_the_c_abi_codes() {
+        let cabi = [
+            goldenmatch_score_cabi::error::NULL_POINTER,
+            goldenmatch_score_cabi::error::BAD_LENGTH,
+            goldenmatch_score_cabi::error::BAD_OFFSETS,
+            goldenmatch_score_cabi::error::INVALID_UTF8,
+        ];
+        for added in [
+            error::BAD_ARRAY_LENGTH,
+            error::SCORER_ID_OUT_OF_RANGE,
+            error::JNI_ERROR,
+        ] {
+            assert!(
+                !cabi.contains(&added),
+                "code {added} is already a score-cabi code"
+            );
+        }
+    }
 }

--- a/packages/rust/extensions/score-jni/src/lib.rs
+++ b/packages/rust/extensions/score-jni/src/lib.rs
@@ -44,7 +44,7 @@
 //! handed pointers, not arrays, so it cannot know an array was too short).
 
 use goldenmatch_score_cabi::goldenmatch_score_pairwise_utf8;
-use jni::objects::{JByteArray, JClass, JDoubleArray, JIntArray, ReleaseMode};
+use jni::objects::{JByteArray, JClass, JDoubleArray, JIntArray, JString, ReleaseMode};
 use jni::sys::jint;
 use jni::JNIEnv;
 
@@ -243,5 +243,51 @@ mod tests {
                 "code {added} is already a score-cabi code"
             );
         }
+    }
+}
+
+// ── record fingerprints (identity graph) ────────────────────────────
+//
+// A second kernel in the same library. The jar carries one `.so` per platform,
+// extracted and dlopen'd once per executor JVM, so a second library would buy a
+// second extraction and a second load and nothing else.
+//
+// The boundary here is a JSON STRING, not Arrow buffers, and that is a
+// deliberate difference from the scorer. Scoring is quadratic in block size --
+// millions of calls -- so its per-call cost had to be amortised over a batch.
+// Fingerprinting is once per RECORD: linear, and orders of magnitude fewer
+// calls. `fingerprint_core::fingerprint_json` already accepts exactly this shape
+// (its manifest names "non-Python callers (pgrx / DuckDB / C ABI)" as the
+// reason), and Spark can build the JSON with `to_json(struct(*))` in the engine
+// with no Python anywhere. Inventing an Arrow protocol here would add a
+// marshaling layer to save a cost that is not being paid.
+
+/// Canonical record fingerprint of a JSON object, as 64 lowercase hex chars.
+///
+/// Returns `null` on any failure -- invalid JSON, a non-object, an unsupported
+/// value -- rather than throwing. A JNI exception must be checked for after
+/// every call and a missed check detonates somewhere unrelated; a null is
+/// visible in the result column and the Java side turns it into a message.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeFingerprint_fingerprintJson<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    json: JString<'local>,
+) -> jni::sys::jstring {
+    let null = std::ptr::null_mut();
+    let Ok(s) = env.get_string(&json) else {
+        return null;
+    };
+    let Ok(text) = s.to_str() else {
+        // Not valid UTF-8. JNI hands back modified UTF-8, so this is reachable
+        // for lone surrogates -- refuse rather than hash something else.
+        return null;
+    };
+    match goldenmatch_fingerprint_core::fingerprint_json(text) {
+        Ok(hex) => match env.new_string(hex) {
+            Ok(js) => js.into_raw(),
+            Err(_) => null,
+        },
+        Err(_) => null,
     }
 }

--- a/packages/rust/extensions/score-jni/src/lib.rs
+++ b/packages/rust/extensions/score-jni/src/lib.rs
@@ -291,3 +291,73 @@ pub extern "system" fn Java_dev_goldensuite_spark_NativeFingerprint_fingerprintJ
         Err(_) => null,
     }
 }
+
+// ── transform chain (normalization) ─────────────────────────────────
+//
+// Third kernel in the same library. The chain arrives as ONE comma-separated
+// string rather than a `String[]`: transform names contain `:` (`substring:0:3`)
+// but never `,`, and a per-row `jobjectArray` would be a JNI transition per
+// element to deliver a value that is the same on every row of the query.
+
+fn split_chain(spec: &str) -> Vec<&str> {
+    spec.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Whether every transform in a comma-separated chain can run here.
+///
+/// Exists so a host can refuse at PLAN time with the offending name, rather
+/// than per row. `bloom_filter` and plugin transforms are Python-only by
+/// design, and discovering that mid-job -- after the plan is distributed -- is
+/// strictly worse than refusing before it starts.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeTransform_supportsChain<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    chain: JString<'local>,
+) -> jni::sys::jboolean {
+    let Ok(s) = env.get_string(&chain) else {
+        return 0;
+    };
+    let Ok(spec) = s.to_str() else {
+        return 0;
+    };
+    let all = split_chain(spec)
+        .iter()
+        .all(|t| goldenmatch_transforms_core::supports(t));
+    u8::from(all)
+}
+
+/// Apply a comma-separated transform chain to one value.
+///
+/// Returns `null` when the value is missing, when a transform legitimately
+/// yields a missing value (`strip_honorifics` on an honorific-only name -- an
+/// ABSENCE, not an empty string, because Fellegi-Sunter reads empty as an
+/// agreement on nothing), or when the chain contains something this kernel
+/// cannot run. The last case is unreachable in practice: the host gates on
+/// `supportsChain` before the plan is built.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeTransform_applyChain<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    value: JString<'local>,
+    chain: JString<'local>,
+) -> jni::sys::jstring {
+    let null = std::ptr::null_mut();
+    let (Ok(v), Ok(c)) = (env.get_string(&value), env.get_string(&chain)) else {
+        return null;
+    };
+    let (Ok(text), Ok(spec)) = (v.to_str(), c.to_str()) else {
+        return null;
+    };
+    let names = split_chain(spec);
+    match goldenmatch_transforms_core::apply_transforms(Some(text), &names) {
+        Ok(Some(out)) => match env.new_string(out) {
+            Ok(js) => js.into_raw(),
+            Err(_) => null,
+        },
+        Ok(None) | Err(_) => null,
+    }
+}

--- a/packages/rust/extensions/score-jni/src/lib.rs
+++ b/packages/rust/extensions/score-jni/src/lib.rs
@@ -361,3 +361,104 @@ pub extern "system" fn Java_dev_goldensuite_spark_NativeTransform_applyChain<'lo
         Ok(None) | Err(_) => null,
     }
 }
+
+// ── survivorship (golden records) ───────────────────────────────────
+//
+// Fourth kernel in the same library. The values reuse `Utf8Batch`'s Arrow
+// layout rather than arriving as a `String[]`: the marshaling is already
+// written, already tested, and already handles the multi-byte case that a
+// per-element `GetStringUTFChars` loop gets wrong. A presence mask rides
+// alongside because a null MEMBER is not an empty value -- survivorship ignores
+// absent members rather than voting for "".
+
+/// Choose the surviving value for one cluster.
+///
+/// Returns `null` when there is no survivor (no non-null members, or
+/// `unanimous_or_null` on a disagreement) and when the strategy is refused.
+/// The host gates on [`Java_dev_goldensuite_spark_NativeSurvivorship_supportsStrategy`]
+/// at plan time, so a refusal is unreachable in practice.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeSurvivorship_mergeField<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    offsets: JIntArray<'local>,
+    data: JByteArray<'local>,
+    present: jni::objects::JBooleanArray<'local>,
+    n: jint,
+    strategy: JString<'local>,
+) -> jni::sys::jstring {
+    let null = std::ptr::null_mut();
+    if n < 0 {
+        return null;
+    }
+    let Ok(strat) = env.get_string(&strategy) else {
+        return null;
+    };
+    let Ok(strat) = strat.to_str().map(str::to_owned) else {
+        return null;
+    };
+
+    let n = n as usize;
+    // SAFETY: the arrays are live for the call; every AutoElements releases on
+    // drop. Values are copied out before scoring because `merge_field` borrows
+    // them and the pins must not outlive this scope.
+    let values: Vec<Option<String>> = unsafe {
+        let (Ok(off), Ok(dat), Ok(pres)) = (
+            env.get_array_elements(&offsets, ReleaseMode::NoCopyBack),
+            env.get_array_elements(&data, ReleaseMode::NoCopyBack),
+            env.get_array_elements(&present, ReleaseMode::NoCopyBack),
+        ) else {
+            return null;
+        };
+        if off.len() < n + 1 || pres.len() < n {
+            return null;
+        }
+        let bytes: &[u8] = std::slice::from_raw_parts(dat.as_ptr() as *const u8, dat.len());
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            if pres[i] == 0 {
+                out.push(None);
+                continue;
+            }
+            let (s, e) = (off[i] as usize, off[i + 1] as usize);
+            if s > e || e > bytes.len() {
+                return null;
+            }
+            match std::str::from_utf8(&bytes[s..e]) {
+                Ok(v) => out.push(Some(v.to_owned())),
+                Err(_) => return null,
+            }
+        }
+        out
+    };
+
+    let refs: Vec<Option<&str>> = values.iter().map(|v| v.as_deref()).collect();
+    match goldenmatch_survivorship_core::merge_field(&refs, &strat) {
+        Ok(Some(v)) => match env.new_string(v) {
+            Ok(js) => js.into_raw(),
+            Err(_) => null,
+        },
+        Ok(None) | Err(_) => null,
+    }
+}
+
+/// Whether the loaded kernel can run `strategy`.
+///
+/// So a host refuses at PLAN time with the strategy named. `source_priority`
+/// and `most_recent` need arguments the Spark path does not pass, and `custom:*`
+/// is arbitrary Python -- discovering that per row, mid-job, would be strictly
+/// worse than refusing before the plan is built.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeSurvivorship_supportsStrategy<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    strategy: JString<'local>,
+) -> jni::sys::jboolean {
+    let Ok(s) = env.get_string(&strategy) else {
+        return 0;
+    };
+    let Ok(name) = s.to_str() else {
+        return 0;
+    };
+    u8::from(goldenmatch_survivorship_core::supports(name))
+}

--- a/packages/rust/extensions/score-jni/src/lib.rs
+++ b/packages/rust/extensions/score-jni/src/lib.rs
@@ -1,0 +1,247 @@
+//! JNI entry points for `dev.goldensuite.spark.NativeScorer`.
+//!
+//! # What crosses the boundary, and why
+//!
+//! Not `String[]`. The obvious JNI signature takes two `jobjectArray`s of
+//! `jstring` and calls `GetStringUTFChars` on each element -- which is a JNI
+//! transition and usually a copy **per string**. At the batch size this arc
+//! settled on (10,000 pairs) that is 20,000 JNI calls to avoid one, which
+//! defeats the entire reason the plan was reshaped into batches in J1.
+//!
+//! So the Java side flattens to **Arrow's string layout** first (see
+//! `Utf8Batch.java`) and passes primitive arrays: an `int[]` of `n + 1` offsets
+//! and a `byte[]` of packed UTF-8, per side. This function then pins five
+//! primitive arrays -- a fixed cost per *batch*, independent of how many pairs
+//! it holds -- and hands their addresses straight to
+//! [`goldenmatch_score_pairwise_utf8`], which is the exact layout that ABI was
+//! designed around.
+//!
+//! # Pinning: non-critical, deliberately
+//!
+//! `GetPrimitiveArrayCritical` avoids a copy but suspends GC for the duration
+//! and forbids any other JNI call inside the region. The copy it saves is one
+//! `memcpy` per array per batch -- five memcpys of a few hundred KB against ten
+//! thousand string comparisons. That is not where the time goes, and stalling
+//! an executor's collector to save it is a bad trade. `get_array_elements`
+//! (non-critical) it is.
+//!
+//! # Nulls
+//!
+//! Absent here, exactly as in `score-cabi`. Null slots arrive as zero-length
+//! slices and the Java caller overwrites their scores with `null` afterwards,
+//! because it holds the presence mask. Encoding "missing" as `""` down here is
+//! the substitution that once made null-vs-null score a perfect 1.0, merging
+//! records whose only shared evidence was a shared absence.
+//!
+//! # Errors are return codes, not exceptions
+//!
+//! Throwing from JNI means the caller must check `ExceptionOccurred` after
+//! every call, and a missed check leaves a pending exception that detonates
+//! somewhere unrelated. A negative `int` return cannot be ignored silently by
+//! the Java side, because `NativeScorer` turns it into a message naming the
+//! code. Codes `-1..=-4` are score-cabi's own, passed through unchanged; this
+//! layer adds `-10..=-12` for faults it can detect and score-cabi cannot (it is
+//! handed pointers, not arrays, so it cannot know an array was too short).
+
+use goldenmatch_score_cabi::goldenmatch_score_pairwise_utf8;
+use jni::objects::{JByteArray, JClass, JDoubleArray, JIntArray, ReleaseMode};
+use jni::sys::jint;
+use jni::JNIEnv;
+
+/// Error codes added by this layer. score-cabi's own codes (`-1..=-4`) pass
+/// through unchanged, so a caller reads one table.
+pub mod error {
+    /// An array was shorter than `n` requires. score-cabi validates offset
+    /// *contents* but is handed raw pointers, so only this layer can see that
+    /// the `int[]` holding them has fewer than `n + 1` slots.
+    pub const BAD_ARRAY_LENGTH: i32 = -10;
+    /// `scorer_id` did not fit in the `u8` the kernel dispatches on.
+    pub const SCORER_ID_OUT_OF_RANGE: i32 = -11;
+    /// A JNI array could not be pinned.
+    pub const JNI_ERROR: i32 = -12;
+}
+
+/// [`error`] code as a human-readable reason, for the Java side's message.
+///
+/// A free function on the Rust side rather than a table in Java so the codes
+/// and their meanings live next to each other; drift between the two would
+/// produce a confident, wrong diagnosis of a real failure.
+pub fn describe(code: i32) -> &'static str {
+    match code {
+        0 => "ok",
+        -1 => "a required buffer pointer was NULL",
+        -2 => "batch length was negative or unrepresentable",
+        -3 => "offsets were decreasing, negative, or ran past the data buffer",
+        -4 => "a slice was not valid UTF-8",
+        error::BAD_ARRAY_LENGTH => "an array was too short for the batch length",
+        error::SCORER_ID_OUT_OF_RANGE => "scorer id outside 0..=255",
+        error::JNI_ERROR => "a JNI array could not be pinned",
+        _ => "unknown error code",
+    }
+}
+
+/// `goldenmatch_score_abi_version()`, for the load-time skew gate.
+///
+/// The host refuses a library whose ABI it does not recognise rather than
+/// calling it and reading the result wrongly -- this repo has already paid once
+/// for a caller silently disagreeing with the kernel it loaded.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeScorer_abiVersion(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    goldenmatch_score_cabi::goldenmatch_score_abi_version() as jint
+}
+
+/// `goldenmatch_score_scorer_id_count()`: how many ids `score_one` dispatches.
+///
+/// The host gates on this so an id the loaded kernel does not know is refused
+/// instead of falling to the catch-all arm and scoring a confident 0.0.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeScorer_scorerIdCount(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    goldenmatch_score_cabi::goldenmatch_score_scorer_id_count() as jint
+}
+
+/// Score `n` pairs from Arrow-layout primitive arrays into `out`.
+///
+/// Returns `0` on success or a negative code (see [`error`] and [`describe`]).
+/// On any error `out` is left as the caller allocated it -- a caller that
+/// ignores the code gets zeros, not a plausible-looking wrong score.
+#[no_mangle]
+pub extern "system" fn Java_dev_goldensuite_spark_NativeScorer_scorePairwiseUtf8<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    scorer_id: jint,
+    a_offsets: JIntArray<'local>,
+    a_data: JByteArray<'local>,
+    b_offsets: JIntArray<'local>,
+    b_data: JByteArray<'local>,
+    n: jint,
+    out: JDoubleArray<'local>,
+) -> jint {
+    if n < 0 {
+        return -2; // score-cabi's BAD_LENGTH, reported before we pin anything.
+    }
+    let scorer_id = match u8::try_from(scorer_id) {
+        Ok(v) => v,
+        Err(_) => return error::SCORER_ID_OUT_OF_RANGE,
+    };
+    let n_usize = n as usize;
+
+    // SAFETY: the arrays are live for the call (the JVM holds the references
+    // that were passed in), and every `AutoElements` releases on drop. Held
+    // simultaneously on purpose -- the kernel reads all four inputs and writes
+    // `out` in one pass.
+    unsafe {
+        let ao = match env.get_array_elements(&a_offsets, ReleaseMode::NoCopyBack) {
+            Ok(v) => v,
+            Err(_) => return error::JNI_ERROR,
+        };
+        let ad = match env.get_array_elements(&a_data, ReleaseMode::NoCopyBack) {
+            Ok(v) => v,
+            Err(_) => return error::JNI_ERROR,
+        };
+        let bo = match env.get_array_elements(&b_offsets, ReleaseMode::NoCopyBack) {
+            Ok(v) => v,
+            Err(_) => return error::JNI_ERROR,
+        };
+        let bd = match env.get_array_elements(&b_data, ReleaseMode::NoCopyBack) {
+            Ok(v) => v,
+            Err(_) => return error::JNI_ERROR,
+        };
+        // CopyBack: this is the only array written, and without it the scores
+        // would be computed into a JVM-side copy that is then discarded --
+        // a silent all-zeros result rather than a failure.
+        let mut o = match env.get_array_elements(&out, ReleaseMode::CopyBack) {
+            Ok(v) => v,
+            Err(_) => return error::JNI_ERROR,
+        };
+
+        // Extents, which score-cabi cannot check: it receives pointers.
+        // Without this an `n` larger than the arrays reads past them, and the
+        // whole reason that ABI validates offsets is to keep a JIT-compiled
+        // host from doing exactly that.
+        if ao.len() < n_usize + 1 || bo.len() < n_usize + 1 || o.len() < n_usize {
+            return error::BAD_ARRAY_LENGTH;
+        }
+
+        goldenmatch_score_pairwise_utf8(
+            scorer_id,
+            ao.as_ptr(),
+            // jbyte is i8; Arrow's data buffer is bytes either way. This is a
+            // reinterpret of the same address, not a conversion.
+            ad.as_ptr() as *const u8,
+            ad.len() as i64,
+            bo.as_ptr(),
+            bd.as_ptr() as *const u8,
+            bd.len() as i64,
+            n as i64,
+            o.as_mut_ptr(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The JNI entry points need a JVM, so what is testable here is the code
+    /// table and the fact that this crate reports the SAME kernel identity as
+    /// the C ABI it wraps. A skew between them would mean the load-time gate is
+    /// checking one library and the scoring is done by another.
+    #[test]
+    fn abi_identity_matches_the_c_abi_it_wraps() {
+        assert_eq!(goldenmatch_score_cabi::goldenmatch_score_abi_version(), 1);
+        assert_eq!(
+            goldenmatch_score_cabi::goldenmatch_score_scorer_id_count(),
+            15
+        );
+    }
+
+    #[test]
+    fn every_code_this_layer_can_return_has_a_description() {
+        for code in [
+            0,
+            -1,
+            -2,
+            -3,
+            -4,
+            error::BAD_ARRAY_LENGTH,
+            error::SCORER_ID_OUT_OF_RANGE,
+            error::JNI_ERROR,
+        ] {
+            assert_ne!(
+                describe(code),
+                "unknown error code",
+                "code {code} has no description; a real failure would be \
+                 diagnosed as 'unknown'"
+            );
+        }
+        assert_eq!(describe(-99), "unknown error code");
+    }
+
+    /// The codes this layer adds must not collide with score-cabi's, because
+    /// they are returned through the same `int` and read from one table.
+    #[test]
+    fn added_codes_do_not_collide_with_the_c_abi_codes() {
+        let cabi = [
+            goldenmatch_score_cabi::error::NULL_POINTER,
+            goldenmatch_score_cabi::error::BAD_LENGTH,
+            goldenmatch_score_cabi::error::BAD_OFFSETS,
+            goldenmatch_score_cabi::error::INVALID_UTF8,
+        ];
+        for added in [
+            error::BAD_ARRAY_LENGTH,
+            error::SCORER_ID_OUT_OF_RANGE,
+            error::JNI_ERROR,
+        ] {
+            assert!(
+                !cabi.contains(&added),
+                "code {added} is already a score-cabi code"
+            );
+        }
+    }
+}

--- a/packages/rust/extensions/survivorship-core/Cargo.toml
+++ b/packages/rust/extensions/survivorship-core/Cargo.toml
@@ -1,0 +1,26 @@
+# survivorship-core -- the pyo3-free golden-record merge, so a survivor is
+# chosen identically on every surface.
+#
+# Written because there was NO pyo3-free implementation: verified against
+# origin/main, `merge_field` appeared only in
+# `packages/rust/extensions/native/src/golden.rs`, which is pyo3 + pyarrow
+# throughout AND is a different thing -- the fused columnar kernel that returns
+# INDICES for the one-box path, not the per-cluster value merge the Spark tier
+# calls.
+#
+# Scope is the SPARK call site: `spark/golden.py` passes values and a strategy
+# and nothing else -- no sources, dates, quality weights or pair scores. The
+# strategies that need those are REFUSED rather than half-implemented, because a
+# survivor chosen by a different rule is a wrong golden record that looks right.
+[workspace]
+
+[package]
+name = "goldenmatch-survivorship-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Pyo3-free golden-record survivorship (merge_field) shared across surfaces"
+
+[lib]
+name = "goldenmatch_survivorship_core"

--- a/packages/rust/extensions/survivorship-core/examples/parity_dump.rs
+++ b/packages/rust/extensions/survivorship-core/examples/parity_dump.rs
@@ -1,0 +1,44 @@
+//! Dump `(values, strategy) -> survivor` for a fixed corpus, for differential
+//! comparison against Python's `merge_field`.
+//!
+//! COMMITTED, like the transforms one, because a port is only as good as the
+//! evidence it matches the original -- and that harness caught two real bugs
+//! (a scorer bound to the wrong crate, and honorifics stripped from the wrong
+//! end) that review had passed.
+//!
+//!     cargo run --example parity_dump > rust.txt
+//!     python scripts/survivorship_parity_dump.py > py.txt
+//!     diff rust.txt py.txt
+//!
+//! The corpus targets TIE-BREAKS, because that is where a port silently
+//! diverges: Python's `Counter.most_common` keeps insertion order and `max()`
+//! keeps the first maximum, while Rust's `max_by_key` keeps the LAST.
+use goldenmatch_survivorship_core::{merge_field, SUPPORTED};
+
+const CASES: &[&[Option<&str>]] = &[
+    &[Some("a"), Some("b")],
+    &[Some("b"), Some("a"), Some("a")],
+    &[Some("a"), Some("a"), Some("b"), Some("b")],
+    &[None, Some("x"), Some("y")],
+    &[None, None],
+    &[Some("a"), None, Some("a")],
+    &[Some("ab"), Some("abcd")],
+    &[Some("ab"), Some("cd")],
+    &[Some("café"), Some("abcde")],
+    &[Some(""), Some("x")],
+    &[Some("same"), Some("same"), Some("same")],
+    &[Some("日本語"), Some("ab")],
+];
+
+fn main() {
+    for case in CASES {
+        for s in SUPPORTED {
+            let got = match merge_field(case, s) {
+                Ok(Some(v)) => format!("{v:?}"),
+                Ok(None) => "None".to_string(),
+                Err(_) => "REFUSED".to_string(),
+            };
+            println!("{s}\t{case:?}\t{got}");
+        }
+    }
+}

--- a/packages/rust/extensions/survivorship-core/src/lib.rs
+++ b/packages/rust/extensions/survivorship-core/src/lib.rs
@@ -1,0 +1,279 @@
+//! Golden-record survivorship, pyo3-free, byte-identical to
+//! `goldenmatch.core.golden.merge_field` **as the Spark tier calls it**.
+//!
+//! # Why this exists
+//!
+//! It did not. Verified against `origin/main`: `merge_field` appeared in exactly
+//! one Rust file, `native/src/golden.rs`, which is pyo3 + pyarrow throughout AND
+//! is a different thing -- the fused columnar kernel returning INDICES for the
+//! one-box path, not the per-cluster value merge. So survivorship was Python-only
+//! and `spark/golden.py` had to be an `arrow_udf`.
+//!
+//! # Scope, and why it is narrow on purpose
+//!
+//! `spark/golden.py` calls `merge_field(values, rule)` -- values and a strategy,
+//! nothing else. No sources, no dates, no quality weights, no pair scores, and
+//! it discards the confidence and source index, keeping only the value. This
+//! crate implements exactly that call.
+//!
+//! The strategies needing the arguments Spark does not pass are [`Refused`], not
+//! approximated:
+//!
+//! - `source_priority` -- Python RAISES without a sources list. Guessing an
+//!   order would silently prefer the wrong system of record.
+//! - `most_recent` -- Python RAISES without dates. Without them there is no
+//!   "recent"; picking the first row would be an arbitrary answer wearing a
+//!   deterministic hat.
+//! - `custom:*` -- arbitrary Python from a plugin registry.
+//!
+//! A survivor chosen by a different rule is a **wrong golden record that looks
+//! right**: no exception, no null, just a plausible value in the output that
+//! nothing downstream can flag.
+//!
+//! # Ordering is semantic here, not incidental
+//!
+//! Python's `Counter.most_common(1)` breaks count ties by INSERTION order, and
+//! `max()` over a list keeps the FIRST maximum. Every tie-break below preserves
+//! first-encountered order for that reason. A `HashMap` would lose it, so the
+//! vote tally is an insertion-ordered `Vec`.
+
+/// A strategy this crate deliberately does not run, and why.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Refused(pub String);
+
+/// Strategies runnable from values alone -- the Spark call site's whole surface.
+pub const SUPPORTED: &[&str] = &[
+    "most_complete",
+    "majority_vote",
+    "first_non_null",
+    "longest_value",
+    "unanimous_or_null",
+    // Falls back to count-majority when pair_scores is None, which is always
+    // the case from Spark. Included because that fallback is the DOCUMENTED
+    // behaviour, not because the edge-weighted form is implemented.
+    "confidence_majority",
+];
+
+/// Whether [`merge_field`] can run `strategy`.
+///
+/// Exposed so a host refuses at PLAN time, naming the strategy, rather than
+/// per row inside a distributed job.
+pub fn supports(strategy: &str) -> bool {
+    SUPPORTED.contains(&strategy)
+}
+
+/// Insertion-ordered tally: `(value, count)` in first-seen order.
+///
+/// Deliberately a `Vec`, not a `HashMap`. Python's `Counter.most_common(1)`
+/// resolves a count tie to the first-inserted key, so iteration order IS the
+/// tie-break rule; a hash map would make the winner depend on hash seeding.
+fn tally<'a>(values: &[(usize, &'a str)]) -> Vec<(&'a str, usize, usize)> {
+    let mut out: Vec<(&str, usize, usize)> = Vec::new();
+    for (i, v) in values {
+        match out.iter_mut().find(|(k, _, _)| k == v) {
+            Some((_, c, _)) => *c += 1,
+            None => out.push((v, 1, *i)),
+        }
+    }
+    out
+}
+
+/// Choose the surviving value for one cluster's collected field values.
+///
+/// `values` is one entry per cluster member; `None` is a missing value.
+/// Returns the survivor, or `None` when there is none (no non-null members, or
+/// `unanimous_or_null` on a disagreement).
+///
+/// Mirrors `merge_field`'s two early-outs before any strategy runs: all-null
+/// yields `None`, and a single distinct non-null value yields that value
+/// regardless of strategy.
+pub fn merge_field(values: &[Option<&str>], strategy: &str) -> Result<Option<String>, Refused> {
+    if strategy.starts_with("custom:") {
+        return Err(Refused(format!(
+            "strategy {strategy:?} dispatches to a Python plugin, which cannot \
+             run outside Python. Refused rather than approximated: a survivor \
+             chosen by a different rule is a wrong golden record that looks \
+             right."
+        )));
+    }
+    if !supports(strategy) {
+        return Err(Refused(match strategy {
+            "source_priority" => "strategy \"source_priority\" needs a sources \
+                list, which the Spark path does not supply -- Python raises \
+                rather than guessing, and so does this. Guessing an order would \
+                silently prefer the wrong system of record."
+                .to_string(),
+            "most_recent" => "strategy \"most_recent\" needs a dates list, which \
+                the Spark path does not supply -- Python raises rather than \
+                guessing. Without dates there is no \"recent\", and picking the \
+                first row would be an arbitrary answer wearing a deterministic \
+                hat."
+                .to_string(),
+            other => format!("unknown strategy {other:?}"),
+        }));
+    }
+
+    let non_null: Vec<(usize, &str)> = values
+        .iter()
+        .enumerate()
+        .filter_map(|(i, v)| v.map(|s| (i, s)))
+        .collect();
+    if non_null.is_empty() {
+        return Ok(None);
+    }
+    // All non-null values identical -> that value, whatever the strategy.
+    let first = non_null[0].1;
+    if non_null.iter().all(|(_, v)| *v == first) {
+        return Ok(Some(first.to_string()));
+    }
+
+    let winner = match strategy {
+        // `str(v)` length in Python; every Spark value is already a string.
+        // Length is in CHARACTERS, not bytes -- Python's len() counts code
+        // points, so a byte length would prefer an accented value over a longer
+        // ASCII one.
+        "most_complete" | "longest_value" => {
+            let max_len = non_null
+                .iter()
+                .map(|(_, v)| v.chars().count())
+                .max()
+                .unwrap_or(0);
+            // FIRST maximum: Python takes longest[0] when the tie is unbroken.
+            non_null
+                .iter()
+                .find(|(_, v)| v.chars().count() == max_len)
+                .map(|(_, v)| *v)
+        }
+        "majority_vote" | "confidence_majority" => {
+            let counts = tally(&non_null);
+            // `max_by_key` returns the LAST maximum in Rust and the FIRST in
+            // Python's `most_common`. Fold keeping strict `>` to match Python.
+            counts
+                .iter()
+                .fold(None::<(&str, usize)>, |best, (v, c, _)| match best {
+                    Some((_, bc)) if *c <= bc => best,
+                    _ => Some((v, *c)),
+                })
+                .map(|(v, _)| v)
+        }
+        "first_non_null" => Some(non_null[0].1),
+        // Disagreement is deliberately a NULL, not a guess: the strategy exists
+        // for compliance fields where a heuristic value is worse than none.
+        // Unanimity was already handled by the early-out above, so reaching
+        // here means members disagree.
+        "unanimous_or_null" => None,
+        _ => unreachable!("supports() gates this match"),
+    };
+    Ok(winner.map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn m(vals: &[Option<&str>], s: &str) -> Option<String> {
+        merge_field(vals, s).unwrap()
+    }
+
+    #[test]
+    fn all_null_yields_none_for_every_strategy() {
+        for s in SUPPORTED {
+            assert_eq!(m(&[None, None], s), None, "{s}");
+        }
+    }
+
+    #[test]
+    fn a_single_distinct_value_wins_regardless_of_strategy() {
+        // merge_field's early-out, before any strategy runs.
+        for s in SUPPORTED {
+            assert_eq!(m(&[Some("a"), None, Some("a")], s), Some("a".into()), "{s}");
+        }
+    }
+
+    #[test]
+    fn most_complete_takes_the_longest_then_first() {
+        assert_eq!(
+            m(&[Some("ab"), Some("abcd")], "most_complete"),
+            Some("abcd".into())
+        );
+        // Tie -> FIRST, matching Python's longest[0].
+        assert_eq!(
+            m(&[Some("ab"), Some("cd")], "most_complete"),
+            Some("ab".into())
+        );
+    }
+
+    #[test]
+    fn length_is_counted_in_characters_not_bytes() {
+        // "café" is 4 chars / 5 bytes; "abcde" is 5 chars / 5 bytes. A byte
+        // comparison would call these tied and take the first.
+        assert_eq!(
+            m(&[Some("café"), Some("abcde")], "longest_value"),
+            Some("abcde".into())
+        );
+    }
+
+    #[test]
+    fn majority_vote_breaks_count_ties_by_first_seen() {
+        assert_eq!(
+            m(&[Some("b"), Some("a"), Some("a")], "majority_vote"),
+            Some("a".into())
+        );
+        // 1-1 tie: Python's Counter.most_common keeps insertion order, so "b".
+        assert_eq!(
+            m(&[Some("b"), Some("a")], "majority_vote"),
+            Some("b".into())
+        );
+    }
+
+    #[test]
+    fn confidence_majority_falls_back_to_count_majority() {
+        // Without pair_scores -- which Spark never supplies -- Python documents
+        // this as vanilla count-majority.
+        assert_eq!(
+            m(&[Some("b"), Some("a"), Some("a")], "confidence_majority"),
+            Some("a".into())
+        );
+    }
+
+    #[test]
+    fn first_non_null_skips_leading_nulls() {
+        assert_eq!(
+            m(&[None, Some("x"), Some("y")], "first_non_null"),
+            Some("x".into())
+        );
+    }
+
+    #[test]
+    fn unanimous_or_null_emits_null_on_disagreement() {
+        assert_eq!(
+            m(&[Some("a"), Some("a")], "unanimous_or_null"),
+            Some("a".into())
+        );
+        // A heuristic value would be worse than none for this strategy's whole
+        // use case (medical IDs, licence numbers).
+        assert_eq!(m(&[Some("a"), Some("b")], "unanimous_or_null"), None);
+        // Nulls are ignored: absence is not contradiction.
+        assert_eq!(
+            m(&[Some("a"), None, Some("a")], "unanimous_or_null"),
+            Some("a".into())
+        );
+    }
+
+    #[test]
+    fn strategies_needing_arguments_spark_never_passes_are_refused() {
+        for s in ["source_priority", "most_recent", "custom:mine", "nope"] {
+            assert!(!supports(s) || s.starts_with("custom:"), "{s}");
+            let err = merge_field(&[Some("a"), Some("b")], s).unwrap_err();
+            assert!(!err.0.is_empty(), "{s} refused without a reason");
+        }
+    }
+
+    #[test]
+    fn a_refusal_beats_a_plausible_wrong_survivor() {
+        // The property the refusals exist for: these must NOT quietly return a
+        // value. A wrong golden record raises nothing and looks right.
+        assert!(merge_field(&[Some("a"), Some("b")], "most_recent").is_err());
+        assert!(merge_field(&[Some("a"), Some("b")], "source_priority").is_err());
+    }
+}

--- a/packages/rust/extensions/transforms-core/Cargo.toml
+++ b/packages/rust/extensions/transforms-core/Cargo.toml
@@ -1,0 +1,35 @@
+# transforms-core -- the pyo3-free transform chain, so a value normalizes
+# identically on every surface.
+#
+# Written because there was NO Rust implementation: verified against origin/main,
+# not one file under packages/rust/ mentioned `apply_transform`,
+# `normalize_whitespace`, `strip_honorifics` or any sibling. The transform chain
+# was Python-only, which is why `config_pipeline._transformed` is an `arrow_udf`
+# and why a Spark cluster still needed a packed virtualenv to normalize a column.
+#
+# **Only the transforms that can be byte-identical live here.** `bloom_filter`
+# (PPRL CLK, HMAC-keyed) and plugin transforms (arbitrary Python) are absent on
+# purpose -- see `apply_transform`'s docs. A transform that ALMOST matches is
+# worse than one that is missing: normalization feeds blocking and scoring, so a
+# one-character difference silently changes which records are compared at all.
+[workspace]
+
+[package]
+name = "goldenmatch-transforms-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Pyo3-free transform chain (normalization) shared across surfaces"
+
+[lib]
+name = "goldenmatch_transforms_core"
+
+[dependencies]
+# soundex / metaphone, already pyo3-free and already byte-identical to
+# jellyfish. Not reimplemented here -- that is the whole point.
+# soundex: `canonical_soundex` documents itself as byte-identical to SCORE-CORE's
+# soundex, not goldenphonetic's. Both are pyo3-free; binding the wrong one is a
+# silent divergence, so both are declared and each transform names its source.
+goldenmatch-score-core = { path = "../score-core" }
+goldenphonetic-core = { path = "../goldenphonetic-core" }

--- a/packages/rust/extensions/transforms-core/examples/parity_dump.rs
+++ b/packages/rust/extensions/transforms-core/examples/parity_dump.rs
@@ -1,0 +1,70 @@
+//! Dump `(value, transform) -> result` for a fixed corpus, for differential
+//! comparison against Python.
+//!
+//! COMMITTED on purpose. A port is only as good as the evidence it matches the
+//! original, and evidence that lives in a scratch directory cannot be re-run by
+//! the next person to touch this crate. `scripts/transforms_parity_dump.py`
+//! prints the same corpus through `goldenmatch.utils.transforms`; the two
+//! outputs must be byte-identical.
+//!
+//!     cargo run --example parity_dump > rust.txt
+//!     python scripts/transforms_parity_dump.py > py.txt
+//!     diff rust.txt py.txt
+//!
+//! The corpus is chosen for the ways a port breaks, not for readability:
+//! multi-byte values (code-point vs byte slicing), case mappings that change
+//! length, exotic whitespace (Python and Rust disagree on the C1 separators),
+//! honorific-only values (missing vs empty), and empty strings.
+use goldenmatch_transforms_core::apply_transform;
+
+const VALUES: &[&str] = &[
+    "Jonathan Smith",
+    "  Dr. Jonathan   Smith  ",
+    "",
+    "café",
+    "Zoë Müller",
+    "日本語テキスト",
+    "O'Brien-Smith Jr.",
+    "ACME Corporation 123",
+    "straße",
+    "İstanbul",
+    "a\u{1c}b",
+    "\t mixed \n whitespace \r ",
+    "Mr.",
+    "Prof Dr Alice",
+    "123-456-7890",
+];
+
+const TRANSFORMS: &[&str] = &[
+    "lowercase",
+    "uppercase",
+    "strip",
+    "strip_all",
+    "digits_only",
+    "alpha_only",
+    "normalize_whitespace",
+    "token_sort",
+    "first_token",
+    "last_token",
+    "soundex",
+    "metaphone",
+    "strip_honorifics",
+    "substring:0:3",
+    "substring:2:5",
+    "substring:0:99",
+    "qgram:2",
+    "qgram:3",
+];
+
+fn main() {
+    for v in VALUES {
+        for t in TRANSFORMS {
+            let out = match apply_transform(Some(v), t) {
+                Ok(Some(s)) => format!("{s:?}"),
+                Ok(None) => "None".to_string(),
+                Err(e) => format!("UNSUPPORTED({})", e.0.split(' ').next().unwrap_or("")),
+            };
+            println!("{t}\t{v:?}\t{out}");
+        }
+    }
+}

--- a/packages/rust/extensions/transforms-core/src/lib.rs
+++ b/packages/rust/extensions/transforms-core/src/lib.rs
@@ -1,0 +1,456 @@
+//! The transform chain, pyo3-free, byte-identical to
+//! `goldenmatch.utils.transforms`.
+//!
+//! # Why this exists
+//!
+//! It did not. Verified against `origin/main`: not one file under
+//! `packages/rust/` mentioned `apply_transform`, `normalize_whitespace`,
+//! `strip_honorifics` or any sibling. Normalization was Python-only, which is
+//! why `config_pipeline._transformed` is an `arrow_udf` and why a Spark cluster
+//! still needed a packed virtualenv to lowercase a column.
+//!
+//! # What is deliberately NOT here
+//!
+//! `bloom_filter` (PPRL CLK, HMAC-keyed, security-level presets) and plugin
+//! transforms (arbitrary Python from a registry). Both are refused by
+//! [`apply_transform`] rather than approximated.
+//!
+//! **A transform that almost matches is worse than one that is missing.**
+//! Normalization feeds blocking and scoring, so a one-character difference does
+//! not surface as a wrong answer -- it changes which records are ever compared,
+//! and the pair simply never appears. There is no threshold to absorb that and
+//! no test downstream that would notice.
+//!
+//! # Parity notes, where Python and Rust could plausibly disagree
+//!
+//! - **Case.** Python `str.lower()`/`.upper()` and Rust `to_lowercase()`/
+//!   `to_uppercase()` both do full Unicode case mapping including the
+//!   one-to-many cases (`ß` -> `SS`, `İ` -> `i̇`).
+//! - **Whitespace.** Python's `\s` (on `str`, Unicode by default) and
+//!   `char::is_whitespace` agree on the common set but NOT everywhere: Python's
+//!   `str.isspace()` counts the C1 separators `U+001C..U+001F`, Rust's
+//!   `is_whitespace` does not. [`is_py_space`] encodes Python's set explicitly
+//!   rather than borrowing Rust's, so the two cannot drift apart on a control
+//!   character nobody thinks about.
+//! - **Slicing.** Python slices by CODE POINT and tolerates out-of-range
+//!   indices. [`substring`] does the same over `char_indices`, not bytes --
+//!   byte slicing would panic mid-character on any multi-byte value.
+//! - **Sorting.** Python sorts `str` by code point; Rust sorts `&str` by bytes,
+//!   and for UTF-8 those orders are identical. Relied on by `token_sort` and
+//!   `qgram`.
+
+use std::borrow::Cow;
+
+/// Honorifics stripped by `strip_honorifics`, matching
+/// `goldenmatch.utils.transforms._HONORIFICS`.
+/// Tokens `strip_honorifics` drops, byte-for-byte from
+/// `goldenmatch.utils.transforms._STRIP_HONORIFIC_TOKENS`.
+///
+/// Duplicated rather than derived because this crate must work with no Python
+/// present -- and pinned against the Python set by
+/// `scripts/transforms_parity_dump.py`, so the duplication cannot drift
+/// unnoticed. It includes POST-NOMINALS (`jr`, `phd`, `esq`), which is why
+/// stripping only LEADING tokens is wrong: the first version of this port did
+/// that and turned "O'Brien-Smith Jr." into "O'Brien-Smith Jr." where Python
+/// gives "O'Brien-Smith". Caught by the differential dump, not by review.
+const HONORIFICS: &[&str] = &[
+    // courtesy titles
+    "mr",
+    "mrs",
+    "ms",
+    "miss",
+    "mstr",
+    // academic / professional
+    "dr",
+    "prof",
+    "professor",
+    // religious (abbreviated titles only, not office names)
+    "rev",
+    "revd",
+    "reverend",
+    // knighthoods / unambiguous honorifics
+    "sir",
+    "dame",
+    "kt",
+    "bt",
+    "baronet",
+    // generational / post-nominal suffixes
+    "jr",
+    "sr",
+    "esq",
+    "esquire",
+    "phd",
+    "md",
+    "dds",
+    "dvm",
+];
+
+/// Python's whitespace set for `str`, which is what both `\s` in a Unicode
+/// regex and `str.strip()` use.
+///
+/// Written out rather than delegating to `char::is_whitespace` because the two
+/// differ: Python counts `U+001C..U+001F` (the ASCII file/group/record/unit
+/// separators) as whitespace and Rust does not. Borrowing Rust's predicate would
+/// leave a value containing one of those normalizing differently on the two
+/// surfaces -- which changes its block and removes the pair from consideration
+/// entirely, invisibly.
+pub fn is_py_space(c: char) -> bool {
+    c.is_whitespace() || matches!(c, '\u{1c}' | '\u{1d}' | '\u{1e}' | '\u{1f}')
+}
+
+/// `re.sub(r"\s+", "", value)`.
+fn strip_all(value: &str) -> String {
+    value.chars().filter(|c| !is_py_space(*c)).collect()
+}
+
+/// `re.sub(r"\s+", " ", value).strip()`.
+fn normalize_whitespace(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut in_space = false;
+    for c in value.chars() {
+        if is_py_space(c) {
+            in_space = true;
+        } else {
+            if in_space && !out.is_empty() {
+                out.push(' ');
+            }
+            in_space = false;
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Python's `value.strip()`.
+fn py_strip(value: &str) -> &str {
+    value.trim_matches(is_py_space)
+}
+
+/// Python's whitespace `split()`: no empty tokens, leading/trailing ignored.
+fn py_split(value: &str) -> Vec<&str> {
+    value.split(is_py_space).filter(|t| !t.is_empty()).collect()
+}
+
+/// Python's `value[start:end]`, by CODE POINT, tolerating out-of-range indices.
+///
+/// Byte slicing would panic in the middle of any multi-byte character; this is
+/// the transform most likely to be handed a name with an accent in it.
+fn substring(value: &str, start: i64, end: i64) -> String {
+    let n = value.chars().count() as i64;
+    let clamp = |i: i64| -> usize {
+        let i = if i < 0 { (n + i).max(0) } else { i.min(n) };
+        i as usize
+    };
+    let (s, e) = (clamp(start), clamp(end));
+    if e <= s {
+        return String::new();
+    }
+    value.chars().skip(s).take(e - s).collect()
+}
+
+/// `qgram:q` -- sorted unique q-grams of `##value##`, first 5, space-joined.
+fn qgram(value: &str, q: usize) -> String {
+    if q == 0 {
+        return String::new();
+    }
+    let padded: Vec<char> = format!("##{value}##").chars().collect();
+    if padded.len() < q {
+        return String::new();
+    }
+    let mut grams: Vec<String> = (0..=padded.len() - q)
+        .map(|i| padded[i..i + q].iter().collect::<String>())
+        .collect();
+    grams.sort_unstable();
+    grams.dedup();
+    grams.truncate(5);
+    grams.join(" ")
+}
+
+/// `strip_honorifics`: drop leading honorific tokens. Returns `None` when the
+/// value was honorifics only -- a MISSING value, not an empty string, because
+/// downstream Fellegi-Sunter reads empty as an agreement on nothing.
+fn strip_honorifics(value: &str) -> Option<String> {
+    // EVERY token is tested, not just the leading ones: the set carries
+    // post-nominals (`jr`, `phd`, `esq`), so "Smith Jr." must lose its suffix.
+    // Stripping only a leading run was this port's first bug.
+    let kept: Vec<&str> = py_split(value)
+        .into_iter()
+        .filter(|t| {
+            let bare: String = t
+                .chars()
+                .filter(|c| c.is_alphanumeric())
+                .flat_map(|c| c.to_lowercase())
+                .collect();
+            !bare.is_empty() && !HONORIFICS.contains(&bare.as_str())
+        })
+        .collect();
+    // Nothing surviving is MISSING, not empty: an empty string reads downstream
+    // as an agreement on nothing rather than an absence of evidence.
+    let residual = kept.join(" ");
+    let residual = py_strip(&residual).to_string();
+    if residual.is_empty() {
+        None
+    } else {
+        Some(residual)
+    }
+}
+
+/// A transform this crate refuses, and why.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Unsupported(pub String);
+
+/// Whether [`apply_transform`] can run `name` at all.
+///
+/// Exposed so a HOST can refuse a whole chain up front -- at plan time, with the
+/// offending transform named -- rather than discovering it per row, mid-job.
+pub fn supports(name: &str) -> bool {
+    match name {
+        "lowercase"
+        | "uppercase"
+        | "strip"
+        | "strip_all"
+        | "soundex"
+        | "metaphone"
+        | "digits_only"
+        | "alpha_only"
+        | "normalize_whitespace"
+        | "token_sort"
+        | "first_token"
+        | "last_token"
+        | "strip_honorifics" => true,
+        _ => {
+            (name.starts_with("substring:") && parse_substring(name).is_some())
+                || (name.starts_with("qgram:") && parse_qgram(name).is_some())
+        }
+    }
+}
+
+fn parse_substring(name: &str) -> Option<(i64, i64)> {
+    let mut parts = name.split(':');
+    parts.next()?;
+    let a = parts.next()?.parse::<i64>().ok()?;
+    let b = parts.next()?.parse::<i64>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((a, b))
+}
+
+fn parse_qgram(name: &str) -> Option<usize> {
+    let mut parts = name.split(':');
+    parts.next()?;
+    let q = parts.next()?.parse::<usize>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(q)
+}
+
+/// One named transform. `None` in, `None` out, exactly as Python.
+///
+/// Returns `Err(Unsupported)` for `bloom_filter` and for plugin transforms
+/// rather than guessing. Those are refusals by design, not gaps to fill later:
+/// `bloom_filter` is HMAC-keyed PPRL and a plugin is arbitrary Python.
+pub fn apply_transform(value: Option<&str>, name: &str) -> Result<Option<String>, Unsupported> {
+    let Some(v) = value else {
+        return Ok(None);
+    };
+    let out = match name {
+        "lowercase" => v.to_lowercase(),
+        "uppercase" => v.to_uppercase(),
+        "strip" => py_strip(v).to_string(),
+        "strip_all" => strip_all(v),
+        // score-core's, NOT goldenphonetic's. `canonical_soundex` documents
+        // itself as "byte-identical to score-core `soundex`", and the two
+        // differ: goldenphonetic seeds on the first character whatever it is,
+        // so "  Dr. ..." coded to " 362" and "123-456" to "1000" instead of
+        // "" . Binding the plausible crate rather than the documented one was
+        // this port's other bug, and only the differential dump found it.
+        "soundex" => goldenmatch_score_core::soundex(v),
+        "metaphone" => goldenphonetic_core::metaphone(v),
+        "digits_only" => v.chars().filter(|c| c.is_ascii_digit()).collect(),
+        "alpha_only" => v.chars().filter(|c| c.is_ascii_alphabetic()).collect(),
+        "normalize_whitespace" => normalize_whitespace(v),
+        "token_sort" => {
+            let mut t = py_split(v);
+            t.sort_unstable();
+            t.join(" ")
+        }
+        "first_token" => py_split(v)
+            .first()
+            .map_or_else(|| v.to_string(), |s| s.to_string()),
+        "last_token" => py_split(v)
+            .last()
+            .map_or_else(|| v.to_string(), |s| s.to_string()),
+        "strip_honorifics" => return Ok(strip_honorifics(v)),
+        _ => {
+            if let Some((a, b)) = name
+                .starts_with("substring:")
+                .then(|| parse_substring(name))
+                .flatten()
+            {
+                substring(v, a, b)
+            } else if let Some(q) = name
+                .starts_with("qgram:")
+                .then(|| parse_qgram(name))
+                .flatten()
+            {
+                qgram(v, q)
+            } else {
+                return Err(Unsupported(format!(
+                    "transform {name:?} is not available outside Python. \
+                     `bloom_filter` is HMAC-keyed PPRL and plugin transforms are \
+                     arbitrary Python; both are refused rather than approximated, \
+                     because normalization feeds BLOCKING -- a value that \
+                     normalizes differently lands in a different block and the \
+                     pair is never compared at all."
+                )));
+            }
+        }
+    };
+    Ok(Some(out))
+}
+
+/// A whole chain, left to right. Short-circuits on `None`, exactly as
+/// `apply_transforms` does: once a value is missing, later transforms have
+/// nothing to act on and must not resurrect it as `""`.
+pub fn apply_transforms(
+    value: Option<&str>,
+    names: &[&str],
+) -> Result<Option<String>, Unsupported> {
+    let mut cur: Option<String> = value.map(|s| s.to_string());
+    for name in names {
+        match apply_transform(cur.as_deref(), name)? {
+            Some(next) => cur = Some(next),
+            None => return Ok(None),
+        }
+    }
+    Ok(cur)
+}
+
+/// Convenience for hosts holding an owned chain.
+pub fn apply_transforms_owned(
+    value: Option<&str>,
+    names: &[String],
+) -> Result<Option<String>, Unsupported> {
+    let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+    apply_transforms(value, &refs)
+}
+
+/// Borrowed passthrough for the common single-transform case.
+pub fn apply_transform_cow<'a>(value: &'a str, name: &str) -> Result<Cow<'a, str>, Unsupported> {
+    match apply_transform(Some(value), name)? {
+        Some(s) => Ok(Cow::Owned(s)),
+        None => Ok(Cow::Borrowed("")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(v: &str, name: &str) -> String {
+        apply_transform(Some(v), name).unwrap().unwrap_or_default()
+    }
+
+    #[test]
+    fn none_passes_through_every_transform() {
+        for name in ["lowercase", "strip", "token_sort", "soundex"] {
+            assert_eq!(apply_transform(None, name).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn basic_string_ops() {
+        assert_eq!(t("AbC", "lowercase"), "abc");
+        assert_eq!(t("AbC", "uppercase"), "ABC");
+        assert_eq!(t("  x  ", "strip"), "x");
+        assert_eq!(t("a b\tc", "strip_all"), "abc");
+        assert_eq!(t("a  b\t\nc ", "normalize_whitespace"), "a b c");
+        assert_eq!(t("a1b2-c", "digits_only"), "12");
+        assert_eq!(t("a1b2-c", "alpha_only"), "abc");
+        assert_eq!(t(" b a ", "token_sort"), "a b");
+        assert_eq!(t(" first second ", "first_token"), "first");
+        assert_eq!(t(" first second ", "last_token"), "second");
+    }
+
+    #[test]
+    fn substring_slices_by_code_point_not_bytes() {
+        // The bug byte slicing would cause: panic or a mangled character on any
+        // accented name.
+        assert_eq!(t("café", "substring:0:3"), "caf");
+        assert_eq!(t("café", "substring:3:4"), "é");
+        assert_eq!(t("日本語テキスト", "substring:0:3"), "日本語");
+        // Python tolerates out-of-range indices rather than raising.
+        assert_eq!(t("ab", "substring:0:99"), "ab");
+        assert_eq!(t("ab", "substring:5:9"), "");
+    }
+
+    #[test]
+    fn qgram_matches_the_python_construction() {
+        // "##ab##" -> bigrams: ##, #a, ab, b#, ## -> unique sorted, first 5.
+        assert_eq!(t("ab", "qgram:2"), "## #a ab b#");
+    }
+
+    #[test]
+    fn strip_honorifics_returns_missing_not_empty() {
+        assert_eq!(
+            apply_transform(Some("Dr. Jonathan Smith"), "strip_honorifics").unwrap(),
+            Some("Jonathan Smith".to_string())
+        );
+        // Honorific-only is MISSING. Returning "" would read downstream as an
+        // agreement on an empty value rather than an absence of evidence.
+        assert_eq!(
+            apply_transform(Some("Dr. Mr."), "strip_honorifics").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn a_chain_short_circuits_on_missing() {
+        // Once strip_honorifics yields None the value is GONE; a later
+        // `lowercase` must not turn it back into "".
+        assert_eq!(
+            apply_transforms(Some("Dr."), &["strip_honorifics", "lowercase"]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn python_only_transforms_are_refused_not_approximated() {
+        for name in [
+            "bloom_filter",
+            "bloom_filter:high",
+            "legal_form_strip",
+            "nope",
+        ] {
+            assert!(!supports(name), "{name} should not be supported");
+            assert!(apply_transform(Some("x"), name).is_err(), "{name}");
+        }
+    }
+
+    #[test]
+    fn malformed_parameterised_specs_are_refused() {
+        // A typo must not silently become a no-op transform.
+        for name in [
+            "substring:",
+            "substring:a:b",
+            "substring:1",
+            "qgram:",
+            "qgram:x",
+        ] {
+            assert!(!supports(name), "{name} should not be supported");
+            assert!(apply_transform(Some("x"), name).is_err(), "{name}");
+        }
+    }
+
+    #[test]
+    fn python_counts_the_c1_separators_as_whitespace() {
+        // Rust's char::is_whitespace does NOT. Borrowing it would leave a value
+        // containing one of these normalizing differently on the two surfaces --
+        // a different block, and the pair never compared.
+        assert!(is_py_space('\u{1c}'));
+        assert!(!'\u{1c}'.is_whitespace());
+        assert_eq!(t("a\u{1c}b", "strip_all"), "ab");
+    }
+}

--- a/scripts/bench_spark_compare.py
+++ b/scripts/bench_spark_compare.py
@@ -55,15 +55,35 @@ def main(argv: list[str] | None = None) -> int:
         print("   so this is the section-1 differentiator on its own.)")
 
     rj = jvm["timing"]["median_s"]
-    if rj:
+    # The comparison this arc was built for. Both arms now run the same scorer
+    # (J2 removed the `exact`-only restriction), so the ONLY difference left is
+    # where the kernel runs: in a forked Python worker behind an Arrow
+    # serialisation hop, or in the executor JVM behind a JNI downcall.
+    like_for_like = pure.get("scorer") == jvm.get("scorer")
+    if rj and like_for_like:
+        print(f"  batched_jvm vs row_python (pure):   {rp / rj:.2f}x")
+        if rn:
+            print(f"  batched_jvm vs row_python (NATIVE): {rn / rj:.2f}x")
+            print("  (the honest one: same kernel both sides, so the ratio is")
+            print("   the HOP -- Arrow serialise + fork + interpreter -- alone.)")
+    elif rj:
         print(f"  batched_jvm vs pure row_python: {rp / rj:.2f}x")
-    print()
-    print("  CAVEAT, load-bearing: batched_jvm scores `exact` while both")
-    print("  row_python arms score jaro_winkler, because the J0 jar carries no")
-    print("  algorithms of its own. The JVM comparison is CALLING MECHANISM only")
-    print("  and flatters the JVM arm; like-for-like needs J2. The pure-vs-native")
-    print("  comparison above has no such caveat -- it is the same code path")
-    print("  twice with one flag changed.")
+        print(f"  NOT like-for-like: batched_jvm ran {jvm.get('scorer')!r}, "
+              f"row_python ran {pure.get('scorer')!r}.")
+
+    impl = jvm.get("jvm_impl")
+    if impl and impl != "NativeScorer":
+        print()
+        print(f"  WARNING: the JVM arm resolved {impl}, not NativeScorer -- it")
+        print("  fell back to the J0 `exact`-only scorer and this ratio is not")
+        print("  measuring the kernel.")
+    if jvm.get("jvm_runtime"):
+        print()
+        print(f"  executor JVM: {jvm['jvm_runtime']}")
+        print("  (heap matters: the batched path materialises each group as an")
+        print("   array in JVM heap, so its ceiling is a property of the")
+        print("   executor rather than of the design. An OOM at an unknown heap")
+        print("   size measures a configuration, not an architecture.)")
 
     with open(out_path, "w", encoding="utf-8") as fh:
         json.dump(
@@ -71,8 +91,10 @@ def main(argv: list[str] | None = None) -> int:
                 "row_python_pure": pure,
                 "row_python_native": native,
                 "batched_jvm": jvm,
+                "like_for_like": like_for_like,
                 "native_speedup": (rp / rn) if rn else None,
                 "jvm_vs_pure": (rp / rj) if rj else None,
+                "jvm_vs_native": (rn / rj) if (rj and rn) else None,
             },
             fh,
             indent=2,

--- a/scripts/bench_spark_compare.py
+++ b/scripts/bench_spark_compare.py
@@ -30,12 +30,20 @@ def main(argv: list[str] | None = None) -> int:
     arms = [
         ("row_python (pure)", pure),
         ("row_python (NATIVE)", native),
-        ("batched_jvm (exact)", jvm),
+        (f"batched_jvm ({jvm.get('scorer', '?')})", jvm),
     ]
     for name, a in arms:
         r = a["timing"]
-        res = a.get("native_resolved")
-        tag = "" if res is None else f"  native_resolved={res}"
+        # `native_resolved` is the pyo3 loader's state ON THE DRIVER, which says
+        # something about the row_python arms and NOTHING about the JVM arm --
+        # that one reaches the kernel through JNI, and printing `False` next to
+        # it reads as "the kernel did not run" when it did. Report what actually
+        # answers the question for each arm.
+        if a.get("path") == "batched_jvm":
+            tag = f"  impl={a.get('jvm_impl', '?')}"
+        else:
+            res = a.get("native_resolved")
+            tag = "" if res is None else f"  native_resolved={res}"
         print(f"  {name:22} median {r['median_s']:8.3f}s   "
               f"(min {r['min_s']:.3f} max {r['max_s']:.3f})   "
               f"rows_out={r['rows_out']:,}{tag}")

--- a/scripts/bench_spark_scoring.py
+++ b/scripts/bench_spark_scoring.py
@@ -10,22 +10,37 @@ is the harness that stops that being an assertion.
     row_python    the shipped path: `score_and_dedup`, a pandas_udf. Spark
                   serialises an Arrow batch to a FORKED PYTHON WORKER, which
                   calls the scorer and sends results back.
-    batched_jvm   J1's plan through J0's jar: pairs grouped into arrays, one
-                  Java UDF call per batch, IN the executor JVM.
+    batched_jvm   J1's plan through the J2 jar: pairs grouped into arrays, one
+                  Java UDF call per batch, scored by the Rust kernel over JNI,
+                  IN the executor JVM. No Python worker at all.
 
 Both compute the same thing over the same pairs, so the delta is the mechanism.
 
-## What it does NOT yet compare
+## Like-for-like, at last
 
-Native scoring. J0's jar implements `exact` only, deliberately -- a Java
-jaro-winkler would be a fourth implementation of a kernel that exists once in
-Rust. So this measures the CALLING MECHANISM (Python worker vs in-JVM) with the
-scoring held trivial, which is the honest question at this stage: if crossing to
-a Python worker is not the bottleneck, J2's JNI work buys little, and it is
-better to know that before writing it.
+This bench used to carry a load-bearing caveat: J0's jar implemented `exact`
+only -- deliberately, because a Java jaro-winkler would have been a fourth
+implementation of a kernel that exists once in Rust -- so the arms could not run
+the same scorer. It measured the CALLING MECHANISM with the work held trivial,
+and every reading of it had to be hedged.
 
-`exact` being cheap makes the comparison HARSHER on the JVM path, not kinder:
-with almost no work per pair, per-call overhead is the whole signal.
+J2 removed that. Both arms now run `jaro_winkler` by default (`--scorer`), and
+the difference between them is the mechanism alone:
+
+    row_python    Arrow batch -> serialise -> FORKED PYTHON WORKER -> Rust
+                  (via the pyo3 wheel, when GOLDENMATCH_NATIVE=1 and the
+                  shipped executor env carries it) -> serialise back
+    batched_jvm   array UDF -> Rust, in the same JVM, no hop
+
+Same kernel at the bottom of both. `score_one` either way.
+
+## The arm asserts what it is
+
+The jar falls back to the `exact`-only scorer when its native library will not
+load. Benching that against a native row_python arm would produce a number for
+the wrong thing, which is worse than no number because it looks like one -- so
+the arm asks the EXECUTOR what it resolved and refuses to run if it is not the
+kernel.
 
 ## One arm per PROCESS, and why
 
@@ -110,25 +125,33 @@ def _candidate_pairs(df):
     ).select(F.col(f"a.{_ID}").alias("a"), F.col(f"b.{_ID}").alias("b"))
 
 
-def _row_python(spark, df):
-    """The shipped path: pandas_udf -> forked Python worker."""
+def _row_python(df, scorer_name: str):
+    """The shipped path: arrow_udf -> forked Python worker."""
     from goldenmatch.spark.scoring import score_and_dedup
 
     out = score_and_dedup(
         df, block_col="blk", value_col="name", id_col=_ID,
-        scorer_name="jaro_winkler", threshold=0.0,
+        scorer_name=scorer_name, threshold=0.0,
     )
     return out.count()
 
 
-def _batched_jvm(spark, df, udf_name):
-    """J1's plan through J0's jar: one call per batch, in the executor JVM."""
+def _batched_jvm(spark, df, udf_name, scorer_name: str):
+    """J1's plan through the J2 jar: one call per batch, in the executor JVM,
+    scoring with the Rust kernel over JNI.
+
+    ``scorer_name`` is ``jaro_winkler`` by default now, NOT ``exact``. J0's jar
+    carried no algorithms, so the only scorer both arms could run was string
+    equality -- which measured the calling mechanism with the work held trivial
+    and left "like-for-like needs J2" as this bench's load-bearing caveat. J2
+    removed it, so the arms can finally do the same work.
+    """
     from goldenmatch.spark.batched import dedup_max, score_pairs_batched
     from goldenmatch.spark.jvm import scorer_id
 
     scored = score_pairs_batched(
         _candidate_pairs(df), df, id_col=_ID, value_col="name",
-        scorer_id=scorer_id("exact"), udf_name=udf_name,
+        scorer_id=scorer_id(scorer_name), udf_name=udf_name,
     )
     return dedup_max(scored).count()
 
@@ -148,6 +171,14 @@ def main(argv=None) -> int:
              "this on the driver alone changes nothing.",
     )
     ap.add_argument(
+        "--scorer",
+        default="jaro_winkler",
+        help="Scorer BOTH arms run. Defaults to jaro_winkler now that J2 exists: "
+             "J0's jar carried no algorithms, so the only scorer both arms could "
+             "run was `exact`, and this bench's load-bearing caveat was that "
+             "like-for-like needed J2.",
+    )
+    ap.add_argument(
         "--path",
         choices=["row_python", "batched_jvm"],
         required=True,
@@ -161,7 +192,13 @@ def main(argv=None) -> int:
     # happened would have resolved it under the old value.
     os.environ["GOLDENMATCH_NATIVE"] = args.native
 
-    from goldenmatch.spark.jvm import JvmScorerUnavailable, find_jar, install
+    from goldenmatch.spark.jvm import (
+        NATIVE_IMPL,
+        JvmScorerUnavailable,
+        find_jar,
+        implementation,
+        install,
+    )
     from pyspark.sql import SparkSession
 
     remote = os.environ.get("GOLDENMATCH_SPARK_REMOTE", "local[*]")
@@ -209,9 +246,12 @@ def main(argv=None) -> int:
         "native": args.native,
     }
 
+    results["scorer"] = args.scorer
+
     if args.path == "row_python":
-        print("[row_python] arrow_udf -> forked Python worker", flush=True)
-        results["timing"] = _time(lambda: _row_python(spark, df),
+        print(f"[row_python] arrow_udf -> forked Python worker, "
+              f"scorer={args.scorer}", flush=True)
+        results["timing"] = _time(lambda: _row_python(df, args.scorer),
                                   repeats=args.repeats)
     else:
         try:
@@ -219,9 +259,30 @@ def main(argv=None) -> int:
         except JvmScorerUnavailable as exc:
             print(f"::error::no JVM scorer jar: {exc}")
             return 2
-        print("[batched_jvm] array UDF, in the executor JVM", flush=True)
-        results["timing"] = _time(lambda: _batched_jvm(spark, df, udf_name),
-                                  repeats=args.repeats)
+
+        # REFUSE to bench the fallback. The jar drops to the `exact`-only J0
+        # scorer when its native library will not load, which keeps a job alive
+        # and would leave this arm reporting a number for the wrong thing --
+        # against an arm doing real jaro-winkler work. That is worse than no
+        # number, because it looks like one.
+        impl, diagnostics, runtime = implementation(spark)
+        results["jvm_impl"] = impl
+        results["jvm_runtime"] = runtime
+        print(f"  executor: {impl} | {runtime}\n  {diagnostics}", flush=True)
+        if impl != NATIVE_IMPL:
+            print(
+                f"::error::the executor resolved {impl}, not {NATIVE_IMPL}. "
+                f"This arm would be measuring the J0 fallback against a native "
+                f"row_python arm. Diagnostics: {diagnostics}"
+            )
+            return 3
+
+        print(f"[batched_jvm] array UDF, in the executor JVM, "
+              f"scorer={args.scorer}", flush=True)
+        results["timing"] = _time(
+            lambda: _batched_jvm(spark, df, udf_name, args.scorer),
+            repeats=args.repeats,
+        )
 
     # Report what the kernel ACTUALLY resolved to, not what was asked for. A
     # missing wheel silently yields the pure floor, and a bench that reports the

--- a/scripts/bench_spark_scoring.py
+++ b/scripts/bench_spark_scoring.py
@@ -289,6 +289,10 @@ def main(argv=None) -> int:
     # requested flag rather than the resolved one would label pure-Python
     # numbers as native -- which is exactly how this harness misreported its
     # first result.
+    # NOTE this is the pyo3 loader's state on the DRIVER, and it answers the
+    # question only for the row_python arms (whose worker env is built from the
+    # same package set). It says nothing about batched_jvm, which reaches the
+    # kernel through JNI in the executor JVM -- `jvm_impl` is that arm's answer.
     try:
         from goldenmatch.core._native_loader import native_enabled
 

--- a/scripts/diag_spark_batched_oom.py
+++ b/scripts/diag_spark_batched_oom.py
@@ -117,6 +117,28 @@ def _deduped(df, pairs, batch_size, udf_name, scorer_id):
     return flat.groupBy("a", "b").agg(F.max("score").alias("score"))
 
 
+def _shipped(df, pairs, batch_size, udf_name, scorer_id):
+    """Stages 1-6 rebuilt through the SHIPPED functions, not this file's copies.
+
+    Everything above is a reimplementation. That is deliberate -- rebuilding the
+    plan locally is what lets a single operator be isolated -- but it makes every
+    stage above a LOOKALIKE, and this project's own lesson from the last round of
+    this investigation was to measure the shipped basis rather than something
+    adjacent to it.
+
+    So if stage 6 passes and this fails, the difference is not in the plan at
+    all: it is in `batched.py`, and the bisect above has been exonerating code
+    that never ran.
+    """
+    from goldenmatch.spark.batched import dedup_max, score_pairs_batched
+
+    scored = score_pairs_batched(
+        pairs, df, id_col=_ID, value_col="name",
+        scorer_id=scorer_id, udf_name=udf_name, batch_size=batch_size,
+    )
+    return dedup_max(scored)
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--rows", type=int, default=200_000)
@@ -155,7 +177,27 @@ def main(argv=None) -> int:
         # isolation fix, rather than fixing two things and learning nothing.
         ("6 + dedup_max (groupBy a,b)",
          lambda: _deduped(df, pairs, args.batch_size, udf_name, sid).count()),
+        # The whole thing through the SHIPPED functions. If 6 passes and this
+        # fails, the plan is innocent and `batched.py` differs from the copy
+        # above in some way this bisect has been blind to.
+        ("7 SHIPPED score_pairs_batched + dedup_max",
+         lambda: _shipped(df, pairs, args.batch_size, udf_name, sid).count()),
     ]
+
+    # The heap ceiling, before anything else. An OOM at an unknown heap size
+    # measures a configuration rather than a design, and `local[*]` takes
+    # Spark's default (1g) unless SPARK_DRIVER_MEMORY was set before the JVM
+    # launched -- a client-side `spark.driver.memory` is too late to change -Xmx.
+    # A Connect client has no SparkContext to ask, but the jar's probe runs IN
+    # the JVM that knows.
+    try:
+        from goldenmatch.spark.jvm import implementation
+
+        impl, diagnostics, runtime = implementation(spark)
+        print(f"\nexecutor JVM: {runtime}\nscorer: {impl}\n  {diagnostics}",
+              flush=True)
+    except Exception as exc:  # noqa: BLE001 - diagnostics must never be fatal
+        print(f"\ncould not read the executor JVM info: {exc}", flush=True)
 
     print(f"\nrows={args.rows:,} block_size={args.block_size} "
           f"batch_size={args.batch_size:,}", flush=True)

--- a/scripts/diag_spark_batched_oom.py
+++ b/scripts/diag_spark_batched_oom.py
@@ -98,6 +98,29 @@ def _scored(df, pairs, batch_size, udf_name, scorer_id):
     )
 
 
+def _scored_forced(df, pairs, batch_size, udf_name, scorer_id):
+    """Stage 4 with the UDF's output actually CONSUMED.
+
+    Stage 4 ends in ``.count()``, and counting rows does not need the `scores`
+    column -- Catalyst prunes unused columns, and a deterministic UDF with no
+    side effects is exactly what it is entitled to prune. So stage 4 measuring
+    the same wall as stage 3 does NOT mean scoring is free; it may mean scoring
+    never happened. Reporting that as "the JNI call costs nothing" would be a
+    confident claim built on an optimisation.
+
+    So reduce each batch's score array to one number. The UDF's result is now
+    load-bearing and cannot be pruned, while the row count stays at one per
+    batch -- no explode, so this isolates SCORING from UN-BATCHING, which is the
+    split that decides whether a faster kernel could move the number at all.
+    """
+    from pyspark.sql import functions as F
+
+    s = _scored(df, pairs, batch_size, udf_name, scorer_id)
+    return s.select(
+        F.aggregate(F.col("scores"), F.lit(0.0), lambda acc, x: acc + x).alias("total")
+    ).agg(F.sum("total"))
+
+
 def _exploded(df, pairs, batch_size, udf_name, scorer_id):
     from pyspark.sql import functions as F
 
@@ -177,8 +200,15 @@ def main(argv=None) -> int:
         ("2 + join to source", lambda: _joined(df, pairs).count()),
         ("3 + groupBy/collect (NO UDF)",
          lambda: _grouped(df, pairs, args.batch_size).count()),
-        ("4 + UDF",
+        ("4 + UDF (count only)",
          lambda: _scored(df, pairs, args.batch_size, udf_name, sid).count()),
+        # THE attribution stage. 4 counts rows, which does not need the scores
+        # column -- so Catalyst is free to prune the UDF and 4 can match 3 while
+        # scoring nothing. 4b consumes every score, without exploding, so
+        # (4b - 3) is SCORING and (5 - 4b) is UN-BATCHING. That split decides
+        # whether a faster kernel could move this number at all.
+        ("4b + UDF (scores CONSUMED)",
+         lambda: _scored_forced(df, pairs, args.batch_size, udf_name, sid).count()),
         ("5 + zip/explode",
          lambda: _exploded(df, pairs, args.batch_size, udf_name, sid).count()),
         # The bench does this and the earlier bisect did not, so it was the one

--- a/scripts/diag_spark_batched_oom.py
+++ b/scripts/diag_spark_batched_oom.py
@@ -144,6 +144,16 @@ def main(argv=None) -> int:
     ap.add_argument("--rows", type=int, default=200_000)
     ap.add_argument("--block-size", type=int, default=20)
     ap.add_argument("--batch-size", type=int, default=10_000)
+    ap.add_argument(
+        "--scorer",
+        default="exact",
+        help="Scorer for the UDF stages. Use the BENCH's scorer (jaro_winkler) "
+             "when the question is attribution rather than the OOM: stage 3 runs "
+             "no UDF at all, so `stage 3 vs stage 7` splits the wall between the "
+             "PLAN (shuffle + collect_list + explode, which Connect forces on "
+             "any batched UDF) and the SCORING. With a different scorer the two "
+             "halves are not comparable to the bench number.",
+    )
     args = ap.parse_args(argv)
 
     from goldenmatch.spark.jvm import find_jar, install, scorer_id
@@ -160,7 +170,7 @@ def main(argv=None) -> int:
 
     df = spark.createDataFrame(_rows(args.rows, args.block_size), _SCHEMA).cache()
     pairs = _candidates(df)
-    sid = scorer_id("exact")
+    sid = scorer_id(args.scorer)
 
     stages = [
         ("1 candidates", lambda: pairs.count()),

--- a/scripts/spark_jar_only_inventory.py
+++ b/scripts/spark_jar_only_inventory.py
@@ -160,7 +160,11 @@ def _probe_survivorship(spark, df, ctx):
 
 
 def _probe_identity_record_ids(spark, df, ctx):
-    """`identity.derive_record_ids`: stable fingerprints, an arrow_udf."""
+    """`identity.derive_record_ids` through the JAR's fingerprint kernel.
+
+    Was an arrow_udf and therefore Python-only; now routed to
+    `golden_fingerprint`, which hashes `to_json(struct(...))` with the same
+    pyo3-free `fingerprint-core` the Python path uses."""
     from goldenmatch.spark.identity import derive_record_ids
     from pyspark.sql import functions as F
 
@@ -168,7 +172,9 @@ def _probe_identity_record_ids(spark, df, ctx):
     # PK it is a pure column expression and would pass here, which would be a
     # true but misleading result.
     src = df.withColumn("__source__", F.lit("probe"))
-    out = derive_record_ids(src, id_col="__row_id__")
+    out = derive_record_ids(
+        src, id_col="__row_id__", fingerprint_udf=ctx["fingerprint_udf"]
+    )
     ids = _consume(out, "record_id")
     return f"{len(ids)} record ids, e.g. {ids[0]!r}"
 
@@ -225,7 +231,9 @@ def main(argv=None) -> int:
     print(f"executor JVM: {runtime}\nscorer: {impl}\n  {diagnostics}\n", flush=True)
 
     df = spark.createDataFrame(_rows(), _SCHEMA).cache()
-    ctx = {"udf_name": udf_name}
+    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME
+
+    ctx = {"udf_name": udf_name, "fingerprint_udf": FINGERPRINT_UDF_NAME}
 
     print("=" * 74, flush=True)
     print("  WHAT RUNS WITH NO PYTHON ON THE EXECUTORS", flush=True)

--- a/scripts/spark_jar_only_inventory.py
+++ b/scripts/spark_jar_only_inventory.py
@@ -137,12 +137,19 @@ def _probe_clustering(spark, df, ctx):
 
 
 def _probe_normalization(spark, df, ctx):
-    """`config_pipeline._transformed`: an arrow_udf running goldenmatch's
-    transform chain. Needs a Python worker."""
+    """`config_pipeline._transformed` through the JAR's transform kernel.
+
+    Was an arrow_udf and therefore Python-only; now routed to
+    `golden_transform`, which runs the same pyo3-free `transforms-core` the
+    Python path uses."""
     from goldenmatch.spark.config_pipeline import _transformed
 
     out = df.select(
-        _transformed(df["name"], ["lowercase", "strip_punctuation"]).alias("v")
+        _transformed(
+            df["name"],
+            ["lowercase", "normalize_whitespace"],
+            transform_udf=ctx["transform_udf"],
+        ).alias("v")
     )
     vals = _consume(out, "v")
     return f"{len(vals)} normalized values, e.g. {vals[0]!r}"
@@ -231,9 +238,13 @@ def main(argv=None) -> int:
     print(f"executor JVM: {runtime}\nscorer: {impl}\n  {diagnostics}\n", flush=True)
 
     df = spark.createDataFrame(_rows(), _SCHEMA).cache()
-    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME
+    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME, TRANSFORM_UDF_NAME
 
-    ctx = {"udf_name": udf_name, "fingerprint_udf": FINGERPRINT_UDF_NAME}
+    ctx = {
+        "udf_name": udf_name,
+        "fingerprint_udf": FINGERPRINT_UDF_NAME,
+        "transform_udf": TRANSFORM_UDF_NAME,
+    }
 
     print("=" * 74, flush=True)
     print("  WHAT RUNS WITH NO PYTHON ON THE EXECUTORS", flush=True)

--- a/scripts/spark_jar_only_inventory.py
+++ b/scripts/spark_jar_only_inventory.py
@@ -1,0 +1,242 @@
+"""What of the Spark tier survives with NO Python on the executors?
+
+## The question this answers
+
+The J-arc's real justification is not throughput -- that was measured and the
+JVM path lost (bench run 31656227516). It is deployment: a jar that
+``addArtifact`` delivers, against a packed virtualenv that has to be built for
+the executor platform and shipped to the cluster. "No Python on the executors"
+is the claim.
+
+That claim is currently unproven and, read against the source, partly false.
+J2 put SCORING in the JVM, but the tier still defines Python UDFs for
+normalization (``config_pipeline._transformed``), survivorship
+(``golden.make_merge_udf``) and the identity graph (five in ``identity.py``).
+Clustering needs none -- ``clustering.py`` is pure Spark SQL. So the honest
+answer is somewhere between "scoring only" and "everything", and nobody has
+measured which.
+
+## Why `local[*]` cannot answer it by omission
+
+The obvious experiment -- run the tier without shipping an executor env -- proves
+nothing. Under ``local[*]`` the Python worker forks from the DRIVER's
+interpreter, which has goldenmatch installed, so every UDF works and the run is
+green while telling you nothing about a real cluster.
+
+So this ships an env that is deliberately **EMPTY**: a bare virtualenv with no
+goldenmatch, no pyarrow, nothing. Any operation that needs a Python worker now
+fails with ``ModuleNotFoundError`` exactly as it would on a cluster with no
+cluster-side install. Anything that survives is running in the JVM or in Spark
+SQL, and is genuinely jar-only.
+
+Failures here are the POINT. This is an inventory, not a gate: it turns "which
+parts need Python on executors" from a reading of the source into a list.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+
+_SCHEMA = "__row_id__ long, blk string, name string, city string"
+
+
+def _rows():
+    return [
+        (0, "b0", "jonathan smith", "boston"),
+        (1, "b0", "jonathon smyth", "Boston"),
+        (2, "b0", "alice jones", "denver"),
+        (3, "b1", "acme corporation", "reno"),
+        (4, "b1", "acme corp", "Reno"),
+        (5, "b1", "zeta industries", "miami"),
+    ]
+
+
+def _probe_pure_spark_sql(spark, df, ctx):
+    """A block self-join: no UDF of any kind. The control -- if this fails, the
+    session is broken and every other result here is meaningless."""
+    from pyspark.sql import functions as F
+
+    a, b = df.alias("a"), df.alias("b")
+    pairs = a.join(
+        b,
+        (F.col("a.blk") == F.col("b.blk"))
+        & (F.col("a.__row_id__") < F.col("b.__row_id__")),
+    )
+    return f"{pairs.count()} candidate pairs"
+
+
+def _probe_jvm_scoring(spark, df, ctx):
+    """J2: scoring through the jar. The thing this whole arc built."""
+    from goldenmatch.spark.batched import dedup_max, score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+    from pyspark.sql import functions as F
+
+    a, b = df.alias("a"), df.alias("b")
+    pairs = a.join(
+        b,
+        (F.col("a.blk") == F.col("b.blk"))
+        & (F.col("a.__row_id__") < F.col("b.__row_id__")),
+    ).select(
+        F.col("a.__row_id__").alias("a"), F.col("b.__row_id__").alias("b")
+    )
+    scored = score_pairs_batched(
+        pairs, df, id_col="__row_id__", value_col="name",
+        scorer_id=scorer_id("jaro_winkler"), udf_name=ctx["udf_name"],
+    )
+    rows = dedup_max(scored).collect()
+    return f"{len(rows)} scored pairs, max={max(r['score'] for r in rows):.4f}"
+
+
+def _probe_python_scoring(spark, df, ctx):
+    """The shipped Python path, for contrast. Expected to FAIL here -- that is
+    the whole point of the comparison."""
+    from goldenmatch.spark.scoring import score_and_dedup
+
+    out = score_and_dedup(
+        df, block_col="blk", value_col="name", id_col="__row_id__",
+        scorer_name="jaro_winkler", threshold=0.0,
+    )
+    return f"{out.count()} scored pairs"
+
+
+def _probe_clustering(spark, df, ctx):
+    """`clustering.py` defines no UDFs at all -- connected components is
+    expressed in Spark SQL. If that reading is right this passes."""
+    from goldenmatch.spark.clustering import connected_components
+
+    edges = spark.createDataFrame([(0, 1), (1, 2), (3, 4)], "a long, b long")
+    out = connected_components(edges, df, id_col="__row_id__")
+    return f"{out.count()} labelled nodes"
+
+
+def _probe_normalization(spark, df, ctx):
+    """`config_pipeline._transformed`: an arrow_udf running goldenmatch's
+    transform chain. Needs a Python worker."""
+    from goldenmatch.spark.config_pipeline import _transformed
+
+    out = df.select(_transformed(df["name"], ["lowercase", "strip_punctuation"]))
+    return f"{out.count()} normalized values"
+
+
+def _probe_survivorship(spark, df, ctx):
+    """`golden.make_merge_udf`: survivorship merge, an arrow_udf."""
+    from goldenmatch.spark.golden import make_merge_udf
+    from pyspark.sql import functions as F
+
+    merge = make_merge_udf("most_common")
+    out = df.groupBy("blk").agg(F.collect_list("city").alias("city"))
+    return f"{out.select(merge(F.col('city'))).count()} merged groups"
+
+
+def _probe_identity_record_ids(spark, df, ctx):
+    """`identity.derive_record_ids`: stable fingerprints, an arrow_udf."""
+    from goldenmatch.spark.identity import derive_record_ids
+    from pyspark.sql import functions as F
+
+    # No source PK, so the h1 fingerprint path runs -- the arrow_udf one. With a
+    # PK it is a pure column expression and would pass here, which would be a
+    # true but misleading result.
+    src = df.withColumn("__source__", F.lit("probe"))
+    out = derive_record_ids(src, id_col="__row_id__")
+    return f"{out.count()} record ids"
+
+
+#: name -> (callable, what a failure MEANS). The second half matters: a failure
+#: here is a fact about deployment, not a bug, and labelling it as such stops the
+#: inventory being read as a broken build.
+PROBES = [
+    ("pure Spark SQL (block join)", _probe_pure_spark_sql,
+     "the session itself is broken; ignore every result below"),
+    ("clustering (connected components)", _probe_clustering,
+     "clustering needs a Python worker after all"),
+    ("JVM scoring (J2, via the jar)", _probe_jvm_scoring,
+     "the jar path does not work without Python -- the arc's premise"),
+    ("Python scoring (the shipped path)", _probe_python_scoring,
+     "EXPECTED: this is the path J2 exists to replace"),
+    ("normalization (transform chain)", _probe_normalization,
+     "normalization needs Python on executors"),
+    ("survivorship (golden merge)", _probe_survivorship,
+     "survivorship needs Python on executors"),
+    ("identity (record fingerprints)", _probe_identity_record_ids,
+     "the identity graph needs Python on executors"),
+]
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="spark-jar-only-inventory.json")
+    args = ap.parse_args(argv)
+
+    from goldenmatch.spark.jvm import find_jar, implementation, install
+    from pyspark.sql import SparkSession
+
+    remote = os.environ.get("GOLDENMATCH_SPARK_REMOTE", "local[*]")
+    spark = SparkSession.builder.remote(remote).getOrCreate()
+
+    pyenv = os.environ.get("GOLDENMATCH_SPARK_PYENV")
+    if not pyenv:
+        print(
+            "::error::no GOLDENMATCH_SPARK_PYENV. Under local[*] the Python "
+            "worker forks from the DRIVER's interpreter, which HAS goldenmatch "
+            "-- so every UDF would work and this inventory would report that "
+            "nothing needs Python on executors, which is false. Ship the "
+            "deliberately-empty env."
+        )
+        return 2
+    from goldenmatch.spark.deps import ship_python_environment
+
+    ship_python_environment(spark, pyenv)
+    print(f"shipped executor env: {pyenv}", flush=True)
+
+    udf_name = install(spark, jar=find_jar())
+    impl, diagnostics, runtime = implementation(spark)
+    print(f"executor JVM: {runtime}\nscorer: {impl}\n  {diagnostics}\n", flush=True)
+
+    df = spark.createDataFrame(_rows(), _SCHEMA).cache()
+    ctx = {"udf_name": udf_name}
+
+    print("=" * 74, flush=True)
+    print("  WHAT RUNS WITH NO PYTHON ON THE EXECUTORS", flush=True)
+    print("=" * 74, flush=True)
+    results = []
+    for name, fn, meaning in PROBES:
+        try:
+            detail = fn(spark, df, ctx)
+            print(f"  WORKS   {name:38} {detail}", flush=True)
+            results.append({"probe": name, "works": True, "detail": detail})
+        except Exception as exc:  # noqa: BLE001 - cataloguing failures IS the job
+            first = str(exc).strip().splitlines()[0][:110] if str(exc).strip() else ""
+            print(f"  NEEDS   {name:38} {type(exc).__name__}: {first}", flush=True)
+            print(f"          -> {meaning}", flush=True)
+            results.append({
+                "probe": name, "works": False,
+                "error": f"{type(exc).__name__}: {first}", "meaning": meaning,
+            })
+
+    works = [r["probe"] for r in results if r["works"]]
+    needs = [r["probe"] for r in results if not r["works"]]
+    print("=" * 74)
+    print(f"  jar-only today: {len(works)}/{len(results)}")
+    print(f"  still needs a Python worker: {', '.join(needs) if needs else 'nothing'}")
+
+    payload = {
+        "jvm_impl": impl, "jvm_runtime": runtime,
+        "works": works, "needs_python": needs, "results": results,
+    }
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+    print(f"\nwrote {args.out}")
+    # Deliberately exit 0 even with failures: this is an INVENTORY. A red build
+    # would say "something broke", when what it found is a fact about the tier.
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001
+        traceback.print_exc()
+        sys.exit(2)

--- a/scripts/spark_jar_only_inventory.py
+++ b/scripts/spark_jar_only_inventory.py
@@ -156,13 +156,21 @@ def _probe_normalization(spark, df, ctx):
 
 
 def _probe_survivorship(spark, df, ctx):
-    """`golden.make_merge_udf`: survivorship merge, an arrow_udf."""
-    from goldenmatch.spark.golden import make_merge_udf
+    """`golden` survivorship through the JAR's kernel.
+
+    Was an arrow_udf and therefore Python-only; now routed to
+    `golden_survivorship`, which runs the same pyo3-free `survivorship-core`
+    the Python path uses."""
+    from goldenmatch.spark.golden import merge_expr
     from pyspark.sql import functions as F
 
-    merge = make_merge_udf("most_common")
     grouped = df.groupBy("blk").agg(F.collect_list("city").alias("city"))
-    vals = _consume(grouped.select(merge(F.col("city")).alias("v")), "v")
+    vals = _consume(
+        grouped.select(
+            merge_expr(F.col("city"), "majority_vote", ctx["survivorship_udf"]).alias("v")
+        ),
+        "v",
+    )
     return f"{len(vals)} merged groups, e.g. {vals[0]!r}"
 
 
@@ -238,12 +246,17 @@ def main(argv=None) -> int:
     print(f"executor JVM: {runtime}\nscorer: {impl}\n  {diagnostics}\n", flush=True)
 
     df = spark.createDataFrame(_rows(), _SCHEMA).cache()
-    from goldenmatch.spark.jvm import FINGERPRINT_UDF_NAME, TRANSFORM_UDF_NAME
+    from goldenmatch.spark.jvm import (
+        FINGERPRINT_UDF_NAME,
+        SURVIVORSHIP_UDF_NAME,
+        TRANSFORM_UDF_NAME,
+    )
 
     ctx = {
         "udf_name": udf_name,
         "fingerprint_udf": FINGERPRINT_UDF_NAME,
         "transform_udf": TRANSFORM_UDF_NAME,
+        "survivorship_udf": SURVIVORSHIP_UDF_NAME,
     }
 
     print("=" * 74, flush=True)

--- a/scripts/spark_jar_only_inventory.py
+++ b/scripts/spark_jar_only_inventory.py
@@ -54,6 +54,28 @@ def _rows():
     ]
 
 
+def _consume(df, col: str) -> list:
+    """Collect ``col`` and return its values, forcing whatever produced it to run.
+
+    **A probe must never end in ``.count()``.** Counting rows does not need any
+    particular column, so Catalyst prunes the ones nobody reads -- and a
+    deterministic side-effect-free UDF is exactly what it is entitled to prune.
+    A probe that counts therefore reports WORKS for a Python UDF that never
+    executed, which is the opposite of what this inventory exists to find.
+
+    That is not hypothetical. The first run of this script reported 6 of 7
+    probes working with an empty executor env, including normalization,
+    survivorship and identity -- all three of which define ``arrow_udf``s and
+    cannot possibly work without a Python worker. They were pruned. (The same
+    mistake had already been found and fixed one file over, in the batched-plan
+    bisect, hours earlier.)
+
+    So every probe routes through here: collect the values and hand them back,
+    so the column is load-bearing and the UDF has to run.
+    """
+    return [r[0] for r in df.select(col).collect()]
+
+
 def _probe_pure_spark_sql(spark, df, ctx):
     """A block self-join: no UDF of any kind. The control -- if this fails, the
     session is broken and every other result here is meaningless."""
@@ -99,7 +121,8 @@ def _probe_python_scoring(spark, df, ctx):
         df, block_col="blk", value_col="name", id_col="__row_id__",
         scorer_name="jaro_winkler", threshold=0.0,
     )
-    return f"{out.count()} scored pairs"
+    scores = _consume(out, "score")
+    return f"{len(scores)} scored pairs, max={max(scores):.4f}"
 
 
 def _probe_clustering(spark, df, ctx):
@@ -109,7 +132,8 @@ def _probe_clustering(spark, df, ctx):
 
     edges = spark.createDataFrame([(0, 1), (1, 2), (3, 4)], "a long, b long")
     out = connected_components(edges, df, id_col="__row_id__")
-    return f"{out.count()} labelled nodes"
+    labels = _consume(out, out.columns[-1])
+    return f"{len(labels)} labelled nodes, {len(set(labels))} components"
 
 
 def _probe_normalization(spark, df, ctx):
@@ -117,8 +141,11 @@ def _probe_normalization(spark, df, ctx):
     transform chain. Needs a Python worker."""
     from goldenmatch.spark.config_pipeline import _transformed
 
-    out = df.select(_transformed(df["name"], ["lowercase", "strip_punctuation"]))
-    return f"{out.count()} normalized values"
+    out = df.select(
+        _transformed(df["name"], ["lowercase", "strip_punctuation"]).alias("v")
+    )
+    vals = _consume(out, "v")
+    return f"{len(vals)} normalized values, e.g. {vals[0]!r}"
 
 
 def _probe_survivorship(spark, df, ctx):
@@ -127,8 +154,9 @@ def _probe_survivorship(spark, df, ctx):
     from pyspark.sql import functions as F
 
     merge = make_merge_udf("most_common")
-    out = df.groupBy("blk").agg(F.collect_list("city").alias("city"))
-    return f"{out.select(merge(F.col('city'))).count()} merged groups"
+    grouped = df.groupBy("blk").agg(F.collect_list("city").alias("city"))
+    vals = _consume(grouped.select(merge(F.col("city")).alias("v")), "v")
+    return f"{len(vals)} merged groups, e.g. {vals[0]!r}"
 
 
 def _probe_identity_record_ids(spark, df, ctx):
@@ -141,7 +169,8 @@ def _probe_identity_record_ids(spark, df, ctx):
     # true but misleading result.
     src = df.withColumn("__source__", F.lit("probe"))
     out = derive_record_ids(src, id_col="__row_id__")
-    return f"{out.count()} record ids"
+    ids = _consume(out, "record_id")
+    return f"{len(ids)} record ids, e.g. {ids[0]!r}"
 
 
 #: name -> (callable, what a failure MEANS). The second half matters: a failure

--- a/scripts/survivorship_parity_dump.py
+++ b/scripts/survivorship_parity_dump.py
@@ -1,0 +1,71 @@
+"""Print the survivorship corpus through PYTHON's ``merge_field``, for
+differential comparison with ``survivorship-core``'s Rust port.
+
+Committed alongside the Rust half. The transforms harness of the same shape
+caught two real bugs review had passed, which is the argument for keeping this
+one runnable rather than running it once in a scratch directory.
+
+    cargo run --example parity_dump --manifest-path \
+        packages/rust/extensions/survivorship-core/Cargo.toml > rust.txt
+    python scripts/survivorship_parity_dump.py > py.txt
+    diff rust.txt py.txt
+
+The corpus targets TIE-BREAKS, because that is where this port silently
+diverges: Python's ``Counter.most_common`` keeps insertion order and ``max()``
+keeps the first maximum, while Rust's ``max_by_key`` keeps the LAST. A tie
+resolved the other way is a different golden record with no error attached.
+
+Only the strategies the SPARK call site can reach are dumped -- it passes values
+and a strategy and nothing else, so ``source_priority`` and ``most_recent``
+raise in Python and are refused in Rust.
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+CASES = [
+    ["a", "b"],
+    ["b", "a", "a"],
+    ["a", "a", "b", "b"],
+    [None, "x", "y"],
+    [None, None],
+    ["a", None, "a"],
+    ["ab", "abcd"],
+    ["ab", "cd"],
+    ["café", "abcde"],
+    ["", "x"],
+    ["same", "same", "same"],
+    ["日本語", "ab"],
+]
+
+SUPPORTED = [
+    "most_complete", "majority_vote", "first_non_null", "longest_value",
+    "unanimous_or_null", "confidence_majority",
+]
+
+
+def _rust_opt(v: str | None) -> str:
+    return "None" if v is None else f'Some({v!r})'.replace("'", '"')
+
+
+def main() -> int:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", newline="\n")
+    from goldenmatch.config.schemas import GoldenFieldRule
+    from goldenmatch.core.golden import merge_field
+
+    for case in CASES:
+        shown = "[" + ", ".join(_rust_opt(v) for v in case) + "]"
+        for s in SUPPORTED:
+            try:
+                merged, _conf, _src = merge_field(list(case), GoldenFieldRule(strategy=s))
+            except Exception:  # noqa: BLE001 - a refusal is a result
+                out = "REFUSED"
+            else:
+                out = "None" if merged is None else f'{merged!r}'.replace("'", '"')
+            print(f"{s}\t{shown}\t{out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/transforms_parity_dump.py
+++ b/scripts/transforms_parity_dump.py
@@ -1,0 +1,116 @@
+"""Print the transform corpus through PYTHON, for differential comparison with
+``transforms-core``'s Rust port.
+
+Committed alongside the Rust half (``packages/rust/extensions/transforms-core/
+examples/parity_dump.rs``) because a port is only as good as the evidence it
+matches the original, and evidence in a scratch directory cannot be re-run by
+the next person to touch the crate.
+
+    cargo run --example parity_dump --manifest-path \\
+        packages/rust/extensions/transforms-core/Cargo.toml > rust.txt
+    python scripts/transforms_parity_dump.py > py.txt
+    diff rust.txt py.txt
+
+Byte-identical output is the bar. Normalization feeds BLOCKING, so a value that
+transforms differently on the two surfaces does not produce a wrong score -- it
+lands in a different block, the pair is never compared, and nothing downstream
+notices. A tolerance would defeat the entire check.
+
+The corpus is chosen for the ways a port breaks, not for readability: multi-byte
+values (code-point vs byte slicing), case mappings that change length
+(``straße`` -> ``STRASSE``), exotic whitespace (Python counts the C1 separators
+``U+001C..U+001F``; Rust's ``char::is_whitespace`` does not), honorific-only
+values (missing vs empty), and empty strings.
+
+**Keep the two corpora identical.** They are duplicated rather than shared
+because the point is to run each side through its own language's idea of what
+the value is; a shared fixture file read by both would be strictly better and is
+a fair follow-up, but it must not paper over an encoding difference.
+"""
+from __future__ import annotations
+
+import io
+import sys
+import unicodedata
+
+VALUES = [
+    "Jonathan Smith",
+    "  Dr. Jonathan   Smith  ",
+    "",
+    "café",
+    "Zoë Müller",
+    "日本語テキスト",
+    "O'Brien-Smith Jr.",
+    "ACME Corporation 123",
+    "straße",
+    "İstanbul",
+    "ab",
+    "\t mixed \n whitespace \r ",
+    "Mr.",
+    "Prof Dr Alice",
+    "123-456-7890",
+]
+
+TRANSFORMS = [
+    "lowercase", "uppercase", "strip", "strip_all", "digits_only", "alpha_only",
+    "normalize_whitespace", "token_sort", "first_token", "last_token",
+    "soundex", "metaphone", "strip_honorifics",
+    "substring:0:3", "substring:2:5", "substring:0:99", "qgram:2", "qgram:3",
+]
+
+
+def _rust_repr(s: str) -> str:
+    """Rust's ``{:?}`` for a string, so the two dumps are comparable.
+
+    Rust escapes ``\\`` and ``"`` and the usual control characters, and prints
+    everything else -- including non-ASCII -- literally. Python's ``repr`` uses
+    single quotes and escapes differently, so it cannot be compared directly.
+    """
+    out = ['"']
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif c == "\n":
+            out.append("\\n")
+        elif c == "\r":
+            out.append("\\r")
+        elif c == "\t":
+            out.append("\\t")
+        elif c == "\0":
+            out.append("\\0")
+        elif ord(c) < 0x20 or ord(c) == 0x7F or unicodedata.combining(c):
+            # Rust's ``{:?}`` uses ``char::escape_debug``, which escapes
+            # GRAPHEME-EXTEND characters as well as control ones. ``"İ".lower()``
+            # yields ``i`` + U+0307 (combining dot above), which Rust prints as
+            # ``i\\u{307}`` and a naive Python repr prints literally. That is a
+            # difference between the two DEBUG FORMATS, not between the
+            # transforms, and reading it as a divergence sends you hunting a bug
+            # that is not there -- it did, for one round. Match Rust's escaping
+            # so a diff means what it says.
+            out.append(f"\\u{{{ord(c):x}}}")
+        else:
+            out.append(c)
+    out.append('"')
+    return "".join(out)
+
+
+def main() -> int:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", newline="\n")
+    from goldenmatch.utils.transforms import apply_transform
+
+    for v in VALUES:
+        for t in TRANSFORMS:
+            try:
+                got = apply_transform(v, t)
+            except Exception as exc:  # noqa: BLE001 - a refusal is a result
+                out = f"UNSUPPORTED({type(exc).__name__})"
+            else:
+                out = "None" if got is None else _rust_repr(got)
+            print(f"{t}\t{_rust_repr(v)}\t{out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

J0's jar could score `exact` and nothing else. J2 removes that restriction by **calling** the Rust kernel from the executor JVM rather than reimplementing it:

```
NativeScorer (Java) -> JNI -> score-cabi -> score-core::score_one
```

The same dispatcher already behind pyo3 `native`, `datafusion-udf` and `score-wasm`. A fifth host, not a fifth implementation.

## What crosses the boundary

Not `String[]`. That signature costs a JNI transition and usually a copy **per string** -- 20,000 of them per 10,000-pair batch, to avoid one, which undoes the reason J1 reshaped the plan into batches at all.

So `Utf8Batch` flattens to Arrow's string layout (`int32` offsets + packed UTF-8) and the JNI layer pins five primitive arrays: a fixed cost per **batch**, independent of how many pairs it holds. That is the exact layout `score-cabi` was designed around, so nothing is converted at the seam.

Pinning is deliberately **non-critical**. `GetPrimitiveArrayCritical` saves one `memcpy` per array per batch and suspends GC to do it -- five memcpys against ten thousand string comparisons is not where the time goes.

Nulls stay a **host** decision, as score-cabi's header states. Null slots cross as zero-length slices and their scores are discarded via the presence mask. Wasted work, chosen over an index remapping that could silently attach a score to the wrong pair.

## One jar, nothing installed

The `.so` rides **inside the jar** and is extracted per JVM, so `addArtifact` still delivers everything: no `java.library.path`, no library placed on every executor. Replacing the packed-virtualenv apparatus with a different deployment apparatus would have been no progress.

CI builds `linux-x86-64` only (what a Spark executor runs). The loader already resolves the other os/arch names, so adding one is a build change, not a code change.

## The fallback announces itself

If the library will not load, the jar falls back to the `exact`-only scorer -- a distributed job must not die because one executor could not `dlopen` something.

But a fallback nobody can see is worse than none: the query still returns numbers, from a narrower path, and every version string still looks right. This repo has lost real time to exactly that shape. So:

- `golden_score_impl` reports what an **executor** resolved and why.
- `NativeSelfTest` and the lane parity test both **assert** it resolved `NativeScorer`.
- The probe takes a column it ignores. A zero-arg deterministic UDF is foldable (`children.forall(_.foldable)` is vacuously true), so Catalyst would evaluate it on the **driver** and answer the wrong question perfectly.

Load-time skew gate: ABI version and scorer-id count are checked before use, and an id outside the loaded kernel's range is refused rather than falling to `score_one`'s catch-all and returning a confident `0.0`.

## A real divergence, found and fixed

Building the parity gate turned one up. For a `token_sort` pair whose exact answer is 12/13:

| path | value |
|---|---|
| kernel (`score_one`) | `0.9230769230769231` |
| the tier's Python floor | `0.923076923076923` |

Self-inflicted: the floor called the 0-100 `token_sort_ratio` and divided by 100, and `(x * 100) / 100` is not `x`. One ULP.

One ULP is ignorable for a score you **report**. This tier **thresholds** these -- which is the argument `scorers.py`'s own docstring already makes about f32 narrowing. Fixed by splitting `strsim.token_sort_similarity` (`[0, 1]`) out of `token_sort_ratio` (0-100, byte-identical to before; rapidfuzz parity intact).

**Not bundled:** the same `/ 100.0` round trip is written at ~8 other call sites (`core.scorer`, `core.boost`, `core.explainer`, `backends.score_buckets`, `native`, `backends.datafusion_backend`) and carries the same deviation. Moving those changes thresholded scores repo-wide against pinned expectations in several suites. Flagged in `strsim`'s docstring for its own change and its own gate run.

## Verification

Run locally, end to end, before CI -- library built, extracted from the classpath, `dlopen`'d, JNI boundary crossed:

- `NativeSelfTest`: 21 assertions green, including 10,000 pairs in one call, batch alignment, multi-byte identity, and `null`-vs-`null` returning `null` rather than `1.0`.
- **All 36 (scorer x pair) values byte-identical** between the JVM and the tier's Python scorer, after the `token_sort` fix. Before it, 2 of 36 differed -- which is how the bug was found.
- `cargo test` / `clippy -D warnings` / `fmt` clean on `score-jni`; 138 Python tests green across the Spark tier and `strsim` suites.

## Gates added

- `rust` job: `cargo test` / `clippy` / `build --release` for `score-jni`. In the **blocking** job, not an informational lane -- a change to `score-core` or `score-cabi` that broke this binding would otherwise compile nowhere until someone touched a Spark file.
- `spark_connect`: build the library, assert the JNI symbols are **exported**, assert the `.so` is **in the jar**, run `NativeSelfTest`, then the Spark parity gate.
- `filters.yml`: the lane now watches `score-jni`, `score-cabi`, `score-core` and `strsim.py` -- the kernel and the oracle it is measured against.
- `javac -encoding UTF-8`: sources carry multi-byte parity fixtures and javac otherwise reads the platform default.

## Not in scope

No routing change. Nothing selects the JVM path by default -- this makes it *correct and gated*, not *on*. The `batched_jvm` OOM from the bench arc is still open and unexplained; the next experiment there is a bisect stage that calls the **shipped** `score_pairs_batched` rather than a lookalike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
