### PR TITLE
docs(semantic): ratify key-integrity single-sourcing (ADR 0059 + conformance entry)

### DIFF
--- a/context-network/decisions/0059-semantic-key-integrity-single-sourced-kernel.md
+++ b/context-network/decisions/0059-semantic-key-integrity-single-sourced-kernel.md
@@ -1,0 +1,89 @@
+# 0059 — Semantic-layer structural certification is single-sourced through `key-integrity-core`
+
+**Status:** accepted (2026-08-13, Ben) • **Ratifies (does not build):** the shipped `key-integrity-core` kernel + its Python-native / TS-wasm / SQL bindings • **Builds on:** [0047 (one product, two engines)](0047-one-product-two-engines-architecture.md), [0049 (metric-aware key certification)](0049-metric-aware-key-certification.md), [0046 (cross-language phase-handoff conformance)](0046-cross-language-phase-handoff-conformance.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+An audit asked: "do the parity port to Rust kernels for the semantic layer, and the
+other languages fall out from that." The finding was that **it is already done** — the
+semantic layer's one clean columnar primitive (structural key-integrity certification:
+uniqueness-at-grain + fan-out) is authored once in Rust and bound by every surface. The
+gap was not code; it was that this single-sourcing was undocumented and kept being
+re-discovered. This ADR ratifies the state and the one design choice inside it that
+looks like a weakness but is not (the opt-in default), so it stops being re-litigated.
+
+The capability: distinct key groups, `duplicate_key_groups`, `max_fan_out`,
+`is_unique_at_grain`, and per-measure fan-out (`SUM(all) / SUM(per-group max)`).
+
+## Decision (the ratified state)
+1. **One authoritative owner: `key-integrity-core`.** The structural reduction lives in
+   the pyo3/pgrx/wasm-free Rust crate `packages/rust/extensions/key-integrity-core`
+   (`certify_structural` / the `certify_structural_json` JSON-in/JSON-out boundary). It
+   is the single source of truth.
+2. **Every non-Rust surface binds that one core** over the JSON boundary — chosen
+   precisely because it is the shape wasm-bindgen, PyArrow, pgrx and DuckDB can all feed
+   identically:
+   - **TypeScript** ← `key-integrity-wasm` (a ~5-line wasm-bindgen re-export) →
+     `certifyStructural`;
+   - **Python** ← the `certify_structural_json` shim in `goldenmatch-native` →
+     `_structural_native`;
+   - **SQL** ← pgrx `goldenmatch_certify_structural` + the DuckDB UDF.
+3. **The join-cardinality family sits on top with no second implementation.**
+   `certify_serving_joins` / `certify_cube_joins` / `certify_osi_relationships` are thin
+   wrappers that **delegate** to `certify_key_integrity` on **both** Python and TS, so
+   cardinality trust inherits the one kernel rather than re-deriving group-by per surface.
+4. **Conformance is one shared golden oracle.**
+   `key-integrity-core/golden/key_integrity_golden.json` is **generated from the Python
+   reference** (`scripts/emit_key_integrity_golden.py`) and asserted by all three
+   surfaces — Rust `include_str!` (`golden.rs`), Python direct-read
+   (`test_key_integrity_native_parity.py`, which also asserts `native == pyarrow`), and
+   TS `toBeCloseTo` (`key-integrity-wasm.parity.test.ts`). A `fixture_drift` CI job
+   regenerates the TS copy from the live core so it cannot drift.
+5. **The default execution path is deliberately the pure-Arrow / pure-TS reference, and
+   the shared kernel is opt-in** (`GOLDENMATCH_KEY_INTEGRITY_NATIVE` on Python;
+   `enableKeyIntegrityWasm()` on TS). This is recorded as
+   `default_routed: opt-in` in `parity/thesis_conformance.yaml`
+   (`semantic-key-integrity-single-sourced-kernel`), and `enableKeyIntegrityWasm` is
+   listed under `default_routing.ts_batteries.opt_in`.
+
+## Why opt-in default is the correct call, not a latent second source
+This is the one point that reads like a T1 violation and is not. The two-engines
+decision tests actively say *keep it opt-in* here:
+- **T5 (Arrow at bulk boundaries).** pyarrow's native `group_by` already **is** the
+  Arrow-at-bulk boundary and is the reference the golden is generated from. The kernel
+  path adds a JSON marshal on top of it.
+- **T3 (kernelize on measurement).** The JSON-marshaled kernel path is **measurably
+  slower** than the pyarrow `group_by` on this shape. Kernelizing on measurement means
+  the faster pure-Arrow path stays the default; the kernel exists for the **single-owner
+  guarantee (T1)**, enforced by the golden gate, not for speed.
+- Making the kernel the default would be a measured regression with no correctness gain —
+  the surfaces are already byte/numerically identical by the golden. So "shared owner,
+  classified-fallback default" is `default_routed: opt-in`, not `default_routed: false`
+  (the latent-second-source flag).
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — `key-integrity-core`; no second source of truth across
+  Python / TS / SQL, including the delegating cardinality wrappers.
+- **Conformance defines correctness** ✅ — one Python-generated golden, asserted exact
+  (integer fields) / within `1e-9` (floats) on all three surfaces; drift-guarded.
+- **Arrow at bulk boundaries** ✅ — the *default* path is native pyarrow `group_by`; the
+  kernel's JSON boundary is the smallest stable primitive every non-Rust caller shares.
+- **Kernelize on measurement** ✅ — the opt-in default is a measurement call, not an
+  omission; documented as such so it can't be "fixed" into a regression.
+
+## Consequences / honest flags
+- **Ratifying, not additive.** No new capability ships here — this records what exists so
+  the single-sourcing is auditable (thesis_conformance entry) instead of rediscovered.
+- **The opt-in default is load-bearing.** If a future change flips either host to the
+  kernel by default, the correct move is to re-measure first and, if it is a regression,
+  keep it opt-in — do not treat `default_routed: opt-in` as a bug to close.
+- **`key-integrity-native` as a dedicated crate does not exist** (the shim lives in the
+  shared `goldenmatch-native` binding); this is intentional and sufficient — the core
+  header notes a dedicated native crate "can follow" if the wiring ever warrants it.
+- **The rest of the semantic layer stays Python-authoritative by design.**
+  `discover_semantic_model`, the discovery slices, the resolution tier, the LLM namer and
+  warehouse introspection are orchestration / stateful capabilities, not clean columnar
+  cores; kernelizing them would force stateful logic into a columnar kernel (the T4
+  anti-pattern). They are correctly `python_only`, not a parity gap.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -55,6 +55,22 @@
 > Ossie `0.2.0.dev0` required-field + enum constraints that also flags the
 > non-Ossie keys (`cardinality`/`foreign_key`/`aggregation`) hand-written docs
 > tend to invent. The arc is complete — the whole crawl→walk→run is landed.
