### PR TITLE
feat(fs): one EM session per blocking pass, combined

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 472,
+      "module_count": 473,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7949,6 +7949,19 @@
           ],
           "imports": [
             "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.spark.em",
+          "file": "packages/python/goldenmatch/goldenmatch/spark/em.py",
+          "purpose": "Count agreement patterns on the cluster, so FS training need not sample.",
+          "defines": [
+            "agreement_pattern_counts",
+            "gamma_columns"
+          ],
+          "imports": [
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.spark.probabilistic"
           ]
         },
         {

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4233,6 +4233,7 @@
             "set_fs_label_anchors",
             "train_em",
             "train_em_continuous",
+            "train_em_per_pass",
             "vectorized_scorer_supported"
           ],
           "imports": [

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1205,6 +1205,132 @@ def _training_pair_conditioning(
     return fallback_pairs, [frozenset(blocking_fields)] * len(fallback_pairs)
 
 
+def train_em_per_pass(
+    df: pl.DataFrame,
+    mk: MatchkeyConfig,
+    blocks: list,
+    *,
+    blocking_fields: list[str] | None = None,
+    **kw: object,
+) -> EMResult:
+    """One EM session per BLOCKING PASS, combined -- Splink's decomposition.
+
+    ``train_em`` pools every pass into a single run and masks per (pair, field):
+    a pair emitted by a pass that blocks on ``zip`` carries no ``zip``
+    likelihood, but ``zip`` is still learnable from pairs emitted by other
+    passes. That is correct and it is one pass over the data.
+
+    Splink decomposes the same problem differently: it runs a separate EM
+    session per ``blocking_rule_for_training``, records which comparisons
+    ``cannot_be_estimated`` under that rule (the ones the rule blocks on), and
+    combines the sessions. Two properties follow, and they are the reason to
+    have this alongside the pooled run:
+
+    1. **Each session is independent**, so they can be trained anywhere --
+       including one per executor, or one per SQL engine round trip. The pooled
+       run couples every pass into one convergence loop.
+    2. **The aggregation key loses the pass.** Within a session the conditioning
+       is constant, so counting comparison vectors needs no pass column: it is
+       ``GROUP BY <gammas>``, exactly the shape ``count_agreement_patterns_sql``
+       produces. That is what makes the counts computable by a cluster and the
+       iteration cheap, -- see ``pair_weights`` on :func:`train_em`.
+
+    Combination: a field's ``m`` is the pair-count-weighted mean of the sessions
+    that could estimate it (those whose pass does NOT block on it). A field no
+    session can estimate keeps whatever the sessions gave it, which is the fixed
+    prior -- the same treatment the pooled run's ``always_conditioned`` applies,
+    rather than a different answer for the same situation.
+
+    Weighted by pair count, not a plain mean: a pass contributing 10 pairs and
+    one contributing 10,000 are not equal evidence, and an unweighted mean would
+    let a tiny pass swing a field it barely observed.
+
+    Args:
+        blocks: ``BlockResult``s carrying ``blocking_fields`` provenance. Blocks
+            are grouped by that tuple; each distinct value is one pass.
+        blocking_fields: legacy union, forwarded to :func:`train_em` for block
+            producers that carry no provenance.
+        **kw: forwarded verbatim to :func:`train_em`.
+    """
+    by_pass: dict[tuple[str, ...], list] = {}
+    for b in blocks or []:
+        by_pass.setdefault(tuple(getattr(b, "blocking_fields", ()) or ()), []).append(b)
+
+    # One pass (or none, or no provenance at all) -- there is nothing to
+    # decompose, and delegating keeps a single-pass config bit-identical to the
+    # pooled run rather than routing it through a combination step that would
+    # have to be proven a no-op.
+    if len(by_pass) <= 1:
+        return train_em(df, mk, blocks=blocks, blocking_fields=blocking_fields, **kw)
+
+    sessions: list[tuple[tuple[str, ...], EMResult, float]] = []
+    for fields, pass_blocks in sorted(by_pass.items()):
+        # `n_rows()` rather than a pair count: the sampler decides how many
+        # pairs it draws, and weighting by block size is the honest proxy for
+        # "how much evidence this pass brought" without training twice to
+        # find out.
+        weight = float(sum(max(int(b.n_rows()), 0) for b in pass_blocks))
+        if weight <= 0:
+            continue
+        em = train_em(
+            df, mk, blocks=pass_blocks, blocking_fields=list(fields), **kw
+        )
+        sessions.append((fields, em, weight))
+        logger.info(
+            "EM session: pass=%s blocks=%d rows=%.0f converged=%s",
+            fields or "(none)", len(pass_blocks), weight, em.converged,
+        )
+
+    if not sessions:
+        return train_em(df, mk, blocks=blocks, blocking_fields=blocking_fields, **kw)
+
+    base = sessions[0][1]
+    m_probs: dict[str, list[float]] = {}
+    for f in mk.fields:
+        name = f.field
+        estimable = [
+            (em, w) for fields, em, w in sessions
+            if name not in fields and name in em.m_probs
+        ]
+        if not estimable:
+            # No pass leaves this field free. Every session fell back to the
+            # fixed prior for it, so they agree and the first is as good as any
+            # -- and this is exactly the pooled run's `always_conditioned` case.
+            m_probs[name] = list(base.m_probs[name])
+            continue
+        total = sum(w for _, w in estimable)
+        n_levels = len(estimable[0][0].m_probs[name])
+        m_probs[name] = [
+            sum(em.m_probs[name][k] * w for em, w in estimable) / total
+            for k in range(n_levels)
+        ]
+
+    # u is estimated from RANDOM pairs, which do not depend on the pass, so the
+    # sessions agree by construction; taking the first states that rather than
+    # averaging identical numbers and implying they might differ.
+    u_probs = {k: list(v) for k, v in base.u_probs.items()}
+    total_w = sum(w for _, _, w in sessions)
+    proportion = sum(em.proportion_matched * w for _, em, w in sessions) / total_w
+
+    match_weights = {
+        name: [
+            math.log2(max(m, 1e-10) / max(u, 1e-10))
+            for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
+        ]
+        for name in m_probs
+    }
+    return EMResult(
+        m_probs=m_probs,
+        u_probs=u_probs,
+        match_weights=match_weights,
+        converged=all(em.converged for _, em, _ in sessions),
+        iterations=max(em.iterations for _, em, _ in sessions),
+        proportion_matched=proportion,
+        tf_freqs=base.tf_freqs,
+        tf_collision=base.tf_collision,
+    )
+
+
 def train_em(
     df: pl.DataFrame,
     mk: MatchkeyConfig,

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -1,0 +1,143 @@
+"""Count agreement patterns on the cluster, so FS training need not sample.
+
+## The chain this is one link of
+
+EM's E-step reads only the comparison vector (a level per field), so pairs with
+the same vector are interchangeable and every M-step quantity is a sum that is
+linear in how many pairs share it. That makes training decomposable into:
+
+    compute gammas distributed  ->  GROUP BY them  ->  train_em(pair_weights=counts)
+
+This module is the first two. The third is ``core.probabilistic.train_em``'s
+``pair_weights``, and the per-pass split it runs under is
+``train_em_per_pass``.
+
+Splink does exactly this -- ``count_agreement_patterns_sql`` is
+``select {gammas}, count(*) group by {gammas}`` -- and then runs the iteration
+itself as engine-side SQL. This does the counting in the engine and leaves the
+iteration on the driver, which is a real difference and is stated rather than
+glossed: what it buys is that the iteration's input stops being a sample and
+stops being proportional to the pair count.
+
+## Why the result is small
+
+The number of distinct vectors is at most ``prod(levels + 1)`` -- one extra for
+``-1`` unobserved -- and within a session the blocking conditioning is constant,
+so the pass needs no column of its own. A five-field model with four levels each
+is at most 3,125 rows no matter whether it compared a thousand pairs or ten
+billion. That bound is the whole reason this is safe to ``collect()``.
+
+## No Python on the executors
+
+``fs_level_expr`` and the weight lookup were always Spark SQL; the only part
+that needed a Python worker was the per-field similarity call, and
+``scorer_udf`` routes that to the jar's row-shaped kernel. So the counting runs
+jar-only, like the scoring path it borrows from.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Refuse rather than silently truncate. A model whose fields have many levels
+#: can in principle exceed this, and a `collect()` of an unexpectedly large
+#: frame is an OOM on the driver -- the failure mode this repo has paid for
+#: repeatedly. The bound is checked against the ACTUAL row count, not the
+#: theoretical one, so a sparse model is not penalised for what it could emit.
+MAX_PATTERNS = 200_000
+
+
+def gamma_columns(mk: Any, lhs: str, rhs: str, *,
+                  scorer_udf: str | None = None,
+                  transform_udf: str | None = None) -> list[Any]:
+    """One ``gamma_<field>`` column per comparison field: its FS level.
+
+    The SAME expressions the scoring path builds, from the same functions --
+    ``_field_similarity_and_observed`` then ``fs_level_expr``. Restating the
+    ladder here would be a second implementation of what a level MEANS, and a
+    training run that disagreed with scoring about levels would produce weights
+    for a partition of the data that scoring never reproduces.
+    """
+    from goldenmatch.core.probabilistic import fs_missing_mode
+    from goldenmatch.spark.probabilistic import (
+        _field_similarity_and_observed,
+        fs_level_expr,
+    )
+
+    missing_mode = fs_missing_mode(mk)
+    out = []
+    for f in mk.fields:
+        sim, observed = _field_similarity_and_observed(
+            f, lhs, rhs, scorer_udf=scorer_udf, transform_udf=transform_udf
+        )
+        out.append(
+            fs_level_expr(f, sim, observed, missing_mode=missing_mode)
+            .alias(f"gamma_{f.resolved_field}")
+        )
+    return out
+
+
+def agreement_pattern_counts(
+    joined: Any,
+    mk: Any,
+    *,
+    lhs: str,
+    rhs: str,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+    max_patterns: int = MAX_PATTERNS,
+) -> list[tuple[tuple[int, ...], int]]:
+    """``[(comparison_vector, count)]`` over every pair in ``joined``.
+
+    ``joined`` is a candidate frame already joined to both sides under the
+    aliases ``lhs``/``rhs`` -- the same shape ``score_candidates`` builds -- so
+    this counts whatever pairs the caller blocked, with no sampling anywhere.
+
+    The returned vectors are ordered by ``mk.fields``, which is the order
+    ``_build_comparison_matrix`` produces on the one-box, so a caller can hand
+    them straight to a comparison matrix without re-deriving the column order.
+    """
+    from pyspark.sql import functions as F
+
+    gammas = gamma_columns(
+        mk, lhs, rhs, scorer_udf=scorer_udf, transform_udf=transform_udf
+    )
+    names = [f"gamma_{f.resolved_field}" for f in mk.fields]
+    grouped = (
+        joined.select(*gammas)
+        .groupBy(*[F.col(n) for n in names])
+        .agg(F.count(F.lit(1)).alias("agreement_pattern_count"))
+    )
+
+    # Bound BEFORE collecting. `count()` on the grouped frame is one more
+    # distributed pass and costs a fraction of what materialising an
+    # unexpectedly large result on the driver would.
+    n = grouped.count()
+    if n > max_patterns:
+        raise ValueError(
+            f"{n} distinct agreement patterns exceeds max_patterns="
+            f"{max_patterns}. The bound is prod(levels + 1) over the "
+            f"matchkey's fields, so this means the model has more level "
+            f"combinations than expected -- collecting it would move the "
+            f"training bottleneck back onto the driver, which is what this "
+            f"path exists to avoid."
+        )
+
+    rows = grouped.collect()
+    out = [
+        (tuple(int(r[name]) for name in names), int(r["agreement_pattern_count"]))
+        for r in rows
+    ]
+    # Sorted, so a model trained from these counts does not depend on the order
+    # Spark happened to return partitions in. Determinism here is cheap and its
+    # absence would be invisible: two runs would differ only in floating-point
+    # accumulation order.
+    out.sort()
+    total = sum(c for _, c in out)
+    logger.info(
+        "FS EM: %d distinct agreement patterns over %d pairs (%.4g%% of pairs)",
+        len(out), total, 100.0 * len(out) / max(total, 1),
+    )
+    return out

--- a/packages/python/goldenmatch/tests/test_fs_em_per_pass.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_per_pass.py
@@ -1,0 +1,176 @@
+"""One EM session per blocking pass, combined -- Splink's decomposition.
+
+`train_em` pools every pass into one run and masks per (pair, field). That is
+correct, and it couples every pass into a single convergence loop with an
+aggregation key that has to carry the pass.
+
+Splink runs a separate session per `blocking_rule_for_training`, records which
+comparisons `cannot_be_estimated` under that rule, and combines. Two things
+follow: sessions are independent (trainable anywhere), and WITHIN a session the
+conditioning is constant -- so counting comparison vectors is `GROUP BY <gammas>`
+with no pass column, which is the shape `count_agreement_patterns_sql` produces
+and the reason the counts can be computed by a cluster.
+
+These tests need no Spark. If the decomposition is wrong here, no amount of
+distributed plumbing makes the trained model right.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.blocker import build_blocks
+from goldenmatch.core.probabilistic import train_em, train_em_per_pass
+
+from tests.test_probabilistic import _make_probabilistic_mk
+
+
+def _frame(n_blocks: int = 14) -> pl.DataFrame:
+    """Rows that block usefully on BOTH `zip` and `last_name`.
+
+    Two passes are the point: a pass keyed on `zip` cannot estimate `zip`, and a
+    pass keyed on `last_name` cannot estimate `last_name`, so each field is
+    estimable in exactly one of them. That is the situation the decomposition
+    exists for, and a fixture where both passes block on the same field would
+    prove nothing.
+    """
+    first, last, zips, ids = [], [], [], []
+    for b in range(n_blocks):
+        for firstname, lastname, z in (
+            (f"ann{b}", f"lee{b}", f"{b:02d}"),
+            (f"ann{b}", f"lee{b}", f"{b:02d}"),
+            (f"anna{b}", f"lee{b}", f"{b:02d}"),
+            (f"bob{b}", f"lee{b}", f"{(b + 50):02d}"),
+        ):
+            ids.append(len(ids) + 1)
+            first.append(firstname)
+            last.append(lastname)
+            zips.append(z)
+    return pl.DataFrame(
+        {"__row_id__": ids, "first_name": first, "last_name": last, "zip": zips}
+    )
+
+
+def _cfg(*passes: list[str]) -> BlockingConfig:
+    """`build_blocks` takes a BlockingConfig; `passes` are BlockingKeyConfigs."""
+    if len(passes) == 1:
+        return BlockingConfig(keys=[BlockingKeyConfig(fields=list(passes[0]))])
+    return BlockingConfig(
+        strategy="multi_pass",
+        passes=[BlockingKeyConfig(fields=list(fs)) for fs in passes],
+    )
+
+
+def _blocks(df, cfg):
+    return build_blocks(df, cfg)
+
+
+def _train(fn, df, blocks, **kw):
+    return fn(
+        df, _make_probabilistic_mk(), blocks,
+        n_sample_pairs=600, max_iterations=25, seed=11, **kw
+    ) if fn is train_em_per_pass else fn(
+        df, _make_probabilistic_mk(), blocks=blocks,
+        n_sample_pairs=600, max_iterations=25, seed=11, **kw
+    )
+
+
+def test_a_single_pass_is_bit_identical_to_the_pooled_run():
+    """The degenerate case must DELEGATE, not merely agree closely.
+
+    With one pass there is nothing to decompose, and routing it through a
+    combination step would need that step proven a no-op. Delegating makes it
+    one by construction -- and it means adopting this function cannot move a
+    single-pass model at all.
+    """
+    df = _frame()
+    cfg = _cfg(["zip"])
+    blocks = _blocks(df, cfg)
+
+    pooled = _train(train_em, df, blocks)
+    per_pass = _train(train_em_per_pass, df, blocks)
+
+    assert per_pass.m_probs == pooled.m_probs
+    assert per_pass.u_probs == pooled.u_probs
+    assert per_pass.proportion_matched == pooled.proportion_matched
+
+
+def test_two_passes_produce_two_sessions_and_a_combined_model():
+    """The real case: each field estimable in the pass that does not block it."""
+    df = _frame()
+    cfg = _cfg(["zip"], ["last_name"])
+    blocks = _blocks(df, cfg)
+    passes = {tuple(b.blocking_fields) for b in blocks}
+    assert len(passes) == 2, (
+        f"the fixture produced {passes}; the decomposition needs two distinct "
+        f"passes or this test is measuring the single-pass delegation"
+    )
+
+    em = _train(train_em_per_pass, df, blocks)
+
+    for f in _make_probabilistic_mk().fields:
+        probs = em.m_probs[f.field]
+        assert len(probs) == f.levels
+        assert all(p >= 0.0 for p in probs)
+        assert sum(probs) == pytest.approx(1.0, abs=1e-9), (
+            f"{f.field} m does not sum to 1 after combining sessions: {probs}"
+        )
+
+
+def test_a_field_blocked_by_ONE_pass_is_still_learned():
+    """`zip` is conditioned out of the zip pass and free in the last_name pass.
+
+    The pooled run gets this right by masking per pair; the decomposition has to
+    get it right by EXCLUDING the session that cannot estimate it. If the
+    combination naively averaged both sessions, the zip pass's fixed prior would
+    be dragged into the answer -- which is the specific way this design fails,
+    and it fails quietly because the result is still a valid probability vector.
+    """
+    df = _frame()
+    blocks = _blocks(df, _cfg(["zip"], ["last_name"]))
+    combined = _train(train_em_per_pass, df, blocks)
+
+    only_lastname_pass = [b for b in blocks if tuple(b.blocking_fields) == ("last_name",)]
+    assert only_lastname_pass, "fixture produced no last_name-keyed blocks"
+    solo = _train(train_em, df, only_lastname_pass, blocking_fields=["last_name"])
+
+    # `zip` is estimable in exactly one session, so the weighted mean over
+    # estimable sessions IS that session -- exactly, not approximately.
+    assert combined.m_probs["zip"] == pytest.approx(solo.m_probs["zip"], abs=1e-12), (
+        "combined `zip` is not the estimate from the only pass that could make "
+        "one, so a session that cannot estimate it is being averaged in"
+    )
+
+
+def test_the_combination_is_deterministic():
+    """Sessions are combined in sorted pass order, so two runs agree.
+
+    Iterating a dict of passes in insertion order would make the model depend on
+    block discovery order -- reproducible on one machine and not on another.
+    """
+    df = _frame()
+    blocks = _blocks(df, _cfg(["zip"], ["last_name"]))
+
+    a = _train(train_em_per_pass, df, blocks)
+    b = _train(train_em_per_pass, df, list(reversed(blocks)))
+
+    for field in a.m_probs:
+        assert a.m_probs[field] == pytest.approx(b.m_probs[field], abs=1e-12), field
+
+
+def test_blocks_without_provenance_fall_back_to_the_pooled_run():
+    """Custom/legacy `BlockResult` producers carry no `blocking_fields`.
+
+    They must keep working rather than being silently treated as one anonymous
+    pass whose conditioning is empty -- which would let every field be
+    'estimable' and quietly change models that used to be conditioned.
+    """
+    df = _frame()
+    blocks = _blocks(df, _cfg(["zip"]))
+    for b in blocks:
+        b.blocking_fields = ()
+
+    pooled = _train(train_em, df, blocks, blocking_fields=["zip"])
+    fell_back = _train(train_em_per_pass, df, blocks, blocking_fields=["zip"])
+
+    assert fell_back.m_probs == pooled.m_probs

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -351,3 +351,92 @@ def test_the_batched_shape_still_refuses_fs(source, jvm_registered):
             cands, source, cfg, id_col=_ID, scorer_udf=UDF_NAME,
             scorer_shape="batch",
         )
+
+
+# ── agreement-pattern counts, computed on the cluster ────────────────
+
+def _driver_pattern_counts(spark_df, cfg):
+    """The same counts, derived on the driver with the ONE-BOX's functions.
+
+    `comparison_vector` is what `_build_comparison_matrix` calls, so this is the
+    reference the trained model would have been built from -- not a
+    reimplementation of the level ladder, which would only prove the two
+    reimplementations agree.
+    """
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import comparison_vector
+    from goldenmatch.spark.config_pipeline import generate_candidates
+
+    mk = cfg.get_matchkeys()[0]
+    by_id = {r[0]: dict(zip(_COLS, r)) for r in _ROWS}
+    counts = Counter()
+    for r in generate_candidates(spark_df, cfg, id_col=_ID).collect():
+        vec = comparison_vector(by_id[int(r["a"])], by_id[int(r["b"])], mk)
+        counts[tuple(int(v) for v in vec)] += 1
+    return sorted(counts.items())
+
+
+def _spark_pattern_counts(spark_df, cfg, **kw):
+    from goldenmatch.spark.config_pipeline import generate_candidates
+    from goldenmatch.spark.em import agreement_pattern_counts
+    from pyspark.sql import functions as F
+
+    lhs, rhs = "__lhs__", "__rhs__"
+    joined = (
+        generate_candidates(spark_df, cfg, id_col=_ID).alias("__cand__")
+        .join(spark_df.alias(lhs), F.col(f"{lhs}.{_ID}") == F.col("__cand__.a"))
+        .join(spark_df.alias(rhs), F.col(f"{rhs}.{_ID}") == F.col("__cand__.b"))
+    )
+    return agreement_pattern_counts(
+        joined, cfg.get_matchkeys()[0], lhs=lhs, rhs=rhs, **kw
+    )
+
+
+@pytest.mark.parametrize("missing", ["unobserved", "disagree"])
+def test_pattern_counts_match_the_one_box_comparison_vectors(source, missing):
+    """THE gate for distributed training input.
+
+    If these counts are wrong, `train_em(pair_weights=counts)` trains on a
+    population that does not exist -- and it would converge happily and produce
+    a plausible model, because a wrong count is still a positive integer.
+    """
+    cfg = _config(missing)
+    assert _spark_pattern_counts(source, cfg) == _driver_pattern_counts(source, cfg)
+
+
+def test_the_counts_sum_to_the_candidate_pair_count(source):
+    """No pair may be dropped or double-counted by the GROUP BY.
+
+    Stated separately from the vector comparison above because the two fail
+    differently: a wrong LEVEL shows up there, a lost PAIR shows up here, and a
+    pair lost to a null-handling bug in the ladder could leave every surviving
+    pattern correct.
+    """
+    from goldenmatch.spark.config_pipeline import generate_candidates
+
+    cfg = _config()
+    want = generate_candidates(source, cfg, id_col=_ID).count()
+    got = sum(c for _, c in _spark_pattern_counts(source, cfg))
+    assert got == want
+
+
+def test_pattern_counts_are_identical_jar_only(source, jvm_registered):
+    """And with no Python on the executors, which is the point of computing
+    them out there at all: a training run that needed an executor virtualenv
+    would leave the jar-only claim only half true."""
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    cfg = _config()
+    assert _spark_pattern_counts(
+        source, cfg, scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME
+    ) == _driver_pattern_counts(source, cfg)
+
+
+def test_an_oversized_pattern_space_is_refused_not_collected(source):
+    """`collect()` of an unexpectedly large frame is a driver OOM, which is the
+    failure this whole path exists to avoid -- so the bound is checked against
+    the real row count before anything is materialised."""
+    cfg = _config()
+    with pytest.raises(ValueError, match="max_patterns"):
+        _spark_pattern_counts(source, cfg, max_patterns=1)


### PR DESCRIPTION
Splink's decomposition, added alongside the pooled run rather than replacing it.

**Stacked on #2548** (weighted comparison rows), which is in the merge queue --
the first commit here is that PR's. It drops out on rebase once #2548 lands.

## Why not just keep the pooled run

`train_em` pools every pass into one run and masks per (pair, field): a pair
from a pass blocking on `zip` carries no `zip` likelihood, but `zip` stays
learnable from other passes. That is correct. It also couples every pass into
one convergence loop, and its aggregation key has to carry the pass.

Splink runs a session per `blocking_rule_for_training`, records the comparisons
that `cannot_be_estimated` under that rule, and combines. Two properties follow:

1. **Sessions are independent** -- trainable anywhere, one per executor or one
   per engine round trip. The pooled run cannot be split.
2. **Within a session the conditioning is constant**, so counting comparison
   vectors needs no pass column: `GROUP BY <gammas>`, exactly the shape
   `count_agreement_patterns_sql` produces. That is what makes the counts
   computable by a cluster and the iteration cheap over `pair_weights`.

## Combination

A field's `m` is the **pair-count-weighted mean** over the sessions that could
estimate it. Weighted, not a plain mean -- a pass contributing 10 pairs and one
contributing 10,000 are not equal evidence, and an unweighted mean lets a tiny
pass swing a field it barely observed.

A field no session can estimate keeps the fixed prior, which is the pooled run's
`always_conditioned` treatment rather than a second answer for the same
situation. `u` comes from random pairs and does not depend on the pass, so
taking the first session's states that instead of averaging identical numbers.

## Gates (none need Spark)

- **A single pass DELEGATES** to `train_em`. Adopting this cannot move a
  single-pass model at all -- a no-op by construction rather than by proof.
- **Two passes each estimate the field the other blocks on**, and the combined
  `zip` equals the last_name-pass estimate *exactly*. A naive average would drag
  the zip pass's fixed prior in, and would fail quietly: the result is still a
  valid probability vector.
- **Deterministic under reversed block order.** Sessions combine in sorted pass
  order, not dict insertion order -- otherwise the model depends on block
  discovery order and reproduces on one machine but not another.
- **Blocks with no `blocking_fields` provenance fall back to the pooled run**
  rather than being read as one anonymous unconditioned pass, which would let
  every field look estimable and silently change existing models.

175 existing probabilistic/EM/blocking tests pass unchanged.

## What still is not distributed

This is the decomposition, not the distribution. Each session still trains on a
driver-side sample of its own pass's pairs. What it buys is that the remaining
step is now the shape Splink actually implements: per session, compute gammas
distributed (which #2545 made possible with no executor Python), `GROUP BY`
them, and feed the counts to `train_em(pair_weights=...)`.

I have not benched any of this, and none of it has run on a cluster.
