### PR TITLE
fix(semantic): respect the caller's identity config in build_resolved_crosswalk (#2521)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Fixed
+- **`build_resolved_crosswalk` respects the caller's `config.identity` instead
+  of replacing it (#2521).** It constructed a fresh `IdentityConfig` with
+  `backend="sqlite"` hardcoded and `emit_singletons` omitted, so a
+  caller-supplied identity section was discarded wholesale -- silently, with no
+  diagnostic. Those two settings are the only single-node scale levers the
+  identity docs describe (`emit_singletons: false`, and moving the store to
+  Postgres for its bulk `COPY` write path), which made the documented scale
+  guidance unreachable through this entry point. A user who set
+  `identity.backend: postgres` and called this function still got SQLite with
+  singletons on, and at ~2x the documented ~100k-row SQLite ceiling the runtime
+  advisory would name a fix the entry point could not apply.
+
+  The function now merges rather than replaces, overriding only what it is
+  inherently deciding -- `enabled`, `source_pk_column`, `dataset`, and the
+  sqlite `path` when a `store_path` was passed. `backend`, `connection` and
+  `emit_singletons` are left to the caller, and the identity store is opened
+  with the configured backend rather than a second hardcoded
+  `IdentityStore(backend="sqlite", ...)`.
+
+  Backward compatible by construction: `IdentityConfig`'s defaults are
+  `backend="sqlite"` and `emit_singletons=True`, exactly the behaviour that was
+  hardcoded, so a config whose `identity` was never touched resolves to an
+  identical run. Two related sharp edges are also closed -- passing
+  `store_path` alongside a non-sqlite backend now warns instead of silently
+  ignoring the path, and the returned `ResolvedCrosswalk.store_path` reports
+  `None` in that case rather than a file the run never wrote.
 - **Auto-config no longer scores a field that every candidate pair agrees on by
   construction (#2526).** Blocking makes its key constant inside each block, so
   when the same column is also a scored field in the weighted matchkey it

--- a/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/crosswalk.py
@@ -15,6 +15,7 @@ runs (the whole point of "resolve once"); omit it for an ephemeral run.
 """
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from dataclasses import dataclass
@@ -23,6 +24,8 @@ from typing import Any
 import pyarrow as pa
 
 from goldenmatch.semantic.key_integrity import _to_arrow
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -74,8 +77,17 @@ def build_resolved_crosswalk(
         dataset: identity-graph dataset scope (defaults to `source_name`).
         store_path: SQLite path for the identity graph. Pass a stable path to make
             entity ids durable across runs ("resolve once"); omit for an ephemeral
-            temp store.
+            temp store. Ignored (with a warning) when `config.identity.backend` is
+            not sqlite, since a postgres store is addressed by its connection.
         config: an explicit GoldenMatchConfig; zero-config auto-config otherwise.
+            Its `identity` section is RESPECTED, not replaced: `backend`,
+            `connection` and `emit_singletons` are the caller's to set. This
+            function overrides only what it is inherently deciding -- `enabled`,
+            `source_pk_column`, `dataset`, and the sqlite `path` when a
+            `store_path` was given. `emit_singletons=False` and
+            `backend="postgres"` are the two documented single-node scale levers
+            (see `docs-site/goldenmatch/identity-graph.mdx`); both reach the
+            resolver through here.
 
     Returns:
         A `ResolvedCrosswalk`. The resolved key is the control plane's stable id.
@@ -90,10 +102,6 @@ def build_resolved_crosswalk(
         raise ValueError(f"build_resolved_crosswalk: source_pk column not in table: {source_pk!r}")
 
     dataset = dataset or source_name
-    ephemeral = store_path is None
-    if ephemeral:
-        fd, store_path = tempfile.mkstemp(prefix="gm_crosswalk_", suffix=".db")
-        os.close(fd)
 
     # Zero-config (or the caller's config), with the identity graph enabled so the
     # pipeline assigns durable stable ids. Disable rerank so certification never
@@ -102,18 +110,52 @@ def build_resolved_crosswalk(
     for mk in cfg.get_matchkeys():
         if getattr(mk, "rerank", False):
             mk.rerank = False
-    cfg.identity = IdentityConfig(
-        enabled=True,
-        backend="sqlite",
-        path=store_path,
-        source_pk_column=source_pk,
-        dataset=dataset,
-    )
+
+    # MERGE the caller's identity settings rather than replacing them (#2521).
+    # This function owns only what it is inherently deciding -- it is resolving
+    # THIS frame into THIS dataset -- and must leave the storage and cost levers
+    # (`backend`, `connection`, `emit_singletons`) to the caller. Those are the
+    # only two single-node scale controls the identity docs describe, and
+    # hardcoding them here made the documented guidance unreachable through this
+    # entry point, silently.
+    #
+    # Backward compatible by construction: `IdentityConfig`'s defaults are
+    # `backend="sqlite"` and `emit_singletons=True`, which is exactly the
+    # behaviour this used to hardcode. A config whose `identity` was never
+    # touched resolves to the same run as before.
+    supplied = getattr(cfg, "identity", None)
+    identity = IdentityConfig() if supplied is None else supplied.model_copy(deep=True)
+    identity.enabled = True
+    identity.source_pk_column = source_pk
+    identity.dataset = dataset
+
+    # The ephemeral temp store is a SQLite-only concept; a postgres store is
+    # durable by definition and has no file to create or clean up.
+    ephemeral = identity.backend == "sqlite" and store_path is None
+    if identity.backend == "sqlite":
+        if store_path is None:
+            fd, store_path = tempfile.mkstemp(prefix="gm_crosswalk_", suffix=".db")
+            os.close(fd)
+        identity.path = store_path
+    elif store_path is not None:
+        # Don't drop it silently -- that is the failure mode this fixes.
+        logger.warning(
+            "build_resolved_crosswalk: store_path=%r is ignored because "
+            "config.identity.backend is %r, not 'sqlite'. The identity graph will "
+            "use the configured connection; pass backend='sqlite' if you meant to "
+            "write to that file.",
+            store_path, identity.backend,
+        )
+    cfg.identity = identity
 
     try:
         dedupe_df(df, config=cfg, source_name=source_name, confidence_required=False)
 
-        store = IdentityStore(backend="sqlite", path=store_path)
+        store = IdentityStore(
+            backend=identity.backend,
+            path=identity.path,
+            connection=identity.connection,
+        )
         pks = table.column(source_pk).to_pylist()
         record_ids = [f"{source_name}:{pk}" for pk in pks]
         mapping = store.lookup_entity_ids(record_ids)
@@ -150,6 +192,10 @@ def build_resolved_crosswalk(
         n_records=len(pks),
         n_entities=n_entities,
         unmapped=unmapped,
-        store_path=None if ephemeral else store_path,
+        # Only report a path the run actually used: it is None for an ephemeral
+        # store, and for a non-sqlite backend where any `store_path` was ignored.
+        store_path=(
+            store_path if (identity.backend == "sqlite" and not ephemeral) else None
+        ),
         note=note,
     )

--- a/packages/python/goldenmatch/tests/test_crosswalk_identity_config_2521.py
+++ b/packages/python/goldenmatch/tests/test_crosswalk_identity_config_2521.py
@@ -1,0 +1,178 @@
+"""#2521: `build_resolved_crosswalk` must respect the caller's identity config.
+
+It used to replace `cfg.identity` wholesale with a freshly built `IdentityConfig`
+hardcoding `backend="sqlite"` and omitting `emit_singletons` -- the only two
+single-node scale levers the identity docs describe. A caller who followed that
+documentation got SQLite with singletons on, silently, with no diagnostic.
+
+These tests assert on the config the resolver is actually handed, by capturing it
+at the `dedupe_df` boundary, so they fail if the merge regresses regardless of
+what the store does afterwards.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from goldenmatch.config.schemas import IdentityConfig
+
+
+def _frame():
+    return pa.table({
+        "pk": ["1", "2", "3", "4"],
+        "name": ["Alice Smith", "Alice Smyth", "Bob Jones", "Robert Jones"],
+        "city": ["Leeds", "Leeds", "York", "York"],
+    })
+
+
+def _capture_config(monkeypatch):
+    """Intercept the config handed to the resolver, and stop before any store IO."""
+    seen: dict = {}
+
+    def _fake_dedupe_df(df, *, config=None, **kw):
+        seen["config"] = config
+        raise _Stop
+
+    class _Stop(Exception):
+        pass
+
+    import goldenmatch._api as api
+    monkeypatch.setattr(api, "dedupe_df", _fake_dedupe_df)
+    return seen, _Stop
+
+
+def _run(monkeypatch, **kwargs):
+    seen, stop = _capture_config(monkeypatch)
+    from goldenmatch.semantic.crosswalk import build_resolved_crosswalk
+    with pytest.raises(stop):
+        build_resolved_crosswalk(_frame(), source_pk="pk", source_name="s", **kwargs)
+    return seen["config"].identity
+
+
+class TestCallerIdentityIsRespected:
+    def test_postgres_backend_and_connection_survive(self, tmp_path):
+        # The exact reproduction from the issue: a postgres DSN plus
+        # emit_singletons=False, both previously discarded.
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            cfg = _cfg_with(IdentityConfig(
+                enabled=True, backend="postgres",
+                connection="postgresql://example/db", emit_singletons=False,
+            ))
+            identity = _run(monkeypatch, config=cfg)
+        finally:
+            monkeypatch.undo()
+        assert identity.backend == "postgres"
+        assert identity.connection == "postgresql://example/db"
+        assert identity.emit_singletons is False
+
+    def test_emit_singletons_false_survives_on_sqlite(self, tmp_path):
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            cfg = _cfg_with(IdentityConfig(enabled=True, emit_singletons=False))
+            identity = _run(
+                monkeypatch, config=cfg, store_path=str(tmp_path / "x.db"),
+            )
+        finally:
+            monkeypatch.undo()
+        assert identity.emit_singletons is False
+        assert identity.backend == "sqlite"
+
+    def test_store_path_still_wins_for_the_sqlite_path(self, tmp_path):
+        # `store_path` is an explicit argument, so it beats a config default.
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        p = str(tmp_path / "durable.db")
+        try:
+            cfg = _cfg_with(IdentityConfig(enabled=True, path="/should/not/be/used.db"))
+            identity = _run(monkeypatch, config=cfg, store_path=p)
+        finally:
+            monkeypatch.undo()
+        assert identity.path == p
+
+    def test_function_owned_fields_are_overridden(self, tmp_path):
+        # These describe THIS call, so the caller does not get to set them.
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            cfg = _cfg_with(IdentityConfig(
+                enabled=False, source_pk_column="wrong", dataset="wrong",
+            ))
+            identity = _run(
+                monkeypatch, config=cfg, store_path=str(tmp_path / "x.db"),
+            )
+        finally:
+            monkeypatch.undo()
+        assert identity.enabled is True
+        assert identity.source_pk_column == "pk"
+        assert identity.dataset == "s"  # defaults to source_name
+
+    def test_untouched_identity_reproduces_the_old_behaviour(self, tmp_path):
+        # Backward compatibility is the point: IdentityConfig's defaults ARE what
+        # this function used to hardcode, so an untouched config is unchanged.
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        p = str(tmp_path / "x.db")
+        try:
+            identity = _run(monkeypatch, store_path=p)
+        finally:
+            monkeypatch.undo()
+        assert identity.backend == "sqlite"
+        assert identity.emit_singletons is True
+        assert identity.path == p
+        assert identity.enabled is True
+
+
+class TestNonSqliteStorePathIsNotSilent:
+    def test_store_path_with_postgres_warns(self, tmp_path, caplog):
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            cfg = _cfg_with(IdentityConfig(
+                enabled=True, backend="postgres", connection="postgresql://x/y",
+            ))
+            with caplog.at_level("WARNING", logger="goldenmatch.semantic.crosswalk"):
+                _run(monkeypatch, config=cfg, store_path=str(tmp_path / "ignored.db"))
+        finally:
+            monkeypatch.undo()
+        assert any("is ignored" in r.getMessage() for r in _ours(caplog)), caplog.text
+
+    def test_no_warning_on_the_sqlite_path(self, tmp_path, caplog):
+        pytest.importorskip("polars")
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            with caplog.at_level("WARNING", logger="goldenmatch.semantic.crosswalk"):
+                _run(monkeypatch, store_path=str(tmp_path / "x.db"))
+        finally:
+            monkeypatch.undo()
+        # Scope to THIS module's logger: auto-config legitimately warns about the
+        # fixture's own shape, and caplog collects every logger's records.
+        assert not _ours(caplog), caplog.text
+
+
+def _ours(caplog):
+    return [r for r in caplog.records if r.name == "goldenmatch.semantic.crosswalk"]
+
+
+def _cfg_with(identity: IdentityConfig):
+    """A minimal real config carrying the given identity section."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=0.8,
+            fields=[MatchkeyField(field="name", scorer="token_sort", weight=1.0)],
+        )],
+        # A weighted matchkey requires blocking (schema-enforced).
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+        ),
+        identity=identity,
+    )


### PR DESCRIPTION
## What and why

Closes #2521.

`build_resolved_crosswalk` replaced `cfg.identity` with a freshly built `IdentityConfig`, hardcoding `backend="sqlite"` and omitting `emit_singletons`. A caller-supplied identity section was discarded wholesale, **silently**.

Those two settings are the only single-node scale levers the identity docs describe - `emit_singletons: false`, and moving the store to Postgres for its bulk `COPY` write path - so following the documented scale guidance through this entry point had no effect. Worse, at roughly 2x the documented ~100k-row SQLite ceiling the runtime advisory fires and *names* the fix, while the entry point that produced it can apply neither half of it.

## The fix

Merge rather than replace. The function overrides only what it is inherently deciding - it is resolving **this** frame into **this** dataset - and leaves the storage and cost levers to the caller:

| field | owner | why |
|---|---|---|
| `enabled`, `source_pk_column`, `dataset` | the function | describe this call |
| `path` | the function, **only** when `store_path` was passed | `store_path` is an explicit argument |
| `backend`, `connection`, `emit_singletons` | **the caller** | the documented scale levers |

The store is also opened with the configured backend, rather than a second hardcoded `IdentityStore(backend="sqlite", ...)` a few lines later.

## Backward compatible by construction

`IdentityConfig`'s defaults are `backend="sqlite"` and `emit_singletons=True` - **exactly** what this used to hardcode. So a config whose `identity` was never touched resolves to an identical run; there is no behaviour change for existing callers. `test_untouched_identity_reproduces_the_old_behaviour` pins that specifically rather than leaving it as an argument.

## Adjacent sharp edges, same shape as the bug

The issue's own ranking put "silent discard is the worst of the options" last for a reason, so the neighbouring silent discards are closed too:

- Passing `store_path` alongside a non-sqlite backend now **warns** instead of ignoring the path without a word.
- The returned `ResolvedCrosswalk.store_path` reports `None` in that case, instead of naming a file the run never wrote.
- The ephemeral temp-file create/unlink dance is skipped for non-sqlite backends, where there is no file to manage.

## Reproduction, before and after

The issue's exact snippet, with the resolver boundary instrumented (no live postgres needed):

```
build_resolved_crosswalk: store_path='out.db' is ignored because
config.identity.backend is 'postgres', not 'sqlite'. ...

backend         = 'postgres'    (was hardcoded 'sqlite')
connection      = 'postgresql://example/db'    (was dropped)
emit_singletons = False    (was forced True)
enabled/pk/ds   = True / 'pk' / 's'
```

## Testing

- New `tests/test_crosswalk_identity_config_2521.py` - 7 tests. They assert on the config **actually handed to the resolver**, captured at the `dedupe_df` boundary, so they fail if the merge regresses regardless of what the store does downstream. Covers: postgres backend + DSN survive, `emit_singletons=False` survives, `store_path` still wins for the sqlite path, function-owned fields are still overridden, the untouched-config equivalence, and both the warn / don't-warn cases.
- `tests/test_resolved_crosswalk.py` (the existing 6) still pass - **13 passed** together.
- `ruff check packages/python/goldenmatch` clean; pyright reports no new errors in the changed files; `check_context_budget.py` OK; codemap regenerated.

## Note on the docstring

`store_path`'s docstring said "SQLite path for the identity graph", so SQLite-only may have been the original intent. The issue is right that either way the interaction with `config.identity` should not be a silent drop. This PR takes option (1) from the issue - make it genuinely configurable - and documents on the function which fields it owns and which it leaves alone, so the boundary is stated rather than implied.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed
- [ ] `pre-commit run --all-files` - not run in full; ruff + pyright + context-budget + codemap gates run individually and are clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_