+>
+> **Cross-language single-sourcing (ratified,
+> [0059](../decisions/0059-semantic-key-integrity-single-sourced-kernel.md)).** The
+> one clean columnar primitive under all of this — the **structural** key-integrity
+> certifier (uniqueness-at-grain + fan-out) — is authored ONCE in the Rust crate
+> `key-integrity-core` and bound by every surface (TS via `key-integrity-wasm`,
+> Python via the `certify_structural_json` native shim, SQL via pgrx + DuckDB), with
+> one Python-generated golden asserted on all three. The join-cardinality wrappers
+> (`certify_serving_joins`/`certify_cube_joins`/`certify_osi_relationships`) delegate
+> to it on both Python and TS — no second source of truth. The shared kernel is
+> **opt-in by design** (pyarrow's `group_by` IS the Arrow-at-bulk boundary and is
+> measurably faster; the kernel exists for the single-owner guarantee, not speed).
+> Recorded on the thesis-conformance board as
+> `semantic-key-integrity-single-sourced-kernel` (`default_routed: opt-in`). The rest
+> of the semantic layer (discovery, resolution tier, namer, warehouse introspection)
+> is orchestration/stateful and correctly stays Python-authoritative.
 > Greenfield when written: no prior repo code, doc, or decision referenced this
 > ecosystem (grep, 2026-07-30).
 

--- a/docs-site/thesis-weaknesses.mdx
+++ b/docs-site/thesis-weaknesses.mdx
@@ -10,7 +10,7 @@ The [suite matrix](/suite-matrix) renders cross-language *surface* parity. This 
 
 ## Standing
 
-**2** open weakness(es) — 🟢 low 2. **8** resolved (archived below). Undeclared (a real divergence with no conformance level / contract): **0**.
+**3** open weakness(es) — 🟢 low 3. **8** resolved (archived below). Undeclared (a real divergence with no conformance level / contract): **0**.
 
 A weakness is a place the codebase does not yet fully meet the frame; each maps to one of the five decision tests (tenets). *Declared* means the divergence has a conformance level and a test — an accepted, contained cost — not an accident. The `declared: false` class is the dangerous one and is flagged below. Resolved items are archived off this live board (conformance v2 — the live list is the real risk surface, not a museum of closed wins) but kept for the record.
 
