### PR TITLE
ci(spark): deselect the two-path tests the cluster cannot host, by count

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -334,6 +334,7 @@ jobs:
             --deselect 'tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \
             --deselect 'tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \
             --deselect 'tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_rowwise_config_scoring_matches_the_python_path_exactly'             --deselect 'tests/test_spark_jvm_native_parity.py::test_mint_entity_ids_pure_sql_matches_the_udf_path' \
             | tee pytest.out && rc=0 || rc=$?
           # pytest IGNORES a --deselect that matches nothing, so a wrong node id
           # means the tests simply RUN. That is how run 6 failed: the ids were
@@ -346,8 +347,14 @@ jobs:
           # drift again this says so instead of the failure looking like a
           # scoring bug. Hence `rc` capture rather than relying on `set -e`,
           # which would exit here first and never print the explanation.
-          if ! grep -qE '[0-9]+ deselected' pytest.out; then
-            echo "::error::no tests were deselected. The --deselect node ids no longer match -- pytest's rootdir is packages/python/goldenmatch, so ids start at 'tests/', not 'packages/python/goldenmatch/tests/'. The four two-path tests ran on a cluster that cannot host their Python arm."
+          # The COUNT, not just "some": adding a two-path test without adding
+          # its deselect would leave the others matching, print "4 deselected"
+          # and let the new one fail on a cluster that cannot host its Python
+          # arm -- reading as a defect in the path under test. That is exactly
+          # how test_rowwise_config_scoring... and test_mint_entity_ids... first
+          # reddened this lane.
+          if ! grep -qE ' 6 deselected' pytest.out; then
+            echo "::error::expected 6 deselected. Either a --deselect node id no longer matches (pytest IGNORES one that matches nothing) or a two-path test was added without one. pytest's rootdir is packages/python/goldenmatch, so ids start at 'tests/', NOT 'packages/python/goldenmatch/tests/'. Either way, a test needing a Python worker just ran on a cluster that has none, and its failure reads as a defect in the path under test."
             exit 1
           fi
           exit "$rc"


### PR DESCRIPTION
The cluster lane is red on two tests, neither of which is a defect.

```
FAILED test_rowwise_config_scoring_matches_the_python_path_exactly   (#2541)
FAILED test_mint_entity_ids_pure_sql_matches_the_udf_path            (#2524)

[PYTHON_VERSION_MISMATCH] Python in worker has different version: 3.10
than that in driver: 3.12
```

Both compare a JVM path against the **Python** path, and both arms have to run
distributed. These workers are stock Spark images with no goldenmatch and a
Python 3.10 that goldenmatch's `>=3.11` floor rejects, so that comparison cannot
exist there. They already run under `local[*]` in `spark_connect`, which is
where a both-arms comparison belongs -- what they test is plan construction,
which does not care how many hosts it lands on.

`test_the_two_jvm_shapes_agree` is deliberately NOT deselected: both its arms
are JVM, so it needs no Python worker and the cluster is exactly where it should
run.

## The guard was too weak, which is why this happened

`grep -qE 'deselected'` passes as soon as the pre-existing four match. So adding
a two-path test without adding its deselect prints "4 deselected", satisfies the
guard, and lets the new test fail on a cluster that cannot host its Python arm
-- reading as a defect in the path under test. It now checks the COUNT.

## And a trap the workflow linter caught

The count regex was first written `\b6`, and the backslash-b reached the file as
a literal `0x08` backspace, which YAML rejects outright:

```
does not parse: unacceptable character #x0008
```

`scripts/check_workflow_yaml.py` caught it before it cost a CI round trip -- the
same lint added after a collapsed line continuation cost three. A literal
leading space matches both pytest summary shapes and cannot do that.

## Why a separate PR

#2541 was already in the merge queue when this fix was written, and a queued
branch cannot be updated (`GH006: protected branch update failed`). Rather than
dequeue a green PR, the fix lands on its own.
