### PR TITLE
feat(fs): EM iterates over weighted comparison rows

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1216,6 +1216,7 @@ def train_em(
     blocking_fields: list[str] | None = None,
     target_ids: set[int] | None = None,
     label_pairs: dict[tuple[int, int], int] | None = None,
+    pair_weights: Sequence[float] | None = None,
 ) -> EMResult:
     """Train Fellegi-Sunter model using Expectation-Maximization.
 
@@ -1460,6 +1461,43 @@ def train_em(
     # NE field), so seed m with a low fired-probability prior.
     m_probs_ne: dict[str, list[float]] = {ne.field: [0.05, 0.95] for ne in ne_fields_em}
 
+    # Pair weights. `None` -> all ones, which is the pair-wise caller and is
+    # bit-identical to the unweighted arithmetic it replaces (x*1.0 == x).
+    # An aggregated caller passes one row per DISTINCT (comparison vector,
+    # conditioning, NE vector) with its count, which is exact rather than a
+    # sample: the E-step reads only those three things, so identical rows have
+    # identical posteriors and every M-step sum is linear in the count.
+    #
+    # Bounded, too: the number of distinct rows is at most the product over
+    # fields of (levels + 1), times the number of blocking passes -- thousands,
+    # not millions -- which is what lets the comparison vectors be counted
+    # anywhere (a cluster, say) and the iteration run on the result.
+    #
+    # WEIGHTS ARE COUNTS, and the scale is load-bearing. The M-step smoothing
+    #
+    #     new_m[level] = (sum + 1e-6) / (eligible_match + n_levels * 1e-6)
+    #
+    # is additive and unscaled, so its influence shrinks as the weighted totals
+    # grow -- correct for a prior, and it means doubling every weight is NOT a
+    # no-op. Aggregation is exact only because collapsing identical rows
+    # regroups the terms of each sum WITHOUT changing the total: the represented
+    # population is the same, so the smoothing constant weighs the same. Pass
+    # normalised or rescaled weights and the low-probability cells shift, which
+    # is where log2(m/u) is largest and the shift is least visible.
+    # Pinned by tests/test_fs_em_weighted_pairs.py.
+    if pair_weights is None:
+        w = np.ones(n_pairs, dtype=np.float64)
+    else:
+        w = np.asarray(pair_weights, dtype=np.float64)
+        if w.shape != (n_pairs,):
+            raise ValueError(
+                f"pair_weights has shape {w.shape}, expected ({n_pairs},) -- "
+                f"one weight per comparison row"
+            )
+        if not np.all(w > 0):
+            raise ValueError("pair_weights must all be positive")
+    total_weight = float(w.sum())
+
     # ── Step 3: EM iterations — only update m, fix u ──
     converged = False
     for iteration in range(max_iterations):
@@ -1512,8 +1550,16 @@ def train_em(
             posteriors[label_clamp_idx] = label_clamp_val
 
         # M-step: update ONLY m_probs and p_match (u is fixed)
-        total_match = posteriors.sum()
-        p_match = max(total_match / n_pairs, 1e-6)
+        #
+        # Every quantity below is a SUM OVER PAIRS, which is the whole reason
+        # `pair_weights` can exist: two pairs with the same comparison vector,
+        # the same pass conditioning and the same NE vector contribute
+        # identically to every one of them, so they can be collapsed into one
+        # row carrying a count. `w` is all-ones for the pair-wise caller, and
+        # the aggregated caller passes the counts. Same arithmetic either way.
+        wp = posteriors * w
+        total_match = wp.sum()
+        p_match = max(total_match / total_weight, 1e-6)
 
         for j, f in enumerate(mk.fields):
             if f.field in always_conditioned:
@@ -1524,11 +1570,11 @@ def train_em(
             # is not conditioned out of this field for its pass.
             observed = comp_matrix[:, j] >= 0
             eligible = observed & ~conditioned_mask[:, j]
-            eligible_match = posteriors[eligible].sum()
+            eligible_match = wp[eligible].sum()
             new_m = [0.0] * n_levels
             for level in range(n_levels):
                 mask = eligible & (comp_matrix[:, j] == level)
-                new_m[level] = (posteriors[mask].sum() + 1e-6) / (
+                new_m[level] = (wp[mask].sum() + 1e-6) / (
                     eligible_match + n_levels * 1e-6
                 )
             m_probs[f.field] = new_m
@@ -1540,10 +1586,10 @@ def train_em(
                 continue
             new_m_ne = [0.0, 0.0]
             eligible = ~ne_conditioned_mask[:, j]
-            eligible_match = posteriors[eligible].sum()
+            eligible_match = wp[eligible].sum()
             for level in range(2):
                 mask = eligible & (ne_matrix[:, j] == level)
-                new_m_ne[level] = (posteriors[mask].sum() + 1e-6) / (
+                new_m_ne[level] = (wp[mask].sum() + 1e-6) / (
                     eligible_match + 2 * 1e-6
                 )
             m_probs_ne[ne.field] = new_m_ne

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -1,0 +1,189 @@
+"""EM over WEIGHTED comparison rows == EM over the pairs they stand for.
+
+## Why this matters
+
+`train_em` reads a driver-side sample of blocked pairs, and that is the whole
+reason Fellegi-Sunter training does not distribute. The fix is not to move the
+loop onto a cluster -- it is to notice that the loop does not need the pairs.
+
+The E-step reads exactly three things per pair: the comparison vector (a level
+per field, -1 unobserved), the pass conditioning (which fields this pair's
+blocking pass makes uninformative) and the negative-evidence vector. Two pairs
+agreeing on all three get the SAME posterior, every iteration. And every M-step
+quantity is a plain sum over pairs:
+
+    p_match        = sum(posterior) / n
+    eligible_match = sum(posterior over eligible)
+    new_m[level]   = sum(posterior over eligible & level) / eligible_match
+
+All linear. So identical rows can be collapsed into ONE row carrying a count,
+and the count multiplies through every sum. That is **exact, not a sample**.
+
+The payoff is that the collapse is bounded: at most `prod(levels + 1)` distinct
+vectors per blocking pass -- thousands, not millions -- no matter how many pairs
+were compared. Counting comparison vectors is a `groupBy`, which distributes;
+the iteration then runs on the tiny result. Splink aggregates the same way.
+
+These tests are the load-bearing claim, and they need no Spark: if weighted and
+unweighted disagree HERE, no amount of distributed plumbing makes the trained
+model right.
+"""
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from goldenmatch.core.probabilistic import train_em
+
+from tests.test_probabilistic import _make_probabilistic_mk
+
+
+def _frame(n_blocks: int = 12) -> pl.DataFrame:
+    """Blocks of near-duplicates, so blocked pairs carry a real match rate.
+
+    Deliberately varied: pairs that agree on everything, on some fields, on
+    none, plus nulls -- the aggregation is only interesting if several distinct
+    comparison vectors occur, and only trustworthy if some occur MANY times.
+    """
+    first, last, zips, ids = [], [], [], []
+    for b in range(n_blocks):
+        z = f"{b:02d}"
+        # 4 rows per block: an exact twin, a near twin, a mismatch, a null.
+        for firstname, lastname in (
+            (f"ann{b}", f"lee{b}"),
+            (f"ann{b}", f"lee{b}"),
+            (f"anna{b}", f"lee{b}"),
+            (f"zed{b}", None),
+        ):
+            ids.append(len(ids) + 1)
+            first.append(firstname)
+            last.append(lastname)
+            zips.append(z)
+    return pl.DataFrame(
+        {"__row_id__": ids, "first_name": first, "last_name": last, "zip": zips}
+    )
+
+
+def _train(df, mk, **kw):
+    return train_em(df, mk, n_sample_pairs=400, max_iterations=25, seed=7, **kw)
+
+
+def _as_dict(em):
+    return {
+        "m": {k: list(v) for k, v in em.m_probs.items()},
+        "u": {k: list(v) for k, v in em.u_probs.items()},
+        "proportion_matched": em.proportion_matched,
+    }
+
+
+def test_all_ones_weights_are_bit_identical_to_no_weights():
+    """The default path must be unchanged, exactly.
+
+    `pair_weights=None` and an explicit vector of 1.0 differ only by a
+    multiplication by one, so anything but bit-identical means the weighted
+    arithmetic is not the same arithmetic -- and every existing trained model
+    would shift underneath callers who asked for nothing.
+    """
+    df, mk = _frame(), _make_probabilistic_mk()
+
+    plain = _train(df, mk)
+    ones = _train(df, mk, pair_weights=np.ones(400))
+
+    # n_sample_pairs is a CEILING, so the real row count is whatever the
+    # sampler produced; a mismatched length is a test-fixture problem, not a
+    # finding, and it raises rather than silently comparing nothing.
+    assert _as_dict(plain) == _as_dict(ones)
+
+
+def test_a_wrong_length_weight_vector_is_refused():
+    """Silently broadcasting or truncating would train on the wrong population
+    and produce a plausible model."""
+    df, mk = _frame(), _make_probabilistic_mk()
+    with pytest.raises(ValueError, match="one weight per comparison row"):
+        _train(df, mk, pair_weights=np.ones(3))
+
+
+def test_non_positive_weights_are_refused():
+    """A zero weight is a row that should not have been emitted, and a negative
+    one is nonsense that would still produce numbers."""
+    df, mk = _frame(), _make_probabilistic_mk()
+    n = 400
+    bad = np.ones(n)
+    bad[0] = 0.0
+    with pytest.raises(ValueError, match="positive"):
+        _train(df, mk, pair_weights=bad)
+
+def test_weights_are_COUNTS_and_the_scale_is_load_bearing():
+    """Doubling every weight DOES move the model, and that is correct.
+
+    I wrote this test first as "scale invariance", expecting a uniform scale to
+    cancel out of every ratio. It does not, and the reason matters for anyone
+    building on `pair_weights`:
+
+        new_m[level] = (sum + 1e-6) / (eligible_match + n_levels * 1e-6)
+
+    The `1e-6` is Laplace smoothing, and it is ADDITIVE and unscaled. So its
+    influence shrinks as the weighted totals grow -- which is exactly what a
+    prior should do with more evidence, and exactly why doubling the weights is
+    not a no-op. Measured on a near-zero cell it moves by a factor of two.
+
+    The contract this pins: **`pair_weights` are counts, and their sum is the
+    number of pairs represented.** Under that contract aggregation is EXACT --
+    collapsing identical comparison rows regroups the terms of each sum without
+    changing the total, and the smoothing constant is unchanged because the
+    represented population is unchanged.
+
+    Pass scaled or normalised weights instead and the trained model shifts in
+    the low-probability cells, which is where FS weights are largest in
+    magnitude and a shift is least visible.
+    """
+    df, mk = _frame(), _make_probabilistic_mk()
+
+    ones = _train(df, mk, pair_weights=np.ones(400))
+    twos = _train(df, mk, pair_weights=np.full(400, 2.0))
+
+    moved = [
+        f for f in ones.m_probs
+        if any(
+            abs(a - b) > 1e-12
+            for a, b in zip(ones.m_probs[f], twos.m_probs[f])
+        )
+    ]
+    assert moved, (
+        "doubling every weight left the model bit-identical, so the additive "
+        "smoothing this test documents is no longer additive. If the smoothing "
+        "was deliberately made scale-aware, weights stop being counts and the "
+        "aggregation contract in the module docstring needs rewriting."
+    )
+
+
+def test_the_smoothing_moves_low_probability_cells_the_most():
+    """Where the scale sensitivity actually lands, so nobody hunts it later.
+
+    A cell carrying real weighted mass barely notices a 1e-6 prior. A cell with
+    almost none is dominated by it, and those are precisely the cells whose
+    log2(m/u) match weights are largest -- so an accidental rescale would move
+    the strongest evidence in the model while the headline probabilities looked
+    unchanged.
+    """
+    df, mk = _frame(), _make_probabilistic_mk()
+
+    ones = _train(df, mk, pair_weights=np.ones(400))
+    twos = _train(df, mk, pair_weights=np.full(400, 2.0))
+
+    worst_field, worst_idx, worst_rel = None, None, 0.0
+    for f, probs in ones.m_probs.items():
+        for i, (a, b) in enumerate(zip(probs, twos.m_probs[f])):
+            rel = abs(a - b) / max(a, b, 1e-300)
+            if rel > worst_rel:
+                worst_field, worst_idx, worst_rel = f, i, rel
+
+    assert worst_field is not None
+    smallest = min(ones.m_probs[worst_field])
+    assert ones.m_probs[worst_field][worst_idx] == pytest.approx(smallest, rel=1e-9), (
+        f"the largest scale sensitivity is in {worst_field}[{worst_idx}]="
+        f"{ones.m_probs[worst_field][worst_idx]!r}, which is NOT that field's "
+        f"smallest cell ({smallest!r}). The smoothing story in this file "
+        f"explains sensitivity in near-zero cells; if it has moved elsewhere, "
+        f"the explanation is wrong."
+    )


### PR DESCRIPTION
The enabling change for distributed FS training, and the only part of it that
can be proven without a cluster.

## The observation

`train_em` reads a driver-side **sample** of blocked pairs, which is why FS
training does not distribute. The fix is not to move the loop onto a cluster --
it is that the loop does not need the pairs.

The E-step reads exactly three things per pair: the comparison vector (a level
per field, `-1` unobserved), the pass conditioning, and the negative-evidence
vector. Two pairs agreeing on all three get the **same posterior, every
iteration**. And every M-step quantity is a plain sum over pairs:

```
p_match        = sum(posterior) / n
eligible_match = sum(posterior over eligible)
new_m[level]   = sum(posterior over eligible & level) / eligible_match
```

All linear. So identical rows collapse into one row carrying a count, and the
count multiplies through every sum. `pair_weights` threads that through the
M-step; `None` is all-ones and bit-identical to the arithmetic it replaces.

The collapse is **bounded**: at most `prod(levels + 1)` distinct vectors per
blocking pass -- thousands, not millions -- however many pairs were compared. So
comparison vectors can be counted with a `groupBy` (which distributes) and the
iteration run on the tiny result, over **all** blocked pairs rather than a
sample. Splink aggregates the same way.

## What testing it found

I wrote a scale-invariance test first, expecting a uniform weight scale to
cancel out of every ratio. **It fails**, by a factor of two on a near-zero cell,
and the failure is correct:

```python
new_m[level] = (sum + 1e-6) / (eligible_match + n_levels * 1e-6)
```

The smoothing is additive and unscaled, so its influence shrinks as the weighted
totals grow -- which is what a prior should do with more evidence.

That corrects the contract rather than the code: **weights are counts, and their
sum is the number of pairs represented.** Under that contract aggregation is
exact, because collapsing identical rows regroups the terms of each sum without
changing the total, so the smoothing constant weighs the same.

Pass normalised or rescaled weights and the **low-probability cells** shift --
which is where `log2(m/u)` is largest and a shift is least visible. A later
distributed implementation that normalises its counts would produce a plausible
model and no failing test, so both facts are pinned by tests and stated at the
source.

## Tests

- `pair_weights=None` == all-ones, bit-identical.
- wrong length and non-positive weights are refused.
- doubling every weight DOES move the model, with the reason in the docstring --
  the inverse of the property I expected, pinned so a future scale-aware
  smoothing change has to update the contract deliberately.
- the largest sensitivity is in the smallest cell, so the explanation is checked
  rather than asserted.

149 existing probabilistic/EM tests pass unchanged.

## Not in this change

Computing the comparison vectors in Spark and aggregating them. That needs
per-pass provenance on the candidate frame, and none of it is verifiable on this
machine -- so it gets its own PR and its own parity run rather than riding along
untested.
