### PR TITLE
ci(spark): test the arc's claim on a REAL cluster, not local[*]

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -330,10 +330,27 @@ jobs:
           python -m pytest -v --timeout=600 --timeout-method=thread \
             packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py \
             packages/python/goldenmatch/tests/test_spark_jvm_parity.py \
-            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_jvm_scoring_matches_the_python_path_exactly' \
-            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \
-            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \
-            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path'
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_jvm_scoring_matches_the_python_path_exactly' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path' \
+            | tee pytest.out && rc=0 || rc=$?
+          # pytest IGNORES a --deselect that matches nothing, so a wrong node id
+          # means the tests simply RUN. That is how run 6 failed: the ids were
+          # repo-root-relative while pytest's rootdir is
+          # packages/python/goldenmatch (its pyproject.toml is the configfile),
+          # so the real ids start at `tests/`. Nothing warned; the four just ran
+          # and failed, reading like a defect in the scoring path.
+          #
+          # Checked BEFORE propagating pytest's exit code, so that when the ids
+          # drift again this says so instead of the failure looking like a
+          # scoring bug. Hence `rc` capture rather than relying on `set -e`,
+          # which would exit here first and never print the explanation.
+          if ! grep -qE '[0-9]+ deselected' pytest.out; then
+            echo "::error::no tests were deselected. The --deselect node ids no longer match -- pytest's rootdir is packages/python/goldenmatch, so ids start at 'tests/', not 'packages/python/goldenmatch/tests/'. The four two-path tests ran on a cluster that cannot host their Python arm."
+            exit 1
+          fi
+          exit "$rc"
 
       # The inventory against REAL workers. Note there is no
       # GOLDENMATCH_SPARK_PYENV here and that is the point: these containers are

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -32,10 +32,10 @@ on:
   workflow_dispatch:
     inputs:
       spark_image_tag:
-        description: "apache/spark image tag (the client pyspark is pinned to match)"
+        description: "Override the apache/spark image tag (default: match whatever the [spark] extra resolves)"
         required: false
         type: string
-        default: "4.0.0"
+        default: ""
   schedule:
     # Nightly, after the usual working day. Cheap insurance that the topology
     # still works; nothing here gates a merge.
@@ -62,8 +62,9 @@ on:
 permissions:
   contents: read
 
-env:
-  SPARK_IMAGE_TAG: ${{ inputs.spark_image_tag || '4.0.0' }}
+# SPARK_IMAGE_TAG is DERIVED from the resolved client below, not set here. See
+# the install step: the product's `[spark]` extra decides the Spark version, and
+# the cluster follows it.
 
 jobs:
   # The aarch64 half of the jar. Present because `build_spark_jar.sh` REFUSES a
@@ -122,15 +123,43 @@ jobs:
       # the deployment story being tested: one file, from the client, nothing
       # installed on the cluster.
       #
