### PR TITLE
feat(semantic): ontology live-catalog write-back (RDF → file / SPARQL Graph Store)

### DIFF
--- a/context-network/decisions/0057-ontology-live-catalog-writeback.md
+++ b/context-network/decisions/0057-ontology-live-catalog-writeback.md
@@ -1,0 +1,57 @@
+# 0057 — Ontology layer: live-catalog write-back (RDF → file / SPARQL Graph Store)
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch.semantic.{write_ontology_catalog, write_resolved_identity_graph}` + `goldenmatch ontology discover --endpoint/--graph-iri/--mode` • **Builds on:** [0053–0056 (ontology layer + front door)](0053-ontology-layer-rdf-owl-provider.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+The last deferred piece of the ontology arc. The emitters (`emit_sameas_graph`,
+`discover_ontology`, `emit_ontology_shapes`, `emit_golden_triples`) produce RDF as
+a *string*; the semantic layer already persists its YAML declaration to a catalog
+file (`write_resolved_catalog`). This adds the ontology analogue and the "live"
+half — writing the RDF into a running triple store — so "resolve once, every SPARQL
+query inherits correct identity" lands in the catalog, not just a return value.
+
+## Decision
+1. **`write_ontology_catalog(rdf, dest=None, *, endpoint=None, …)`** — one function,
+   two destinations, exactly one required:
+   - `dest`: write the RDF to a **file** (refuses to clobber unless `overwrite`);
+   - `endpoint`: a **SPARQL 1.1 Graph Store HTTP Protocol** URL — `mode="replace"`
+     → HTTP **PUT** (replace the named graph), `mode="merge"` → **POST** (add
+     triples); `graph_iri` selects the named graph (`?default` otherwise). Content-Type
+     is derived from the RDF `fmt`.
+   Returns a small status dict. HTTP/URL errors are wrapped in a clear `RuntimeError`.
+2. **`write_resolved_identity_graph(crosswalk, …)`** — the convenience wrapper:
+   emit a `ResolvedCrosswalk`'s `owl:sameAs`/PROV-O graph and write it in one call.
+3. **CLI write-back.** `goldenmatch ontology discover` gains `--endpoint`
+   / `--graph-iri` / `--mode` so a discovered ontology can be pushed to a triple
+   store from the shell. A new flag on an existing command — **not** a new
+   parity surface (no new command/tool); the CLI-options docs regenerate.
+4. **Stdlib-only, no new dependency.** The write path uses `urllib` (mirroring
+   `client.py`); persisting an already-serialized string needs **no rdflib**, so
+   `write_ontology_catalog` runs on a plain install and in the normal test lane.
+   Only *producing* the RDF (`write_resolved_identity_graph` → `emit_sameas_graph`)
+   needs the `goldenmatch[ontology]` extra.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — a thin persistence adapter over the emitters +
+  the control plane's resolved ids. It **conforms to** the SPARQL Graph Store
+  protocol; it does not implement a triple store (the replaceable-backend rule —
+  Fuseki / GraphDB / Neptune are the backends).
+- **Conformance defines correctness** ✅ — the endpoint path speaks the W3C Graph
+  Store protocol (PUT/POST, `?graph=`), verified by request-construction tests.
+
+## Consequences / honest flags
+- **No live triple store in CI.** The endpoint path is proven by mocking `urllib`
+  (method / URL / Content-Type / body); an integration test against a real Fuseki
+  is a possible follow-on. The file path is tested directly.
+- **Auth is caller's responsibility for now.** The endpoint call sends no
+  credentials; a triple store behind auth needs a follow-on (a header/token
+  parameter). Kept out of v1 to avoid a half-built auth surface.
+- **`mode="replace"` PUT replaces the whole named graph** (Graph Store semantics) —
+  intended for a GoldenMatch-owned identity graph, not co-mingled with other data;
+  use a dedicated `graph_iri` and `merge` when appending.
+- **Ontology arc fully complete.** With 0057 the whole arc — v1 (0053), consume/audit
+  (0054), produce/discover (0055), CLI+MCP front door (0056), live-catalog
+  write-back (0057) — is landed; no deferred items remain for the ontology layer.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -31,8 +31,10 @@
 > arc is complete** (0053 v1 + 0054 consume/audit + 0055 produce/discover) and now
 > has a **CLI + MCP front door** ([0056](../decisions/0056-ontology-cli-mcp-front-door.md):
 > `goldenmatch ontology certify|discover`, `ontology_certify`/`ontology_discover`
-> MCP tools); **live-catalog write-back** (RDF → triple store) is the last deferred
-> piece.
+> MCP tools) and **live-catalog write-back** ([0057](../decisions/0057-ontology-live-catalog-writeback.md):
+> `write_ontology_catalog` / `write_resolved_identity_graph` → file or a live
+> SPARQL 1.1 Graph Store endpoint; `ontology discover --endpoint`). **The ontology
+> arc is fully complete — no deferred items remain.**
 > Captures the framing for how GoldenMatch relates to the semantic-layer /
 > metrics-layer ecosystem (dbt Semantic Layer + MetricFlow, Cube, and the Open
 > Semantic Interchange spec), and a crawl→walk→run plan. Problem **A**

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -885,6 +885,9 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `ontology discover` | `--output` | text | `None` | Write the draft OWL ontology (Turtle) to this path. |
 | `ontology discover` | `--base-iri` | text | `None` | Base IRI for the emitted terms. |
 | `ontology discover` | `--ontology-iri` | text | `None` | IRI for the ontology node. |
+| `ontology discover` | `--endpoint` | text | `None` | Write the OWL to a live SPARQL 1.1 Graph Store endpoint (a triple store). |
+| `ontology discover` | `--graph-iri` | text | `None` | Named graph for --endpoint (default graph if omitted). |
+| `ontology discover` | `--mode` | text | `'replace'` | --endpoint write mode: replace (PUT) or merge (POST). |
 | `ontology discover` | `--json` | boolean | `False` | Emit the discovery result as JSON. |
 | `ontology discover` | `--fail-untrustworthy` | boolean | `False` | Exit non-zero if any discovered class key is not unique at grain (CI gate). |
 | `pprl auto-config` | `file` | path | **required** | Data file to analyze (CSV) |

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 469,
+      "module_count": 470,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7174,6 +7174,7 @@
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.ontology",
+            "goldenmatch.semantic.ontology_catalog",
             "goldenmatch.semantic.osi",
             "goldenmatch.semantic.serving"
           ]
@@ -7648,6 +7649,19 @@
           "imports": [
             "goldenmatch.semantic.discovery.keys",
             "goldenmatch.semantic.key_integrity"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.ontology_catalog",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/ontology_catalog.py",
+          "purpose": "Live-catalog write-back for the ontology layer — persist emitted RDF.",
+          "defines": [
+            "_as_rdf_string",
+            "write_ontology_catalog",
+            "write_resolved_identity_graph"
+          ],
+          "imports": [
+            "goldenmatch.semantic.ontology"
           ]
         },
         {

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -4416,6 +4416,27 @@
               "help": "IRI for the ontology node."
             },
             {
+              "name": "--endpoint",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the OWL to a live SPARQL 1.1 Graph Store endpoint (a triple store)."
+            },
+            {
+              "name": "--graph-iri",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Named graph for --endpoint (default graph if omitted)."
+            },
+            {
+              "name": "--mode",
+              "type": "text",
+              "required": false,
+              "default": "'replace'",
+              "help": "--endpoint write mode: replace (PUT) or merge (POST)."
+            },
+            {
               "name": "--json",
               "type": "boolean",
               "required": false,

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -1266,6 +1266,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Ontology-layer live-catalog write-back.** `write_ontology_catalog(rdf, dest=…)`
+  writes emitted RDF to a file, or (`endpoint=…`) PUTs/POSTs it to a live SPARQL
+  1.1 Graph Store endpoint (a triple store — `mode="replace"`/`"merge"`,
+  `graph_iri`); `write_resolved_identity_graph(crosswalk, …)` emits a crosswalk's
+  `owl:sameAs`/PROV-O graph and writes it in one call. `goldenmatch ontology
+  discover` gains `--endpoint` / `--graph-iri` / `--mode` to push a discovered
+  ontology to a triple store. Stdlib-only (`urllib`, no new dependency); the write
+  path needs no rdflib. GoldenMatch conforms to the Graph Store protocol, it does
+  not implement a triple store. Completes the ontology arc. See ADR 0057.
 - **Ontology-layer CLI + MCP front door.** `goldenmatch ontology certify
   <ontology.ttl> --data Class=path` and `goldenmatch ontology discover --data
   Class=path [-o out.ttl]` surface the ontology-layer certify/discover

--- a/packages/python/goldenmatch/goldenmatch/cli/ontology.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/ontology.py
@@ -107,6 +107,16 @@ def discover_cmd(
     ),
     base_iri: str | None = typer.Option(None, "--base-iri", help="Base IRI for the emitted terms."),
     ontology_iri: str | None = typer.Option(None, "--ontology-iri", help="IRI for the ontology node."),
+    endpoint: str | None = typer.Option(
+        None, "--endpoint",
+        help="Write the OWL to a live SPARQL 1.1 Graph Store endpoint (a triple store).",
+    ),
+    graph_iri: str | None = typer.Option(
+        None, "--graph-iri", help="Named graph for --endpoint (default graph if omitted).",
+    ),
+    mode: str = typer.Option(
+        "replace", "--mode", help="--endpoint write mode: replace (PUT) or merge (POST).",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit the discovery result as JSON."),
     fail_untrustworthy: bool = typer.Option(
         False, "--fail-untrustworthy",
@@ -116,7 +126,7 @@ def discover_cmd(
     """Discover a draft OWL ontology from data, every owl:hasKey pre-graded."""
     import json
 
-    from goldenmatch.semantic import discover_ontology
+    from goldenmatch.semantic import discover_ontology, write_ontology_catalog
     from goldenmatch.semantic.ontology import DEFAULT_BASE_IRI
 
     frames = _read_frames(data)
@@ -131,6 +141,16 @@ def discover_cmd(
     if output:
         with open(output, "w", encoding="utf-8") as fh:
             fh.write(disc.turtle)
+
+    endpoint_status: dict | None = None
+    if endpoint:
+        try:
+            endpoint_status = write_ontology_catalog(
+                disc.turtle, endpoint=endpoint, graph_iri=graph_iri, mode=mode,
+            )
+        except (RuntimeError, ValueError) as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=4) from exc
 
     all_trustworthy = all(c["is_trustworthy"] for c in disc.classes) if disc.classes else True
     if as_json:
@@ -156,6 +176,11 @@ def discover_cmd(
             console.print(tbl)
         if output:
             console.print(f"[dim]wrote {output}[/dim]")
+        if endpoint_status:
+            console.print(
+                f"[dim]{endpoint_status['method']} -> {endpoint_status['endpoint']} "
+                f"(graph {endpoint_status['graph']}): HTTP {endpoint_status['status']}[/dim]"
+            )
 
     if fail_untrustworthy and not all_trustworthy:
         raise typer.Exit(code=1)

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -123,6 +123,10 @@ from goldenmatch.semantic.ontology import (
     parse_ontology,
     reconcile_ontology_identity,
 )
+from goldenmatch.semantic.ontology_catalog import (
+    write_ontology_catalog,
+    write_resolved_identity_graph,
+)
 from goldenmatch.semantic.osi import (
     OsiDataset,
     OsiField,
@@ -223,6 +227,8 @@ __all__ = [
     "OntologyCertification",
     "OntologyReconciliation",
     "DiscoveredOntology",
+    "write_ontology_catalog",
+    "write_resolved_identity_graph",
     # semantic-model discovery (Phase 1) — certified key discovery per table
     "discover_keys",
     "KeyCandidate",

--- a/packages/python/goldenmatch/goldenmatch/semantic/ontology_catalog.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/ontology_catalog.py
@@ -1,0 +1,152 @@
+"""Live-catalog write-back for the ontology layer — persist emitted RDF.
+
+The ontology emitters (`emit_sameas_graph`, `discover_ontology`,
+`emit_ontology_shapes`, `emit_golden_triples`) PRODUCE RDF as a string. This is
+the last mile: write that RDF to a **file** catalog, or PUT/POST it to a live
+**SPARQL 1.1 Graph Store HTTP Protocol** endpoint (a triple store — Fuseki,
+GraphDB, Neptune, …) so "resolve once, every SPARQL query inherits correct
+identity" lands in the running catalog, not just a returned string.
+
+GoldenMatch conforms to the Graph Store protocol; it does not implement a triple
+store (the replaceable-backend rule). The write path is stdlib-only (`urllib`) —
+no rdflib needed to persist an already-serialized string, and no new dependency.
+`write_resolved_identity_graph` is the convenience wrapper: emit a crosswalk's
+`owl:sameAs`/PROV-O graph and write it in one call.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+# RDF serialization format -> HTTP Content-Type (SPARQL Graph Store bodies).
+_CONTENT_TYPES = {
+    "turtle": "text/turtle",
+    "ttl": "text/turtle",
+    "nt": "application/n-triples",
+    "ntriples": "application/n-triples",
+    "xml": "application/rdf+xml",
+    "pretty-xml": "application/rdf+xml",
+    "json-ld": "application/ld+json",
+    "json-ld11": "application/ld+json",
+}
+
+
+def _as_rdf_string(rdf: Any, fmt: str) -> str:
+    """Coerce `rdf` to a serialized string: pass a str through; serialize an
+    rdflib Graph (or anything with `.serialize`) in `fmt`."""
+    if isinstance(rdf, str):
+        return rdf
+    if hasattr(rdf, "serialize"):
+        return rdf.serialize(format=fmt)
+    raise TypeError(f"write_ontology_catalog: rdf must be a str or an rdflib Graph, got {type(rdf)!r}")
+
+
+def write_ontology_catalog(
+    rdf: Any,
+    dest: str | Path | None = None,
+    *,
+    endpoint: str | None = None,
+    graph_iri: str | None = None,
+    mode: str = "replace",
+    overwrite: bool = False,
+    fmt: str = "turtle",
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Persist emitted RDF to a file OR a live SPARQL Graph Store endpoint.
+
+    Exactly one destination:
+      - `dest`: write the RDF to this file (refuses to clobber unless `overwrite`);
+      - `endpoint`: a SPARQL 1.1 Graph Store HTTP Protocol URL. `mode="replace"`
+        does an HTTP PUT (replace the named graph), `mode="merge"` a POST (add
+        triples). `graph_iri` selects the named graph (default graph if omitted).
+
+    Args:
+        rdf: a serialized RDF string (e.g. `emit_sameas_graph(...)`) or an rdflib Graph.
+        fmt: the RDF serialization (`turtle` default) — sets the endpoint Content-Type.
+
+    Returns:
+        A small status dict describing what was written (`{"written": path, "bytes": n}`
+        or `{"endpoint": ..., "graph": ..., "mode": ..., "status": http_status}`).
+    """
+    if (dest is None) == (endpoint is None):
+        raise ValueError("write_ontology_catalog: pass exactly one of dest= or endpoint=")
+
+    body = _as_rdf_string(rdf, fmt)
+
+    if dest is not None:
+        out = Path(dest)
+        if out.exists() and not overwrite:
+            raise FileExistsError(
+                f"write_ontology_catalog: {out} already exists; pass overwrite=True to replace it"
+            )
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(body, encoding="utf-8")
+        return {"written": str(out), "bytes": len(body.encode("utf-8"))}
+
+    # --- live SPARQL Graph Store endpoint ---
+    key = mode.strip().lower()
+    if key not in ("replace", "merge"):
+        raise ValueError(f"write_ontology_catalog: mode must be 'replace' or 'merge', got {mode!r}")
+    http_method = "PUT" if key == "replace" else "POST"
+    content_type = _CONTENT_TYPES.get(fmt.strip().lower(), "text/turtle")
+
+    # Graph Store Protocol: ?graph=<iri> for a named graph, ?default otherwise.
+    sep = "&" if "?" in endpoint else "?"
+    query = urlencode({"graph": graph_iri}) if graph_iri else "default"
+    url = f"{endpoint}{sep}{query}"
+
+    from urllib.error import HTTPError, URLError
+    from urllib.request import Request, urlopen
+
+    req = Request(url, data=body.encode("utf-8"), method=http_method,
+                  headers={"Content-Type": content_type})
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # noqa: S310 - caller-supplied catalog URL
+            status = getattr(resp, "status", None) or resp.getcode()
+    except HTTPError as exc:
+        raise RuntimeError(
+            f"write_ontology_catalog: {http_method} {url} failed: HTTP {exc.code} {exc.reason}"
+        ) from exc
+    except URLError as exc:
+        raise RuntimeError(f"write_ontology_catalog: could not reach {endpoint}: {exc.reason}") from exc
+
+    return {
+        "endpoint": endpoint,
+        "graph": graph_iri or "urn:x-arq:DefaultGraph",
+        "mode": key,
+        "method": http_method,
+        "status": int(status),
+        "bytes": len(body.encode("utf-8")),
+    }
+
+
+def write_resolved_identity_graph(
+    crosswalk: Any,
+    *,
+    dest: str | Path | None = None,
+    endpoint: str | None = None,
+    graph_iri: str | None = None,
+    mode: str = "replace",
+    overwrite: bool = False,
+    base_iri: str | None = None,
+    run_name: str = "resolution",
+    target_class: str | None = None,
+    fmt: str = "turtle",
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Emit a `ResolvedCrosswalk`'s `owl:sameAs` + PROV-O graph and write it to a
+    file or a live SPARQL endpoint in one call — "resolve once, push the conformed
+    identity into the running catalog." Thin wrapper over `emit_sameas_graph`
+    (which needs the `goldenmatch[ontology]` extra) + `write_ontology_catalog`.
+    """
+    from goldenmatch.semantic.ontology import DEFAULT_BASE_IRI, emit_sameas_graph
+
+    rdf = emit_sameas_graph(
+        crosswalk, base_iri=base_iri or DEFAULT_BASE_IRI, run_name=run_name,
+        target_class=target_class, fmt=fmt,
+    )
+    return write_ontology_catalog(
+        rdf, dest, endpoint=endpoint, graph_iri=graph_iri, mode=mode,
+        overwrite=overwrite, fmt=fmt, timeout=timeout,
+    )

--- a/packages/python/goldenmatch/tests/test_ontology_catalog.py
+++ b/packages/python/goldenmatch/tests/test_ontology_catalog.py
@@ -1,0 +1,120 @@
+"""Live-catalog write-back for the ontology layer (write_ontology_catalog).
+
+These test the write path with a plain RDF string, so they need no rdflib and run
+in the normal lane. The endpoint tests mock urllib (no live triple store).
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.semantic import write_ontology_catalog
+
+_TTL = "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n<urn:a> owl:sameAs <urn:b> .\n"
+
+
+def test_write_to_file(tmp_path):
+    dest = tmp_path / "sub" / "graph.ttl"
+    out = write_ontology_catalog(_TTL, dest)
+    assert out["written"] == str(dest) and out["bytes"] == len(_TTL.encode("utf-8"))
+    assert dest.read_text(encoding="utf-8") == _TTL
+
+
+def test_write_to_file_refuses_clobber(tmp_path):
+    dest = tmp_path / "graph.ttl"
+    write_ontology_catalog(_TTL, dest)
+    with pytest.raises(FileExistsError):
+        write_ontology_catalog(_TTL, dest)
+    # overwrite=True replaces
+    out = write_ontology_catalog(_TTL + "# more\n", dest, overwrite=True)
+    assert out["bytes"] > len(_TTL.encode("utf-8"))
+
+
+def test_requires_exactly_one_destination(tmp_path):
+    with pytest.raises(ValueError):
+        write_ontology_catalog(_TTL)  # neither
+    with pytest.raises(ValueError):
+        write_ontology_catalog(_TTL, tmp_path / "x.ttl", endpoint="http://ts/data")  # both
+
+
+def test_rejects_bad_mode():
+    with pytest.raises(ValueError):
+        write_ontology_catalog(_TTL, endpoint="http://ts/data", mode="upsert")
+
+
+def _mock_urlopen(monkeypatch, status=204):
+    captured: dict = {}
+
+    class _Resp:
+        def __init__(self):
+            self.status = status
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def getcode(self):
+            return status
+
+    def fake(req, timeout=None):
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        captured["content_type"] = req.get_header("Content-type")
+        captured["body"] = req.data
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    return captured
+
+
+def test_endpoint_replace_is_put_named_graph(monkeypatch):
+    captured = _mock_urlopen(monkeypatch, status=204)
+    out = write_ontology_catalog(_TTL, endpoint="http://ts/data",
+                                 graph_iri="urn:g", mode="replace")
+    assert captured["method"] == "PUT"
+    assert "graph=urn%3Ag" in captured["url"]
+    assert captured["content_type"] == "text/turtle"
+    assert captured["body"] == _TTL.encode("utf-8")
+    assert out["status"] == 204 and out["method"] == "PUT" and out["graph"] == "urn:g"
+
+
+def test_endpoint_merge_is_post_default_graph(monkeypatch):
+    captured = _mock_urlopen(monkeypatch, status=200)
+    out = write_ontology_catalog(_TTL, endpoint="http://ts/data", mode="merge")
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("?default")
+    assert out["status"] == 200 and out["mode"] == "merge"
+
+
+def test_endpoint_http_error_is_wrapped(monkeypatch):
+    from urllib.error import HTTPError
+
+    def boom(req, timeout=None):
+        raise HTTPError(req.full_url, 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    with pytest.raises(RuntimeError, match="HTTP 403"):
+        write_ontology_catalog(_TTL, endpoint="http://ts/data")
+
+
+def test_write_resolved_identity_graph_to_file(tmp_path):
+    pytest.importorskip("rdflib")
+    import pyarrow as pa
+    import rdflib
+    from goldenmatch.semantic import write_resolved_identity_graph
+    from rdflib.namespace import OWL
+
+    class _XW:
+        resolved_key = "resolved_entity_id"
+
+        def to_arrow(self):
+            return pa.table({
+                "source": ["crm", "crm"],
+                "source_pk": ["1", "2"],
+                "resolved_entity_id": ["e1", "e1"],
+            })
+
+    dest = tmp_path / "identity.ttl"
+    out = write_resolved_identity_graph(_XW(), dest=dest, base_iri="https://ex.test/id/")
+    assert out["written"] == str(dest)
+    g = rdflib.Graph()
+    g.parse(str(dest), format="turtle")
+    # both records were written as owl:sameAs to the same canonical entity
+    assert len(list(g.triples((None, OWL.sameAs, None)))) == 2

--- a/packages/python/goldenmatch/tests/test_ontology_frontdoor.py
+++ b/packages/python/goldenmatch/tests/test_ontology_frontdoor.py
@@ -104,3 +104,26 @@ def test_mcp_ontology_discover_returns_turtle(tmp_path):
 def test_mcp_ontology_certify_input_guards():
     assert "error" in _tool_ontology_certify("", {"Patient": "x.csv"})
     assert "error" in _tool_ontology_certify("o.ttl", {})
+
+
+def test_cli_ontology_discover_endpoint_write_back(tmp_path, monkeypatch):
+    captured = {}
+
+    class _Resp:
+        status = 204
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def getcode(self): return 204
+
+    def fake(req, timeout=None):
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    csv = _customers_csv(tmp_path)
+    res = runner.invoke(app, ["ontology", "discover", "-d", f"Customer={csv}",
+                              "--endpoint", "http://ts/data", "--graph-iri", "urn:g"])
+    assert res.exit_code == 0, res.output
+    assert captured["method"] == "PUT" and "graph=urn%3Ag" in captured["url"]
+    assert "HTTP 204" in res.output

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -4416,6 +4416,27 @@
               "help": "IRI for the ontology node."
             },
             {
+              "name": "--endpoint",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write the OWL to a live SPARQL 1.1 Graph Store endpoint (a triple store)."
+            },
+            {
+              "name": "--graph-iri",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Named graph for --endpoint (default graph if omitted)."
+            },
+            {
+              "name": "--mode",
+              "type": "text",
+              "required": false,
+              "default": "'replace'",
+              "help": "--endpoint write mode: replace (PUT) or merge (POST)."
+            },
+            {
               "name": "--json",
               "type": "boolean",
               "required": false,


### PR DESCRIPTION
## What and why

The **last deferred piece** of the ontology arc (**ADR 0057**). The emitters
produce RDF as a string; the semantic layer already persists its YAML to a catalog
file (`write_resolved_catalog`). This adds the ontology analogue **and** the "live"
half — writing the RDF into a running triple store — so "resolve once, every SPARQL
query inherits correct identity" lands in the catalog, not just a return value.

## Changes

- **`write_ontology_catalog(rdf, dest=… | endpoint=…)`** — one function, two
  destinations (exactly one required):
  - `dest`: write to a **file** (refuses to clobber unless `overwrite`);
  - `endpoint`: a **SPARQL 1.1 Graph Store HTTP Protocol** URL —
    `mode="replace"` → **PUT** (replace the named graph), `mode="merge"` → **POST**;
    `graph_iri` selects the graph (`?default` otherwise); Content-Type from `fmt`.
    HTTP/URL errors wrapped in a clear `RuntimeError`.
- **`write_resolved_identity_graph(crosswalk, …)`** — emit a crosswalk's
  `owl:sameAs`/PROV-O graph and write it in one call.
- **CLI**: `goldenmatch ontology discover --endpoint URL [--graph-iri IRI]
  [--mode replace|merge]` pushes a discovered ontology to a triple store.
- **Stdlib-only** (`urllib`, mirroring `client.py`) — no new dependency, and the
  write path needs **no rdflib** (persisting an already-serialized string), so
  `write_ontology_catalog` runs on a plain install and in the normal test lane.

GoldenMatch conforms to the Graph Store protocol; it does not implement a triple
store (replaceable-backend rule). Not a new parity surface (a flag on an existing
command); config-matrix + agent-manifest regenerated.

## Testing

- `pytest tests/test_ontology_catalog.py tests/test_ontology_frontdoor.py tests/test_ontology.py tests/test_mcp_new_tools.py` → **51 passed** (file write + clobber-guard, PUT-replace/POST-merge with mocked urllib incl. `?graph=` encoding + Content-Type + body, HTTP-error wrap, crosswalk wrapper round-trip, CLI `--endpoint` write-back)
- Ran the **full config_matrix job battery up front** (config-matrix / suite-matrix / thesis-weaknesses / api-surface / llms-counts `--check` + 74 job tests) + `check_docs_consistency` → all green
- `ruff` clean

## Checklist

- [x] Tests added/updated and passing locally
- [x] Generated docs regenerated (config-matrix + agent-manifest; suite-matrix/api-surface/llms unchanged — a CLI *option*, not a new command)
- [x] `CHANGELOG.md` + ADR 0057 + planning-doc status (arc complete)
- [x] No new dependency; no secrets/tokens committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_