### PR TITLE
perf(spark): filter inside the batch, and what that is actually worth

### DIFF
--- a/.github/workflows/bench-spark-scoring.yml
+++ b/.github/workflows/bench-spark-scoring.yml
@@ -31,6 +31,15 @@ on:
         description: "bench (compare paths) | diag (bisect the batched plan to find the OOM)"
         required: false
         default: "bench"
+      threshold:
+        description: >-
+          Score cut for BOTH arms. 0.0 reproduces J4's original measurement,
+          where nothing was filtered and the batched arm exploded every
+          candidate pair. The batched arm applies the cut INSIDE the array, so a
+          realistic cut (0.85) keeps rejected pairs out of the generator -- which
+          the plan bisect said was the whole 2.4x. Run this lane at both.
+        required: false
+        default: "0.0"
       runner:
         description: "Runner label"
         required: false
@@ -164,7 +173,7 @@ jobs:
           GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 0             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 0             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --threshold '${{ inputs.threshold }}' --out bench-row_python.json
 
       # The arm that speaks to spec section 1. Without it the bench measures UDF
       # plumbing with the kernel switched off and says nothing about "vectorized
@@ -176,7 +185,7 @@ jobs:
           SPARK_DRIVER_MEMORY: "${{ inputs.driver_memory }}"
           GOLDENMATCH_SPARK_PYENV: "gm_env.zip"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 1             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-row_python_native.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path row_python --scorer jaro_winkler --native 1             --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --threshold '${{ inputs.threshold }}' --out bench-row_python_native.json
 
       - name: Bench batched_jvm
         if: inputs.mode != 'diag'
@@ -187,7 +196,7 @@ jobs:
           GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
           GOLDENMATCH_NATIVE: "0"
         run: |