-      # pyspark pinned to the image tag. A client/server version skew across
-      # Connect fails in ways that read like a bug in this repo.
-      - name: Install the client (pyspark pinned to the cluster's version)
+      # Installed UNPINNED, via the extra, exactly as `ci.yml` does and exactly
+      # as a user would -- then the CLUSTER is pinned to whatever that resolved.
+      #
+      # The first version of this lane had it backwards: it pinned the client to
+      # the image tag. That makes the image the source of truth for a version
+      # the product does not choose, so the lane would happily test a Spark no
+      # user of this package runs. It failed immediately and usefully -- pinned
+      # to 4.0.0, which has no `arrow_udf`, so the Python path (the ORACLE every
+      # parity test compares against) could not run at all while the JVM path
+      # was fine.
+      - name: Install the client, then pin the cluster to what it resolved
         run: |
           set -euo pipefail
-          python -m pip install --quiet "pyspark[connect]==${SPARK_IMAGE_TAG}"
           python -m pip install --quiet -e 'packages/python/goldenmatch[spark]'
           python -m pip install --quiet pytest pytest-timeout
-          python -c "import pyspark; print('client pyspark', pyspark.__version__)"
+          V="$(python -c 'import pyspark; print(pyspark.__version__)')"
+          echo "client pyspark: $V"
+          TAG="${{ inputs.spark_image_tag }}"
+          if [ -n "$TAG" ]; then
+            echo "image tag OVERRIDDEN to $TAG (client is $V)"
+          else
+            TAG="$V"
+          fi
+          echo "SPARK_IMAGE_TAG=$TAG" >> "$GITHUB_ENV"
+          # `arrow_udf` is what the tier's Python path is built on, and its
+          # absence is a version problem that surfaces deep inside a UDF rather
+          # than at setup. Check it HERE, where the message can say so.
+          python -c "
+          from pyspark.sql import functions as F
+          import sys
+          if not hasattr(F, 'arrow_udf'):
+              sys.exit('::error::pyspark ' + __import__('pyspark').__version__ +
+                       ' has no arrow_udf. The tier is Arrow-native, so the Python '
+                       'path -- the oracle every parity test compares against -- '
+                       'cannot run. Nothing below would be measuring parity.')
+          print('arrow_udf present')
+          "
 
       - name: Build the jar
         env:
@@ -221,10 +250,38 @@ jobs:
           print(f"OK: executor {exec_id} loaded the native kernel from the shipped jar")
           PY
 
+      # The parity tests need a Python environment on the executors, and that is
+      # not a contradiction -- it is two different questions needing two
+      # different setups, both of which require a real cluster:
+      #
+      #   "Does the JVM path work on real executors, and agree with Python?"
+      #     -> needs BOTH arms runnable, so the oracle must exist. THIS step.
+      #   "Is Python actually unnecessary?"
+      #     -> needs the executors genuinely bare. The inventory step below.
+      #
+      # Running the parity tests bare would not prove the jar-only claim; it
+      # would just delete the oracle and leave the JVM path compared against
+      # nothing. (That is what the first run did, by accident.)
+      - name: Pack a runtime venv for the executors (the parity ORACLE)
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/gmenv
+          /tmp/gmenv/bin/pip install --quiet --upgrade pip
+          # pyarrow named explicitly: the tier's UDFs are `arrow_udf` over
+          # `pa.Array`, so the worker contract is stated rather than transitive.
+          # NO pandas -- ci.yml gates on its absence and the reason holds here.
+          /tmp/gmenv/bin/pip install --quiet ./packages/python/goldenmatch pyarrow
+          venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
+          ls -lh gm_env.tar.gz
+
       - name: JVM parity + scoring, on the cluster
         env:
           GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+          # The `spark` fixture ships this to the executors -- its own comment
+          # notes that real Spark forks a Python worker with its own
+          # environment, which is the failure class `local[*]` cannot show.
+          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
         run: |
           set -euo pipefail
           python -m pytest -v --timeout=600 --timeout-method=thread \

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -262,16 +262,42 @@ jobs:
       # Running the parity tests bare would not prove the jar-only claim; it
       # would just delete the oracle and leave the JVM path compared against
       # nothing. (That is what the first run did, by accident.)
-      - name: Pack a runtime venv for the executors (the parity ORACLE)
+      # Built INSIDE the executor image, not on the runner.
+      #
+      # The first attempt built it on the runner with venv-pack, exactly as
+      # `ci.yml` does, and every executor died with:
+      #
+      #   Cannot run program "./environment/bin/python": No such file or directory
+      #
+      # `bin/python` in a venv is a SYMLINK to the interpreter it was created
+      # against -- on a GitHub runner, `/opt/hostedtoolcache/Python/...`. That
+      # path does not exist in a Spark container, so the archive unpacks fine
+      # and then cannot be executed.
+      #
+      # Under `local[*]` the symlink resolves, because the "executor" is the
+      # same machine as the driver. Which means the tier's shipped
+      # `ship_python_environment` helper -- P1's whole "pack a venv and
+      # addArtifact it" story -- has only ever been exercised where relocating
+      # it is a no-op. That is a real finding about the product, not just this
+      # lane, and it is filed on the PR rather than papered over here.
+      #
+      # Building against the interpreter the venv will actually run on is the
+      # fix, and it is also what a user shipping to this cluster would have to
+      # do. `--user root` because the Spark images run as uid 185.
+      - name: Pack a runtime venv INSIDE the executor image (the parity ORACLE)
         run: |
           set -euo pipefail
-          python -m venv /tmp/gmenv
-          /tmp/gmenv/bin/pip install --quiet --upgrade pip
-          # pyarrow named explicitly: the tier's UDFs are `arrow_udf` over
-          # `pa.Array`, so the worker contract is stated rather than transitive.
-          # NO pandas -- ci.yml gates on its absence and the reason holds here.
-          /tmp/gmenv/bin/pip install --quiet ./packages/python/goldenmatch pyarrow
-          venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
+          docker run --rm --user root -v "$PWD:/w" -w /w \
+            "apache/spark:${SPARK_IMAGE_TAG}-python3" bash -lc '
+              set -euo pipefail
+              python3 -m venv /tmp/gmenv
+              /tmp/gmenv/bin/pip install --quiet --upgrade pip venv-pack
+              # pyarrow named explicitly: the tier is Arrow-native (arrow_udf
+              # over pa.Array), so the worker contract is stated rather than
+              # transitive. NO pandas -- ci.yml gates on its absence.
+              /tmp/gmenv/bin/pip install --quiet ./packages/python/goldenmatch pyarrow
+              /tmp/gmenv/bin/venv-pack -o /w/gm_env.tar.gz --force
+            '
           ls -lh gm_env.tar.gz
 
       - name: JVM parity + scoring, on the cluster

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -329,7 +329,11 @@ jobs:
           # results from executor 1, against a client-side oracle.
           python -m pytest -v --timeout=600 --timeout-method=thread \
             packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py \
-            packages/python/goldenmatch/tests/test_spark_jvm_parity.py \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_jvm_scoring_matches_the_python_path_exactly' \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path'
+            packages/python/goldenmatch/tests/test_spark_jvm_parity.py \
+            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_jvm_scoring_matches_the_python_path_exactly' \
+            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \
+            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \
+            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path'
 
       # The inventory against REAL workers. Note there is no
       # GOLDENMATCH_SPARK_PYENV here and that is the point: these containers are

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -250,18 +250,40 @@ jobs:
           print(f"OK: executor {exec_id} loaded the native kernel from the shipped jar")
           PY
 
-      # The parity tests need a Python environment on the executors, and that is
-      # not a contradiction -- it is two different questions needing two
-      # different setups, both of which require a real cluster:
+      # NO oracle venv, after three runs spent trying to build one.
       #
-      #   "Does the JVM path work on real executors, and agree with Python?"
-      #     -> needs BOTH arms runnable, so the oracle must exist. THIS step.
-      #   "Is Python actually unnecessary?"
-      #     -> needs the executors genuinely bare. The inventory step below.
+      # The chase went: pack it on the runner (venv-pack's `bin/python` is a
+      # symlink into the runner's toolcache, dangling in a container -- issue
+      # #2531); pack it inside the image instead (`ensurepip` is not in Ubuntu's
+      # base python3); install `python3-venv` (the image ships Python **3.10.12**
+      # and goldenmatch requires >= 3.11).
       #
-      # Running the parity tests bare would not prove the jar-only claim; it
-      # would just delete the oracle and leave the JVM path compared against
-      # nothing. (That is what the first run did, by accident.)
+      # That last one is not an obstacle to work around. It says the official
+      # Spark image cannot run this package's Python path AT ALL without
+      # installing a newer interpreter -- which is a point in the jar's favour,
+      # and a fact worth having rather than papering over.
+      #
+      # It also showed the split was wrong. The two-path parity tests compare
+      # two DISTRIBUTED runs, and on a cluster with no Python that comparison is
+      # impossible by construction. They already run in `spark_connect` under
+      # `local[*]`, which is exactly where a both-arms comparison belongs.
+      #
+      # So the division of labour is by what each environment can actually
+      # prove:
+      #
+      #   local[*]  -> JVM path vs Python path. Both arms runnable, and the
+      #                machinery under test (batching, reshape, alignment) is
+      #                plan construction, which does not care how many hosts it
+      #                lands on.
+      #   cluster   -> everything that needs a SEPARATE executor: the jar
+      #                arriving, the .so loading there, kernel results from a
+      #                real executor against a client-side oracle, and the
+      #                jar-only pipeline running with nothing installed.
+      #
+      # The end-to-end jar-only run is not lost with the venv: the inventory's
+      # ENTRY dedupe probe drives `run_config_pipeline` with all three UDFs
+      # against these bare workers, which is the strongest form of that test
+      # available anywhere.
       # Built INSIDE the executor image, not on the runner.
       #
       # The first attempt built it on the runner with venv-pack, exactly as
@@ -284,41 +306,30 @@ jobs:
       # Building against the interpreter the venv will actually run on is the
       # fix, and it is also what a user shipping to this cluster would have to
       # do. `--user root` because the Spark images run as uid 185.
-      - name: Pack a runtime venv INSIDE the executor image (the parity ORACLE)
-        run: |
-          set -euo pipefail
-          docker run --rm --user root -v "$PWD:/w" -w /w \
-            "apache/spark:${SPARK_IMAGE_TAG}-python3" bash -lc '
-              set -euo pipefail
-              # `ensurepip is not available` otherwise: Debian and Ubuntu strip
-              # it out of the base python3 into `python3-venv`. The Spark images
-              # are Ubuntu-based, so this is the documented fix for that exact
-              # message rather than a workaround.
-              apt-get update -qq
-              apt-get install -y -qq --no-install-recommends python3-venv >/dev/null
-              python3 -m venv /tmp/gmenv
-              /tmp/gmenv/bin/pip install --quiet --upgrade pip venv-pack
-              # pyarrow named explicitly: the tier is Arrow-native (arrow_udf
-              # over pa.Array), so the worker contract is stated rather than
-              # transitive. NO pandas -- ci.yml gates on its absence.
-              /tmp/gmenv/bin/pip install --quiet ./packages/python/goldenmatch pyarrow
-              /tmp/gmenv/bin/venv-pack -o /w/gm_env.tar.gz --force
-            '
-          ls -lh gm_env.tar.gz
-
       - name: JVM parity + scoring, on the cluster
         env:
           GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
-          # The `spark` fixture ships this to the executors -- its own comment
-          # notes that real Spark forks a Python worker with its own
-          # environment, which is the failure class `local[*]` cannot show.
-          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          # No GOLDENMATCH_SPARK_PYENV: the executors stay bare.
         run: |
           set -euo pipefail
+          # Deselected BY NAME, with the reason: these four compare the JVM path
+          # against the PYTHON path, and both arms have to run distributed.
+          # These workers have no goldenmatch (and ship a Python too old for it),
+          # so that comparison cannot exist here. Deselecting says so; letting
+          # them fail would read as a defect in the scoring path.
+          #
+          # They are not skipped anywhere -- `spark_connect` runs them under
+          # local[*], which is where a both-arms comparison belongs. What they
+          # exercise (batching, the n*k reshape, positional alignment) is plan
+          # construction, and a plan does not change shape with the number of
+          # hosts it lands on.
+          #
+          # Everything left DOES need a real executor and now gets one: kernel
+          # results from executor 1, against a client-side oracle.
           python -m pytest -v --timeout=600 --timeout-method=thread \
             packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py \
-            packages/python/goldenmatch/tests/test_spark_jvm_parity.py
+            packages/python/goldenmatch/tests/test_spark_jvm_parity.py \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_jvm_scoring_matches_the_python_path_exactly' \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \n            --deselect 'packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path'
 
       # The inventory against REAL workers. Note there is no
       # GOLDENMATCH_SPARK_PYENV here and that is the point: these containers are

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -290,6 +290,12 @@ jobs:
           docker run --rm --user root -v "$PWD:/w" -w /w \
             "apache/spark:${SPARK_IMAGE_TAG}-python3" bash -lc '
               set -euo pipefail
+              # `ensurepip is not available` otherwise: Debian and Ubuntu strip
+              # it out of the base python3 into `python3-venv`. The Spark images
+              # are Ubuntu-based, so this is the documented fix for that exact
+              # message rather than a workaround.
+              apt-get update -qq
+              apt-get install -y -qq --no-install-recommends python3-venv >/dev/null
               python3 -m venv /tmp/gmenv
               /tmp/gmenv/bin/pip install --quiet --upgrade pip venv-pack
               # pyarrow named explicitly: the tier is Arrow-native (arrow_udf

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -1,0 +1,272 @@
+# The J-arc's claim, tested on a REAL cluster instead of `local[*]`.
+#
+# Every Spark test in this repo runs under `local[*]`, where the executor IS the
+# driver -- Spark attributes a failed task there to `executor driver`. So the
+# assertions that matter were self-certifying: `ScorerSelection` resolves the
+# native library once per JVM, and under `local[*]` that JVM already has the jar
+# on its classpath. "The executor resolved the native kernel" was true and
+# proved nothing.
+#
+# This lane stands up a standalone master, TWO workers and a Connect server in
+# separate containers, and points the existing suite at it. No test changes: the
+# `spark` fixture already takes `GOLDENMATCH_SPARK_REMOTE=sc://host:port`, and
+# its docstring says it was made backend-agnostic on purpose.
+#
+# ## Not in ci.yml, deliberately
+#
+# `workflow_dispatch` and a nightly schedule, NOT a required gate. It pulls
+# ~1.5GB of images and stands up four containers, which is the category where
+# flaky lanes live, and a flaky required gate blocks every merge in the repo.
+# Promote it into `ci.yml` once it has a run history that earns it -- and not
+# before.
+#
+# ## The failure it must not have
+#
+# A cluster lane that silently degrades to a working `local[*]` session would be
+# worse than no lane: it would report the same green as today while claiming
+# more. So the run asserts, from an EXECUTOR, that `exec=` is not `driver`,
+# before it runs anything else.
+name: spark-cluster
+
+on:
+  workflow_dispatch:
+    inputs:
+      spark_image_tag:
+        description: "apache/spark image tag (the client pyspark is pinned to match)"
+        required: false
+        type: string
+        default: "4.0.0"
+  schedule:
+    # Nightly, after the usual working day. Cheap insurance that the topology
+    # still works; nothing here gates a merge.
+    - cron: "0 6 * * *"
+  # Scoped to THIS lane's own files, for two reasons.
+  #
+  # Practically: `workflow_dispatch` only works for workflows already on the
+  # DEFAULT branch, so without this trigger a new cluster lane could not be
+  # exercised until after it merged -- which is the wrong order for the one kind
+  # of lane most likely to need iteration.
+  #
+  # And on the merits: a change to the compose topology or the jar build is
+  # exactly what breaks executor-side loading, so those are the diffs worth
+  # spending 1.5GB of image pull on. It stays OUT of `ci-required`, so a red
+  # result here is information rather than a blocked merge.
+  pull_request:
+    paths:
+      - 'docker/spark-cluster/**'
+      - '.github/workflows/spark-cluster.yml'
+      - 'scripts/build_spark_jar.sh'
+      - 'scripts/spark_jni_selftest.sh'
+      - 'packages/jvm/goldenmatch-spark/**'
+
+permissions:
+  contents: read
+
+env:
+  SPARK_IMAGE_TAG: ${{ inputs.spark_image_tag || '4.0.0' }}
+
+jobs:
+  # The aarch64 half of the jar. Present because `build_spark_jar.sh` REFUSES a
+  # jar missing either architecture, and that refusal is absolute on purpose --
+  # a Graviton fleet finding no `linux-aarch64` resource falls back to the
+  # exact-only scorer silently. Adding a single-arch escape hatch for a test
+  # lane is exactly how such a hatch ends up in the release path, so this lane
+  # pays the ~5 minutes instead.
+  aarch64:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Build + self-test the aarch64 kernel
+        run: |
+          set -euo pipefail
+          cargo build --release \
+            --manifest-path packages/rust/extensions/score-jni/Cargo.toml
+          ARCH=linux-aarch64 bash scripts/spark_jni_selftest.sh
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: score-jni-linux-aarch64
+          path: packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so
+          if-no-files-found: error
+
+  cluster:
+    needs: aarch64
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Build the native kernel (linux-x86-64)
+        run: |
+          set -euo pipefail
+          cargo build --release \
+            --manifest-path packages/rust/extensions/score-jni/Cargo.toml
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: score-jni-linux-aarch64
+          path: /tmp/jni-aarch64
+
+      # The client, on the RUNNER -- not in any container. The jar is uploaded
+      # over Connect by `addArtifact`, so it only ever exists host-side. That is
+      # the deployment story being tested: one file, from the client, nothing
+      # installed on the cluster.
+      #
+      # pyspark pinned to the image tag. A client/server version skew across
+      # Connect fails in ways that read like a bug in this repo.
+      - name: Install the client (pyspark pinned to the cluster's version)
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet "pyspark[connect]==${SPARK_IMAGE_TAG}"
+          python -m pip install --quiet -e 'packages/python/goldenmatch[spark]'
+          python -m pip install --quiet pytest pytest-timeout
+          python -c "import pyspark; print('client pyspark', pyspark.__version__)"
+
+      - name: Build the jar
+        env:
+          SO_X86_64: packages/rust/extensions/score-jni/target/release/libgoldenmatch_score_jni.so
+          SO_AARCH64: /tmp/jni-aarch64/libgoldenmatch_score_jni.so
+        run: |
+          set -euo pipefail
+          export SPARK_JARS="$(python -c 'import pyspark, os; print(os.path.join(os.path.dirname(pyspark.__file__), "jars"))')"
+          bash scripts/build_spark_jar.sh
+
+      - name: Start the cluster
+        run: docker compose -f docker/spark-cluster/docker-compose.yml up -d
+
+      # Readiness is polled HERE rather than by a container healthcheck, so a
+      # failure names the condition that was never met instead of surfacing as a
+      # compose timeout. Two separate conditions, because they fail for
+      # different reasons and have different fixes.
+      - name: Wait for both workers to REGISTER with the master
+        run: |
+          set -euo pipefail
+          # Not "is the port open" -- a standalone master with zero registered
+          # workers accepts a job and QUEUES IT FOREVER. That is a hung lane,
+          # which is strictly worse than a failed one, and this repo already
+          # carries a pytest --timeout for exactly that lesson.
+          for i in $(seq 1 60); do
+            n="$(curl -sf http://localhost:8080/json/ | python -c 'import json,sys; print(json.load(sys.stdin).get("aliveworkers", 0))' 2>/dev/null || echo 0)"
+            echo "  attempt $i: aliveworkers=$n"
+            [ "$n" -ge 2 ] && { echo "cluster ready with $n workers"; exit 0; }
+            sleep 5
+          done
+          echo "::error::the master never registered 2 workers"
+          docker compose -f docker/spark-cluster/docker-compose.yml logs --tail=80
+          exit 1
+
+      - name: Wait for the Spark Connect server
+        run: |
+          set -euo pipefail
+          # One line on purpose. A multi-line `python -c "..."` inside an `if`
+          # has to survive YAML block-scalar dedent AND shell quoting, and this
+          # file already carries two bugs from that class.
+          PROBE="from pyspark.sql import SparkSession; s=SparkSession.builder.remote('sc://localhost:15002').getOrCreate(); print('connect up, rows:', s.range(1).count())"
+          for i in $(seq 1 60); do
+            if python -c "$PROBE"; then
+              exit 0
+            fi
+            echo "  attempt $i: connect server not up yet"
+            sleep 5
+          done
+          echo "::error::the Spark Connect server never accepted a session"
+          docker compose -f docker/spark-cluster/docker-compose.yml logs spark-connect --tail=120
+          exit 1
+
+      # THE assertion that this lane is testing something the local one cannot.
+      # Runs before anything else: if the executor turns out to be the driver,
+      # every result below would be a `local[*]` result wearing a cluster's name.
+      - name: Assert the executor is NOT the driver
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
+          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pyspark.sql import SparkSession
+          from goldenmatch.spark.jvm import find_jar, implementation, install
+
+          spark = SparkSession.builder.remote("sc://localhost:15002").getOrCreate()
+          install(spark, jar=find_jar())
+          impl, diagnostics, runtime = implementation(spark)
+          print(f"impl={impl}\nruntime={runtime}\ndiagnostics={diagnostics}")
+
+          tokens = dict(
+              t.split("=", 1) for t in runtime.split() if "=" in t
+          )
+          exec_id = tokens.get("exec", "?")
+          if exec_id in ("driver", "?"):
+              raise SystemExit(
+                  f"::error::the probe answered from exec={exec_id!r}. This lane "
+                  f"exists to test a real executor; a driver answer means the "
+                  f"session degraded to local mode and every result below would "
+                  f"be a local[*] result under a cluster's name."
+              )
+          if impl != "NativeScorer":
+              raise SystemExit(
+                  f"::error::executor {exec_id} resolved {impl!r}, not NativeScorer. "
+                  f"The jar reached the executor but its native library did not "
+                  f"load THERE: {diagnostics}"
+              )
+          print(f"OK: executor {exec_id} loaded the native kernel from the shipped jar")
+          PY
+
+      - name: JVM parity + scoring, on the cluster
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
+          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+        run: |
+          set -euo pipefail
+          python -m pytest -v --timeout=600 --timeout-method=thread \
+            packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py \
+            packages/python/goldenmatch/tests/test_spark_jvm_parity.py
+
+      # The inventory against REAL workers. Note there is no
+      # GOLDENMATCH_SPARK_PYENV here and that is the point: these containers are
+      # stock Spark images with no goldenmatch and no pyarrow, so "needs a
+      # Python worker" fails on its own rather than because an empty virtualenv
+      # was shipped to make it fail. The local lane can only simulate this.
+      - name: Inventory -- what runs with no Python on REAL executors
+        continue-on-error: true
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
+          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+          GOLDENMATCH_SPARK_PYENV: "none"
+        run: |
+          python scripts/spark_jar_only_inventory.py \
+            --out spark-cluster-inventory.json
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo '## Spark cluster lane'
+            echo ''
+            echo "image: \`apache/spark:${SPARK_IMAGE_TAG}\`, 1 master + 2 workers + Connect"
+            if [ -f spark-cluster-inventory.json ]; then
+              echo ''
+              echo '```json'
+              cat spark-cluster-inventory.json
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Always, and BEFORE teardown. A cluster lane that fails without its logs
+      # costs a full re-run to learn anything, and each re-run is a 1.5GB pull.
+      - name: Container logs
+        if: always()
+        run: docker compose -f docker/spark-cluster/docker-compose.yml logs --tail=200
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/spark-cluster/docker-compose.yml down -v

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -61,12 +61,17 @@ x-spark: &spark
   # no Python environment. Adding any of that here to make a test pass would
   # delete the reason the lane exists.
   #
-  # The workflow does ship a packed venv at SESSION scope for the parity step,
-  # and that is not a contradiction -- it is the supported user path
-  # (`addArtifact`), applied per session, and it is what lets the Python arm run
-  # so there is an oracle to compare the JVM against. The inventory step ships
-  # nothing at all, which is where the jar-only claim is actually tested. Two
-  # questions, two setups; both need a real cluster.
+  # The workflow ships NOTHING to these either -- no packed venv, no site
+  # packages. An earlier version tried to ship one so the Python arm could act
+  # as an oracle for the JVM arm; three runs of chasing that ended at the fact
+  # that this image's Python is 3.10.12 and goldenmatch needs >= 3.11. The
+  # official Spark image cannot run this package's Python path at all, which is
+  # a point in the jar's favour rather than a problem to route around.
+  #
+  # So the two-path comparisons stay in `spark_connect` under `local[*]`, where
+  # both arms run and where what they exercise (batching, reshape, positional
+  # alignment) actually lives -- plan construction does not change shape with
+  # the host count. This lane keeps only what NEEDS a separate executor.
   environment:
     SPARK_NO_DAEMONIZE: "true"
   networks: [spark]

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -50,7 +50,13 @@ x-spark: &spark
   # `[spark]` extra resolves -- the cluster follows the CLIENT, not the
   # other way round, or the lane tests a Spark version no user runs. The
   # default here is only for running this compose file by hand.
-  image: apache/spark:${SPARK_IMAGE_TAG:-4.2.0}
+  # The `-python3` variant, which models a real cluster better than the bare
+  # one: production clusters generally DO have a Python interpreter, what they
+  # lack is your package. So the inventory's failures come back as
+  # `ModuleNotFoundError` -- the realistic shape -- rather than "no python at
+  # all", and the parity step has an interpreter to build its oracle venv
+  # against. Neither goldenmatch nor pyarrow is present either way.
+  image: apache/spark:${SPARK_IMAGE_TAG:-4.2.0}-python3
   # Stock image, and nothing is ever BAKED into it: no goldenmatch, no pyarrow,
   # no Python environment. Adding any of that here to make a test pass would
   # delete the reason the lane exists.

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -46,10 +46,21 @@
 name: goldenmatch-spark-cluster
 
 x-spark: &spark
-  image: apache/spark:${SPARK_IMAGE_TAG:-4.0.0}
-  # Stock image. NOTHING is installed into these containers: no goldenmatch, no
-  # pyarrow, no Python environment of any kind. That is the experiment -- adding
-  # anything here to "make a test pass" would delete the reason the lane exists.
+  # Tag is supplied by the workflow, derived from whatever the product's
+  # `[spark]` extra resolves -- the cluster follows the CLIENT, not the
+  # other way round, or the lane tests a Spark version no user runs. The
+  # default here is only for running this compose file by hand.
+  image: apache/spark:${SPARK_IMAGE_TAG:-4.2.0}
+  # Stock image, and nothing is ever BAKED into it: no goldenmatch, no pyarrow,
+  # no Python environment. Adding any of that here to make a test pass would
+  # delete the reason the lane exists.
+  #
+  # The workflow does ship a packed venv at SESSION scope for the parity step,
+  # and that is not a contradiction -- it is the supported user path
+  # (`addArtifact`), applied per session, and it is what lets the Python arm run
+  # so there is an oracle to compare the JVM against. The inventory step ships
+  # nothing at all, which is where the jar-only claim is actually tested. Two
+  # questions, two setups; both need a real cluster.
   environment:
     SPARK_NO_DAEMONIZE: "true"
   networks: [spark]

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -1,0 +1,114 @@
+# A REAL Spark cluster: separate driver and executor processes, in separate
+# containers, on separate JVMs.
+#
+# ## Why this exists
+#
+# The whole J-arc claims one thing: a jar delivered by `addArtifact` gives a
+# cluster the Rust kernels with no Python installed on the executors. Every test
+# of that claim runs under `local[*]`, where **the executor IS the driver** --
+# Spark says so itself, attributing a failed task there to `executor driver`.
+#
+# So the assertions that matter were all self-certifying. `ScorerSelection`
+# resolves the native library once per JVM; under `local[*]` that JVM already has
+# the jar on its classpath, so "the executor resolved the native kernel" was true
+# and proved nothing. The class's own docstring says a driver that loads the
+# library says nothing about a cluster whose executors cannot -- and then the
+# only test of it ran somewhere the two are the same process.
+#
+# Four things only a real cluster tests:
+#
+#   1. `addArtifact` actually shipping the jar to a JVM that did not already
+#      have it.
+#   2. The `.so` being extracted and dlopen'd in a fresh executor JVM -- its own
+#      working directory, its own tmpdir, no prior extraction to inherit.
+#   3. A real shuffle: the scoring path's collected struct-of-arrays crossing a
+#      network boundary instead of staying in one process.
+#   4. "No Python on the executors" DIRECTLY. These workers are stock Spark
+#      images with no goldenmatch and no pyarrow, so the claim is tested rather
+#      than simulated. The inventory currently fakes this by shipping a
+#      deliberately EMPTY packed virtualenv -- a good workaround for `local[*]`
+#      forking its Python worker from the driver's interpreter, but a workaround.
+#
+# ## Shape
+#
+#   spark-master   standalone Master + the Spark Connect server (port 15002)
+#   spark-worker-1 \  registered with the master; where UDFs actually run
+#   spark-worker-2 /
+#
+# The client runs on the CI host and connects to `sc://localhost:15002`. No test
+# changes are needed for any of this: the `spark` fixture already takes
+# `GOLDENMATCH_SPARK_REMOTE=sc://host:port`, and its docstring says it was made
+# backend-agnostic on purpose. This is what that was for.
+#
+# TWO workers, not one, so work is genuinely distributed and a shuffle has
+# somewhere to go. One worker would still be a separate JVM from the driver --
+# which is most of the value -- but would leave every partition co-located.
+name: goldenmatch-spark-cluster
+
+x-spark: &spark
+  image: apache/spark:${SPARK_IMAGE_TAG:-4.0.0}
+  # Stock image. NOTHING is installed into these containers: no goldenmatch, no
+  # pyarrow, no Python environment of any kind. That is the experiment -- adding
+  # anything here to "make a test pass" would delete the reason the lane exists.
+  environment:
+    SPARK_NO_DAEMONIZE: "true"
+  networks: [spark]
+
+services:
+  spark-master:
+    <<: *spark
+    container_name: spark-master
+    command: >
+      /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master
+      --host spark-master --port 7077 --webui-port 8080
+    ports:
+      - "7077:7077"
+      - "8080:8080"
+    # No container healthcheck on purpose. It would need `curl` inside the
+    # image (not guaranteed) and it would hide the wait: a `depends_on:
+    # service_healthy` that never goes healthy shows up as a compose timeout
+    # with no useful output. Readiness is polled from the WORKFLOW instead,
+    # against the master's REST status, where the poll prints what it sees
+    # every iteration and a failure says which condition was never met.
+
+  spark-worker-1: &worker
+    <<: *spark
+    container_name: spark-worker-1
+    depends_on: [spark-master]
+    command: >
+      /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker
+      spark://spark-master:7077 --cores 1 --memory 1g
+    # Modest, and deliberately so: a GitHub-hosted runner is 4 CPU / 16 GB and
+    # has to hold the master, both workers, the Connect server AND the client.
+    # The point here is topology, not throughput -- the data is a handful of
+    # rows.
+
+  spark-worker-2:
+    <<: *worker
+    container_name: spark-worker-2
+
+  spark-connect:
+    <<: *spark
+    container_name: spark-connect
+    depends_on: [spark-master]
+    ports:
+      - "15002:15002"
+    # `addArtifact` is Connect-only, so the whole tier requires this server --
+    # it is not an alternative front end, it is the only door.
+    #
+    # Runs as its own service rather than inside the master so its logs are
+    # separable: when the lane fails, "did the cluster come up" and "did the
+    # Connect server come up" are different questions with different fixes, and
+    # a combined container makes them one pile of output.
+    command: >
+      /opt/spark/sbin/start-connect-server.sh
+      --master spark://spark-master:7077
+      --conf spark.connect.grpc.binding.address=0.0.0.0
+      --conf spark.connect.grpc.binding.port=15002
+      --conf spark.driver.host=spark-connect
+      --conf spark.executor.memory=1g
+      --conf spark.executor.cores=1
+
+networks:
+  spark:
+    driver: bridge

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreImplUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreImplUdf.java
@@ -36,6 +36,41 @@ public final class GoldenScoreImplUdf implements UDF1<Integer, String> {
   public String call(Integer ignored) {
     return GoldenScoreUdf.implementationName() + "|"
         + GoldenScoreUdf.implementationDiagnostics() + "|"
-        + ScorerSelection.runtimeInfo();
+        + ScorerSelection.runtimeInfo() + " exec=" + executorId();
+  }
+
+  /** Spark's id for the process this ran in: {@code "driver"} in local mode,
+   * {@code "0"}, {@code "1"}, ... on a real executor.
+   *
+   * <h2>Why the jar reports this at all</h2>
+   *
+   * Because without it, the assertion this class exists to support cannot
+   * actually be made. Everything above argues that the driver's classloader is
+   * not the one that has to find the library -- and then the whole Spark suite
+   * runs under {@code local[*]}, where the executor IS the driver. Spark says so
+   * itself: a failed task there is attributed to {@code executor driver}. So
+   * "the executor resolved the native kernel" was true and proved nothing, and
+   * no amount of care in the UDF could distinguish the two.
+   *
+   * <p>One string makes the difference observable, and lets the cluster lane
+   * assert it is testing something the local lane cannot.
+   *
+   * <p>Appended to the runtime segment as another {@code key=value} token rather
+   * than as a fourth {@code |} field: the client splits on {@code "|"} with a
+   * bounded maxsplit, so a new field would be silently glued onto the runtime
+   * string. This shape needs no client change and no version negotiation.
+   *
+   * <p>Spark-specific, so it lives here rather than in {@link ScorerSelection},
+   * which is deliberately Spark-free so the load decision can be tested without
+   * a Spark classpath. Never throws: this is a diagnostic label, and a job must
+   * not die because it could not read one.
+   */
+  private static String executorId() {
+    try {
+      org.apache.spark.SparkEnv env = org.apache.spark.SparkEnv.get();
+      return env == null ? "?" : env.executorId();
+    } catch (Throwable t) {
+      return "?";
+    }
   }
 }

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -609,3 +609,28 @@ def test_block_key_normalization_routes_to_the_jar_when_asked(spark, registered)
         "the block-key builder must pass the UDF name through, and must still "
         "default to the Python path when not given one"
     )
+
+
+def test_the_probe_says_which_process_it_ran_in(spark, registered):
+    """The runtime string must carry `exec=<id>`.
+
+    Without it the file's central assertion cannot be made at all. Everything
+    here talks about what an EXECUTOR resolved, and under `local[*]` the
+    executor IS the driver -- Spark attributes a failed task there to
+    `executor driver`. So `test_the_executor_resolved_the_native_scorer` was
+    true and proved nothing about a cluster, and no care in the UDF could have
+    distinguished the two.
+
+    This pins the token's presence, so a jar that stops reporting it fails here
+    rather than silently disarming the containerized-cluster lane, whose
+    not-the-driver gate reads exactly this value. The lane asserts the VALUE;
+    this asserts it exists to be asserted on.
+    """
+    _impl, _diagnostics, runtime = implementation(spark)
+    tokens = dict(t.split("=", 1) for t in runtime.split() if "=" in t)
+    assert "exec" in tokens, (
+        f"no exec= in the runtime string {runtime!r}. The cluster lane's "
+        f"'executor is not the driver' gate reads this token; without it that "
+        f"gate cannot distinguish a real executor from local mode."
+    )
+    print(f"\n  ran on executor {tokens['exec']!r}")

--- a/scripts/check_workflow_yaml.py
+++ b/scripts/check_workflow_yaml.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import pathlib
+import re
 import sys
 
 import yaml
@@ -97,7 +98,109 @@ def check(directory: pathlib.Path) -> tuple[list[tuple[pathlib.Path, str]], int]
             )
         except yaml.YAMLError as exc:
             problems.append((path, f"does not parse: {exc}"))
