### PR TITLE
feat(semantic): ontology CLI + MCP front door (certify + discover)

### DIFF
--- a/context-network/decisions/0056-ontology-cli-mcp-front-door.md
+++ b/context-network/decisions/0056-ontology-cli-mcp-front-door.md
@@ -1,0 +1,51 @@
+# 0056 — Ontology layer: CLI + MCP front door
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch ontology {certify,discover}` CLI subgroup + MCP tools `ontology_certify` / `ontology_discover` • **Builds on:** [0053–0055 (ontology layer)](0053-ontology-layer-rdf-owl-provider.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+The ontology layer (0053–0055) shipped library-only; a CLI/MCP front door was
+deferred across the whole semantic arc as a parity-surface decision. The semantic
+layer already has one (`certify-keys` / `discover-model` CLI, `certify_semantic_model`
+/ `discover_semantic_model` MCP). This gives the ontology layer the same reach, so
+an agent or a shell user — not just a Python caller — can certify and discover.
+
+## Decision
+1. **CLI `ontology` subgroup** (`cli/ontology.py`, registered like `identity`):
+   `ontology certify <ontology.ttl> --data Class=path…` (certify the declared
+   `owl:hasKey`/IFP keys against instance data, `--fail-untrustworthy` for a CI
+   gate) and `ontology discover --data Class=path… [-o out.ttl]` (discover a draft
+   OWL ontology, keys pre-graded). Mirrors `certify-keys` / `discover-model`
+   (data as repeatable `Name=path`, `--json`, Rich table). Advisory only.
+2. **MCP tools `ontology_certify` / `ontology_discover`** (`mcp/server.py`),
+   returning `OntologyCertification.to_dict()` / `DiscoveredOntology.to_dict()`
+   (+ the Turtle) — the same wire shapes the library and (future) REST emit. A
+   shared `_load_class_frames` loader mirrors `_tool_discover_semantic_model`.
+3. **Parity-gated, declared `python_only`.** Both surfaces are added to
+   `parity/goldenmatch.yaml` (`cli_commands.python_only: ontology`,
+   `mcp_tools.python_only: ontology_certify/ontology_discover`) — like
+   `discover_semantic_model` / `discover-model`, no TS port (the ontology layer is
+   rdflib-backed, outside the edge/WASM surface). Tool-count assertions updated
+   (`_BASE_TOOLS` 46→48, `TOOLS` 95→97); the generated api-surface + config-matrix
+   docs regenerated.
+4. **`rdflib`-optional, fail-clean.** The handlers lazy-import the ontology
+   functions; without the `goldenmatch[ontology]` extra they return / print the
+   `_require_rdflib` install hint rather than crashing the CLI or MCP server.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — the front door is a thin adapter over
+  `certify_ontology` / `discover_ontology` (→ the single key-integrity certifier);
+  no new logic.
+- **Conformance defines correctness** ✅ — the parity gate now covers these
+  surfaces; the emitted shapes match the library's `to_dict()`.
+
+## Consequences / honest flags
+- **CLI covers certify + discover, not reconcile/emit.** Those need a resolved
+  `ResolvedCrosswalk` (an ER run) rather than just files; they stay library-reachable.
+  A `reconcile`/`emit` subcommand is a possible follow-on.
+- **No REST endpoint yet** — the semantic layer has `POST /semantic/discover`; an
+  ontology REST route is a follow-on (the MCP + CLI cover the agent + shell paths).
+- **Still deferred:** live-catalog write-back (ADR 0057, next) — writing the
+  emitted RDF to a triple store.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -28,8 +28,11 @@
 > from data, `owl:hasKey` pre-graded by the certifier — the generative half).
 > `rdflib` optional (`goldenmatch[ontology]`); GoldenMatch is the identity provider
 > FOR the reasoner/triple store, never a reimplementation of one. **The ontology
-> arc is complete** (0053 v1 + 0054 consume/audit + 0055 produce/discover); a
-> CLI/MCP front door + live-catalog write-back stay deferred (parity surface).
+> arc is complete** (0053 v1 + 0054 consume/audit + 0055 produce/discover) and now
+> has a **CLI + MCP front door** ([0056](../decisions/0056-ontology-cli-mcp-front-door.md):
+> `goldenmatch ontology certify|discover`, `ontology_certify`/`ontology_discover`
+> MCP tools); **live-catalog write-back** (RDF → triple store) is the last deferred
+> piece.
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -877,6 +877,16 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `migrate-splink` | `--verify-threshold` | float | `0.5` | Splink match-probability cut for --verify |
 | `migrate-splink` | `--strict` | boolean | `False` | Fail on any lossy mapping (warnings), not just errors |
 | `migrate-splink` | `--id-column` | text | `None` | Column holding each row's id (default: auto-detect unique_id/id/record_id) |
+| `ontology certify` | `ontology` | text | **required** | OWL/RDF ontology file (Turtle / RDF-XML / JSON-LD / N-Triples). |
+| `ontology certify` | `--data` | text | **required** | Instance data for a class as Class=path (repeatable), e.g. -d Patient=patients.csv |
+| `ontology certify` | `--json` | boolean | `False` | Emit the certification report as JSON. |
+| `ontology certify` | `--fail-untrustworthy` | boolean | `False` | Exit non-zero if any declared identity key is not unique at grain (CI gate). |
+| `ontology discover` | `--data` | text | **required** | A class's instance data as Class=path (repeatable), e.g. -d Customer=customers.csv |
+| `ontology discover` | `--output` | text | `None` | Write the draft OWL ontology (Turtle) to this path. |
+| `ontology discover` | `--base-iri` | text | `None` | Base IRI for the emitted terms. |
+| `ontology discover` | `--ontology-iri` | text | `None` | IRI for the ontology node. |
+| `ontology discover` | `--json` | boolean | `False` | Emit the discovery result as JSON. |
+| `ontology discover` | `--fail-untrustworthy` | boolean | `False` | Exit non-zero if any discovered class key is not unique at grain (CI gate). |
 | `pprl auto-config` | `file` | path | **required** | Data file to analyze (CSV) |
 | `pprl auto-config` | `--security` | text | `'high'` | Security level: standard, high, paranoid |
 | `pprl auto-config` | `--llm` | boolean | `False` | Use LLM for enhanced recommendations |
@@ -956,7 +966,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 ## MCP tools
 
-95 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
+97 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
 
 | Tool | Description |
 |---|---|
@@ -1032,6 +1042,8 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `memory_export` | Return all corrections as a list of dicts (CSV-shaped). Caller is responsible for writing the file. Optionally filter by dataset. |
 | `memory_import` | Import corrections from a list of dicts (the exact shape memory_export returns). Upserts into the store: higher trust wins, same trust = latest wins. Returns the count imported. |
 | `memory_stats` | Return Learning Memory status: total correction count, last learn time, and current learned adjustments. Cheap; safe for status checks. |
+| `ontology_certify` | Ontology-layer front door (consume): certify the identity keys an OWL/RDF ontology DECLARES (owl:hasKey, inverse-functional properties) against real instance data. The ontology asserts identity but resolves it only by brittle exact-match; this returns a per-key verdict (unique-at-grain + fan-out) so an over-merging IFP/key is caught before a reasoner trusts it. Advisory. Needs the goldenmatch[ontology] extra. |
+| `ontology_discover` | Ontology-layer front door (generate): point GoldenMatch at a set of class instance tables and it PROPOSES a draft OWL ontology -- one owl:Class per frame whose owl:hasKey is chosen and PRE-GRADED by the certifier (gm:keyTrustworthy / gm:keyUniquenessEstimate). Discovery is hypothesis; certification is the falsification test. Returns the discovery result + the Turtle. Needs the goldenmatch[ontology] extra. |
 | `plan_routing` | Project per-stage distributed routing (scoring/clustering/golden) for a given data shape + cluster. Pure; no controller run. |
 | `pprl_auto_config` | Analyze the loaded dataset and recommend optimal PPRL (privacy-preserving record linkage) configuration. Returns recommended fields, bloom filter parameters, threshold, and explanation. |
 | `pprl_link` | Run privacy-preserving record linkage between two parties' data. Computes bloom filters, matches records without sharing raw data. Specify fields, threshold, and security level. |

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.12.0` | `1.28.0` | `goldenmatch` | 95 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.12.0` | `1.28.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.4.0` | `0.8.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.19.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.4.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
@@ -59,10 +59,11 @@ neglect:
   (`read_file`, `write_csv`, `server_info`) were the last holdouts, and Python now
   exposes all eight.
 
