### PR TITLE
ci(goldenmatch): run the ontology tests for real (install [ontology] extra)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,10 @@ jobs:
       # optional `documents` extra; install it so tests/documents RUN rather than error at
       # collection (missing PIL/fitz). Same rationale as the datafusion extra above.
       - run: uv pip install -e 'packages/python/goldenmatch[documents]'
+      # Ontology-layer (goldenmatch.semantic.ontology) tests need rdflib from the
+      # optional `ontology` extra; install it so tests/test_ontology.py RUN rather
+      # than importorskip-SKIP (a false green). Same rationale as the extras above.
+      - run: uv pip install -e 'packages/python/goldenmatch[ontology]'
       # Suite-wide lints run once (shard 1), not per shard.
       - if: matrix.shard == 1
         run: uv run ruff check packages/python/goldenmatch

--- a/context-network/decisions/0053-ontology-layer-rdf-owl-provider.md
+++ b/context-network/decisions/0053-ontology-layer-rdf-owl-provider.md
@@ -61,10 +61,15 @@ stands on.
   `certify_ontology_keys` certifies are Arrow.
 
 ## Consequences / honest flags
-- **`rdflib`-gated tests skip in the default CI lane.** `uv sync` does not install
-  optional extras, so the ontology tests `importorskip` there (verified locally,
-  6 passing). A dedicated `[ontology]` CI lane is a possible follow-on; the
-  optional-dep-skip matches the ray/lance/torch precedent.
+- **`rdflib`-gated tests run in the required `python_goldenmatch` lane
+  (2026-08-13 follow-on).** The tests `importorskip("rdflib")`, so absent the extra
+  they SKIP (a false green). Rather than leave that, the required `python_goldenmatch`
+  job now installs `goldenmatch[ontology]` (one step, mirroring how it already
+  installs the `datafusion` / `documents` extras "so tests RUN rather than
+  importorskip-SKIP"), so `tests/test_ontology.py` executes for real inside the
+  merge gate. The default `uv sync` still omits optional extras (a plain
+  `pip install goldenmatch` stays rdflib-free); coverage comes from the extra
+  installed in that one lane, not a separate job.
 - **Reasoning is out of scope by design.** `owl:sameAs` transitive closure, OWL DL
   inference and SHACL *execution* belong to a reasoner/triple store; GoldenMatch
   emits the shapes and triples, it does not evaluate them.


### PR DESCRIPTION
## What and why

The ADR 0053 follow-on: give the ontology tests real CI coverage. They
`importorskip("rdflib")`, so without the extra installed they **SKIP** in CI — a
false green on shipped code (`goldenmatch.semantic.ontology`).

The required `python_goldenmatch` job already installs the `datafusion` and
`documents` extras for exactly this reason ("so tests RUN rather than
importorskip-SKIP (a false green)"). This adds `goldenmatch[ontology]` the same
way, so `tests/test_ontology.py` executes inside the merge gate.

## Changes

- **`.github/workflows/ci.yml`** — one `uv pip install -e
  'packages/python/goldenmatch[ontology]'` step in the `python_goldenmatch` job,
  right after the `[documents]` install, with a comment mirroring that precedent.
  No new job, no new filter, no `ci-required` edit — the tests are **already
  collected** by that lane's `pytest packages/python/goldenmatch` (not in its
  `--ignore` list); they just needed rdflib present to run instead of skip.
- **ADR 0053** — the "tests skip in CI" honest-flag updated to record the resolution.

A plain `pip install goldenmatch` stays rdflib-free — the default `uv sync`
omits optional extras; coverage comes from the extra installed in that one lane.

## Testing

- `check_workflow_yaml.py` → 121 files parse, no duplicate keys
- `check_filter_coverage.py` → OK (filters unchanged)
- `pytest tests/test_ontology.py` (rdflib installed, = what CI now runs) → **6 passed**
- Confirmed `test_ontology.py` is not in the job's `--ignore` list, and the
  `[ontology]` extra resolves.

## Checklist

- [x] Change is minimal and mirrors an established precedent in the same job
- [x] Workflow YAML validated (parse + duplicate-key + filter coverage)
- [x] Ontology tests pass with rdflib installed
- [x] No secrets/tokens committed; no user-facing behavior change (CI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_