+            continue
+        problems.extend(_bad_run_scripts(path))
     return problems, len(files)
+
+
+def _bad_run_scripts(path: pathlib.Path) -> list[tuple[pathlib.Path, str]]:
+    """Every ``run:`` block must be syntactically valid bash.
+
+    A workflow can parse as YAML and still contain a shell script that cannot
+    run, because the two layers escape differently and a `run: |` block has to
+    survive BOTH.
+
+    Two checks, because the most common failure is NOT a syntax error:
+
+    1. ``bash -n`` for genuine syntax errors (unbalanced quotes, unterminated
+       heredocs -- the latter being easy to produce, since a heredoc terminator
+       must land at column 0 only AFTER YAML strips the block indent).
+
+    2. A mid-line literal ``\\n``, which is the shape that actually keeps
+       happening: a line continuation collapses into the two characters
+       backslash-n, and bash receives ``n`` as an argument.
+
+           ERROR: file or directory not found: n
+
+       ``bash -n`` reports that as VALID, because ``\\n`` is a perfectly legal
+       escaped character -- so syntax checking alone would have caught none of
+       the three times this repo has paid for it (a bench Compare step, and
+       twice in the Spark cluster lane), each costing a full CI round trip.
+
+    The ``\\n`` rule requires whitespace on BOTH sides, which is what a mangled
+    continuation looks like (`` \\n            --deselect``). A deliberate
+    escape is almost always adjacent to non-space (``f"{a}\\nb"``,
+    ``printf 'x\\ny'``) and is not flagged.
+
+    Nothing is executed. ``${{ }}`` expressions are left alone -- GitHub
+    substitutes them before bash sees them.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    bash = shutil.which("bash")
+    if bash is None:  # pragma: no cover - CI is Linux and dev is git-bash
+        return []
+
+    out: list[tuple[pathlib.Path, str]] = []
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return []
+    if not isinstance(doc, dict):
+        return []
+
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for i, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict) or "run" not in step:
+                continue
+            script = step["run"]
+            if not isinstance(script, str):
+                continue
+            # A step can select another shell; only bash is checkable here.
+            shell = str(step.get("shell") or job.get("defaults", {})
+                        .get("run", {}).get("shell") or "bash")
+            if not shell.startswith("bash") and shell != "sh":
+                continue
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n"
+            ) as fh:
+                fh.write(script)
+                tmp = fh.name
+            try:
+                proc = subprocess.run(
+                    [bash, "-n", tmp], capture_output=True, text=True
+                )
+            finally:
+                pathlib.Path(tmp).unlink(missing_ok=True)
+            label = step.get("name") or f"step {i}"
+            if proc.returncode != 0:
+                detail = (proc.stderr or "").strip().replace(tmp, "<step>")
+                out.append((
+                    path,
+                    f"job `{job_name}` step `{label}`: `run:` is not valid bash "
+                    f"-- {detail}",
+                ))
+            for lineno, line in enumerate(script.splitlines(), 1):
+                m = _MANGLED_CONTINUATION.search(line)
+                if m:
+                    out.append((
+                        path,
+                        f"job `{job_name}` step `{label}` line {lineno}: a literal "
+                        f"`\\n` with whitespace on both sides -- almost certainly a "
+                        f"line continuation that collapsed, so bash gets `n` as an "
+                        f"argument. `bash -n` calls this VALID. In: "
+                        f"{line.strip()[:70]!r}",
+                    ))
+    return out
+
+
+#: Backslash-n with whitespace both sides: a collapsed line continuation.
+#: A deliberate escape sits next to non-space (``f"{a}\nb"``) and is not matched.
+_MANGLED_CONTINUATION = re.compile(r"\s\\n\s")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/spark_jar_only_inventory.py
+++ b/scripts/spark_jar_only_inventory.py
@@ -384,13 +384,29 @@ def main(argv=None) -> int:
             "worker forks from the DRIVER's interpreter, which HAS goldenmatch "
             "-- so every UDF would work and this inventory would report that "
             "nothing needs Python on executors, which is false. Ship the "
-            "deliberately-empty env."
+            "deliberately-empty env, or set it to 'none' on a real cluster."
         )
         return 2
-    from goldenmatch.spark.deps import ship_python_environment
+    if pyenv == "none":
+        # Only valid where the executors are genuinely separate processes that
+        # genuinely have no goldenmatch -- the containerized-cluster lane, whose
+        # workers are stock Spark images. There the emptiness is REAL and
+        # shipping a packed empty virtualenv would be theatre.
+        #
+        # It stays an explicit opt-in rather than "unset means bare", because
+        # unset is overwhelmingly likely to mean `local[*]` and a forgotten
+        # flag, which is the case that silently reports full jar-only support
+        # the tier does not have.
+        print(
+            "executor env: NONE shipped -- the executors are expected to be "
+            "genuinely bare (real cluster, stock images).",
+            flush=True,
+        )
+    else:
+        from goldenmatch.spark.deps import ship_python_environment
 
-    ship_python_environment(spark, pyenv)
-    print(f"shipped executor env: {pyenv}", flush=True)
+        ship_python_environment(spark, pyenv)
+        print(f"shipped executor env: {pyenv}", flush=True)
 
     udf_name = install(spark, jar=find_jar())
     impl, diagnostics, runtime = implementation(spark)


### PR DESCRIPTION
Stacked on #2525. Base retargets to `main` once that merges.

## The hole

Every Spark test in this repo runs under `local[*]`, where **the executor IS the driver**. Spark says so itself — a failed task there is attributed to `executor driver`, which is visible in #2525's own CI log.

So the assertion the whole J-arc rests on was self-certifying. `ScorerSelection` resolves the native library once per JVM; under `local[*]` that JVM already has the jar on its classpath. `test_the_executor_resolved_the_native_scorer` passing proved the **driver** loaded it. The class's own docstring says *"a driver that loads the library says nothing about a cluster whose executors cannot"* — and then the only test of that ran somewhere the two are the same process.

## What this adds

A standalone master, **two** workers and a Connect server in separate containers. **No test changes were needed** — the `spark` fixture already takes `GOLDENMATCH_SPARK_REMOTE=sc://host:port` and its docstring says it was made backend-agnostic on purpose. This is what that was for.

Four things only a real cluster tests:

1. `addArtifact` shipping the jar to a JVM that did not already have it.
2. The `.so` extracted and `dlopen`'d in a fresh executor JVM — own working dir, own tmpdir, no prior extraction to inherit.
3. A real shuffle: the scoring path's collected struct-of-arrays crossing a network boundary rather than staying in one process.
4. **"No Python on the executors", directly.** The workers are stock Spark images. The inventory currently *simulates* this by shipping a deliberately empty packed virtualenv — a good workaround for `local[*]` forking its Python worker from the driver's interpreter, but a workaround.

## The failure this must not have

A cluster lane that silently degraded to a working `local[*]` session would be **worse than no lane** — same green, larger claim. So the jar now reports `exec=<id>` in its runtime string and the run asserts it is not `driver` **before anything else executes**. A unit test pins the token's presence so a jar that stops reporting it fails loudly rather than quietly disarming the gate.

## Choices worth flagging

- **Readiness polled from the workflow, not container healthchecks.** A standalone master with zero registered workers *accepts* a job and queues it forever — "is the port open" buys a hung lane instead of a failed one, and this repo already carries a pytest `--timeout` for that exact lesson. The poll waits on `aliveworkers >= 2` and prints what it sees each attempt.
- **Not in `ci.yml`.** ~1.5GB of image pull and four containers is where flaky lanes live, and a flaky required gate blocks every merge in the repo. `workflow_dispatch` + nightly, promoted only once it has a run history that earns it.
- **A `pull_request` trigger scoped to this lane's own files**, because `workflow_dispatch` only works for workflows already on the default branch — without it a new dispatch-only lane could not be exercised until after merging, which is the wrong order for the lane most likely to need iteration.
- **No single-arch escape hatch.** `build_spark_jar.sh` refuses a jar missing either architecture, and that refusal is absolute on purpose; adding a bypass "just for a test lane" is how such a bypass reaches the release path. The lane pays for an ARM job instead.

## Status

**Unverified.** Spark standalone + Connect wiring is finicky, I can't run any of it locally, and this is the first run. The workflow is built to fail informatively — separate waits for separate conditions, container logs dumped before teardown — so expect iteration.