-So GoldenMatch's **85 TS tools vs 95 Python** breaks down as 85 shared operations,
+So GoldenMatch's **85 TS tools vs 97 Python** breaks down as 85 shared operations,
 **zero TS-only**, and 10 Python-only tools (the VLM document-ingest pair, the
 distributed routing trio, `list_plugins`, `pprl_auto_config`, the
-semantic-model discovery front door `discover_semantic_model`, and the
+semantic-model discovery front door `discover_semantic_model`, the ontology
+front door (`ontology_certify` / `ontology_discover`), and the
 semantic-layer catalog front doors — `certify_semantic_model` and
 `emit_semantic_model_from_store` (the dialect emitters are Python-only)). The TS MCP surface
 is now a strict subset of the Python one — every TS tool has a Python counterpart of
@@ -131,7 +132,7 @@ graph, privacy-preserving linkage. The flagship — a native wheel, SQL extensio
 
 **Servers** — REST (`goldenmatch serve`: `/match`, `/autoconfig`, `/clusters`,
 `/reviews`, `/controller/telemetry`, …) · A2A (`goldenmatch agent-serve`) · local
-web UI (`goldenmatch serve-ui`) · **95 MCP tools**.
+web UI (`goldenmatch serve-ui`) · **97 MCP tools**.
 
 **Native / SQL** — `goldenmatch-native` wheel, a Postgres extension (pgrx:
 `goldenmatch_dedupe`, `goldenmatch_autoconfig`, `goldenmatch_connected_components`, …),

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,13 +14,13 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 95 | 202 | 51 | 42 | Yes | Yes |
+| `goldenmatch` | 97 | 202 | 51 | 43 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
 | `goldenanalysis` | 4 | 8 | — | 4 | Yes | Yes |
 | `infermap` | 4 | 19 | — | 5 | Yes | Yes |
-| **suite** | **136** | | | | | |
+| **suite** | **138** | | | | | |
 
 ## Compute substrate — the Rust `-core` kernel is the reference
 
