### PR TITLE
feat(spark): Fellegi-Sunter runs in the executor JVM

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7988,6 +7988,7 @@
           "imports": [
             "goldenmatch.core.probabilistic",
             "goldenmatch.spark.config_pipeline",
+            "goldenmatch.spark.jvm",
             "goldenmatch.spark.scorers"
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
@@ -866,10 +866,15 @@ def _score_candidates_jvm(
 
 
 def _refuse_probabilistic(matchkeys: list) -> None:
-    """Both JVM shapes refuse a probabilistic matchkey, for one reason.
+    """The BATCHED JVM shape refuses a probabilistic matchkey.
 
-    Shared rather than duplicated: two copies of a refusal drift, and the shape
-    a caller picked is not a reason to accept work the JVM cannot do.
+    Not the row-shaped one, which runs Fellegi-Sunter -- see
+    :func:`_score_candidates_jvm_rowwise`. The batched shape scores per-SLOT
+    into flat arrays and reshapes them back, and FS is not a per-slot quantity:
+    a level is a threshold ladder over ONE field's similarity, and the weights
+    are summed across fields into a single bit total. Expressing that over the
+    reshaped arrays would be a second implementation of the FS combine, which
+    is exactly the duplication that drifts silently.
     """
     for mk in matchkeys:
         mk_type = getattr(mk, "type", None) or getattr(mk, "comparison", None)
@@ -934,8 +939,12 @@ def _score_candidates_jvm_rowwise(
     from goldenmatch.spark.jvm import scorer_id
 
     matchkeys = list(config.get_matchkeys())
-    _refuse_probabilistic(matchkeys)
-
+    # NO refusal here. Probabilistic matchkeys run on this path: FS levels, the
+    # weight lookup, the bit sum and the posterior are ALREADY Spark SQL, and
+    # the one part that ever needed a Python worker was the per-field
+    # similarity call. Handing that to the jar's row-shaped kernel makes
+    # Fellegi-Sunter -- the thing Splink does -- run with nothing installed on
+    # the executors.
     slots, index = _weighted_scorer_slots(config)
 
     parts = [F.col("__cand__.a").alias("a"), F.col("__cand__.b").alias("b")]
@@ -970,6 +979,26 @@ def _score_candidates_jvm_rowwise(
         mk_type = getattr(mk, "type", None) or getattr(mk, "comparison", None)
         if mk_type == "exact":
             parts.append(_matchkey_score_expr(mk, lhs, rhs).alias(f"e{m}"))
+        elif mk_type == "probabilistic":
+            # P(match) from the trained model, projected here rather than built
+            # in the combine below so the FS expression is evaluated ONCE per
+            # pair -- the same reason the per-slot scores are projected by name.
+            from goldenmatch.spark.probabilistic import fs_score_expr
+
+            em = (fs_models or {}).get(mk.name)
+            if em is None:
+                raise ValueError(
+                    f"matchkey {mk.name!r} is probabilistic but no trained "
+                    f"model was resolved for it. FS scoring distributes; EM "
+                    f"training does not -- train on the one-box and pass the "
+                    f"model via fs_model_path."
+                )
+            parts.append(
+                fs_score_expr(
+                    mk, em, lhs, rhs,
+                    scorer_udf=scorer_udf, transform_udf=transform_udf,
+                ).alias(f"p{m}")
+            )
 
     scored = joined.select(*parts)
 
@@ -984,6 +1013,11 @@ def _score_candidates_jvm_rowwise(
         mk_type = getattr(mk, "type", None) or getattr(mk, "comparison", None)
         if mk_type == "exact":
             score = F.col(f"e{m}")
+        elif mk_type == "probabilistic":
+            # P(match), NOT a weighted similarity average -- a different
+            # quantity on a different scale, which is why `_matchkey_threshold`
+            # cuts it at `link_threshold` rather than `threshold`.
+            score = F.col(f"p{m}")
         else:
             nums, dens = [], []
             for f in mk.fields:
@@ -1172,8 +1206,14 @@ def run_config_pipeline(
     Connect sees one row and must be handed its batch explicitly. See
     :func:`_score_candidates_jvm`.
 
-    Probabilistic matchkeys are refused under ``scorer_udf`` rather than left on
-    the Python path, so "no error" cannot mean "still needs a virtualenv".
+    Probabilistic matchkeys run under ``scorer_udf`` on the ROW shape and are
+    refused on the batch one. FS levels, the weight lookup, the bit sum and the
+    posterior were always Spark SQL; the only part needing a Python worker was
+    the per-field similarity call, and the jar's row-shaped kernel takes that.
+    So Fellegi-Sunter -- the thing Splink does -- now runs with nothing
+    installed on the executors. EM TRAINING still does not distribute: it reads
+    a driver-side sample of blocked pairs, so a trained model must be supplied
+    via ``fs_model_path``.
     """
     if config is None:
         # P6 zero-config. Deriving the config costs a driver-side sample plus a

--- a/packages/python/goldenmatch/goldenmatch/spark/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/probabilistic.py
@@ -156,7 +156,9 @@ def fs_posterior(total_weight: float, prior_w: float) -> float:
 # ── Spark expressions ────────────────────────────────────────────────
 
 def _field_similarity_and_observed(
-    field: Any, lhs: str, rhs: str
+    field: Any, lhs: str, rhs: str, *,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
 ) -> tuple[Any, Any]:
     """``(similarity, observed)`` for one comparison field.
 
@@ -164,24 +166,44 @@ def _field_similarity_and_observed(
     either value is None" -- and deliberately NOT from the similarity kernel,
     which substitutes ``""`` for a missing value and therefore reports
     null-vs-null as a perfect 1.0.
+
+    **This is the only part of Spark FS that ever needed Python.** Everything
+    above it -- levels, the weight lookup, the sum, the posterior -- is already
+    Spark SQL. So passing ``scorer_udf`` (and ``transform_udf``) is the whole of
+    what it takes to run Fellegi-Sunter with nothing installed on the executors:
+    the similarity call moves to the jar's row-shaped kernel and the rest was
+    never leaving the JVM in the first place.
     """
     from pyspark.sql import functions as F
 
     from goldenmatch.spark.config_pipeline import _transformed
-    from goldenmatch.spark.scorers import make_scorer_udf
 
     col = field.resolved_field
     a_raw, b_raw = F.col(f"{lhs}.{col}"), F.col(f"{rhs}.{col}")
 
     chain = list(getattr(field, "transforms", None) or [])
     if chain:
-        a_val, b_val = _transformed(a_raw, chain), _transformed(b_raw, chain)
+        a_val = _transformed(a_raw, chain, transform_udf=transform_udf)
+        b_val = _transformed(b_raw, chain, transform_udf=transform_udf)
     else:
         a_val, b_val = a_raw.cast("string"), b_raw.cast("string")
 
     if field.scorer == "exact":
+        # No kernel either way: the agreement IS the similarity, in SQL.
         sim = F.when(a_val == b_val, F.lit(1.0)).otherwise(F.lit(0.0))
+    elif scorer_udf is not None:
+        from goldenmatch.spark.jvm import scorer_id
+
+        # `scorer_id` RAISES for a scorer the jar cannot run, and that is the
+        # right behaviour: silently falling back to the arrow_udf would mean a
+        # caller who asked for a jar-only run still needs an executor
+        # virtualenv, and would find out from a ModuleNotFoundError mid-job.
+        sim = F.call_udf(
+            scorer_udf, F.lit(int(scorer_id(field.scorer))), a_val, b_val
+        )
     else:
+        from goldenmatch.spark.scorers import make_scorer_udf
+
         sim = make_scorer_udf(field.scorer)(a_val, b_val)
 
     return sim, (a_raw.isNotNull() & b_raw.isNotNull())
@@ -225,14 +247,20 @@ def _weight_lookup_expr(level: Any, weights: list[float]) -> Any:
     return expr.otherwise(F.lit(_UNOBSERVED_WEIGHT))
 
 
-def fs_match_weight_expr(mk: Any, em: Any, lhs: str, rhs: str) -> Any:
+def fs_match_weight_expr(
+    mk: Any, em: Any, lhs: str, rhs: str, *,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+) -> Any:
     """Total FS match weight in bits for a pair, as a Spark expression."""
     from goldenmatch.core.probabilistic import fs_missing_mode
 
     missing_mode = fs_missing_mode(mk)
     total = None
     for f in mk.fields:
-        sim, observed = _field_similarity_and_observed(f, lhs, rhs)
+        sim, observed = _field_similarity_and_observed(
+            f, lhs, rhs, scorer_udf=scorer_udf, transform_udf=transform_udf
+        )
         level = fs_level_expr(f, sim, observed, missing_mode=missing_mode)
         w = _weight_lookup_expr(level, em.match_weights[f.resolved_field])
         total = w if total is None else (total + w)
@@ -257,8 +285,15 @@ def fs_posterior_expr(total_weight: Any, prior_w: float) -> Any:
     )
 
 
-def fs_score_expr(mk: Any, em: Any, lhs: str, rhs: str) -> Any:
-    """P(match) for a pair under a trained FS model, as a Spark expression."""
+def fs_score_expr(
+    mk: Any, em: Any, lhs: str, rhs: str, *,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+) -> Any:
+    """P(match) for a pair under a trained FS model, as a Spark expression.
+
+    With ``scorer_udf`` set, every part of this runs in the executor JVM.
+    """
     from goldenmatch.core.probabilistic import prior_weight
 
     _validate_fs_spark_supported(mk, em)
@@ -268,7 +303,12 @@ def fs_score_expr(mk: Any, em: Any, lhs: str, rhs: str) -> Any:
         "(proportion_matched=%.6g)",
         mk.name, len(mk.fields), prior_w, em.proportion_matched,
     )
