### PR TITLE
fix(block-analyzer): make the recall warnings claim only what they can support (#2540)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2388,6 +2388,7 @@
             "_token_candidates",
             "_token_candidates_enabled",
             "_token_index",
+            "_warn_on_recall",
             "analyze_blocking",
             "check_coverage",
             "detect_column_type",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Fixed
+- **The blocking-recall warnings now claim only what the estimate supports, and
+  surface the trade-off the ranking makes silently (#2540).**
+  `estimated_recall` is measured against the pairs the matchkey emits over an
+  *unblocked* sample, so its denominator includes the scorer's false positives -
+  pairs blocking is right to drop. Its ceiling is therefore that population's
+  true-match fraction rather than 100% (measured on DBLP-ACM: 40.5% true). The
+  low-recall warning compared that estimate against an absolute 30% floor and
+  asserted *"expect most true matches to be missed"*, which the estimate cannot
+  support: on DBLP-ACM `title[:5]` scores 0.037 while genuinely retaining
+  **98.2%** of true pairs, so the warning fired while an excellent candidate sat
+  in the list. It now reports the figure as a lower bound and says why.
+
+  A second, **relative** warning carries the actionable signal. Ranking is
+  `score x estimated_recall` with no recall floor, so a key that drops most
+  matchable pairs can win on comparison count alone and nothing said so. When the
+  ranked pick retains materially less than the best candidate measured, both are
+  now named with their costs — on DBLP-ACM: *chosen `title[:5] + authors[:5]` at
+  23.5% and 1,667 comparisons, versus `title[:3]` at 59.5% and 117,348* — so a
+  2.5x retention trade for 70x fewer comparisons is visible rather than implicit.
+  Comparing two estimates over the same target population cancels the estimator
+  bias above, which is exactly what an absolute floor cannot do.
+
+  Ranking behaviour is unchanged; these are log-only. The underlying objective
+  problem (no recall floor) and the biased denominator are tracked on #2540.
 - **`build_resolved_crosswalk` respects the caller's `config.identity` instead
   of replacing it (#2521).** It constructed a fresh `IdentityConfig` with
   `backend="sqlite"` hardcoded and `emit_singletons` omitted, so a

--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -688,6 +688,15 @@ _SCORE_SAMPLE_SIZE = 100_000
 #: every candidate), not to police a well-tuned plan that trades a little recall
 #: for tractability.
 _LOW_RECALL_WARN = 0.30
+# The ranked pick is flagged when it retains less than this share of what the
+# best-recall candidate in the same list retains. Compares two estimates measured
+# against the SAME target population, so the estimator's own bias cancels -- which
+# is exactly what `_LOW_RECALL_WARN` cannot do, since an absolute floor is compared
+# against an estimate whose ceiling is the target's true-match fraction (#2540).
+# 0.75 measured: DBLP-ACM's ratio is 0.395 (rank 1 at 0.235 vs `title[:3]` at
+# 0.595) and fires; a plan within a quarter of the best available is not a
+# trade-off worth interrupting anyone over.
+_RECALL_TRADEOFF_RATIO = 0.75
 
 
 def analyze_blocking(
@@ -805,22 +814,72 @@ def analyze_blocking(
     # ranking is not a race to maximise recall alone.
     suggestions.sort(key=lambda s: (s.score * s.estimated_recall, s.score), reverse=True)
 
-    if suggestions and suggestions[0].estimated_recall < _LOW_RECALL_WARN:
+    if suggestions:
+        _warn_on_recall(suggestions, scored[0][1].get("coverage", 0.0))
+
+    return suggestions
+
+
+def _warn_on_recall(suggestions: list, coverage: float) -> None:
+    """Surface a low-recall blocking plan, and any higher-recall plan it outranked.
+
+    Two separate signals, because they mean different things and the absolute one
+    alone was misleading (#2540):
+
+    **Relative** -- the ranked pick retains materially less than the best candidate
+    measured. `rank = score x estimated_recall` has no recall floor, so a key that
+    drops most matchable pairs can win purely on comparison count, and nothing said
+    so. Measured on DBLP-ACM: rank 1 is `title[:5] + authors[:5]` at 0.235 estimated
+    recall and 1,667 comparisons, while `title[:3]` sits in the same list at 0.595
+    and 117,348 -- 2.5x the retention traded away for 70x fewer comparisons,
+    silently. This is the actionable one: the alternative is named, so the choice
+    can be overridden.
+
+    **Absolute** -- every candidate is under `_LOW_RECALL_WARN`. This one is a
+    weaker claim than it used to make. `estimated_recall` is measured against the
+    pairs the matchkey emits over an *unblocked* sample, which includes the
+    scorer's false positives, so its ceiling is that population's true-match
+    fraction rather than 1.0 (measured on DBLP-ACM: 40.5% true, so no candidate
+    could exceed ~0.4 however good). The old text asserted "expect most true
+    matches to be missed", which the estimate cannot support -- `title[:5]` scores
+    0.037 there while genuinely retaining 98.2% of true pairs. It is a lower bound
+    on true-match retention, and is phrased as one.
+    """
+    top = suggestions[0]
+    best_recall = max(suggestions, key=lambda s: s.estimated_recall)
+
+    if (
+        best_recall.description != top.description
+        and top.estimated_recall < _RECALL_TRADEOFF_RATIO * best_recall.estimated_recall
+    ):
+        logger.warning(
+            "Auto-suggest: the chosen blocking plan %r retains an estimated %.1f%% "
+            "of matchable pairs (%s comparisons), but candidate %r retains %.1f%% "
+            "(%s comparisons). Ranking is score x recall with no recall floor, so "
+            "the cheaper plan won on comparison count. If recall matters more than "
+            "cost here, set that key explicitly. See #2540.",
+            top.description, 100.0 * top.estimated_recall,
+            f"{top.total_comparisons:,}",
+            best_recall.description, 100.0 * best_recall.estimated_recall,
+            f"{best_recall.total_comparisons:,}",
+        )
+
+    if top.estimated_recall < _LOW_RECALL_WARN:
         # Not a hard reject. On a frame where EVERY candidate is below the floor
         # -- which is the Amazon-Google case -- rejecting them all leaves
         # degenerate blocking, and one mega-block is worse than a poor key. The
-        # honest move is to run and say so, loudly, rather than to report a
-        # 5%-recall plan as a normal success.
+        # honest move is to run and say so rather than report it as a clean success.
         logger.warning(
-            "Auto-suggest: best blocking candidate %r estimates only %.1f%% recall "
-            "(coverage %.1f%%). Every candidate considered was below %.0f%%, so this "
-            "is a low-recall blocking plan, not a tuned one -- expect most true "
-            "matches to be missed. Provide an explicit blocking config if this "
-            "dataset matters. See #2488.",
-            suggestions[0].description,
-            100.0 * suggestions[0].estimated_recall,
-            100.0 * scored[0][1].get("coverage", 0.0),
+            "Auto-suggest: best blocking candidate %r estimates %.1f%% recall "
+            "(coverage %.1f%%), below the %.0f%% floor. Treat this as a LOWER BOUND "
+            "on true-match retention, not a measurement of it: the denominator is "
+            "the pairs the matchkey emits over an unblocked sample, so it includes "
+            "scorer false positives that blocking is right to drop, and its ceiling "
+            "is that population's true-match fraction rather than 100%%. Blocking "
+            "may still be weak here -- verify against known duplicates, or provide "
+            "an explicit blocking config, before trusting the plan. See #2488, #2540.",
+            top.description,
+            100.0 * top.estimated_recall,
+            100.0 * coverage,
             100.0 * _LOW_RECALL_WARN,
         )
-
-    return suggestions

--- a/packages/python/goldenmatch/tests/test_blocking_recall_warnings_2540.py
+++ b/packages/python/goldenmatch/tests/test_blocking_recall_warnings_2540.py
@@ -1,0 +1,107 @@
+"""#2540: the blocking-recall warnings must claim only what the estimate supports.
+
+`estimated_recall` is measured against the pairs the matchkey emits over an
+UNBLOCKED sample, so it includes the scorer's false positives -- pairs blocking is
+right to drop. Its ceiling is therefore that population's true-match fraction, not
+1.0 (measured on DBLP-ACM: 40.5% true). The absolute floor warning used to assert
+"expect most true matches to be missed", which the estimate cannot support:
+`title[:5]` scores 0.037 there while genuinely retaining 98.2% of true pairs.
+
+A second, RELATIVE warning carries the actionable signal, because it compares two
+estimates over the same target population and so cancels that bias.
+"""
+from __future__ import annotations
+
+import logging
+
+from goldenmatch.core.block_analyzer import (
+    _LOW_RECALL_WARN,
+    _RECALL_TRADEOFF_RATIO,
+    BlockingSuggestion,
+    _warn_on_recall,
+)
+
+LOGGER = "goldenmatch.core.block_analyzer"
+
+
+def _s(desc, recall, comparisons=1000, score=0.1):
+    return BlockingSuggestion(
+        keys=[{"key_fields": ["x"], "transforms": ["lowercase"], "description": desc}],
+        group_count=10, max_group_size=5, mean_group_size=2.0,
+        total_comparisons=comparisons, estimated_recall=recall,
+        score=score, description=desc,
+    )
+
+
+def _msgs(caplog):
+    return [r.getMessage() for r in caplog.records if r.name == LOGGER]
+
+
+class TestRelativeTradeoffWarning:
+    def test_fires_when_a_higher_recall_candidate_is_outranked(self, caplog):
+        # DBLP-ACM's real shape: rank 1 is cheap and lossy, a much higher-recall
+        # candidate sits in the same list and lost on comparison count.
+        sugg = [_s("title[:5] + authors[:5]", 0.235, 1_667),
+                _s("title[:3]", 0.595, 117_348)]
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall(sugg, coverage=0.997)
+        m = " ".join(_msgs(caplog))
+        assert "title[:3]" in m and "59.5%" in m
+        assert "no recall floor" in m
+        # It must name the cost, so the trade-off is judgeable.
+        assert "1,667" in m and "117,348" in m
+
+    def test_silent_when_the_pick_is_close_to_the_best(self, caplog):
+        sugg = [_s("a", 0.80, 1_000), _s("b", 0.85, 90_000)]
+        assert 0.80 >= _RECALL_TRADEOFF_RATIO * 0.85
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall(sugg, coverage=1.0)
+        assert not [m for m in _msgs(caplog) if "no recall floor" in m]
+
+    def test_silent_when_the_pick_IS_the_best_recall(self, caplog):
+        sugg = [_s("a", 0.9), _s("b", 0.4)]
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall(sugg, coverage=1.0)
+        assert not [m for m in _msgs(caplog) if "no recall floor" in m]
+
+    def test_fires_independently_of_the_absolute_floor(self, caplog):
+        # Both candidates well above the floor, but the pick still gives up 60%
+        # of the available retention -- the absolute warning cannot see this.
+        sugg = [_s("cheap", 0.35, 500), _s("thorough", 0.95, 500_000)]
+        assert 0.35 > _LOW_RECALL_WARN
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall(sugg, coverage=1.0)
+        m = _msgs(caplog)
+        assert any("no recall floor" in x for x in m)
+        assert not any("LOWER BOUND" in x for x in m)
+
+
+class TestAbsoluteFloorWarning:
+    def test_does_not_assert_true_matches_will_be_missed(self, caplog):
+        # The retired claim. `title[:5]` scored 0.037 on DBLP-ACM while retaining
+        # 98.2% of true pairs, so this assertion was simply false there.
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall([_s("k", 0.037)], coverage=0.997)
+        m = " ".join(_msgs(caplog))
+        assert "expect most true matches to be missed" not in m
+
+    def test_states_the_estimate_is_a_lower_bound_and_why(self, caplog):
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall([_s("k", 0.037)], coverage=0.997)
+        m = " ".join(_msgs(caplog))
+        assert "LOWER BOUND" in m
+        assert "false positives" in m  # names the reason the denominator inflates
+        assert "3.7%" in m
+
+    def test_silent_above_the_floor(self, caplog):
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall([_s("k", _LOW_RECALL_WARN + 0.01)], coverage=1.0)
+        assert not [m for m in _msgs(caplog) if "LOWER BOUND" in m]
+
+    def test_both_can_fire_together(self, caplog):
+        sugg = [_s("cheap", 0.10, 500), _s("thorough", 0.60, 500_000)]
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _warn_on_recall(sugg, coverage=1.0)
+        m = _msgs(caplog)
+        assert any("no recall floor" in x for x in m)
+        assert any("LOWER BOUND" in x for x in m)


### PR DESCRIPTION
## What and why

Two problems with the low-recall blocking warning — one of correctness, one of omission. Both are log-only; **ranking behaviour is unchanged**.

### 1. The warning asserted something the estimate cannot support

`estimated_recall` is measured against the pairs the matchkey emits over an **unblocked** sample, so the denominator includes the scorer's false positives — pairs blocking is *right* to drop. Its ceiling is therefore that population's true-match fraction, not 1.0. Measured on DBLP-ACM:

```
target pairs built   247
  of which TRUE      100  (40.5%)
  chaff              147  (59.5%)
```

So no candidate there could score above ~0.4 however good it was. The warning compared that estimate against an absolute 30% floor and concluded *"expect most true matches to be missed"* — a claim about true matches the number cannot carry. On DBLP-ACM `title[:5]` scores **0.037** while genuinely retaining **98.2%** of true pairs, so the warning fired at full volume with an excellent candidate sitting in the list.

It now reports the figure as a lower bound and states why.

### 2. It said nothing about the trade-off the ranking was making

Ranking is `score x estimated_recall` with **no recall floor**, so a key that drops most matchable pairs can win on comparison count alone. A second, relative warning names the outranked alternative and both costs:

> chosen `title[:5] + authors[:5]` retains an estimated **23.5%** (1,667 comparisons), but candidate `title[:3]` retains **59.5%** (117,348 comparisons)

2.5x the retention traded for 70x fewer comparisons — previously invisible.

**The relative signal is the trustworthy one precisely because it compares two estimates over the same target population, so the bias in (1) cancels.** That is exactly what an absolute floor cannot do, and it is the reason for keeping both rather than replacing one with the other. The asymmetry is written down next to each.

## Why this and not the estimator itself

Panel validation for fixing the denominator came back **negative** (full data on #2540):

| dataset | all emitted (today) | mutual best match | top 50% by score |
|---|---|---|---|
| dblp_acm | 0.310 (335 pairs, 104 true) | 0.566 (182, 103 true) | 0.607 (168, 102 true) |
| person | 0.368 (910 pairs, 335 true) | 0.616 (232, **143** true) | 0.562 (464, 261 true) |

Mutual-best-match is nearly free on dblp_acm (1:1 data, every true pair *is* an MBM) but keeps only 143 of 335 true pairs on `person`, which has genuine 3-member clusters — trading a known bias for an unknown one. Top-50% is arbitrary. Neither gets the target above ~60% true, so the cap and the reward-for-retaining-chaff both survive.

And by the arithmetic on #2540, **no estimator fix reorders these candidates anyway** — with true recalls substituted, `title[:5] + authors[:5]` still beats `title[:5]` 0.207 to 0.089 on selectivity. The objective problem (no recall floor) and the biased denominator stay tracked on #2540.

## Changes

- `core/block_analyzer.py`: extract `_warn_on_recall`; correct the absolute warning's claim; add the relative trade-off warning and `_RECALL_TRADEOFF_RATIO = 0.75` (DBLP-ACM's actual ratio, 0.395, recorded in the constant's comment).
- `tests/test_blocking_recall_warnings_2540.py`: 8 tests, including one asserting the retired claim is **gone**, and one where both candidates clear the 30% floor yet 60% of retention is given up — the case the absolute warning structurally cannot see.
- `CHANGELOG.md`, codemap regenerated.

## Testing

- New tests: **8 passed**.
- `test_block*` + `test_autoconfig*` + `test_suggest*`: **997 passed, 6 skipped, 1 failed**. The failure is `test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above`, which is **pre-existing** — verified by reverting `block_analyzer.py` to `origin/main` and re-running, where it fails identically. It concerns the suggest kernel's dip/valley detection, unrelated to blocking warnings. Flagging rather than fixing, since it is not this PR's.
- `ruff` clean; `pyright` clean on the changed files; `check_context_budget.py` OK; `make docs` regenerates with no drift (run because this adds a module-level function and `docs_regen` gates on drift).

`uv.lock` was rewritten by `make docs` with a 14KB shrink from local resolution; reverted rather than committed, since nothing here requires it.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed
- [ ] `pre-commit run --all-files` — not run in full; ruff + pyright + context-budget + docs-regen run individually and are clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_