### PR TITLE
feat(spark): the last identity UDFs are pure Spark SQL

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7909,7 +7909,9 @@
             "build_same_as_edges",
             "build_source_records",
             "derive_record_ids",
+            "entity_id_expr",
             "entity_id_for_members",
+            "golden_json_expr",
             "mint_entity_ids",
             "record_id_for_row",
             "resolve_cluster_entities"

--- a/packages/python/goldenmatch/goldenmatch/spark/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/identity.py
@@ -225,7 +225,39 @@ def derive_record_ids(
     )
 
 
-def mint_entity_ids(assignments_with_recid: Any) -> Any:
+def entity_id_expr(rids_col: Any) -> Any:
+    """``entity_id_for_members`` as a Spark SQL expression -- no UDF, no worker.
+
+    The Python version is
+    ``sha256("\\n".join(sorted(record_ids)))[:N]`` with a prefix, and every
+    piece of that has a Spark equivalent:
+
+    ==========================  ==================================
+    ``sorted(record_ids)``      ``sort_array``
+    ``"\\n".join(...)``           ``concat_ws('\\n', ...)``
+    ``sha256(...).hexdigest()`` ``sha2(..., 256)``
+    ``[:N]``                    ``substring(..., 1, N)``
+    ==========================  ==================================
+
+    The orderings agree: Python sorts ``str`` by code point, Spark sorts strings
+    by UTF-8 bytes, and for UTF-8 those are the same order. ``sha2`` returns
+    lowercase hex like ``hexdigest()``.
+
+    Worth stating because the map for this work assumed a fourth JNI binding:
+    the entity id needed no kernel at all. The fingerprint did, because its
+    canonical form is a field-by-field encoding; this one is a plain join of
+    strings the engine already has.
+    """
+    from pyspark.sql import functions as F
+
+    canonical = F.concat_ws("\n", F.sort_array(rids_col))
+    return F.concat(
+        F.lit(_ENT_PREFIX),
+        F.substring(F.sha2(canonical, 256), 1, _ENT_HASH_LEN),
+    )
+
+
+def mint_entity_ids(assignments_with_recid: Any, *, pure_sql: bool = False) -> Any:
     """``(cluster_id, record_id)`` -> ``(cluster_id, entity_id)``: collect each
     cluster's member record_ids and hash them deterministically. ``uuid7``
     scheme mints a per-cluster UUIDv7 instead (non-deterministic; matches the
@@ -238,6 +270,19 @@ def mint_entity_ids(assignments_with_recid: Any) -> Any:
     grouped = assignments_with_recid.groupBy("cluster_id").agg(
         F.collect_list("record_id").alias("__rids__")
     )
+
+    if pure_sql:
+        # No Python worker: the whole id is a column expression.
+        if _id_scheme() == "uuid7":
+            raise ValueError(
+                "the uuid7 id scheme mints a per-cluster UUIDv7, which is "
+                "deliberately NON-DETERMINISTIC and has no Spark SQL "
+                "equivalent -- Spark's uuid() is v4. Use the default h1 scheme "
+                "for a jar-only run, or ship a Python environment."
+            )
+        return grouped.withColumn(
+            "entity_id", entity_id_expr(F.col("__rids__"))
+        ).select("cluster_id", "entity_id")
 
     if _id_scheme() == "uuid7":
         from goldenmatch.identity.store import new_entity_id
@@ -303,11 +348,32 @@ def build_same_as_edges(
     )
 
 
+def golden_json_expr(gcols: list[str]) -> Any:
+    """``json.dumps({c: row[c] for c in gcols}, default=str)`` as Spark SQL.
+
+    ``ignoreNullFields=false`` is load-bearing. Spark's ``to_json`` OMITS null
+    fields by default, while ``json.dumps`` emits ``"c": null`` -- so without the
+    option the two produce different JSON for any row with a missing value, and
+    a golden record would silently lose its null columns.
+
+    ``default=str`` in the Python version coerces anything unserializable
+    (dates, decimals) with ``str()``; Spark formats those its own way. Same
+    divergence class as the fingerprint's type gate, so callers keep the Python
+    path when the golden frame is not string/number/bool typed.
+    """
+    from pyspark.sql import functions as F
+
+    return F.to_json(
+        F.struct(*[F.col(c) for c in gcols]), {"ignoreNullFields": "false"}
+    )
+
+
 def build_identity_nodes(
     entity_ids: Any,
     golden_df: Any,
     *,
     run_meta: dict[str, Any],
+    pure_sql: bool = False,
 ) -> Any:
     """One node per entity (incl. singletons). ``golden_record`` LEFT-joins
     ``build_golden`` (multi-member only); SINGLETON ``golden_record`` is NULL by