-    return fs_posterior_expr(fs_match_weight_expr(mk, em, lhs, rhs), prior_w)
+    return fs_posterior_expr(
+        fs_match_weight_expr(
+            mk, em, lhs, rhs, scorer_udf=scorer_udf, transform_udf=transform_udf
+        ),
+        prior_w,
+    )
 
 
 # ── model resolution ─────────────────────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -100,8 +100,13 @@ def source(spark):
     return spark.createDataFrame(_ROWS, _COLS)
 
 
-def _spark_scores(spark_df, cfg) -> dict[tuple[int, int], float]:
-    """Every candidate pair's FS posterior, unthresholded."""
+def _spark_scores(spark_df, cfg, *, scorer_udf=None, transform_udf=None) -> dict[tuple[int, int], float]:
+    """Every candidate pair's FS posterior, unthresholded.
+
+    ``scorer_udf`` routes the per-field similarity to the jar's row-shaped
+    kernel instead of the arrow_udf, which is the ONLY part of Spark FS that
+    ever needed a Python worker.
+    """
     from goldenmatch.spark.config_pipeline import generate_candidates
     from goldenmatch.spark.probabilistic import fs_score_expr
     from pyspark.sql import functions as F
@@ -117,7 +122,10 @@ def _spark_scores(spark_df, cfg) -> dict[tuple[int, int], float]:
     out = joined.select(
         F.col("__cand__.a").alias("a"),
         F.col("__cand__.b").alias("b"),
-        fs_score_expr(mk, _em(), lhs, rhs).alias("p"),
+        fs_score_expr(
+            mk, _em(), lhs, rhs,
+            scorer_udf=scorer_udf, transform_udf=transform_udf,
+        ).alias("p"),
     )
     return {(int(r["a"]), int(r["b"])): float(r["p"]) for r in out.collect()}
 