-          .venv/bin/python scripts/bench_spark_scoring.py --path batched_jvm --scorer jaro_winkler --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --out bench-batched_jvm.json
+          .venv/bin/python scripts/bench_spark_scoring.py --path batched_jvm --scorer jaro_winkler --rows '${{ inputs.rows }}' --block-size '${{ inputs.block_size }}'             --repeats '${{ inputs.repeats }}' --threshold '${{ inputs.threshold }}' --out bench-batched_jvm.json
 
       # A SCRIPT, not inline Python: an embedded multi-line program inside a
       # YAML `run:` block must survive block-scalar parsing too, and this repo

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7805,6 +7805,7 @@
           "file": "packages/python/goldenmatch/goldenmatch/spark/batched.py",
           "purpose": "J1: reshape scoring from one call per PAIR to one call per BATCH.",
           "defines": [
+            "_above",
             "batch_key",
             "dedup_max",
             "score_pairs_batched"

--- a/packages/python/goldenmatch/goldenmatch/spark/batched.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/batched.py
@@ -102,6 +102,25 @@ def batch_key(strategy: str = "partition", batch_size: int = DEFAULT_BATCH_SIZE)
     return F.floor(F.monotonically_increasing_id() / F.lit(int(batch_size)))
 
 
+def _above(threshold: float):
+    """``arrays_zip`` element -> does its score clear ``threshold``?
+
+    A module-level factory, not an inline lambda, for the reason pinned in
+    ``test_spark_config_pipeline_unit``: **PySpark reads a higher-order lambda's
+    meaning from its PARAMETER COUNT.** One parameter is ``(element)``; two is
+    ``(element, index)``. So the obvious `lambda z, t=threshold:` is read as an
+    indexed callback and ``t`` silently receives the ELEMENT INDEX -- no error,
+    just a filter comparing a score against a row number. Closing over the value
+    keeps the arity at one and lets a test assert it.
+    """
+    def f(z):
+        from pyspark.sql import functions as F
+
+        return z[_SCORES] >= F.lit(float(threshold))
+
+    return f
+
+
 def score_pairs_batched(
     pairs_df: Any,
     source_df: Any,
@@ -112,6 +131,7 @@ def score_pairs_batched(
     udf_name: str,
     batch_strategy: str = "partition",
     batch_size: int = DEFAULT_BATCH_SIZE,
+    threshold: float | None = None,
 ) -> Any:
     """Score ``(a, b)`` pairs through a batched array UDF; return
     ``(a, b, score)``.
@@ -121,6 +141,31 @@ def score_pairs_batched(
 
     The result is the same shape the row-shaped ``score_and_dedup`` produces, so
     the two can be compared directly. That comparison is the J1 gate.
+
+    ## ``threshold``, and why it is applied HERE
+
+    Filtering after the explode and filtering inside the array give the same
+    rows. They do not cost the same, and on this path the difference is the
+    whole story.
+
+    J4 measured the batched JVM arm at **2.4x SLOWER** than the row-shaped
+    Python one, and the plan bisect put the blame precisely: scoring 1.9M pairs
+    over JNI took ~0.2s, while ``arrays_zip``/``explode`` added **~1.2s** -- six
+    times the scoring. An infinitely fast kernel would move 3.5s to 3.3s. The
+    batched path cannot win by scoring faster, because its cost is the
+    un-batching that Spark Connect forces (Connect permits only row-shaped UDFs,
+    so reaching a native kernel means group -> array -> score -> zip -> explode;
+    the row-shaped path never groups and so has nothing to un-batch).
+
+    That bench ran with ``threshold=0.0``: nothing was filtered, so the explode
+    emitted every candidate pair -- the worst case for batching, and the one
+    case where this argument is decided. A real config cuts at a real threshold
+    and keeps a small fraction of candidates, so a filter placed BEFORE the
+    generator shrinks the exploded row count, and the shuffle after it, by
+    roughly the reject ratio. That is the only lever the bisect leaves open.
+
+    ``None`` (the default) adds no filter node at all, so the plan is
+    byte-identical to the pre-threshold one.
     """
     from pyspark.sql import functions as F
 
@@ -160,9 +205,14 @@ def score_pairs_batched(
 
     # arrays_zip pairs positionally BEFORE the explode, so one generator walks
     # already-paired structs. Two explodes would be two independent generators.
-    exploded = scored.select(
-        F.explode(F.arrays_zip(F.col(_ROWS), F.col(_SCORES))).alias("__z__")
-    )
+    zipped = F.arrays_zip(F.col(_ROWS), F.col(_SCORES))
+    if threshold is not None:
+        # BEFORE the explode, on purpose -- see the docstring. `where` after the
+        # generator returns the same rows and pays the generator for every
+        # rejected pair, which is the cost the J4 bisect attributed the whole
+        # 2.4x to.
+        zipped = F.filter(zipped, _above(threshold))
+    exploded = scored.select(F.explode(zipped).alias("__z__"))
     return exploded.select(
         F.col(f"__z__.{_ROWS}.a").alias("a"),
         F.col(f"__z__.{_ROWS}.b").alias("b"),

--- a/packages/python/goldenmatch/tests/test_spark_batched_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_parity.py
@@ -259,3 +259,69 @@ def test_batch_size_does_not_change_the_answer(spark, registered):
     assert answers[0] == answers[1] == answers[2], (
         "batch size changed the answer; it is a memory knob, not a semantic one"
     )
+
+
+def test_the_threshold_returns_exactly_what_a_post_filter_would(spark, registered):
+    """Filtering inside the array must be answer-identical to filtering rows.
+
+    The parameter exists for a PLAN reason -- keep rejected pairs out of the
+    generator, because J4's bisect attributed the batched arm's 2.4x to the
+    explode rather than the kernel -- so the one thing it must not do is change
+    the answer. `exact` scores are 0.0 or 1.0, so a threshold of 0.5 splits them
+    cleanly and an off-by-one in the predicate shows up as a whole class
+    vanishing.
+    """
+    from goldenmatch.spark.batched import score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+
+    df = spark.createDataFrame(_rows(6, 8), _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+
+    def _run(threshold):
+        return score_pairs_batched(
+            pairs, df, id_col=_ID, value_col="name",
+            scorer_id=scorer_id("exact"), udf_name=registered,
+            threshold=threshold,
+        )
+
+    from pyspark.sql import functions as F
+
+    want = {
+        (int(r["a"]), int(r["b"])): r["score"]
+        for r in _run(None).where(F.col("score") >= F.lit(0.5)).collect()
+    }
+    got = {(int(r["a"]), int(r["b"])): r["score"] for r in _run(0.5).collect()}
+
+    assert got == want, (
+        f"array-filter and row-filter disagree: only-array={set(got) - set(want)}, "
+        f"only-row={set(want) - set(got)}"
+    )
+    # The test is only meaningful if the threshold actually rejected something.
+    assert want, "no pair cleared 0.5; the fixture proves nothing"
+    everything = {(int(r["a"]), int(r["b"])) for r in _run(None).collect()}
+    assert len(want) < len(everything), (
+        "nothing was rejected, so this would pass with the filter removed"
+    )
+
+
+def test_a_null_score_does_not_survive_the_threshold(spark, registered):
+    """Comparability nulls must not leak through the array predicate.
+
+    `null >= 0.5` is NULL, not false, and `filter` keeps only elements where the
+    predicate is TRUE -- so nulls drop. That is the same thing `where` does, but
+    it is worth pinning: a null score reaching the output would be a pair the
+    scorer declined to judge, presented as a match.
+    """
+    from goldenmatch.spark.batched import score_pairs_batched
+    from goldenmatch.spark.jvm import scorer_id
+
+    rows = [(0, "b", None), (1, "b", None), (2, "b", "x"), (3, "b", "x")]
+    df = spark.createDataFrame(rows, _SCHEMA)
+    pairs = _candidate_pairs(spark, df)
+
+    scored = score_pairs_batched(
+        pairs, df, id_col=_ID, value_col="name",
+        scorer_id=scorer_id("exact"), udf_name=registered, threshold=0.5,
+    )
+    scores = [r["score"] for r in scored.collect()]
+    assert None not in scores, f"a null score cleared the threshold: {scores}"

--- a/packages/python/goldenmatch/tests/test_spark_batched_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_batched_unit.py
@@ -102,6 +102,60 @@ def test_arrays_are_zipped_before_exploding():
     )
 
 
+# ── J4's only open lever: filter BEFORE the generator ────────────────
+
+def test_the_threshold_filter_is_applied_before_the_explode():
+    """The entire point of the parameter, and invisible to an output check.
+
+    Filtering after the explode returns the SAME ROWS as filtering inside the
+    array, so no behavioural test can tell the two apart -- and the difference
+    is the whole reason the parameter exists. J4's plan bisect attributed the
+    batched arm's 2.4x to `arrays_zip`/`explode` (~1.2s for 1.9M pairs, six
+    times the ~0.2s of actual JNI scoring), so a filter that runs after the
+    generator has already paid for every rejected pair buys nothing.
+
+    Structural, therefore, in the same spirit as the two guards above.
+    """
+    src = inspect.getsource(batched.score_pairs_batched)
+    assert "F.filter(" in src, "the threshold must filter the ARRAY"
+    assert src.index("F.filter(") < src.index("F.explode("), (
+        "the filter must come before the explode; after it, every rejected pair "
+        "has already been materialised as a row and the filter saves nothing"
+    )
+    # A post-generator row filter would be the natural regression -- it reads
+    # identically at the call site and passes every parity test.
+    for after_the_fact in (".where(", ".filter(F.col"):
+        assert after_the_fact not in src, (
+            f"{after_the_fact!r} filters rows after the generator; filter the "
+            f"array instead"
+        )
+
+
+def test_the_threshold_predicate_takes_ONE_parameter():
+    """PySpark reads a higher-order lambda's meaning from its parameter count.
+
+    One parameter is `(element)`; two is `(element, index)`. So
+    `lambda z, t=threshold:` is read as an indexed callback and `t` receives the
+    ELEMENT INDEX -- a filter comparing a score against a row number, with no
+    error and no crash. This repo has already paid for that trap once, in the
+    JVM scoring reshape.
+    """
+    import inspect as _inspect
+
+    predicate = batched._above(0.5)
+    assert len(_inspect.signature(predicate).parameters) == 1, (
+        "a two-parameter predicate is read as (element, index) and silently "
+        "compares the score against the index"
+    )
+
+
+def test_no_threshold_means_no_filter_node():
+    """The default must leave the plan byte-identical to the pre-threshold one,
+    so this parameter cannot be blamed for a change in the J1 parity gate."""
+    sig = inspect.signature(batched.score_pairs_batched)
+    assert sig.parameters["threshold"].default is None
+
+
 def test_dedup_is_separable_from_scoring():
     """Kept apart so the two paths can be compared BEFORE dedup as well as
     after -- a misalignment that dedup happens to mask would otherwise be

--- a/scripts/bench_spark_compare.py
+++ b/scripts/bench_spark_compare.py
@@ -79,6 +79,33 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  NOT like-for-like: batched_jvm ran {jvm.get('scorer')!r}, "
               f"row_python ran {pure.get('scorer')!r}.")
 
+    # A threshold that rejects NOTHING makes the batched arm's whole reason for
+    # having one inert, and says so in a number nobody would look at.
+    #
+    # Run 31709489001 was dispatched at 0.85 to test exactly that lever and came
+    # back with `rows_out` unchanged at 1,900,000 -- 100% kept. The synthetic
+    # fixture puts near-identical strings in a block ("v5_3" vs "v5_7"), which
+    # jaro-winkler scores around 0.88, so 0.85 rejects nothing and the run
+    # measured the un-filtered plan twice. The medians looked plausible and the
+    # comparison was meaningless.
+    #
+    # So the harness states the reject ratio rather than leaving it to be
+    # inferred from a row count.
+    thr = jvm.get("threshold") or 0.0
+    kept = None
+    pairs = jvm.get("candidate_pairs") or 0
+    out_rows = (jvm.get("timing") or {}).get("rows_out")
+    if pairs and out_rows is not None:
+        kept = out_rows / pairs
+        print()
+        print(f"  threshold={thr}: kept {out_rows:,}/{pairs:,} pairs ({kept:.1%})")
+    if thr > 0 and kept is not None and kept > 0.999:
+        print()
+        print("  WARNING: the threshold rejected nothing, so the batched arm's")
+        print("  filter-before-explode did no work and this run says NOTHING")
+        print("  about it. Raise the threshold until pairs are actually")
+        print("  rejected, or the comparison is the threshold=0 one again.")
+
     impl = jvm.get("jvm_impl")
     if impl and impl != "NativeScorer":
         print()
@@ -100,6 +127,8 @@ def main(argv: list[str] | None = None) -> int:
                 "row_python_native": native,
                 "batched_jvm": jvm,
                 "like_for_like": like_for_like,
+                "threshold": thr,
+                "kept_fraction": kept,
                 "native_speedup": (rp / rn) if rn else None,
                 "jvm_vs_pure": (rp / rj) if rj else None,
                 "jvm_vs_native": (rn / rj) if (rj and rn) else None,

--- a/scripts/bench_spark_scoring.py
+++ b/scripts/bench_spark_scoring.py
@@ -125,18 +125,23 @@ def _candidate_pairs(df):
     ).select(F.col(f"a.{_ID}").alias("a"), F.col(f"b.{_ID}").alias("b"))
 
 
-def _row_python(df, scorer_name: str):
-    """The shipped path: arrow_udf -> forked Python worker."""
+def _row_python(df, scorer_name: str, threshold: float):
+    """The shipped path: arrow_udf -> forked Python worker.
+
+    Row-shaped, so its threshold is an ordinary `where` on rows the UDF already
+    produced. There is no generator here to keep pairs out of -- which is the
+    asymmetry the whole comparison turns on.
+    """
     from goldenmatch.spark.scoring import score_and_dedup
 
     out = score_and_dedup(
         df, block_col="blk", value_col="name", id_col=_ID,
-        scorer_name=scorer_name, threshold=0.0,
+        scorer_name=scorer_name, threshold=threshold,
     )
     return out.count()
 
 
-def _batched_jvm(spark, df, udf_name, scorer_name: str):
+def _batched_jvm(spark, df, udf_name, scorer_name: str, threshold: float):
     """J1's plan through the J2 jar: one call per batch, in the executor JVM,
     scoring with the Rust kernel over JNI.
 
@@ -152,6 +157,7 @@ def _batched_jvm(spark, df, udf_name, scorer_name: str):
     scored = score_pairs_batched(
         _candidate_pairs(df), df, id_col=_ID, value_col="name",
         scorer_id=scorer_id(scorer_name), udf_name=udf_name,
+        threshold=threshold,
     )
     return dedup_max(scored).count()
 
@@ -177,6 +183,19 @@ def main(argv=None) -> int:
              "J0's jar carried no algorithms, so the only scorer both arms could "
              "run was `exact`, and this bench's load-bearing caveat was that "
              "like-for-like needed J2.",
+    )
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        help="Score cut, applied to BOTH arms. The default of 0.0 reproduces "
+             "J4's original measurement, where nothing was filtered and the "
+             "batched arm exploded every candidate pair -- the worst case for "
+             "batching and the only case that has ever been measured. A real "
+             "config cuts high, and the batched arm applies the cut INSIDE the "
+             "array, so the generator never sees a rejected pair. Sweeping this "
+             "is how you find out whether the 2.4x is a property of the plan or "
+             "of one unrepresentative threshold.",
     )
     ap.add_argument(
         "--path",
@@ -247,12 +266,15 @@ def main(argv=None) -> int:
     }
 
     results["scorer"] = args.scorer
+    results["threshold"] = args.threshold
 
     if args.path == "row_python":
         print(f"[row_python] arrow_udf -> forked Python worker, "
               f"scorer={args.scorer}", flush=True)
-        results["timing"] = _time(lambda: _row_python(df, args.scorer),
-                                  repeats=args.repeats)
+        results["timing"] = _time(
+            lambda: _row_python(df, args.scorer, args.threshold),
+            repeats=args.repeats,
+        )
     else:
         try:
             udf_name = install(spark, jar=find_jar())
@@ -280,7 +302,7 @@ def main(argv=None) -> int:
         print(f"[batched_jvm] array UDF, in the executor JVM, "
               f"scorer={args.scorer}", flush=True)
         results["timing"] = _time(
-            lambda: _batched_jvm(spark, df, udf_name, args.scorer),
+            lambda: _batched_jvm(spark, df, udf_name, args.scorer, args.threshold),
             repeats=args.repeats,
         )
 


### PR DESCRIPTION
Measures J4's one open lever and reports what it is worth. **It does not close
the 2.4x**, and the title avoids claiming otherwise.

## Background

J4 measured the batched JVM arm at 2.4x slower than the row-shaped Python one.
The plan bisect blamed the un-batching Spark Connect forces, not the kernel:
scoring 1.9M pairs over JNI was ~0.1-0.2s while `arrays_zip`/`explode` added
~1.2-1.4s. That bench ran at `threshold=0.0`, so nothing was filtered and the
generator emitted every candidate pair -- the worst case for batching, and the
only case that had ever been measured. Filtering inside the batch was the one
lever left.

## The change

`score_pairs_batched` takes a `threshold` and applies it to the ARRAY, before
the explode. Same rows out as a `where` afterwards; the generator and the
shuffle behind it never see a rejected pair. `None` (default) adds no filter
node, so the plan is byte-identical and the J1 parity gate is untouched. The
bench and its workflow take `--threshold`, passed to both arms.

## Measured (200k rows -> 1.9M pairs, local[*], 12GB heap, 16 cpus)

Run 31710127644, `kept_fraction = 0.0526` -- 94.7% of pairs rejected:

| arm | thr=0.0 | thr=0.95 | delta |
|---|---|---|---|
| row_python_pure | 2.276s | 2.117s | -7.0% |
| row_python_native | 1.381s | 1.168s | -15.4% |
| batched_jvm | 4.040s | 3.577s | **-11.5%** |
| **jvm vs native** | **2.93x slower** | **3.06x slower** | -- |

The filter is worth 0.46s. The gap does not close, because `row_python` speeds
up too: its output and the dedup behind it shrink by the same 94.7%.

**Why only 11.5%.** If the un-batching cost were proportional to OUTPUT rows,
dropping 94.7% of them should have recovered ~1.3s. It recovered 0.46s. The
reason is in the plan: `arrays_zip` materialises all 1.9M zipped structs BEFORE
`filter` can reject any of them, so the zip is paid in full at any threshold.
Only the generator downstream of it shrinks.

## Fresh bisect (run 31710605445, same shape)

```
1  candidates                             1,900,000  (2.2s)
2  + join to source                       1,900,000  (1.9s)
3  + groupBy/collect (NO UDF)                   206  (2.3s)
4b + UDF (scores CONSUMED)                        1  (2.4s)
5  + zip/explode                          1,900,000  (3.8s)
6  + dedup_max                            1,900,000  (3.9s)
7  SHIPPED score_pairs_batched + dedup     1,900,000  (3.2s)
```

Single-shot stages, so these are NOT comparable to the bench's warm medians --
stage 2 coming in under stage 1 shows a noise floor around +/-0.3s. What they
are good for is the deltas: JNI scoring is ~0.1s (4b - 3) and zip/explode is
**+1.4s**, the largest jump in the plan by a wide margin.

## Why I am not chasing the rest

The remaining un-batching cost is input-proportional, and removing it would mean
the Java UDF returning only survivors. Extrapolating the bisect's explode share
(~37%) onto the measured wall, a **zero-cost** explode would put the batched arm
near 2.3s against `row_python_native`'s 1.17s -- still about 2x slower. That is
an extrapolation, not a measurement, but it is the right order of magnitude and
it says the ceiling is not the explode either.

The batched path pays a `groupBy` + `collect_list` -- a shuffle plus array
materialisation -- that the row-shaped path never performs at all. That is the
floor, and Connect imposes it by permitting only row-shaped UDFs.

**So: do not route Spark scoring through the JVM for speed.** The J-arc's other
two justifications are untouched and were always the real ones -- one kernel
with many host bindings, and a jar instead of a Python environment on every
executor (proven end to end by the cluster lane in #2529).

## Kept anyway

The filter is correct, free, and 11.5% is real on a path people will use for
deployment reasons regardless.

## A harness bug this found

The first attempt dispatched `threshold=0.85` and came back with `rows_out`
unchanged at 1,900,000 -- **100% kept**. The synthetic fixture puts near-
identical strings in a block (`v5_3` vs `v5_7`), which jaro-winkler scores about
0.88, so 0.85 rejected nothing and the run measured the unfiltered plan twice.
Both medians looked plausible; nothing in the output said the experiment was
void. The compare step now prints the kept fraction and warns outright when a
non-zero threshold rejects nothing, and both land in the artifact JSON.

## Tests

Three structural guards, none needing Spark (run locally):

- the filter must appear BEFORE the explode. No behavioural test can catch this
  -- filtering after the generator returns identical rows, and that difference
  is the entire point.
- no `.where(` / `.filter(F.col` in the function, since a post-generator row
  filter is the natural regression and passes every parity test.
- the predicate takes ONE parameter. PySpark reads a higher-order lambda's
  meaning from its parameter count, so `lambda z, t=threshold:` is read as
  `(element, index)` and `t` silently receives the row index.

Parity tests in the Spark lanes pin that the array filter returns exactly what a
row filter would, including that null scores do not clear it.
