### PR TITLE
feat(fs): train from counted comparison vectors, and the distributed caller

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4143,6 +4143,7 @@
             "_build_tf_tables",
             "_calibrate_link_threshold",
             "_deconvolve_post_blocking_u",
+            "_em_iterate",
             "_em_ne_fields",
             "_embedding_pair_sims",
             "_emit_triu_pairs",
@@ -4233,6 +4234,7 @@
             "set_fs_label_anchors",
             "train_em",
             "train_em_continuous",
+            "train_em_from_counts",
             "train_em_per_pass",
             "vectorized_scorer_supported"
           ],

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4142,6 +4142,7 @@
             "_build_ne_matrix",
             "_build_tf_tables",
             "_calibrate_link_threshold",
+            "_combine_em_sessions",
             "_deconvolve_post_blocking_u",
             "_em_iterate",
             "_em_ne_fields",
@@ -4187,6 +4188,7 @@
             "_ne_scalar_contribution",
             "_ne_scorer_vectorizable",
             "_ne_u_probs_from_matrix",
+            "_neutral_u_for",
             "_otsu_threshold",
             "_record_concat_value",
             "_record_concat_values",
@@ -4206,6 +4208,7 @@
             "continuous_scores",
             "enforce_weight_monotonicity",
             "estimate_m_from_labels",
+            "estimate_u_from_counts",
             "explain_pair_fs",
             "fs_missing_mode",
             "fs_model_preloaded",
@@ -7916,6 +7919,8 @@
             "blocking_passes",
             "build_golden_from_rules",
             "generate_candidates",
+            "join_candidates_to_sources",
+            "pass_candidates",
             "run_config_pipeline",
             "score_candidates",
             "weighted_pair_score"