@@ -212,3 +220,134 @@ def test_probabilistic_without_a_model_fails_before_any_spark_work(source):
 
     with pytest.raises(ValueError, match="model_path"):
         run_config_pipeline(source, _config(), id_col=_ID, golden_cols=["first"])
+
+
+# ── Fellegi-Sunter, in the executor JVM ──────────────────────────────
+#
+# The Spark tier ran FS with the per-field similarity on an arrow_udf, which
+# means a Python worker on every executor. Everything AROUND that call -- the
+# level ladder, the weight lookup, the bit sum, the posterior -- was already
+# Spark SQL. So routing one call to the jar is the whole of what it takes to run
+# the thing Splink does with nothing installed on the cluster.
+#
+# EM TRAINING still does not distribute (driver-side sample of blocked pairs);
+# these tests supply a trained model, which is the shipped contract.
+
+def _jar():
+    from goldenmatch.spark.jvm import JvmScorerUnavailable, find_jar
+
+    try:
+        return find_jar()
+    except JvmScorerUnavailable as exc:
+        pytest.skip(f"no JVM scorer jar built: {exc}")
+
+
+@pytest.fixture()
+def jvm_registered(spark):
+    from goldenmatch.spark.jvm import JvmScorerUnavailable, install
+
+    try:
+        return install(spark, jar=_jar())
+    except JvmScorerUnavailable as exc:
+        pytest.skip(f"cannot register the JVM scorer: {exc}")
+
+
+@pytest.mark.parametrize("missing", ["unobserved", "disagree"])
+def test_fs_in_the_jvm_matches_the_python_path_exactly(source, jvm_registered, missing):
+    """THE gate. Same posterior, pair for pair, with no Python on the executor.
+
+    Exact equality, no tolerance: both sides run the same Rust `score_one` over
+    the same bytes and everything downstream of it is the same SQL. A tolerance
+    would hide the class of bug this exists to catch, because those bugs produce
+    PLAUSIBLE probabilities -- a level ladder read one threshold off still
+    yields a number in [0, 1] for every pair.
+    """
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    cfg = _config(missing)
+    want = _spark_scores(source, cfg)
+    got = _spark_scores(
+        source, cfg, scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME
+    )
+
+    assert set(got) == set(want), (
+        f"different pair sets: only-jvm={sorted(set(got) - set(want))} "
+        f"only-python={sorted(set(want) - set(got))}"
+    )
+    mismatched = {k: (got[k], want[k]) for k in want if got[k] != want[k]}
+    assert not mismatched, (
+        f"missing={missing}: JVM and Python FS disagree. Both reach the same "
+        f"score_one and the level/weight/posterior arithmetic is the same SQL, "
+        f"so a difference is a level read at the wrong threshold or a weight "
+        f"from the wrong index -- (jvm, python): {mismatched}"
+    )
+    assert want, "no pairs scored; the fixture proves nothing"
+
+
+@pytest.mark.parametrize("missing", ["unobserved", "disagree"])
+def test_fs_in_the_jvm_matches_the_ONE_BOX(source, jvm_registered, missing):
+    """And against the one-box directly, not only against the Spark path.
+
+    Transitivity would give this, but stating it means a change that moved the
+    Spark FS expression and the JVM route together -- they share every line
+    except the similarity call -- cannot pass while both have drifted off the
+    reference implementation.
+    """
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    cfg = _config(missing)
+    mk = cfg.get_matchkeys()[0]
+    got = _spark_scores(
+        source, cfg, scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME
+    )
+
+    by_id = {r[0]: dict(zip(_COLS, r)) for r in _ROWS}
+    for (a, b), p in got.items():
+        want = _reference_posterior(by_id[a], by_id[b], mk)
+        assert p == pytest.approx(want, abs=1e-12), (
+            f"pair ({a}, {b}): JVM FS returned {p!r}, the one-box {want!r}"
+        )
+
+
+def test_the_end_to_end_probabilistic_pipeline_runs_jar_only(source, jvm_registered, tmp_path):
+    """A whole FS dedupe with the scorer, transforms and survivorship in the jar.
+
+    This is the claim in one test: Fellegi-Sunter, distributed, with nothing
+    goldenmatch-shaped installed on an executor.
+    """
+    import json
+
+    from goldenmatch.spark.config_pipeline import run_config_pipeline
+    from goldenmatch.spark.jvm import SURVIVORSHIP_UDF_NAME, TRANSFORM_UDF_NAME, UDF_NAME
+
+    model = tmp_path / "fs_model.json"
+    model.write_text(json.dumps(_em().to_dict()), encoding="utf-8")
+
+    out = run_config_pipeline(
+        source, _config(), id_col=_ID,
+        golden_cols=["first", "last", "city"],
+        fs_model_path=str(model),
+        scorer_udf=UDF_NAME, transform_udf=TRANSFORM_UDF_NAME,
+        survivorship_udf=SURVIVORSHIP_UDF_NAME,
+    )
+    rows = out.collect()
+    assert rows, "the FS pipeline produced no golden records"
+
+
+def test_the_batched_shape_still_refuses_fs(source, jvm_registered):
+    """The batch shape has no FS combine and must say so rather than guess.
+
+    Its scores are per-SLOT in flat arrays; a level is a threshold ladder over
+    ONE field's similarity and the weights sum across fields. Expressing that
+    over the reshaped arrays would be a second implementation of the FS combine.
+    """
+    from goldenmatch.spark.config_pipeline import generate_candidates, score_candidates
+    from goldenmatch.spark.jvm import UDF_NAME
+
+    cfg = _config()
+    cands = generate_candidates(source, cfg, id_col=_ID)
+    with pytest.raises(NotImplementedError, match="Fellegi-Sunter"):
+        score_candidates(
+            cands, source, cfg, id_col=_ID, scorer_udf=UDF_NAME,
+            scorer_shape="batch",
+        )