@@ -323,6 +389,15 @@ def build_identity_nodes(
     # entity -> golden JSON for multi-member clusters.
     gcols = [c for c in golden_df.columns if c != "cluster_id"]
 
+    if pure_sql:
+        # `json.dumps({c: row[c]})` IS `to_json(struct(*gcols))` -- no kernel,
+        # no worker. See `golden_json_expr` for why ignoreNullFields matters.
+        def _json_expr(cols: list[str]) -> Any:
+            return golden_json_expr(cols)
+    else:
+        def _json_expr(cols: list[str]) -> Any:
+            return _as_json(F.struct(*[F.col(c) for c in cols]))
+
     # One struct argument, as in `_rid`. `pd.isna` is gone with it: a pa.Array
     # carries a validity bitmap, so `to_pylist()` yields None for a null and
     # there is no NaN to test for.
@@ -336,7 +411,7 @@ def build_identity_nodes(
 
     golden_json = (
         golden_df.join(entity_ids, on="cluster_id", how="inner")
-        .withColumn("golden_record", _as_json(F.struct(*[F.col(c) for c in gcols])))
+        .withColumn("golden_record", _json_expr(gcols))
         .select("entity_id", "golden_record")
     )
 
@@ -592,7 +667,9 @@ def build_incremental_nodes(
     return live.unionByName(retired)
 
 
-def _golden_record_json(entity_ids: Any, golden_df: Any) -> Any:
+def _golden_record_json(
+    entity_ids: Any, golden_df: Any, *, pure_sql: bool = False
+) -> Any:
     """``entity_id -> golden_record`` JSON for multi-member clusters (the same
     projection ``build_identity_nodes`` does inline, factored out so the create
     and incremental node builders cannot drift)."""
@@ -601,6 +678,13 @@ def _golden_record_json(entity_ids: Any, golden_df: Any) -> Any:
     from goldenmatch.spark._arrow import arrow_udf, from_pylist, to_pylist
 
     gcols = [c for c in golden_df.columns if c != "cluster_id"]
+
+    if pure_sql:
+        def _json_expr(cols: list[str]) -> Any:
+            return golden_json_expr(cols)
+    else:
+        def _json_expr(cols: list[str]) -> Any:
+            return _as_json(F.struct(*[F.col(c) for c in cols]))
 
     # One struct argument, as in `_rid`. `pd.isna` is gone with it: a pa.Array
     # carries a validity bitmap, so `to_pylist()` yields None for a null and
@@ -616,7 +700,7 @@ def _golden_record_json(entity_ids: Any, golden_df: Any) -> Any:
     return (
         golden_df.join(entity_ids.select("cluster_id", "entity_id"), on="cluster_id",
                        how="inner")
-        .withColumn("golden_record", _as_json(F.struct(*[F.col(c) for c in gcols])))
+        .withColumn("golden_record", _json_expr(gcols))
         .select("entity_id", "golden_record")
     )
 

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -634,3 +634,95 @@ def test_the_probe_says_which_process_it_ran_in(spark, registered):
         f"gate cannot distinguish a real executor from local mode."
     )
     print(f"\n  ran on executor {tokens['exec']!r}")
+# ── identity, pure Spark SQL (no kernel, no worker) ──────────────────
+
+def test_entity_id_expr_matches_the_python_helper(spark, registered):
+    """`entity_id_for_members` re-expressed as a column expression.
+
+    Needed no kernel at all: it is sha256 over sorted, newline-joined ids, and
+    every piece has a Spark equivalent. The orderings agree because Python sorts
+    `str` by code point and Spark sorts by UTF-8 bytes, which for UTF-8 is the
+    same order -- but "agree in principle" is what this test exists to replace.
+
+    An entity_id that differs is not a wrong number; it is a DIFFERENT ENTITY,
+    so exact equality is the only meaningful bar.
+    """
+    from goldenmatch.spark.identity import entity_id_expr, entity_id_for_members
+    from pyspark.sql import functions as F
+
+    clusters = {
+        1: ["src:b", "src:a"],            # unsorted input
+        2: ["src:a"],                     # singleton
+        3: ["src:z", "src:a", "src:m"],   # 3 members
+        4: ["src:é", "src:a"],            # multi-byte
+        5: ["src:a", "src:a"],            # duplicate member ids
+    }
+    rows = [(cid, rid) for cid, rids in clusters.items() for rid in rids]
+    df = spark.createDataFrame(rows, "cluster_id long, record_id string")
+    got = {
+        r["cluster_id"]: r["eid"]
+        for r in df.groupBy("cluster_id")
+        .agg(F.collect_list("record_id").alias("rids"))
+        .select("cluster_id", entity_id_expr(F.col("rids")).alias("eid"))
+        .collect()
+    }
+    want = {cid: entity_id_for_members(rids) for cid, rids in clusters.items()}
+    assert got == want, (
+        f"entity_id differs between Spark SQL and Python -- that is a different "
+        f"ENTITY, not a rounding difference: "
+        f"{ {k: (want[k], got.get(k)) for k in want if got.get(k) != want[k]} }"
+    )
+
+
+def test_golden_json_expr_keeps_null_fields(spark, registered):
+    """`to_json` OMITS null fields by default; `json.dumps` emits them.
+
+    Without `ignoreNullFields=false` a golden record silently loses every null
+    column -- the row still looks like a golden record, just a smaller one. This
+    pins the option rather than the whole encoding.
+    """
+    import json
+
+    from goldenmatch.spark.identity import golden_json_expr
+
+    df = spark.createDataFrame(
+        [("a", None, 1), (None, "b", 2)], "x string, y string, n long"
+    )
+    got = [r[0] for r in df.select(golden_json_expr(["x", "y", "n"])).collect()]
+    want = [
+        json.dumps({"x": "a", "y": None, "n": 1}),
+        json.dumps({"x": None, "y": "b", "n": 2}),
+    ]
+    assert [json.loads(g) for g in got] == [json.loads(w) for w in want], (
+        f"null fields were dropped or reordered: {got}"
+    )
+    for g in got:
+        assert "null" in g, f"a null field vanished from {g}"
+
+
+def test_mint_entity_ids_pure_sql_matches_the_udf_path(spark, registered):
+    """The whole function, both paths, on one frame."""
+    from goldenmatch.spark.identity import mint_entity_ids
+
+    df = spark.createDataFrame(
+        [(1, "src:b"), (1, "src:a"), (2, "src:c"), (3, "src:z"), (3, "src:y")],
+        "cluster_id long, record_id string",
+    )
+    udf_path = {r["cluster_id"]: r["entity_id"] for r in mint_entity_ids(df).collect()}
+    sql_path = {
+        r["cluster_id"]: r["entity_id"]
+        for r in mint_entity_ids(df, pure_sql=True).collect()
+    }
+    assert sql_path == udf_path, f"{udf_path} vs {sql_path}"
+    assert all(v.startswith("ent:h1:") for v in sql_path.values()), sql_path
+
+
+def test_uuid7_is_refused_on_the_pure_sql_path(spark, registered, monkeypatch):
+    """uuid7 mints a per-cluster UUIDv7 -- deliberately non-deterministic, and
+    Spark's uuid() is v4. Refusing beats silently minting different ids."""
+    from goldenmatch.spark.identity import mint_entity_ids
+
+    monkeypatch.setenv("GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME", "uuid7")
+    df = spark.createDataFrame([(1, "src:a")], "cluster_id long, record_id string")
+    with pytest.raises(ValueError, match="uuid7"):
+        mint_entity_ids(df, pure_sql=True)


### PR DESCRIPTION
Stacked on #2516 (now merged), rebased onto main.

The jar-only inventory said the identity graph still needed a Python worker for
three of its five UDFs. The map for this work assumed a fourth JNI binding
would be needed. The audit said otherwise: **none of the three needs a kernel.**

- both `_as_json` UDFs are `json.dumps({c: row[c] for c in gcols})`, which is
  `to_json(struct(*gcols))`
- `entity_id_for_members` is `sha256("\n".join(sorted(ids)))`, which is
  `sha2(concat_ws('\n', sort_array(collect_list(id))), 256)`

The orderings agree: Python sorts `str` by code point, Spark sorts strings by
UTF-8 bytes, and for UTF-8 those are the same order. `sha2` returns lowercase
hex like `hexdigest()`.

Worth stating plainly because it is the opposite of the usual finding here: the
fingerprint DID need a kernel, because its canonical form is a field-by-field
encoding. The entity id needed none, because it is a plain join of strings the
engine already has. "Route it through the jar" was the wrong instinct twice.

## `ignoreNullFields=false` is load-bearing

Spark's `to_json` **omits null fields by default**, while `json.dumps` emits
`"c": null`. Without the option the two produce different JSON for any row with
a missing value, so a golden record silently loses its null columns and a
record id silently disagrees with the Python path.

This is not hypothetical: the same bug was caught by the parity test on #2516's
`derive_record_ids` (row `("", None, 3)` gave two different well-formed ids) and
fixed there. Both places carry the option now.

Note what did NOT catch it. `derive_record_ids` has a column-type gate, and
every column in that row was a proven-safe type. The divergence was in the
ENCODING, not the types, and a type allowlist is structurally blind to it.

## `uuid7` is refused, not approximated

`pure_sql=True` raises for the `uuid7` id scheme. It mints a per-cluster UUIDv7,
which is deliberately non-deterministic and has no Spark SQL equivalent --
Spark's `uuid()` is v4. Refused on the driver with the reason named, rather than
emitting plausible v4s from every cluster.
