### PR TITLE
feat(semantic): Feast feature-store dialect for the key-integrity certifier

### DIFF
--- a/context-network/decisions/0060-feast-feature-store-provider.md
+++ b/context-network/decisions/0060-feast-feature-store-provider.md
@@ -1,0 +1,84 @@
+# 0060 — Feast (feature-store) provider: the metric-aware wedge, one layer over into ML
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch.semantic.feast` (`parse_feast_models` / `parse_feast_objects`, `feast_join_keys`, `certify_feast_feature_views`, `emit_feast_from_crosswalk`, `emit_feast_yaml`) + a `"feast"` dialect in `certify_semantic_model` • **Builds on:** [0049 (metric-aware key certification)](0049-metric-aware-key-certification.md), [0050 (resolved-crosswalk emit)](0050-resolved-crosswalk-emit.md), [0052 (Cube dialect)](0052-cube-dialect-and-osi-validation.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+The semantic-layer wedge (0049) proved that a metric can be perfectly *defined* yet
+numerically *wrong* when the entity keys its joins run on were never resolved. A
+**feature store is the same join graph, one layer over into ML**: a Feast
+`FeatureView` is keyed on an `Entity`, and the entity's `join_keys` are the identity
+the features silently assume. The three break modes reappear and bite ML directly:
+
+- **duplicated join key → fan-out** — an aggregated feature double-counts; a
+  point-in-time join multiplies rows;
+- **fragmented entity → undercount / training-serving skew** — one real entity split
+  across keys trains the model on half a customer;
+- **non-conformed keys across sources** — the feature view can't join to the entity.
+
+Feast's `Entity(join_keys=[...])` maps one-to-one onto MetricFlow `entity (primary)`
+and Cube `primary_key`, so the *exact* certifier applies. This surface fits the
+"missing provider" filter (an established ecosystem that runs on entity keys and
+assumes resolved identity as an input it never produces) that also selected the
+metrics and ontology layers.
+
+## Decision
+A new dialect module `goldenmatch/semantic/feast.py`, structured exactly like the
+Cube dialect (0052) — consume, certify (bridge A), emit (bridge B):
+
+1. **Consume.** `parse_feast_models(source)` reads a declarative
+   `{entities, feature_views}` doc (path / YAML / dict); `parse_feast_objects(
+   entities, feature_views)` duck-types live Feast SDK objects (e.g.
+   `store.list_entities()` / `store.list_feature_views()`) — **no `feast` import in
+   goldenmatch**, so the package never depends on it. `feast_join_keys` resolves
+   each feature view to the entity `join_keys` it rides on.
+2. **Certify (bridge A).** `certify_feast_feature_views(repo, frames, resolve=…)`
+   certifies each feature view's entity join key via `certify_key_integrity`, **with
+   the view's features as the fan-out measures** — so the certificate quantifies
+   exactly "how much does aggregating this feature over a not-truly-unique key
+   inflate it." `resolve=True` adds the ER fragmentation/undercount tier, made
+   metric-aware by `semantic_field_roles` (a feature value is never identity
+   evidence — you don't merge two customers because they share a churn score).
+3. **Emit (bridge B).** `emit_feast_from_crosswalk(crosswalk, …)` declares the
+   GoldenMatch-resolved key as the entity `join_keys` and a feature view keyed on it,
+   provenance (+ optional certificate verdict) in `tags.goldenmatch`.
+   `parse_feast_models(emit_feast_yaml(...))` round-trips.
+4. **Front-door wiring, no new surface.** `certify_semantic_model` auto-detects a
+   top-level `feature_views:` as the `"feast"` dialect and dispatches to
+   `certify_feast_feature_views`; `semantic_field_roles` learns the Feast role split
+   (join_keys = identity, features = measures). The CLI (`certify-keys`), MCP
+   (`certify_semantic_model`), and REST surfaces certify a feature repo with **no new
+   MCP tool / CLI command / A2A skill** — same posture as Cube. Library-only,
+   advisory, parity-free.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — an *adapter surface* over the existing
+  `certify_key_integrity` (which is single-sourced through `key-integrity-core`,
+  0059). GoldenMatch does **not** author features, feature transforms, or
+  materialization — Feast keeps that. No second source of truth.
+- **Conformance defines correctness** ✅ — Feast is another dialect target; the
+  reader/emitter round-trips and the certifier is the same shared owner.
+- **Compute vs. control stay distinct** ✅ — the Feast doc is small metadata (YAML /
+  duck-typed objects), correctly not Arrow-marshaled; the certification rides the
+  columnar key-integrity path.
+- **Zero-config should embarrass the alternatives** ✅ — point it at a feature repo +
+  the offline frames and get a per-feature fan-out / undercount report on the first
+  run; Feast itself offers nothing here.
+
+## Consequences / honest flags
+- **Declaration only, no materialization.** Like every other dialect, this reads/
+  writes the *declaration*; it does not run Feast's offline/online stores or
+  point-in-time joins. `frames` are supplied by the caller (the offline source).
+- **Feast discovery is deferred.** v1 is consume + certify + emit (bridges A + B),
+  mirroring Cube's initial add. Generating a Feast repo from raw tables via
+  `discover_semantic_model(dialect="feast")` is a follow-on (the discovery
+  orchestrator is dialect-pluggable but out of scope here).
+- **`parse_feast_objects` is duck-typed, not schema-locked.** It reads `.name` /
+  `.join_keys` / `.features`-or-`.schema` / `.batch_source|.source` off whatever it's
+  given; a future Feast rename of those attributes would need a follow-up (the
+  declarative-doc path is unaffected).
+- **No new parity surface** — verified: `feast` appears in zero gated Python surfaces
+  (mcp_tools / cli_commands / a2a_skills / scorers / …), so `parity/goldenmatch.yaml`
+  is unchanged, consistent with Cube.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -71,6 +71,24 @@
 > `semantic-key-integrity-single-sourced-kernel` (`default_routed: opt-in`). The rest
 > of the semantic layer (discovery, resolution tier, namer, warehouse introspection)
 > is orchestration/stateful and correctly stays Python-authoritative.
+>
+> **Feature-store surface (Feast,
+> [0060](../decisions/0060-feast-feature-store-provider.md)).** The wedge one layer
+> over into ML: a Feast `FeatureView` is keyed on an `Entity`'s `join_keys`, and a
+> duplicated join key fans out every aggregated feature (a `sum`/`count`
+> double-counts), a fragmented entity splits its own feature history
+> (training-serving skew), non-conformed keys can't join. Feast's
+> `Entity(join_keys=[...])` maps one-to-one onto MetricFlow `entity (primary)` /
+> Cube `primary_key`, so the same certifier applies. `goldenmatch.semantic.feast`:
+> `parse_feast_models` / `parse_feast_objects` (declarative doc or duck-typed Feast
+> SDK objects — no `feast` dependency), `feast_join_keys`,
+> `certify_feast_feature_views` (bridge A — features are the fan-out measures),
+> `emit_feast_from_crosswalk` (bridge B). `certify_semantic_model` auto-detects a
+> top-level `feature_views:` as the `"feast"` dialect, so the CLI/MCP/REST front
+> doors certify a feature repo with no new surface (parity-free, like Cube). The
+> next missing provider surfaces from the same filter: **BI semantic-model dialects
+> (Malloy/LookML)** and **data contracts (ODCS)**; the CDP/activation lane is
+> competitive prior art, not a plug-under gap.
 > Greenfield when written: no prior repo code, doc, or decision referenced this
 > ecosystem (grep, 2026-07-30).
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 470,
+      "module_count": 471,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7173,6 +7173,7 @@
             "goldenmatch.semantic.crosswalk",
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.discovery",
+            "goldenmatch.semantic.feast",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.ontology",
@@ -7195,6 +7196,7 @@
           "imports": [
             "goldenmatch.semantic.certify",
             "goldenmatch.semantic.cube",
+            "goldenmatch.semantic.feast",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi"
@@ -7232,6 +7234,7 @@
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.blocking",
             "goldenmatch.semantic.cube",
+            "goldenmatch.semantic.feast",
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi"
@@ -7574,6 +7577,35 @@
           ],
           "imports": [
             "goldenmatch.semantic.discovery.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.feast",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/feast.py",
+          "purpose": "Feast (feature-store) reader + emitter — the feature-store dialect.",
+          "defines": [
+            "FeastEntity",
+            "FeastFeatureView",
+            "FeastRepo",
+            "_as_name_list",
+            "_entity_join_keys",
+            "_parse_entity",
+            "_parse_feature_view",
+            "certify_feast_feature_views",
+            "emit_feast",
+            "emit_feast_entity",
+            "emit_feast_feature_view",
+            "emit_feast_from_crosswalk",
+            "emit_feast_yaml",
+            "feast_join_keys",
+            "parse_feast_models",
+            "parse_feast_objects"
+          ],
+          "imports": [
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.blocking",
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow"
           ]
         },
         {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+- **Feast (feature-store) dialect for the semantic-layer certifier
+  (`goldenmatch.semantic.feast`).** A feature store is a join graph one layer over
+  into ML: a `FeatureView` is keyed on an `Entity`'s `join_keys`, and a duplicated
+  join key fans out every aggregated feature (a `sum`/`count` double-counts), a
+  fragmented entity splits its own feature history (training-serving skew), and
+  non-conformed keys can't join. Feast's `Entity(join_keys=[...])` maps one-to-one
+  onto MetricFlow `entity (primary)` / Cube `primary_key`, so the same certifier
+  applies. New: `parse_feast_models` / `parse_feast_objects` (declarative doc or
+  duck-typed Feast SDK objects -- no `feast` dependency), `feast_join_keys`,
+  `certify_feast_feature_views` (bridge to wedge A -- certifies each view's entity
+  join key with the view's **features as the fan-out measures**),
+  `emit_feast_from_crosswalk` (bridge to wedge B -- declares the resolved key as the
+  entity `join_keys`), and `emit_feast_yaml` (round-trips through
+  `parse_feast_models`). `certify_semantic_model` now auto-detects a top-level
+  `feature_views:` as the `"feast"` dialect, so the CLI / MCP / REST front doors
+  certify a feature repo with no new surface. Library-only, advisory, parity-free --
+  it never mutates a feature or a key.
+
 ### Fixed
 - **`build_resolved_crosswalk` respects the caller's `config.identity` instead
   of replacing it (#2521).** It constructed a fresh `IdentityConfig` with

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -92,6 +92,17 @@ from goldenmatch.semantic.discovery import (
     score_model,
     score_naming,
 )
+from goldenmatch.semantic.feast import (
+    FeastEntity,
+    FeastFeatureView,
+    FeastRepo,
+    certify_feast_feature_views,
+    emit_feast_from_crosswalk,
+    emit_feast_yaml,
+    feast_join_keys,
+    parse_feast_models,
+    parse_feast_objects,
+)
 from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
     certify_structural_json,
@@ -208,6 +219,16 @@ __all__ = [
     "CubeDimension",
     "CubeMeasure",
     "CubeJoin",
+    # follow-on — Feast (feature-store) dialect (reader + emitter + bridges)
+    "parse_feast_models",
+    "parse_feast_objects",
+    "feast_join_keys",
+    "certify_feast_feature_views",
+    "emit_feast_yaml",
+    "emit_feast_from_crosswalk",
+    "FeastEntity",
+    "FeastFeatureView",
+    "FeastRepo",
     # ontology layer — RDF/OWL/SHACL native identity provider (bidirectional)
     "parse_ontology",
     "ontology_identity_keys",

--- a/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
@@ -114,6 +114,16 @@ def semantic_field_roles(source: str | Any) -> SemanticFieldRoles:
                 (keys if d.primary_key else dimensions).append(d.name)
             for m in cube.measures:
                 measures.append(m.name)
+    elif dialect == "feast":
+        from goldenmatch.semantic.feast import parse_feast_models
+
+        repo = parse_feast_models(data)
+        for e in repo.entities:
+            keys.extend(e.join_keys)
+        # A feature value is never identity evidence (don't merge two customers
+        # because they share a churn score), so features are measures.
+        for fv in repo.feature_views:
+            measures.extend(fv.features)
     else:  # osi
         from goldenmatch.semantic.osi import parse_osi_models
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/certify.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/certify.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
 from goldenmatch.semantic.cube import certify_cube_joins
+from goldenmatch.semantic.feast import certify_feast_feature_views
 from goldenmatch.semantic.key_integrity import certify_key_integrity
 from goldenmatch.semantic.metricflow import _load, parse_semantic_models
 from goldenmatch.semantic.osi import certify_osi_relationships
@@ -39,7 +40,7 @@ class SemanticCertification:
     """The result of certifying a whole semantic model: the detected dialect and
     one `KeyCertification` per declared key that had a supplied frame."""
 
-    dialect: str                         # "metricflow" | "cube" | "osi"
+    dialect: str                         # "metricflow" | "cube" | "osi" | "feast"
     entries: list[KeyCertification] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)  # targets with no frame
     note: str = ""
@@ -63,7 +64,8 @@ def detect_dialect(data: dict[str, Any]) -> str:
     """Detect the semantic-layer dialect from a loaded document's top-level shape.
 
     Cube uses a `cubes:` list, MetricFlow a `semantic_models:` list, OSI/Ossie a
-    `semantic_model` list (singular) + `version`. Raises if none match.
+    `semantic_model` list (singular) + `version`, Feast a `feature_views:` list.
+    Raises if none match.
     """
     if "cubes" in data:
         return "cube"
@@ -71,10 +73,12 @@ def detect_dialect(data: dict[str, Any]) -> str:
         return "metricflow"
     if "semantic_model" in data:
         return "osi"
+    if "feature_views" in data:
+        return "feast"
     raise ValueError(
         "certify_semantic_model: could not detect a semantic-layer dialect; "
         "expected a top-level 'cubes' (Cube), 'semantic_models' (dbt/MetricFlow), "
-        "or 'semantic_model' (OSI/Ossie) key"
+        "'semantic_model' (OSI/Ossie), or 'feature_views' (Feast) key"
     )
 
 
@@ -141,6 +145,14 @@ def certify_semantic_model(
             entries.append(KeyCertification(
                 target=rep["to_cube"], key=list(rep["key"]), certificate=rep["certificate"],
                 context=f"join from {rep['from_cube']}",
+            ))
+    elif dialect == "feast":
+        # certify_feast_feature_views certifies the entity join key each feature
+        # view rides on, with the view's features as the fan-out measures.
+        for rep in certify_feast_feature_views(data, frames, resolve=resolve, roles=roles):
+            entries.append(KeyCertification(
+                target=rep["feature_view"], key=list(rep["key"]), certificate=rep["certificate"],
+                context=f"entity {rep['entity']}",
             ))
     else:  # osi
         for rep in certify_osi_relationships(data, frames, resolve=resolve, roles=roles):

--- a/packages/python/goldenmatch/goldenmatch/semantic/feast.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/feast.py
@@ -1,0 +1,354 @@
+"""Feast (feature-store) reader + emitter — the feature-store dialect.
+
+A feature store is a join graph too, one layer over into ML: a **`FeatureView`**
+is keyed on an **`Entity`**, and the entity's **`join_keys`** are the identity the
+features silently assume. The three break modes the metrics-layer wedge catches
+reappear here, and bite ML directly:
+
+- **duplicated join key -> fan-out**: an aggregated feature (`sum` / `count` over a
+  not-truly-unique entity key) double-counts; a point-in-time join multiplies rows;
+- **fragmented entity -> undercount / training-serving skew**: one real entity split
+  across keys splits its own feature history, so the model trains on half a customer;
+- **non-conformed keys across sources**: the feature view can't join to the entity
+  at all.
+
+Feast's `Entity(join_keys=[...])` maps one-to-one onto MetricFlow `entity (primary)`
+and Cube `primary_key` — so exactly the same certifier applies:
+
+- **consume** a Feast repo to learn the declared entities + the keys each feature
+  view rides on (`parse_feast_models` / `parse_feast_objects`, `feast_join_keys`) —
+  "what to resolve";
+- **certify** (bridge to wedge A) each feature view's entity join key against the
+  source data, with the view's **features as the measures** whose fan-out is
+  quantified (`certify_feast_feature_views`);
+- **emit** (bridge to wedge B) a Feast `Entity` + `FeatureView` declaring the
+  GoldenMatch-resolved key as the entity `join_keys`, provenance in `tags`
+  (`emit_feast_from_crosswalk`). `parse_feast_models(emit_feast_yaml(...))`
+  round-trips.
+
+Reads/writes the DECLARATION only (a declarative `{entities, feature_views}` doc or
+duck-typed Feast SDK objects — no `feast` import in goldenmatch); it never touches a
+warehouse. Library-only, advisory, parity-free (it plugs into the existing
+`certify_semantic_model` dialect dispatch, adding no new surface).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.semantic.metricflow import _load
+
+# --- model -------------------------------------------------------------------
+
+
+@dataclass
+class FeastEntity:
+    """A Feast entity — the identity abstraction. `join_keys` is THE key the
+    feature views join on (Feast's modern spelling; a legacy singular `join_key`
+    is normalized to a one-element list on parse)."""
+
+    name: str
+    join_keys: list[str] = field(default_factory=list)
+    value_type: str = "STRING"
+    description: str = ""
+
+
+@dataclass
+class FeastFeatureView:
+    """A Feast feature view — keyed on one or more entities (by NAME). `features`
+    are the field names the view serves; they are the measures whose fan-out a
+    duplicated entity key inflates. `source` names the offline table backing it."""
+
+    name: str
+    entities: list[str] = field(default_factory=list)
+    features: list[str] = field(default_factory=list)
+    source: str | None = None
+    ttl: str | None = None
+    tags: dict[str, Any] | None = None
+
+
+@dataclass
+class FeastRepo:
+    entities: list[FeastEntity] = field(default_factory=list)
+    feature_views: list[FeastFeatureView] = field(default_factory=list)
+
+    def entity_by_name(self, name: str) -> FeastEntity | None:
+        for e in self.entities:
+            if e.name == name:
+                return e
+        return None
+
+
+# --- parse (consume) ---------------------------------------------------------
+
+
+def _as_name_list(value: Any) -> list[str]:
+    """A list of names from either `["a", "b"]` or `[{"name": "a"}, ...]` (Feast
+    `schema=[Field(name=...)]` / `features=[Feature(name=...)]` both project to
+    names here)."""
+    out: list[str] = []
+    for item in value or []:
+        if isinstance(item, str):
+            if item.strip():
+                out.append(item.strip())
+        elif isinstance(item, dict):
+            n = str(item.get("name", "")).strip()
+            if n:
+                out.append(n)
+        else:  # duck-typed SDK object with a `.name`
+            n = str(getattr(item, "name", "") or "").strip()
+            if n:
+                out.append(n)
+    return out
+
+
+def _entity_join_keys(e: dict[str, Any]) -> list[str]:
+    """Read `join_keys` (modern, list) falling back to a singular `join_key`."""
+    jk = e.get("join_keys")
+    if isinstance(jk, list) and jk:
+        return [str(k).strip() for k in jk if str(k).strip()]
+    single = e.get("join_key")
+    if isinstance(single, str) and single.strip():
+        return [single.strip()]
+    # A Feast entity with neither declared defaults its join key to its own name.
+    name = str(e.get("name", "")).strip()
+    return [name] if name else []
+
+
+def _parse_entity(e: dict[str, Any]) -> FeastEntity:
+    return FeastEntity(
+        name=str(e.get("name", "")).strip(),
+        join_keys=_entity_join_keys(e),
+        value_type=str(e.get("value_type", "STRING")),
+        description=str(e.get("description", "")),
+    )
+
+
+def _parse_feature_view(fv: dict[str, Any]) -> FeastFeatureView:
+    # Feature names live under `features` or `schema` (Feast renamed the kwarg);
+    # accept either. Entity refs are names (or objects with `.name`).
+    features = _as_name_list(fv.get("features")) or _as_name_list(fv.get("schema"))
+    return FeastFeatureView(
+        name=str(fv.get("name", "")).strip(),
+        entities=_as_name_list(fv.get("entities")),
+        features=features,
+        source=(str(fv["source"]).strip() if fv.get("source") is not None else None),
+        ttl=(str(fv["ttl"]) if fv.get("ttl") is not None else None),
+        tags=fv.get("tags"),
+    )
+
+
+def parse_feast_models(source: str | Any) -> FeastRepo:
+    """Parse a declarative Feast repo (path, YAML/JSON string, or dict) into a
+    `FeastRepo`.
+
+    Expects a top-level `entities:` list and a `feature_views:` list — a faithful
+    projection of the Feast object model (`Entity` / `FeatureView`). An entity that
+    declares no `join_keys` defaults its key to its own name (Feast's own default).
+    """
+    data = _load(source)
+    entities = [_parse_entity(e) for e in (data.get("entities") or []) if isinstance(e, dict)]
+    feature_views = [
+        _parse_feature_view(fv) for fv in (data.get("feature_views") or []) if isinstance(fv, dict)
+    ]
+    return FeastRepo(entities=entities, feature_views=feature_views)
+
+
+def parse_feast_objects(entities: Any, feature_views: Any) -> FeastRepo:
+    """Build a `FeastRepo` from live Feast SDK objects — e.g.
+    `parse_feast_objects(store.list_entities(), store.list_feature_views())`.
+
+    Duck-typed: reads `.name` / `.join_keys` (or legacy `.join_key`) off each entity
+    and `.name` / `.entities` / `.features`-or-`.schema` / `.batch_source|.source`
+    off each feature view. No `feast` import — so goldenmatch never depends on it.
+    """
+    ents: list[FeastEntity] = []
+    for e in entities or []:
+        jk = getattr(e, "join_keys", None)
+        if not jk:
+            single = getattr(e, "join_key", None)
+            jk = [single] if single else []
+        name = str(getattr(e, "name", "") or "").strip()
+        ents.append(FeastEntity(
+            name=name,
+            join_keys=[str(k).strip() for k in (jk or []) if str(k).strip()] or ([name] if name else []),
+            value_type=str(getattr(e, "value_type", "STRING")),
+            description=str(getattr(e, "description", "") or ""),
+        ))
+    fvs: list[FeastFeatureView] = []
+    for fv in feature_views or []:
+        ent_refs = getattr(fv, "entities", None) or []
+        # Feast feature views reference entities by name (str) or by Entity object.
+        ent_names = [r if isinstance(r, str) else str(getattr(r, "name", "") or "") for r in ent_refs]
+        feats = _as_name_list(getattr(fv, "features", None)) or _as_name_list(getattr(fv, "schema", None))
+        src = getattr(fv, "batch_source", None) or getattr(fv, "source", None)
+        src_name = str(getattr(src, "name", "") or "").strip() or (str(src).strip() if src else None)
+        fvs.append(FeastFeatureView(
+            name=str(getattr(fv, "name", "") or "").strip(),
+            entities=[n.strip() for n in ent_names if n.strip()],
+            features=feats,
+            source=src_name,
+            tags=getattr(fv, "tags", None),
+        ))
+    return FeastRepo(entities=ents, feature_views=fvs)
+
+
+def feast_join_keys(repo: FeastRepo | str | Any) -> list[dict[str, Any]]:
+    """The keys each feature view rides on — the identity its features assume. One
+    entry per (feature_view, entity): `{feature_view, entity, key, features,
+    source}`, where `key` is the entity's resolved `join_keys`. This is what
+    GoldenMatch should resolve / certify (metric-aware)."""
+    repo = repo if isinstance(repo, FeastRepo) else parse_feast_models(repo)
+    out: list[dict[str, Any]] = []
+    for fv in repo.feature_views:
+        for ent_name in fv.entities:
+            ent = repo.entity_by_name(ent_name)
+            key = ent.join_keys if ent is not None else [ent_name]
+            out.append({
+                "feature_view": fv.name,
+                "entity": ent_name,
+                "key": list(key),
+                "features": list(fv.features),
+                "source": fv.source,
+            })
+    return out
+
+
+# --- emit (produce) ----------------------------------------------------------
+
+
+def emit_feast_entity(e: FeastEntity) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": e.name, "join_keys": list(e.join_keys)}
+    if e.value_type:
+        out["value_type"] = e.value_type
+    if e.description:
+        out["description"] = e.description
+    return out
+
+
+def emit_feast_feature_view(fv: FeastFeatureView) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": fv.name, "entities": list(fv.entities)}
+    if fv.features:
+        out["features"] = list(fv.features)
+    if fv.source is not None:
+        out["source"] = fv.source
+    if fv.ttl is not None:
+        out["ttl"] = fv.ttl
+    if fv.tags:
+        out["tags"] = fv.tags
+    return out
+
+
+def emit_feast(repo: FeastRepo) -> dict[str, Any]:
+    return {
+        "entities": [emit_feast_entity(e) for e in repo.entities],
+        "feature_views": [emit_feast_feature_view(fv) for fv in repo.feature_views],
+    }
+
+
+def emit_feast_yaml(repo: FeastRepo) -> str:
+    """Render a `FeastRepo` as a declarative Feast doc (`entities:` +
+    `feature_views:`). Round-trips through `parse_feast_models`."""
+    import yaml
+
+    return yaml.safe_dump(emit_feast(repo), sort_keys=False, default_flow_style=False)
+
+
+def emit_feast_from_crosswalk(
+    crosswalk: Any,
+    *,
+    feature_view: str,
+    source_join_column: str | None = None,
+    entity_name: str = "resolved_entity",
+    resolved_field: str | None = None,
+    features: list[str] | None = None,
+    certificate: Any = None,
+) -> str:
+    """Emit a declarative Feast doc for a `ResolvedCrosswalk` (wedge B): an `Entity`
+    whose `join_keys` is the GoldenMatch-resolved key, plus a `FeatureView` keyed on
+    it — so every feature is served against resolved identity, not a raw source PK.
+    GoldenMatch provenance (+ an optional key-integrity certificate) rides in the
+    feature view's `tags.goldenmatch`.
+    """
+    resolved_field = resolved_field or getattr(crosswalk, "resolved_key", "resolved_entity_id")
+    join_col = source_join_column or resolved_field
+
+    ent = FeastEntity(name=entity_name, join_keys=[join_col], value_type="STRING")
+
+    gm: dict[str, Any] = {
+        "generated_by": "goldenmatch.semantic",
+        "resolved_key": resolved_field,
+        "n_records": getattr(crosswalk, "n_records", None),
+        "n_entities": getattr(crosswalk, "n_entities", None),
+        "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
+    }
+    if certificate is not None:
+        from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+        gm["key_integrity"] = certificate_verdict(certificate)
+
+    fv = FeastFeatureView(
+        name=feature_view,
+        entities=[entity_name],
+        features=list(features or []),
+        source=getattr(crosswalk, "source", None) or feature_view,
+        tags={"goldenmatch": gm},
+    )
+    return emit_feast_yaml(FeastRepo(entities=[ent], feature_views=[fv]))
+
+
+# --- bridge: certify the keys a Feast repo's feature views join on (wedge A) ---
+
+
+def certify_feast_feature_views(
+    repo: FeastRepo | str | Any,
+    frames: dict[str, Any],
+    *,
+    resolve: bool = False,
+    roles: Any = None,
+) -> list[dict[str, Any]]:
+    """For each feature view, certify the entity `join_keys` it rides on via wedge A
+    — certifying exactly the identity the features depend on, with the view's
+    **features as the measures** whose fan-out is quantified (a duplicated join key
+    inflates every aggregated feature).
+
+    `frames` maps a feature-view name (or its `source` name) to the table backing it
+    (pyarrow / polars / pandas / dict). A view whose frame is absent, or whose entity
+    declares no join key, is skipped. `resolve=True` also measures entity
+    fragmentation / undercount via ER (fail-open); pass `roles` (a
+    `SemanticFieldRoles`) to make that ER metric-aware — it resolves on descriptive
+    columns and never on a feature value (a churn score is not identity evidence).
+
+    Returns `[{feature_view, entity, key, certificate}]`.
+    """
+    from goldenmatch.semantic.blocking import _frame_columns, metric_aware_attributes
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    repo = repo if isinstance(repo, FeastRepo) else parse_feast_models(repo)
+    out: list[dict[str, Any]] = []
+    for jk in feast_join_keys(repo):
+        key = jk["key"]
+        if not key:
+            continue
+        df = frames.get(jk["feature_view"])
+        if df is None and jk["source"] is not None:
+            df = frames.get(jk["source"])
+        if df is None:
+            continue
+        cols = _frame_columns(df)
+        # features present in the frame are the fan-out measures.
+        measures = [f for f in jk["features"] if f in cols]
+        attributes = (
+            metric_aware_attributes(roles, cols)
+            if (resolve and roles is not None) else None
+        )
+        cert = certify_key_integrity(
+            df, key=key, measures=measures, resolve=resolve, attributes=attributes
+        )
+        out.append({
+            "feature_view": jk["feature_view"],
+            "entity": jk["entity"],
+            "key": list(key),
+            "certificate": cert,
+        })
+    return out

--- a/packages/python/goldenmatch/scripts/emit_semantic_certify_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_semantic_certify_fixtures.py
@@ -68,6 +68,10 @@ def _bootstrap() -> object:
     _load("goldenmatch.semantic.metricflow", "semantic/metricflow.py")
     _load("goldenmatch.semantic.cube", "semantic/cube.py")
     _load("goldenmatch.semantic.osi", "semantic/osi.py")
+    # certify_semantic_model imports the feast dialect unconditionally (feast is
+    # Python-only / has no TS port, so it adds no fixture case — but the module
+    # must resolve for certify.py to import in this isolated bootstrap).
+    _load("goldenmatch.semantic.feast", "semantic/feast.py")
     return _load("goldenmatch.semantic.certify", "semantic/certify.py").certify_semantic_model
 
 

--- a/packages/python/goldenmatch/scripts/emit_semantic_roles_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_semantic_roles_fixtures.py
@@ -62,6 +62,9 @@ except ImportError:  # toolkit not installed -> isolated loader (dependency orde
     _load("goldenmatch.semantic.cube", "semantic/cube.py")
     _load("goldenmatch.semantic.osi", "semantic/osi.py")
     _load("goldenmatch.semantic.key_integrity", "semantic/key_integrity.py")
+    # feast is imported unconditionally by certify.py and (lazily) by blocking's
+    # semantic_field_roles; load it so both resolve in this isolated bootstrap.
+    _load("goldenmatch.semantic.feast", "semantic/feast.py")
     _load("goldenmatch.semantic.certify", "semantic/certify.py")
     _blocking = _load("goldenmatch.semantic.blocking", "semantic/blocking.py")
     metric_aware_attributes = _blocking.metric_aware_attributes

--- a/packages/python/goldenmatch/tests/test_feast.py
+++ b/packages/python/goldenmatch/tests/test_feast.py
@@ -1,0 +1,192 @@
+"""Feast (feature-store) dialect: parse + certify + emit, and the front-door wiring.
+
+The feature-store wedge: a `FeatureView` is keyed on an `Entity`'s `join_keys`, and
+a duplicated join key fans out every aggregated feature. These lock the parse of the
+declarative repo, the bridge to wedge A (`certify_feast_feature_views`), the
+crosswalk emit (wedge B), and that `certify_semantic_model` auto-detects "feast".
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from goldenmatch.semantic.certify import certify_semantic_model, detect_dialect
+from goldenmatch.semantic.feast import (
+    FeastEntity,
+    FeastFeatureView,
+    FeastRepo,
+    certify_feast_feature_views,
+    emit_feast_from_crosswalk,
+    emit_feast_yaml,
+    feast_join_keys,
+    parse_feast_models,
+    parse_feast_objects,
+)
+
+# A small declarative Feast repo: a customer entity keyed on customer_id, and a
+# feature view serving two features against it.
+_REPO_DOC = {
+    "entities": [
+        {"name": "customer", "join_keys": ["customer_id"], "value_type": "STRING"},
+    ],
+    "feature_views": [
+        {
+            "name": "customer_stats",
+            "entities": ["customer"],
+            "features": ["lifetime_value", "n_orders"],
+            "source": "customer_stats_source",
+        },
+    ],
+}
+
+
+def test_parse_reads_entities_and_feature_views():
+    repo = parse_feast_models(_REPO_DOC)
+    assert [e.name for e in repo.entities] == ["customer"]
+    assert repo.entity_by_name("customer").join_keys == ["customer_id"]
+    fv = repo.feature_views[0]
+    assert fv.name == "customer_stats"
+    assert fv.entities == ["customer"]
+    assert fv.features == ["lifetime_value", "n_orders"]
+    assert fv.source == "customer_stats_source"
+
+
+def test_entity_without_join_keys_defaults_to_its_name():
+    repo = parse_feast_models({"entities": [{"name": "driver"}], "feature_views": []})
+    assert repo.entity_by_name("driver").join_keys == ["driver"]
+
+
+def test_legacy_singular_join_key_is_normalized():
+    repo = parse_feast_models(
+        {"entities": [{"name": "customer", "join_key": "customer_id"}], "feature_views": []}
+    )
+    assert repo.entity_by_name("customer").join_keys == ["customer_id"]
+
+
+def test_features_read_from_schema_kwarg():
+    # Feast renamed `features=` -> `schema=[Field(...)]`; accept either.
+    repo = parse_feast_models({
+        "entities": [{"name": "c", "join_keys": ["id"]}],
+        "feature_views": [{"name": "v", "entities": ["c"], "schema": [{"name": "amt"}, {"name": "qty"}]}],
+    })
+    assert repo.feature_views[0].features == ["amt", "qty"]
+
+
+def test_feast_join_keys_resolves_entity_to_join_keys():
+    jk = feast_join_keys(parse_feast_models(_REPO_DOC))
+    assert jk == [{
+        "feature_view": "customer_stats",
+        "entity": "customer",
+        "key": ["customer_id"],
+        "features": ["lifetime_value", "n_orders"],
+        "source": "customer_stats_source",
+    }]
+
+
+def test_parse_feast_objects_duck_types_sdk_objects():
+    # Emulate feast SDK objects (store.list_entities() / list_feature_views()).
+    ent = SimpleNamespace(name="customer", join_keys=["customer_id"], value_type="STRING", description="")
+    src = SimpleNamespace(name="customer_stats_source")
+    fv = SimpleNamespace(
+        name="customer_stats", entities=["customer"],
+        features=[SimpleNamespace(name="lifetime_value"), SimpleNamespace(name="n_orders")],
+        batch_source=src, tags=None,
+    )
+    repo = parse_feast_objects([ent], [fv])
+    assert repo.entity_by_name("customer").join_keys == ["customer_id"]
+    assert repo.feature_views[0].features == ["lifetime_value", "n_orders"]
+    assert repo.feature_views[0].source == "customer_stats_source"
+
+
+def test_certify_clean_join_key_is_trustworthy():
+    frames = {"customer_stats": {
+        "customer_id": ["a", "b", "c"],
+        "lifetime_value": [10, 20, 30],
+        "n_orders": [1, 2, 3],
+    }}
+    reps = certify_feast_feature_views(parse_feast_models(_REPO_DOC), frames)
+    assert len(reps) == 1
+    cert = reps[0]["certificate"]
+    assert reps[0]["key"] == ["customer_id"]
+    assert cert.is_unique_at_grain
+    assert cert.is_trustworthy()
+    assert cert.max_fan_out == 1.0
+
+
+def test_certify_duplicated_join_key_fans_out_features():
+    # customer 'a' appears twice -> a sum(lifetime_value) double-counts it.
+    frames = {"customer_stats": {
+        "customer_id": ["a", "a", "b"],
+        "lifetime_value": [10, 10, 5],
+        "n_orders": [1, 1, 2],
+    }}
+    reps = certify_feast_feature_views(parse_feast_models(_REPO_DOC), frames)
+    cert = reps[0]["certificate"]
+    assert not cert.is_unique_at_grain
+    assert cert.duplicate_key_groups == 1
+    assert cert.max_fan_out == 2.0
+    # sum over raw rows (10+10+5=25) vs one-per-entity (10+5=15) -> 25/15.
+    assert cert.measure_fan_out["lifetime_value"] == 25 / 15
+
+
+def test_certify_semantic_model_auto_detects_feast():
+    assert detect_dialect(_REPO_DOC) == "feast"
+    frames = {"customer_stats": {
+        "customer_id": ["a", "a", "b"],
+        "lifetime_value": [10, 10, 5],
+        "n_orders": [1, 1, 2],
+    }}
+    report = certify_semantic_model(_REPO_DOC, frames)
+    assert report.dialect == "feast"
+    assert report.n_certified == 1
+    e = report.entries[0]
+    assert e.target == "customer_stats"
+    assert e.context == "entity customer"
+    assert not report.all_trustworthy  # the duplicated key is caught
+
+
+def test_feature_view_without_a_frame_is_skipped():
+    reps = certify_feast_feature_views(parse_feast_models(_REPO_DOC), {})
+    assert reps == []
+
+
+def test_emit_from_crosswalk_round_trips():
+    crosswalk = SimpleNamespace(
+        resolved_key="resolved_entity_id", n_records=100, n_entities=60,
+        reduction_ratio=0.4, source="customer_stats",
+    )
+    yaml_text = emit_feast_from_crosswalk(
+        crosswalk, feature_view="customer_stats_resolved",
+        features=["lifetime_value"], certificate=None,
+    )
+    repo = parse_feast_models(yaml_text)
+    # the emitted entity declares the resolved key as its join key
+    ent = repo.entities[0]
+    assert ent.join_keys == ["resolved_entity_id"]
+    fv = repo.feature_views[0]
+    assert fv.name == "customer_stats_resolved"
+    assert fv.entities == [ent.name]
+    assert fv.features == ["lifetime_value"]
+    assert fv.tags["goldenmatch"]["resolved_key"] == "resolved_entity_id"
+
+
+def test_emit_feast_yaml_round_trips():
+    repo = FeastRepo(
+        entities=[FeastEntity(name="customer", join_keys=["customer_id"])],
+        feature_views=[FeastFeatureView(
+            name="v", entities=["customer"], features=["amt"], source="v_src"
+        )],
+    )
+    back = parse_feast_models(emit_feast_yaml(repo))
+    assert back.entities[0].join_keys == ["customer_id"]
+    assert back.feature_views[0].features == ["amt"]
+    assert back.feature_views[0].source == "v_src"
+
+
+def test_semantic_field_roles_treats_features_as_measures():
+    from goldenmatch.semantic.blocking import semantic_field_roles
+
+    roles = semantic_field_roles(_REPO_DOC)
+    assert "customer_id" in roles.keys
+    # a feature value is never identity evidence
+    assert "lifetime_value" in roles.measures
+    assert "n_orders" in roles.measures


### PR DESCRIPTION
## What and why

A feature store is the semantic-layer wedge **one layer over into ML**. A Feast `FeatureView` is keyed on an `Entity`, and the entity's `join_keys` are the identity its features silently assume. The three break modes bite ML directly:

- **duplicated join key -> fan-out** — an aggregated feature (`sum`/`count`) double-counts; a point-in-time join multiplies rows
- **fragmented entity -> undercount / training-serving skew** — one real entity split across keys trains the model on half a customer
- **non-conformed keys** — the feature view can't join to the entity

Feast's `Entity(join_keys=[...])` maps one-to-one onto MetricFlow `entity (primary)` / Cube `primary_key`, so the **same certifier applies**. Decision: **ADR 0060**. This was the top "missing provider surface" from the [semantic-layer roadmap](../blob/main/context-network/planning/semantic-layer-interchange.md) analysis.

## Changes

New `goldenmatch/semantic/feast.py`, structured exactly like the Cube dialect (consume / certify / emit):

- **Consume** — `parse_feast_models` (declarative `{entities, feature_views}` doc: path / YAML / dict) + `parse_feast_objects` (duck-types live Feast SDK objects like `store.list_entities()` — **no `feast` dependency in goldenmatch**). `feast_join_keys` resolves each view to its entity `join_keys`.
- **Certify (bridge A)** — `certify_feast_feature_views` certifies each view's entity join key via `certify_key_integrity`, with the view's **features as the fan-out measures** (so the certificate quantifies exactly how much aggregating a feature over a not-truly-unique key inflates it). `resolve=True` adds the ER fragmentation/undercount tier, made metric-aware so a feature value is never identity evidence.
- **Emit (bridge B)** — `emit_feast_from_crosswalk` declares the resolved key as the entity `join_keys`, provenance in `tags.goldenmatch`; `emit_feast_yaml` round-trips through `parse_feast_models`.
- **Front-door wiring, no new surface** — `certify_semantic_model` auto-detects a top-level `feature_views:` as the `"feast"` dialect; `semantic_field_roles` learns the Feast role split. CLI (`certify-keys`) / MCP (`certify_semantic_model`) / REST certify a feature repo with **no new MCP tool / CLI command / A2A skill** — same posture as Cube. **Parity-free** (verified: `feast` leaks into zero gated Python surfaces).
- ADR 0060 + planning-doc status; `CHANGELOG.md` entry; `agent-codemap.json` regenerated by `make docs`.

## Testing

- `uv run pytest packages/python/goldenmatch/tests/test_feast.py -q` -> **13 passed**
- Regression: `test_cube` + `test_certify_semantic_model` + `test_osi` + `test_metricflow_parse` + `test_auto_semantic_blocking` -> **75 passed** together
- `ruff check` (import-sort included) clean
- `scripts/regen_docs.py --check` -> `Docs are current` (exit 0), the `docs_regen` gate
- Confirmed `feast` appears in **zero** gated Python surfaces (mcp_tools / cli_commands / a2a_skills / scorers / …), so `parity/goldenmatch.yaml` is unchanged
- End-to-end smoke: a duplicated join key is caught (`max_fan_out=2.0`, `all_trustworthy=False`) via the auto-detected front door

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` clean; imports sorted
- [x] Package `CHANGELOG.md` updated (new dialect)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / ADR updated (0060 + planning + regenerated codemap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_