### PR DESCRIPTION
The JVM path refused probabilistic matchkeys, so the one thing Splink actually
does was the one thing the jar-only route could not run. The refusal was wider
than the problem.

## Spark FS was already SQL

Everything except one call was Catalyst expressions that never left the JVM:

| piece | what it is |
|---|---|
| `fs_level_expr` | a threshold ladder over the similarity |
| `_weight_lookup_expr` | a CASE over the trained m/u weights |
| the bit sum | addition |
| `fs_posterior_expr` | a clamped logistic |

And exactly one that did not:

```python
sim = make_scorer_udf(field.scorer)(a_val, b_val)   # -> forked Python worker
```

So `scorer_udf`/`transform_udf` thread through
`_field_similarity_and_observed` -> `fs_match_weight_expr` -> `fs_score_expr`,
and that one call goes to the jar's row-shaped kernel. Nothing else changes,
which is the point: the FS arithmetic has ONE implementation and both routes
reach it.

`_score_candidates_jvm_rowwise` projects `p{m}` per probabilistic matchkey
beside the exact `e{m}`, so the FS expression evaluates once per pair, and the
combine cuts it at `link_threshold` -- P(match) is a different quantity on a
different scale from a weighted similarity average.

## What is still true

**EM training does not distribute.** It reads a driver-side sample of blocked
pairs, so a trained model must be supplied via `fs_model_path`. Unchanged, and
now stated in the docstring rather than implied. Splink trains in-engine; this
does not.

