### PR TITLE
feat(fs): distributed EM -- the caller, and u

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 471,
+      "module_count": 472,
       "modules": [
         {
           "module": "goldenmatch",
@@ -4142,6 +4142,7 @@
             "_build_ne_matrix",
             "_build_tf_tables",
             "_calibrate_link_threshold",
+            "_combine_em_sessions",
             "_deconvolve_post_blocking_u",
             "_em_iterate",
             "_em_ne_fields",
@@ -4187,6 +4188,7 @@
             "_ne_scalar_contribution",
             "_ne_scorer_vectorizable",
             "_ne_u_probs_from_matrix",
+            "_neutral_u_for",
             "_otsu_threshold",
             "_record_concat_value",
             "_record_concat_values",
@@ -4206,6 +4208,7 @@
             "continuous_scores",
             "enforce_weight_monotonicity",
             "estimate_m_from_labels",
+            "estimate_u_from_counts",
             "explain_pair_fs",
             "fs_missing_mode",
             "fs_model_preloaded",
@@ -7884,6 +7887,8 @@
             "blocking_passes",
             "build_golden_from_rules",
             "generate_candidates",
+            "join_candidates_to_sources",
+            "pass_candidates",
             "run_config_pipeline",
             "score_candidates",
             "weighted_pair_score"
@@ -7924,13 +7929,19 @@
         {
           "module": "goldenmatch.spark.em",
           "file": "packages/python/goldenmatch/goldenmatch/spark/em.py",
-          "purpose": "Count agreement patterns on the cluster, so FS training need not sample.",
+          "purpose": "Fellegi-Sunter training on the cluster, with no pair sample anywhere.",
           "defines": [
+            "_refuse_unsupported",
+            "_rows_needed_for_n_pairs",
             "agreement_pattern_counts",
-            "gamma_columns"
+            "estimate_u_distributed",
+            "gamma_columns",
+            "random_pairs",
+            "train_em_distributed"
           ],
           "imports": [
             "goldenmatch.core.probabilistic",
+            "goldenmatch.spark.config_pipeline",
             "goldenmatch.spark.probabilistic"
           ]
         },

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1205,6 +1205,165 @@ def _training_pair_conditioning(
     return fallback_pairs, [frozenset(blocking_fields)] * len(fallback_pairs)
 
 
+def estimate_u_from_counts(
+    mk: MatchkeyConfig,
+    pattern_counts: list[tuple[tuple[int, ...], int]],
+) -> dict[str, list[float]]:
+    """``u`` from COUNTED comparison vectors over random pairs.
+
+    ``u`` is the level distribution among NON-matches. Random pairs are
+    overwhelmingly non-matches, so their observed level distribution estimates
+    it directly -- no EM, which is why ``u`` is a separate computation from
+    ``m`` here and in Splink (``estimate_u.py``).
+
+    The estimator is ``train_em``'s, reached from counts instead of a matrix::
+
+        u[level] = (count(level) + 1e-6) / (observed + n_levels * 1e-6)
+
+    Both parts are sums over pairs, so collapsing identical vectors regroups the
+    terms without changing the totals -- the same aggregation property that lets
+    ``m`` be trained from counts.
+
+    ``observed`` excludes unobserved (``-1``) entries. A field null on one side
+    is missing data, not a disagreement, and putting those pairs in the
+    denominator would shrink every level of a sparse field toward zero and
+    inflate its ``log2(m/u)`` in proportion to how little data supports it.
+
+    ``pattern_counts`` must come from RANDOM (unblocked) pairs. Counts from
+    blocked candidates estimate the level distribution among pairs that already
+    agree on a blocking key, which is not ``u``, and the resulting weights would
+    be wrong with nothing about them looking wrong.
+    """
+    if not pattern_counts:
+        raise ValueError("pattern_counts is empty; nothing to estimate u from")
+
+    n_fields = len(mk.fields)
+    for vec, count in pattern_counts:
+        if len(vec) != n_fields:
+            raise ValueError(
+                f"comparison vector {vec} has {len(vec)} entries but the "
+                f"matchkey has {n_fields} fields -- the vectors must be ordered "
+                f"by mk.fields"
+            )
+        if count <= 0:
+            raise ValueError(f"pattern {vec} has non-positive count {count}")
+
+    u_probs: dict[str, list[float]] = {}
+    for j, f in enumerate(mk.fields):
+        counts = [0.0] * f.levels
+        observed = 0.0
+        for vec, c in pattern_counts:
+            level = vec[j]
+            if level < 0:
+                continue
+            observed += c
+            if level < f.levels:
+                counts[level] += c
+        total = observed + f.levels * 1e-6
+        u_probs[f.field] = [(c + 1e-6) / total for c in counts]
+    return u_probs
+
+
+def _neutral_u_for(field) -> list[float]:
+    """The fixed ``u`` prior for a field EM must not learn from random pairs.
+
+    A configured blocking field carries a deliberate prior (#1835): a
+    disagreement penalty that drives precision, and a BOUNDED agreement weight
+    that preserves recall. Estimating it from random pairs instead collapses a
+    near-unique key's ``u`` toward the smoothing floor, which explodes
+    ``log2(m/u)`` -- 28 bits on historical_50k -- and lets one field dominate
+    the score (measured F1 0.83 -> 0.57).
+
+    One definition, because both the pooled run and the per-pass combination
+    apply it, and two copies that drifted would differ only in the numbers a
+    blocking field's weights are built from.
+
+    The 3-level case is ``[0.34, 0.33, 0.33]`` rather than exact thirds: it is
+    the legacy prior, preserved so adopting this helper moves no model.
+    """
+    if field.levels == 2:
+        return [0.50, 0.50]  # neutral
+    if field.levels == 3:
+        return [0.34, 0.33, 0.33]
+    return [1.0 / field.levels] * field.levels
+
+
+def _combine_em_sessions(
+    mk: MatchkeyConfig,
+    sessions: list[tuple[tuple[str, ...], EMResult, float]],
+) -> EMResult:
+    """Combine independent per-pass EM sessions into one model.
+
+    ``sessions`` is ``(conditioned_fields, result, weight)``. Shared by
+    :func:`train_em_per_pass` and the distributed caller, which differ only in
+    HOW a session is trained -- from a sampled pair list or from counted
+    comparison vectors computed by a cluster. The combination itself is the same
+    question either way, and a second copy would drift silently: every variant
+    of it still returns valid probability vectors.
+
+    **m** is the pair-weighted mean over the sessions that could estimate the
+    field (those whose pass does not block on it), weighted because a pass
+    contributing 10 pairs and one contributing 10,000 are not equal evidence.
+    A field no session can estimate keeps the fixed prior every session gave it.
+
+    **u** is neutralised for the UNION of every pass's blocking fields, matching
+    ``train_em``'s ``always_conditioned |= set(blocking_fields)``. Taking one
+    session's ``u`` wholesale is wrong even though the sessions were all trained
+    against the same random-pair sample: each one neutralises only its OWN
+    blocking fields, so lifting the vector from session 0 leaves every other
+    pass's blocking field carrying the random-pair estimate and re-opens #1835
+    for it.
+    """
+    base = sessions[0][1]
+    blocking_union = {name for fields, _, _ in sessions for name in fields}
+
+    m_probs: dict[str, list[float]] = {}
+    for f in mk.fields:
+        name = f.field
+        estimable = [
+            (em, w) for fields, em, w in sessions
+            if name not in fields and name in em.m_probs
+        ]
+        if not estimable:
+            # No pass leaves this field free. Every session fell back to the
+            # fixed prior for it, so they agree and the first is as good as any
+            # -- and this is exactly the pooled run's `always_conditioned` case.
+            m_probs[name] = list(base.m_probs[name])
+            continue
+        total = sum(w for _, w in estimable)
+        n_levels = len(estimable[0][0].m_probs[name])
+        m_probs[name] = [
+            sum(em.m_probs[name][k] * w for em, w in estimable) / total
+            for k in range(n_levels)
+        ]
+
+    u_probs = {k: list(v) for k, v in base.u_probs.items()}
+    for f in mk.fields:
+        if f.field in blocking_union:
+            u_probs[f.field] = _neutral_u_for(f)
+
+    total_w = sum(w for _, _, w in sessions)
+    proportion = sum(em.proportion_matched * w for _, em, w in sessions) / total_w
+
+    match_weights = {
+        name: [
+            math.log2(max(m, 1e-10) / max(u, 1e-10))
+            for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
+        ]
+        for name in m_probs
+    }
+    return EMResult(
+        m_probs=m_probs,
+        u_probs=u_probs,
+        match_weights=match_weights,
+        converged=all(em.converged for _, em, _ in sessions),
+        iterations=max(em.iterations for _, em, _ in sessions),
+        proportion_matched=proportion,
+        tf_freqs=base.tf_freqs,
+        tf_collision=base.tf_collision,
+    )
+
+
 def train_em_from_counts(
     mk: MatchkeyConfig,
     pattern_counts: list[tuple[tuple[int, ...], int]],
@@ -1341,15 +1500,8 @@ def train_em_per_pass(
        produces. That is what makes the counts computable by a cluster and the
        iteration cheap, -- see ``pair_weights`` on :func:`train_em`.
 
-    Combination: a field's ``m`` is the pair-count-weighted mean of the sessions
-    that could estimate it (those whose pass does NOT block on it). A field no
-    session can estimate keeps whatever the sessions gave it, which is the fixed
-    prior -- the same treatment the pooled run's ``always_conditioned`` applies,
-    rather than a different answer for the same situation.
-
-    Weighted by pair count, not a plain mean: a pass contributing 10 pairs and
-    one contributing 10,000 are not equal evidence, and an unweighted mean would
-    let a tiny pass swing a field it barely observed.
+    Combination is :func:`_combine_em_sessions`, shared with the distributed
+    caller so the two cannot drift on what combining means.
 
     Args:
         blocks: ``BlockResult``s carrying ``blocking_fields`` provenance. Blocks
@@ -1390,51 +1542,7 @@ def train_em_per_pass(
     if not sessions:
         return train_em(df, mk, blocks=blocks, blocking_fields=blocking_fields, **kw)
 
-    base = sessions[0][1]
-    m_probs: dict[str, list[float]] = {}
-    for f in mk.fields:
-        name = f.field
-        estimable = [
-            (em, w) for fields, em, w in sessions
-            if name not in fields and name in em.m_probs
-        ]
-        if not estimable:
-            # No pass leaves this field free. Every session fell back to the
-            # fixed prior for it, so they agree and the first is as good as any
-            # -- and this is exactly the pooled run's `always_conditioned` case.
-            m_probs[name] = list(base.m_probs[name])
-            continue
-        total = sum(w for _, w in estimable)
-        n_levels = len(estimable[0][0].m_probs[name])
-        m_probs[name] = [
-            sum(em.m_probs[name][k] * w for em, w in estimable) / total
-            for k in range(n_levels)
-        ]
-
-    # u is estimated from RANDOM pairs, which do not depend on the pass, so the
-    # sessions agree by construction; taking the first states that rather than
-    # averaging identical numbers and implying they might differ.
-    u_probs = {k: list(v) for k, v in base.u_probs.items()}
-    total_w = sum(w for _, _, w in sessions)
-    proportion = sum(em.proportion_matched * w for _, em, w in sessions) / total_w
-
-    match_weights = {
-        name: [
-            math.log2(max(m, 1e-10) / max(u, 1e-10))
-            for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
-        ]
-        for name in m_probs
-    }
-    return EMResult(
-        m_probs=m_probs,
-        u_probs=u_probs,
-        match_weights=match_weights,
-        converged=all(em.converged for _, em, _ in sessions),
-        iterations=max(em.iterations for _, em, _ in sessions),
-        proportion_matched=proportion,
-        tf_freqs=base.tf_freqs,
-        tf_collision=base.tf_collision,
-    )
+    return _combine_em_sessions(mk, sessions)
 
 
 def _em_iterate(
@@ -1821,12 +1929,7 @@ def train_em(
     # which EM can learn it, so retain the legacy neutral-u/fixed-weight prior.
     for f in mk.fields:
         if f.field in always_conditioned:
-            if f.levels == 2:
-                u_probs[f.field] = [0.50, 0.50]  # neutral
-            elif f.levels == 3:
-                u_probs[f.field] = [0.34, 0.33, 0.33]
-            else:
-                u_probs[f.field] = [1.0 / f.levels] * f.levels
+            u_probs[f.field] = _neutral_u_for(f)
 
     logger.info("u-probabilities estimated from %d random pairs", len(random_pairs))
 

--- a/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/config_pipeline.py
@@ -285,6 +285,71 @@ def blocking_passes(config: Any) -> list[Any]:
     return list(blocking.keys or [])
 
 
+def pass_candidates(
+    source_df: Any,
+    key_config: Any,
+    *,
+    id_col: str,
+    transform_udf: str | None = None,
+) -> Any:
+    """Candidate pairs ``(a, b)``, ``a < b``, from ONE blocking pass.
+
+    Split out of :func:`generate_candidates` because FS training needs the
+    passes separately -- a per-pass EM session is defined by the pass whose
+    conditioning it carries, and a union has lost that. Training against a
+    different candidate set from the one scoring uses would fit a model to a
+    population scoring never sees, so both go through this.
+    """
+    from pyspark.sql import functions as F
+
+    key_col, _fields = _block_key_column(key_config, transform_udf)
+    keyed = source_df.withColumn("__block_key__", key_col)
+    keyed = keyed.where(_valid_key(F.col("__block_key__")))
+    a = keyed.alias("a")
+    b = keyed.alias("b")
+    return a.join(
+        b,
+        (F.col("a.__block_key__") == F.col("b.__block_key__"))
+        & (F.col(f"a.{id_col}") < F.col(f"b.{id_col}")),
+    ).select(
+        F.col(f"a.{id_col}").alias("a"),
+        F.col(f"b.{id_col}").alias("b"),
+    )
+
+
+#: The source aliases a joined candidate frame carries. NOT "a"/"b": the
+#: candidate frame's own columns are named `a` and `b`, so `F.col("a.first")`
+#: would be ambiguous between "alias a, column first" and a field of a
+#: struct-ish `a`. Distinct sentinel aliases remove the question rather than
+#: relying on resolution order.
+CAND_LHS, CAND_RHS = "__lhs__", "__rhs__"
+
+
+def join_candidates_to_sources(
+    candidates: Any, source_df: Any, *, id_col: str
+) -> Any:
+    """Join ``(a, b)`` candidates back to both record sides.
+
+    Shared by scoring and FS training: the field expressions both build resolve
+    against these aliases, so a second copy of this join that named its sides
+    differently would not fail -- it would silently resolve columns to the wrong
+    side of the pair.
+    """
+    from pyspark.sql import functions as F
+
+    return (
+        candidates.alias("__cand__")
+        .join(
+            source_df.alias(CAND_LHS),
+            F.col(f"{CAND_LHS}.{id_col}") == F.col("__cand__.a"),
+        )
+        .join(
+            source_df.alias(CAND_RHS),
+            F.col(f"{CAND_RHS}.{id_col}") == F.col("__cand__.b"),
+        )
+    )
+
+
 def generate_candidates(
     source_df: Any, config: Any, *, id_col: str, transform_udf: str | None = None
 ) -> Any:
@@ -303,22 +368,10 @@ def generate_candidates(
     it. Hence the kernel refuses any chain it cannot run identically instead of
     falling back.
     """
-    from pyspark.sql import functions as F
-
     per_pass = []
     for i, key_config in enumerate(blocking_passes(config)):
-        key_col, _fields = _block_key_column(key_config, transform_udf)
-        keyed = source_df.withColumn("__block_key__", key_col)
-        keyed = keyed.where(_valid_key(F.col("__block_key__")))
-        a = keyed.alias("a")
-        b = keyed.alias("b")
-        pairs = a.join(
-            b,
-            (F.col("a.__block_key__") == F.col("b.__block_key__"))
-            & (F.col(f"a.{id_col}") < F.col(f"b.{id_col}")),
-        ).select(
-            F.col(f"a.{id_col}").alias("a"),
-            F.col(f"b.{id_col}").alias("b"),
+        pairs = pass_candidates(
+            source_df, key_config, id_col=id_col, transform_udf=transform_udf
         )
         logger.debug("Spark tier: blocking pass %d on %s", i, key_config.fields)
         per_pass.append(pairs)
@@ -508,18 +561,8 @@ def score_candidates(
     """
     from pyspark.sql import functions as F
 
-    # The source aliases must NOT be "a"/"b": the candidate frame's own columns
-    # are named `a` and `b`, so `F.col("a.first")` would be ambiguous between
-    # "alias a, column first" and a field of a struct-ish `a`. Distinct sentinel
-    # aliases remove the question rather than relying on resolution order.
-    lhs, rhs = "__lhs__", "__rhs__"
-    a = source_df.alias(lhs)
-    b = source_df.alias(rhs)
-    joined = (
-        candidates.alias("__cand__")
-        .join(a, F.col(f"{lhs}.{id_col}") == F.col("__cand__.a"))
-        .join(b, F.col(f"{rhs}.{id_col}") == F.col("__cand__.b"))
-    )
+    lhs, rhs = CAND_LHS, CAND_RHS
+    joined = join_candidates_to_sources(candidates, source_df, id_col=id_col)
 
     if scorer_udf is not None:
         if scorer_shape not in ("row", "batch"):

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -1,23 +1,28 @@
-"""Count agreement patterns on the cluster, so FS training need not sample.
+"""Fellegi-Sunter training on the cluster, with no pair sample anywhere.
 
-## The chain this is one link of
+## The chain, complete
 
 EM's E-step reads only the comparison vector (a level per field), so pairs with
 the same vector are interchangeable and every M-step quantity is a sum that is
 linear in how many pairs share it. That makes training decomposable into:
 
-    compute gammas distributed  ->  GROUP BY them  ->  train_em(pair_weights=counts)
+    compute gammas distributed  ->  GROUP BY them  ->  train from the counts
 
-This module is the first two. The third is ``core.probabilistic.train_em``'s
-``pair_weights``, and the per-pass split it runs under is
-``train_em_per_pass``.
+:func:`agreement_pattern_counts` is the first two steps; the third is
+``core.probabilistic.train_em_from_counts``. :func:`train_em_distributed` is the
+caller that strings them together, one session per blocking pass, over a ``u``
+that :func:`estimate_u_distributed` counts the same way from random pairs.
 
-Splink does exactly this -- ``count_agreement_patterns_sql`` is
+What this replaces is the INPUT to the iteration, not the iteration. ``train_em``
+reads a driver-side sample of blocked pairs capped by ``n_sample_pairs``, and
+that cap is why a bigger cluster has never bought a better-trained model.
+
+Splink does the same decomposition -- ``count_agreement_patterns_sql`` is
 ``select {gammas}, count(*) group by {gammas}`` -- and then runs the iteration
 itself as engine-side SQL. This does the counting in the engine and leaves the
 iteration on the driver, which is a real difference and is stated rather than
-glossed: what it buys is that the iteration's input stops being a sample and
-stops being proportional to the pair count.
+glossed: the iteration's input is bounded by the number of distinct comparison
+vectors, so leaving it on the driver costs nothing that grows with the data.
 
 ## Why the result is small
 
@@ -141,3 +146,247 @@ def agreement_pattern_counts(
         len(out), total, 100.0 * len(out) / max(total, 1),
     )
     return out
+
+
+# ── u: the half of the likelihood ratio blocking cannot supply ───────
+
+
+def _rows_needed_for_n_pairs(n_pairs: int) -> int:
+    """Rows whose self-pairing yields about ``n_pairs``.
+
+    The inverse of ``p(r) = r(r-1)/2``, solved for ``r``. Splink's
+    ``estimate_u.py`` sizes its sample the same way, for the same reason: a
+    cross join is quadratic, so the knob a caller wants to turn is the pair
+    budget, and the row count is derived from it rather than guessed.
+    """
+    return max(2, int(0.5 * ((8 * n_pairs + 1) ** 0.5 + 1)))
+
+
+def random_pairs(
+    source_df: Any,
+    *,
+    id_col: str,
+    max_pairs: int = 1_000_000,
+    seed: int = 42,
+    lhs: str | None = None,
+    rhs: str | None = None,
+) -> Any:
+    """A joined frame of RANDOM record pairs, for estimating ``u``.
+
+    Sampled and then cross-joined, rather than cross-joined and then sampled:
+    the full cross join is quadratic in the table and is not something to
+    materialise on the way to a sample of it.
+
+    ``sample`` and not ``limit``: ``limit`` takes whatever rows the scan reaches
+    first, which correlates with input order. On a file sorted by name that
+    draws every pair from one corner of the data, and ``u`` -- the level
+    distribution among non-matches -- would be measured on a population that is
+    unusually likely to agree. It would look like a working estimate.
+    """
+    total = source_df.count()
+    if total < 2:
+        raise ValueError(
+            f"u needs at least 2 records to form a pair; the source has {total}"
+        )
+
+    from pyspark.sql import functions as F
+
+    from goldenmatch.spark.config_pipeline import CAND_LHS, CAND_RHS
+
+    lhs = lhs or CAND_LHS
+    rhs = rhs or CAND_RHS
+    want = _rows_needed_for_n_pairs(max_pairs)
+    if want >= total:
+        sample = source_df
+    else:
+        # Oversample by 10% then cap: `sample` draws each row independently, so
+        # the size is binomial around the fraction and a bare fraction lands
+        # under target about half the time.
+        fraction = min(1.0, (want / total) * 1.1)
+        sample = source_df.sample(withReplacement=False, fraction=fraction, seed=seed)
+        sample = sample.limit(want)
+
+    a = sample.alias(lhs)
+    b = sample.alias(rhs)
+    return a.join(b, F.col(f"{lhs}.{id_col}") < F.col(f"{rhs}.{id_col}"))
+
+
+def estimate_u_distributed(
+    source_df: Any,
+    mk: Any,
+    *,
+    id_col: str,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+    max_pairs: int = 1_000_000,
+    seed: int = 42,
+    max_patterns: int = MAX_PATTERNS,
+) -> dict[str, list[float]]:
+    """``u`` estimated on the cluster, from random pairs.
+
+    The same two steps as ``m``: count agreement patterns distributed, then do
+    the arithmetic on the small counted result. ``u`` needs no EM at all -- it
+    is one pass of counting -- so this is ``agreement_pattern_counts`` over a
+    random-pair frame handed to
+    :func:`goldenmatch.core.probabilistic.estimate_u_from_counts`.
+
+    Reusing the same counter is the point. ``u`` and ``m`` must be measured
+    against the SAME definition of a level, or ``log2(m/u)`` divides two numbers
+    that are not about the same partition of the data. Deriving both from
+    ``gamma_columns`` makes that true by construction instead of by review.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+
+    joined = random_pairs(
+        source_df, id_col=id_col, max_pairs=max_pairs, seed=seed
+    )
+    from goldenmatch.spark.config_pipeline import CAND_LHS, CAND_RHS
+
+    counts = agreement_pattern_counts(
+        joined, mk, lhs=CAND_LHS, rhs=CAND_RHS,
+        scorer_udf=scorer_udf, transform_udf=transform_udf,
+        max_patterns=max_patterns,
+    )
+    n_pairs = sum(c for _, c in counts)
+    logger.info(
+        "FS u: estimated from %d random pairs (%d distinct patterns)",
+        n_pairs, len(counts),
+    )
+    return estimate_u_from_counts(mk, counts)
+
+
+# ── the caller: every link, strung together ──────────────────────────
+
+
+def train_em_distributed(
+    source_df: Any,
+    config: Any,
+    mk: Any,
+    *,
+    id_col: str,
+    scorer_udf: str | None = None,
+    transform_udf: str | None = None,
+    u_max_pairs: int = 1_000_000,
+    seed: int = 42,
+    max_iterations: int = 20,
+    convergence: float = 0.001,
+    max_patterns: int = MAX_PATTERNS,
+) -> Any:
+    """Train one matchkey's FS model with no pair sample anywhere.
+
+    The whole chain, in the order the links were built::
+
+        u   <- count gammas over RANDOM pairs        -> estimate_u_from_counts
+        m   <- count gammas per BLOCKING PASS        -> train_em_from_counts
+        one <- combine the per-pass sessions         -> _combine_em_sessions
+
+    What this changes versus ``train_em`` is the input to the iteration, not the
+    iteration: ``train_em`` reads a driver-side sample of blocked pairs, capped
+    by ``n_sample_pairs``, and that cap is the reason a bigger cluster has never
+    bought a better-trained model. Here every pair the blocking produces is
+    counted by the engine, and what reaches the driver is one row per distinct
+    comparison vector -- bounded by ``prod(levels + 1)``, so thousands of rows
+    whether the passes generated a million pairs or ten billion.
+
+    One matchkey per call, because a matchkey is the unit a comparison vector is
+    defined by. A config with several gets several calls and several models,
+    which is the shape ``fs_models`` already takes.
+
+    Returns an ``EMResult``, the same type ``train_em`` returns, usable anywhere
+    a model trained on one box is.
+    """
+    from goldenmatch.core.probabilistic import (
+        _combine_em_sessions,
+        train_em_from_counts,
+    )
+    from goldenmatch.spark.config_pipeline import (
+        CAND_LHS,
+        CAND_RHS,
+        blocking_passes,
+        join_candidates_to_sources,
+        pass_candidates,
+    )
+
+    # Refuse BEFORE submitting anything. `train_em_from_counts` rejects these
+    # too, but reaching that check costs a distributed count over every blocking
+    # pass first -- a config error should not cost a cluster job to discover.
+    _refuse_unsupported(mk)
+
+    passes = blocking_passes(config)
+    if not passes:
+        raise ValueError(
+            "train_em_distributed needs at least one blocking pass "
+            "(config.blocking.keys, or config.blocking.passes for multi_pass); "
+            "without one there are no candidate pairs to estimate m from"
+        )
+
+    u_probs = estimate_u_distributed(
+        source_df, mk, id_col=id_col, scorer_udf=scorer_udf,
+        transform_udf=transform_udf, max_pairs=u_max_pairs, seed=seed,
+        max_patterns=max_patterns,
+    )
+
+    sessions = []
+    for i, key_config in enumerate(passes):
+        fields = tuple(key_config.fields)
+        candidates = pass_candidates(
+            source_df, key_config, id_col=id_col, transform_udf=transform_udf
+        )
+        joined = join_candidates_to_sources(
+            candidates, source_df, id_col=id_col
+        )
+        counts = agreement_pattern_counts(
+            joined, mk, lhs=CAND_LHS, rhs=CAND_RHS,
+            scorer_udf=scorer_udf, transform_udf=transform_udf,
+            max_patterns=max_patterns,
+        )
+        if not counts:
+            # A pass whose every key was null or a missing sentinel produces no
+            # candidates. Skipping is right, and saying so matters: silently
+            # dropping a pass would leave the fields only IT could estimate
+            # sitting on the fixed prior with nothing indicating why.
+            logger.warning(
+                "FS EM: blocking pass %d on %s produced no candidate pairs; "
+                "it contributes no session", i, list(fields),
+            )
+            continue
+        em = train_em_from_counts(
+            mk, counts, u_probs, conditioned_fields=fields,
+            max_iterations=max_iterations, convergence=convergence,
+        )
+        # Weighted by the EXACT pair count, which the counts already carry --
+        # the one-box `train_em_per_pass` has to approximate this with block row
+        # counts because its sampler decides how many pairs it actually draws.
+        weight = float(sum(c for _, c in counts))
+        sessions.append((fields, em, weight))
+        logger.info(
+            "FS EM session: pass=%s pairs=%.0f patterns=%d converged=%s",
+            fields, weight, len(counts), em.converged,
+        )
+
+    if not sessions:
+        raise ValueError(
+            "no blocking pass produced candidate pairs, so there is nothing to "
+            "train m from. Check that the blocking keys are populated -- a key "
+            "that is null or a missing sentinel for every record yields no "
+            "blocks."
+        )
+    return _combine_em_sessions(mk, sessions)
+
+
+def _refuse_unsupported(mk: Any) -> None:
+    """Refuse configs the counted path cannot train, before submitting a job."""
+    from goldenmatch.core.probabilistic import _em_ne_fields
+
+    if _em_ne_fields(mk):
+        raise NotImplementedError(
+            f"matchkey {mk.name!r} has negative-evidence fields, which need a "
+            f"per-pair NE matrix that counted comparison vectors do not carry. "
+            f"Train it with train_em() on sampled pairs."
+        )
+    if any(getattr(f, "tf_adjustment", False) for f in mk.fields):
+        raise NotImplementedError(
+            f"matchkey {mk.name!r} uses term-frequency adjustment, which needs "
+            f"per-value frequencies that counted comparison vectors do not "
+            f"carry. Train it with train_em() on sampled pairs."
+        )

--- a/packages/python/goldenmatch/tests/test_fs_em_per_pass.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_per_pass.py
@@ -174,3 +174,36 @@ def test_blocks_without_provenance_fall_back_to_the_pooled_run():
     fell_back = _train(train_em_per_pass, df, blocks, blocking_fields=["zip"])
 
     assert fell_back.m_probs == pooled.m_probs
+
+
+# ── u for blocking fields: the #1835 prior, across sessions ──────────
+
+def test_every_pass_blocking_field_keeps_the_neutral_u_prior():
+    """The combination must neutralise the UNION of blocking fields.
+
+    A configured blocking field carries a deliberate fixed prior that EM cannot
+    recover from random pairs (#1835): a near-unique key's `u` collapses toward
+    the smoothing floor, which EXPLODES its agreement weight and lets one field
+    dominate the score. `train_em` guards this with
+    `always_conditioned |= set(blocking_fields)` over the union of every pass.
+
+    Each per-pass session neutralises only ITS OWN pass's fields, so lifting `u`
+    from one session leaves every other pass's blocking field carrying the
+    random-pair estimate. Measured on this fixture: `zip` came back
+    [0.977, 0.023] instead of [0.5, 0.5], a 4.4-bit swing in its agreement
+    weight. On a near-unique key it is the ~28-bit collapse #1835 records.
+
+    Nothing about the result looks wrong -- it is a valid probability vector,
+    and only a comparison against the pooled run reveals it.
+    """
+    df = _frame()
+    blocks = _blocks(df, _cfg(["zip"], ["last_name"]))
+
+    pooled = _train(train_em, df, blocks, blocking_fields=["zip", "last_name"])
+    combined = _train(train_em_per_pass, df, blocks)
+
+    for name in ("zip", "last_name"):
+        assert combined.u_probs[name] == pytest.approx(pooled.u_probs[name]), (
+            f"{name} is a blocking field of some pass, so it must carry the "
+            f"neutral prior the pooled run gives it, not a random-pair estimate"
+        )

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -286,3 +286,73 @@ def test_negative_evidence_is_refused_not_silently_dropped():
     matrix, patterns = _patterns_and_matrix(_frame(), _make_probabilistic_mk())
     with pytest.raises(NotImplementedError, match="negative-evidence"):
         train_em_from_counts(mk, patterns, _u_from(matrix, _make_probabilistic_mk()))
+
+
+# ── u, the other half of the likelihood ratio ────────────────────────
+
+def test_u_from_counts_equals_the_u_train_em_estimates():
+    """THE gate for distributed u.
+
+    `train_em` estimates u from a RANDOM pair sample:
+
+        u[level] = (count(level) + 1e-6) / (observed + n_levels * 1e-6)
+
+    which is a per-level count and a denominator that excludes unobserved
+    (-1) entries. Both are sums over pairs, so counted vectors carry everything
+    it needs -- and this asserts that against `train_em`'s ACTUAL output rather
+    than against the formula rewritten in the test, which would pass even if
+    both copies were wrong together.
+
+    The sample is reproduced with the same seeded `_sample_pairs` call
+    `train_em` makes, so the two see the same pairs.
+    """
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import (
+        _build_comparison_matrix,
+        _row_lookup_for_pairs,
+        _sample_pairs,
+        estimate_u_from_counts,
+    )
+
+    df, mk = _frame(), _make_probabilistic_mk()
+    n, seed = 400, 7
+
+    # No blocks and no blocking_fields, so nothing is `always_conditioned` and
+    # train_em applies no neutral-u override -- this compares the ESTIMATE, not
+    # the blocking-field prior, which has its own test.
+    trained = train_em(df, mk, n_sample_pairs=n, max_iterations=25, seed=seed)
+
+    pairs = _sample_pairs(df, min(n, 5000), seed)
+    lookup = _row_lookup_for_pairs(df, [f.field for f in mk.fields], [pairs])
+    matrix = _build_comparison_matrix(pairs, lookup, mk)
+    counts = sorted(Counter(tuple(int(v) for v in r) for r in matrix).items())
+    assert len(counts) < len(matrix), "nothing collapsed; the test proves nothing"
+
+    from_counts = estimate_u_from_counts(mk, counts)
+    for f in mk.fields:
+        assert from_counts[f.field] == pytest.approx(
+            trained.u_probs[f.field], abs=1e-12
+        ), f"{f.field}: counted u differs from the u train_em estimated"
+
+
+def test_u_from_counts_excludes_unobserved_from_the_denominator():
+    """A field null on one side is UNOBSERVED (-1), not a disagreement.
+
+    Dividing by every pair instead of the observed ones would shrink every level
+    of a sparsely-populated field toward zero in proportion to its missingness,
+    inflating log2(m/u) for exactly the fields the data supports least.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+
+    mk = _make_probabilistic_mk()
+    n_fields = len(mk.fields)
+    # 10 pairs observed at level 0, 90 pairs unobserved, on the first field.
+    obs = tuple([0] + [0] * (n_fields - 1))
+    unobs = tuple([-1] + [0] * (n_fields - 1))
+    u = estimate_u_from_counts(mk, [(obs, 10), (unobs, 90)])
+
+    first = mk.fields[0]
+    assert u[first.field][0] == pytest.approx(
+        (10 + 1e-6) / (10 + first.levels * 1e-6), abs=1e-12
+    ), "the 90 unobserved pairs must not be in the denominator"

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -440,3 +440,263 @@ def test_an_oversized_pattern_space_is_refused_not_collected(source):
     cfg = _config()
     with pytest.raises(ValueError, match="max_patterns"):
         _spark_pattern_counts(source, cfg, max_patterns=1)
+
+
+# ── distributed training: u, the per-pass sessions, the combination ──
+#
+# The fixture is deliberately blockable on BOTH `city` and `last`. Two passes
+# are the point: `last` is a comparison field AND pass 2's blocking key, so it
+# is conditioned in one session and free in the other -- the situation the
+# decomposition exists for, and the one where the #1835 neutral-u prior has to
+# survive the combination.
+#
+# It is also deliberately SMALL enough that the u sample takes the whole frame
+# (`_rows_needed_for_n_pairs(1e6)` is 1,414 rows). Spark's `sample` cannot be
+# reproduced on the driver, so a fixture that triggered it would leave the u
+# gate unable to state an expected value -- it could only assert that some
+# numbers came back.
+
+_TRAIN_ROWS = [
+    (0, "jon", "smith", "york"),
+    (1, "john", "smith", "york"),
+    (2, "jonathan", "smyth", "york"),
+    (3, "jon", "smith", "leeds"),
+    (4, "amy", "wong", "leeds"),
+    (5, "amie", "wong", "leeds"),
+    (6, "amy", "wong", "york"),
+    (7, "pat", "jones", "hull"),
+    (8, "patrick", "jones", "hull"),
+    (9, "pat", "jonas", "hull"),
+    (10, "sam", "brown", "hull"),
+    (11, "samuel", "brown", "york"),
+    (12, "sam", "browne", "leeds"),
+    (13, "kim", "smith", "hull"),
+    (14, "kimberly", "smith", "leeds"),
+    (15, "kim", "wong", "york"),
+]
+
+
+def _train_config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[_mk()],
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            passes=[
+                BlockingKeyConfig(fields=["city"]),
+                BlockingKeyConfig(fields=["last"]),
+            ],
+        ),
+    )
+
+
+@pytest.fixture()
+def train_source(spark):
+    return spark.createDataFrame(_TRAIN_ROWS, _COLS)
+
+
+def _by_id():
+    return {r[0]: dict(zip(_COLS, r)) for r in _TRAIN_ROWS}
+
+
+def _driver_counts(pairs, mk):
+    """Counted comparison vectors, via the ONE-BOX's `comparison_vector`."""
+    from collections import Counter
+
+    from goldenmatch.core.probabilistic import comparison_vector
+
+    by_id = _by_id()
+    counts = Counter()
+    for a, b in pairs:
+        vec = comparison_vector(by_id[int(a)], by_id[int(b)], mk)
+        counts[tuple(int(v) for v in vec)] += 1
+    return sorted(counts.items())
+
+
+def _all_driver_pairs():
+    ids = sorted(r[0] for r in _TRAIN_ROWS)
+    return [(a, b) for i, a in enumerate(ids) for b in ids[i + 1:]]
+
+
+def test_training_blocks_exactly_as_scoring_blocks(train_source):
+    """The per-pass candidate sets must union to the scoring candidate set.
+
+    Training on a different population from the one scoring sees produces a
+    model fitted to pairs that never get scored -- weights that are not wrong
+    about anything you can point at, just about the wrong data. Splitting
+    `generate_candidates` into `pass_candidates` is what makes this hold by
+    construction, and this pins that it stayed true.
+    """
+    from goldenmatch.spark.config_pipeline import (
+        blocking_passes,
+        generate_candidates,
+        pass_candidates,
+    )
+
+    cfg = _train_config()
+    union = set()
+    for key_config in blocking_passes(cfg):
+        rows = pass_candidates(train_source, key_config, id_col=_ID).collect()
+        union |= {(int(r["a"]), int(r["b"])) for r in rows}
+
+    scoring = {
+        (int(r["a"]), int(r["b"]))
+        for r in generate_candidates(train_source, cfg, id_col=_ID).collect()
+    }
+    assert union == scoring, (
+        f"per-pass candidates and scoring candidates differ: "
+        f"only-training={sorted(union - scoring)} "
+        f"only-scoring={sorted(scoring - union)}"
+    )
+    assert scoring, "no candidates at all; the fixture proves nothing"
+
+
+def test_distributed_u_is_the_one_box_u_over_random_pairs(train_source):
+    """u must be the level distribution over RANDOM pairs, not blocked ones.
+
+    Blocked candidates already agree on a blocking key, so their level
+    distribution is not u -- it is u conditioned on agreement, which is exactly
+    the quantity u must NOT be. Using it would shrink the denominator of
+    log2(m/u) for every field correlated with the key and inflate its weight.
+
+    The fixture is smaller than the u sample target, so `random_pairs` takes
+    every record and the expected value is computable here exactly.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+    from goldenmatch.spark.em import estimate_u_distributed
+
+    mk = _train_config().get_matchkeys()[0]
+    want = estimate_u_from_counts(mk, _driver_counts(_all_driver_pairs(), mk))
+    got = estimate_u_distributed(train_source, mk, id_col=_ID)
+
+    assert got == pytest.approx(want, abs=1e-12), (
+        "distributed u differs from the one-box estimate over the same pairs"
+    )
+
+
+def test_u_over_random_pairs_differs_from_u_over_blocked_pairs(train_source):
+    """And the distinction is not academic on this fixture.
+
+    If blocked and random pairs gave the same u here, the test above would pass
+    with `estimate_u_distributed` reading the wrong frame entirely.
+    """
+    from goldenmatch.core.probabilistic import estimate_u_from_counts
+    from goldenmatch.spark.config_pipeline import generate_candidates
+    from goldenmatch.spark.em import estimate_u_distributed
+
+    mk = _train_config().get_matchkeys()[0]
+    cfg = _train_config()
+    blocked = [
+        (int(r["a"]), int(r["b"]))
+        for r in generate_candidates(train_source, cfg, id_col=_ID).collect()
+    ]
+    u_blocked = estimate_u_from_counts(mk, _driver_counts(blocked, mk))
+    u_random = estimate_u_distributed(train_source, mk, id_col=_ID)
+
+    assert u_blocked != pytest.approx(u_random, abs=1e-9), (
+        "blocked and random pairs give the same u on this fixture, so it "
+        "cannot distinguish the two and the u gate above proves less than it "
+        "appears to"
+    )
+
+
+def _driver_trained(train_source, mk, cfg):
+    """The model the one-box builds from the same counts, session by session."""
+    from goldenmatch.core.probabilistic import (
+        _combine_em_sessions,
+        estimate_u_from_counts,
+        train_em_from_counts,
+    )
+    from goldenmatch.spark.config_pipeline import blocking_passes, pass_candidates
+
+    u = estimate_u_from_counts(mk, _driver_counts(_all_driver_pairs(), mk))
+    sessions = []
+    for key_config in blocking_passes(cfg):
+        rows = pass_candidates(train_source, key_config, id_col=_ID).collect()
+        pairs = [(int(r["a"]), int(r["b"])) for r in rows]
+        counts = _driver_counts(pairs, mk)
+        em = train_em_from_counts(
+            mk, counts, u, conditioned_fields=tuple(key_config.fields)
+        )
+        sessions.append((tuple(key_config.fields), em, float(len(pairs))))
+    return _combine_em_sessions(mk, sessions)
+
+
+def test_train_em_distributed_equals_the_one_box_over_the_same_pairs(train_source):
+    """THE end-to-end gate.
+
+    Every level in the reference comes from `comparison_vector` -- the one-box's
+    own function, the one a locally-trained model is built from -- so this
+    compares the distributed model against the reference implementation and not
+    against a second copy of the Spark expressions.
+
+    Exact, not approximate: both sides run the same `_em_iterate` over counts
+    that must be identical. A tolerance would hide the failure this exists to
+    catch, since a model trained on subtly wrong counts is still a valid model.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = _train_config()
+    mk = cfg.get_matchkeys()[0]
+
+    want = _driver_trained(train_source, mk, cfg)
+    got = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+
+    for f in mk.fields:
+        assert got.m_probs[f.field] == pytest.approx(
+            want.m_probs[f.field], abs=1e-12
+        ), f"{f.field}: distributed m differs from the one-box"
+        assert got.u_probs[f.field] == pytest.approx(
+            want.u_probs[f.field], abs=1e-12
+        ), f"{f.field}: distributed u differs from the one-box"
+    assert got.proportion_matched == pytest.approx(
+        want.proportion_matched, abs=1e-12
+    )
+
+
+def test_distributed_training_is_jar_only(train_source, jvm_registered):
+    """No Python on the executors, which is the whole claim of this tier.
+
+    Training that needed an executor virtualenv would leave the jar-only story
+    half true in the place it is hardest to notice -- scoring would be jar-only
+    and the model it scores with would not be.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    cfg = _train_config()
+    mk = cfg.get_matchkeys()[0]
+
+    want = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+    got = train_em_distributed(
+        train_source, cfg, mk, id_col=_ID,
+        scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME,
+    )
+    for f in mk.fields:
+        assert got.m_probs[f.field] == pytest.approx(
+            want.m_probs[f.field], abs=1e-12
+        ), f"{f.field}: the jar-only route trained a different model"
+
+
+def test_a_blocking_field_keeps_the_neutral_u_prior(train_source):
+    """`last` is pass 2's blocking key, so it must not carry a learned u.
+
+    #1835: a near-unique blocking key's u collapses toward the smoothing floor,
+    exploding its agreement weight until it dominates the score (F1 0.83 ->
+    0.57). `train_em` guards this over the UNION of blocking fields, and the
+    distributed route has to arrive at the same guard through a different path
+    -- per-pass sessions that each neutralise only their own key.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = _train_config()
+    mk = cfg.get_matchkeys()[0]
+    em = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+
+    assert em.u_probs["last"] == pytest.approx([0.5, 0.5], abs=1e-12), (
+        "`last` is a blocking field of pass 2, so it must carry the neutral "
+        "prior, not an estimate from random pairs"
+    )
+    assert em.u_probs["first"] != pytest.approx([0.5, 0.5], abs=1e-9), (
+        "`first` blocks nothing and must still be LEARNED -- if it also came "
+        "back neutral, the guard is neutralising everything"
+    )

--- a/packages/python/goldenmatch/tests/test_spark_fs_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_unit.py
@@ -271,3 +271,151 @@ def test_a_saved_model_round_trips(tmp_path):
     loaded = resolve_fs_model(mk, model_path=str(p))
     assert loaded.match_weights == em.match_weights
     assert loaded.proportion_matched == pytest.approx(em.proportion_matched)
+
+
+# ── distributed EM: what it refuses, and how it sizes the u sample ───
+#
+# No Spark, so these run on every PR. They cover the checks that must fire
+# BEFORE a cluster job is submitted -- the ones whose whole value is being
+# cheap, and which a Spark-lane-only test would never prove were cheap.
+
+
+class _ExplodingFrame:
+    """Any use of this as a DataFrame raises.
+
+    A refusal that only happens after the frame is touched still costs a
+    distributed count over every blocking pass to discover a config error. This
+    makes "nothing was submitted" a testable claim rather than a code-reading
+    one.
+    """
+
+    def __getattr__(self, name):
+        raise AssertionError(
+            f"the source frame was used ({name!r}) before the config was "
+            f"refused; the check must fire before any job is submitted"
+        )
+
+
+def _ne_matchkey():
+    from goldenmatch.config.schemas import NegativeEvidenceField
+
+    mk = _fs_matchkey()
+    mk.negative_evidence = [
+        NegativeEvidenceField(field="dob", scorer="exact", threshold=0.9)
+    ]
+    return mk
+
+
+def _fs_matchkey():
+    return MatchkeyConfig(
+        name="fs",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="last", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+        ],
+    )
+
+
+def _static_config(mk, keys):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[mk],
+        blocking=BlockingConfig(
+            keys=[BlockingKeyConfig(fields=list(k)) for k in keys]
+        ),
+    )
+
+
+def test_negative_evidence_is_refused_before_a_job_is_submitted():
+    """NE needs a per-pair matrix counted vectors do not carry.
+
+    Refused rather than dropped: training without the NE dimensions produces a
+    model the config did not ask for, and every number in it looks reasonable.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    mk = _ne_matchkey()
+    with pytest.raises(NotImplementedError, match="negative-evidence"):
+        train_em_distributed(
+            _ExplodingFrame(), _static_config(mk, [["city"]]), mk, id_col="id"
+        )
+
+
+def test_term_frequency_adjustment_is_refused_before_a_job_is_submitted():
+    """TF needs per-value frequencies the counts do not carry."""
+    from goldenmatch.spark.em import train_em_distributed
+
+    mk = _fs_matchkey()
+    mk.fields[0].tf_adjustment = True
+    with pytest.raises(NotImplementedError, match="term-frequency"):
+        train_em_distributed(
+            _ExplodingFrame(), _static_config(mk, [["city"]]), mk, id_col="id"
+        )
+
+
+def test_a_config_with_no_blocking_pass_is_refused():
+    """Without a pass there are no candidate pairs, so there is no m to train.
+
+    Returning a fixed-prior model instead would be a trained-looking result from
+    a config that trained on nothing.
+    """
+    from types import SimpleNamespace
+
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = SimpleNamespace(
+        blocking=SimpleNamespace(strategy="static", keys=[], passes=[])
+    )
+    with pytest.raises(ValueError, match="at least one blocking pass"):
+        train_em_distributed(
+            _ExplodingFrame(), cfg, _fs_matchkey(), id_col="id"
+        )
+
+
+@pytest.mark.parametrize("pairs", [10, 1_000, 1_000_000, 100_000_000])
+def test_the_u_sample_is_sized_by_the_pair_budget(pairs):
+    """`r` rows self-pair into `r(r-1)/2`, so the row count inverts that.
+
+    A cross join is quadratic, so the knob worth exposing is the pair budget;
+    picking a row count directly makes the cost a surprise.
+
+    `max_pairs` is a CEILING, so the chosen `r` must not exceed it -- and must
+    be the largest that does not, or the budget silently buys a smaller sample
+    than it paid for. Both directions asserted, because only checking the
+    ceiling would pass for `r = 2`.
+
+    Round-tripped through the forward formula rather than compared to
+    hard-coded numbers, which would pin whatever the implementation happened to
+    return rather than what it owes.
+    """
+    from goldenmatch.spark.em import _rows_needed_for_n_pairs
+
+    r = _rows_needed_for_n_pairs(pairs)
+    assert r * (r - 1) / 2 <= pairs, (
+        f"{r} rows produce {r * (r - 1) / 2:.0f} pairs, over the {pairs} budget"
+    )
+    assert (r + 1) * r / 2 > pairs, (
+        f"{r} rows leave room for more: {r + 1} rows still fit in {pairs}"
+    )
+
+
+def test_a_source_too_small_to_form_a_pair_is_refused():
+    """One record has no pairs, so u would be estimated from nothing.
+
+    The smoothing floor would still return a full set of probabilities.
+    """
+    from types import SimpleNamespace
+
+    from goldenmatch.spark.em import random_pairs
+
+    frame = SimpleNamespace(count=lambda: 1)
+    with pytest.raises(ValueError, match="at least 2 records"):
+        random_pairs(frame, id_col="id")


### PR DESCRIPTION
Closes the chain. The three links landed separately -- counts on the cluster (#2545), per-pass sessions (#2550), training from counts (#2552) -- but **nothing called them**, and one of the two inputs to a Fellegi-Sunter model had no distributed estimator at all.

**Stacked on #2552**, which is stacked on #2550. Both are in the merge queue; their commits drop out on rebase.

## `train_em_distributed`

```
u   <- count gammas over RANDOM pairs   -> estimate_u_from_counts
m   <- count gammas per BLOCKING PASS   -> train_em_from_counts
one <- combine the per-pass sessions    -> _combine_em_sessions
```

What changes is the **input** to the iteration, not the iteration. `train_em` reads a driver-side sample of blocked pairs capped by `n_sample_pairs`, and that cap is why a bigger cluster has never bought a better-trained model. Here every pair the blocking produces is counted by the engine, and what reaches the driver is one row per distinct comparison vector -- bounded by `prod(levels + 1)`, so thousands of rows whether the passes generated a million pairs or ten billion.

## `u`, which nothing distributed could estimate

`u` is the level distribution among non-matches. Random pairs are overwhelmingly non-matches, so it needs no EM -- one pass of counting. `estimate_u_distributed` reuses `agreement_pattern_counts` over a random-pair frame, which matters more than saving code: **`u` and `m` must be measured against the same definition of a level**, or `log2(m/u)` divides two numbers that are not about the same partition of the data. Deriving both from `gamma_columns` makes that true by construction rather than by review.

Sample sizing inverts `r(r-1)/2`, the same way Splink's `estimate_u.py` does -- a cross join is quadratic, so the knob worth exposing is the pair budget. `sample`, not `limit`: `limit` takes whatever rows the scan reaches first, which correlates with input order. On a file sorted by name that draws every pair from one corner of the data, and it would look like a working estimate.

## A bug in #2550, found while building on it

`train_em_per_pass` lifted `u` wholesale from one session, reasoning that `u` comes from random pairs and so cannot vary by pass. **It does vary.** Each session neutralises its *own* blocking fields (the #1835 fixed prior), so the combined model kept a random-pair estimate for every *other* pass's blocking key.

Measured on the test fixture:

| field | pooled `u` | per-pass `u` (before) |
|---|---|---|
| `zip` | `[0.5, 0.5]` | `[0.977, 0.023]` |

A 4.4-bit swing in `zip`'s agreement weight here; on a near-unique key it is the ~28-bit collapse #1835 records, which took F1 from 0.83 to 0.57. Nothing about the output looks wrong -- it is a valid probability vector -- and only a comparison against the pooled run reveals it. The combination now neutralises the union of blocking fields, matching `train_em`.

Verified empirically before fixing, not inferred from reading the code.

## Extractions

So the one-box and distributed routes cannot drift on what they mean:

- `_combine_em_sessions` -- shared by both callers
- `_neutral_u_for` -- one definition of the #1835 prior
- `pass_candidates`, `join_candidates_to_sources` -- so **training blocks and joins exactly as scoring does**. Training on a different candidate set fits a model to a population scoring never sees, and there is nothing in the resulting weights to point at.

## What it refuses, before submitting anything

Negative evidence, term-frequency adjustment, and a config with no blocking pass. Both NE and TF need per-pair inputs counted vectors do not carry; training without them silently produces a model the config did not ask for. The checks fire before the frame is touched -- a config error should not cost a cluster job to discover -- and the tests prove that with a frame that raises on **any** attribute access, rather than by reading the code.

## Tests

No-Spark (every PR): the refusals, the sample-size round trip against the forward formula, the `u`-from-counts gate pinned against **`train_em`'s actual output** rather than the formula rewritten in the test, and the per-pass `u` regression above.

Spark lanes: per-pass candidates union to the scoring candidate set; distributed `u` equals the one-box estimate over the same pairs (the fixture is deliberately smaller than the sample target, so `random_pairs` takes every record and the expected value is computable exactly); blocked-pair `u` **differs** from random-pair `u` on this fixture, so the gate above can distinguish them; the end-to-end model matches a driver-side composition built from `comparison_vector`; and the whole thing trains jar-only.

## Scope

One matchkey per call -- a comparison vector is defined by a matchkey, and a config with several needs several calls, which is the shape `fs_models` already takes. Baseline check: the 45 native/fused-FS failures in this worktree reproduce identically at the parent commit (environment skew, `GOLDENMATCH_NATIVE=0`), so they are not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
