### PR TITLE
feat(semantic): Malloy (malloydata.dev) BI dialect for the key-integrity certifier

### DIFF
--- a/context-network/decisions/0061-malloy-bi-dialect.md
+++ b/context-network/decisions/0061-malloy-bi-dialect.md
@@ -1,0 +1,75 @@
+# 0061 — Malloy (malloydata.dev) BI dialect for the semantic-layer certifier
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch.semantic.malloy` (`parse_malloy_models`, `malloy_join_keys`, `certify_malloy_joins`, `emit_malloy_source`, `emit_malloy_from_crosswalk`) + a `"malloy"` dialect in `certify_semantic_model` • **Builds on:** [0049 (metric-aware key certification)](0049-metric-aware-key-certification.md), [0052 (Cube dialect)](0052-cube-dialect-and-osi-validation.md), [0060 (Feast provider)](0060-feast-feature-store-provider.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+The next missing provider surface from the semantic-layer roadmap filter (an
+established ecosystem that runs on entity keys and assumes resolved identity) is the
+BI-modeling lane. **Malloy** (Google's open semantic modeling language) is the
+cleanest BI reader/emitter to add: its unit is a `source` whose identity is a
+declared `primary_key`, and joins (`join_one` / `join_many` / `join_cross`) ride on
+it — structurally almost identical to Cube's `primary_key` + `joins` block, so the
+metric-aware certifier applies unchanged. (LookML and Power BI are the other BI
+candidates; LookML's explore/join model is messier to parse, so Malloy is the
+higher-leverage first cut — LookML is a follow-on.)
+
+## Decision
+A new dialect module `goldenmatch/semantic/malloy.py`, structured exactly like Cube
+(0052) and Feast (0060) — consume, certify (bridge A), emit (bridge B):
+
+1. **Consume.** `parse_malloy_models(source)` reads a structured `{sources: [...]}`
+   projection (dict / YAML / path) OR raw Malloy `.malloy` DSL text via a **focused
+   declaration parser** (brace-matched `source:` blocks → `primary_key`, `join_*`
+   with `on` conditions, `measure:`, `dimension:`). `malloy_join_keys` resolves each
+   join to the columns it rides on (parsed from the `on` condition).
+2. **Certify (bridge A).** `certify_malloy_joins(model, frames, resolve=…)` certifies
+   the **one-side** key of each join via `certify_key_integrity` — the joined (`to`)
+   source for `join_one`, but the declaring (`from`) source for `join_many` (its key
+   is what must be unique; certifying the many-side FK would spuriously flag a
+   fan-out). `join_cross` has no key and is skipped. Falls back to the one-side
+   source's declared `primary_key` when the `on` columns can't be parsed. Same
+   direction logic as `certify_cube_joins`.
+3. **Emit (bridge B).** `emit_malloy_from_crosswalk` emits a crosswalk source keyed
+   on `source_pk` + a `join_one` from the source to it, returning
+   `(malloy_text, provenance)` — Malloy has no metadata slot in this subset, so the
+   GoldenMatch provenance (+ optional certificate verdict) is returned alongside
+   rather than embedded (the one deliberate shape difference from the YAML dialects,
+   whose `meta.goldenmatch` carries it inline). `emit_malloy_source` round-trips
+   through the DSL parser.
+4. **Front-door wiring, no new surface.** `certify_semantic_model` auto-detects a
+   top-level `sources:` as the `"malloy"` dialect and dispatches to
+   `certify_malloy_joins`; `semantic_field_roles` learns the Malloy role split
+   (primary_key = identity, measures/dimensions). CLI / MCP / REST certify a Malloy
+   model with **no new MCP tool / CLI command / A2A skill** — parity-free, like Cube
+   and Feast.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — an *adapter surface* over the single-sourced
+  `certify_key_integrity` (0059). GoldenMatch does not author Malloy measures,
+  queries, or the model — Malloy keeps that. No second source of truth.
+- **Conformance defines correctness** ✅ — Malloy is another dialect target;
+  `parse_malloy_models(emit_malloy_source(...))` round-trips.
+- **Compute vs. control stay distinct** ✅ — the model is small metadata (DSL text /
+  dict), correctly not Arrow-marshaled; certification rides the columnar key path.
+
+## Consequences / honest flags
+- **The DSL parser is a focused subset, not full Malloy grammar.** It reads the
+  declaration constructs (`source`/`primary_key`/`join_*`/`measure`/`dimension`) via
+  brace-matching + regex — enough for the metric-aware wedge. Full-fidelity parsing
+  (nested refinements, SQL blocks, pipelines) is out of scope; the exact,
+  dependency-free path is the structured `{sources: [...]}` projection, which the
+  front door detects. A Malloy source it can't parse simply yields fewer joins, not
+  a wrong certificate.
+- **Emit returns a tuple, not a string.** Unlike the YAML dialects, provenance is
+  returned alongside the text (no metadata slot). Callers wanting it embedded can
+  attach it in a `// ` comment or a sidecar — deferred.
+- **Declaration only, no query engine.** Like every dialect, this reads/writes the
+  declaration; it does not run Malloy's compiler or query the warehouse. `frames`
+  are caller-supplied.
+- **No new parity surface** — verified: `malloy` appears in zero gated Python
+  surfaces, so `parity/goldenmatch.yaml` is unchanged, consistent with Cube/Feast.
+- **LookML / Power BI are the remaining BI dialects**, and data contracts (ODCS) the
+  remaining adjacent standard — follow-ons from the same filter.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -89,6 +89,20 @@
 > next missing provider surfaces from the same filter: **BI semantic-model dialects
 > (Malloy/LookML)** and **data contracts (ODCS)**; the CDP/activation lane is
 > competitive prior art, not a plug-under gap.