@@ -18,7 +18,7 @@ A weakness is a place the codebase does not yet fully meet the frame; each maps 
 
 | Tenet | Decision test | Open |
 |---|---|---|
-| **T1** | One authoritative semantic owner per capability (no second source of truth). | 1 |
+| **T1** | One authoritative semantic owner per capability (no second source of truth). | 2 |
 | **T2** | Conformance defines correctness (every divergence has a declared level + a test). | 0 |
 | **T3** | Kernelize on measurement (deferrals classified; no silent regress to fallback). | 0 |
 | **T4** | Compute vs control stay architecturally distinct (explicit, versioned seam). | 1 |
@@ -31,6 +31,7 @@ Ranked by severity. *Routing* applies the conformance-v2 default-routing test (0
 | Severity | Tenet | Declared | Routing | Weakness |
 |---|---|---|---|---|
 | 🟢 low | T4 | yes | — | Compute/control shared frame-residency budget: now a contract field (was env-only) |
+| 🟢 low | T1 | yes | opt-in (fallback default) | Semantic-layer structural certification (uniqueness-at-grain + fan-out) is single-sourced through key-integrity-core; Python-native + TS-wasm + SQL all bind that one kernel |
 | 🟢 low | T1 | yes | opt-in (fallback default) | Clustering + goldenanalysis frame kernels: both families now share a kernel (cluster-wasm + analysis-wasm) |
 
 ## Live harvest (auto-detected)

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -65,6 +65,7 @@ default_routing:
       - enableClusterWasm
       - enableFingerprintWasm
       - enableGraphWasm
+      - enableKeyIntegrityWasm  # key-integrity-core structural certifier; opt-in by design (pyarrow/pure-TS is the measured-faster default)
       - enablePerceptualWasm
       - enableSketchWasm
       - enableSuggestWasm
@@ -332,6 +333,51 @@ weaknesses:
       - packages/typescript/goldenanalysis/tests/parity/wasm-frame-kernels.parity.test.ts   # kernel == fixture
       - parity/goldenanalysis.yaml
       - docs/superpowers/specs/2026-07-06-goldenanalysis-wave1b-deferred.md
+
+  - id: semantic-key-integrity-single-sourced-kernel
+    tenet: T1
+    severity: low
+    declared: true
+    default_routed: opt-in
+    title: 'Semantic-layer structural certification (uniqueness-at-grain + fan-out) is single-sourced
+      through key-integrity-core; Python-native + TS-wasm + SQL all bind that one kernel'
+    detail: 'SINGLE-SOURCED. The semantic layer''s structural key-integrity certifier -- distinct
+      key groups, duplicate_key_groups, max_fan_out, is_unique_at_grain, and per-measure fan-out
+      (SUM(all)/SUM(per-group max)) -- is authored ONCE in the pyo3/pgrx/wasm-free Rust crate
+      `key-integrity-core` (certify_structural / certify_structural_json). Every non-Rust surface
+      binds that SAME core over its JSON-in/JSON-out boundary: TS via `key-integrity-wasm`
+      (certifyStructural, the 5-line wasm-bindgen re-export), Python via the `certify_structural_json`
+      shim in `goldenmatch-native` (_structural_native), and SQL via pgrx `goldenmatch_certify_structural`
+      + the DuckDB UDF. There is NO second source of truth: the whole join-cardinality family that
+      sits on top -- certify_serving_joins / certify_cube_joins / certify_osi_relationships -- are
+      thin wrappers that DELEGATE to certify_key_integrity on BOTH Python and TS, so cardinality
+      trust inherits the one kernel rather than re-implementing group-by. Conformance is a single
+      shared golden oracle (key-integrity-core/golden/key_integrity_golden.json, GENERATED from the
+      Python reference by scripts/emit_key_integrity_golden.py) asserted by all three surfaces:
+      Rust include_str! (golden.rs), Python direct-read (test_key_integrity_native_parity.py, which
+      also asserts native == pyarrow), and TS toBeCloseTo (key-integrity-wasm.parity.test.ts); a
+      fixture_drift CI job regenerates the TS copy from the live core so it cannot drift.
+      DEFAULT IS DELIBERATELY OPT-IN (default_routed: opt-in), and this is the CORRECT frame call,
+      not a latent second source: the kernel path is JSON-marshaled and MEASURABLY SLOWER than the
+      pyarrow group_by, which already IS the Arrow-at-bulk boundary (T5) and is the reference the
+      golden is generated from -- so per T3 (kernelize on measurement) the pure-Arrow/pure-TS path
+      stays the default and the shared kernel exists for the single-owner GUARANTEE (T1), enforced by
+      the golden gate, not for speed. Python opt-in: GOLDENMATCH_KEY_INTEGRITY_NATIVE; TS opt-in:
+      enableKeyIntegrityWasm() (edge-bundle discipline, sibling to every other opt-in wasm reroute).
+      Decision: 0059.'
+    evidence:
+      - packages/rust/extensions/key-integrity-core/src/lib.rs   # the one authoritative kernel
+      - packages/rust/extensions/key-integrity-core/golden/key_integrity_golden.json   # shared oracle (Python-generated)
+      - packages/rust/extensions/key-integrity-wasm/src/lib.rs   # TS binding (5-line re-export)
+      - packages/rust/extensions/native/src/key_integrity.rs   # Python-native shim (certify_structural_json)
+      - packages/python/goldenmatch/goldenmatch/semantic/key_integrity.py   # _structural_native / _structural_pyarrow (reference)
+      - packages/python/goldenmatch/goldenmatch/semantic/serving.py   # certify_serving_joins delegates
+      - packages/python/goldenmatch/goldenmatch/semantic/cube.py   # certify_cube_joins delegates
+      - packages/typescript/goldenmatch/src/core/semantic/keyIntegrity.ts   # computeStructural: wasm backend, pure-TS fallback
+      - packages/typescript/goldenmatch/src/core/keyIntegrityWasm.ts   # enableKeyIntegrityWasm (opt-in)
+      - packages/python/goldenmatch/tests/test_key_integrity_native_parity.py   # native == pyarrow == golden
+      - packages/typescript/goldenmatch/tests/parity/key-integrity-wasm.parity.test.ts   # wasm == golden
+      - context-network/decisions/0059-semantic-key-integrity-single-sourced-kernel.md
 
   - id: a2a-skills-bidirectional-fracture
     tenet: T1


### PR DESCRIPTION
## What and why

An audit asked to "port the semantic layer to Rust kernels so the other languages fall out." The finding: it is already done. The semantic layer's one clean columnar primitive, the structural key-integrity certifier (uniqueness-at-grain + per-measure fan-out), is authored once in the pyo3/pgrx/wasm-free Rust crate `key-integrity-core` and bound by every surface. The gap was not code; it was that this single-sourcing was undocumented and kept being rediscovered. This PR closes the loop: it records the state and ratifies the one design choice inside it that looks like a weakness but is not (the opt-in default), so nobody re-litigates it.

No code or behavior changes; docs + conformance inventory only.

## Changes

- **ADR 0059** (`context-network/decisions/0059-semantic-key-integrity-single-sourced-kernel.md`) - ratifies (does not build) the shipped state:
  - one owner `key-integrity-core`; TS binds via `key-integrity-wasm`, Python via the `certify_structural_json` native shim, SQL via pgrx + DuckDB;
  - the join-cardinality wrappers (`certify_serving_joins` / `certify_cube_joins` / `certify_osi_relationships`) delegate to `certify_key_integrity` on both Python and TS, so there is no second source of truth;
  - one Python-generated golden asserted on all three surfaces, drift-guarded;
  - the **opt-in default is the correct T3/T5 call**, not a latent second source: pyarrow's `group_by` already is the Arrow-at-bulk boundary and is measurably faster; the kernel exists for the single-owner guarantee, not speed;
  - the rest of the semantic layer (discovery, resolution tier, namer, warehouse introspection) is orchestration/stateful and correctly stays Python-authoritative.
- **`parity/thesis_conformance.yaml`** - new T1 entry `semantic-key-integrity-single-sourced-kernel` (`default_routed: opt-in`) so the posture is audited on the live board; `enableKeyIntegrityWasm` added to the `ts_batteries.opt_in` inventory.
- **`context-network/planning/semantic-layer-interchange.md`** - cross-language single-sourcing note pointing at 0059.
- **`docs-site/thesis-weaknesses.mdx`** - regenerated from the inventory (the `docs_regen` gate).

## Testing

- `python3 scripts/check_thesis_conformance.py --check` -> `OK` (exit 0)
- `uv run python scripts/regen_docs.py --check` -> `Docs are current -- nothing to regenerate` (exit 0), the exact `docs_regen` CI gate
- YAML validates; new entry + opt_in symbol present

## Checklist

- [x] Tests added/updated and passing locally for the changed package (N/A - docs/inventory only; conformance + docs gates pass)
- [x] `pre-commit`-relevant gates clean (thesis-conformance, docs_regen)
- [x] Package `CHANGELOG.md` updated if behavior changed (N/A - no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (ADR + planning + conformance board)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_