### PR TITLE
feat(semantic): ontology-layer (RDF/OWL/SHACL) native identity provider

### DIFF
--- a/context-network/decisions/0053-ontology-layer-rdf-owl-provider.md
+++ b/context-network/decisions/0053-ontology-layer-rdf-owl-provider.md
@@ -1,0 +1,82 @@
+# 0053 — Ontology layer: RDF / OWL / SHACL native identity provider (bidirectional)
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch.semantic.ontology.{parse_ontology, ontology_identity_keys, certify_ontology_keys, emit_sameas_graph, emit_identity_shacl}` + `Ontology`/`OntologyClass`/`OntologyProperty` • **Builds on:** [0049 (certify)](0049-metric-aware-key-certification.md) + [0050 (resolve+emit)](0050-resolved-crosswalk-emit.md) + [0051 (OSI)](0051-osi-ossie-native-provider.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+The semantic-layer arc (A/B/C + Cube) targets **metrics over join keys**. The
+ontology layer is the same shape one level up: **classes, properties and
+constraints over individuals** (RDF/OWL/SHACL — the W3C stack, distinct from the
+MetricFlow/Cube/OSI packages). It splits onto the classic **TBox / ABox** divide:
+the ontology owns the TBox (what a `Patient` *is*); GoldenMatch owns the ABox
+identity (which records *are* the same `Patient`).
+
+The gap is the same "assumed input," and OWL even names the identity vocabulary —
+`owl:hasKey` (a class's identifying property set), `owl:InverseFunctionalProperty`
+(a value that uniquely identifies an individual, i.e. a single-property key),
+`owl:sameAs` (individual equality) — but its only built-in resolution is brittle
+exact-match, which **over-merges on dirty keys and never merges fragmented ones**.
+That is exactly what GoldenMatch resolves. For agentic AI / GraphRAG (the "knowledge
+layer for enterprise AI" framing) this is the identity substrate the reasoning
+stands on.
+
+## Decision
+1. **Bidirectional, mirroring the OSI wedge — schema-faithful, invent nothing.**
+   - **consume:** `parse_ontology` reads the identity-bearing axioms (`owl:Class`
+     + `owl:hasKey`, `owl:FunctionalProperty` / `owl:InverseFunctionalProperty`
+     with `rdfs:domain`); `ontology_identity_keys` surfaces the declared
+     identifying keys as "what to resolve."
+   - **certify (bridge to A):** `certify_ontology_keys` certifies each declared
+     key against instance frames via the existing key-integrity certifier — the
+     *purest* form of the wedge, because the ontology hands you the key
+     declaration explicitly (`owl:hasKey`/IFP), unlike MetricFlow where it is
+     inferred from entities.
+   - **emit (bridge to B):** `emit_sameas_graph` turns a wedge-B `ResolvedCrosswalk`
+     into RDF — `owl:sameAs` linking each source individual to its resolved
+     canonical individual, with W3C **PROV-O** provenance (`prov:wasDerivedFrom`,
+     `prov:wasGeneratedBy` a resolution activity carrying run metadata).
+   - **conform (O-C flavor):** `emit_identity_shacl` emits a SHACL shape for the
+     post-resolution invariant (each individual carries exactly one resolved id).
+2. **GoldenMatch metadata rides under a documented `gm:` vocabulary** (`GM_NS`)
+   with `rdfs:label`/`rdfs:comment`, honoring the ontology "explicit
+   documentation" + "standard vocabularies" principles (reuse `owl:`/`prov:`/`sh:`,
+   namespace only GM-specific facts).
+3. **`rdflib` is an OPTIONAL dependency** (`goldenmatch[ontology]`), **lazy-imported
+   inside each function**, so `from goldenmatch.semantic import …` never requires
+   it and `import goldenmatch` stays lightweight. Tests `importorskip("rdflib")`
+   (the ray/lance/torch optional-dep convention).
+4. **Library-only, advisory, parity-free** — same discipline as A/B/C; no
+   MCP/CLI/A2A/TS surface (so `api_parity` is untouched), `semantic/` stays out of
+   top-level `goldenmatch/__init__.py`.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — an RDF/OWL adapter over the control plane's
+  resolved ids + the key-integrity certifier; no new identity or metric semantics.
+  It does **not** reimplement an OWL reasoner or a triple store — those are
+  replaceable backends (Jena / RDFox / GraphDB / Protégé), none synonymous with
+  GoldenMatch. GoldenMatch is the identity **provider** for them.
+- **Conformance defines correctness** ✅ — reads/writes the W3C objects
+  (`owl:hasKey`/IFP in, `owl:sameAs` + PROV-O + SHACL out); pinned to those
+  standards rather than inventing a shape.
+- **Arrow at bulk boundaries** ✅ — ontology docs are small metadata; the frames
+  `certify_ontology_keys` certifies are Arrow.
+
+## Consequences / honest flags
+- **`rdflib`-gated tests skip in the default CI lane.** `uv sync` does not install
+  optional extras, so the ontology tests `importorskip` there (verified locally,
+  6 passing). A dedicated `[ontology]` CI lane is a possible follow-on; the
+  optional-dep-skip matches the ray/lance/torch precedent.
+- **Reasoning is out of scope by design.** `owl:sameAs` transitive closure, OWL DL
+  inference and SHACL *execution* belong to a reasoner/triple store; GoldenMatch
+  emits the shapes and triples, it does not evaluate them.
+- **Best-effort axiom coverage.** v1 reads `owl:hasKey` + functional/inverse-
+  functional characteristics with `rdfs:domain`; richer identity signals
+  (property chains, `owl:sameAs` already asserted in-graph, class hierarchies for
+  key inheritance) are follow-ons.
+- **IFP without a domain** is surfaced with `class=None` (it identifies individuals
+  globally) and skipped by `certify_ontology_keys` (no frame to bind) — honest,
+  not guessed.
+- **Still-deferred** (unchanged from 0051/0052): a CLI/MCP front door, live-catalog
+  write-back, and metric-aware *blocking*.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -1,12 +1,24 @@
-# Semantic Layering (MetricFlow / Cube / OSI) — brainstorm / planning
+# Semantic Layering (MetricFlow / Cube / OSI / Ontology) — brainstorm / planning
 
 > **Status:** wedges **A + B + C** SHIPPED + **follow-ons** (Cube dialect, OSI
-> conformance validation) — decisions
+> conformance validation) + the **ontology layer** (RDF/OWL/SHACL) — decisions
 > [0049](../decisions/0049-metric-aware-key-certification.md) (certify) +
 > [0050](../decisions/0050-resolved-crosswalk-emit.md) (resolve once + emit) +
 > [0051](../decisions/0051-osi-ossie-native-provider.md) (OSI/Ossie provider) +
 > [0052](../decisions/0052-cube-dialect-and-osi-validation.md) (Cube dialect +
-> OSI validation).
+> OSI validation) +
+> [0053](../decisions/0053-ontology-layer-rdf-owl-provider.md) (ontology layer:
+> RDF/OWL/SHACL native identity provider).
+>
+> **Ontology layer (0053)** — the semantic-layer thesis one level up (TBox/ABox):
+> an ontology *asserts* identity (`owl:hasKey`, `owl:InverseFunctionalProperty`,
+> `owl:sameAs`) but resolves it only by brittle exact-match. `parse_ontology` +
+> `ontology_identity_keys` (consume the declared identifying keys),
+> `certify_ontology_keys` (bridge to A — certify exactly those keys),
+> `emit_sameas_graph` (bridge to B — `owl:sameAs` + PROV-O), `emit_identity_shacl`
+> (conformance shape). `rdflib` optional (`goldenmatch[ontology]`); GoldenMatch is
+> the identity provider FOR the reasoner/triple store, never a reimplementation of
+> one.
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 467,
+      "module_count": 468,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7149,6 +7149,7 @@
             "goldenmatch.semantic.discovery",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.ontology",
             "goldenmatch.semantic.osi",
             "goldenmatch.semantic.serving"
           ]
@@ -7588,6 +7589,28 @@
           ],
           "imports": [
             "goldenmatch.core.key_integrity_certificate"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.ontology",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/ontology.py",
+          "purpose": "Ontology-layer (RDF / OWL / SHACL) native identity provider.",
+          "defines": [
+            "Ontology",
+            "OntologyClass",
+            "OntologyProperty",
+            "_crosswalk_rows",
+            "_load_graph",
+            "_local",
+            "_require_rdflib",
+            "certify_ontology_keys",
+            "emit_identity_shacl",
+            "emit_sameas_graph",
+            "ontology_identity_keys",
+            "parse_ontology"
+          ],
+          "imports": [
+            "goldenmatch.semantic.key_integrity"
           ]
         },
         {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Ontology-layer (RDF/OWL/SHACL) native identity provider
+  (`goldenmatch.semantic.ontology`).** The semantic-layer wedge one level up: an
+  ontology *asserts* identity (`owl:hasKey`, `owl:InverseFunctionalProperty`,
+  `owl:sameAs`) but resolves it only by brittle exact-match. GoldenMatch fills
+  the gap bidirectionally — **consume** an OWL/RDF ontology to extract its
+  declared identifying keys (`parse_ontology`, `ontology_identity_keys`) and
+  certify exactly those keys against instance data
+  (`certify_ontology_keys`, bridging the key-integrity certifier); **emit** the
+  resolved identity as RDF (`emit_sameas_graph`: `owl:sameAs` + W3C PROV-O
+  provenance) and a conformance shape (`emit_identity_shacl`). `rdflib` is an
+  optional dependency (`pip install goldenmatch[ontology]`), lazy-imported so
+  `from goldenmatch.semantic import …` never requires it; GoldenMatch does not
+  reimplement an OWL reasoner or triple store — it is the identity provider for
+  them. Library-only, advisory. See ADR 0053.
 - **`strategy="token"`: DF-pruned token blocking for free text (#2488).** Every
   candidate the block analyzer can generate is an *exact* key -- a prefix, a
   soundex code, or a compound of two -- so each record lands in exactly one

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -103,6 +103,16 @@ from goldenmatch.semantic.metricflow import (
     emit_semantic_model,
     parse_semantic_models,
 )
+from goldenmatch.semantic.ontology import (
+    Ontology,
+    OntologyClass,
+    OntologyProperty,
+    certify_ontology_keys,
+    emit_identity_shacl,
+    emit_sameas_graph,
+    ontology_identity_keys,
+    parse_ontology,
+)
 from goldenmatch.semantic.osi import (
     OsiDataset,
     OsiField,
@@ -184,6 +194,15 @@ __all__ = [
     "CubeDimension",
     "CubeMeasure",
     "CubeJoin",
+    # ontology layer — RDF/OWL/SHACL native identity provider (bidirectional)
+    "parse_ontology",
+    "ontology_identity_keys",
+    "certify_ontology_keys",
+    "emit_sameas_graph",
+    "emit_identity_shacl",
+    "Ontology",
+    "OntologyClass",
+    "OntologyProperty",
     # semantic-model discovery (Phase 1) — certified key discovery per table
     "discover_keys",
     "KeyCandidate",

--- a/packages/python/goldenmatch/goldenmatch/semantic/ontology.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/ontology.py
@@ -1,0 +1,342 @@
+"""Ontology-layer (RDF / OWL / SHACL) native identity provider.
+
+The ontology layer is the semantic layer one level up: instead of metrics over
+join keys it is classes, properties and constraints over **individuals** — and,
+exactly like the semantic layer, it *asserts* identity without resolving it. OWL
+even names the identity vocabulary — `owl:hasKey`, `owl:InverseFunctionalProperty`
+(a value that uniquely identifies an individual), `owl:sameAs` (individual
+equality) — but its only built-in resolution is brittle exact-match, which
+over-merges on dirty keys and never merges fragmented ones. That gap is exactly
+what GoldenMatch fills: the ontology owns the TBox (what a `Patient` *is*);
+GoldenMatch owns the ABox identity (which records *are* the same `Patient`).
+
+Bidirectional, mirroring the OSI wedge:
+
+- **consume** an OWL/RDF ontology to learn the declared identifying keys
+  (`parse_ontology`, `ontology_identity_keys`) and certify exactly those keys
+  against the instance data (`certify_ontology_keys`, bridging wedge A) — the
+  purest form of the wedge, because the ontology hands you the key declaration
+  explicitly (`owl:hasKey` / IFP);
+- **emit** the resolved identity as RDF (`emit_sameas_graph`, bridging wedge B):
+  `owl:sameAs` linking each source individual to its resolved canonical
+  individual, with W3C **PROV-O** provenance — point a triple store / reasoner at
+  resolved individuals and every SPARQL query inherits correct identity;
+- **conform** (`emit_identity_shacl`): a SHACL shape asserting the post-resolution
+  invariant (each individual carries exactly one resolved id).
+
+`rdflib` is the parser/serializer and an OPTIONAL dependency (`goldenmatch[ontology]`);
+it is imported lazily inside each function, so `from goldenmatch.semantic import …`
+never requires it. GoldenMatch does NOT reimplement an OWL reasoner or a triple
+store — it is the identity provider FOR them (the replaceable-backend rule).
+Library-only, advisory, parity-free.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# W3C vocabulary IRIs (kept as plain strings so importing this module needs no
+# rdflib). The GoldenMatch provenance vocabulary rides under GM_NS.
+GM_NS = "https://goldenmatch.dev/ns#"
+DEFAULT_BASE_IRI = "https://goldenmatch.dev/id/"
+
+
+def _require_rdflib():
+    try:
+        import rdflib  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "The ontology layer needs rdflib. Install it with "
+            "`pip install goldenmatch[ontology]` (or `pip install rdflib`)."
+        ) from exc
+    return rdflib
+
+
+# --- model -------------------------------------------------------------------
+
+
+@dataclass
+class OntologyProperty:
+    name: str                             # local name (fragment / last path segment)
+    iri: str
+    functional: bool = False              # owl:FunctionalProperty (single-valued)
+    inverse_functional: bool = False      # owl:InverseFunctionalProperty (a key)
+    domain: list[str] = field(default_factory=list)  # local names of rdfs:domain classes
+    label: str | None = None
+    comment: str | None = None
+
+
+@dataclass
+class OntologyClass:
+    name: str                             # local name
+    iri: str
+    has_keys: list[list[str]] = field(default_factory=list)  # owl:hasKey axioms (prop local names)
+    label: str | None = None
+    comment: str | None = None
+
+
+@dataclass
+class Ontology:
+    iri: str | None = None
+    classes: list[OntologyClass] = field(default_factory=list)
+    properties: list[OntologyProperty] = field(default_factory=list)
+
+
+# --- parse (consume) ---------------------------------------------------------
+
+
+def _local(uri: Any) -> str:
+    """Local name of an IRI: the fragment after `#`, else the last path segment."""
+    s = str(uri)
+    if "#" in s:
+        return s.rsplit("#", 1)[1]
+    return s.rsplit("/", 1)[-1]
+
+
+def _load_graph(source: str | Any, fmt: str | None = None):
+    """Load an rdflib Graph from a Graph (passthrough), a file path, or an RDF
+    string. Strings default to Turtle; paths let rdflib guess by extension."""
+    import os
+
+    _require_rdflib()
+    from rdflib import Graph
+
+    if isinstance(source, Graph):
+        return source
+    g = Graph()
+    if isinstance(source, str) and os.path.exists(source):
+        g.parse(source, format=fmt) if fmt else g.parse(source)
+    else:
+        g.parse(data=str(source), format=fmt or "turtle")
+    return g
+
+
+def parse_ontology(source: str | Any, *, fmt: str | None = None) -> Ontology:
+    """Parse an OWL/RDF ontology (rdflib Graph, file path, or RDF string) into an
+    `Ontology`, extracting the identity-bearing axioms: `owl:Class` declarations
+    with their `owl:hasKey` composite keys, and the `owl:FunctionalProperty` /
+    `owl:InverseFunctionalProperty` characteristics with `rdfs:domain`.
+    """
+    _require_rdflib()
+    from rdflib import OWL, RDF, RDFS, URIRef
+    from rdflib.collection import Collection
+
+    g = _load_graph(source, fmt)
+
+    def _label(node) -> str | None:
+        v = g.value(node, RDFS.label)
+        return str(v) if v is not None else None
+
+    def _comment(node) -> str | None:
+        v = g.value(node, RDFS.comment)
+        return str(v) if v is not None else None
+
+    classes: list[OntologyClass] = []
+    for c in g.subjects(RDF.type, OWL.Class):
+        if not isinstance(c, URIRef):
+            continue  # skip anonymous class expressions (restrictions, unions)
+        has_keys: list[list[str]] = []
+        for key_node in g.objects(c, OWL.hasKey):
+            props = [_local(p) for p in Collection(g, key_node) if isinstance(p, URIRef)]
+            if props:
+                has_keys.append(props)
+        classes.append(OntologyClass(
+            name=_local(c), iri=str(c), has_keys=has_keys,
+            label=_label(c), comment=_comment(c),
+        ))
+
+    props: dict[str, OntologyProperty] = {}
+
+    def _prop(p) -> OntologyProperty | None:
+        if not isinstance(p, URIRef):
+            return None
+        op = props.get(str(p))
+        if op is None:
+            op = OntologyProperty(
+                name=_local(p), iri=str(p),
+                domain=[_local(d) for d in g.objects(p, RDFS.domain) if isinstance(d, URIRef)],
+                label=_label(p), comment=_comment(p),
+            )
+            props[str(p)] = op
+        return op
+
+    for p in g.subjects(RDF.type, OWL.InverseFunctionalProperty):
+        op = _prop(p)
+        if op is not None:
+            op.inverse_functional = True
+    for p in g.subjects(RDF.type, OWL.FunctionalProperty):
+        op = _prop(p)
+        if op is not None:
+            op.functional = True
+
+    onto_iri = next((str(s) for s in g.subjects(RDF.type, OWL.Ontology)), None)
+    return Ontology(iri=onto_iri, classes=classes, properties=list(props.values()))
+
+
+def ontology_identity_keys(onto: Ontology) -> list[dict[str, Any]]:
+    """The ontology's DECLARED identifying keys — what GoldenMatch should resolve.
+
+    One entry per declared key: `{class, key, source}` where `source` is
+    `owl:hasKey` (composite, class-scoped) or `owl:InverseFunctionalProperty`
+    (single-property, mapped to the property's `rdfs:domain` class). An IFP with
+    no domain is surfaced with `class=None` (it identifies individuals globally).
+    """
+    out: list[dict[str, Any]] = []
+    for c in onto.classes:
+        for key in c.has_keys:
+            out.append({"class": c.name, "key": list(key), "source": "owl:hasKey"})
+    for p in onto.properties:
+        if not p.inverse_functional:
+            continue
+        domains = p.domain or [None]
+        for cls in domains:
+            out.append({"class": cls, "key": [p.name], "source": "owl:InverseFunctionalProperty"})
+    return out
+
+
+# --- bridge: certify the ontology's identity keys (metric-aware, wedge A) ------
+
+
+def certify_ontology_keys(onto: Ontology | str | Any, frames: dict[str, Any]) -> list[dict[str, Any]]:
+    """Certify each of an ontology's declared identifying keys against instance
+    data, via wedge A — certifying exactly the identity the reasoner will trust.
+    `frames` maps class local-name -> table; a declared key whose class has no
+    supplied frame (or a global IFP with `class=None`) is skipped.
+
+    Returns `[{class, key, source, certificate}]`.
+    """
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    if not isinstance(onto, Ontology):
+        onto = parse_ontology(onto)
+
+    out: list[dict[str, Any]] = []
+    for entry in ontology_identity_keys(onto):
+        cls = entry["class"]
+        df = frames.get(cls) if cls is not None else None
+        if df is None:
+            continue
+        cert = certify_key_integrity(df, key=entry["key"])
+        out.append({
+            "class": cls,
+            "key": list(entry["key"]),
+            "source": entry["source"],
+            "certificate": cert,
+        })
+    return out
+
+
+# --- emit (produce) ----------------------------------------------------------
+
+
+def _crosswalk_rows(crosswalk: Any) -> tuple[list[dict[str, Any]], str]:
+    """Return `(rows, resolved_field)` from a `ResolvedCrosswalk` (or any object
+    exposing `to_arrow()`/`table` + `resolved_key`)."""
+    resolved_field = getattr(crosswalk, "resolved_key", "resolved_entity_id")
+    table = crosswalk.to_arrow() if hasattr(crosswalk, "to_arrow") else getattr(crosswalk, "table", crosswalk)
+    rows = table.to_pylist() if hasattr(table, "to_pylist") else list(table)
+    return rows, resolved_field
+
+
+def emit_sameas_graph(
+    crosswalk: Any,
+    *,
+    base_iri: str = DEFAULT_BASE_IRI,
+    run_name: str = "resolution",
+    resolved_field: str | None = None,
+    fmt: str = "turtle",
+) -> str:
+    """Emit the resolved identity of a `ResolvedCrosswalk` (wedge B) as RDF:
+    `owl:sameAs` linking each source individual to its resolved canonical
+    individual, plus W3C PROV-O provenance (the canonical entity
+    `prov:wasDerivedFrom` each source record and `prov:wasGeneratedBy` a single
+    resolution activity carrying GoldenMatch run metadata). Point a triple store
+    or reasoner at the canonical individuals and identity is conformed.
+    """
+    from urllib.parse import quote
+
+    _require_rdflib()
+    from rdflib import OWL, RDF, RDFS, Graph, Literal, Namespace, URIRef
+    from rdflib.namespace import PROV, XSD
+
+    rows, rf = _crosswalk_rows(crosswalk)
+    resolved_field = resolved_field or rf
+    EX = Namespace(base_iri)
+    GM = Namespace(GM_NS)
+
+    g = Graph()
+    g.bind("owl", OWL)
+    g.bind("prov", PROV)
+    g.bind("rdfs", RDFS)
+    g.bind("gm", GM)
+    g.bind("id", EX)
+
+    activity = URIRef(f"{base_iri}activity/{quote(str(run_name), safe='')}")
+    g.add((activity, RDF.type, PROV.Activity))
+    g.add((activity, GM.generatedBy, Literal("goldenmatch.semantic")))
+    n_entities = getattr(crosswalk, "n_entities", None)
+    if n_entities is not None:
+        g.add((activity, GM.nEntities, Literal(int(n_entities), datatype=XSD.integer)))
+    rr = getattr(crosswalk, "reduction_ratio", None)
+    if rr is not None:
+        g.add((activity, GM.reductionRatio, Literal(round(float(rr), 6), datatype=XSD.decimal)))
+    # Documented, human-readable vocabulary (the ontology "explicit documentation" rule).
+    g.add((GM.generatedBy, RDFS.label, Literal("generated by")))
+    g.add((GM.reductionRatio, RDFS.comment,
+           Literal("1 - entities/records: how much resolution collapsed the source key space")))
+
+    for row in rows:
+        rid = row.get(resolved_field)
+        src_name = row.get("source")
+        src_pk = row.get("source_pk")
+        if rid is None or src_pk is None:
+            continue  # unresolved / null source key — nothing to assert
+        src = URIRef(f"{base_iri}record/{quote(str(src_name), safe='')}/{quote(str(src_pk), safe='')}")
+        canon = URIRef(f"{base_iri}entity/{quote(str(rid), safe='')}")
+        g.add((src, RDF.type, PROV.Entity))
+        g.add((canon, RDF.type, PROV.Entity))
+        g.add((src, OWL.sameAs, canon))
+        g.add((canon, PROV.wasDerivedFrom, src))
+        g.add((canon, PROV.wasGeneratedBy, activity))
+
+    return g.serialize(format=fmt)
+
+
+def emit_identity_shacl(
+    *,
+    resolved_field: str = "resolved_entity_id",
+    target_class: str | None = None,
+    base_iri: str = DEFAULT_BASE_IRI,
+    fmt: str = "turtle",
+) -> str:
+    """Emit a SHACL shape for the post-resolution identity invariant: every
+    targeted individual carries exactly one resolved id (`sh:minCount 1`,
+    `sh:maxCount 1` on the resolved-key path). This is the conformance direction —
+    a shape a triple store's SHACL engine validates; GoldenMatch produces it, it
+    does not execute it.
+    """
+    _require_rdflib()
+    from rdflib import RDF, RDFS, Graph, Literal, Namespace, URIRef
+    from rdflib.namespace import SH, XSD
+
+    EX = Namespace(base_iri)
+    GM = Namespace(GM_NS)
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("gm", GM)
+    g.bind("id", EX)
+
+    shape = URIRef(f"{base_iri}shape/ResolvedIdentity")
+    prop = URIRef(f"{base_iri}shape/ResolvedIdentity/resolvedKey")
+    g.add((shape, RDF.type, SH.NodeShape))
+    g.add((shape, RDFS.comment,
+           Literal("Each resolved individual carries exactly one GoldenMatch resolved id.")))
+    if target_class:
+        g.add((shape, SH.targetClass, URIRef(f"{base_iri}class/{target_class}")))
+    g.add((shape, SH.property, prop))
+    g.add((prop, SH.path, GM[resolved_field]))
+    g.add((prop, SH.minCount, Literal(1, datatype=XSD.integer)))
+    g.add((prop, SH.maxCount, Literal(1, datatype=XSD.integer)))
+    g.add((prop, SH.name, Literal(resolved_field)))
+
+    return g.serialize(format=fmt)

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -77,6 +77,12 @@ dev = [
 embeddings = [
     "sentence-transformers>=2.2",
 ]
+# Ontology-layer identity provider (goldenmatch.semantic.ontology): parse OWL/RDF
+# to certify owl:hasKey / IFP identity keys, emit owl:sameAs + PROV-O + SHACL.
+# rdflib is optional — the module lazy-imports it; tests skip when it is absent.
+ontology = [
+    "rdflib>=7.0",
+]
 # Decode adapters for the multimodal-ER crawl tier (ADR 0022). The perceptual
 # kernel itself is dependency-free (operates on decoded luma grids / PCM); these
 # only back core.perceptual.decode_image_to_luma / decode_audio_to_mono so an

--- a/packages/python/goldenmatch/tests/test_ontology.py
+++ b/packages/python/goldenmatch/tests/test_ontology.py
@@ -1,0 +1,142 @@
+"""Tests for the ontology-layer (RDF/OWL/SHACL) identity provider.
+
+rdflib is an optional dependency (`goldenmatch[ontology]`); these skip when it is
+absent, mirroring the ray/lance/torch optional-dep convention.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("rdflib")
+
+from goldenmatch.semantic import (  # noqa: E402
+    Ontology,
+    certify_ontology_keys,
+    emit_identity_shacl,
+    emit_sameas_graph,
+    ontology_identity_keys,
+    parse_ontology,
+)
+
+# A real-shaped OWL ontology in Turtle: a Patient class with a composite
+# owl:hasKey, plus an inverse-functional property (mrn) that identifies a Patient.
+_TTL = """
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <https://example.org/clinic#> .
+
+ex:Clinic a owl:Ontology .
+
+ex:Patient a owl:Class ;
+    rdfs:label "Patient" ;
+    rdfs:comment "A person receiving care." ;
+    owl:hasKey ( ex:firstName ex:lastName ex:birthDate ) .
+
+ex:mrn a owl:InverseFunctionalProperty ;
+    rdfs:domain ex:Patient ;
+    rdfs:label "medical record number" .
+
+ex:ssn a owl:InverseFunctionalProperty, owl:FunctionalProperty ;
+    rdfs:domain ex:Patient .
+"""
+
+
+def test_parse_extracts_classes_keys_and_ifps():
+    onto = parse_ontology(_TTL)
+    assert isinstance(onto, Ontology)
+    assert onto.iri == "https://example.org/clinic#Clinic"
+    patient = next(c for c in onto.classes if c.name == "Patient")
+    assert patient.label == "Patient"
+    assert patient.has_keys == [["firstName", "lastName", "birthDate"]]
+    mrn = next(p for p in onto.properties if p.name == "mrn")
+    assert mrn.inverse_functional and mrn.domain == ["Patient"]
+    ssn = next(p for p in onto.properties if p.name == "ssn")
+    assert ssn.inverse_functional and ssn.functional
+
+
+def test_identity_keys_are_what_to_resolve():
+    onto = parse_ontology(_TTL)
+    keys = {(k["class"], tuple(k["key"]), k["source"]) for k in ontology_identity_keys(onto)}
+    assert ("Patient", ("firstName", "lastName", "birthDate"), "owl:hasKey") in keys
+    assert ("Patient", ("mrn",), "owl:InverseFunctionalProperty") in keys
+    assert ("Patient", ("ssn",), "owl:InverseFunctionalProperty") in keys
+
+
+def test_certify_ontology_keys_bridges_wedge_a():
+    onto = parse_ontology(_TTL)
+    # mrn has a duplicate -> the IFP the reasoner trusts is actually unsafe
+    frames = {"Patient": pa.table({
+        "mrn": ["m1", "m1", "m2"],
+        "ssn": ["a", "b", "c"],
+        "firstName": ["Bob", "Bob", "Amy"],
+        "lastName": ["Smith", "Smith", "Jones"],
+        "birthDate": ["1990-01-01", "1990-01-01", "1985-05-05"],
+    })}
+    rep = certify_ontology_keys(onto, frames)
+    by_key = {tuple(e["key"]): e for e in rep}
+    # the composite hasKey and both IFPs all got certified against the frame
+    assert ("firstName", "lastName", "birthDate") in by_key
+    assert ("mrn",) in by_key and ("ssn",) in by_key
+    mrn_cert = by_key[("mrn",)]["certificate"]
+    assert mrn_cert.estimate == 0.5 and mrn_cert.max_fan_out == 2.0
+    # ssn is unique -> certificate passes
+    assert by_key[("ssn",)]["certificate"].estimate == 1.0
+
+
+def test_certify_accepts_source_string_and_skips_absent_frames():
+    # passing raw Turtle (not a parsed Ontology) + no frames -> nothing to certify
+    assert certify_ontology_keys(_TTL, frames={}) == []
+
+
+class _XW:
+    source = "crm"
+    source_pk_column = "customer_id"
+    resolved_key = "resolved_entity_id"
+    n_records = 3
+    n_entities = 2
+    reduction_ratio = 1 - 2 / 3
+
+    def to_arrow(self):
+        return pa.table({
+            "source": ["crm", "crm", "crm"],
+            "source_pk": ["1", "2", "3"],
+            "resolved_entity_id": ["e1", "e1", "e2"],
+        })
+
+
+def test_emit_sameas_graph_links_sources_to_resolved_entities():
+    import rdflib
+    from rdflib.namespace import OWL, PROV
+
+    ttl = emit_sameas_graph(_XW(), base_iri="https://ex.test/id/")
+    g = rdflib.Graph()
+    g.parse(data=ttl, format="turtle")
+
+    e1 = rdflib.URIRef("https://ex.test/id/entity/e1")
+    rec1 = rdflib.URIRef("https://ex.test/id/record/crm/1")
+    rec2 = rdflib.URIRef("https://ex.test/id/record/crm/2")
+    # records 1 and 2 both resolve to entity e1 (owl:sameAs)
+    assert (rec1, OWL.sameAs, e1) in g
+    assert (rec2, OWL.sameAs, e1) in g
+    # PROV-O: the canonical entity was derived from each source record
+    assert (e1, PROV.wasDerivedFrom, rec1) in g
+    # exactly two distinct canonical entities emitted
+    entities = set(g.objects(predicate=OWL.sameAs))
+    assert len(entities) == 2
+
+
+def test_emit_identity_shacl_asserts_single_resolved_key():
+    import rdflib
+    from rdflib.namespace import SH
+
+    ttl = emit_identity_shacl(resolved_field="resolved_entity_id",
+                              target_class="Patient", base_iri="https://ex.test/id/")
+    g = rdflib.Graph()
+    g.parse(data=ttl, format="turtle")
+    shapes = list(g.subjects(rdflib.RDF.type, SH.NodeShape))
+    assert len(shapes) == 1
+    # the property shape pins the resolved key to exactly one value
+    assert any(int(o) == 1 for o in g.objects(predicate=SH.minCount))
+    assert any(int(o) == 1 for o in g.objects(predicate=SH.maxCount))


### PR DESCRIPTION
## What and why

The semantic-layer wedge **one level up** — the ontology layer (RDF/OWL/SHACL),
on the classic **TBox / ABox** divide. An ontology *asserts* identity
(`owl:hasKey`, `owl:InverseFunctionalProperty`, `owl:sameAs`) but resolves it
only by brittle exact-match — which over-merges on dirty keys and never merges
fragmented ones. GoldenMatch fills that gap: the ontology owns the TBox (what a
`Patient` *is*); GoldenMatch owns the ABox identity (which records *are* the same
`Patient`). Decision:
[ADR 0053](``https://github.com/benseverndev-oss/goldenmatch/blob/claude/semantic-layering-exploration-52p6rd/context-network/decisions/0053-ontology-layer-rdf-owl-provider.md).``

## Changes

New module `goldenmatch/semantic/ontology.py`, bidirectional like the OSI wedge:

- **consume** — `parse_ontology` reads the identity-bearing axioms (`owl:Class` +
  `owl:hasKey`, functional / inverse-functional properties with `rdfs:domain`);
  `ontology_identity_keys` surfaces the declared identifying keys ("what to resolve").
- **certify (bridge to wedge A)** — `certify_ontology_keys` certifies exactly those
  keys against instance frames via the existing key-integrity certifier. The purest
  form of the wedge: the ontology hands you the key declaration explicitly.
- **emit (bridge to wedge B)** — `emit_sameas_graph` turns a `ResolvedCrosswalk` into
  RDF: `owl:sameAs` linking each source individual to its resolved canonical
  individual, with W3C **PROV-O** provenance.
- **conform** — `emit_identity_shacl` emits a SHACL shape for the post-resolution
  invariant (each individual carries exactly one resolved id).

`rdflib` is an **optional** dependency (`goldenmatch[ontology]`), lazy-imported
inside each function so `from goldenmatch.semantic import …` never requires it;
GoldenMatch metadata rides under a documented `gm:` vocabulary. GoldenMatch does
**not** reimplement an OWL reasoner or triple store — it is the identity provider
for them (the replaceable-backend rule).

Library-only, advisory, parity-free: no MCP/CLI/A2A/TS surface (so `api_parity`
is untouched), and `semantic/` stays out of top-level `goldenmatch/__init__.py`.
ADR 0053 + planning-doc status + CHANGELOG entry; `agent-codemap.json` regenerated.

## Testing

- `.venv/bin/python -m pytest tests/test_ontology.py tests/test_osi.py tests/test_cube.py` → **34 passed** (ontology tests `importorskip("rdflib")`, ray/lance precedent — verified locally with rdflib installed)
- `ruff check goldenmatch/semantic/` → clean
- `check_docs_consistency.py` → all PASS (incl. CHANGELOG top == pyproject version)
- `gen_config_matrix.py --check` → OK (no new env vars); `test_agent_codemap.py::test_codemap_current` → pass (regenerated)
- Verified module top is rdflib-free (lazy imports); `import goldenmatch.semantic` works without the extra.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated (`[Unreleased]` / Added)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / decision records updated (ADR 0053 + planning-doc status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_