**The batched shape still refuses**, and the refusal is now accurate rather
than blanket: its scores are per-SLOT in flat arrays, while a level is a ladder
over ONE field's similarity and the weights sum across fields. Expressing that
over the reshaped arrays would be a second implementation of the FS combine.

**No performance claim.** The row-shaped scorer measured 1.95x faster than the
batched one on weighted matchkeys (#2541), and FS now uses the same call, but
the FS path has not been benched. It was not previously runnable in the JVM at
all, so the comparison that matters is against the Python-worker route and it
has not been taken.

## Gates

- JVM FS == the Python Spark path, exactly, under BOTH missing modes
  (`unobserved` and `disagree`). No tolerance: both reach the same `score_one`
  and everything downstream is the same SQL, and the bugs this catches produce
  PLAUSIBLE probabilities -- a ladder read one threshold off still yields a
  number in [0, 1].
- JVM FS == the ONE-BOX directly. Transitivity would give it, but the two Spark
  routes share every line except the similarity call, so stating it catches a
  change that moves both off the reference together.
- a whole FS dedupe end to end with scorer, transforms and survivorship in the
  jar.
- the batched shape still raises for FS.

## Why this matters beyond the tier

This closes the honest gap in the Splink comparison. The migration converter
already reproduces a Splink model (pairwise F1 0.991 against real Splink 4), but
running it distributed still meant a Python environment on every executor. It
no longer does. Training remains the difference.
