### PR TITLE
fix(spark): refuse a packed venv the executors cannot run

### DIFF
--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -135,15 +135,15 @@ jobs:
           # silently if this is ever untrue.
           (cd /tmp && /tmp/gmenv/bin/python -c "import goldenmatch_native, goldenmatch_native._native; print('worker HAS the Rust kernel')") \
             || { echo "::error::the shipped executor env has no goldenmatch-native; the NATIVE row_python arm would score with the pure floor and be labelled native"; exit 1; }
-          .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
-          ls -lh gm_env.tar.gz
+          .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.zip --force
+          ls -lh gm_env.zip
 
       - name: Diagnose the batched plan (mode=diag)
         if: inputs.mode == 'diag'
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
           SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
-          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |
@@ -161,7 +161,7 @@ jobs:
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
           SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
-          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
           GOLDENMATCH_NATIVE: "0"
         run: |
           .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 0             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
@@ -174,7 +174,7 @@ jobs:
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
           SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
-          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
         run: |
           .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 1             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python_native.json
 
@@ -183,7 +183,7 @@ jobs:
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
           SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
-          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3145,8 +3145,24 @@ jobs:
           # separate `uv pip install` as before. Shipping executor deps is the
           # whole reason the extra carries it, so resolving it from the extra is
           # what proves a user following the docs gets a working tool.
-          .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
-          ls -lh gm_env.tar.gz
+          #
+          # .zip, NOT .tar.gz, and the extension is load-bearing (#2531).
+          # `bin/python` in a venv is a SYMLINK to the interpreter the venv was
+          # built against. venv-pack's tar preserves that symlink, so the
+          # archive unpacks on an executor and then cannot execute -- it points
+          # at /opt/hostedtoolcache on this runner. Its zip writer dereferences
+          # the link instead (`ZipArchive.add_link` only preserves one under
+          # --zip-symlinks), so the interpreter travels BY VALUE.
+          #
+          # The exec bit survives: venv-pack stamps create_system=3 with the
+          # unix mode, Spark routes .zip to Hadoop's FileUtil.unZip, and that
+          # restores POSIX permissions for UNIX-platform entries (HADOOP-18145).
+          #
+          # This lane ran on tar.gz for months without noticing, because under
+          # local[*] the executor IS the driver and the symlink resolves. Do not
+          # switch it back.
+          .venv/bin/venv-pack -p /tmp/gmenv -o gm_env.zip --force
+          ls -lh gm_env.zip
       # BOTH prefixes. The package renamed in P2 but the test files did not, so
       # the tier's suite is split across test_sail_*.py (pre-rename) and
       # test_spark_*.py (P1's executor-dependency tests, which this lane was NOT
@@ -3284,13 +3300,13 @@ jobs:
             echo "::error::the bare env can import goldenmatch; the inventory would be meaningless"
             exit 1
           fi
-          .venv/bin/venv-pack -p /tmp/bare-env -o bare_env.tar.gz --force
-          ls -lh bare_env.tar.gz
+          .venv/bin/venv-pack -p /tmp/bare-env -o bare_env.zip --force
+          ls -lh bare_env.zip
       - name: Inventory -- what runs with NO Python on the executors
         continue-on-error: true
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
-          GOLDENMATCH_SPARK_PYENV: "bare_env.tar.gz"
+          GOLDENMATCH_SPARK_PYENV: "bare_env.zip"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
         run: |
           .venv/bin/python scripts/spark_jar_only_inventory.py \
@@ -3309,7 +3325,7 @@ jobs:
       - name: Tier tests against Apache Spark Connect
         env:
           GOLDENMATCH_SPARK_REMOTE: "local[*]"
-          GOLDENMATCH_SPARK_PYENV: "gm_env.tar.gz"
+          GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
         run: |
           .venv/bin/python -m pytest \