@@ -41,8 +41,8 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 87 | 8 | 0 |
-| `goldenmatch` | cli_commands | 33 | 9 | 0 |
+| `goldenmatch` | mcp_tools | 87 | 10 | 0 |
+| `goldenmatch` | cli_commands | 33 | 10 | 0 |
 | `goldenmatch` | a2a_skills | 36 | 15 | 13 |
 | `goldenmatch` | scorers | 24 | 0 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -66,8 +66,8 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 ## Gaps & asymmetries (auto-detected)
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
-- `goldenmatch` **mcp_tools** — Python-only: `discover_semantic_model`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `plan_routing`, `pprl_auto_config`.
-- `goldenmatch` **cli_commands** — Python-only: `discover-model`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `serve-ui`, `setup`, `sync`, `watch`.
+- `goldenmatch` **mcp_tools** — Python-only: `discover_semantic_model`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_plugins`, `ontology_certify`, `ontology_discover`, `plan_routing`, `pprl_auto_config`.
+- `goldenmatch` **cli_commands** — Python-only: `discover-model`, `import-dbt`, `ingest-docs`, `llm`, `migrate-splink`, `ontology`, `serve-ui`, `setup`, `sync`, `watch`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `certify_semantic_model`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `certify_serving_joins`, `customer_360`, `emit_semantic_model_from_store`, `fix_quality`, `memory_import`, `scan_quality`, `score`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -58,8 +58,8 @@ Static signals harvested directly from `parity/*.yaml` + each package's `_native
 | `goldenflow` | transforms | 0 | 1 |
 | `goldenmatch` | a2a_skills | 15 | 13 |
 | `goldenmatch` | blocking_strategies | 2 | 0 |
-| `goldenmatch` | cli_commands | 9 | 0 |
-| `goldenmatch` | mcp_tools | 8 | 0 |
+| `goldenmatch` | cli_commands | 10 | 0 |
+| `goldenmatch` | mcp_tools | 10 | 0 |
 | `goldenpipe` | cli_commands | 1 | 0 |
 
 ## Resolved (archived)

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 468,
+      "module_count": 469,
       "modules": [
         {
           "module": "goldenmatch",
@@ -809,6 +809,7 @@
             "goldenmatch.cli.mcp_serve",
             "goldenmatch.cli.memory",
             "goldenmatch.cli.migrate_splink",
+            "goldenmatch.cli.ontology",
             "goldenmatch.cli.pprl",
             "goldenmatch.cli.review",
             "goldenmatch.cli.rollback",
@@ -892,6 +893,21 @@
             "goldenmatch.cli.import_splink",
             "goldenmatch.config.from_splink",
             "goldenmatch.config.splink_upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.ontology",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/ontology.py",
+          "purpose": "CLI `ontology` command group — the ontology-layer (RDF/OWL/SHACL) front door.",
+          "defines": [
+            "_read_frames",
+            "certify_cmd",
+            "discover_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core.io_arrow",
+            "goldenmatch.semantic",
+            "goldenmatch.semantic.ontology"
           ]
         },
         {
@@ -6645,6 +6661,7 @@
             "_golden_as_table",
             "_handle_tool",
             "_initialize",
+            "_load_class_frames",
             "_load_clusters_json",
             "_load_rows_with_ids",
             "_resolve_alias",
@@ -6676,6 +6693,8 @@
             "_tool_list_strategies",
             "_tool_list_transforms",
             "_tool_match_record",
+            "_tool_ontology_certify",
+            "_tool_ontology_discover",
             "_tool_pprl_auto_config",
             "_tool_pprl_link",
             "_tool_profile_data",
@@ -6734,6 +6753,7 @@
             "goldenmatch.pprl.autoconfig",
             "goldenmatch.pprl.protocol",
             "goldenmatch.semantic",
+            "goldenmatch.semantic.ontology",
             "goldenmatch.tui.engine"
           ]
         },

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -4355,6 +4355,83 @@
           ]
         },
         {
+          "command": "ontology certify",
+          "options": [
+            {
+              "name": "ontology",
+              "type": "text",
+              "required": true,
+              "help": "OWL/RDF ontology file (Turtle / RDF-XML / JSON-LD / N-Triples)."
+            },
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "Instance data for a class as Class=path (repeatable), e.g. -d Patient=patients.csv"
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the certification report as JSON."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any declared identity key is not unique at grain (CI gate)."
+            }
+          ]
+        },
+        {
+          "command": "ontology discover",
+          "options": [
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "A class's instance data as Class=path (repeatable), e.g. -d Customer=customers.csv"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the draft OWL ontology (Turtle) to this path."
+            },
+            {
+              "name": "--base-iri",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Base IRI for the emitted terms."
+            },
+            {
+              "name": "--ontology-iri",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "IRI for the ontology node."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the discovery result as JSON."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any discovered class key is not unique at grain (CI gate)."
+            }
+          ]
+        },
+        {
           "command": "pprl auto-config",
           "options": [
             {
@@ -5236,6 +5313,14 @@
         {
           "name": "memory_stats",
           "description": "Return Learning Memory status: total correction count, last learn time, and current learned adjustments. Cheap; safe for status checks."
+        },
+        {
+          "name": "ontology_certify",
+          "description": "Ontology-layer front door (consume): certify the identity keys an OWL/RDF ontology DECLARES (owl:hasKey, inverse-functional properties) against real instance data. The ontology asserts identity but resolves it only by brittle exact-match; this returns a per-key verdict (unique-at-grain + fan-out) so an over-merging IFP/key is caught before a reasoner trusts it. Advisory. Needs the goldenmatch[ontology] extra."
+        },
+        {
+          "name": "ontology_discover",
+          "description": "Ontology-layer front door (generate): point GoldenMatch at a set of class instance tables and it PROPOSES a draft OWL ontology -- one owl:Class per frame whose owl:hasKey is chosen and PRE-GRADED by the certifier (gm:keyTrustworthy / gm:keyUniquenessEstimate). Discovery is hypothesis; certification is the falsification test. Returns the discovery result + the Turtle. Needs the goldenmatch[ontology] extra."
         },
         {
           "name": "plan_routing",

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - DQbench composite 91.04; PPRL 92.4% F1 on FEBRL4; a durable Identity Graph (stable entity_ids that survive across runs)
 
 ## AI-native surface
-- Every package ships an MCP server (136 tools across the suite), a REST API, and most an A2A agent surface
+- Every package ships an MCP server (138 tools across the suite), a REST API, and most an A2A agent surface
 - One aggregator container exposes the whole suite: `docker run ghcr.io/benseverndev-oss/goldensuite-mcp:latest`
 - Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benseverndev-oss/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -1234,6 +1234,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Ontology-layer CLI + MCP front door.** `goldenmatch ontology certify
+  <ontology.ttl> --data Class=path` and `goldenmatch ontology discover --data
+  Class=path [-o out.ttl]` surface the ontology-layer certify/discover
+  capabilities on the command line (mirroring `certify-keys` / `discover-model`),
+  and MCP tools `ontology_certify` / `ontology_discover` expose the same to
+  agents. `python_only` in the parity gate; `rdflib`-optional (fail-clean install
+  hint without the `goldenmatch[ontology]` extra). See ADR 0056.
 - **Ontology layer, produce + discover (`goldenmatch.semantic.ontology`).**
   Completes the flesh-out with the generative half: `emit_golden_triples` emits
   resolved golden records as typed RDF individuals (`rdf:type` + conformed

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -106,7 +106,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 91.04 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **95 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **97 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### Run on unstructured input (document ingest)
@@ -217,7 +217,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 - **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
-- **REST API + MCP Server** — 95 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
+- **REST API + MCP Server** — 97 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
 - **A2A Agent** — 51 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
@@ -731,7 +731,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (95 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (97 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -33,6 +33,7 @@ from goldenmatch.cli.match import match_cmd
 from goldenmatch.cli.mcp_serve import mcp_serve_cmd
 from goldenmatch.cli.memory import memory_app
 from goldenmatch.cli.migrate_splink import migrate_splink_cmd
+from goldenmatch.cli.ontology import ontology_app
 from goldenmatch.cli.pprl import pprl_app
 from goldenmatch.cli.review import review_cmd
 from goldenmatch.cli.rollback import rollback_cmd, runs_cmd, unmerge_cmd
@@ -136,6 +137,7 @@ app.add_typer(llm_app, name="llm")
 app.add_typer(pprl_app, name="pprl")
 app.add_typer(memory_app, name="memory")
 app.add_typer(identity_app, name="identity")
+app.add_typer(ontology_app, name="ontology")
 app.add_typer(ingest_docs_app, name="ingest-docs")
 app.command("label", help="Build ground truth by labeling record pairs interactively.")(label_cmd)
 app.command("review", help="Review borderline pairs interactively; decisions feed Learning Memory.")(review_cmd)

--- a/packages/python/goldenmatch/goldenmatch/cli/ontology.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/ontology.py
@@ -1,0 +1,161 @@
+"""CLI `ontology` command group — the ontology-layer (RDF/OWL/SHACL) front door.
+
+Surfaces the `goldenmatch.semantic.ontology` capabilities on the command line,
+mirroring `certify-keys` / `discover-model`:
+
+- `ontology certify <ontology.ttl> --data Class=path...` — certify the identity
+  keys (`owl:hasKey` / IFP) an ontology declares against real instance data;
+- `ontology discover --data Class=path...` — discover a DRAFT OWL ontology whose
+  `owl:hasKey` is chosen and PRE-GRADED by the certifier.
+
+Advisory only; nothing auto-ships. `rdflib` is optional (`goldenmatch[ontology]`);
+without it the commands exit with a clear install hint.
+"""
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+ontology_app = typer.Typer(
+    help="Ontology-layer (RDF/OWL/SHACL) identity front door — certify + discover.",
+    no_args_is_help=True,
+)
+
+
+def _read_frames(data: list[str]) -> dict[str, object]:
+    """Parse repeated `Class=path` options into `{class: arrow table}`."""
+    from goldenmatch.core.io_arrow import read_table_arrow
+
+    frames: dict[str, object] = {}
+    for spec in data:
+        if "=" not in spec:
+            console.print(f"[red]--data must be Class=path, got {spec!r}[/red]")
+            raise typer.Exit(code=2)
+        cls, path = spec.split("=", 1)
+        frames[cls.strip()] = read_table_arrow(path.strip())
+    return frames
+
+
+@ontology_app.command("certify")
+def certify_cmd(
+    ontology: str = typer.Argument(
+        ..., help="OWL/RDF ontology file (Turtle / RDF-XML / JSON-LD / N-Triples).",
+    ),
+    data: list[str] = typer.Option(
+        ..., "--data", "-d",
+        help="Instance data for a class as Class=path (repeatable), e.g. -d Patient=patients.csv",
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit the certification report as JSON."),
+    fail_untrustworthy: bool = typer.Option(
+        False, "--fail-untrustworthy",
+        help="Exit non-zero if any declared identity key is not unique at grain (CI gate).",
+    ),
+) -> None:
+    """Certify the identity keys an ontology declares against instance data."""
+    import json
+
+    from goldenmatch.semantic import certify_ontology
+
+    frames = _read_frames(data)
+    try:
+        report = certify_ontology(ontology, frames)
+    except ImportError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=3) from exc
+
+    if as_json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        verdict = "[#2ecc71]all safe[/]" if report.all_safe else "[red]UNSAFE[/]"
+        console.print(
+            f"[bold]Ontology:[/bold] {report.ontology_iri or '-'}   "
+            f"[bold]keys:[/bold] {report.n_keys}   "
+            f"[bold]unsafe:[/bold] {report.n_unsafe}   {verdict}"
+        )
+        if report.keys:
+            tbl = Table(show_header=True, header_style="bold")
+            tbl.add_column("class")
+            tbl.add_column("key")
+            tbl.add_column("source")
+            tbl.add_column("uniqueness", justify="right")
+            tbl.add_column("verdict")
+            for k in report.keys:
+                tbl.add_row(
+                    str(k["class"]), ", ".join(k["key"]), k["source"],
+                    f"{k['estimate']:.3f}",
+                    "[#2ecc71]unique[/]" if k["is_unique"] else "[red]NOT UNIQUE[/]",
+                )
+            console.print(tbl)
+        if report.note:
+            console.print(f"[dim]{report.note}[/dim]")
+
+    if fail_untrustworthy and not report.all_safe:
+        raise typer.Exit(code=1)
+
+
+@ontology_app.command("discover")
+def discover_cmd(
+    data: list[str] = typer.Option(
+        ..., "--data", "-d",
+        help="A class's instance data as Class=path (repeatable), e.g. -d Customer=customers.csv",
+    ),
+    output: str | None = typer.Option(
+        None, "--output", "-o", help="Write the draft OWL ontology (Turtle) to this path.",
+    ),
+    base_iri: str | None = typer.Option(None, "--base-iri", help="Base IRI for the emitted terms."),
+    ontology_iri: str | None = typer.Option(None, "--ontology-iri", help="IRI for the ontology node."),
+    as_json: bool = typer.Option(False, "--json", help="Emit the discovery result as JSON."),
+    fail_untrustworthy: bool = typer.Option(
+        False, "--fail-untrustworthy",
+        help="Exit non-zero if any discovered class key is not unique at grain (CI gate).",
+    ),
+) -> None:
+    """Discover a draft OWL ontology from data, every owl:hasKey pre-graded."""
+    import json
+
+    from goldenmatch.semantic import discover_ontology
+    from goldenmatch.semantic.ontology import DEFAULT_BASE_IRI
+
+    frames = _read_frames(data)
+    try:
+        disc = discover_ontology(
+            frames, base_iri=base_iri or DEFAULT_BASE_IRI, ontology_iri=ontology_iri,
+        )
+    except ImportError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=3) from exc
+
+    if output:
+        with open(output, "w", encoding="utf-8") as fh:
+            fh.write(disc.turtle)
+
+    all_trustworthy = all(c["is_trustworthy"] for c in disc.classes) if disc.classes else True
+    if as_json:
+        print(json.dumps(disc.to_dict(), indent=2))
+    else:
+        console.print(
+            f"[bold]Ontology:[/bold] {disc.ontology_iri or '-'}   "
+            f"[bold]classes:[/bold] {len(disc.classes)}   "
+            f"[bold]all_trustworthy:[/bold] "
+            f"{'[#2ecc71]yes[/]' if all_trustworthy else '[red]no[/]'}"
+        )
+        if disc.classes:
+            tbl = Table(show_header=True, header_style="bold")
+            tbl.add_column("class")
+            tbl.add_column("owl:hasKey")
+            tbl.add_column("uniqueness", justify="right")
+            tbl.add_column("verdict")
+            for c in disc.classes:
+                tbl.add_row(
+                    c["class"], ", ".join(c["key"]), f"{c['estimate']:.3f}",
+                    "[#2ecc71]trustworthy[/]" if c["is_trustworthy"] else "[red]UNTRUSTWORTHY[/]",
+                )
+            console.print(tbl)
+        if output:
+            console.print(f"[dim]wrote {output}[/dim]")
+
+    if fail_untrustworthy and not all_trustworthy:
+        raise typer.Exit(code=1)

--- a/packages/python/goldenmatch/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/goldenmatch/llms.txt
@@ -6,8 +6,8 @@
 Zero-config gets good results and returns the config it chose; the healer (`review_config`) reviews the results and suggests ranked, self-verified tweaks; apply them, results improve, repeat — closing the gap to expert-tuned without you being the expert. Wired into the default pipeline: `dedupe_df` attaches candidate suggestions to `result.suggestions` when a free signal fires (`dedupe_df(suggest=True)` verified, `heal=True` full loop; disable with `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`). Needs `goldenmatch[native]`; degrades gracefully without it. Docs: https://docs.bensevern.dev/docs/goldenmatch/config-suggestions
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (95 tools across data, agent, identity, memory, routing, and document groups)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (95 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- MCP Server: `goldenmatch mcp-serve` (97 tools across data, agent, identity, memory, routing, and document groups)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (97 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (51 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~202 exports

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -867,6 +867,66 @@ _BASE_TOOLS = [
             "required": ["frames"],
         },
     ),
+    Tool(
+        name="ontology_certify",
+        description=(
+            "Ontology-layer front door (consume): certify the identity keys an "
+            "OWL/RDF ontology DECLARES (owl:hasKey, inverse-functional properties) "
+            "against real instance data. The ontology asserts identity but resolves "
+            "it only by brittle exact-match; this returns a per-key verdict "
+            "(unique-at-grain + fan-out) so an over-merging IFP/key is caught before "
+            "a reasoner trusts it. Advisory. Needs the goldenmatch[ontology] extra."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "ontology": {
+                    "type": "string",
+                    "description": "Path to an OWL/RDF ontology file (Turtle/RDF-XML/JSON-LD/N-Triples).",
+                },
+                "frames": {
+                    "type": "object",
+                    "description": (
+                        "Map of class local-name -> instance data file path, e.g. "
+                        "{\"Patient\": \"patients.csv\"}."
+                    ),
+                },
+            },
+            "required": ["ontology", "frames"],
+        },
+    ),
+    Tool(
+        name="ontology_discover",
+        description=(
+            "Ontology-layer front door (generate): point GoldenMatch at a set of "
+            "class instance tables and it PROPOSES a draft OWL ontology -- one "
+            "owl:Class per frame whose owl:hasKey is chosen and PRE-GRADED by the "
+            "certifier (gm:keyTrustworthy / gm:keyUniquenessEstimate). Discovery is "
+            "hypothesis; certification is the falsification test. Returns the "
+            "discovery result + the Turtle. Needs the goldenmatch[ontology] extra."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "frames": {
+                    "type": "object",
+                    "description": (
+                        "Map of class name -> instance data file path, e.g. "
+                        "{\"Customer\": \"customers.csv\"}."
+                    ),
+                },
+                "base_iri": {
+                    "type": "string",
+                    "description": "Base IRI for the emitted terms (optional).",
+                },
+                "ontology_iri": {
+                    "type": "string",
+                    "description": "IRI for the ontology node (optional).",
+                },
+            },
+            "required": ["frames"],
+        },
+    ),
 ]
 
 # --- Cross-language naming aliases (Python<->TS MCP parity) -----------------
@@ -1417,6 +1477,12 @@ def _handle_tool(name: str, args: dict) -> dict:
             args.get("name", False),
             args.get("apply_names", False),
         )
+    elif name == "ontology_certify":
+        return _tool_ontology_certify(args.get("ontology", ""), args.get("frames", {}))
+    elif name == "ontology_discover":
+        return _tool_ontology_discover(
+            args.get("frames", {}), args.get("base_iri"), args.get("ontology_iri")
+        )
     else:
         return {"error": f"Unknown tool: {name}"}
 
@@ -1493,6 +1559,72 @@ def _tool_discover_semantic_model(
         return {"error": str(exc)}
 
     return model.to_dict()
+
+
+def _load_class_frames(frames: dict) -> tuple[dict[str, object] | None, dict | None]:
+    """Shared loader for the ontology tools: `{class: path}` -> `{class: table}`.
+    Returns `(loaded, None)` on success or `(None, error_dict)` on a bad input."""
+    if not isinstance(frames, dict) or not frames:
+        return None, {"error": "frames must map a class name to a data file path."}
+    from goldenmatch.core.io_arrow import read_table_arrow
+
+    loaded: dict[str, object] = {}
+    for cls, path in frames.items():
+        try:
+            loaded[str(cls)] = read_table_arrow(str(path))
+        except FileNotFoundError:
+            return None, {"error": f"data file not found for {cls!r}: {path}"}
+        except Exception as exc:  # noqa: BLE001 - surface a clean tool error
+            return None, {"error": f"could not read data for {cls!r} ({path}): {exc}"}
+    return loaded, None
+
+
+def _tool_ontology_certify(ontology: str, frames: dict) -> dict:
+    """Certify an ontology's declared identity keys against instance data.
+
+    ``ontology`` is a path to an OWL/RDF file; ``frames`` maps class local-name ->
+    data file path. Returns ``OntologyCertification.to_dict()``. Needs the
+    ``goldenmatch[ontology]`` extra (rdflib)."""
+    if not ontology:
+        return {"error": "ontology must be a path to an OWL/RDF file."}
+    loaded, err = _load_class_frames(frames)
+    if err is not None:
+        return err
+
+    from goldenmatch.semantic import certify_ontology
+
+    try:
+        report = certify_ontology(str(ontology), loaded)
+    except ImportError as exc:
+        return {"error": str(exc)}
+    except (FileNotFoundError, OSError) as exc:
+        return {"error": f"could not read ontology {ontology!r}: {exc}"}
+    return report.to_dict()
+
+
+def _tool_ontology_discover(frames: dict, base_iri, ontology_iri) -> dict:
+    """Discover a draft OWL ontology from class instance tables, keys pre-graded.
+
+    ``frames`` maps class name -> data file path. Returns
+    ``DiscoveredOntology.to_dict()`` plus the emitted ``turtle``. Needs the
+    ``goldenmatch[ontology]`` extra (rdflib)."""
+    loaded, err = _load_class_frames(frames)
+    if err is not None:
+        return err
+
+    from goldenmatch.semantic import discover_ontology
+    from goldenmatch.semantic.ontology import DEFAULT_BASE_IRI
+
+    try:
+        disc = discover_ontology(
+            loaded, base_iri=str(base_iri) if base_iri else DEFAULT_BASE_IRI,
+            ontology_iri=str(ontology_iri) if ontology_iri else None,
+        )
+    except ImportError as exc:
+        return {"error": str(exc)}
+    out = disc.to_dict()
+    out["turtle"] = disc.turtle
+    return out
 
 
 def _tool_get_stats() -> dict:

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -26,9 +26,9 @@ def test_total_tool_count_is_94():
     assert len(AGENT_TOOLS) == 19   # +1 retrieve_similar (#1089) +1 upload_dataset
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 18  # +1 customer_360 (D1b) +2 serving surfaces (D)
-    assert len(_BASE_TOOLS) == 46   # +5 core primitives +3 host helpers +1 certify_semantic_model +1 discover_semantic_model
+    assert len(_BASE_TOOLS) == 48   # +5 core primitives +3 host helpers +1 certify_semantic_model +1 discover_semantic_model +2 ontology
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 95   # +2 serving surfaces (certify_serving_joins, emit_semantic_model_from_store) +1 discover_semantic_model
+    assert len(TOOLS) == 97   # +2 serving surfaces (certify_serving_joins, emit_semantic_model_from_store) +1 discover_semantic_model +2 ontology (ontology_certify, ontology_discover)
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_ontology_frontdoor.py
+++ b/packages/python/goldenmatch/tests/test_ontology_frontdoor.py
@@ -1,0 +1,106 @@
+"""CLI + MCP front door for the ontology layer (`goldenmatch ontology`, ontology_* tools).
+
+rdflib is optional (`goldenmatch[ontology]`); skip when absent (ray/lance convention).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("rdflib")
+
+from goldenmatch.cli.main import app  # noqa: E402
+from goldenmatch.mcp.server import _tool_ontology_certify, _tool_ontology_discover  # noqa: E402
+from typer.testing import CliRunner  # noqa: E402
+
+runner = CliRunner()
+
+_ONTOLOGY = """
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix ex:   <https://example.org/clinic#> .
+
+ex:Patient a owl:Class ;
+    owl:hasKey ( ex:mrn ) .
+"""
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def _patients_csv(tmp_path, *, unique=True):
+    mrns = ["m1", "m2", "m3"] if unique else ["m1", "m1", "m3"]
+    return _write(tmp_path, "patients.csv", "mrn\n" + "\n".join(mrns) + "\n")
+
+
+def _customers_csv(tmp_path):
+    return _write(tmp_path, "customers.csv",
+                  "customer_id,city\n1,NY\n2,NY\n3,LA\n4,LA\n")
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_ontology_certify_json_all_safe(tmp_path):
+    onto = _write(tmp_path, "clinic.ttl", _ONTOLOGY)
+    csv = _patients_csv(tmp_path, unique=True)
+    res = runner.invoke(app, ["ontology", "certify", onto, "-d", f"Patient={csv}", "--json"])
+    assert res.exit_code == 0, res.output
+    report = json.loads(res.output)
+    assert report["all_safe"] is True and report["n_keys"] == 1
+    assert report["keys"][0]["key"] == ["mrn"]
+
+
+def test_cli_ontology_certify_fail_untrustworthy_exits_nonzero(tmp_path):
+    onto = _write(tmp_path, "clinic.ttl", _ONTOLOGY)
+    csv = _patients_csv(tmp_path, unique=False)  # duplicate mrn -> unsafe
+    res = runner.invoke(app, ["ontology", "certify", onto, "-d", f"Patient={csv}",
+                              "--fail-untrustworthy"])
+    assert res.exit_code == 1
+
+
+def test_cli_ontology_discover_writes_owl(tmp_path):
+    csv = _customers_csv(tmp_path)
+    out = str(tmp_path / "discovered.ttl")
+    res = runner.invoke(app, ["ontology", "discover", "-d", f"Customer={csv}",
+                              "-o", out, "--json"])
+    assert res.exit_code == 0, res.output
+    disc = json.loads(res.output)
+    assert disc["n_classes"] == 1 and disc["classes"][0]["class"] == "Customer"
+    assert disc["classes"][0]["key"] == ["customer_id"]
+    # the emitted OWL round-trips
+    from goldenmatch.semantic import parse_ontology
+    onto = parse_ontology(out)
+    assert next(c for c in onto.classes if c.name == "Customer").has_keys == [["customer_id"]]
+
+
+def test_cli_ontology_bad_data_spec_errors(tmp_path):
+    onto = _write(tmp_path, "clinic.ttl", _ONTOLOGY)
+    res = runner.invoke(app, ["ontology", "certify", onto, "-d", "no-equals-sign"])
+    assert res.exit_code == 2
+
+
+# --- MCP ---------------------------------------------------------------------
+
+
+def test_mcp_ontology_certify(tmp_path):
+    onto = _write(tmp_path, "clinic.ttl", _ONTOLOGY)
+    csv = _patients_csv(tmp_path, unique=False)
+    out = _tool_ontology_certify(onto, {"Patient": csv})
+    assert out["n_keys"] == 1 and out["all_safe"] is False
+    assert out["keys"][0]["is_unique"] is False
+
+
+def test_mcp_ontology_discover_returns_turtle(tmp_path):
+    csv = _customers_csv(tmp_path)
+    out = _tool_ontology_discover({"Customer": csv}, None, None)
+    assert out["n_classes"] == 1 and out["n_trustworthy"] == 1
+    assert "turtle" in out and "owl:hasKey" in out["turtle"] or "hasKey" in out["turtle"]
+
+
+def test_mcp_ontology_certify_input_guards():
+    assert "error" in _tool_ontology_certify("", {"Patient": "x.csv"})
+    assert "error" in _tool_ontology_certify("o.ttl", {})

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -4355,6 +4355,83 @@
           ]
         },
         {
+          "command": "ontology certify",
+          "options": [
+            {
+              "name": "ontology",
+              "type": "text",
+              "required": true,
+              "help": "OWL/RDF ontology file (Turtle / RDF-XML / JSON-LD / N-Triples)."
+            },
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "Instance data for a class as Class=path (repeatable), e.g. -d Patient=patients.csv"
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the certification report as JSON."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any declared identity key is not unique at grain (CI gate)."
+            }
+          ]
+        },
+        {
+          "command": "ontology discover",
+          "options": [
+            {
+              "name": "--data",
+              "type": "text",
+              "required": true,
+              "help": "A class's instance data as Class=path (repeatable), e.g. -d Customer=customers.csv"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the draft OWL ontology (Turtle) to this path."
+            },
+            {
+              "name": "--base-iri",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Base IRI for the emitted terms."
+            },
+            {
+              "name": "--ontology-iri",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "IRI for the ontology node."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit the discovery result as JSON."
+            },
+            {
+              "name": "--fail-untrustworthy",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit non-zero if any discovered class key is not unique at grain (CI gate)."
+            }
+          ]
+        },
+        {
           "command": "pprl auto-config",
           "options": [
             {
@@ -5236,6 +5313,14 @@
         {
           "name": "memory_stats",
           "description": "Return Learning Memory status: total correction count, last learn time, and current learned adjustments. Cheap; safe for status checks."
+        },
+        {
+          "name": "ontology_certify",
+          "description": "Ontology-layer front door (consume): certify the identity keys an OWL/RDF ontology DECLARES (owl:hasKey, inverse-functional properties) against real instance data. The ontology asserts identity but resolves it only by brittle exact-match; this returns a per-key verdict (unique-at-grain + fan-out) so an over-merging IFP/key is caught before a reasoner trusts it. Advisory. Needs the goldenmatch[ontology] extra."
+        },
+        {
+          "name": "ontology_discover",
+          "description": "Ontology-layer front door (generate): point GoldenMatch at a set of class instance tables and it PROPOSES a draft OWL ontology -- one owl:Class per frame whose owl:hasKey is chosen and PRE-GRADED by the certifier (gm:keyTrustworthy / gm:keyUniquenessEstimate). Discovery is hypothesis; certification is the falsification test. Returns the discovery result + the Turtle. Needs the goldenmatch[ontology] extra."
         },
         {
           "name": "plan_routing",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -147,6 +147,8 @@ mcp_tools:
   - explain_routing
   - lint_routing
   - list_plugins
+  - ontology_certify
+  - ontology_discover
   - plan_routing
   - pprl_auto_config
   ts_only: []
@@ -191,6 +193,7 @@ cli_commands:
   - ingest-docs
   - llm
   - migrate-splink
+  - ontology
   - serve-ui
   - setup
   - sync


### PR DESCRIPTION
## What and why

The first of the two remaining deferred items: a **CLI + MCP front door** for the
ontology layer, giving it the same reach the semantic layer already has
(`certify-keys`/`discover-model`, `certify_semantic_model`/`discover_semantic_model`)
— so agents and shell users, not just Python callers, can certify and discover.
Decision: **ADR 0056**. (Live-catalog write-back is the next PR.)

## Changes

- **CLI `ontology` subgroup** (`cli/ontology.py`, registered like `identity`):
  - `ontology certify <ontology.ttl> --data Class=path…` — certify the declared
    `owl:hasKey`/IFP keys against instance data (`--fail-untrustworthy` = CI gate).
  - `ontology discover --data Class=path… [-o out.ttl]` — discover a draft OWL
    ontology, keys pre-graded by the certifier.
  - Mirrors `certify-keys`/`discover-model` (repeatable `Name=path`, `--json`, Rich table).
- **MCP tools** `ontology_certify` / `ontology_discover` (`mcp/server.py`), returning
  the library's `OntologyCertification` / `DiscoveredOntology` `to_dict()` shapes
  (+ Turtle). Shared `_load_class_frames` loader mirrors `_tool_discover_semantic_model`.
- **Parity-gated `python_only`** (no TS port — rdflib-backed, off the edge/WASM
  surface): `parity/goldenmatch.yaml` + tool-count assertions (`_BASE_TOOLS`
  46→48, `TOOLS` 95→97) + regenerated api-surface / config-matrix / codemap.
- `rdflib` stays optional; handlers **fail-clean** with the `goldenmatch[ontology]`
  install hint when the extra is absent.

## Testing

- `pytest tests/test_ontology_frontdoor.py tests/test_ontology.py tests/test_mcp_new_tools.py tests/test_mcp_host_helpers.py` → **60 passed** (new front-door tests: CLI certify/discover via CliRunner incl. `--fail-untrustworthy` + round-trip, MCP handlers + input guards)
- `emit_python_surface.py goldenmatch` → confirms `ontology_certify`/`ontology_discover` (MCP) + `ontology` (CLI subgroup, no leaked subcommands) match the parity.yaml edits exactly
- `ruff` clean; `check_docs_consistency.py` all PASS; `gen_api_surface.py --check` / `gen_config_matrix.py --check` / `test_codemap_current` → OK (regenerated)
- Tests run for real in the required `python_goldenmatch` lane (`[ontology]` extra)

## Checklist

- [x] Tests added/updated and passing locally
- [x] Parity surfaces declared (`parity/goldenmatch.yaml`) + counts updated
- [x] Generated docs regenerated (api-surface, config-matrix, codemap)
- [x] `CHANGELOG.md` + ADR 0056 + planning-doc status
- [x] No secrets/tokens committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_