### PR TITLE
feat(semantic): ontology layer — deeper consume + certification report + reconciliation

### DIFF
--- a/context-network/decisions/0054-ontology-layer-consume-audit.md
+++ b/context-network/decisions/0054-ontology-layer-consume-audit.md
@@ -1,0 +1,63 @@
+# 0054 — Ontology layer, part 2: deeper consume + certification report + reconciliation
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch.semantic.ontology.{effective_has_keys, certify_ontology, asserted_sameas_pairs, reconcile_ontology_identity}` + `OntologyCertification`/`OntologyReconciliation`; `OntologyClass` gains `parents` + `max_one_properties` • **Builds on:** [0053 (ontology v1)](0053-ontology-layer-rdf-owl-provider.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+ADR 0053 shipped the ontology layer as a v1 bidirectional adapter (consume
+declared keys + certify + emit `owl:sameAs`/PROV-O/SHACL). It was honest about
+being a floor. This is the first of two flesh-out ADRs, deepening the **read /
+audit** side to the depth the semantic layer reached (`certify_semantic_model`,
+`reconcile_model`). ADR 0055 will do the **produce / generate** side.
+
+## Decision
+1. **Deeper parse — inherit keys, read cardinality restrictions.**
+   `parse_ontology` now records each class's named `rdfs:subClassOf` `parents`
+   and, from blank-node `owl:Restriction`s with `owl:onProperty` + a cardinality
+   of 1, its `max_one_properties` (single-valued signals). `effective_has_keys`
+   resolves a class's `owl:hasKey` axioms **including those inherited from
+   ancestors** (a subclass IS identified by its superclass's key), cycle-safe;
+   `ontology_identity_keys` surfaces inherited keys tagged `owl:hasKey(inherited)`.
+2. **Whole-ontology certification report.** `certify_ontology(onto, frames) ->
+   OntologyCertification` certifies every declared identity key and rolls the
+   per-key certificates into one verdict (`all_safe`, `n_unsafe`, per-key
+   `estimate`/`max_fan_out`/`is_unique`), with `to_dict()` — the ontology-layer
+   analogue of `certification_report_dict`. It REUSES `certify_ontology_keys`
+   (→ the wedge-A certifier); it does not fork a second validator.
+3. **Reconciliation — asserted vs resolved identity.** `asserted_sameas_pairs`
+   reads the ontology's ABox `owl:sameAs` links; `reconcile_ontology_identity(
+   source, crosswalk)` diffs them against a wedge-B `ResolvedCrosswalk` and
+   returns an `OntologyReconciliation` flagging **over-merges** (asserted same,
+   resolved different — the exact-match IFP/`sameAs` over-merged) and
+   **fragmentations** (resolved same, never asserted — identity the ontology
+   missed), plus `agreements`. `iri_for` maps a crosswalk record to its individual
+   IRI, defaulting to `emit_sameas_graph`'s scheme so the two compose.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — certification reuses the single key-integrity
+  certifier; reconciliation is a partition diff over the control plane's resolved
+  ids vs the ontology's asserted `sameAs`. No new identity semantics, no reasoner.
+- **Conformance defines correctness** ✅ — reads the real OWL axioms
+  (`hasKey`/`subClassOf`/restrictions/`sameAs`); certification IS the falsification
+  test the whole arc is built on.
+- **Arrow at bulk boundaries** ✅ — ontology docs are small metadata; the frames
+  certified are Arrow.
+
+## Consequences / honest flags
+- **Reconciliation is a structural partition diff, not CCMS.** It reports the
+  actionable IRI-pairs (over-merge / fragmentation bridges) rather than a TWI
+  number; `core/compare_clusters.py` remains available for a scalar summary.
+- **Fragmentation is reported at component granularity** — one bridge pair per
+  extra asserted-component a resolved entity spans (bounded by component count),
+  not every within-entity pair. `max_examples` caps both lists with a `note`.
+- **Cardinality restrictions are parsed but advisory** — `max_one_properties`
+  records a single-valued signal (`owl:maxCardinality`/`cardinality` = 1); it is
+  not yet folded into the certification verdict (a functional-property fan-out
+  check is a candidate follow-on). Qualified-cardinality variants are read.
+- **Still-deferred to 0055:** richer emit (`rdf:type` to classes, per-class SHACL
+  from a parsed ontology) and ontology discovery (draft OWL from data + crosswalk,
+  keys pre-graded). CLI/MCP front door remains deferred (parity surface).
+- **`rdflib`-gated** — tests run in the required `python_goldenmatch` lane via the
+  `[ontology]` extra (per 0053's follow-on).
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -8,17 +8,23 @@
 > [0052](../decisions/0052-cube-dialect-and-osi-validation.md) (Cube dialect +
 > OSI validation) +
 > [0053](../decisions/0053-ontology-layer-rdf-owl-provider.md) (ontology layer:
-> RDF/OWL/SHACL native identity provider).
+> RDF/OWL/SHACL native identity provider) +
+> [0054](../decisions/0054-ontology-layer-consume-audit.md) (deeper consume +
+> certification report + reconciliation).
 >
-> **Ontology layer (0053)** — the semantic-layer thesis one level up (TBox/ABox):
-> an ontology *asserts* identity (`owl:hasKey`, `owl:InverseFunctionalProperty`,
-> `owl:sameAs`) but resolves it only by brittle exact-match. `parse_ontology` +
-> `ontology_identity_keys` (consume the declared identifying keys),
-> `certify_ontology_keys` (bridge to A — certify exactly those keys),
+> **Ontology layer (0053 + 0054)** — the semantic-layer thesis one level up
+> (TBox/ABox): an ontology *asserts* identity (`owl:hasKey`,
+> `owl:InverseFunctionalProperty`, `owl:sameAs`) but resolves it only by brittle
+> exact-match. `parse_ontology` + `ontology_identity_keys` (consume the declared
+> identifying keys, with `owl:hasKey` inheritance down `rdfs:subClassOf`),
+> `certify_ontology_keys` / `certify_ontology` (bridge to A — certify exactly those
+> keys, whole-ontology roll-up), `reconcile_ontology_identity` (diff asserted
+> `owl:sameAs` vs resolved identity — over-merge / fragmentation),
 > `emit_sameas_graph` (bridge to B — `owl:sameAs` + PROV-O), `emit_identity_shacl`
 > (conformance shape). `rdflib` optional (`goldenmatch[ontology]`); GoldenMatch is
 > the identity provider FOR the reasoner/triple store, never a reimplementation of
-> one.
+> one. **Still open (0055):** richer emit (`rdf:type` + per-class SHACL) + ontology
+> discovery (draft OWL from data + crosswalk).
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7600,17 +7600,24 @@
           "purpose": "Ontology-layer (RDF / OWL / SHACL) native identity provider.",
           "defines": [
             "Ontology",
+            "OntologyCertification",
             "OntologyClass",
             "OntologyProperty",
+            "OntologyReconciliation",
+            "_components",
             "_crosswalk_rows",
             "_load_graph",
             "_local",
             "_require_rdflib",
+            "asserted_sameas_pairs",
+            "certify_ontology",
             "certify_ontology_keys",
+            "effective_has_keys",
             "emit_identity_shacl",
             "emit_sameas_graph",
             "ontology_identity_keys",
-            "parse_ontology"
+            "parse_ontology",
+            "reconcile_ontology_identity"
           ],
           "imports": [
             "goldenmatch.semantic.key_integrity"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -1234,6 +1234,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Ontology layer, deeper consume + audit (`goldenmatch.semantic.ontology`).**
+  Builds on the v1 provider: `parse_ontology` now inherits `owl:hasKey` down
+  `rdfs:subClassOf` (`effective_has_keys`) and reads cardinality-1 restrictions;
+  `certify_ontology` rolls every declared identity key into one
+  `OntologyCertification` verdict (the analogue of `certify_semantic_model`); and
+  `reconcile_ontology_identity` diffs the ontology's asserted `owl:sameAs`
+  (`asserted_sameas_pairs`) against a GoldenMatch `ResolvedCrosswalk`, flagging
+  where exact-match identity **over-merged** (asserted same, resolved different)
+  or **fragmented** (resolved same, never asserted). Reuses the key-integrity
+  certifier; no reasoner. See ADR 0054.
 
 - **Registry-introspection tools/skills on MCP + A2A (TS-parity).** `list_scorers`,
   `list_transforms`, and `list_strategies` are now exposed on the Python MCP server

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -105,13 +105,19 @@ from goldenmatch.semantic.metricflow import (
 )
 from goldenmatch.semantic.ontology import (
     Ontology,
+    OntologyCertification,
     OntologyClass,
     OntologyProperty,
+    OntologyReconciliation,
+    asserted_sameas_pairs,
+    certify_ontology,
     certify_ontology_keys,
+    effective_has_keys,
     emit_identity_shacl,
     emit_sameas_graph,
     ontology_identity_keys,
     parse_ontology,
+    reconcile_ontology_identity,
 )
 from goldenmatch.semantic.osi import (
     OsiDataset,
@@ -197,12 +203,18 @@ __all__ = [
     # ontology layer — RDF/OWL/SHACL native identity provider (bidirectional)
     "parse_ontology",
     "ontology_identity_keys",
+    "effective_has_keys",
     "certify_ontology_keys",
+    "certify_ontology",
+    "asserted_sameas_pairs",
+    "reconcile_ontology_identity",
     "emit_sameas_graph",
     "emit_identity_shacl",
     "Ontology",
     "OntologyClass",
     "OntologyProperty",
+    "OntologyCertification",
+    "OntologyReconciliation",
     # semantic-model discovery (Phase 1) — certified key discovery per table
     "discover_keys",
     "KeyCandidate",

--- a/packages/python/goldenmatch/goldenmatch/semantic/ontology.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/ontology.py
@@ -13,10 +13,15 @@ GoldenMatch owns the ABox identity (which records *are* the same `Patient`).
 Bidirectional, mirroring the OSI wedge:
 
 - **consume** an OWL/RDF ontology to learn the declared identifying keys
-  (`parse_ontology`, `ontology_identity_keys`) and certify exactly those keys
-  against the instance data (`certify_ontology_keys`, bridging wedge A) — the
-  purest form of the wedge, because the ontology hands you the key declaration
-  explicitly (`owl:hasKey` / IFP);
+  (`parse_ontology`, `ontology_identity_keys` — with `owl:hasKey` inheritance
+  down `rdfs:subClassOf`) and certify exactly those keys against the instance
+  data (`certify_ontology_keys` / `certify_ontology` for the whole-ontology
+  roll-up, bridging wedge A) — the purest form of the wedge, because the ontology
+  hands you the key declaration explicitly (`owl:hasKey` / IFP);
+- **reconcile** (`reconcile_ontology_identity`) the ontology's ASSERTED identity
+  (its `owl:sameAs` links) against GoldenMatch-resolved identity, flagging where
+  exact-match over-merged (asserted same, resolved different) or fragmented
+  (resolved same, never asserted);
 - **emit** the resolved identity as RDF (`emit_sameas_graph`, bridging wedge B):
   `owl:sameAs` linking each source individual to its resolved canonical
   individual, with W3C **PROV-O** provenance — point a triple store / reasoner at
@@ -71,6 +76,8 @@ class OntologyClass:
     name: str                             # local name
     iri: str
     has_keys: list[list[str]] = field(default_factory=list)  # owl:hasKey axioms (prop local names)
+    parents: list[str] = field(default_factory=list)         # named rdfs:subClassOf superclasses
+    max_one_properties: list[str] = field(default_factory=list)  # props with a max/exact cardinality-1 restriction
     label: str | None = None
     comment: str | None = None
 
@@ -131,6 +138,11 @@ def parse_ontology(source: str | Any, *, fmt: str | None = None) -> Ontology:
         v = g.value(node, RDFS.comment)
         return str(v) if v is not None else None
 
+    # cardinality predicates whose value 1 makes a property single-valued (a
+    # functional/identity signal) when it sits in an owl:Restriction on a class.
+    _CARD_PREDS = (OWL.maxCardinality, OWL.cardinality,
+                   OWL.maxQualifiedCardinality, OWL.qualifiedCardinality)
+
     classes: list[OntologyClass] = []
     for c in g.subjects(RDF.type, OWL.Class):
         if not isinstance(c, URIRef):
@@ -140,8 +152,22 @@ def parse_ontology(source: str | Any, *, fmt: str | None = None) -> Ontology:
             props = [_local(p) for p in Collection(g, key_node) if isinstance(p, URIRef)]
             if props:
                 has_keys.append(props)
+        # rdfs:subClassOf: a named superclass is a parent (key inheritance); a
+        # blank-node owl:Restriction with cardinality 1 marks a single-valued prop.
+        parents: list[str] = []
+        max_one: list[str] = []
+        for sup in g.objects(c, RDFS.subClassOf):
+            if isinstance(sup, URIRef):
+                parents.append(_local(sup))
+            elif (sup, RDF.type, OWL.Restriction) in g:
+                prop = g.value(sup, OWL.onProperty)
+                if isinstance(prop, URIRef) and any(
+                    str(g.value(sup, cp)) == "1" for cp in _CARD_PREDS if g.value(sup, cp) is not None
+                ):
+                    max_one.append(_local(prop))
         classes.append(OntologyClass(
             name=_local(c), iri=str(c), has_keys=has_keys,
+            parents=parents, max_one_properties=max_one,
             label=_label(c), comment=_comment(c),
         ))
 
@@ -173,18 +199,44 @@ def parse_ontology(source: str | Any, *, fmt: str | None = None) -> Ontology:
     return Ontology(iri=onto_iri, classes=classes, properties=list(props.values()))
 
 
+def effective_has_keys(onto: Ontology, class_name: str) -> list[list[str]]:
+    """A class's `owl:hasKey` axioms INCLUDING those inherited from its (transitive)
+    `rdfs:subClassOf` ancestors — a subclass is identified by its superclass's key.
+    Cycle-safe; preserves order (own keys first)."""
+    by_name = {c.name: c for c in onto.classes}
+    keys: list[list[str]] = []
+    seen: set[str] = set()
+    stack = [class_name]
+    while stack:
+        n = stack.pop(0)
+        if n in seen:
+            continue
+        seen.add(n)
+        c = by_name.get(n)
+        if c is None:
+            continue
+        for k in c.has_keys:
+            if k not in keys:
+                keys.append(k)
+        stack.extend(c.parents)
+    return keys
+
+
 def ontology_identity_keys(onto: Ontology) -> list[dict[str, Any]]:
     """The ontology's DECLARED identifying keys — what GoldenMatch should resolve.
 
     One entry per declared key: `{class, key, source}` where `source` is
-    `owl:hasKey` (composite, class-scoped) or `owl:InverseFunctionalProperty`
-    (single-property, mapped to the property's `rdfs:domain` class). An IFP with
-    no domain is surfaced with `class=None` (it identifies individuals globally).
+    `owl:hasKey` (or `owl:hasKey(inherited)` for a key inherited from a
+    superclass) or `owl:InverseFunctionalProperty` (single-property, mapped to the
+    property's `rdfs:domain` class). An IFP with no domain is surfaced with
+    `class=None` (it identifies individuals globally).
     """
     out: list[dict[str, Any]] = []
     for c in onto.classes:
-        for key in c.has_keys:
-            out.append({"class": c.name, "key": list(key), "source": "owl:hasKey"})
+        own = {tuple(k) for k in c.has_keys}
+        for key in effective_has_keys(onto, c.name):
+            source = "owl:hasKey" if tuple(key) in own else "owl:hasKey(inherited)"
+            out.append({"class": c.name, "key": list(key), "source": source})
     for p in onto.properties:
         if not p.inverse_functional:
             continue
@@ -224,6 +276,198 @@ def certify_ontology_keys(onto: Ontology | str | Any, frames: dict[str, Any]) ->
             "certificate": cert,
         })
     return out
+
+
+@dataclass
+class OntologyCertification:
+    """A roll-up of certifying every declared identity key of an ontology — the
+    ontology-layer analogue of `certify_semantic_model`'s report. `all_safe` is
+    True only when at least one key was certified and every one is unique."""
+
+    ontology_iri: str | None
+    keys: list[dict[str, Any]]           # {class, key, source, estimate, max_fan_out, is_unique, certificate}
+    n_keys: int
+    n_unsafe: int
+    all_safe: bool
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ontology_iri": self.ontology_iri,
+            "n_keys": self.n_keys,
+            "n_unsafe": self.n_unsafe,
+            "all_safe": self.all_safe,
+            "keys": [{k: v for k, v in e.items() if k != "certificate"} for e in self.keys],
+            "note": self.note,
+        }
+
+
+def certify_ontology(onto: Ontology | str | Any, frames: dict[str, Any]) -> OntologyCertification:
+    """Certify EVERY declared identity key of an ontology and roll the per-key
+    certificates into one report. Unsafe keys are those whose value is not unique
+    at grain (the ontology's `owl:hasKey`/IFP is exactly the axiom a reasoner
+    trusts, so an unsafe one silently corrupts inference)."""
+    parsed = onto if isinstance(onto, Ontology) else parse_ontology(onto)
+    rows = certify_ontology_keys(parsed, frames)
+    keys: list[dict[str, Any]] = []
+    n_unsafe = 0
+    for r in rows:
+        cert = r["certificate"]
+        is_unique = bool(getattr(cert, "is_unique_at_grain", False))
+        if not is_unique:
+            n_unsafe += 1
+        keys.append({
+            "class": r["class"], "key": r["key"], "source": r["source"],
+            "estimate": cert.estimate, "max_fan_out": cert.max_fan_out,
+            "is_unique": is_unique, "certificate": cert,
+        })
+    note = "" if keys else "no declared key had a matching frame to certify"
+    return OntologyCertification(
+        ontology_iri=parsed.iri, keys=keys, n_keys=len(keys),
+        n_unsafe=n_unsafe, all_safe=(bool(keys) and n_unsafe == 0), note=note,
+    )
+
+
+# --- reconcile: asserted identity vs GoldenMatch-resolved identity ------------
+
+
+def asserted_sameas_pairs(source: str | Any, *, fmt: str | None = None) -> list[tuple[str, str]]:
+    """Every `owl:sameAs` link asserted in an RDF graph, as `(iri_a, iri_b)` — the
+    identity the ontology already claims (its ABox `sameAs`), which reconciliation
+    diffs against GoldenMatch-resolved identity."""
+    _require_rdflib()
+    from rdflib import OWL, URIRef
+
+    g = _load_graph(source, fmt)
+    return [(str(a), str(b)) for a, b in g.subject_objects(OWL.sameAs)
+            if isinstance(a, URIRef) and isinstance(b, URIRef)]
+
+
+def _components(pairs: list[tuple[str, str]]) -> dict[str, str]:
+    """Union-find over `owl:sameAs` pairs -> `{iri: component_representative}`."""
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in pairs:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    return {x: find(x) for x in parent}
+
+
+@dataclass
+class OntologyReconciliation:
+    """The diff between the ontology's ASSERTED identity (`owl:sameAs`) and
+    GoldenMatch's RESOLVED identity (a `ResolvedCrosswalk`).
+
+    - `over_merges`: pairs the ontology asserts `owl:sameAs` but GoldenMatch
+      resolved to DIFFERENT entities (the exact-match IFP/sameAs over-merged);
+    - `fragmentations`: individuals GoldenMatch resolved to the SAME entity that
+      the ontology did NOT link (identity the ontology missed);
+    - `agreements`: asserted-same pairs GoldenMatch confirms.
+    """
+
+    agreements: int
+    over_merges: list[tuple[str, str]]
+    fragmentations: list[tuple[str, str]]
+    n_asserted_links: int
+    n_resolved_records: int
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agreements": self.agreements,
+            "n_over_merges": len(self.over_merges),
+            "n_fragmentations": len(self.fragmentations),
+            "over_merges": [list(p) for p in self.over_merges],
+            "fragmentations": [list(p) for p in self.fragmentations],
+            "n_asserted_links": self.n_asserted_links,
+            "n_resolved_records": self.n_resolved_records,
+            "note": self.note,
+        }
+
+
+def reconcile_ontology_identity(
+    source: str | Any,
+    crosswalk: Any,
+    *,
+    base_iri: str = DEFAULT_BASE_IRI,
+    iri_for: Any = None,
+    resolved_field: str | None = None,
+    fmt: str | None = None,
+    max_examples: int = 100,
+) -> OntologyReconciliation:
+    """Reconcile an ontology's asserted `owl:sameAs` identity against a
+    GoldenMatch `ResolvedCrosswalk`, flagging where exact-match identity
+    over-merged (asserted same, resolved different) or fragmented (resolved same,
+    never asserted). `iri_for(source, source_pk) -> iri` maps a crosswalk record
+    to its ontology individual IRI; the default matches `emit_sameas_graph`'s
+    `{base}record/{source}/{pk}` scheme.
+    """
+    from collections import defaultdict
+    from urllib.parse import quote
+
+    rows, rf = _crosswalk_rows(crosswalk)
+    resolved_field = resolved_field or rf
+    if iri_for is None:
+        def iri_for(src: Any, pk: Any) -> str:
+            return f"{base_iri}record/{quote(str(src), safe='')}/{quote(str(pk), safe='')}"
+
+    resolved: dict[str, Any] = {}
+    for row in rows:
+        rid = row.get(resolved_field)
+        pk = row.get("source_pk")
+        if rid is None or pk is None:
+            continue
+        resolved[iri_for(row.get("source"), pk)] = rid
+
+    asserted = asserted_sameas_pairs(source, fmt=fmt)
+    comp = _components(asserted)
+
+    agreements = 0
+    over: list[tuple[str, str]] = []
+    for a, b in asserted:
+        ra, rb = resolved.get(a), resolved.get(b)
+        if ra is None or rb is None:
+            continue
+        if ra == rb:
+            agreements += 1
+        else:
+            over.append((a, b))
+
+    by_entity: dict[Any, list[str]] = defaultdict(list)
+    for iri, rid in resolved.items():
+        by_entity[rid].append(iri)
+    frag: list[tuple[str, str]] = []
+    for iris in by_entity.values():
+        if len(iris) < 2:
+            continue
+        # one representative per asserted component (unasserted iris are singletons);
+        # >1 representative => GoldenMatch bridged identity the ontology left split.
+        rep_by_comp: dict[Any, str] = {}
+        for iri in iris:
+            rep_by_comp.setdefault(comp.get(iri, ("solo", iri)), iri)
+        reps = list(rep_by_comp.values())
+        for other in reps[1:]:
+            frag.append((reps[0], other))
+
+    note = ""
+    if len(over) > max_examples or len(frag) > max_examples:
+        note = f"examples capped at {max_examples}"
+    return OntologyReconciliation(
+        agreements=agreements,
+        over_merges=over[:max_examples],
+        fragmentations=frag[:max_examples],
+        n_asserted_links=len(asserted),
+        n_resolved_records=len(resolved),
+        note=note,
+    )
 
 
 # --- emit (produce) ----------------------------------------------------------

--- a/packages/python/goldenmatch/tests/test_ontology.py
+++ b/packages/python/goldenmatch/tests/test_ontology.py
@@ -12,11 +12,15 @@ pytest.importorskip("rdflib")
 
 from goldenmatch.semantic import (  # noqa: E402
     Ontology,
+    asserted_sameas_pairs,
+    certify_ontology,
     certify_ontology_keys,
+    effective_has_keys,
     emit_identity_shacl,
     emit_sameas_graph,
     ontology_identity_keys,
     parse_ontology,
+    reconcile_ontology_identity,
 )
 
 # A real-shaped OWL ontology in Turtle: a Patient class with a composite
@@ -140,3 +144,109 @@ def test_emit_identity_shacl_asserts_single_resolved_key():
     # the property shape pins the resolved key to exactly one value
     assert any(int(o) == 1 for o in g.objects(predicate=SH.minCount))
     assert any(int(o) == 1 for o in g.objects(predicate=SH.maxCount))
+
+
+# --- PR1: deeper consume + certification report + reconciliation --------------
+
+# Patient is a subclass of Person; Person carries the owl:hasKey, and a
+# cardinality-1 restriction marks mrn single-valued on Patient.
+_TTL_INHERIT = """
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <https://example.org/clinic#> .
+
+ex:Person a owl:Class ;
+    owl:hasKey ( ex:ssn ) .
+
+ex:Patient a owl:Class ;
+    rdfs:subClassOf ex:Person ;
+    rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ex:mrn ; owl:maxCardinality 1 ] .
+"""
+
+
+def test_subclass_inherits_haskey():
+    onto = parse_ontology(_TTL_INHERIT)
+    patient = next(c for c in onto.classes if c.name == "Patient")
+    assert patient.parents == ["Person"]
+    # the composite (here single) key is inherited from Person
+    assert effective_has_keys(onto, "Patient") == [["ssn"]]
+    # ...and surfaces as an identity key tagged inherited
+    keys = {(k["class"], tuple(k["key"]), k["source"]) for k in ontology_identity_keys(onto)}
+    assert ("Patient", ("ssn",), "owl:hasKey(inherited)") in keys
+    assert ("Person", ("ssn",), "owl:hasKey") in keys
+
+
+def test_cardinality_one_restriction_parsed():
+    onto = parse_ontology(_TTL_INHERIT)
+    patient = next(c for c in onto.classes if c.name == "Patient")
+    assert patient.max_one_properties == ["mrn"]
+
+
+def test_certify_ontology_rolls_up_safe_and_unsafe():
+    onto = parse_ontology(_TTL)  # Patient: hasKey(firstName,lastName,birthDate) + mrn/ssn IFPs
+    frames = {"Patient": pa.table({
+        "mrn": ["m1", "m1", "m2"],       # duplicate -> unsafe
+        "ssn": ["a", "b", "c"],          # unique -> safe
+        "firstName": ["Bob", "Bob", "Amy"],
+        "lastName": ["Smith", "Smith", "Jones"],
+        "birthDate": ["1990-01-01", "1990-01-01", "1985-05-05"],
+    })}
+    report = certify_ontology(onto, frames)
+    assert report.n_keys == 3 and report.n_unsafe >= 1
+    assert report.all_safe is False
+    d = report.to_dict()
+    assert d["n_keys"] == 3 and "certificate" not in d["keys"][0]
+    mrn = next(k for k in report.keys if k["key"] == ["mrn"])
+    assert mrn["is_unique"] is False
+
+
+def test_certify_ontology_all_safe_when_every_key_unique():
+    onto = parse_ontology(_TTL)
+    frames = {"Patient": pa.table({
+        "mrn": ["m1", "m2", "m3"], "ssn": ["a", "b", "c"],
+        "firstName": ["A", "B", "C"], "lastName": ["x", "y", "z"],
+        "birthDate": ["2000-01-01", "2000-01-02", "2000-01-03"],
+    })}
+    report = certify_ontology(onto, frames)
+    assert report.all_safe is True and report.n_unsafe == 0
+
+
+class _RXW:
+    """Crosswalk: 4 crm records -> entities e1 (1,2,3) and e2 (4)."""
+    resolved_key = "resolved_entity_id"
+
+    def to_arrow(self):
+        return pa.table({
+            "source": ["crm"] * 4,
+            "source_pk": ["1", "2", "3", "4"],
+            "resolved_entity_id": ["e1", "e1", "e1", "e2"],
+        })
+
+
+_ASSERTED = """
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+<https://ex.test/id/record/crm/1> owl:sameAs <https://ex.test/id/record/crm/2> .
+<https://ex.test/id/record/crm/3> owl:sameAs <https://ex.test/id/record/crm/4> .
+"""
+
+
+def test_asserted_sameas_pairs_reads_links():
+    pairs = asserted_sameas_pairs(_ASSERTED)
+    assert ("https://ex.test/id/record/crm/1", "https://ex.test/id/record/crm/2") in pairs
+    assert len(pairs) == 2
+
+
+def test_reconcile_flags_over_merge_and_fragmentation():
+    rec = reconcile_ontology_identity(_ASSERTED, _RXW(), base_iri="https://ex.test/id/")
+    # (1,2): asserted same, both resolved e1 -> agreement
+    assert rec.agreements == 1
+    # (3,4): asserted same but e1 != e2 -> over-merge
+    assert rec.over_merges == [("https://ex.test/id/record/crm/3",
+                                "https://ex.test/id/record/crm/4")]
+    # e1 spans the {1,2} component and the unasserted 3 -> fragmentation bridge
+    assert rec.fragmentations == [("https://ex.test/id/record/crm/1",
+                                   "https://ex.test/id/record/crm/3")]
+    assert rec.n_asserted_links == 2 and rec.n_resolved_records == 4
+    d = rec.to_dict()
+    assert d["agreements"] == 1 and d["n_over_merges"] == 1 and d["n_fragmentations"] == 1


### PR DESCRIPTION
## What and why

Part 2 of the ontology flesh-out (**ADR 0054**) — the **read / audit** side,
bringing the ontology layer to the depth the semantic layer reached
(`certify_semantic_model`, `reconcile_model`). (Part 3, ADR 0055, will do the
produce/generate side: richer emit + ontology discovery.)

## Changes

- **Deeper parse** — `parse_ontology` now inherits `owl:hasKey` down
  `rdfs:subClassOf` (`effective_has_keys`; a subclass IS identified by its
  superclass's key, surfaced tagged `owl:hasKey(inherited)`) and reads
  cardinality-1 `owl:Restriction`s into `OntologyClass.max_one_properties`
  (single-valued signals). `OntologyClass` gains `parents` + `max_one_properties`.
- **Whole-ontology certification report** — `certify_ontology(onto, frames) ->
  OntologyCertification` rolls every declared identity key into one verdict
  (`all_safe`, `n_unsafe`, per-key `estimate`/`max_fan_out`/`is_unique`, `to_dict()`).
  Reuses the wedge-A certifier; no second validator.
- **Reconciliation** — `asserted_sameas_pairs` reads the ontology's `owl:sameAs`;
  `reconcile_ontology_identity(source, crosswalk) -> OntologyReconciliation` diffs
  it against a `ResolvedCrosswalk`, flagging **over-merges** (asserted same,
  resolved different) and **fragmentations** (resolved same, never asserted), plus
  `agreements`. `iri_for` defaults to `emit_sameas_graph`'s scheme so they compose.

Library-only, advisory, parity-free; `rdflib` stays optional and lazy-imported.

## Testing

- `pytest tests/test_ontology.py tests/test_osi.py tests/test_cube.py` → **40 passed** (6 new ontology tests: inheritance, cardinality-1 parse, certify roll-up safe/unsafe, `asserted_sameas_pairs`, reconciliation over-merge+fragmentation+agreement)
- `ruff check goldenmatch/semantic/` → clean
- `check_docs_consistency.py` → all PASS; `gen_config_matrix.py --check` → OK (no new env vars); `test_agent_codemap.py::test_codemap_current` → pass (regenerated)
- The ontology tests run for real in the required `python_goldenmatch` lane (`[ontology]` extra, per ADR 0053's follow-on)

## Checklist

- [x] Tests added/updated and passing locally
- [x] `ruff` clean; doc gates green
- [x] `CHANGELOG.md` updated (`[Unreleased]` / Added)
- [x] Decision record added (ADR 0054) + planning-doc status
- [x] No secrets/tokens committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_