### PR TITLE
fix(autoconfig): a domain-extracted field is not an identity claim by default (#2526)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1887,6 +1887,7 @@
             "_has_fuzzy_tolerant_transform",
             "_has_geographic_evidence",
             "_is_bibliographic_dataset",
+            "_is_identity_claim",
             "_is_perfect_surrogate",
             "_is_person_name_column",
             "_is_probabilistic_shape",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+- **A domain-extracted field no longer becomes a standalone identity claim
+  unless it is actually an identifier (#2526).** Auto-config promoted every
+  `exact` entry in `_DOMAIN_SCORER_MAP` to its own exact matchkey -- "same value
+  implies same entity", on its own, with nothing else consulted. On DBLP-ACM
+  that produced `domain_exact_title_key` over `__title_key__`, which is the
+  first significant *word* of the title, so zero-config asserted that two papers
+  whose titles start with the same word are the same paper: 33,563 asserted
+  pairs against 2,224 in ground truth, clusters up to 96 members, precision
+  0.068.
+
+  Two mechanisms combined. The eligibility floor was `cardinality_ratio < 0.01`,
+  which only rejects *near-constant* columns -- `__title_key__` sits at 0.29 and
+  cleared it by 29x, where an identity claim needs cardinality near 1.0. And the
+  per-column weight in `_DOMAIN_SCORER_MAP`, which is the author's own statement
+  of confidence (0.2 for `__color__`, 0.8 for `__title_key__`, 1.0 for
+  `__model_norm__` and `__sw_part_num__`), was read and then discarded when the
+  standalone matchkey was built -- so a weak partial signal became a
+  full-strength identity claim regardless.
+
+  A domain `exact` field now stands alone only when its declared weight says it
+  is an identifier and its cardinality agrees; anything weaker folds into the
+  weighted matchkey *at its declared weight*, so the signal is still compared,
+  just not trusted on its own. Measured on DBLP-ACM zero-config: F1
+  **0.1277 -> 0.4593**, precision 0.068 -> 0.301, largest cluster 96 -> 43.
+  Retaining the signal beats dropping the matchkey outright, which scored
+  0.2815.
+
+  This does not close the DBLP-ACM gap to the ~0.92 configured runs reach. The
+  remainder is a separate recall problem that the controller already reports
+  (`failing_subprofile=scoring`, best-effort RED) and is tracked apart from this.
+
 ### Changed
 - **The FS link-threshold refit is ON by default (#2518 follow-up).** The FS
   path is otherwise non-iterated: it commits a fixed 0.50 link cutoff, which

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1246,6 +1246,37 @@ _DOMAIN_SCORER_MAP = {
     "__title_key__": ("exact", 0.8, ["lowercase"]),
 }
 
+# A domain-extracted `exact` field becomes a STANDALONE exact matchkey -- "same
+# value implies same entity", on its own, with nothing else consulted -- only if
+# it is a genuine identifier. `_DOMAIN_SCORER_MAP` already states that: the weight
+# is the author's own confidence, 1.0 for identifiers (`__model_norm__`,
+# `__sw_part_num__`) and lower for partial signals (`__color__` 0.2,
+# `__title_key__` 0.8). That weight used to be read and then DISCARDED when the
+# standalone matchkey was built, so every exact entry made a full-strength
+# identity claim regardless.
+#
+# Measured on DBLP-ACM (#2526): `__title_key__` is the first significant WORD of
+# the title, so `domain_exact_title_key` asserted "two papers whose titles start
+# with the same word are the same paper" -- 33,563 pairs against 2,224 in ground
+# truth, clusters up to 96, precision 0.068. It cleared the old `< 0.01`
+# cardinality floor 29x over (ratio 0.29), because that floor only rejects
+# NEAR-CONSTANT columns; an identity claim needs cardinality near 1.0.
+_DOMAIN_IDENTITY_WEIGHT = 1.0
+# Belt-and-braces on top of the declared weight: even a 1.0-weighted extractor
+# cannot be an identity claim on data where the column is coarse in practice. A
+# real identifier is near-unique; this rejects the degenerate case where an
+# extractor collapses a column on some dataset it was not tuned for.
+_DOMAIN_IDENTITY_MIN_CARDINALITY = 0.5
+
+
+def _is_identity_claim(col: str, weight: float, cardinality_ratio: float) -> bool:
+    """Whether a domain-extracted ``exact`` field may stand alone as its own
+    exact matchkey, versus being folded into the weighted matchkey at its
+    declared weight. See `_DOMAIN_IDENTITY_WEIGHT` for why the weight decides."""
+    if weight < _DOMAIN_IDENTITY_WEIGHT:
+        return False
+    return cardinality_ratio >= _DOMAIN_IDENTITY_MIN_CARDINALITY
+
 
 # Free-text col_types where data-entry corruption is common and `token_sort`
 # (word-order-robust but character-noise-fragile) underperforms. Surfaced by the
@@ -5072,8 +5103,13 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
             if scorer == "exact" and cardinality_ratio < 0.01:
                 continue
             mf = MatchkeyField(field=col, scorer=scorer, weight=weight, transforms=transforms)
-            if scorer == "exact":
+            if scorer == "exact" and _is_identity_claim(col, weight, cardinality_ratio):
                 domain_exact.append(mf)
+            elif scorer == "exact":
+                # A weak exact signal: still compared, but as a WEIGHTED field
+                # carrying its declared weight -- never as a standalone identity
+                # claim. See `_is_identity_claim`.
+                domain_fuzzy.append(mf)
             else:
                 domain_fuzzy.append(mf)
 

--- a/packages/python/goldenmatch/tests/parity/autoconfig-classification.json
+++ b/packages/python/goldenmatch/tests/parity/autoconfig-classification.json
@@ -49,18 +49,11 @@
               "lowercase",
               "strip"
             ]
-          }
-        ]
-      },
-      {
-        "name": "domain_exact_title_key",
-        "type": "exact",
-        "threshold": 0.5,
-        "fields": [
+          },
           {
             "field": "__title_key__",
-            "scorer": null,
-            "weight": null,
+            "scorer": "exact",
+            "weight": 0.8,
             "transforms": [
               "lowercase"
             ]

--- a/packages/python/goldenmatch/tests/test_domain_identity_claim_2526.py
+++ b/packages/python/goldenmatch/tests/test_domain_identity_claim_2526.py
@@ -1,0 +1,78 @@
+"""#2526: a domain-extracted `exact` field is an identity claim only if it is
+actually an identifier.
+
+A STANDALONE exact matchkey asserts "same value implies same entity" on its own,
+with nothing else consulted. `_DOMAIN_SCORER_MAP` already records how much each
+derived column is worth -- 1.0 for identifiers (`__model_norm__`,
+`__sw_part_num__`), lower for partial signals (`__color__` 0.2, `__title_key__`
+0.8) -- and that weight used to be read and then discarded when the standalone
+matchkey was built, so every exact entry made a full-strength claim regardless.
+
+Measured on DBLP-ACM: `__title_key__` is the first significant WORD of the title,
+so the emitted `domain_exact_title_key` asserted 33,563 pairs against 2,224 in
+ground truth (precision 0.068, clusters up to 96). It cleared the old
+`< 0.01` cardinality floor 29x over, because that floor only rejects
+NEAR-CONSTANT columns.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.autoconfig import (
+    _DOMAIN_IDENTITY_MIN_CARDINALITY,
+    _DOMAIN_IDENTITY_WEIGHT,
+    _DOMAIN_SCORER_MAP,
+    _is_identity_claim,
+)
+
+
+class TestIsIdentityClaim:
+    def test_identifier_weight_and_high_cardinality_stands_alone(self):
+        assert _is_identity_claim("__model_norm__", 1.0, 0.95) is True
+
+    @pytest.mark.parametrize("weight", [0.2, 0.3, 0.5, 0.8, 0.99])
+    def test_sub_identifier_weight_never_stands_alone(self, weight):
+        # Even at cardinality 1.0: the weight is the author's statement that this
+        # is a partial signal, and a partial signal is not an identity claim.
+        assert _is_identity_claim("__whatever__", weight, 1.0) is False
+
+    def test_identifier_weight_with_collapsed_cardinality_does_not_stand_alone(self):
+        # Belt-and-braces: a 1.0-weighted extractor that collapses on data it was
+        # not tuned for is not an identifier ON THIS DATA.
+        assert _is_identity_claim("__model_norm__", 1.0, 0.01) is False
+
+    def test_the_dblp_acm_case_is_rejected(self):
+        # __title_key__ measured on DBLP-ACM: weight 0.8, 1427 distinct over 4910.
+        weight = _DOMAIN_SCORER_MAP["__title_key__"][1]
+        assert _is_identity_claim("__title_key__", weight, 1427 / 4910) is False
+
+    def test_old_cardinality_floor_would_have_accepted_it(self):
+        # The regression guard: 0.29 clears a 0.01 floor by 29x, which is why the
+        # old check passed it through. Locks in WHY the criterion changed, so a
+        # future "simplify back to a cardinality floor" has to confront it.
+        assert (1427 / 4910) > 0.01
+        assert (1427 / 4910) < _DOMAIN_IDENTITY_MIN_CARDINALITY
+
+
+class TestDomainScorerMapContract:
+    def test_every_exact_entry_declares_a_weight(self):
+        for col, (scorer, weight, _transforms) in _DOMAIN_SCORER_MAP.items():
+            if scorer == "exact":
+                assert isinstance(weight, (int, float)), col
+                assert 0.0 < weight <= _DOMAIN_IDENTITY_WEIGHT, col
+
+    def test_the_known_identifiers_still_qualify(self):
+        # These are the columns whose standalone-exact behaviour must NOT change:
+        # genuine identifiers in the electronics / software domain packs.
+        for col in ("__model__", "__model_norm__", "__sw_part_num__"):
+            scorer, weight, _ = _DOMAIN_SCORER_MAP[col]
+            assert scorer == "exact", col
+            assert _is_identity_claim(col, weight, 0.9) is True, col
+
+    def test_the_known_partial_signals_do_not(self):
+        # Each of these would otherwise assert e.g. "same colour implies same
+        # product" as a standalone matchkey.
+        for col in ("__color__", "__sw_edition__", "__sw_platform__",
+                    "__sw_version__", "__title_key__"):
+            scorer, weight, _ = _DOMAIN_SCORER_MAP[col]
+            assert scorer == "exact", col
+            assert _is_identity_claim(col, weight, 0.9) is False, col


### PR DESCRIPTION
## What and why

Closes the precision half of #2526.

Auto-config promoted **every** `exact` entry in `_DOMAIN_SCORER_MAP` to its own standalone exact matchkey - "same value implies same entity", on its own, with nothing else consulted. On DBLP-ACM that produced `domain_exact_title_key` over `__title_key__`, which is the first significant **word** of the title (`core/domain.py:410-426`). So zero-config asserted that two papers whose titles start with the same word are the same paper.

| | |
|---|---|
| distinct `__title_key__` values | 1427 over 4910 titles |
| records sharing a key with >=1 other | 4684 (**95.4%**) |
| pairs the exact matchkey asserts | **33,563** |
| ground-truth pairs | 2,224 |

Top keys: `efficient` (104 records), `data` (96), `database` (86), `query` (58).

```
F1 0.1277   P 0.0684   R 0.9505    fp 28,770 vs tp 2,114    largest cluster 96
```

## Two mechanisms, same block (`core/autoconfig.py:5059-5086`)

**1. The eligibility floor was calibrated for the wrong failure mode.** `cardinality_ratio < 0.01` only rejects *near-constant* columns. `__title_key__` sits at 0.29 and cleared it by 29x. An identity claim needs cardinality near 1.0 - compare the neighbouring guard that rejects `id` at ratio >= 1.0 as a "perfectly-unique surrogate key", and geo/zip as "a blocking signal, not an identity claim". `__title_key__` is squarely the latter and never got the label.

**2. The declared confidence weight was discarded exactly where it decides behaviour.** `_DOMAIN_SCORER_MAP` carries a weight per column - the author's own statement of how much the signal is worth:

```python
"__color__":       ("exact", 0.2, ...)    # a weak partial signal
"__sw_edition__":  ("exact", 0.3, ...)
"__sw_version__":  ("exact", 0.5, ...)
"__title_key__":   ("exact", 0.8, ...)
"__model_norm__":  ("exact", 1.0, ...)    # a genuine identifier
"__sw_part_num__": ("exact", 1.0, ...)
```

It is read at `:5065`, attached at `:5075`, then dropped at `:5085`, which rebuilds the field as `MatchkeyField(field=..., transforms=...)`. So every exact entry became a full-strength standalone identity claim regardless. `__color__` at 0.2 would have asserted "same colour implies same product".

## The fix

Use the metadata already present rather than inventing a threshold. A domain `exact` field stands alone only when its declared weight says it is an identifier (1.0) **and** its cardinality agrees (>= 0.5 - belt-and-braces for an extractor collapsing on data it was not tuned for). Anything weaker folds into the weighted matchkey **at its declared weight**: still compared, just not trusted alone.

Measured on DBLP-ACM zero-config:

| | F1 | P | R | largest cluster |
|---|---|---|---|---|
| before | 0.1277 | 0.0684 | 0.9505 | 96 |
| **after** | **0.4593** | 0.3010 | 0.9690 | 43 |
| (for comparison) deleting the matchkey outright | 0.2815 | 0.4878 | 0.1978 | 14 |

Retaining the signal at its declared weight beats deleting it - recall improves too (0.9505 -> 0.9690), because the key still contributes instead of being all-or-nothing.

## Genuine identifiers are unaffected - demonstrated, not argued

The risk this change carries is to the electronics/software domains that legitimately use `domain_exact`. The autoconfig parity pin covers `abt_buy`, which exercises `__model__` / `__model_norm__` at weight 1.0, so it answers the question directly: **both remain standalone exact matchkeys.** The criterion did what it claims.

`abt_buy`'s pin *did* show other diffs, so I ran a control - re-pinning all three datasets against clean-main `autoconfig.py`, then again against this branch:

| dataset | clean main | this branch | attribution |
|---|---|---|---|
| `dblp_acm` | UNCHANGED | CHANGED | **this PR** |
| `abt_buy` | CHANGED | CHANGED, identically | **pre-existing drift** |
| `ncvr_10k` | not regenerable here | not regenerable here | untouched |

So only `dblp_acm` is re-blessed, and the re-pin script *asserts* the other two entries are byte-identical rather than rewriting them. `abt_buy`'s drift is real - `threshold` null -> 0.5 on both exact matchkeys, `description` dropped from `fuzzy_match`, and a blocking change - but it predates this branch. Re-blessing it here would launder an unrelated change through this PR, so it is filed separately.

Worth flagging for that follow-up: `abt_buy`'s controller stops on `stop_reason=BUDGET_TIME` after a ~480s iteration, so its pinned output is partly a function of machine speed. A parity pin over a time-budgeted controller is not reproducible across hosts, which is the likely reason it drifted unnoticed.

Note also what the pin was doing before this PR: it recorded `domain_exact_title_key` as expected output. The gate had **blessed the defect**.

## Scope, stated plainly

This does **not** close the DBLP-ACM gap to the ~0.92 that configured runs reach. The remainder is a separate *recall* problem which the controller already reports (`stop_reason=BUDGET_ITERATIONS`, `failing_subprofile=scoring`, best-effort RED). I would rather split that out than let one issue quietly become two, so #2526 keeps it.

Also unchanged here: `dblp_acm` and `historical_50k` are still `(NEW)` in `scripts/suggest_quality/baselines/scorecard.json`, so none of these numbers are gated. Re-blessing should follow the recall work, not precede it - blessing 0.4593 now would lock in a number that is still known-bad.

## Testing

- Autoconfig + domain + product suites: **739 passed, 5 skipped, 1 failed**. The one failure was `test_autoconfig_parity_pins_unchanged`, i.e. the pin recording the old behaviour; re-pinned in `523d6a896` after the control run above. Nothing else in the autoconfig or domain surface moved.
- `test_autoconfig_parity_pins_unchanged` + the new `test_domain_identity_claim_2526.py`: **13 passed**.
- DBLP-ACM zero-config A/B above, via `scripts.suggest_quality` datasets and `evaluate_clusters` against ground truth.
- `ruff check packages/python/goldenmatch` clean; `check_context_budget.py` OK; codemap regenerated (no drift).
- `synthetic_benchmarks` (the #528 clean-precision gate) and `quality_gate` are both in `ci-required` and both exercise auto-config, so CI is a real check on this rather than a formality.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed
- [ ] `pre-commit run --all-files` - not run in full; ruff + context-budget + codemap gates run individually and are clean