+>
+> **BI surface (Malloy,
+> [0061](../decisions/0061-malloy-bi-dialect.md)).** Malloy (Google's open semantic
+> modeling language) is the cleanest BI reader/emitter: a `source`'s identity is its
+> declared `primary_key`, and `join_one`/`join_many`/`join_cross` ride on it —
+> structurally the same as Cube, so the certifier applies unchanged.
+> `goldenmatch.semantic.malloy`: `parse_malloy_models` (structured `{sources: [...]}`
+> projection OR raw `.malloy` DSL text via a focused declaration parser),
+> `malloy_join_keys`, `certify_malloy_joins` (bridge A — one-side-key direction,
+> skips `join_cross`), `emit_malloy_from_crosswalk` (bridge B, returns
+> `(text, provenance)` as Malloy has no metadata slot). `certify_semantic_model`
+> auto-detects a top-level `sources:` as `"malloy"`, parity-free like Cube/Feast.
+> Remaining from the filter: **LookML / Power BI** (messier parse) and **data
+> contracts (ODCS)**.
 > Greenfield when written: no prior repo code, doc, or decision referenced this
 > ecosystem (grep, 2026-07-30).
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7661,7 +7661,8 @@
           "imports": [
             "goldenmatch.core.key_integrity_certificate",
             "goldenmatch.semantic.blocking",
-            "goldenmatch.semantic.key_integrity"
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow"
           ]
         },
         {

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 471,
+      "module_count": 472,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7176,6 +7176,7 @@
             "goldenmatch.semantic.discovery",
             "goldenmatch.semantic.feast",
             "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.malloy",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.ontology",
             "goldenmatch.semantic.ontology_catalog",
@@ -7199,6 +7200,7 @@
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.feast",
             "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.malloy",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi"
           ]
@@ -7237,6 +7239,7 @@
             "goldenmatch.semantic.cube",
             "goldenmatch.semantic.feast",
             "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.malloy",
             "goldenmatch.semantic.metricflow",
             "goldenmatch.semantic.osi"
           ]
@@ -7631,6 +7634,34 @@
             "goldenmatch.core._native_loader",
             "goldenmatch.core.autoconfig",
             "goldenmatch.core.key_integrity_certificate"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.malloy",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/malloy.py",
