### PR TITLE
docs(semantic): record the ontology layer under the same key-integrity single-sourcing (0059)

### DIFF
--- a/context-network/decisions/0059-semantic-key-integrity-single-sourced-kernel.md
+++ b/context-network/decisions/0059-semantic-key-integrity-single-sourced-kernel.md
@@ -84,6 +84,20 @@ decision tests actively say *keep it opt-in* here:
   warehouse introspection are orchestration / stateful capabilities, not clean columnar
   cores; kernelizing them would force stateful logic into a columnar kernel (the T4
   anti-pattern). They are correctly `python_only`, not a parity gap.
+- **The ontology layer (0053-0057) is the same case, and a clean one.** Where it does
+  identity work it *inherits* this kernel: `certify_ontology_keys` / `certify_ontology`
+  delegate to `certify_key_integrity` (so ontology key-certification rides the one
+  `key-integrity-core` owner, no second source), and `discover_ontology` reuses the
+  certifier-backed `discover_keys`. Everything else — `parse_ontology`,
+  `emit_sameas_graph` / `emit_identity_shacl` / `emit_ontology_shapes` /
+  `emit_golden_triples`, `reconcile_ontology_identity` — is `rdflib` (RDF/OWL/SHACL/PROV-O)
+  orchestration with no columnar primitive to kernelize. Its `python_only` surfaces
+  (`ontology_certify` / `ontology_discover` / the `ontology` CLI) are by-design: there is
+  no edge `rdflib` (standing intentional-asymmetry principle), and porting the RDF surface
+  to Rust/WASM would *reimplement a triple store* — the exact "conform to backends, don't
+  reimplement" anti-pattern 0053 was written to avoid (GoldenMatch is the identity provider
+  FOR the reasoner/triple store, not a reimplementation of one). Not a parity gap; not a
+  kernel candidate.
 
 ---
 **Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/parity/thesis_conformance.yaml
+++ b/parity/thesis_conformance.yaml
@@ -351,7 +351,12 @@ weaknesses:
       + the DuckDB UDF. There is NO second source of truth: the whole join-cardinality family that
       sits on top -- certify_serving_joins / certify_cube_joins / certify_osi_relationships -- are
       thin wrappers that DELEGATE to certify_key_integrity on BOTH Python and TS, so cardinality
-      trust inherits the one kernel rather than re-implementing group-by. Conformance is a single
+      trust inherits the one kernel rather than re-implementing group-by. The ontology layer
+      (0053-0057) rides the same owner: certify_ontology_keys / certify_ontology delegate to
+      certify_key_integrity and discover_ontology reuses the certifier-backed discover_keys, while
+      its rdflib RDF/OWL/SHACL emit+parse surface is python_only by design (no edge rdflib; a
+      Rust/WASM RDF port would reimplement a triple store -- the conform-don''t-reimplement
+      anti-pattern 0053 avoids). Conformance is a single
       shared golden oracle (key-integrity-core/golden/key_integrity_golden.json, GENERATED from the
       Python reference by scripts/emit_key_integrity_golden.py) asserted by all three surfaces:
       Rust include_str! (golden.rs), Python direct-read (test_key_integrity_native_parity.py, which


### PR DESCRIPTION
## What and why

Follow-up to #2542 (ADR 0059). That PR ratified that the semantic layer's structural key-integrity certifier is single-sourced through `key-integrity-core`, and flagged that the discovery/resolution tier correctly stays Python-authoritative — but it did not explicitly name the **ontology arc (0053-0057)**. A review question asked where the ontology layer sits. This records the answer so it is not rediscovered.

The finding: the ontology layer is the same case, and a clean one. No code or behavior change; docs + conformance inventory only.

## Changes

- **ADR 0059** — new honest-flag bullet: where the ontology layer does identity work it **inherits** the kernel (`certify_ontology_keys` / `certify_ontology` delegate to `certify_key_integrity`; `discover_ontology` reuses the certifier-backed `discover_keys`), and its `rdflib` RDF/OWL/SHACL emit+parse surface is `python_only` **by design** — no edge `rdflib`, and a Rust/WASM RDF port would reimplement a triple store (the "conform to backends, don't reimplement" anti-pattern 0053 was written to avoid; GoldenMatch is the identity provider FOR the reasoner/triple store, not a reimplementation of one). Not a parity gap, not a kernel candidate.
- **`parity/thesis_conformance.yaml`** — the `semantic-key-integrity-single-sourced-kernel` entry's detail extended to note the ontology delegation.

## Testing

- `python3 scripts/check_thesis_conformance.py --check` -> `OK` (exit 0)
- `scripts/gen_thesis_weaknesses.py --write` -> `thesis-weaknesses.mdx` unchanged (the generator summarizes title/severity, not the detail prose), so the `docs_regen` gate stays green with no doc delta
- Cherry-picked cleanly onto fresh `main` after #2542 squashed

## Checklist

- [x] Tests added/updated and passing locally for the changed package (N/A - docs/inventory only; conformance gate passes)
- [x] `pre-commit`-relevant gates clean (thesis-conformance, docs_regen)
- [x] Package `CHANGELOG.md` updated if behavior changed (N/A - no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (ADR + conformance board)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_