@@ -7956,13 +7961,19 @@
         {
           "module": "goldenmatch.spark.em",
           "file": "packages/python/goldenmatch/goldenmatch/spark/em.py",
-          "purpose": "Count agreement patterns on the cluster, so FS training need not sample.",
+          "purpose": "Fellegi-Sunter training on the cluster, with no pair sample anywhere.",
           "defines": [
+            "_refuse_unsupported",
+            "_rows_needed_for_n_pairs",
             "agreement_pattern_counts",
-            "gamma_columns"
+            "estimate_u_distributed",
+            "gamma_columns",
+            "random_pairs",
+            "train_em_distributed"
           ],
           "imports": [
             "goldenmatch.core.probabilistic",
+            "goldenmatch.spark.config_pipeline",
             "goldenmatch.spark.probabilistic"
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1205,6 +1205,165 @@ def _training_pair_conditioning(
     return fallback_pairs, [frozenset(blocking_fields)] * len(fallback_pairs)
 
 
+def estimate_u_from_counts(
+    mk: MatchkeyConfig,
+    pattern_counts: list[tuple[tuple[int, ...], int]],
+) -> dict[str, list[float]]:
+    """``u`` from COUNTED comparison vectors over random pairs.
+
+    ``u`` is the level distribution among NON-matches. Random pairs are
+    overwhelmingly non-matches, so their observed level distribution estimates
+    it directly -- no EM, which is why ``u`` is a separate computation from
+    ``m`` here and in Splink (``estimate_u.py``).
+
+    The estimator is ``train_em``'s, reached from counts instead of a matrix::
+
+        u[level] = (count(level) + 1e-6) / (observed + n_levels * 1e-6)
+
+    Both parts are sums over pairs, so collapsing identical vectors regroups the
+    terms without changing the totals -- the same aggregation property that lets
+    ``m`` be trained from counts.
+
+    ``observed`` excludes unobserved (``-1``) entries. A field null on one side
+    is missing data, not a disagreement, and putting those pairs in the
+    denominator would shrink every level of a sparse field toward zero and
+    inflate its ``log2(m/u)`` in proportion to how little data supports it.
+
+    ``pattern_counts`` must come from RANDOM (unblocked) pairs. Counts from
+    blocked candidates estimate the level distribution among pairs that already
+    agree on a blocking key, which is not ``u``, and the resulting weights would
+    be wrong with nothing about them looking wrong.
+    """
+    if not pattern_counts:
+        raise ValueError("pattern_counts is empty; nothing to estimate u from")
+
+    n_fields = len(mk.fields)
+    for vec, count in pattern_counts:
+        if len(vec) != n_fields:
+            raise ValueError(
+                f"comparison vector {vec} has {len(vec)} entries but the "
+                f"matchkey has {n_fields} fields -- the vectors must be ordered "
+                f"by mk.fields"
+            )
+        if count <= 0:
+            raise ValueError(f"pattern {vec} has non-positive count {count}")
+
+    u_probs: dict[str, list[float]] = {}
+    for j, f in enumerate(mk.fields):
+        counts = [0.0] * f.levels
+        observed = 0.0
+        for vec, c in pattern_counts:
+            level = vec[j]
+            if level < 0:
+                continue
+            observed += c
+            if level < f.levels:
+                counts[level] += c
+        total = observed + f.levels * 1e-6
+        u_probs[f.field] = [(c + 1e-6) / total for c in counts]
+    return u_probs
+
+
+def _neutral_u_for(field) -> list[float]:
+    """The fixed ``u`` prior for a field EM must not learn from random pairs.
+
+    A configured blocking field carries a deliberate prior (#1835): a
+    disagreement penalty that drives precision, and a BOUNDED agreement weight
+    that preserves recall. Estimating it from random pairs instead collapses a
+    near-unique key's ``u`` toward the smoothing floor, which explodes
+    ``log2(m/u)`` -- 28 bits on historical_50k -- and lets one field dominate
+    the score (measured F1 0.83 -> 0.57).
+
+    One definition, because both the pooled run and the per-pass combination
+    apply it, and two copies that drifted would differ only in the numbers a
+    blocking field's weights are built from.
+
+    The 3-level case is ``[0.34, 0.33, 0.33]`` rather than exact thirds: it is
+    the legacy prior, preserved so adopting this helper moves no model.
+    """
+    if field.levels == 2:
+        return [0.50, 0.50]  # neutral
+    if field.levels == 3:
+        return [0.34, 0.33, 0.33]
+    return [1.0 / field.levels] * field.levels
+
+
+def _combine_em_sessions(
+    mk: MatchkeyConfig,
+    sessions: list[tuple[tuple[str, ...], EMResult, float]],
+) -> EMResult:
+    """Combine independent per-pass EM sessions into one model.
+
+    ``sessions`` is ``(conditioned_fields, result, weight)``. Shared by
+    :func:`train_em_per_pass` and the distributed caller, which differ only in
+    HOW a session is trained -- from a sampled pair list or from counted
+    comparison vectors computed by a cluster. The combination itself is the same
+    question either way, and a second copy would drift silently: every variant
+    of it still returns valid probability vectors.
+
+    **m** is the pair-weighted mean over the sessions that could estimate the
+    field (those whose pass does not block on it), weighted because a pass
+    contributing 10 pairs and one contributing 10,000 are not equal evidence.
+    A field no session can estimate keeps the fixed prior every session gave it.
+
+    **u** is neutralised for the UNION of every pass's blocking fields, matching
+    ``train_em``'s ``always_conditioned |= set(blocking_fields)``. Taking one
+    session's ``u`` wholesale is wrong even though the sessions were all trained
+    against the same random-pair sample: each one neutralises only its OWN
+    blocking fields, so lifting the vector from session 0 leaves every other
+    pass's blocking field carrying the random-pair estimate and re-opens #1835
+    for it.
+    """
+    base = sessions[0][1]
+    blocking_union = {name for fields, _, _ in sessions for name in fields}
+
+    m_probs: dict[str, list[float]] = {}
+    for f in mk.fields:
+        name = f.field
+        estimable = [
+            (em, w) for fields, em, w in sessions
+            if name not in fields and name in em.m_probs
+        ]
+        if not estimable:
+            # No pass leaves this field free. Every session fell back to the
+            # fixed prior for it, so they agree and the first is as good as any
+            # -- and this is exactly the pooled run's `always_conditioned` case.
+            m_probs[name] = list(base.m_probs[name])
+            continue
+        total = sum(w for _, w in estimable)
+        n_levels = len(estimable[0][0].m_probs[name])
+        m_probs[name] = [
+            sum(em.m_probs[name][k] * w for em, w in estimable) / total
+            for k in range(n_levels)
+        ]
+
+    u_probs = {k: list(v) for k, v in base.u_probs.items()}
+    for f in mk.fields:
+        if f.field in blocking_union:
+            u_probs[f.field] = _neutral_u_for(f)
+
+    total_w = sum(w for _, _, w in sessions)
+    proportion = sum(em.proportion_matched * w for _, em, w in sessions) / total_w
+
+    match_weights = {
+        name: [
+            math.log2(max(m, 1e-10) / max(u, 1e-10))
+            for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
+        ]
+        for name in m_probs
+    }
+    return EMResult(
+        m_probs=m_probs,
+        u_probs=u_probs,
+        match_weights=match_weights,
+        converged=all(em.converged for _, em, _ in sessions),
+        iterations=max(em.iterations for _, em, _ in sessions),
+        proportion_matched=proportion,
+        tf_freqs=base.tf_freqs,
+        tf_collision=base.tf_collision,
+    )
+
+
 def train_em_from_counts(
     mk: MatchkeyConfig,
     pattern_counts: list[tuple[tuple[int, ...], int]],
@@ -1341,15 +1500,8 @@ def train_em_per_pass(
        produces. That is what makes the counts computable by a cluster and the
        iteration cheap, -- see ``pair_weights`` on :func:`train_em`.
 
-    Combination: a field's ``m`` is the pair-count-weighted mean of the sessions
-    that could estimate it (those whose pass does NOT block on it). A field no
-    session can estimate keeps whatever the sessions gave it, which is the fixed
-    prior -- the same treatment the pooled run's ``always_conditioned`` applies,
-    rather than a different answer for the same situation.
-
-    Weighted by pair count, not a plain mean: a pass contributing 10 pairs and
-    one contributing 10,000 are not equal evidence, and an unweighted mean would
-    let a tiny pass swing a field it barely observed.
+    Combination is :func:`_combine_em_sessions`, shared with the distributed
+    caller so the two cannot drift on what combining means.
 
     Args:
         blocks: ``BlockResult``s carrying ``blocking_fields`` provenance. Blocks
@@ -1390,51 +1542,7 @@ def train_em_per_pass(
     if not sessions:
         return train_em(df, mk, blocks=blocks, blocking_fields=blocking_fields, **kw)
 
-    base = sessions[0][1]
-    m_probs: dict[str, list[float]] = {}
-    for f in mk.fields:
-        name = f.field
-        estimable = [
-            (em, w) for fields, em, w in sessions
-            if name not in fields and name in em.m_probs
-        ]
-        if not estimable:
-            # No pass leaves this field free. Every session fell back to the
-            # fixed prior for it, so they agree and the first is as good as any
-            # -- and this is exactly the pooled run's `always_conditioned` case.
-            m_probs[name] = list(base.m_probs[name])
-            continue
-        total = sum(w for _, w in estimable)
-        n_levels = len(estimable[0][0].m_probs[name])
-        m_probs[name] = [
-            sum(em.m_probs[name][k] * w for em, w in estimable) / total
-            for k in range(n_levels)
-        ]
-
-    # u is estimated from RANDOM pairs, which do not depend on the pass, so the
-    # sessions agree by construction; taking the first states that rather than
-    # averaging identical numbers and implying they might differ.
-    u_probs = {k: list(v) for k, v in base.u_probs.items()}
-    total_w = sum(w for _, _, w in sessions)
-    proportion = sum(em.proportion_matched * w for _, em, w in sessions) / total_w
-
-    match_weights = {
-        name: [
-            math.log2(max(m, 1e-10) / max(u, 1e-10))
-            for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
-        ]
-        for name in m_probs
-    }
-    return EMResult(
-        m_probs=m_probs,
-        u_probs=u_probs,
-        match_weights=match_weights,
-        converged=all(em.converged for _, em, _ in sessions),
-        iterations=max(em.iterations for _, em, _ in sessions),
-        proportion_matched=proportion,
-        tf_freqs=base.tf_freqs,
-        tf_collision=base.tf_collision,
-    )
+    return _combine_em_sessions(mk, sessions)
 
 
 def _em_iterate(
@@ -1821,12 +1929,7 @@ def train_em(
     # which EM can learn it, so retain the legacy neutral-u/fixed-weight prior.
     for f in mk.fields:
         if f.field in always_conditioned:
-            if f.levels == 2:
-                u_probs[f.field] = [0.50, 0.50]  # neutral
-            elif f.levels == 3:
-                u_probs[f.field] = [0.34, 0.33, 0.33]
-            else:
-                u_probs[f.field] = [1.0 / f.levels] * f.levels
+            u_probs[f.field] = _neutral_u_for(f)
 
     logger.info("u-probabilities estimated from %d random pairs", len(random_pairs))
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1205,6 +1205,112 @@ def _training_pair_conditioning(
     return fallback_pairs, [frozenset(blocking_fields)] * len(fallback_pairs)
 
 
+def train_em_from_counts(
+    mk: MatchkeyConfig,
+    pattern_counts: list[tuple[tuple[int, ...], int]],
+    u_probs: dict[str, list[float]],
+    *,
+    conditioned_fields: Sequence[str] = (),
+    max_iterations: int = 20,
+    convergence: float = 0.001,
+) -> EMResult:
+    """Train FS from COUNTED comparison vectors instead of a pair sample.
+
+    The last link of ``compute gammas distributed -> GROUP BY them ->
+    train_em(pair_weights=counts)``. ``pattern_counts`` is what
+    :func:`goldenmatch.spark.em.agreement_pattern_counts` returns: one row per
+    distinct comparison vector, with how many pairs had it.
+
+    Calls the SAME :func:`_em_iterate` as :func:`train_em`, so this is not a
+    second EM -- it is the same loop reached without a sampler. The vectors are
+    ordered by ``mk.fields``, matching ``_build_comparison_matrix``.
+
+    Args:
+        u_probs: estimated from RANDOM (unblocked) pairs, which this function
+            does not see. Required rather than defaulted: u is half the
+            likelihood ratio, and inventing it here would produce a model whose
+            weights are wrong in a direction nobody could spot from the m
+            estimates. Splink keeps the same separation (``estimate_u.py``).
+        conditioned_fields: fields the blocking pass makes uninformative -- the
+            pass conditioning, constant within a session, which is exactly why
+            the counts needed no pass column.
+
+    Not supported here, and refused rather than ignored: negative evidence and
+    term-frequency adjustment. Both need per-pair inputs this function is not
+    given (an NE matrix, and the value frequencies), and silently dropping them
+    would train a different model from the one the config asks for.
+    """
+    if not pattern_counts:
+        raise ValueError("pattern_counts is empty; nothing to train on")
+    if _em_ne_fields(mk):
+        raise NotImplementedError(
+            f"matchkey {mk.name!r} has negative-evidence fields, which need a "
+            f"per-pair NE matrix that counted comparison vectors do not carry. "
+            f"Train it with train_em() on sampled pairs."
+        )
+    if any(getattr(f, "tf_adjustment", False) for f in mk.fields):
+        raise NotImplementedError(
+            f"matchkey {mk.name!r} uses term-frequency adjustment, which needs "
+            f"per-value frequencies that counted comparison vectors do not "
+            f"carry. Train it with train_em() on sampled pairs."
+        )
+
+    n_fields = len(mk.fields)
+    for vec, count in pattern_counts:
+        if len(vec) != n_fields:
+            raise ValueError(
+                f"comparison vector {vec} has {len(vec)} entries but the "
+                f"matchkey has {n_fields} fields -- the vectors must be ordered "
+                f"by mk.fields"
+            )
+        if count <= 0:
+            raise ValueError(f"pattern {vec} has non-positive count {count}")
+
+    comp_matrix = np.asarray([v for v, _ in pattern_counts], dtype=np.int64)
+    w = np.asarray([float(c) for _, c in pattern_counts], dtype=np.float64)
+    total_weight = float(w.sum())
+
+    conditioned = set(conditioned_fields)
+    conditioned_mask = np.asarray(
+        [[f.field in conditioned for f in mk.fields]] * len(pattern_counts),
+        dtype=bool,
+    )
+    # Constant across rows within a session, so a field conditioned by this
+    # pass is conditioned for every row -- the `always_conditioned` case, and
+    # the reason those fields keep the fixed prior rather than being learned
+    # from evidence the blocking removed.
+    always_conditioned = {f.field for f in mk.fields if f.field in conditioned}
+
+    empty_ne = np.zeros((len(pattern_counts), 0), dtype=np.int64)
+    m_probs, _m_ne, p_match, converged, iterations = _em_iterate(
+        mk, comp_matrix, empty_ne, conditioned_mask,
+        np.zeros((len(pattern_counts), 0), dtype=bool),
+        w, total_weight, [], u_probs, {}, always_conditioned, set(),
+        None, None, max_iterations, convergence,
+    )
+
+    match_weights = {
+        f.field: [
+            math.log2(max(m, 1e-10) / max(u, 1e-10))
+            for m, u in zip(m_probs[f.field], u_probs[f.field])
+        ]
+        for f in mk.fields
+        if f.field in m_probs and f.field in u_probs
+    }
+    logger.info(
+        "EM from counts: %d patterns, %.0f pairs, converged=%s in %d iterations",
+        len(pattern_counts), total_weight, converged, iterations,
+    )
+    return EMResult(
+        m_probs=m_probs,
+        u_probs={k: list(v) for k, v in u_probs.items()},
+        match_weights=match_weights,
+        converged=converged,
+        iterations=iterations,
+        proportion_matched=p_match,
+    )
+
+
 def train_em_per_pass(
     df: pl.DataFrame,
     mk: MatchkeyConfig,
@@ -1329,6 +1435,197 @@ def train_em_per_pass(
         tf_freqs=base.tf_freqs,
         tf_collision=base.tf_collision,
     )
+
+
+def _em_iterate(
+    mk: MatchkeyConfig,
+    comp_matrix,
+    ne_matrix,
+    conditioned_mask,
+    ne_conditioned_mask,
+    w,
+    total_weight: float,
+    ne_fields_em: list,
+    u_probs: dict[str, list[float]],
+    u_probs_ne: dict[str, list[float]],
+    always_conditioned: set,
+    always_conditioned_ne: set,
+    label_clamp_idx,
+    label_clamp_val,
+    max_iterations: int,
+    convergence: float,
+):
+    """The EM loop itself: seed m, iterate to convergence, return the estimates.
+
+    Extracted so there is ONE implementation of the iteration and two ways to
+    reach it -- from sampled pairs (:func:`train_em`) and from precomputed
+    comparison rows carrying counts (:func:`train_em_from_counts`). A second
+    copy would drift, and the drift would be invisible: both copies would go on
+    producing valid probability vectors.
+
+    It reads nothing it is not handed. Every input is a matrix over rows, a mask
+    over rows, or a fixed parameter -- which is exactly why the rows can be
+    counted somewhere else (a cluster) and passed in as ``w``.
+
+    Returns ``(m_probs, m_probs_ne, p_match, converged, iterations)``.
+    """
+    n_pairs = comp_matrix.shape[0]
+    # Initialize m with strong priors (matches mostly agree at highest level)
+    p_match = 0.02  # conservative prior
+    m_probs = {}
+    for j, f in enumerate(mk.fields):
+        n_levels = f.levels
+        # Exponential prior: highest level gets most mass
+        raw = [2 ** k for k in range(n_levels)]
+        total = sum(raw)
+        m_probs[f.field] = [r / total for r in raw]
+
+    # NE dims: fired is rare in matches (a true match usually agrees on the
+    # NE field), so seed m with a low fired-probability prior.
+    m_probs_ne: dict[str, list[float]] = {ne.field: [0.05, 0.95] for ne in ne_fields_em}
+
+    # Pair weights. `None` -> all ones, which is the pair-wise caller and is
+    # bit-identical to the unweighted arithmetic it replaces (x*1.0 == x).
+    # An aggregated caller passes one row per DISTINCT (comparison vector,
+    # conditioning, NE vector) with its count, which is exact rather than a
+    # sample: the E-step reads only those three things, so identical rows have
+    # identical posteriors and every M-step sum is linear in the count.
+    #
+    # Bounded, too: the number of distinct rows is at most the product over
+    # fields of (levels + 1), times the number of blocking passes -- thousands,
+    # not millions -- which is what lets the comparison vectors be counted
+    # anywhere (a cluster, say) and the iteration run on the result.
+    #
+    # WEIGHTS ARE COUNTS, and the scale is load-bearing. The M-step smoothing
+    #
+    #     new_m[level] = (sum + 1e-6) / (eligible_match + n_levels * 1e-6)
+    #
+    # is additive and unscaled, so its influence shrinks as the weighted totals
+    # grow -- correct for a prior, and it means doubling every weight is NOT a
+    # no-op. Aggregation is exact only because collapsing identical rows
+    # regroups the terms of each sum WITHOUT changing the total: the represented
+    # population is the same, so the smoothing constant weighs the same. Pass
+    # normalised or rescaled weights and the low-probability cells shift, which
+    # is where log2(m/u) is largest and the shift is least visible.
+    # Pinned by tests/test_fs_em_weighted_pairs.py.
+    # ── Step 3: EM iterations — only update m, fix u ──
+    converged = False
+    for iteration in range(max_iterations):
+        old_m = {k: list(v) for k, v in m_probs.items()}
+        old_m_ne = {k: list(v) for k, v in m_probs_ne.items()}
+
+        # E-step: compute posterior P(match | comparison vector).
+        # Vectorized over pairs (this was the FS-training bottleneck: a
+        # per-pair Python loop with math.log/exp -- ~1.1s of a 1.46s
+        # train_em at n_sample_pairs=10000). Per-field log-prob lookup tables
+        # are gathered by level and summed left-to-right (j = 0..n_fields-1),
+        # matching the scalar accumulation order so results stay
+        # bit-identical to the loop it replaces.
+        log_m = np.zeros(n_pairs)
+        log_u = np.zeros(n_pairs)
+        for j, f in enumerate(mk.fields):
+            levels_j = comp_matrix[:, j]
+            observed = levels_j >= 0
+            m_table = np.log(np.maximum(np.asarray(m_probs[f.field], dtype=np.float64), 1e-10))
+            u_table = np.log(np.maximum(np.asarray(u_probs[f.field], dtype=np.float64), 1e-10))
+            # Compose #1819 (unobserved: level -1 carries no evidence) with
+            # #1835 (pass-conditioned pairs carry no evidence for this field).
+            eligible = observed & ~conditioned_mask[:, j]
+            log_m[eligible] += m_table[levels_j[eligible]]
+            log_u[eligible] += u_table[levels_j[eligible]]
+
+        # NE dims: same E-step accumulation, 2-entry [fired, not_fired]
+        # lookup tables indexed by the NE matrix's {0, 1} columns.
+        for j, ne in enumerate(ne_fields_em):
+            levels_j = ne_matrix[:, j]
+            m_table = np.log(np.maximum(np.asarray(m_probs_ne[ne.field], dtype=np.float64), 1e-10))
+            u_table = np.log(np.maximum(np.asarray(u_probs_ne[ne.field], dtype=np.float64), 1e-10))
+            eligible = ~ne_conditioned_mask[:, j]
+            log_m[eligible] += m_table[levels_j[eligible]]
+            log_u[eligible] += u_table[levels_j[eligible]]
+
+        log_match = math.log(max(p_match, 1e-10)) + log_m
+        log_nonmatch = math.log(max(1 - p_match, 1e-10)) + log_u
+
+        max_log = np.maximum(log_match, log_nonmatch)
+        e_match = np.exp(log_match - max_log)
+        e_nonmatch = np.exp(log_nonmatch - max_log)
+        posteriors = e_match / (e_match + e_nonmatch)
+
+        # Semi-supervised clamp: pin labeled anchors' responsibility to the
+        # label so the M-step re-estimates m (and p_match) with those pairs as
+        # ground truth. u stays fixed from the random-pair estimate, exactly as
+        # in unsupervised EM. No-op when no anchors were supplied.
+        if label_clamp_idx is not None:
+            posteriors[label_clamp_idx] = label_clamp_val
+
+        # M-step: update ONLY m_probs and p_match (u is fixed)
+        #
+        # Every quantity below is a SUM OVER PAIRS, which is the whole reason
+        # `pair_weights` can exist: two pairs with the same comparison vector,
+        # the same pass conditioning and the same NE vector contribute
+        # identically to every one of them, so they can be collapsed into one
+        # row carrying a count. `w` is all-ones for the pair-wise caller, and
+        # the aggregated caller passes the counts. Same arithmetic either way.
+        wp = posteriors * w
+        total_match = wp.sum()
+        p_match = max(total_match / total_weight, 1e-6)
+
+        for j, f in enumerate(mk.fields):
+            if f.field in always_conditioned:
+                continue  # skip blocked fields
+            n_levels = f.levels
+            # Compose #1819 + #1835: a pair contributes to this field's m
+            # only when the comparison was OBSERVED (level >= 0) and the pair
+            # is not conditioned out of this field for its pass.
+            observed = comp_matrix[:, j] >= 0
+            eligible = observed & ~conditioned_mask[:, j]
+            eligible_match = wp[eligible].sum()
+            new_m = [0.0] * n_levels
+            for level in range(n_levels):
+                mask = eligible & (comp_matrix[:, j] == level)
+                new_m[level] = (wp[mask].sum() + 1e-6) / (
+                    eligible_match + n_levels * 1e-6
+                )
+            m_probs[f.field] = new_m
+
+        # NE dimensions use the same pair-level conditioning. A field that
+        # blocks one pass can still learn its veto from the other passes.
+        for j, ne in enumerate(ne_fields_em):
+            if ne.field in always_conditioned_ne:
+                continue
+            new_m_ne = [0.0, 0.0]
+            eligible = ~ne_conditioned_mask[:, j]
+            eligible_match = wp[eligible].sum()
+            for level in range(2):
+                mask = eligible & (ne_matrix[:, j] == level)
+                new_m_ne[level] = (wp[mask].sum() + 1e-6) / (
+                    eligible_match + 2 * 1e-6
+                )
+            m_probs_ne[ne.field] = new_m_ne
+
+        # Check convergence (only m changes)
+        max_delta = 0.0
+        for f in mk.fields:
+            if f.field in always_conditioned:
+                continue
+            for k in range(f.levels):
+                max_delta = max(max_delta, abs(m_probs[f.field][k] - old_m[f.field][k]))
+        for ne in ne_fields_em:
+            if ne.field in always_conditioned_ne:
+                continue
+            for k in range(2):
+                max_delta = max(max_delta, abs(m_probs_ne[ne.field][k] - old_m_ne[ne.field][k]))
+
+        if max_delta < convergence:
+            converged = True
+            logger.info("EM converged after %d iterations (delta=%.6f)", iteration + 1, max_delta)
+            break
+
+    if not converged:
+        logger.warning("EM did not converge after %d iterations (delta=%.6f)", max_iterations, max_delta)
+
+    return m_probs, m_probs_ne, p_match, converged, iteration + 1
 
 
 def train_em(
@@ -1573,44 +1870,6 @@ def train_em(
             label_clamp_val = np.asarray(vals, dtype=np.float64)
             logger.info("EM using %d semi-supervised label anchors", len(idxs))
 
-    # Initialize m with strong priors (matches mostly agree at highest level)
-    p_match = 0.02  # conservative prior
-    m_probs = {}
-    for j, f in enumerate(mk.fields):
-        n_levels = f.levels
-        # Exponential prior: highest level gets most mass
-        raw = [2 ** k for k in range(n_levels)]
-        total = sum(raw)
-        m_probs[f.field] = [r / total for r in raw]
-
-    # NE dims: fired is rare in matches (a true match usually agrees on the
-    # NE field), so seed m with a low fired-probability prior.
-    m_probs_ne: dict[str, list[float]] = {ne.field: [0.05, 0.95] for ne in ne_fields_em}
-
-    # Pair weights. `None` -> all ones, which is the pair-wise caller and is
-    # bit-identical to the unweighted arithmetic it replaces (x*1.0 == x).
-    # An aggregated caller passes one row per DISTINCT (comparison vector,
-    # conditioning, NE vector) with its count, which is exact rather than a
-    # sample: the E-step reads only those three things, so identical rows have
-    # identical posteriors and every M-step sum is linear in the count.
-    #
-    # Bounded, too: the number of distinct rows is at most the product over
-    # fields of (levels + 1), times the number of blocking passes -- thousands,
-    # not millions -- which is what lets the comparison vectors be counted
-    # anywhere (a cluster, say) and the iteration run on the result.
-    #
-    # WEIGHTS ARE COUNTS, and the scale is load-bearing. The M-step smoothing
-    #
-    #     new_m[level] = (sum + 1e-6) / (eligible_match + n_levels * 1e-6)
-    #
-    # is additive and unscaled, so its influence shrinks as the weighted totals
-    # grow -- correct for a prior, and it means doubling every weight is NOT a
-    # no-op. Aggregation is exact only because collapsing identical rows
-    # regroups the terms of each sum WITHOUT changing the total: the represented
-    # population is the same, so the smoothing constant weighs the same. Pass
-    # normalised or rescaled weights and the low-probability cells shift, which
-    # is where log2(m/u) is largest and the shift is least visible.
-    # Pinned by tests/test_fs_em_weighted_pairs.py.
     if pair_weights is None:
         w = np.ones(n_pairs, dtype=np.float64)
     else:
@@ -1624,122 +1883,14 @@ def train_em(
             raise ValueError("pair_weights must all be positive")
     total_weight = float(w.sum())
 
-    # ── Step 3: EM iterations — only update m, fix u ──
-    converged = False
-    for iteration in range(max_iterations):
-        old_m = {k: list(v) for k, v in m_probs.items()}
-        old_m_ne = {k: list(v) for k, v in m_probs_ne.items()}
-
-        # E-step: compute posterior P(match | comparison vector).
-        # Vectorized over pairs (this was the FS-training bottleneck: a
-        # per-pair Python loop with math.log/exp -- ~1.1s of a 1.46s
-        # train_em at n_sample_pairs=10000). Per-field log-prob lookup tables
-        # are gathered by level and summed left-to-right (j = 0..n_fields-1),
-        # matching the scalar accumulation order so results stay
-        # bit-identical to the loop it replaces.
-        log_m = np.zeros(n_pairs)
-        log_u = np.zeros(n_pairs)
-        for j, f in enumerate(mk.fields):
-            levels_j = comp_matrix[:, j]
-            observed = levels_j >= 0
-            m_table = np.log(np.maximum(np.asarray(m_probs[f.field], dtype=np.float64), 1e-10))
-            u_table = np.log(np.maximum(np.asarray(u_probs[f.field], dtype=np.float64), 1e-10))
-            # Compose #1819 (unobserved: level -1 carries no evidence) with
-            # #1835 (pass-conditioned pairs carry no evidence for this field).
-            eligible = observed & ~conditioned_mask[:, j]
-            log_m[eligible] += m_table[levels_j[eligible]]
-            log_u[eligible] += u_table[levels_j[eligible]]
-
-        # NE dims: same E-step accumulation, 2-entry [fired, not_fired]
-        # lookup tables indexed by the NE matrix's {0, 1} columns.
-        for j, ne in enumerate(ne_fields_em):
-            levels_j = ne_matrix[:, j]
-            m_table = np.log(np.maximum(np.asarray(m_probs_ne[ne.field], dtype=np.float64), 1e-10))
-            u_table = np.log(np.maximum(np.asarray(u_probs_ne[ne.field], dtype=np.float64), 1e-10))
-            eligible = ~ne_conditioned_mask[:, j]
-            log_m[eligible] += m_table[levels_j[eligible]]
-            log_u[eligible] += u_table[levels_j[eligible]]
-
-        log_match = math.log(max(p_match, 1e-10)) + log_m
-        log_nonmatch = math.log(max(1 - p_match, 1e-10)) + log_u
-
-        max_log = np.maximum(log_match, log_nonmatch)
-        e_match = np.exp(log_match - max_log)
-        e_nonmatch = np.exp(log_nonmatch - max_log)
-        posteriors = e_match / (e_match + e_nonmatch)
-
-        # Semi-supervised clamp: pin labeled anchors' responsibility to the
-        # label so the M-step re-estimates m (and p_match) with those pairs as
-        # ground truth. u stays fixed from the random-pair estimate, exactly as
-        # in unsupervised EM. No-op when no anchors were supplied.
-        if label_clamp_idx is not None:
-            posteriors[label_clamp_idx] = label_clamp_val
-
-        # M-step: update ONLY m_probs and p_match (u is fixed)
-        #
-        # Every quantity below is a SUM OVER PAIRS, which is the whole reason
-        # `pair_weights` can exist: two pairs with the same comparison vector,
-        # the same pass conditioning and the same NE vector contribute
-        # identically to every one of them, so they can be collapsed into one
-        # row carrying a count. `w` is all-ones for the pair-wise caller, and
-        # the aggregated caller passes the counts. Same arithmetic either way.
-        wp = posteriors * w
-        total_match = wp.sum()
-        p_match = max(total_match / total_weight, 1e-6)
-
-        for j, f in enumerate(mk.fields):
-            if f.field in always_conditioned:
-                continue  # skip blocked fields
-            n_levels = f.levels
-            # Compose #1819 + #1835: a pair contributes to this field's m
-            # only when the comparison was OBSERVED (level >= 0) and the pair
-            # is not conditioned out of this field for its pass.
-            observed = comp_matrix[:, j] >= 0
-            eligible = observed & ~conditioned_mask[:, j]
-            eligible_match = wp[eligible].sum()
-            new_m = [0.0] * n_levels
-            for level in range(n_levels):
-                mask = eligible & (comp_matrix[:, j] == level)
-                new_m[level] = (wp[mask].sum() + 1e-6) / (
-                    eligible_match + n_levels * 1e-6
-                )
-            m_probs[f.field] = new_m
-
-        # NE dimensions use the same pair-level conditioning. A field that
-        # blocks one pass can still learn its veto from the other passes.
-        for j, ne in enumerate(ne_fields_em):
-            if ne.field in always_conditioned_ne:
-                continue
-            new_m_ne = [0.0, 0.0]
-            eligible = ~ne_conditioned_mask[:, j]
-            eligible_match = wp[eligible].sum()
-            for level in range(2):
-                mask = eligible & (ne_matrix[:, j] == level)
-                new_m_ne[level] = (wp[mask].sum() + 1e-6) / (
-                    eligible_match + 2 * 1e-6
-                )
-            m_probs_ne[ne.field] = new_m_ne
-
-        # Check convergence (only m changes)
-        max_delta = 0.0
-        for f in mk.fields:
-            if f.field in always_conditioned:
-                continue
-            for k in range(f.levels):
-                max_delta = max(max_delta, abs(m_probs[f.field][k] - old_m[f.field][k]))
-        for ne in ne_fields_em:
-            if ne.field in always_conditioned_ne:
-                continue
-            for k in range(2):
-                max_delta = max(max_delta, abs(m_probs_ne[ne.field][k] - old_m_ne[ne.field][k]))
-
-        if max_delta < convergence:
-            converged = True
-            logger.info("EM converged after %d iterations (delta=%.6f)", iteration + 1, max_delta)
-            break
-
-    if not converged:
-        logger.warning("EM did not converge after %d iterations (delta=%.6f)", max_iterations, max_delta)
+    (
+        m_probs, m_probs_ne, p_match, converged, _em_iterations
+    ) = _em_iterate(
+        mk, comp_matrix, ne_matrix, conditioned_mask, ne_conditioned_mask,
+        w, total_weight, ne_fields_em, u_probs, u_probs_ne,
+        always_conditioned, always_conditioned_ne,
+        label_clamp_idx, label_clamp_val, max_iterations, convergence,
+    )
 
     # Compute match weights: log2(m/u)
     # For blocking fields, use fixed priors since EM can't learn from
@@ -1834,7 +1985,7 @@ def train_em(
         u_probs=u_probs,
         match_weights=match_weights,
         converged=converged,
-        iterations=min(iteration + 1, max_iterations) if not converged else iteration + 1,
+        iterations=_em_iterations,
         proportion_matched=p_match,
         tf_freqs=tf_freqs,
         tf_collision=tf_collision,

--- a/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
@@ -285,6 +285,71 @@ def blocking_passes(config: Any) -> list[Any]:
     return list(blocking.keys or [])
 
 
+def pass_candidates(
+    source_df: Any,
+    key_config: Any,
+    *,
+    id_col: str,
+    transform_udf: str | None = None,
+) -> Any:
+    """Candidate pairs ``(a, b)``, ``a < b``, from ONE blocking pass.
+
+    Split out of :func:`generate_candidates` because FS training needs the
+    passes separately -- a per-pass EM session is defined by the pass whose
+    conditioning it carries, and a union has lost that. Training against a
+    different candidate set from the one scoring uses would fit a model to a
+    population scoring never sees, so both go through this.
+    """
+    from pyspark.sql import functions as F
+
+    key_col, _fields = _block_key_column(key_config, transform_udf)
+    keyed = source_df.withColumn("__block_key__", key_col)
+    keyed = keyed.where(_valid_key(F.col("__block_key__")))
+    a = keyed.alias("a")
+    b = keyed.alias("b")
+    return a.join(
+        b,
+        (F.col("a.__block_key__") == F.col("b.__block_key__"))
+        & (F.col(f"a.{id_col}") < F.col(f"b.{id_col}")),
+    ).select(
+        F.col(f"a.{id_col}").alias("a"),
+        F.col(f"b.{id_col}").alias("b"),
+    )
+
+
+#: The source aliases a joined candidate frame carries. NOT "a"/"b": the
+#: candidate frame's own columns are named `a` and `b`, so `F.col("a.first")`
+#: would be ambiguous between "alias a, column first" and a field of a
+#: struct-ish `a`. Distinct sentinel aliases remove the question rather than
+#: relying on resolution order.
+CAND_LHS, CAND_RHS = "__lhs__", "__rhs__"
+
+
+def join_candidates_to_sources(
+    candidates: Any, source_df: Any, *, id_col: str
+) -> Any:
+    """Join ``(a, b)`` candidates back to both record sides.
+
+    Shared by scoring and FS training: the field expressions both build resolve
+    against these aliases, so a second copy of this join that named its sides
+    differently would not fail -- it would silently resolve columns to the wrong
+    side of the pair.
+    """
+    from pyspark.sql import functions as F
+
+    return (
+        candidates.alias("__cand__")
+        .join(
+            source_df.alias(CAND_LHS),
+            F.col(f"{CAND_LHS}.{id_col}") == F.col("__cand__.a"),
+        )
+        .join(
+            source_df.alias(CAND_RHS),
+            F.col(f"{CAND_RHS}.{id_col}") == F.col("__cand__.b"),
+        )
+    )
+
+
 def generate_candidates(
     source_df: Any, config: Any, *, id_col: str, transform_udf: str | None = None
 ) -> Any:
@@ -303,22 +368,10 @@ def generate_candidates(
     it. Hence the kernel refuses any chain it cannot run identically instead of
     falling back.
     """
-    from pyspark.sql import functions as F
-
     per_pass = []
     for i, key_config in enumerate(blocking_passes(config)):
-        key_col, _fields = _block_key_column(key_config, transform_udf)
-        keyed = source_df.withColumn("__block_key__", key_col)
-        keyed = keyed.where(_valid_key(F.col("__block_key__")))
-        a = keyed.alias("a")
-        b = keyed.alias("b")
-        pairs = a.join(
-            b,
-            (F.col("a.__block_key__") == F.col("b.__block_key__"))
-            & (F.col(f"a.{id_col}") < F.col(f"b.{id_col}")),
-        ).select(
-            F.col(f"a.{id_col}").alias("a"),
-            F.col(f"b.{id_col}").alias("b"),
+        pairs = pass_candidates(
+            source_df, key_config, id_col=id_col, transform_udf=transform_udf
         )
         logger.debug("Spark tier: blocking pass %d on %s", i, key_config.fields)
         per_pass.append(pairs)
@@ -508,18 +561,8 @@ def score_candidates(
     """
     from pyspark.sql import functions as F
 
-    # The source aliases must NOT be "a"/"b": the candidate frame's own columns
-    # are named `a` and `b`, so `F.col("a.first")` would be ambiguous between
-    # "alias a, column first" and a field of a struct-ish `a`. Distinct sentinel
-    # aliases remove the question rather than relying on resolution order.
-    lhs, rhs = "__lhs__", "__rhs__"
-    a = source_df.alias(lhs)
-    b = source_df.alias(rhs)
-    joined = (
-        candidates.alias("__cand__")
-        .join(a, F.col(f"{lhs}.{id_col}") == F.col("__cand__.a"))
-        .join(b, F.col(f"{rhs}.{id_col}") == F.col("__cand__.b"))
-    )
+    lhs, rhs = CAND_LHS, CAND_RHS
+    joined = join_candidates_to_sources(candidates, source_df, id_col=id_col)
 
     if scorer_udf is not None:
         if scorer_shape not in ("row", "batch"):

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -173,15 +173,30 @@ def random_pairs(
 ) -> Any:
     """A joined frame of RANDOM record pairs, for estimating ``u``.
 
-    Sampled and then cross-joined, rather than cross-joined and then sampled:
-    the full cross join is quadratic in the table and is not something to
-    materialise on the way to a sample of it.
+    Sampled and then self-joined, rather than joined and then sampled: the full
+    cross join is quadratic in the table and is not something to materialise on
+    the way to a sample of it.
 
-    ``sample`` and not ``limit``: ``limit`` takes whatever rows the scan reaches
-    first, which correlates with input order. On a file sorted by name that
-    draws every pair from one corner of the data, and ``u`` -- the level
-    distribution among non-matches -- would be measured on a population that is
-    unusually likely to agree. It would look like a working estimate.
+    Not ``limit``: ``limit`` takes whatever rows the scan reaches first, which
+    correlates with input order. On a file sorted by name that draws every pair
+    from one corner of the data, and ``u`` -- the level distribution among
+    NON-matches -- would be measured on a population unusually likely to agree.
+    It would look like a working estimate.
+
+    Not ``DataFrame.sample`` either, and this one is subtler. Both sides of the
+    self-join reference the same plan, so the sampler is evaluated twice; it is
+    seeded per partition, so the two evaluations agree **as long as the two
+    scans partition identically**. That holds in practice and is not guaranteed
+    -- AQE, a differing shuffle, or one side being cached would break it. If it
+    ever did break, the join would pair rows from two different samples and
+    still return a complete, plausible set of probabilities.
+
+    A hash of the id is deterministic per ROW rather than per partition, so the
+    question does not arise. ``xxhash64`` is uniform enough to select on
+    directly, and folding the seed in keeps the sample reproducible and
+    steerable. The cost is that the size is binomial around the target rather
+    than exact -- about +/-3% of the rows at the default budget, so +/-5% of the
+    pairs, which is noise against a level distribution.
     """
     total = source_df.count()
     if total < 2:
@@ -199,12 +214,14 @@ def random_pairs(
     if want >= total:
         sample = source_df
     else:
-        # Oversample by 10% then cap: `sample` draws each row independently, so
-        # the size is binomial around the fraction and a bare fraction lands
-        # under target about half the time.
-        fraction = min(1.0, (want / total) * 1.1)
-        sample = source_df.sample(withReplacement=False, fraction=fraction, seed=seed)
-        sample = sample.limit(want)
+        # `pmod` and not `abs`: hashing can return the minimum int64, whose
+        # absolute value is not representable and comes back negative -- which
+        # would silently exclude those rows from every sample.
+        buckets = 1 << 31
+        h = F.pmod(
+            F.xxhash64(F.col(id_col), F.lit(int(seed))), F.lit(buckets)
+        )
+        sample = source_df.where(h < F.lit(float(want) / total * buckets))
 
     a = sample.alias(lhs)
     b = sample.alias(rhs)

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -1,23 +1,28 @@
-"""Count agreement patterns on the cluster, so FS training need not sample.
+"""Fellegi-Sunter training on the cluster, with no pair sample anywhere.
 
-## The chain this is one link of
+## The chain, complete
 
 EM's E-step reads only the comparison vector (a level per field), so pairs with
 the same vector are interchangeable and every M-step quantity is a sum that is
 linear in how many pairs share it. That makes training decomposable into:
 
-    compute gammas distributed  ->  GROUP BY them  ->  train_em(pair_weights=counts)
+    compute gammas distributed  ->  GROUP BY them  ->  train from the counts
 
-This module is the first two. The third is ``core.probabilistic.train_em``'s
-``pair_weights``, and the per-pass split it runs under is
-``train_em_per_pass``.
+:func:`agreement_pattern_counts` is the first two steps; the third is
+``core.probabilistic.train_em_from_counts``. :func:`train_em_distributed` is the
+caller that strings them together, one session per blocking pass, over a ``u``
+that :func:`estimate_u_distributed` counts the same way from random pairs.
 
-Splink does exactly this -- ``count_agreement_patterns_sql`` is
+What this replaces is the INPUT to the iteration, not the iteration. ``train_em``
+reads a driver-side sample of blocked pairs capped by ``n_sample_pairs``, and
+that cap is why a bigger cluster has never bought a better-trained model.
+
+Splink does the same decomposition -- ``count_agreement_patterns_sql`` is
 ``select {gammas}, count(*) group by {gammas}`` -- and then runs the iteration
 itself as engine-side SQL. This does the counting in the engine and leaves the
 iteration on the driver, which is a real difference and is stated rather than
-glossed: what it buys is that the iteration's input stops being a sample and
-stops being proportional to the pair count.
+glossed: the iteration's input is bounded by the number of distinct comparison
+vectors, so leaving it on the driver costs nothing that grows with the data.
 
 ## Why the result is small
 
@@ -141,3 +146,247 @@ def agreement_pattern_counts(
         len(out), total, 100.0 * len(out) / max(total, 1),
     )
     return out
+
+
+# ── u: the half of the likelihood ratio blocking cannot supply ───────
+
+
+def _rows_needed_for_n_pairs(n_pairs: int) -> int:
+    """Rows whose self-pairing yields about ``n_pairs``.
+
+    The inverse of ``p(r) = r(r-1)/2``, solved for ``r``. Splink's
+    ``estimate_u.py`` sizes its sample the same way, for the same reason: a
+    cross join is quadratic, so the knob a caller wants to turn is the pair
+    budget, and the row count is derived from it rather than guessed.
+    """
+    return max(2, int(0.5 * ((8 * n_pairs + 1) ** 0.5 + 1)))
+
+
+def random_pairs(
+    source_df: Any,
+    *,
+    id_col: str,
+    max_pairs: int = 1_000_000,
+    seed: int = 42,
+    lhs: str | None = None,
+    rhs: str | None = None,
+) -> Any:
+    """A joined frame of RANDOM record pairs, for estimating ``u``.
+
+    Sampled and then cross-joined, rather than cross-joined and then sampled:
+    the full cross join is quadratic in the table and is not something to
+    materialise on the way to a sample of it.
+
+    ``sample`` and not ``limit``: ``limit`` takes whatever rows the scan reaches
+    first, which correlates with input order. On a file sorted by name that
+    draws every pair from one corner of the data, and ``u`` -- the level
+    distribution among non-matches -- would be measured on a population that is
+    unusually likely to agree. It would look like a working estimate.
+    """
+    total = source_df.count()
+    if total < 2:
+        raise ValueError(
+            f"u needs at least 2 records to form a pair; the source has {total}"
+        )
+
+    from pyspark.sql import functions as F
+
+    from goldenmatch.spark.config_pipeline import CAND_LHS, CAND_RHS
+
+    lhs = lhs or CAND_LHS
+    rhs = rhs or CAND_RHS
+    want = _rows_needed_for_n_pairs(max_pairs)
+    if want >= total:
+        sample = source_df
+    else:
+        # Oversample by 10% then cap: `sample` draws each row independently, so
+        # the size is binomial around the fraction and a bare fraction lands
+        # under target about half the time.
+        fraction = min(1.0, (want / total) * 1.1)
+        sample = source_df.sample(withReplacement=False, fraction=fraction, seed=seed)
+        sample = sample.limit(want)
+
+    a = sample.alias(lhs)
+    b = sample.alias(rhs)
+    return a.join(b, F.col(f"{lhs}.{id_col}") < F.col(f"{rhs}.{id_col}"))
+
+
+def estimate_u_distributed(
+    source_df: Any,
+    mk: Any,
+    *,
+    id_col: str,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+    max_pairs: int = 1_000_000,
+    seed: int = 42,
+    max_patterns: int = MAX_PATTERNS,
+) -> dict[str, list[float]]:
+    """``u`` estimated on the cluster, from random pairs.
+
+    The same two steps as ``m``: count agreement patterns distributed, then do
+    the arithmetic on the small counted result. ``u`` needs no EM at all -- it
+    is one pass of counting -- so this is ``agreement_pattern_counts`` over a
+    random-pair frame handed to
+    :func:`goldenmatch.core.probabilistic.estimate_u_from_counts`.
+
+    Reusing the same counter is the point. ``u`` and ``m`` must be measured
+    against the SAME definition of a level, or ``log2(m/u)`` divides two numbers
+    that are not about the same partition of the data. Deriving both from
+    ``gamma_columns`` makes that true by construction instead of by review.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+
+    joined = random_pairs(
+        source_df, id_col=id_col, max_pairs=max_pairs, seed=seed
+    )
+    from goldenmatch.spark.config_pipeline import CAND_LHS, CAND_RHS
+
+    counts = agreement_pattern_counts(
+        joined, mk, lhs=CAND_LHS, rhs=CAND_RHS,
+        scorer_udf=scorer_udf, transform_udf=transform_udf,
+        max_patterns=max_patterns,
+    )
+    n_pairs = sum(c for _, c in counts)
+    logger.info(
+        "FS u: estimated from %d random pairs (%d distinct patterns)",
+        n_pairs, len(counts),
+    )
+    return estimate_u_from_counts(mk, counts)
+
+
+# ── the caller: every link, strung together ──────────────────────────
+
+
+def train_em_distributed(
+    source_df: Any,
+    config: Any,
+    mk: Any,
+    *,
+    id_col: str,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+    u_max_pairs: int = 1_000_000,
+    seed: int = 42,
+    max_iterations: int = 20,
+    convergence: float = 0.001,
+    max_patterns: int = MAX_PATTERNS,
+) -> Any:
+    """Train one matchkey's FS model with no pair sample anywhere.
+
+    The whole chain, in the order the links were built::
+
+        u   <- count gammas over RANDOM pairs        -> estimate_u_from_counts
+        m   <- count gammas per BLOCKING PASS        -> train_em_from_counts
+        one <- combine the per-pass sessions         -> _combine_em_sessions
+
+    What this changes versus ``train_em`` is the input to the iteration, not the
+    iteration: ``train_em`` reads a driver-side sample of blocked pairs, capped
+    by ``n_sample_pairs``, and that cap is the reason a bigger cluster has never
+    bought a better-trained model. Here every pair the blocking produces is
+    counted by the engine, and what reaches the driver is one row per distinct
+    comparison vector -- bounded by ``prod(levels + 1)``, so thousands of rows
+    whether the passes generated a million pairs or ten billion.
+
+    One matchkey per call, because a matchkey is the unit a comparison vector is
+    defined by. A config with several gets several calls and several models,
+    which is the shape ``fs_models`` already takes.
+
+    Returns an ``EMResult``, the same type ``train_em`` returns, usable anywhere
+    a model trained on one box is.
+    """
+    from goldenmatch.core.probabilistic import (
+        _combine_em_sessions,
+        train_em_from_counts,
+    )
+    from goldenmatch.spark.config_pipeline import (
+        CAND_LHS,
+        CAND_RHS,
+        blocking_passes,
+        join_candidates_to_sources,
+        pass_candidates,
+    )
+
+    # Refuse BEFORE submitting anything. `train_em_from_counts` rejects these
+    # too, but reaching that check costs a distributed count over every blocking
+    # pass first -- a config error should not cost a cluster job to discover.
+    _refuse_unsupported(mk)
+
+    passes = blocking_passes(config)
+    if not passes:
+        raise ValueError(
+            "train_em_distributed needs at least one blocking pass "
+            "(config.blocking.keys, or config.blocking.passes for multi_pass); "
+            "without one there are no candidate pairs to estimate m from"
+        )
+
+    u_probs = estimate_u_distributed(
+        source_df, mk, id_col=id_col, scorer_udf=scorer_udf,
+        transform_udf=transform_udf, max_pairs=u_max_pairs, seed=seed,
+        max_patterns=max_patterns,
+    )
+
+    sessions = []
+    for i, key_config in enumerate(passes):
+        fields = tuple(key_config.fields)
+        candidates = pass_candidates(
+            source_df, key_config, id_col=id_col, transform_udf=transform_udf
+        )
+        joined = join_candidates_to_sources(
+            candidates, source_df, id_col=id_col
+        )
+        counts = agreement_pattern_counts(
+            joined, mk, lhs=CAND_LHS, rhs=CAND_RHS,
+            scorer_udf=scorer_udf, transform_udf=transform_udf,
+            max_patterns=max_patterns,
+        )
+        if not counts:
+            # A pass whose every key was null or a missing sentinel produces no
+            # candidates. Skipping is right, and saying so matters: silently
+            # dropping a pass would leave the fields only IT could estimate
+            # sitting on the fixed prior with nothing indicating why.
+            logger.warning(
+                "FS EM: blocking pass %d on %s produced no candidate pairs; "
+                "it contributes no session", i, list(fields),
+            )
+            continue
+        em = train_em_from_counts(
+            mk, counts, u_probs, conditioned_fields=fields,
+            max_iterations=max_iterations, convergence=convergence,
+        )
+        # Weighted by the EXACT pair count, which the counts already carry --
+        # the one-box `train_em_per_pass` has to approximate this with block row
+        # counts because its sampler decides how many pairs it actually draws.
+        weight = float(sum(c for _, c in counts))
+        sessions.append((fields, em, weight))
+        logger.info(
+            "FS EM session: pass=%s pairs=%.0f patterns=%d converged=%s",
+            fields, weight, len(counts), em.converged,
+        )
+
+    if not sessions:
+        raise ValueError(
+            "no blocking pass produced candidate pairs, so there is nothing to "
+            "train m from. Check that the blocking keys are populated -- a key "
+            "that is null or a missing sentinel for every record yields no "
+            "blocks."
+        )
+    return _combine_em_sessions(mk, sessions)
+
+
+def _refuse_unsupported(mk: Any) -> None:
+    """Refuse configs the counted path cannot train, before submitting a job."""
+    from goldenmatch.core.probabilistic import _em_ne_fields
+
+    if _em_ne_fields(mk):
+        raise NotImplementedError(
+            f"matchkey {mk.name!r} has negative-evidence fields, which need a "
+            f"per-pair NE matrix that counted comparison vectors do not carry. "
+            f"Train it with train_em() on sampled pairs."
+        )
+    if any(getattr(f, "tf_adjustment", False) for f in mk.fields):
+        raise NotImplementedError(
+            f"matchkey {mk.name!r} uses term-frequency adjustment, which needs "
+            f"per-value frequencies that counted comparison vectors do not "
+            f"carry. Train it with train_em() on sampled pairs."
+        )

--- a/packages/python/goldenmatch/tests/test_fs_em_per_pass.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_per_pass.py
@@ -174,3 +174,36 @@ def test_blocks_without_provenance_fall_back_to_the_pooled_run():
     fell_back = _train(train_em_per_pass, df, blocks, blocking_fields=["zip"])
 
     assert fell_back.m_probs == pooled.m_probs
+
+
+# ── u for blocking fields: the #1835 prior, across sessions ──────────
+
+def test_every_pass_blocking_field_keeps_the_neutral_u_prior():
+    """The combination must neutralise the UNION of blocking fields.
+
+    A configured blocking field carries a deliberate fixed prior that EM cannot
+    recover from random pairs (#1835): a near-unique key's `u` collapses toward
+    the smoothing floor, which EXPLODES its agreement weight and lets one field
+    dominate the score. `train_em` guards this with
+    `always_conditioned |= set(blocking_fields)` over the union of every pass.
+
+    Each per-pass session neutralises only ITS OWN pass's fields, so lifting `u`
+    from one session leaves every other pass's blocking field carrying the
+    random-pair estimate. Measured on this fixture: `zip` came back
+    [0.977, 0.023] instead of [0.5, 0.5], a 4.4-bit swing in its agreement
+    weight. On a near-unique key it is the ~28-bit collapse #1835 records.
+
+    Nothing about the result looks wrong -- it is a valid probability vector,
+    and only a comparison against the pooled run reveals it.
+    """
+    df = _frame()
+    blocks = _blocks(df, _cfg(["zip"], ["last_name"]))
+
+    pooled = _train(train_em, df, blocks, blocking_fields=["zip", "last_name"])
+    combined = _train(train_em_per_pass, df, blocks)
+
+    for name in ("zip", "last_name"):
+        assert combined.u_probs[name] == pytest.approx(pooled.u_probs[name]), (
+            f"{name} is a blocking field of some pass, so it must carry the "
+            f"neutral prior the pooled run gives it, not a random-pair estimate"
+        )

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -187,3 +187,102 @@ def test_the_smoothing_moves_low_probability_cells_the_most():
         f"explains sensitivity in near-zero cells; if it has moved elsewhere, "
         f"the explanation is wrong."
     )
+
+
+# ── the last link: counts in, model out ──────────────────────────────
+
+def _patterns_and_matrix(df, mk, n=400, seed=7):
+    """The comparison rows `train_em` would build, plus their counted form."""
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import (
+        _build_comparison_matrix,
+        _row_lookup_for_pairs,
+    )
+    ids = df["__row_id__"].to_list()
+    pairs = [(a, b) for i, a in enumerate(ids) for b in ids[i + 1:]][:n]
+    cols = [f.field for f in mk.fields]
+    lookup = _row_lookup_for_pairs(df, cols, [pairs])
+    matrix = _build_comparison_matrix(pairs, lookup, mk)
+    counts = Counter(tuple(int(v) for v in row) for row in matrix)
+    return matrix, sorted(counts.items())
+
+
+def _u_from(matrix, mk):
+    """A fixed u, so the comparison isolates the m estimation."""
+    out = {}
+    for j, f in enumerate(mk.fields):
+        col = matrix[:, j]
+        obs = float((col >= 0).sum())
+        out[f.field] = [
+            (float((col == lvl).sum()) + 1e-6) / (obs + f.levels * 1e-6)
+            for lvl in range(f.levels)
+        ]
+    return out
+
+
+def test_counts_train_the_same_model_as_the_rows_they_stand_for():
+    """THE gate for distributed training.
+
+    `train_em_from_counts` over collapsed vectors must equal `_em_iterate` over
+    the full row set, because collapsing regroups the terms of each sum without
+    changing the total. Exact, not approximate -- if this drifts, a model
+    trained on a cluster is quietly not the model the one-box would have built.
+    """
+    import numpy as np
+    from goldenmatch.core.probabilistic import _em_iterate, train_em_from_counts
+
+    df, mk = _frame(), _make_probabilistic_mk()
+    matrix, patterns = _patterns_and_matrix(df, mk)
+    u = _u_from(matrix, mk)
+
+    n = matrix.shape[0]
+    full_m, _, full_p, _, _ = _em_iterate(
+        mk, matrix, np.zeros((n, 0), dtype=np.int64),
+        np.zeros((n, len(mk.fields)), dtype=bool), np.zeros((n, 0), dtype=bool),
+        np.ones(n), float(n), [], u, {}, set(), set(), None, None, 20, 0.001,
+    )
+    counted = train_em_from_counts(mk, patterns, u)
+
+    assert len(patterns) < n, (
+        f"{len(patterns)} patterns for {n} rows -- nothing collapsed, so this "
+        f"would pass with the weighting removed"
+    )
+    for f in mk.fields:
+        assert counted.m_probs[f.field] == pytest.approx(
+            full_m[f.field], abs=1e-12
+        ), f"{f.field}: counted and row-wise EM disagree"
+    assert counted.proportion_matched == pytest.approx(full_p, abs=1e-12)
+
+
+def test_a_vector_of_the_wrong_width_is_refused():
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk = _make_probabilistic_mk()
+    with pytest.raises(ValueError, match="ordered by mk.fields"):
+        train_em_from_counts(mk, [((0, 1), 5)], _u_from(*_patterns_and_matrix(_frame(), mk)[:1], mk))
+
+
+def test_empty_counts_are_refused():
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk = _make_probabilistic_mk()
+    matrix, _ = _patterns_and_matrix(_frame(), mk)
+    with pytest.raises(ValueError, match="nothing to train on"):
+        train_em_from_counts(mk, [], _u_from(matrix, mk))
+
+
+def test_negative_evidence_is_refused_not_silently_dropped():
+    """NE needs a per-pair matrix the counts do not carry. Training without it
+    would produce a model the config did not ask for, and it would look fine."""
+    from goldenmatch.config.schemas import NegativeEvidenceField
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk = _make_probabilistic_mk(
+        negative_evidence=[
+            NegativeEvidenceField(field="zip", scorer="exact", threshold=0.9)
+        ]
+    )
+    matrix, patterns = _patterns_and_matrix(_frame(), _make_probabilistic_mk())
+    with pytest.raises(NotImplementedError, match="negative-evidence"):
+        train_em_from_counts(mk, patterns, _u_from(matrix, _make_probabilistic_mk()))

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -286,3 +286,73 @@ def test_negative_evidence_is_refused_not_silently_dropped():
     matrix, patterns = _patterns_and_matrix(_frame(), _make_probabilistic_mk())
     with pytest.raises(NotImplementedError, match="negative-evidence"):
         train_em_from_counts(mk, patterns, _u_from(matrix, _make_probabilistic_mk()))
+
+
+# ── u, the other half of the likelihood ratio ────────────────────────
+
+def test_u_from_counts_equals_the_u_train_em_estimates():
+    """THE gate for distributed u.
+
+    `train_em` estimates u from a RANDOM pair sample:
+
+        u[level] = (count(level) + 1e-6) / (observed + n_levels * 1e-6)
+
+    which is a per-level count and a denominator that excludes unobserved
+    (-1) entries. Both are sums over pairs, so counted vectors carry everything
+    it needs -- and this asserts that against `train_em`'s ACTUAL output rather
+    than against the formula rewritten in the test, which would pass even if
+    both copies were wrong together.
+
+    The sample is reproduced with the same seeded `_sample_pairs` call
+    `train_em` makes, so the two see the same pairs.
+    """
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import (
+        _build_comparison_matrix,
+        _row_lookup_for_pairs,
+        _sample_pairs,
+        estimate_u_from_counts,
+    )
+
+    df, mk = _frame(), _make_probabilistic_mk()
+    n, seed = 400, 7
+
+    # No blocks and no blocking_fields, so nothing is `always_conditioned` and
+    # train_em applies no neutral-u override -- this compares the ESTIMATE, not
+    # the blocking-field prior, which has its own test.
+    trained = train_em(df, mk, n_sample_pairs=n, max_iterations=25, seed=seed)
+
+    pairs = _sample_pairs(df, min(n, 5000), seed)
+    lookup = _row_lookup_for_pairs(df, [f.field for f in mk.fields], [pairs])
+    matrix = _build_comparison_matrix(pairs, lookup, mk)
+    counts = sorted(Counter(tuple(int(v) for v in r) for r in matrix).items())
+    assert len(counts) < len(matrix), "nothing collapsed; the test proves nothing"
+
+    from_counts = estimate_u_from_counts(mk, counts)
+    for f in mk.fields:
+        assert from_counts[f.field] == pytest.approx(
+            trained.u_probs[f.field], abs=1e-12
+        ), f"{f.field}: counted u differs from the u train_em estimated"
+
+
+def test_u_from_counts_excludes_unobserved_from_the_denominator():
+    """A field null on one side is UNOBSERVED (-1), not a disagreement.
+
+    Dividing by every pair instead of the observed ones would shrink every level
+    of a sparsely-populated field toward zero in proportion to its missingness,
+    inflating log2(m/u) for exactly the fields the data supports least.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+
+    mk = _make_probabilistic_mk()
+    n_fields = len(mk.fields)
+    # 10 pairs observed at level 0, 90 pairs unobserved, on the first field.
+    obs = tuple([0] + [0] * (n_fields - 1))
+    unobs = tuple([-1] + [0] * (n_fields - 1))
+    u = estimate_u_from_counts(mk, [(obs, 10), (unobs, 90)])
+
+    first = mk.fields[0]
+    assert u[first.field][0] == pytest.approx(
+        (10 + 1e-6) / (10 + first.levels * 1e-6), abs=1e-12
+    ), "the 90 unobserved pairs must not be in the denominator"

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -653,12 +653,22 @@ def test_train_em_distributed_equals_the_one_box_over_the_same_pairs(train_sourc
     )
 
 
-def test_distributed_training_is_jar_only(train_source, jvm_registered):
-    """No Python on the executors, which is the whole claim of this tier.
+def test_the_jar_route_trains_the_same_model_as_the_arrow_route(
+    train_source, jvm_registered
+):
+    """Routing the similarity call to the jar must not move the model.
 
-    Training that needed an executor virtualenv would leave the jar-only story
-    half true in the place it is hardest to notice -- scoring would be jar-only
-    and the model it scores with would not be.
+    This does NOT establish "no Python on the executors", and naming it that
+    way would be a lie a green lane would keep telling. This lane runs under
+    `local[*]`, where the Python worker forks from the DRIVER's interpreter --
+    which has goldenmatch installed -- so the arrow route works here and would
+    work here even if it could never work on a cluster.
+
+    What it does establish is the precondition: the two routes agree, so the
+    jar route is a real alternative rather than a differently-wrong one. The
+    executor claim is tested where it can be, on the two-worker cluster lane,
+    by `test_fs_training_runs_with_no_python_on_the_executors` in
+    test_spark_jvm_native_parity.py.
     """
     from goldenmatch.spark.em import train_em_distributed
     from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -700,3 +700,67 @@ def test_a_blocking_field_keeps_the_neutral_u_prior(train_source):
         "`first` blocks nothing and must still be LEARNED -- if it also came "
         "back neutral, the guard is neutralising everything"
     )
+
+
+def _random_pair_ids(train_source, **kw):
+    from goldenmatch.spark.config_pipeline import CAND_LHS, CAND_RHS
+    from goldenmatch.spark.em import random_pairs
+    from pyspark.sql import functions as F
+
+    joined = random_pairs(train_source, id_col=_ID, **kw)
+    rows = joined.select(
+        F.col(f"{CAND_LHS}.{_ID}").alias("a"), F.col(f"{CAND_RHS}.{_ID}").alias("b")
+    ).collect()
+    return {(int(r["a"]), int(r["b"])) for r in rows}
+
+
+def test_both_sides_of_the_u_self_join_draw_the_SAME_sample(train_source):
+    """The pairs must be every combination of ONE sample, not a cross of two.
+
+    Both sides of the self-join reference the same plan, so whatever selects the
+    sample is evaluated twice. `DataFrame.sample` seeds per PARTITION, so its two
+    evaluations agree only while the two scans partition identically -- true in
+    practice, not guaranteed, and a mismatch would pair rows from two different
+    samples and still return a full set of plausible probabilities.
+
+    `k` distinct ids can form exactly `k(k-1)/2` ordered pairs. Asserting that
+    identity is what catches a mismatch: two different samples of the same size
+    produce a different count, and the intersection would be smaller.
+
+    `max_pairs` is forced low enough to actually trigger sampling -- the fixture
+    is otherwise below the default target and the whole frame is taken, which
+    would make this pass without exercising anything.
+    """
+    pairs = _random_pair_ids(train_source, max_pairs=10)
+    assert pairs, "no random pairs at all"
+
+    ids = {i for p in pairs for i in p}
+    k = len(ids)
+    assert k < len(_TRAIN_ROWS), (
+        f"all {k} records were taken, so no sampling happened and this test "
+        f"exercises nothing -- lower max_pairs"
+    )
+    assert len(pairs) == k * (k - 1) // 2, (
+        f"{len(pairs)} pairs over {k} distinct ids; one sample of {k} yields "
+        f"{k * (k - 1) // 2}. The two sides of the join drew different rows."
+    )
+    assert all(a < b for a, b in pairs), "pairs are not canonically ordered"
+
+
+def test_the_u_sample_is_reproducible_across_runs(train_source):
+    """Same seed, same rows -- so a model retrained tomorrow has the same u.
+
+    A per-row hash gives this; drawing from a PRNG whose state depends on how
+    the scan happened to be partitioned does not, and the difference only shows
+    up as two runs disagreeing slightly for no visible reason.
+    """
+    assert _random_pair_ids(train_source, max_pairs=10) == _random_pair_ids(
+        train_source, max_pairs=10
+    )
+
+
+def test_a_different_seed_draws_a_different_sample(train_source):
+    """Otherwise the seed is decoration and the previous test proves nothing."""
+    a = _random_pair_ids(train_source, max_pairs=10, seed=1)
+    b = _random_pair_ids(train_source, max_pairs=10, seed=99)
+    assert a != b, "the seed does not reach the sample selection"

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -440,3 +440,263 @@ def test_an_oversized_pattern_space_is_refused_not_collected(source):
     cfg = _config()
     with pytest.raises(ValueError, match="max_patterns"):
         _spark_pattern_counts(source, cfg, max_patterns=1)
+
+
+# ── distributed training: u, the per-pass sessions, the combination ──
+#
+# The fixture is deliberately blockable on BOTH `city` and `last`. Two passes
+# are the point: `last` is a comparison field AND pass 2's blocking key, so it
+# is conditioned in one session and free in the other -- the situation the
+# decomposition exists for, and the one where the #1835 neutral-u prior has to
+# survive the combination.
+#
+# It is also deliberately SMALL enough that the u sample takes the whole frame
+# (`_rows_needed_for_n_pairs(1e6)` is 1,414 rows). Spark's `sample` cannot be
+# reproduced on the driver, so a fixture that triggered it would leave the u
+# gate unable to state an expected value -- it could only assert that some
+# numbers came back.
+
+_TRAIN_ROWS = [
+    (0, "jon", "smith", "york"),
+    (1, "john", "smith", "york"),
+    (2, "jonathan", "smyth", "york"),
+    (3, "jon", "smith", "leeds"),
+    (4, "amy", "wong", "leeds"),
+    (5, "amie", "wong", "leeds"),
+    (6, "amy", "wong", "york"),
+    (7, "pat", "jones", "hull"),
+    (8, "patrick", "jones", "hull"),
+    (9, "pat", "jonas", "hull"),
+    (10, "sam", "brown", "hull"),
+    (11, "samuel", "brown", "york"),
+    (12, "sam", "browne", "leeds"),
+    (13, "kim", "smith", "hull"),
+    (14, "kimberly", "smith", "leeds"),
+    (15, "kim", "wong", "york"),
+]
+
+
+def _train_config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[_mk()],
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            passes=[
+                BlockingKeyConfig(fields=["city"]),
+                BlockingKeyConfig(fields=["last"]),
+            ],
+        ),
+    )
+
+
+@pytest.fixture()
+def train_source(spark):
+    return spark.createDataFrame(_TRAIN_ROWS, _COLS)
+
+
+def _by_id():
+    return {r[0]: dict(zip(_COLS, r)) for r in _TRAIN_ROWS}
+
+
+def _driver_counts(pairs, mk):
+    """Counted comparison vectors, via the ONE-BOX's `comparison_vector`."""
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import comparison_vector
+
+    by_id = _by_id()
+    counts = Counter()
+    for a, b in pairs:
+        vec = comparison_vector(by_id[int(a)], by_id[int(b)], mk)
+        counts[tuple(int(v) for v in vec)] += 1
+    return sorted(counts.items())
+
+
+def _all_driver_pairs():
+    ids = sorted(r[0] for r in _TRAIN_ROWS)
+    return [(a, b) for i, a in enumerate(ids) for b in ids[i + 1:]]
+
+
+def test_training_blocks_exactly_as_scoring_blocks(train_source):
+    """The per-pass candidate sets must union to the scoring candidate set.
+
+    Training on a different population from the one scoring sees produces a
+    model fitted to pairs that never get scored -- weights that are not wrong
+    about anything you can point at, just about the wrong data. Splitting
+    `generate_candidates` into `pass_candidates` is what makes this hold by
+    construction, and this pins that it stayed true.
+    """
+    from goldenmatch.spark.config_pipeline import (
+        blocking_passes,
+        generate_candidates,
+        pass_candidates,
+    )
+
+    cfg = _train_config()
+    union = set()
+    for key_config in blocking_passes(cfg):
+        rows = pass_candidates(train_source, key_config, id_col=_ID).collect()
+        union |= {(int(r["a"]), int(r["b"])) for r in rows}
+
+    scoring = {
+        (int(r["a"]), int(r["b"]))
+        for r in generate_candidates(train_source, cfg, id_col=_ID).collect()
+    }
+    assert union == scoring, (
+        f"per-pass candidates and scoring candidates differ: "
+        f"only-training={sorted(union - scoring)} "
+        f"only-scoring={sorted(scoring - union)}"
+    )
+    assert scoring, "no candidates at all; the fixture proves nothing"
+
+
+def test_distributed_u_is_the_one_box_u_over_random_pairs(train_source):
+    """u must be the level distribution over RANDOM pairs, not blocked ones.
+
+    Blocked candidates already agree on a blocking key, so their level
+    distribution is not u -- it is u conditioned on agreement, which is exactly
+    the quantity u must NOT be. Using it would shrink the denominator of
+    log2(m/u) for every field correlated with the key and inflate its weight.
+
+    The fixture is smaller than the u sample target, so `random_pairs` takes
+    every record and the expected value is computable here exactly.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+    from goldenmatch.spark.em import estimate_u_distributed
+
+    mk = _train_config().get_matchkeys()[0]
+    want = estimate_u_from_counts(mk, _driver_counts(_all_driver_pairs(), mk))
+    got = estimate_u_distributed(train_source, mk, id_col=_ID)
+
+    assert got == pytest.approx(want, abs=1e-12), (
+        "distributed u differs from the one-box estimate over the same pairs"
+    )
+
+
+def test_u_over_random_pairs_differs_from_u_over_blocked_pairs(train_source):
+    """And the distinction is not academic on this fixture.
+
+    If blocked and random pairs gave the same u here, the test above would pass
+    with `estimate_u_distributed` reading the wrong frame entirely.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+    from goldenmatch.spark.config_pipeline import generate_candidates
+    from goldenmatch.spark.em import estimate_u_distributed
+
+    mk = _train_config().get_matchkeys()[0]
+    cfg = _train_config()
+    blocked = [
+        (int(r["a"]), int(r["b"]))
+        for r in generate_candidates(train_source, cfg, id_col=_ID).collect()
+    ]
+    u_blocked = estimate_u_from_counts(mk, _driver_counts(blocked, mk))
+    u_random = estimate_u_distributed(train_source, mk, id_col=_ID)
+
+    assert u_blocked != pytest.approx(u_random, abs=1e-9), (
+        "blocked and random pairs give the same u on this fixture, so it "
+        "cannot distinguish the two and the u gate above proves less than it "
+        "appears to"
+    )
+
+
+def _driver_trained(train_source, mk, cfg):
+    """The model the one-box builds from the same counts, session by session."""
+    from goldenmatch.core.probabilistic import (
+        _combine_em_sessions,
+        estimate_u_from_counts,
+        train_em_from_counts,
+    )
+    from goldenmatch.spark.config_pipeline import blocking_passes, pass_candidates
+
+    u = estimate_u_from_counts(mk, _driver_counts(_all_driver_pairs(), mk))
+    sessions = []
+    for key_config in blocking_passes(cfg):
+        rows = pass_candidates(train_source, key_config, id_col=_ID).collect()
+        pairs = [(int(r["a"]), int(r["b"])) for r in rows]
+        counts = _driver_counts(pairs, mk)
+        em = train_em_from_counts(
+            mk, counts, u, conditioned_fields=tuple(key_config.fields)
+        )
+        sessions.append((tuple(key_config.fields), em, float(len(pairs))))
+    return _combine_em_sessions(mk, sessions)
+
+
+def test_train_em_distributed_equals_the_one_box_over_the_same_pairs(train_source):
+    """THE end-to-end gate.
+
+    Every level in the reference comes from `comparison_vector` -- the one-box's
+    own function, the one a locally-trained model is built from -- so this
+    compares the distributed model against the reference implementation and not
+    against a second copy of the Spark expressions.
+
+    Exact, not approximate: both sides run the same `_em_iterate` over counts
+    that must be identical. A tolerance would hide the failure this exists to
+    catch, since a model trained on subtly wrong counts is still a valid model.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = _train_config()
+    mk = cfg.get_matchkeys()[0]
+
+    want = _driver_trained(train_source, mk, cfg)
+    got = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+
+    for f in mk.fields:
+        assert got.m_probs[f.field] == pytest.approx(
+            want.m_probs[f.field], abs=1e-12
+        ), f"{f.field}: distributed m differs from the one-box"
+        assert got.u_probs[f.field] == pytest.approx(
+            want.u_probs[f.field], abs=1e-12
+        ), f"{f.field}: distributed u differs from the one-box"
+    assert got.proportion_matched == pytest.approx(
+        want.proportion_matched, abs=1e-12
+    )
+
+
+def test_distributed_training_is_jar_only(train_source, jvm_registered):
+    """No Python on the executors, which is the whole claim of this tier.
+
+    Training that needed an executor virtualenv would leave the jar-only story
+    half true in the place it is hardest to notice -- scoring would be jar-only
+    and the model it scores with would not be.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    cfg = _train_config()
+    mk = cfg.get_matchkeys()[0]
+
+    want = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+    got = train_em_distributed(
+        train_source, cfg, mk, id_col=_ID,
+        scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME,
+    )
+    for f in mk.fields:
+        assert got.m_probs[f.field] == pytest.approx(
+            want.m_probs[f.field], abs=1e-12
+        ), f"{f.field}: the jar-only route trained a different model"
+
+
+def test_a_blocking_field_keeps_the_neutral_u_prior(train_source):
+    """`last` is pass 2's blocking key, so it must not carry a learned u.
+
+    #1835: a near-unique blocking key's u collapses toward the smoothing floor,
+    exploding its agreement weight until it dominates the score (F1 0.83 ->
+    0.57). `train_em` guards this over the UNION of blocking fields, and the
+    distributed route has to arrive at the same guard through a different path
+    -- per-pass sessions that each neutralise only their own key.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = _train_config()
+    mk = cfg.get_matchkeys()[0]
+    em = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+
+    assert em.u_probs["last"] == pytest.approx([0.5, 0.5], abs=1e-12), (
+        "`last` is a blocking field of pass 2, so it must carry the neutral "
+        "prior, not an estimate from random pairs"
+    )
+    assert em.u_probs["first"] != pytest.approx([0.5, 0.5], abs=1e-9), (
+        "`first` blocks nothing and must still be LEARNED -- if it also came "
+        "back neutral, the guard is neutralising everything"
+    )

--- a/packages/python/goldenmatch/tests/test_spark_fs_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_unit.py
@@ -271,3 +271,151 @@ def test_a_saved_model_round_trips(tmp_path):
     loaded = resolve_fs_model(mk, model_path=str(p))
     assert loaded.match_weights == em.match_weights
     assert loaded.proportion_matched == pytest.approx(em.proportion_matched)
+
+
+# ── distributed EM: what it refuses, and how it sizes the u sample ───
+#
+# No Spark, so these run on every PR. They cover the checks that must fire
+# BEFORE a cluster job is submitted -- the ones whose whole value is being
+# cheap, and which a Spark-lane-only test would never prove were cheap.
+
+
+class _ExplodingFrame:
+    """Any use of this as a DataFrame raises.
+
+    A refusal that only happens after the frame is touched still costs a
+    distributed count over every blocking pass to discover a config error. This
+    makes "nothing was submitted" a testable claim rather than a code-reading
+    one.
+    """
+
+    def __getattr__(self, name):
+        raise AssertionError(
+            f"the source frame was used ({name!r}) before the config was "
+            f"refused; the check must fire before any job is submitted"
+        )
+
+
+def _ne_matchkey():
+    from goldenmatch.config.schemas import NegativeEvidenceField
+
+    mk = _fs_matchkey()
+    mk.negative_evidence = [
+        NegativeEvidenceField(field="dob", scorer="exact", threshold=0.9)
+    ]
+    return mk
+
+
+def _fs_matchkey():
+    return MatchkeyConfig(
+        name="fs",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="last", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+        ],
+    )
+
+
+def _static_config(mk, keys):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[mk],
+        blocking=BlockingConfig(
+            keys=[BlockingKeyConfig(fields=list(k)) for k in keys]
+        ),
+    )
+
+
+def test_negative_evidence_is_refused_before_a_job_is_submitted():
+    """NE needs a per-pair matrix counted vectors do not carry.
+
+    Refused rather than dropped: training without the NE dimensions produces a
+    model the config did not ask for, and every number in it looks reasonable.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    mk = _ne_matchkey()
+    with pytest.raises(NotImplementedError, match="negative-evidence"):
+        train_em_distributed(
+            _ExplodingFrame(), _static_config(mk, [["city"]]), mk, id_col="id"
+        )
+
+
+def test_term_frequency_adjustment_is_refused_before_a_job_is_submitted():
+    """TF needs per-value frequencies the counts do not carry."""
+    from goldenmatch.spark.em import train_em_distributed
+
+    mk = _fs_matchkey()
+    mk.fields[0].tf_adjustment = True
+    with pytest.raises(NotImplementedError, match="term-frequency"):
+        train_em_distributed(
+            _ExplodingFrame(), _static_config(mk, [["city"]]), mk, id_col="id"
+        )
+
+
+def test_a_config_with_no_blocking_pass_is_refused():
+    """Without a pass there are no candidate pairs, so there is no m to train.
+
+    Returning a fixed-prior model instead would be a trained-looking result from
+    a config that trained on nothing.
+    """
+    from types import SimpleNamespace
+
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = SimpleNamespace(
+        blocking=SimpleNamespace(strategy="static", keys=[], passes=[])
+    )
+    with pytest.raises(ValueError, match="at least one blocking pass"):
+        train_em_distributed(
+            _ExplodingFrame(), cfg, _fs_matchkey(), id_col="id"
+        )
+
+
+@pytest.mark.parametrize("pairs", [10, 1_000, 1_000_000, 100_000_000])
+def test_the_u_sample_is_sized_by_the_pair_budget(pairs):
+    """`r` rows self-pair into `r(r-1)/2`, so the row count inverts that.
+
+    A cross join is quadratic, so the knob worth exposing is the pair budget;
+    picking a row count directly makes the cost a surprise.
+
+    `max_pairs` is a CEILING, so the chosen `r` must not exceed it -- and must
+    be the largest that does not, or the budget silently buys a smaller sample
+    than it paid for. Both directions asserted, because only checking the
+    ceiling would pass for `r = 2`.
+
+    Round-tripped through the forward formula rather than compared to
+    hard-coded numbers, which would pin whatever the implementation happened to
+    return rather than what it owes.
+    """
+    from goldenmatch.spark.em import _rows_needed_for_n_pairs
+
+    r = _rows_needed_for_n_pairs(pairs)
+    assert r * (r - 1) / 2 <= pairs, (
+        f"{r} rows produce {r * (r - 1) / 2:.0f} pairs, over the {pairs} budget"
+    )
+    assert (r + 1) * r / 2 > pairs, (
+        f"{r} rows leave room for more: {r + 1} rows still fit in {pairs}"
+    )
+
+
+def test_a_source_too_small_to_form_a_pair_is_refused():
+    """One record has no pairs, so u would be estimated from nothing.
+
+    The smoothing floor would still return a full set of probabilities.
+    """
+    from types import SimpleNamespace
+
+    from goldenmatch.spark.em import random_pairs
+
+    frame = SimpleNamespace(count=lambda: 1)
+    with pytest.raises(ValueError, match="at least 2 records"):
+        random_pairs(frame, id_col="id")

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -818,3 +818,155 @@ def test_an_unknown_scorer_shape_is_refused(spark):
             cands, src, cfg, id_col="__row_id__", scorer_udf=UDF_NAME,
             scorer_shape="batched",
         )
+
+
+# ── FS training, on a real executor ──────────────────────────────────
+#
+# `train_em_distributed` computes comparison vectors IN the engine and counts
+# them there. Every other test of it runs under `local[*]`, where a Python
+# worker forks from the driver's interpreter -- which has goldenmatch -- so the
+# arrow-udf route works and proves nothing about executors. Here the executors
+# are separate hosts with no goldenmatch, so a training path that still needed a
+# Python worker fails with ModuleNotFoundError instead of quietly passing.
+#
+# The oracle is client-side: `pass_candidates` and `random_pairs` are pure Spark
+# SQL, so collecting their output needs nothing on the executor, and the levels
+# are then derived with `comparison_vector` -- the one-box's own function, which
+# is what a locally-trained model is built from.
+
+
+def _fs_config():
+    """Two passes, one of them keyed on a COMPARISON field.
+
+    `last` is both a comparison field and pass 2's blocking key, so it is
+    conditioned in one session and free in the other. A config whose passes
+    blocked only on non-comparison columns would exercise the plumbing without
+    exercising the conditioning that makes per-pass sessions necessary.
+    """
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            passes=[
+                BlockingKeyConfig(fields=["blk"]),
+                BlockingKeyConfig(fields=["last"]),
+            ],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="fs", type="probabilistic",
+                fields=[
+                    MatchkeyField(field="first", scorer="jaro_winkler",
+                                  levels=2, partial_threshold=0.8),
+                    MatchkeyField(field="last", scorer="jaro_winkler",
+                                  levels=2, partial_threshold=0.8),
+                ],
+            ),
+        ],
+    )
+
+
+def _client_side_model(source, mk, cfg):
+    """The model the one-box builds from the same pairs, derived on the client.
+
+    Only pure-SQL frames are collected (`random_pairs`, `pass_candidates`), so
+    this side needs nothing installed on an executor -- which is the point: if
+    the ORACLE needed a Python worker, this test could not distinguish "training
+    is jar-only" from "both sides need the same missing thing".
+    """
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import (
+        _combine_em_sessions,
+        comparison_vector,
+        estimate_u_from_counts,
+        train_em_from_counts,
+    )
+    from goldenmatch.spark.config_pipeline import (
+        CAND_LHS,
+        CAND_RHS,
+        blocking_passes,
+        pass_candidates,
+    )
+    from goldenmatch.spark.em import random_pairs
+    from pyspark.sql import functions as F
+
+    cols = ["__row_id__", "blk", "first", "last", "city"]
+    by_id = {int(r["__row_id__"]): {c: r[c] for c in cols}
+             for r in source.select(*cols).collect()}
+
+    def counts(pairs):
+        c = Counter()
+        for a, b in pairs:
+            vec = comparison_vector(by_id[a], by_id[b], mk)
+            c[tuple(int(v) for v in vec)] += 1
+        return sorted(c.items())
+
+    rp = random_pairs(source, id_col="__row_id__").select(
+        F.col(f"{CAND_LHS}.__row_id__").alias("a"),
+        F.col(f"{CAND_RHS}.__row_id__").alias("b"),
+    ).collect()
+    u = estimate_u_from_counts(mk, counts([(int(r["a"]), int(r["b"])) for r in rp]))
+
+    sessions = []
+    for key_config in blocking_passes(cfg):
+        rows = pass_candidates(
+            source, key_config, id_col="__row_id__"
+        ).collect()
+        pairs = [(int(r["a"]), int(r["b"])) for r in rows]
+        if not pairs:
+            continue
+        em = train_em_from_counts(
+            mk, counts(pairs), u, conditioned_fields=tuple(key_config.fields)
+        )
+        sessions.append((tuple(key_config.fields), em, float(len(pairs))))
+    return _combine_em_sessions(mk, sessions)
+
+
+def test_fs_training_runs_with_no_python_on_the_executors(spark, registered):
+    """THE gate for distributed FS training on a cluster.
+
+    Fellegi-Sunter training is the last thing in this tier that was only ever
+    exercised where a Python worker happened to be available. Scoring being
+    jar-only while the model it scores with is not would leave the claim half
+    true in the place hardest to notice -- nothing about a model trained through
+    a Python worker looks different from one that was not.
+
+    Exact, not approximate: both sides reach the same Rust `score_one` and
+    everything above it is the same arithmetic. A tolerance would hide the class
+    of bug this catches, since a model trained on subtly wrong levels is still a
+    model.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    source = _parity_source(spark)
+    cfg = _fs_config()
+    mk = cfg.get_matchkeys()[0]
+
+    got = train_em_distributed(
+        source, cfg, mk, id_col="__row_id__",
+        scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME,
+    )
+    want = _client_side_model(source, mk, cfg)
+
+    for f in mk.fields:
+        assert got.m_probs[f.field] == pytest.approx(
+            want.m_probs[f.field], abs=1e-12
+        ), f"{f.field}: the executor-trained m differs from the client oracle"
+        assert got.u_probs[f.field] == pytest.approx(
+            want.u_probs[f.field], abs=1e-12
+        ), f"{f.field}: the executor-estimated u differs from the client oracle"
+    assert got.proportion_matched == pytest.approx(
+        want.proportion_matched, abs=1e-12
+    )
+    # `last` keys pass 2, so it must carry the #1835 neutral prior rather than
+    # an estimate the blocking made unrepresentative.
+    assert got.u_probs["last"] == pytest.approx([0.5, 0.5], abs=1e-12)


### PR DESCRIPTION
> **Scope grew.** This PR now also carries #2553, *"distributed EM -- the caller, and u"*, which was opened against this branch and merged into it. That commit adds `train_em_distributed`, `estimate_u_from_counts` / `estimate_u_distributed`, the `pass_candidates` / `join_candidates_to_sources` extractions, and **a fix to a `u` bug in #2550** found while building on it (`train_em_per_pass` lifted `u` from one session, leaving every other pass's blocking field carrying a random-pair estimate instead of the #1835 neutral prior -- measured `[0.977, 0.023]` where the pooled run gives `[0.5, 0.5]`). See #2553 for the full write-up of that half.
>
> Also: this branch was **red on `docs_regen` / `config_matrix`** before that commit -- `docs/agent-codemap.json` was stale for `train_em_from_counts` and `_em_iterate`. Regenerated now.

---

`train_em_from_counts(mk, pattern_counts, u_probs)` is the last link of
`compute gammas distributed -> GROUP BY them -> train_em(pair_weights=counts)`.
It takes exactly what `spark.em.agreement_pattern_counts` returns.

**Stacked on #2550**, which is in the merge queue -- its two commits are the
first two here and drop out on rebase.

## One loop, two ways in

The EM iteration is extracted into `_em_iterate`, and **both** entry points call
it: `train_em` from a sampled pair list, `train_em_from_counts` from counted
vectors. A second copy would drift, and the drift would be invisible -- both
copies would go on producing valid probability vectors.

The extraction is behaviour-preserving by construction (`_em_iterate` reads
nothing it is not handed) and **207 existing probabilistic / EM / NE /
determinism tests pass unchanged**. `iterations` now comes from the helper's
return rather than a leaked loop variable; the old
`min(iteration + 1, max_iterations)` was a no-op since the loop cannot exceed
its own bound.

## The gate

`train_em_from_counts` over collapsed vectors == `_em_iterate` over the full row
set, to 1e-12 -- with an assertion that the collapse actually happened (fewer
patterns than rows), so it cannot pass with the weighting removed. That is the
aggregation theorem checked end to end rather than argued.

## What it refuses, and why refusing is the point

- **Negative evidence** and **term-frequency adjustment** need per-pair inputs
  (an NE matrix, per-value frequencies) that counted vectors do not carry.
  Refused, not silently dropped: training without them yields a model the config
  did not ask for, and it would look entirely reasonable.
- **`u_probs` is required, not defaulted.** u is half the likelihood ratio and
  is estimated from random *unblocked* pairs, which this function never sees.
  Inventing it would produce weights wrong in a direction nobody could spot from
  the m estimates. Splink keeps the same separation (`estimate_u.py`).
- Wrong-width vectors and non-positive counts.

`conditioned_fields` carries the pass conditioning, constant within a session --
which is exactly why the counts needed no pass column.

## Where this leaves distributed EM

Every link now exists and is verified:

| link | PR |
|---|---|
| gammas computed distributed, jar-only | #2545 |
| `GROUP BY` -> counts | #2550 |
| counts -> trained model | this |

**What is still missing is the caller that strings them together** -- a
`train_em_distributed(source_df, config, ...)` that runs
`agreement_pattern_counts` per pass and feeds each result to
`train_em_from_counts`, plus a distributed `u` estimate over random pairs
(Splink's `estimate_u.py` equivalent), which no link here provides.

So: not yet a distributed EM you can call. Every piece it needs is built, tested
and honest about its limits.