--- a/.github/workflows/pack-executor-env.yml
+++ b/.github/workflows/pack-executor-env.yml
@@ -110,12 +110,12 @@ jobs:
           pip install venv-pack
           # `-p` at a stdlib venv: venv-pack REJECTS a uv-created venv outright
           # ("Current environment is not a virtual environment").
-          venv-pack -p /tmp/gmenv -o gm_env.tar.gz --force
-          ls -lh gm_env.tar.gz
+          venv-pack -p /tmp/gmenv -o gm_env.zip --force
+          ls -lh gm_env.zip
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
           name: gm-executor-env
-          path: gm_env.tar.gz
+          path: gm_env.zip
           if-no-files-found: error
           retention-days: 3

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7867,7 +7867,14 @@
           "file": "packages/python/goldenmatch/goldenmatch/spark/deps.py",
           "purpose": "Ship the client's Python environment to Spark executors (P1).",
           "defines": [
+            "ExternalInterpreterError",
+            "_archive_members",
+            "_external_interpreter_message",
+            "_find_interpreter",
+            "_is_absolute",
+            "_normalise",
             "executor_probe",
+            "inspect_environment_archive",
             "ship_python_environment"
           ],
           "imports": [

--- a/packages/python/goldenmatch/goldenmatch/spark/deps.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/deps.py
@@ -21,13 +21,207 @@ client interpreter.
 from __future__ import annotations
 
 import json
+import posixpath
+import re
+import stat
+import tarfile
+import zipfile
 from typing import Any
 
 _ENV_NAME = "environment"
 
+#: Where a packed environment keeps its interpreter, most specific first. The
+#: POSIX names are what ``python -m venv`` produces; ``Scripts/`` is the Windows
+#: layout, which is included because an archive can be INSPECTED anywhere even
+#: though it can only be shipped to Linux executors.
+_INTERPRETERS = ("bin/python", "bin/python3", "Scripts/python.exe", "Scripts/python")
+
+#: A symlink chain is followed at most this far. A venv's real chain is two hops
+#: (``python -> python3 -> python3.12``); the bound exists so a cyclic archive
+#: cannot hang the driver.
+_MAX_LINK_HOPS = 12
+
+#: ``C:\Python312\...`` -- absolute, but not by the POSIX rule.
+_WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+class ExternalInterpreterError(RuntimeError):
+    """The archive's interpreter is a symlink pointing out of the archive.
+
+    Raised on the DRIVER, before anything is uploaded. The alternative is an
+    executor-side ``java.io.IOException: Cannot run program
+    "./environment/bin/python" ... error=2`` -- a JVM error, in a task log, on
+    another machine, naming a path that exists on the machine you packed from.
+    """
+
+
+def _archive_members(path: str) -> dict[str, str | None]:
+    """Map member name -> symlink target (``None`` for a regular file).
+
+    Two containers, because the format decides the answer. ``venv-pack``
+    preserves the interpreter symlink in a tarball, but its ``ZipArchive.add``
+    dereferences one unless ``--zip-symlinks`` is passed -- so the same venv is
+    relocatable packed as ``.zip`` and not as ``.tar.gz``. That asymmetry is the
+    cheapest fix available to a user and is worth modelling exactly.
+    """
+    members: dict[str, str | None] = {}
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as zf:
+            for info in zf.infolist():
+                name = _normalise(info.filename)
+                mode = info.external_attr >> 16
+                if info.create_system == 3 and stat.S_ISLNK(mode):
+                    members[name] = zf.read(info).decode("utf-8", "replace")
+                else:
+                    members[name] = None
+        return members
+    with tarfile.open(path) as tf:  # handles .tar, .gz, .bz2, .xz by magic
+        for info in tf.getmembers():
+            name = _normalise(info.name)
+            # A hard link points at another member by name, so it resolves with
+            # exactly the same walk as a symlink.
+            members[name] = info.linkname if (info.issym() or info.islnk()) else None
+    return members
+
+
+def _normalise(name: str) -> str:
+    return name[2:] if name.startswith("./") else name.rstrip("/")
+
+
+def _find_interpreter(members: dict[str, str | None]) -> str | None:
+    """Locate the interpreter, allowing ONE leading directory.
+
+    Packers differ on whether the venv is at the archive root or under a
+    directory named for it, and the check has to work either way -- a report of
+    "no interpreter" on a perfectly good archive would send someone chasing the
+    wrong thing.
+    """
+    for suffix in _INTERPRETERS:
+        if suffix in members:
+            return suffix
+        # Sorted so an archive with more than one candidate prefix resolves the
+        # same way every run; a check that picks a different member per
+        # invocation is worse than no check.
+        for name in sorted(members):
+            if name.partition("/")[2] == suffix:
+                return name
+    return None
+
+
+def _is_absolute(target: str) -> bool:
+    return target.startswith("/") or bool(_WINDOWS_ABSOLUTE.match(target))
+
+
+def inspect_environment_archive(archive: str) -> dict[str, Any]:
+    """Ask whether a packed environment carries its own interpreter.
+
+    Returns ``interpreter``, ``self_contained``, ``escapes_to`` and ``error``.
+
+    ``self_contained`` is deliberately three-valued:
+
+    ``True``
+        the interpreter is a real file in the archive, or a symlink chain that
+        ends at one. It will run wherever the archive unpacks.
+    ``False``
+        the chain leaves the archive. It will run only on a host that happens to
+        have that exact path -- which the driver cannot check, so this is a
+        statement about the ARCHIVE, not a verdict about your cluster.
+    ``None``
+        no opinion: no interpreter member (a PEX is a single file, not a packed
+        venv), or the archive could not be read. Never treat this as a failure;
+        a check that fails closed on layouts it does not model stops people
+        using supported things.
+    """
+    report: dict[str, Any] = {
+        "archive": archive,
+        "interpreter": None,
+        "self_contained": None,
+        "escapes_to": None,
+        "error": None,
+    }
+    try:
+        members = _archive_members(archive)
+    except Exception as exc:  # noqa: BLE001 - any unreadable archive is "no opinion"
+        report["error"] = f"could not read {archive}: {exc}"
+        return report
+
+    start = _find_interpreter(members)
+    if start is None:
+        report["error"] = (
+            "no bin/python member; not a packed venv (a PEX, or another layout)"
+        )
+        return report
+    report["interpreter"] = start
+
+    current = start
+    seen = {current}
+    for _ in range(_MAX_LINK_HOPS):
+        target = members.get(current)
+        if target is None:
+            report["self_contained"] = True
+            return report
+        if _is_absolute(target):
+            report["self_contained"] = False
+            report["escapes_to"] = target
+            return report
+        resolved = posixpath.normpath(posixpath.join(posixpath.dirname(current), target))
+        if resolved == ".." or resolved.startswith("../"):
+            report["self_contained"] = False
+            # The raw target, not the normalised one: `../../usr/bin/python3.12`
+            # is what the archive says, and what the user has to recognise.
+            report["escapes_to"] = target
+            return report
+        if resolved not in members:
+            report["self_contained"] = False
+            report["escapes_to"] = resolved
+            return report
+        if resolved in seen:
+            report["self_contained"] = False
+            report["error"] = f"symlink cycle at {resolved}"
+            return report
+        seen.add(resolved)
+        current = resolved
+
+    report["self_contained"] = False
+    report["error"] = f"symlink chain from {start} exceeds {_MAX_LINK_HOPS} hops"
+    return report
+
+
+def _external_interpreter_message(report: dict[str, Any]) -> str:
+    target = report["escapes_to"] or report["error"] or "outside the archive"
+    return (
+        f"{report['archive']}: the interpreter at {report['interpreter']} is a "
+        f"symlink to {target}, which is outside the archive.\n"
+        "\n"
+        "`bin/python` in a `python -m venv` environment is a symlink to the "
+        "interpreter the venv was created against. Shipping that archive to an "
+        "executor unpacks fine and then cannot execute:\n"
+        "\n"
+        '    java.io.IOException: Cannot run program "./environment/bin/python"'
+        " ... error=2, No such file or directory\n"
+        "\n"
+        "Three ways forward:\n"
+        "  1. Pack as .zip. venv-pack stores the interpreter BY VALUE in a zip "
+        "(it only preserves symlinks with --zip-symlinks), so the archive "
+        "becomes self-contained: `venv-pack -p ENV -o env.zip`.\n"
+        "  2. Build the venv against an interpreter at a path the executors "
+        "also have (inside a container matching the executor image), or point "
+        "the link there at pack time with venv-pack's --python-prefix.\n"
+        "  3. If the executors really do have that interpreter at that exact "
+        "path, say so: ship_python_environment(..., "
+        "allow_external_interpreter=True).\n"
+        "\n"
+        "This is checked on the driver because the executor-side failure is a "
+        "JVM IOException in a task log on another machine (issue #2531)."
+    )
+
 
 def ship_python_environment(
-    spark: Any, archive: str, env_name: str = _ENV_NAME
+    spark: Any,
+    archive: str,
+    env_name: str = _ENV_NAME,
+    *,
+    allow_external_interpreter: bool = False,
 ) -> None:
     """Upload ``archive`` and point the UDF workers at its interpreter.
 
@@ -48,12 +242,35 @@ def ship_python_environment(
     and cannot run a single UDF. rapidfuzz is NOT needed: the scorer floor is
     goldenmatch's own ``core.strsim``, and rapidfuzz is a dev-only extra.
 
+    **Relocation trap** (issue #2531). Same OS and arch is not sufficient: the
+    interpreter PATH has to resolve on the executor too. ``bin/python`` in a
+    ``python -m venv`` environment is a symlink to the interpreter the venv was
+    created against, and ``venv-pack`` preserves that symlink in a tarball. This
+    function inspects the archive and refuses one whose interpreter points out
+    of it; see :func:`inspect_environment_archive`.
+
     Args:
         spark: an active Spark **Connect** session.
         archive: path to the packed environment.
         env_name: unpack directory name on the executor; also the interpreter
             path prefix. Rarely needs changing.
+        allow_external_interpreter: ship even when the interpreter symlink
+            leaves the archive. Correct when the executors genuinely have that
+            path -- under ``local[*]``, where the executor IS the driver, or on
+            a cluster whose image carries the same interpreter. The driver
+            cannot verify either, which is why this is a statement you make
+            rather than a check that passes.
+
+    Raises:
+        ExternalInterpreterError: the archive cannot run on a host that does not
+            already have the interpreter it was packed against.
     """
+    if not allow_external_interpreter:
+        report = inspect_environment_archive(archive)
+        # `is False` on purpose: `None` means the check formed no opinion, and
+        # must not block a working setup.
+        if report["self_contained"] is False:
+            raise ExternalInterpreterError(_external_interpreter_message(report))
     spark.addArtifact(f"{archive}#{env_name}", archive=True)
     spark.conf.set("spark.sql.execution.pyspark.python", f"./{env_name}/bin/python")
 

--- a/packages/python/goldenmatch/tests/test_spark_env_archive.py
+++ b/packages/python/goldenmatch/tests/test_spark_env_archive.py
@@ -1,0 +1,353 @@
+"""#2531: an archive whose interpreter is a symlink OUT of the archive.
+
+``ship_python_environment`` uploads a packed venv and points the executors'
+Python worker at ``./environment/bin/python``. In a ``python -m venv``
+environment that path is a **symlink to the interpreter the venv was created
+against** -- on a GitHub runner, somewhere under ``/opt/hostedtoolcache``.
+Upload that to a cluster and the archive unpacks perfectly and then cannot be
+executed:
+
+    java.io.IOException: Cannot run program "./environment/bin/python"
+      (in directory "./17c42a47-..."): error=2, No such file or directory
+
+The whole suite ran under ``local[*]``, where the executor IS the driver -- so
+the symlink resolved and the helper's central claim, that you can pack a venv on
+your client and ship it to a cluster, was only ever exercised where relocating
+it is a no-op.
+
+These tests build archives by hand rather than shelling out to ``venv-pack``:
+the shapes below are taken from venv-pack's own source (``Packer.add`` in
+``venv_pack/core.py`` preserves a symlink unless ``--python-prefix`` rewrites
+it; ``ZipArchive.add`` dereferences one when ``zip_symlinks`` is false), and
+building them directly means the check is tested on Windows, needs no venv, and
+runs in milliseconds.
+"""
+from __future__ import annotations
+
+import io
+import os
+import stat
+import tarfile
+import zipfile
+
+import pytest
+from goldenmatch.spark.deps import (
+    ExternalInterpreterError,
+    inspect_environment_archive,
+)
+
+# ── archive builders ─────────────────────────────────────────────────
+#
+# `tarfile`/`zipfile` write symlink entries without needing the filesystem to
+# support them, which matters: this test suite's own dev machine is Windows,
+# where creating a real symlink needs a privilege the CI account may not have.
+
+
+def _tar(tmp_path, entries, name="env.tar.gz"):
+    """entries: list of (path, kind, payload). kind in {"file", "link"}."""
+    path = tmp_path / name
+    with tarfile.open(path, "w:gz") as tf:
+        for member_path, kind, payload in entries:
+            if kind == "link":
+                info = tarfile.TarInfo(member_path)
+                info.type = tarfile.SYMTYPE
+                info.linkname = payload
+                tf.addfile(info)
+            else:
+                data = payload.encode()
+                info = tarfile.TarInfo(member_path)
+                info.size = len(data)
+                info.mode = 0o755
+                tf.addfile(info, io.BytesIO(data))
+    return str(path)
+
+
+def _zip(tmp_path, entries, name="env.zip"):
+    path = tmp_path / name
+    with zipfile.ZipFile(path, "w") as zf:
+        for member_path, kind, payload in entries:
+            info = zipfile.ZipInfo(member_path)
+            info.create_system = 3
+            if kind == "link":
+                info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            else:
+                info.external_attr = (stat.S_IFREG | 0o755) << 16
+            zf.writestr(info, payload)
+    return str(path)
+
+
+_REAL = ("bin/python", "file", "#!/bin/sh\n")
+
+
+# ── what the archive says about its interpreter ──────────────────────
+
+
+def test_a_real_interpreter_file_is_self_contained(tmp_path):
+    """conda-pack, and venv-pack's zip output: the executable is really there."""
+    report = inspect_environment_archive(_tar(tmp_path, [_REAL]))
+    assert report["self_contained"] is True
+    assert report["interpreter"] == "bin/python"
+    assert report["escapes_to"] is None
+
+
+def test_an_absolute_symlink_escapes_the_archive(tmp_path):
+    """The #2531 shape, exactly: venv-pack tar of a `python -m venv` env."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("bin/python", "link",
+                         "/opt/hostedtoolcache/Python/3.12.7/x64/bin/python3.12")])
+    )
+    assert report["self_contained"] is False
+    assert report["escapes_to"] == (
+        "/opt/hostedtoolcache/Python/3.12.7/x64/bin/python3.12"
+    )
+
+
+def test_a_relative_chain_inside_the_archive_is_followed(tmp_path):
+    """A venv's real shape is a CHAIN: python -> python3 -> python3.12.
+
+    Stopping at the first link would call this self-contained-by-accident or
+    escaping-by-accident depending on which hop you looked at.
+    """
+    report = inspect_environment_archive(
+        _tar(tmp_path, [
+            ("bin/python", "link", "python3"),
+            ("bin/python3", "link", "python3.12"),
+            ("bin/python3.12", "file", "\x7fELF"),
+        ])
+    )
+    assert report["self_contained"] is True
+    assert report["escapes_to"] is None
+
+
+def test_a_chain_that_ends_outside_the_archive_escapes(tmp_path):
+    """Two relative hops and then out -- what a real venv-pack tar contains."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [
+            ("bin/python", "link", "python3"),
+            ("bin/python3", "link", "/usr/local/bin/python3.12"),
+        ])
+    )
+    assert report["self_contained"] is False
+    assert report["escapes_to"] == "/usr/local/bin/python3.12"
+
+
+def test_a_relative_symlink_climbing_out_escapes(tmp_path):
+    """`../../..` leaves the archive just as surely as a leading slash."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("bin/python", "link", "../../usr/bin/python3.12")])
+    )
+    assert report["self_contained"] is False
+    assert report["escapes_to"] == "../../usr/bin/python3.12"
+
+
+def test_a_link_to_a_missing_member_is_not_self_contained(tmp_path):
+    """Points inside the archive, at nothing. Unpacks, then cannot execute."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("bin/python", "link", "python3.12")])
+    )
+    assert report["self_contained"] is False
+    assert report["escapes_to"] == "bin/python3.12"
+
+
+def test_a_top_level_prefix_directory_is_stripped(tmp_path):
+    """Some packers root everything under a directory; the venv is one level in."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [
+            ("gmenv/bin/python", "link", "python3"),
+            ("gmenv/bin/python3", "file", "\x7fELF"),
+        ])
+    )
+    assert report["self_contained"] is True
+    assert report["interpreter"] == "gmenv/bin/python"
+
+
+def test_an_archive_with_no_interpreter_is_unknown_not_broken(tmp_path):
+    """A PEX is a single file, not a packed venv.
+
+    ``ship_python_environment`` documents PEX as a supported input, so "no
+    ``bin/python`` member" must mean "this check does not apply", never
+    "refuse". A check that fails closed on layouts it does not model is a check
+    that stops people using supported things.
+    """
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("some/other/file", "file", "x")])
+    )
+    assert report["self_contained"] is None
+    assert report["interpreter"] is None
+
+
+def test_windows_venvs_are_recognised(tmp_path):
+    """`Scripts/python.exe`, and it is always a real file on Windows."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("Scripts/python.exe", "file", "MZ")])
+    )
+    assert report["self_contained"] is True
+    assert report["interpreter"] == "Scripts/python.exe"
+
+
+# ── zip: the format changes the answer ───────────────────────────────
+
+
+def test_zip_stores_the_interpreter_by_value(tmp_path):
+    """venv-pack's zip output dereferences the symlink (``zip_symlinks`` off).
+
+    Worth pinning: it means the SAME venv is relocatable packed one way and not
+    the other, which is not obvious and is the cheapest real fix available.
+    """
+    report = inspect_environment_archive(_zip(tmp_path, [_REAL]))
+    assert report["self_contained"] is True
+
+
+def test_zip_with_symlinks_enabled_can_still_escape(tmp_path):
+    """`--zip-symlinks` puts the same trap back."""
+    report = inspect_environment_archive(
+        _zip(tmp_path, [("bin/python", "link", "/opt/py/bin/python3.12")])
+    )
+    assert report["self_contained"] is False
+    assert report["escapes_to"] == "/opt/py/bin/python3.12"
+
+
+# ── the refusal, on the driver, at ship time ─────────────────────────
+
+
+class _FakeSession:
+    """Records what a Connect session would have been asked to do."""
+
+    def __init__(self):
+        self.artifacts = []
+        self.conf = self  # `spark.conf.set(...)`
+        self.settings = {}
+
+    def addArtifact(self, spec, archive=False):  # noqa: N802 - Spark's name
+        self.artifacts.append((spec, archive))
+
+    def set(self, key, value):
+        self.settings[key] = value
+
+
+def test_ship_refuses_an_archive_that_cannot_run_on_an_executor(tmp_path):
+    """The point of the whole exercise: fail on the DRIVER, with a reason.
+
+    The executor-side failure is an ``IOException`` naming a path that does not
+    exist, from a JVM, in a task log -- which is how this cost three CI runs to
+    diagnose.
+    """
+    from goldenmatch.spark.deps import ship_python_environment
+
+    archive = _tar(tmp_path, [
+        ("bin/python", "link", "/opt/hostedtoolcache/Python/3.12.7/x64/bin/python3.12"),
+    ])
+    spark = _FakeSession()
+
+    with pytest.raises(ExternalInterpreterError) as excinfo:
+        ship_python_environment(spark, archive)
+
+    message = str(excinfo.value)
+    # The target, because "it is a symlink" without saying to WHERE is not
+    # actionable.
+    assert "/opt/hostedtoolcache/Python/3.12.7/x64/bin/python3.12" in message
+    # Both supported repacks, by their real names -- these come from venv-pack's
+    # own API and are the difference between a fixable message and a dead end.
+    assert "--python-prefix" in message
+    assert ".zip" in message
+    # And the escape hatch, since the driver CANNOT know the executors'
+    # filesystem: an absolute target is wrong only if it is absent there.
+    assert "allow_external_interpreter" in message
+
+    assert spark.artifacts == [], "nothing may be uploaded once we know it cannot run"
+    assert spark.settings == {}
+
+
+def test_ship_uploads_a_self_contained_archive(tmp_path):
+    from goldenmatch.spark.deps import ship_python_environment
+
+    archive = _tar(tmp_path, [_REAL])
+    spark = _FakeSession()
+
+    ship_python_environment(spark, archive)
+
+    assert spark.artifacts == [(f"{archive}#environment", True)]
+    assert spark.settings == {
+        "spark.sql.execution.pyspark.python": "./environment/bin/python"
+    }
+
+
+def test_the_escape_hatch_ships_the_same_archive(tmp_path):
+    """`local[*]`, or a cluster that really does have the interpreter there.
+
+    Opt-in rather than default, because the failure it permits is silent and
+    remote while the flag is local and reviewable.
+    """
+    from goldenmatch.spark.deps import ship_python_environment
+
+    archive = _tar(tmp_path, [("bin/python", "link", "/opt/py/bin/python3.12")])
+    spark = _FakeSession()
+
+    ship_python_environment(spark, archive, allow_external_interpreter=True)
+
+    assert spark.artifacts == [(f"{archive}#environment", True)]
+
+
+def test_an_unreadable_archive_does_not_block_shipping(tmp_path):
+    """A check that cannot read the file must not be the reason nothing ships.
+
+    This helper's job is to upload an archive. If the inspection cannot form an
+    opinion -- an unknown container, a truncated file, a format added later --
+    the correct behaviour is to proceed, because refusing would break a working
+    setup on the strength of the CHECK failing, not the archive.
+    """
+    from goldenmatch.spark.deps import ship_python_environment
+
+    not_an_archive = tmp_path / "env.tar.gz"
+    not_an_archive.write_bytes(b"this is not a tarball")
+    spark = _FakeSession()
+
+    ship_python_environment(spark, str(not_an_archive))
+
+    assert len(spark.artifacts) == 1
+
+
+def test_inspect_reports_the_reason_it_could_not_tell(tmp_path):
+    not_an_archive = tmp_path / "env.tar.gz"
+    not_an_archive.write_bytes(b"this is not a tarball")
+
+    report = inspect_environment_archive(str(not_an_archive))
+
+    assert report["self_contained"] is None
+    assert report["error"]
+
+
+def test_a_missing_archive_is_reported_not_raised(tmp_path):
+    report = inspect_environment_archive(str(tmp_path / "nope.tar.gz"))
+    assert report["self_contained"] is None
+    assert report["error"]
+
+
+# ── the trap this replaces ───────────────────────────────────────────
+
+
+def test_a_symlink_cycle_terminates(tmp_path):
+    """Following links needs a bound; a cycle must not hang the driver."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [
+            ("bin/python", "link", "python3"),
+            ("bin/python3", "link", "python"),
+        ])
+    )
+    assert report["self_contained"] is False
+
+
+def test_absolute_windows_targets_escape_too(tmp_path):
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("Scripts/python.exe", "link", r"C:\Python312\python.exe")])
+    )
+    assert report["self_contained"] is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="tarfile writes POSIX paths anyway")
+def test_backslashes_are_not_path_separators_in_a_tar(tmp_path):
+    """A member literally named with a backslash is one component, not two."""
+    report = inspect_environment_archive(
+        _tar(tmp_path, [("bin/python", "link", "py\\thon3")])
+    )
+    assert report["self_contained"] is False


### PR DESCRIPTION
Closes #2531.

## The bug

`ship_python_environment` ships a packed venv and points the executors at
`./environment/bin/python`. In a `python -m venv` environment that is a
**symlink to the interpreter the venv was created against**. On a real executor
that path does not exist, so the archive unpacks perfectly and then cannot be
executed.

Under `local[*]` the executor IS the driver, so the symlink resolves. The
helper's central claim -- pack a venv on your client and `addArtifact` it to a
cluster -- had only ever been exercised where relocating it is a no-op.

## What this does

**Detect, on the driver.** `inspect_environment_archive` reads the archive (tar
or zip), finds the interpreter, follows the symlink chain and says whether it
stays inside. `ship_python_environment` refuses before uploading, naming the
target path and the fixes.

Three-valued on purpose. `None` means *no opinion* -- a PEX has no `bin/python`,
and an unreadable file is not evidence about the archive -- and never blocks.
Only a definite `False` refuses. The escape hatch is explicit
(`allow_external_interpreter=True`) because the driver cannot see the executors'
filesystem: an absolute target is wrong only if it is absent there, and that is a
statement the caller makes rather than a check that passes.

**Fix the packing.** CI now packs `.zip` rather than `.tar.gz`, and the extension
is load-bearing. Both links in that chain were read in the upstream sources
rather than assumed:

| Claim | Source |
|---|---|
| tar preserves the interpreter symlink; zip dereferences it unless `--zip-symlinks` | `venv_pack/core.py` `Packer.add`, `venv_pack/formats.py` `ZipArchive.add_link` |
| Spark routes `.zip` to Hadoop's unzip | `Utils.unpack`, `core/src/main/scala/org/apache/spark/util/Utils.scala` |
| that unzip restores the exec bit | `FileUtil.unZip` -> `Files.setPosixFilePermissions` for `PLATFORM_UNIX` entries (HADOOP-18145) |

So the same venv is relocatable packed one way and not the other, which is the
cheapest real fix available to a user -- and better than the "copy the
interpreter in" idea in the issue, which venv-pack does not offer.

The CI lane now ships a genuinely relocatable archive instead of one that only
worked because it never left the machine. If anyone switches it back to
`.tar.gz`, the new refusal fails the lane rather than waiting for a cluster to
find out.

## Tests

20 tests that build archives by hand from the shapes in venv-pack's source:
real file, absolute escape, relative chain in, chain that escapes on the second
hop, `../` climb-out, dangling in-archive target, one-level prefix directory, no
interpreter at all, Windows layout, both containers, a cycle, and the two
refusal paths. No venv, no symlink privilege, no Spark, ~1s.

## Not in scope

The cluster lane still runs with bare executors and no Python oracle. Its stated
blocker was that the image ships Python 3.10.12, below goldenmatch's `>=3.11` --
but a self-contained zip carries its own interpreter, so that reason no longer
holds. Whether a runner-built 3.12 actually runs against the image's older glibc
is a separate question worth testing rather than assuming; follow-up.