+          "purpose": "Malloy (malloydata.dev) semantic-model reader + emitter — the BI dialect.",
+          "defines": [
+            "MalloyJoin",
+            "MalloyModel",
+            "MalloySource",
+            "_from_structured",
+            "_looks_like_dsl",
+            "_match_braces",
+            "_normalize_pk",
+            "_on_refs",
+            "_parse_dsl",
+            "_parse_join_dict",
+            "_parse_source_dict",
+            "certify_malloy_joins",
+            "emit_malloy_from_crosswalk",
+            "emit_malloy_source",
+            "malloy_join_keys",
+            "parse_malloy_models"
+          ],
+          "imports": [
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.blocking",
+            "goldenmatch.semantic.key_integrity"
           ]
         },
         {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Malloy (malloydata.dev) BI dialect for the semantic-layer certifier
+  (`goldenmatch.semantic.malloy`).** Malloy's unit is a `source` whose identity is
+  its declared `primary_key`, with `join_one`/`join_many`/`join_cross` riding on it
+  — structurally the same as Cube's `primary_key` + joins, so the same certifier
+  applies. New: `parse_malloy_models` (a structured `{sources: [...]}` projection
+  OR raw `.malloy` DSL text via a focused declaration parser), `malloy_join_keys`,
+  `certify_malloy_joins` (bridge to wedge A — certifies the one-side key of each
+  join, picking the declaring side for `join_many` and skipping `join_cross`),
+  `emit_malloy_source` (round-trips through the DSL parser) and
+  `emit_malloy_from_crosswalk` (bridge to wedge B — declares the resolved key as a
+  `primary_key` + a `join_one` to it, returning `(malloy_text, provenance)` since
+  Malloy has no metadata slot in this subset). `certify_semantic_model` auto-detects
+  a top-level `sources:` as the `"malloy"` dialect. Library-only, advisory,
+  parity-free.
 - **Feast (feature-store) dialect for the semantic-layer certifier
   (`goldenmatch.semantic.feast`).** A feature store is a join graph one layer over
   into ML: a `FeatureView` is keyed on an `Entity`'s `join_keys`, and a duplicated

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -107,6 +107,16 @@ from goldenmatch.semantic.key_integrity import (
     certify_key_integrity,
     certify_structural_json,
 )
+from goldenmatch.semantic.malloy import (
+    MalloyJoin,
+    MalloyModel,
+    MalloySource,
+    certify_malloy_joins,
+    emit_malloy_from_crosswalk,
+    emit_malloy_source,
+    malloy_join_keys,
+    parse_malloy_models,
+)
 from goldenmatch.semantic.metricflow import (
     DeclaredKeySpec,
     emit_from_crosswalk,
@@ -229,6 +239,15 @@ __all__ = [
     "FeastEntity",
     "FeastFeatureView",
     "FeastRepo",
+    # follow-on — Malloy (malloydata.dev) BI dialect (reader + emitter + bridges)
+    "parse_malloy_models",
+    "malloy_join_keys",
+    "certify_malloy_joins",
+    "emit_malloy_source",
+    "emit_malloy_from_crosswalk",
+    "MalloyModel",
+    "MalloySource",
+    "MalloyJoin",
     # ontology layer — RDF/OWL/SHACL native identity provider (bidirectional)
     "parse_ontology",
     "ontology_identity_keys",

--- a/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
@@ -124,6 +124,13 @@ def semantic_field_roles(source: str | Any) -> SemanticFieldRoles:
         # because they share a churn score), so features are measures.
         for fv in repo.feature_views:
             measures.extend(fv.features)
+    elif dialect == "malloy":
+        from goldenmatch.semantic.malloy import parse_malloy_models
+
+        for src in parse_malloy_models(data).sources:
+            keys.extend(src.primary_key)
+            dimensions.extend(src.dimensions)
+            measures.extend(src.measures)
     else:  # osi
         from goldenmatch.semantic.osi import parse_osi_models
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/certify.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/certify.py
@@ -20,6 +20,7 @@ from goldenmatch.core.key_integrity_certificate import KeyIntegrityCertificate
 from goldenmatch.semantic.cube import certify_cube_joins
 from goldenmatch.semantic.feast import certify_feast_feature_views
 from goldenmatch.semantic.key_integrity import certify_key_integrity
+from goldenmatch.semantic.malloy import certify_malloy_joins
 from goldenmatch.semantic.metricflow import _load, parse_semantic_models
 from goldenmatch.semantic.osi import certify_osi_relationships
 
@@ -40,7 +41,7 @@ class SemanticCertification:
     """The result of certifying a whole semantic model: the detected dialect and
     one `KeyCertification` per declared key that had a supplied frame."""
 
-    dialect: str                         # "metricflow" | "cube" | "osi" | "feast"
+    dialect: str                         # "metricflow" | "cube" | "osi" | "feast" | "malloy"
     entries: list[KeyCertification] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)  # targets with no frame
     note: str = ""
@@ -75,10 +76,13 @@ def detect_dialect(data: dict[str, Any]) -> str:
         return "osi"
     if "feature_views" in data:
         return "feast"
+    if "sources" in data:
+        return "malloy"
     raise ValueError(
         "certify_semantic_model: could not detect a semantic-layer dialect; "
         "expected a top-level 'cubes' (Cube), 'semantic_models' (dbt/MetricFlow), "
-        "'semantic_model' (OSI/Ossie), or 'feature_views' (Feast) key"
+        "'semantic_model' (OSI/Ossie), 'feature_views' (Feast), or 'sources' "
+        "(Malloy) key"
     )
 
 
@@ -153,6 +157,13 @@ def certify_semantic_model(
             entries.append(KeyCertification(
                 target=rep["feature_view"], key=list(rep["key"]), certificate=rep["certificate"],
                 context=f"entity {rep['entity']}",
+            ))
+    elif dialect == "malloy":
+        # certify_malloy_joins certifies the one-side key of each source join.
+        for rep in certify_malloy_joins(data, frames, resolve=resolve, roles=roles):
+            entries.append(KeyCertification(
+                target=rep["to_source"], key=list(rep["key"]), certificate=rep["certificate"],
+                context=f"join from {rep['from_source']}",
             ))
     else:  # osi
         for rep in certify_osi_relationships(data, frames, resolve=resolve, roles=roles):

--- a/packages/python/goldenmatch/goldenmatch/semantic/malloy.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/malloy.py
@@ -1,0 +1,354 @@
+"""Malloy (malloydata.dev) semantic-model reader + emitter — the BI dialect.
+
+Malloy is Google's open semantic modeling language. Its unit is a **`source`**
+(`source: users is table('users') { primary_key: id }`), whose identity is the
+declared **`primary_key`**; joins ride on it via `join_one:` / `join_many:` /
+`join_cross:` with an `on` condition. So — exactly as with Cube's `primary_key` +
+joins and MetricFlow entities — the join key is the identity the metrics silently
+assume, and it is what `certify_key_integrity` must check.
+
+- **consume** a Malloy model to learn the declared primary keys + the keys each
+  join rides on (`parse_malloy_models`, `malloy_join_keys`) — "what to resolve".
+  Reads a structured `{sources: [...]}` projection (dict / YAML) OR raw `.malloy`
+  DSL text (a focused parser for the declaration constructs);
+- **certify** (bridge to wedge A) the one-side key of each join
+  (`certify_malloy_joins`) — certifying exactly the identity the metrics depend on;
+- **emit** (bridge to wedge B) a Malloy source declaring the GoldenMatch-resolved
+  key as a `primary_key` + a `join_one` to it (`emit_malloy_from_crosswalk`).
+  `parse_malloy_models(emit_malloy_source(...))` round-trips.
+
+Declaration only, advisory, parity-free (it plugs into the existing
+`certify_semantic_model` dialect dispatch on a top-level `sources:` key). The DSL
+reader handles the common well-formed shape; the structured `{sources: ...}` form
+is the exact, dependency-free path the front door detects.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# join_one -> to-one (joined source is the one-side), join_many -> to-many
+# (declaring source is the one-side), join_cross -> cross (no key to certify).
+_JOIN_KINDS = {"join_one": "one", "join_many": "many", "join_cross": "cross"}
+# `source.column` dotted refs inside an `on` condition.
+_REF = re.compile(r"\b(\w+)\.(\w+)\b")
+
+
+# --- model -------------------------------------------------------------------
+
+
+@dataclass
+class MalloyJoin:
+    name: str                            # the joined source's name
+    relationship: str                    # "one" / "many" / "cross"
+    on: str = ""                         # the ON condition, e.g. "a.id = b.a_id"
+
+
+@dataclass
+class MalloySource:
+    name: str
+    table: str | None = None             # table('...') target
+    base: str | None = None              # an extended/refined source name
+    primary_key: list[str] = field(default_factory=list)  # declared primary_key
+    joins: list[MalloyJoin] = field(default_factory=list)
+    measures: list[str] = field(default_factory=list)
+    dimensions: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MalloyModel:
+    sources: list[MalloySource] = field(default_factory=list)
+
+    def source_by_name(self, name: str) -> MalloySource | None:
+        for s in self.sources:
+            if s.name == name:
+                return s
+        return None
+
+
+# --- parse (consume) ---------------------------------------------------------
+
+
+def _normalize_pk(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return []
+
+
+def _parse_join_dict(j: dict[str, Any]) -> MalloyJoin:
+    rel = str(j.get("relationship", "one")).strip().lower()
+    # accept "join_one" / "one_to_many" style too
+    rel = _JOIN_KINDS.get(rel, rel)
+    if rel in ("one_to_many", "many"):
+        rel = "many"
+    elif rel in ("many_to_one", "one_to_one", "one"):
+        rel = "one"
+    elif "cross" in rel:
+        rel = "cross"
+    return MalloyJoin(
+        name=str(j.get("name", "")).strip(),
+        relationship=rel,
+        on=str(j.get("on", j.get("sql", ""))).strip(),
+    )
+
+
+def _parse_source_dict(s: dict[str, Any]) -> MalloySource:
+    return MalloySource(
+        name=str(s.get("name", "")).strip(),
+        table=(str(s["table"]).strip() if s.get("table") is not None else None),
+        base=(str(s["base"]).strip() if s.get("base") is not None else None),
+        primary_key=_normalize_pk(s.get("primary_key")),
+        joins=[_parse_join_dict(j) for j in (s.get("joins") or []) if isinstance(j, dict)],
+        measures=[str(m).strip() for m in (s.get("measures") or []) if str(m).strip()],
+        dimensions=[str(d).strip() for d in (s.get("dimensions") or []) if str(d).strip()],
+    )
+
+
+def _looks_like_dsl(text: str) -> bool:
+    return bool(re.search(r"(^|\n)\s*source:\s*\w+\s+is\b", text))
+
+
+def parse_malloy_models(source: str | Any) -> MalloyModel:
+    """Parse a Malloy model into a `MalloyModel`.
+
+    Accepts a structured `{sources: [...]}` projection (dict / YAML string / path)
+    OR raw Malloy `.malloy` DSL text (or a path to it). The structured form is the
+    exact, dependency-free path; the DSL reader handles the common declaration
+    shape (`source: N is table('t') { primary_key: k; join_one: J on ...; measure:
+    m is ...; dimension: d is ... }`).
+    """
+    if isinstance(source, dict):
+        data = source
+    elif isinstance(source, (str, Path)) and os.path.exists(source):
+        text = Path(source).read_text(encoding="utf-8")
+        return _parse_dsl(text) if (str(source).endswith(".malloy") or _looks_like_dsl(text)) \
+            else _from_structured(yaml.safe_load(text) or {})
+    elif isinstance(source, str) and _looks_like_dsl(source):
+        return _parse_dsl(source)
+    else:
+        data = yaml.safe_load(str(source)) or {}
+    return _from_structured(data)
+
+
+def _from_structured(data: dict[str, Any]) -> MalloyModel:
+    return MalloyModel(
+        sources=[_parse_source_dict(s) for s in (data.get("sources") or []) if isinstance(s, dict)]
+    )
+
+
+def _match_braces(text: str, open_idx: int) -> int:
+    """Index of the `}` matching the `{` at `open_idx` (or len(text) if unbalanced)."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return len(text)
+
+
+_SOURCE_HEAD = re.compile(r"source:\s*(\w+)\s+is\s+([^\{\n]+?)\s*(\{|$|\n)", re.MULTILINE)
+
+
+def _parse_dsl(text: str) -> MalloyModel:
+    """A focused parser for well-formed Malloy source declarations. Extracts each
+    `source:`'s name, `table('...')`/base, `primary_key`, joins and measures/
+    dimensions. Not a full Malloy grammar — the declaration constructs only."""
+    sources: list[MalloySource] = []
+    for m in _SOURCE_HEAD.finditer(text):
+        name = m.group(1)
+        head = m.group(2).strip()
+        table = None
+        base = None
+        tbl = re.search(r"table\(\s*['\"]([^'\"]+)['\"]\s*\)", head)
+        if tbl:
+            table = tbl.group(1)
+        else:  # `is other_source` / `is other_source extend`
+            base = head.split()[0] if head else None
+        body = ""
+        if m.group(3) == "{":
+            close = _match_braces(text, m.end() - 1)
+            body = text[m.end():close]
+        src = MalloySource(name=name, table=table, base=base)
+        pk = re.search(r"primary_key:\s*(\w+)", body)
+        if pk:
+            src.primary_key = [pk.group(1)]
+        for jm in re.finditer(
+            r"(join_one|join_many|join_cross):\s*(\w+)(?:\s+is\s+[^\n]*?)?"
+            r"(?:\s+(?:on|with)\s+([^\n]+))?(?=\n|$)",
+            body,
+        ):
+            src.joins.append(MalloyJoin(
+                name=jm.group(2),
+                relationship=_JOIN_KINDS[jm.group(1)],
+                on=(jm.group(3) or "").strip(),
+            ))
+        src.measures = [mm.group(1) for mm in re.finditer(r"measure:\s*(\w+)\s+is\b", body)]
+        src.dimensions = [dm.group(1) for dm in re.finditer(r"dimension:\s*(\w+)\s+is\b", body)]
+        sources.append(src)
+    return MalloyModel(sources=sources)
+
+
+def _on_refs(on: str) -> list[tuple[str, str]]:
+    """`(source, column)` pairs from an `on` condition's dotted refs."""
+    return [(src, col) for src, col in _REF.findall(on or "")]
+
+
+def malloy_join_keys(model: MalloyModel | str | Any) -> list[dict[str, Any]]:
+    """The keys each join rides on — the identity its metrics depend on. One entry
+    per join: `{from_source, to_source, relationship, from_columns, to_columns,
+    on}`, columns best-effort parsed from the `on` condition. `join_cross` has no
+    key and is emitted with empty columns."""
+    model = model if isinstance(model, MalloyModel) else parse_malloy_models(model)
+    out: list[dict[str, Any]] = []
+    for src in model.sources:
+        for j in src.joins:
+            from_cols: list[str] = []
+            to_cols: list[str] = []
+            for ref_src, col in _on_refs(j.on):
+                if ref_src == src.name:
+                    from_cols.append(col)
+                elif ref_src == j.name:
+                    to_cols.append(col)
+            out.append({
+                "from_source": src.name,
+                "to_source": j.name,
+                "relationship": j.relationship,
+                "from_columns": from_cols,
+                "to_columns": to_cols,
+                "on": j.on,
+            })
+    return out
+
+
+# --- emit (produce) ----------------------------------------------------------
+
+
+def emit_malloy_source(model: MalloyModel | MalloySource | list[MalloySource]) -> str:
+    """Render `MalloySource`(s) as Malloy DSL text. Round-trips through
+    `parse_malloy_models`."""
+    if isinstance(model, MalloyModel):
+        sources = model.sources
+    elif isinstance(model, MalloySource):
+        sources = [model]
+    else:
+        sources = list(model)
+    blocks: list[str] = []
+    for s in sources:
+        base = f"table('{s.table}')" if s.table else (s.base or "table('')")
+        lines = [f"source: {s.name} is {base} {{"]
+        if s.primary_key:
+            lines.append(f"  primary_key: {s.primary_key[0]}")
+        for j in s.joins:
+            kind = {"one": "join_one", "many": "join_many", "cross": "join_cross"}.get(
+                j.relationship, "join_one")
+            on = f" on {j.on}" if (j.on and kind != "join_cross") else ""
+            lines.append(f"  {kind}: {j.name}{on}")
+        lines.append("}")
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks) + "\n"
+
+
+def emit_malloy_from_crosswalk(
+    crosswalk: Any,
+    *,
+    source_name: str,
+    source_join_column: str | None = None,
+    crosswalk_source: str = "crosswalk",
+    crosswalk_table: str | None = None,
+    resolved_field: str | None = None,
+    certificate: Any = None,
+) -> str:
+    """Emit Malloy DSL for a `ResolvedCrosswalk` (wedge B): a crosswalk source keyed
+    on `source_pk` (a `primary_key`), plus a `join_one` from the source to it — so
+    metrics group by the conformed `resolved_entity_id`. Returned as a
+    `(malloy_text, provenance)` tuple: Malloy has no metadata slot in this subset,
+    so GoldenMatch provenance (+ optional certificate verdict) is returned
+    alongside rather than embedded.
+    """
+    src_pk = getattr(crosswalk, "source_pk_column", "source_pk")
+    resolved_field = resolved_field or getattr(crosswalk, "resolved_key", "resolved_entity_id")
+    join_col = source_join_column or src_pk
+
+    xw = MalloySource(name=crosswalk_source, table=crosswalk_table, primary_key=[src_pk])
+    src = MalloySource(
+        name=source_name,
+        joins=[MalloyJoin(
+            name=crosswalk_source, relationship="one",
+            on=f"{source_name}.{join_col} = {crosswalk_source}.{src_pk}",
+        )],
+    )
+    provenance: dict[str, Any] = {
+        "generated_by": "goldenmatch.semantic",
+        "resolved_key": resolved_field,
+        "n_records": getattr(crosswalk, "n_records", None),
+        "n_entities": getattr(crosswalk, "n_entities", None),
+        "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
+    }
+    if certificate is not None:
+        from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+        provenance["key_integrity"] = certificate_verdict(certificate)
+    return emit_malloy_source([src, xw]), provenance
+
+
+# --- bridge: certify the keys a Malloy model joins on (metric-aware, wedge A) --
+
+
+def certify_malloy_joins(
+    model: MalloyModel | str | Any, frames: dict[str, Any], *, resolve: bool = False,
+    roles: Any = None,
+) -> list[dict[str, Any]]:
+    """For each join in a Malloy model, certify the ONE-side key it joins on via
+    wedge A. The one-side depends on direction: for `join_one` the joined (`to`)
+    source is the one-side, but for `join_many` the declaring (`from`) source is,
+    so its key is what must be unique. `join_cross` has no key and is skipped.
+    `frames` maps source name -> table; a join whose one-side frame is absent or
+    whose one-side columns can't be parsed is skipped. `resolve=True` also measures
+    fragmentation / undercount via ER (fail-open); pass `roles` (a
+    `SemanticFieldRoles`) to make that ER metric-aware.
+
+    Returns `[{from_source, to_source, key, certificate}]`.
+    """
+    from goldenmatch.semantic.blocking import _frame_columns, metric_aware_attributes
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    model = model if isinstance(model, MalloyModel) else parse_malloy_models(model)
+    out: list[dict[str, Any]] = []
+    for jk in malloy_join_keys(model):
+        if jk["relationship"] == "cross":
+            continue
+        if jk["relationship"] == "many":
+            one_source, one_columns = jk["from_source"], jk["from_columns"]
+        else:  # one -> the joined (to) source is the one-side
+            one_source, one_columns = jk["to_source"], jk["to_columns"]
+        # fall back to the declared primary_key of the one-side source
+        if not one_columns:
+            s = model.source_by_name(one_source)
+            one_columns = list(s.primary_key) if s is not None else []
+        df = frames.get(one_source)
+        if df is None or not one_columns:
+            continue
+        attributes = (
+            metric_aware_attributes(roles, _frame_columns(df))
+            if (resolve and roles is not None) else None
+        )
+        cert = certify_key_integrity(
+            df, key=one_columns, resolve=resolve, attributes=attributes
+        )
+        out.append({
+            "from_source": jk["from_source"],
+            "to_source": jk["to_source"],
+            "key": list(one_columns),
+            "certificate": cert,
+        })
+    return out

--- a/packages/python/goldenmatch/goldenmatch/semantic/malloy.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/malloy.py
@@ -24,13 +24,11 @@ is the exact, dependency-free path the front door detects.
 """
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
-import yaml
+from goldenmatch.semantic.metricflow import _load
 
 # join_one -> to-one (joined source is the one-side), join_many -> to-many
 # (declaring source is the one-side), join_cross -> cross (no key to certify).
@@ -111,33 +109,32 @@ def _parse_source_dict(s: dict[str, Any]) -> MalloySource:
     )
 
 
+# Leading whitespace is [ \t] only (never \s) so it can't overlap the ^ line
+# anchor on a newline -- keeps every DSL regex linear on user-provided model text
+# (no polynomial backtracking).
 def _looks_like_dsl(text: str) -> bool:
-    return bool(re.search(r"(^|\n)\s*source:\s*\w+\s+is\b", text))
+    return bool(re.search(r"^[ \t]*source:[ \t]*\w+[ \t]+is\b", text, re.MULTILINE))
 
 
 def parse_malloy_models(source: str | Any) -> MalloyModel:
     """Parse a Malloy model into a `MalloyModel`.
 
     Accepts a structured `{sources: [...]}` projection (dict / YAML string / path)
-    OR raw Malloy `.malloy` DSL text (or a path to it). The structured form is the
-    exact, dependency-free path; the DSL reader handles the common declaration
-    shape (`source: N is table('t') { primary_key: k; join_one: J on ...; measure:
-    m is ...; dimension: d is ... }`).
+    OR raw Malloy DSL **text**. The structured form is the exact, dependency-free
+    path; the DSL reader handles the common declaration shape (`source: N is
+    table('t') { primary_key: k; join_one: J on ...; measure: m is ...; dimension:
+    d is ... }`). A raw `.malloy` FILE is read by the caller —
+    `parse_malloy_models(Path('m.malloy').read_text())` — so this function opens no
+    file itself; structured YAML/dict/path goes through the shared dialect loader.
     """
-    if isinstance(source, dict):
-        data = source
-    elif isinstance(source, (str, Path)) and os.path.exists(source):
-        text = Path(source).read_text(encoding="utf-8")
-        return _parse_dsl(text) if (str(source).endswith(".malloy") or _looks_like_dsl(text)) \
-            else _from_structured(yaml.safe_load(text) or {})
-    elif isinstance(source, str) and _looks_like_dsl(source):
+    if isinstance(source, str) and _looks_like_dsl(source):
         return _parse_dsl(source)
-    else:
-        data = yaml.safe_load(str(source)) or {}
-    return _from_structured(data)
+    return _from_structured(_load(source))
 
 
-def _from_structured(data: dict[str, Any]) -> MalloyModel:
+def _from_structured(data: Any) -> MalloyModel:
+    if not isinstance(data, dict):
+        return MalloyModel()
     return MalloyModel(
         sources=[_parse_source_dict(s) for s in (data.get("sources") or []) if isinstance(s, dict)]
     )
@@ -156,44 +153,54 @@ def _match_braces(text: str, open_idx: int) -> int:
     return len(text)
 
 
-_SOURCE_HEAD = re.compile(r"source:\s*(\w+)\s+is\s+([^\{\n]+?)\s*(\{|$|\n)", re.MULTILINE)
+# Head = source name + rest-of-head up to `{` or newline. `[^\n{]*` is one greedy
+# negated class (linear, no backtracking); leading ws is [ \t]. The body braces are
+# located by a bounded string scan, not a regex, so nothing here is polynomial.
+_SOURCE_HEAD = re.compile(r"^[ \t]*source:[ \t]*(\w+)[ \t]+is[ \t]+([^\n{]*)", re.MULTILINE)
+_TABLE = re.compile(r"table\([ \t]*['\"]([^'\"]+)['\"]")
+_JOIN_LINE = re.compile(r"(join_one|join_many|join_cross):[ \t]*(\w+)([^\n]*)")
+_ON_CLAUSE = re.compile(r"\b(?:on|with)[ \t]+(.+)$")
+_PRIMARY_KEY = re.compile(r"primary_key:[ \t]*(\w+)")
+_MEASURE = re.compile(r"measure:[ \t]*(\w+)[ \t]+is\b")
+_DIMENSION = re.compile(r"dimension:[ \t]*(\w+)[ \t]+is\b")
 
 
 def _parse_dsl(text: str) -> MalloyModel:
     """A focused parser for well-formed Malloy source declarations. Extracts each
     `source:`'s name, `table('...')`/base, `primary_key`, joins and measures/
-    dimensions. Not a full Malloy grammar — the declaration constructs only."""
+    dimensions. Not a full Malloy grammar — the declaration constructs only. Every
+    regex matches over `[ \t]` / negated classes on a bounded span, so parsing is
+    linear on any (user-provided) input."""
+    heads = list(_SOURCE_HEAD.finditer(text))
     sources: list[MalloySource] = []
-    for m in _SOURCE_HEAD.finditer(text):
+    for i, m in enumerate(heads):
         name = m.group(1)
         head = m.group(2).strip()
         table = None
         base = None
-        tbl = re.search(r"table\(\s*['\"]([^'\"]+)['\"]\s*\)", head)
+        tbl = _TABLE.search(head)
         if tbl:
             table = tbl.group(1)
-        else:  # `is other_source` / `is other_source extend`
-            base = head.split()[0] if head else None
-        body = ""
-        if m.group(3) == "{":
-            close = _match_braces(text, m.end() - 1)
-            body = text[m.end():close]
+        elif head:  # `is other_source` / `is other_source extend`
+            base = head.split()[0]
+        # body = between the first `{` after the head and its matching `}`, bounded
+        # so it can't spill past the next `source:` head (a linear string scan).
+        next_start = heads[i + 1].start() if i + 1 < len(heads) else len(text)
+        brace_open = text.find("{", m.end(), next_start)
+        body = text[brace_open + 1:_match_braces(text, brace_open)] if brace_open != -1 else ""
         src = MalloySource(name=name, table=table, base=base)
-        pk = re.search(r"primary_key:\s*(\w+)", body)
+        pk = _PRIMARY_KEY.search(body)
         if pk:
             src.primary_key = [pk.group(1)]
-        for jm in re.finditer(
-            r"(join_one|join_many|join_cross):\s*(\w+)(?:\s+is\s+[^\n]*?)?"
-            r"(?:\s+(?:on|with)\s+([^\n]+))?(?=\n|$)",
-            body,
-        ):
+        for jm in _JOIN_LINE.finditer(body):
+            on = _ON_CLAUSE.search(jm.group(3))
             src.joins.append(MalloyJoin(
                 name=jm.group(2),
                 relationship=_JOIN_KINDS[jm.group(1)],
-                on=(jm.group(3) or "").strip(),
+                on=(on.group(1).strip() if on else ""),
             ))
-        src.measures = [mm.group(1) for mm in re.finditer(r"measure:\s*(\w+)\s+is\b", body)]
-        src.dimensions = [dm.group(1) for dm in re.finditer(r"dimension:\s*(\w+)\s+is\b", body)]
+        src.measures = [mm.group(1) for mm in _MEASURE.finditer(body)]
+        src.dimensions = [dm.group(1) for dm in _DIMENSION.finditer(body)]
         sources.append(src)
     return MalloyModel(sources=sources)
 

--- a/packages/python/goldenmatch/scripts/emit_semantic_certify_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_semantic_certify_fixtures.py
@@ -68,10 +68,11 @@ def _bootstrap() -> object:
     _load("goldenmatch.semantic.metricflow", "semantic/metricflow.py")
     _load("goldenmatch.semantic.cube", "semantic/cube.py")
     _load("goldenmatch.semantic.osi", "semantic/osi.py")
-    # certify_semantic_model imports the feast dialect unconditionally (feast is
-    # Python-only / has no TS port, so it adds no fixture case — but the module
-    # must resolve for certify.py to import in this isolated bootstrap).
+    # certify_semantic_model imports the feast + malloy dialects unconditionally
+    # (both are Python-only / have no TS port, so they add no fixture case — but the
+    # modules must resolve for certify.py to import in this isolated bootstrap).
     _load("goldenmatch.semantic.feast", "semantic/feast.py")
+    _load("goldenmatch.semantic.malloy", "semantic/malloy.py")
     return _load("goldenmatch.semantic.certify", "semantic/certify.py").certify_semantic_model
 
 

--- a/packages/python/goldenmatch/scripts/emit_semantic_roles_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_semantic_roles_fixtures.py
@@ -62,9 +62,11 @@ except ImportError:  # toolkit not installed -> isolated loader (dependency orde
     _load("goldenmatch.semantic.cube", "semantic/cube.py")
     _load("goldenmatch.semantic.osi", "semantic/osi.py")
     _load("goldenmatch.semantic.key_integrity", "semantic/key_integrity.py")
-    # feast is imported unconditionally by certify.py and (lazily) by blocking's
-    # semantic_field_roles; load it so both resolve in this isolated bootstrap.
+    # feast + malloy are imported unconditionally by certify.py and (lazily) by
+    # blocking's semantic_field_roles; load them so both resolve in this isolated
+    # bootstrap.
     _load("goldenmatch.semantic.feast", "semantic/feast.py")
+    _load("goldenmatch.semantic.malloy", "semantic/malloy.py")
     _load("goldenmatch.semantic.certify", "semantic/certify.py")
     _blocking = _load("goldenmatch.semantic.blocking", "semantic/blocking.py")
     metric_aware_attributes = _blocking.metric_aware_attributes

--- a/packages/python/goldenmatch/tests/test_malloy.py
+++ b/packages/python/goldenmatch/tests/test_malloy.py
@@ -1,0 +1,187 @@
+"""Malloy (malloydata.dev) BI dialect: parse (structured + DSL) + certify + emit,
+and the front-door wiring.
+
+Malloy's identity is a source's `primary_key`, and `join_one`/`join_many`/
+`join_cross` ride on it. These lock the structured + DSL parse, the bridge to wedge
+A (`certify_malloy_joins`, one-side-key direction), the crosswalk emit (wedge B),
+and that `certify_semantic_model` auto-detects a top-level `sources:` as "malloy".
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from goldenmatch.semantic.certify import certify_semantic_model, detect_dialect
+from goldenmatch.semantic.malloy import (
+    MalloyJoin,
+    MalloyModel,
+    MalloySource,
+    certify_malloy_joins,
+    emit_malloy_from_crosswalk,
+    emit_malloy_source,
+    malloy_join_keys,
+    parse_malloy_models,
+)
+
+# Structured projection: an orders source that join_one's to customers on the
+# customer key. The one-side (customers.id) is the identity a per-customer metric
+# depends on.
+_MODEL_DOC = {
+    "sources": [
+        {"name": "customers", "table": "customers", "primary_key": "id",
+         "measures": ["lifetime_value"]},
+        {"name": "orders", "table": "orders", "primary_key": "order_id",
+         "joins": [{"name": "customers", "relationship": "one",
+                    "on": "orders.customer_id = customers.id"}],
+         "measures": ["amount"]},
+    ],
+}
+
+_DSL = """
+source: customers is table('customers') {
+  primary_key: id
+  measure: lifetime_value is sum(amount)
+}
+
+source: orders is table('orders') {
+  primary_key: order_id
+  join_one: customers on orders.customer_id = customers.id
+  measure: amount is sum(total)
+  dimension: order_month is month(created_at)
+}
+"""
+
+
+def test_parse_structured():
+    model = parse_malloy_models(_MODEL_DOC)
+    assert [s.name for s in model.sources] == ["customers", "orders"]
+    orders = model.source_by_name("orders")
+    assert orders.primary_key == ["order_id"]
+    assert orders.joins[0].name == "customers"
+    assert orders.joins[0].relationship == "one"
+
+
+def test_parse_dsl_text():
+    model = parse_malloy_models(_DSL)
+    assert {s.name for s in model.sources} == {"customers", "orders"}
+    customers = model.source_by_name("customers")
+    assert customers.table == "customers"
+    assert customers.primary_key == ["id"]
+    assert customers.measures == ["lifetime_value"]
+    orders = model.source_by_name("orders")
+    assert orders.primary_key == ["order_id"]
+    assert len(orders.joins) == 1
+    assert orders.joins[0].name == "customers"
+    assert orders.joins[0].relationship == "one"
+    assert "orders.customer_id = customers.id" in orders.joins[0].on
+    assert orders.dimensions == ["order_month"]
+
+
+def test_join_keys_parses_on_condition():
+    jk = malloy_join_keys(parse_malloy_models(_MODEL_DOC))
+    assert len(jk) == 1
+    j = jk[0]
+    assert j["from_source"] == "orders"
+    assert j["to_source"] == "customers"
+    assert j["relationship"] == "one"
+    assert j["from_columns"] == ["customer_id"]
+    assert j["to_columns"] == ["id"]
+
+
+def test_certify_join_one_certifies_the_to_side_key():
+    # customers.id is the one-side; it must be unique. Here it is.
+    frames = {
+        "customers": {"id": ["a", "b", "c"], "lifetime_value": [10, 20, 30]},
+        "orders": {"order_id": [1, 2, 3, 4], "customer_id": ["a", "a", "b", "c"]},
+    }
+    reps = certify_malloy_joins(parse_malloy_models(_MODEL_DOC), frames)
+    assert len(reps) == 1
+    assert reps[0]["to_source"] == "customers"
+    assert reps[0]["key"] == ["id"]
+    assert reps[0]["certificate"].is_trustworthy()
+
+
+def test_certify_catches_a_non_unique_one_side_key():
+    # customers.id duplicated -> a per-customer metric fans out.
+    frames = {
+        "customers": {"id": ["a", "a", "b"], "lifetime_value": [10, 10, 20]},
+        "orders": {"order_id": [1, 2, 3], "customer_id": ["a", "a", "b"]},
+    }
+    reps = certify_malloy_joins(parse_malloy_models(_MODEL_DOC), frames)
+    cert = reps[0]["certificate"]
+    assert not cert.is_unique_at_grain
+    assert cert.max_fan_out == 2.0
+
+
+def test_join_many_certifies_the_declaring_side():
+    # join_many: the declaring (from) source is the one-side.
+    doc = {"sources": [
+        {"name": "customers", "table": "customers", "primary_key": "id",
+         "joins": [{"name": "orders", "relationship": "many",
+                    "on": "customers.id = orders.customer_id"}]},
+    ]}
+    frames = {"customers": {"id": ["a", "b", "c"]}}
+    reps = certify_malloy_joins(parse_malloy_models(doc), frames)
+    assert reps[0]["key"] == ["id"]  # the declaring source's key, not orders'
+    assert reps[0]["certificate"].is_unique_at_grain
+
+
+def test_join_cross_is_skipped():
+    doc = {"sources": [
+        {"name": "a", "table": "a", "primary_key": "id",
+         "joins": [{"name": "b", "relationship": "cross"}]},
+    ]}
+    reps = certify_malloy_joins(parse_malloy_models(doc), {"a": {"id": [1, 2]}, "b": {"x": [1]}})
+    assert reps == []
+
+
+def test_certify_semantic_model_auto_detects_malloy():
+    assert detect_dialect(_MODEL_DOC) == "malloy"
+    frames = {
+        "customers": {"id": ["a", "a", "b"], "lifetime_value": [10, 10, 20]},
+        "orders": {"order_id": [1, 2, 3], "customer_id": ["a", "a", "b"]},
+    }
+    report = certify_semantic_model(_MODEL_DOC, frames)
+    assert report.dialect == "malloy"
+    assert report.n_certified == 1
+    assert report.entries[0].target == "customers"
+    assert report.entries[0].context == "join from orders"
+    assert not report.all_trustworthy
+
+
+def test_emit_source_round_trips_through_dsl_parser():
+    model = MalloyModel(sources=[
+        MalloySource(name="orders", table="orders", primary_key=["order_id"],
+                     joins=[MalloyJoin(name="customers", relationship="one",
+                                       on="orders.customer_id = customers.id")]),
+    ])
+    text = emit_malloy_source(model)
+    back = parse_malloy_models(text)
+    orders = back.source_by_name("orders")
+    assert orders.table == "orders"
+    assert orders.primary_key == ["order_id"]
+    assert orders.joins[0].name == "customers"
+    assert orders.joins[0].relationship == "one"
+
+
+def test_emit_from_crosswalk_returns_text_and_provenance():
+    crosswalk = SimpleNamespace(
+        source_pk_column="source_pk", resolved_key="resolved_entity_id",
+        n_records=100, n_entities=60, reduction_ratio=0.4,
+    )
+    text, provenance = emit_malloy_from_crosswalk(crosswalk, source_name="orders")
+    back = parse_malloy_models(text)
+    xw = back.source_by_name("crosswalk")
+    assert xw.primary_key == ["source_pk"]
+    orders = back.source_by_name("orders")
+    assert orders.joins[0].name == "crosswalk"
+    assert provenance["resolved_key"] == "resolved_entity_id"
+
+
+def test_semantic_field_roles_reads_malloy():
+    from goldenmatch.semantic.blocking import semantic_field_roles
+
+    roles = semantic_field_roles(_MODEL_DOC)
+    assert "id" in roles.keys
+    assert "order_id" in roles.keys
+    assert "lifetime_value" in roles.measures
+    assert "amount" in roles.measures


### PR DESCRIPTION
## What and why

The next missing provider surface from the [semantic-layer roadmap](../blob/main/context-network/planning/semantic-layer-interchange.md) filter is the BI-modeling lane. **Malloy** (Google's open semantic modeling language) is the cleanest BI reader/emitter to add: a `source`'s identity is its declared `primary_key`, and `join_one`/`join_many`/`join_cross` ride on it — structurally almost identical to Cube's `primary_key` + `joins`, so the metric-aware certifier applies unchanged. Decision: **ADR 0061**. Follows the Feast dialect (#2549 / ADR 0060).

## Changes

New `goldenmatch/semantic/malloy.py`, structured like Cube/Feast (consume / certify / emit):

- **Consume** — `parse_malloy_models` reads a structured `{sources: [...]}` projection (dict / YAML) **OR raw `.malloy` DSL text** via a focused declaration parser (brace-matched `source:` blocks → `primary_key`, `join_*` with `on` conditions, `measure:`, `dimension:`). `malloy_join_keys` resolves each join to the columns it rides on.
- **Certify (bridge A)** — `certify_malloy_joins` certifies the **one-side** key of each join via `certify_key_integrity`: the joined source for `join_one`, the declaring source for `join_many` (its key must be unique — certifying the many-side FK would spuriously flag a fan-out), skipping `join_cross`. Falls back to the one-side's declared `primary_key`. Same direction logic as `certify_cube_joins`.
- **Emit (bridge B)** — `emit_malloy_source` round-trips through the DSL parser; `emit_malloy_from_crosswalk` declares the resolved key as a `primary_key` + a `join_one` to it, returning `(malloy_text, provenance)` (Malloy has no metadata slot in this subset — the one deliberate shape difference from the YAML dialects).
- **Front-door wiring, no new surface** — `certify_semantic_model` auto-detects a top-level `sources:` as the `"malloy"` dialect; `semantic_field_roles` learns the role split (primary_key = identity, measures/dimensions). **Parity-free** (verified: `malloy` leaks into zero gated Python surfaces), like Cube/Feast.
- Also added `malloy` to the isolated semantic-fixture bootstraps (`emit_semantic_{certify,roles}_fixtures.py`) since `certify.py` now imports it — import-only, fixtures regenerate byte-identical (the `ts_parity_freshness` lesson from #2549).
- ADR 0061 + planning-doc status; `CHANGELOG.md` entry; `agent-codemap.json` regenerated.

## Testing

- `uv run pytest packages/python/goldenmatch/tests/test_malloy.py -q` → **11 passed**
- Regression: `test_cube` + `test_certify_semantic_model` + `test_osi` + `test_feast` + `test_malloy` + `test_auto_semantic_blocking` → **80 passed** together
- `ruff check` (import-sort included) clean
- Both fixture emitters regenerate **byte-identical** (no drift) with the malloy bootstrap addition
- `scripts/regen_docs.py --check` → `Docs are current` (exit 0)
- Confirmed `malloy` appears in **zero** gated Python surfaces, so `parity/goldenmatch.yaml` is unchanged
- End-to-end smoke: a non-unique join one-side key is caught (`max_fan_out=2.0`, `all_trustworthy=False`) via the auto-detected front door

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` clean; imports sorted
- [x] Package `CHANGELOG.md` updated (new dialect)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / ADR updated (0061 + planning + regenerated codemap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_