### PR TITLE
feat(semantic): ODCS (Open Data Contract Standard) dialect for the key-integrity certifier

### DIFF
--- a/context-network/decisions/0062-odcs-data-contract-dialect.md
+++ b/context-network/decisions/0062-odcs-data-contract-dialect.md
@@ -1,0 +1,89 @@
+# 0062 — ODCS (Open Data Contract Standard) dialect for the semantic-layer certifier
+
+**Status:** accepted (2026-08-13, Ben) • **Shipped:** `goldenmatch.semantic.odcs` (`parse_odcs_contract`, `odcs_identity_keys`, `certify_odcs_contract`, `emit_odcs_yaml`, `emit_odcs_from_crosswalk`) + an `"odcs"` dialect in `certify_semantic_model` • **Builds on:** [0049 (metric-aware key certification)](0049-metric-aware-key-certification.md), [0052 (Cube dialect)](0052-cube-dialect-and-osi-validation.md), [0060 (Feast provider)](0060-feast-feature-store-provider.md), [0061 (Malloy dialect)](0061-malloy-bi-dialect.md) • **Planning:** [../planning/semantic-layer-interchange.md](../planning/semantic-layer-interchange.md)
+
+## Context
+The remaining adjacent-standard surface from the semantic-layer roadmap filter is
+the **data-contract** lane. A data contract is the most *literal* statement of the
+semantic-layer thesis: it is a machine-readable promise about a dataset, and its
+identity promise is declared right in the schema. In **ODCS** (Open Data Contract
+Standard — the PayPal-origin spec now under the Bitol project / Linux Foundation AI
+& Data), a v3 `schema` object's properties carry **`primaryKey: true`** (ordered by
+**`primaryKeyPosition`** for a composite key) and **`unique: true`**. The contract
+*asserts* "these columns identify a row" — and nothing checks that assertion against
+the data. That is the same gap 0049 catches, except here it is the contract's
+headline term: a duplicated primary key means the uniqueness promise is simply
+false, and every downstream consumer that trusts the contract inherits the miscount.
+
+ODCS `primaryKey`/`primaryKeyPosition` maps one-to-one onto MetricFlow
+`entity (primary)`, Cube `primary_key`, and Malloy `primary_key` — so the
+metric-aware certifier applies unchanged.
+
+## Decision
+A new dialect module `goldenmatch/semantic/odcs.py`, structured exactly like Cube
+(0052), Feast (0060), and Malloy (0061) — consume, certify (bridge A), emit
+(bridge B):
+
+1. **Consume.** `parse_odcs_contract(source)` reads a declarative ODCS doc (dict /
+   YAML / JSON / path) into an `ODCSContract` of `ODCSSchemaObject`s. It reads the
+   **v3** shape (`schema:` / `properties:`) canonically and is tolerant of the
+   **legacy v2** spelling on read (`dataset:` / `columns:`, `isPrimary` / `isUnique`)
+   so an existing contract certifies without a rewrite. `odcs_identity_keys` yields
+   each object's declared identity keys: the composite primary key (properties with
+   `primaryKey: true`, ordered by `primaryKeyPosition`) **plus each standalone
+   `unique` property** — a data contract commonly promises both, and each is worth
+   certifying. No `open-data-contract-standard` dependency; it reads the plain doc.
+2. **Certify (bridge A).** `certify_odcs_contract(contract, frames, resolve=…)`
+   certifies **every declared key** of each schema object via `certify_key_integrity`
+   — one certificate for the composite primary key, one per standalone `unique`
+   property — with the object's **numeric properties as the fan-out measures** a
+   duplicated key would inflate under aggregation (mirrors Feast treating features as
+   measures; the numeric/descriptive split comes from ODCS `logicalType`). A frame is
+   matched by object `name` or `physicalName`.
+3. **Emit (bridge B).** `emit_odcs_from_crosswalk` emits a v3 `DataContract` whose
+   schema object declares the GoldenMatch-resolved key as `primaryKey: true` +
+   `unique: true`, with provenance (+ optional certificate verdict) in the contract's
+   `customProperties` `goldenmatch` entry — ODCS *has* a metadata slot, so provenance
+   is embedded inline (like the Cube/Feast YAML dialects, unlike Malloy's tuple).
+   `parse_odcs_contract(emit_odcs_yaml(...))` round-trips.
+4. **Front-door wiring, no new surface.** `certify_semantic_model` auto-detects
+   `kind: DataContract` (v3, unambiguous) — or an `apiVersion` + `schema`/`dataset`
+   list for the kind-less v2 — as the `"odcs"` dialect and dispatches to
+   `certify_odcs_contract`; `semantic_field_roles` learns the ODCS role split
+   (primaryKey = identity, numeric = measures, descriptive = dimensions). CLI / MCP /
+   REST certify a data contract with **no new MCP tool / CLI command / A2A skill** —
+   parity-free, like Cube / Feast / Malloy.
+
+## Conformance to the two-engines frame (0047)
+- **One authoritative owner** ✅ — an *adapter surface* over the single-sourced
+  `certify_key_integrity` (0059). GoldenMatch does not author the contract, its
+  quality rules, or its SLAs — the contract owner keeps that. No second source of
+  truth; `quality` blocks are passed through opaquely, never rewritten.
+- **Conformance defines correctness** ✅ — ODCS is another dialect target;
+  `parse_odcs_contract(emit_odcs_yaml(...))` round-trips, and the v2 reader is a
+  semantically-equivalent ingest of the older spelling.
+- **Compute vs. control stay distinct** ✅ — the contract is small metadata
+  (YAML/JSON), correctly not Arrow-marshaled; certification rides the columnar key
+  path.
+
+## Consequences / honest flags
+- **One entry per declared key, not one per object.** Unlike the join dialects
+  (one entry per join), ODCS emits one certificate for the composite PK and one for
+  each `unique` property, since the contract makes multiple distinct identity
+  promises. The front-door `context` disambiguates (`primary key` vs
+  `unique: <col>`).
+- **Reads the declaration only.** Like every dialect, this reads/writes the contract
+  document; it does not evaluate the contract's `quality` rules, honor its SLAs, or
+  query a warehouse. `frames` are caller-supplied. Certifying the identity promise is
+  precisely the term no ODCS tool verifies against data.
+- **Numeric = measure is a heuristic.** A data contract does not label "measures"; we
+  treat numeric `logicalType` non-key properties as the fan-out targets. This is
+  advisory framing for the fan-out report, not a claim about business semantics — and
+  it never affects the uniqueness verdict, which is the load-bearing result.
+- **No new parity surface** — verified: `odcs` appears in zero gated Python surfaces,
+  so `parity/goldenmatch.yaml` is unchanged, consistent with Cube / Feast / Malloy.
+- **LookML / Power BI remain the open BI dialects** — the last follow-ons from the
+  same filter; the data-contract and BI-Malloy lanes are now landed.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-08-13

--- a/context-network/planning/semantic-layer-interchange.md
+++ b/context-network/planning/semantic-layer-interchange.md
@@ -103,6 +103,25 @@
 > auto-detects a top-level `sources:` as `"malloy"`, parity-free like Cube/Feast.
 > Remaining from the filter: **LookML / Power BI** (messier parse) and **data
 > contracts (ODCS)**.
+>
+> **Data-contract surface (ODCS,
+> [0062](../decisions/0062-odcs-data-contract-dialect.md)).** A data contract is the
+> most literal statement of the thesis: it *asserts* identity right in the schema
+> (`primaryKey: true`, ordered by `primaryKeyPosition`; `unique: true`) and nobody
+> checks the assertion against the data — so a duplicated PK makes the contract's own
+> uniqueness promise false. ODCS's `primaryKey` maps one-to-one onto MetricFlow
+> `entity (primary)` / Cube / Malloy `primary_key`, so the certifier applies
+> unchanged. `goldenmatch.semantic.odcs`: `parse_odcs_contract` (v3 `schema:`/
+> `properties:` canonically, tolerant of the legacy v2 `dataset:`/`columns:`/
+> `isPrimary` spelling on read — no `open-data-contract-standard` dependency),
+> `odcs_identity_keys` (the composite PK **plus each standalone `unique` property**),
+> `certify_odcs_contract` (bridge A — one certificate per declared key, numeric
+> properties as the fan-out measures), `emit_odcs_from_crosswalk` (bridge B —
+> resolved key as `primaryKey`, provenance embedded in `customProperties` since ODCS
+> has a metadata slot). `certify_semantic_model` auto-detects `kind: DataContract`
+> as the `"odcs"` dialect, parity-free like Cube/Feast/Malloy. **Remaining from the
+> filter: LookML / Power BI** (messier parse) — the BI-Malloy and data-contract lanes
+> are now landed.
 > Greenfield when written: no prior repo code, doc, or decision referenced this
 > ecosystem (grep, 2026-07-30).
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 473,
+      "module_count": 474,
       "modules": [
         {
           "module": "goldenmatch",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 472,
+      "module_count": 473,
       "modules": [
         {
           "module": "goldenmatch",
@@ -7178,6 +7178,7 @@
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.malloy",
             "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.odcs",
             "goldenmatch.semantic.ontology",
             "goldenmatch.semantic.ontology_catalog",
             "goldenmatch.semantic.osi",
@@ -7202,6 +7203,7 @@
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.malloy",
             "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.odcs",
             "goldenmatch.semantic.osi"
           ]
         },
@@ -7241,6 +7243,7 @@
             "goldenmatch.semantic.key_integrity",
             "goldenmatch.semantic.malloy",
             "goldenmatch.semantic.metricflow",
+            "goldenmatch.semantic.odcs",
             "goldenmatch.semantic.osi"
           ]
         },
@@ -7681,6 +7684,33 @@
           ],
           "imports": [
             "goldenmatch.core.key_integrity_certificate"
+          ]
+        },
+        {
+          "module": "goldenmatch.semantic.odcs",
+          "file": "packages/python/goldenmatch/goldenmatch/semantic/odcs.py",
+          "purpose": "ODCS (Open Data Contract Standard) reader + emitter — the data-contract dialect.",
+          "defines": [
+            "ODCSContract",
+            "ODCSProperty",
+            "ODCSSchemaObject",
+            "_as_bool",
+            "_object_from_dict",
+            "_property_from_dict",
+            "certify_odcs_contract",
+            "emit_odcs",
+            "emit_odcs_from_crosswalk",
+            "emit_odcs_object",
+            "emit_odcs_property",
+            "emit_odcs_yaml",
+            "odcs_identity_keys",
+            "parse_odcs_contract"
+          ],
+          "imports": [
+            "goldenmatch.core.key_integrity_certificate",
+            "goldenmatch.semantic.blocking",
+            "goldenmatch.semantic.key_integrity",
+            "goldenmatch.semantic.metricflow"
           ]
         },
         {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **ODCS (Open Data Contract Standard) dialect for the semantic-layer certifier
+  (`goldenmatch.semantic.odcs`).** A data contract declares its identity right in
+  the schema — `primaryKey: true` (ordered by `primaryKeyPosition` for a composite
+  key) and `unique: true` — and nothing checks that promise against the data, so a
+  duplicated key makes the contract's own uniqueness guarantee false. ODCS
+  `primaryKey` maps one-to-one onto MetricFlow `entity (primary)` / Cube / Malloy
+  `primary_key`, so the same certifier applies. New: `parse_odcs_contract` (reads
+  the v3 `schema:`/`properties:` shape, tolerant of the legacy v2
+  `dataset:`/`columns:`/`isPrimary` spelling on read — no
+  `open-data-contract-standard` dependency), `odcs_identity_keys` (the composite
+  primary key **plus each standalone `unique` property**), `certify_odcs_contract`
+  (bridge to wedge A — one certificate per declared key, with the object's numeric
+  properties as the fan-out measures) and `emit_odcs_from_crosswalk` (bridge to
+  wedge B — declares the resolved key as `primaryKey`, provenance embedded in
+  `customProperties`). `certify_semantic_model` auto-detects `kind: DataContract`
+  as the `"odcs"` dialect. Library-only, advisory, parity-free.
 - **Malloy (malloydata.dev) BI dialect for the semantic-layer certifier
   (`goldenmatch.semantic.malloy`).** Malloy's unit is a `source` whose identity is
   its declared `primary_key`, with `join_one`/`join_many`/`join_cross` riding on it

--- a/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/__init__.py
@@ -124,6 +124,16 @@ from goldenmatch.semantic.metricflow import (
     emit_semantic_model,
     parse_semantic_models,
 )
+from goldenmatch.semantic.odcs import (
+    ODCSContract,
+    ODCSProperty,
+    ODCSSchemaObject,
+    certify_odcs_contract,
+    emit_odcs_from_crosswalk,
+    emit_odcs_yaml,
+    odcs_identity_keys,
+    parse_odcs_contract,
+)
 from goldenmatch.semantic.ontology import (
     DiscoveredOntology,
     Ontology,
@@ -248,6 +258,15 @@ __all__ = [
     "MalloyModel",
     "MalloySource",
     "MalloyJoin",
+    # follow-on — ODCS (Open Data Contract Standard) dialect (reader + emitter + bridges)
+    "parse_odcs_contract",
+    "odcs_identity_keys",
+    "certify_odcs_contract",
+    "emit_odcs_yaml",
+    "emit_odcs_from_crosswalk",
+    "ODCSContract",
+    "ODCSSchemaObject",
+    "ODCSProperty",
     # ontology layer — RDF/OWL/SHACL native identity provider (bidirectional)
     "parse_ontology",
     "ontology_identity_keys",

--- a/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/blocking.py
@@ -131,6 +131,15 @@ def semantic_field_roles(source: str | Any) -> SemanticFieldRoles:
             keys.extend(src.primary_key)
             dimensions.extend(src.dimensions)
             measures.extend(src.measures)
+    elif dialect == "odcs":
+        from goldenmatch.semantic.odcs import parse_odcs_contract
+
+        for obj in parse_odcs_contract(data).schema_objects:
+            keys.extend(obj.identity_key())
+            # numeric properties are aggregation targets (never identity evidence);
+            # the descriptive columns are the dimensions to resolve on.
+            measures.extend(obj.numeric_measures())
+            dimensions.extend(obj.dimensions())
     else:  # osi
         from goldenmatch.semantic.osi import parse_osi_models
 

--- a/packages/python/goldenmatch/goldenmatch/semantic/certify.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/certify.py
@@ -22,6 +22,7 @@ from goldenmatch.semantic.feast import certify_feast_feature_views
 from goldenmatch.semantic.key_integrity import certify_key_integrity
 from goldenmatch.semantic.malloy import certify_malloy_joins
 from goldenmatch.semantic.metricflow import _load, parse_semantic_models
+from goldenmatch.semantic.odcs import certify_odcs_contract
 from goldenmatch.semantic.osi import certify_osi_relationships
 
 
@@ -41,7 +42,7 @@ class SemanticCertification:
     """The result of certifying a whole semantic model: the detected dialect and
     one `KeyCertification` per declared key that had a supplied frame."""
 
-    dialect: str                         # "metricflow" | "cube" | "osi" | "feast" | "malloy"
+    dialect: str                         # "metricflow" | "cube" | "osi" | "feast" | "malloy" | "odcs"
     entries: list[KeyCertification] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)  # targets with no frame
     note: str = ""
@@ -65,9 +66,14 @@ def detect_dialect(data: dict[str, Any]) -> str:
     """Detect the semantic-layer dialect from a loaded document's top-level shape.
 
     Cube uses a `cubes:` list, MetricFlow a `semantic_models:` list, OSI/Ossie a
-    `semantic_model` list (singular) + `version`, Feast a `feature_views:` list.
+    `semantic_model` list (singular) + `version`, Feast a `feature_views:` list,
+    Malloy a `sources:` list, and ODCS a `kind: DataContract` + a `schema:` list.
     Raises if none match.
     """
+    # ODCS is detected on its unambiguous `kind: DataContract` marker first, so a
+    # contract that also happens to carry a generic key can't be misread.
+    if str(data.get("kind", "")).strip() == "DataContract":
+        return "odcs"
     if "cubes" in data:
         return "cube"
     if "semantic_models" in data:
@@ -78,11 +84,15 @@ def detect_dialect(data: dict[str, Any]) -> str:
         return "feast"
     if "sources" in data:
         return "malloy"
+    # ODCS v2 (pre-Bitol) had no `kind`; a top-level `schema:`/`dataset:` list with
+    # an `apiVersion` is the data-contract shape.
+    if "apiVersion" in data and isinstance(data.get("schema") or data.get("dataset"), list):
+        return "odcs"
     raise ValueError(
         "certify_semantic_model: could not detect a semantic-layer dialect; "
         "expected a top-level 'cubes' (Cube), 'semantic_models' (dbt/MetricFlow), "
-        "'semantic_model' (OSI/Ossie), 'feature_views' (Feast), or 'sources' "
-        "(Malloy) key"
+        "'semantic_model' (OSI/Ossie), 'feature_views' (Feast), 'sources' "
+        "(Malloy), or 'kind: DataContract' (ODCS) key"
     )
 
 
@@ -164,6 +174,15 @@ def certify_semantic_model(
             entries.append(KeyCertification(
                 target=rep["to_source"], key=list(rep["key"]), certificate=rep["certificate"],
                 context=f"join from {rep['from_source']}",
+            ))
+    elif dialect == "odcs":
+        # certify_odcs_contract certifies each schema object's declared identity
+        # key — the composite primary key plus each standalone `unique` property.
+        for rep in certify_odcs_contract(data, frames, resolve=resolve, roles=roles):
+            ctx = "primary key" if rep["kind"] == "primary_key" else f"unique: {rep['key'][0]}"
+            entries.append(KeyCertification(
+                target=rep["object"], key=list(rep["key"]), certificate=rep["certificate"],
+                context=ctx,
             ))
     else:  # osi
         for rep in certify_osi_relationships(data, frames, resolve=resolve, roles=roles):

--- a/packages/python/goldenmatch/goldenmatch/semantic/odcs.py
+++ b/packages/python/goldenmatch/goldenmatch/semantic/odcs.py
@@ -1,0 +1,395 @@
+"""ODCS (Open Data Contract Standard) reader + emitter — the data-contract dialect.
+
+A data contract is the most literal statement of the semantic-layer thesis: it is
+a machine-readable *promise* about a dataset's shape — and its identity promise is
+declared right there in the schema. In ODCS v3 (Bitol / Linux Foundation), a
+`schema` object's properties carry **`primaryKey: true`** (ordered by
+**`primaryKeyPosition`** for a composite key) and **`unique: true`** — the contract
+asserts "these columns identify a row." Nobody checks that assertion against the
+data. That is the same gap the metrics-layer wedge catches, and on a data contract
+it is the *headline* term: the three break modes bite the contract's own guarantees:
+
+- **duplicated primary key -> the uniqueness promise is false**: the contract says
+  `order_id` is the primary key, but it fans out — every downstream `sum`/`count`
+  that trusts the contract double-counts;
+- **fragmented identity -> undercount**: one real entity split across key values
+  breaks the contract's grain silently;
+- **broken `unique` constraint**: a declared-unique `email` that isn't.
+
+ODCS `primaryKey`/`primaryKeyPosition` maps one-to-one onto MetricFlow
+`entity (primary)`, Cube `primary_key`, and Malloy `primary_key` — so exactly the
+same certifier applies:
+
+- **consume** a contract to learn each schema object's declared identity keys — the
+  composite primary key AND each standalone `unique` property (`parse_odcs_contract`,
+  `odcs_identity_keys`) — "what to resolve";
+- **certify** (bridge to wedge A) each declared key against the data, with the
+  object's **numeric properties as the fan-out measures** a duplicated key would
+  inflate under aggregation (`certify_odcs_contract`);
+- **emit** (bridge to wedge B) an ODCS contract whose schema object declares the
+  GoldenMatch-resolved key as `primaryKey`, provenance in `customProperties`
+  (`emit_odcs_from_crosswalk`). `parse_odcs_contract(emit_odcs_yaml(...))`
+  round-trips.
+
+Reads the DECLARATION only — a declarative ODCS doc (v3 `schema:`/`properties:`,
+tolerant of the v2 `dataset:`/`columns:` spelling on read). No `open-data-contract-
+standard` dependency; it never touches a warehouse. Library-only, advisory,
+parity-free (it plugs into the existing `certify_semantic_model` dialect dispatch,
+adding no new surface).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from goldenmatch.semantic.metricflow import _load
+
+# ODCS `logicalType` values that denote a numeric column — the ones a duplicated
+# key fans out under aggregation, so they're the metric-aware measures. (ODCS's
+# vocabulary is {string, date, number, integer, object, array, boolean}; the
+# extra spellings accept a physicalType/loose-doc leaking through.)
+_NUMERIC_LOGICAL = {
+    "number", "integer", "decimal", "float", "double", "bigint", "long", "numeric",
+}
+
+
+# --- model -------------------------------------------------------------------
+
+
+@dataclass
+class ODCSProperty:
+    """One column property of an ODCS schema object. `primary_key` +
+    `primary_key_position` declare the (composite) identity key; `unique` is a
+    standalone uniqueness constraint. `logical_type` decides whether the column is
+    a numeric fan-out measure."""
+
+    name: str
+    logical_type: str = ""
+    physical_type: str = ""
+    primary_key: bool = False
+    primary_key_position: int | None = None
+    unique: bool = False
+    required: bool = False
+
+    @property
+    def is_numeric(self) -> bool:
+        return self.logical_type.strip().lower() in _NUMERIC_LOGICAL
+
+
+@dataclass
+class ODCSSchemaObject:
+    """One ODCS `schema` object (a table / dataset). `properties` carry the
+    declared identity. `quality` is passed through opaquely (GoldenMatch does not
+    author quality rules — it certifies the identity ones hold)."""
+
+    name: str
+    physical_name: str | None = None
+    properties: list[ODCSProperty] = field(default_factory=list)
+    quality: list[Any] = field(default_factory=list)
+
+    def identity_key(self) -> list[str]:
+        """The declared composite primary key: `primaryKey: true` properties in
+        `primaryKeyPosition` order (properties without a position sort last, in
+        declaration order — a stable tiebreak)."""
+        pk = [p for p in self.properties if p.primary_key]
+        pk.sort(key=lambda p: (p.primary_key_position is None,
+                               p.primary_key_position or 0))
+        return [p.name for p in pk]
+
+    def unique_keys(self) -> list[str]:
+        """Standalone `unique: true` properties that are NOT already part of the
+        primary key — each a separate candidate key the contract promises."""
+        pk_set = set(self.identity_key())
+        return [p.name for p in self.properties if p.unique and p.name not in pk_set]
+
+    def numeric_measures(self) -> list[str]:
+        """Numeric non-key properties — the columns a duplicated key inflates."""
+        key_set = set(self.identity_key())
+        return [p.name for p in self.properties if p.is_numeric and p.name not in key_set]
+
+    def dimensions(self) -> list[str]:
+        """Non-numeric non-key properties — the identity-bearing attributes."""
+        key_set = set(self.identity_key())
+        return [
+            p.name for p in self.properties
+            if not p.is_numeric and p.name not in key_set
+        ]
+
+
+@dataclass
+class ODCSContract:
+    api_version: str = ""
+    kind: str = "DataContract"
+    id: str = ""
+    version: str = ""
+    name: str = ""
+    status: str = ""
+    schema_objects: list[ODCSSchemaObject] = field(default_factory=list)
+    custom_properties: list[dict[str, Any]] = field(default_factory=list)
+
+    def object_by_name(self, name: str) -> ODCSSchemaObject | None:
+        for o in self.schema_objects:
+            if o.name == name:
+                return o
+        return None
+
+
+# --- parse (consume) ---------------------------------------------------------
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "yes", "1")
+    return bool(value)
+
+
+def _property_from_dict(p: dict[str, Any]) -> ODCSProperty:
+    # v3 uses `name`/`primaryKey`/`unique`; the v2 spelling was
+    # `column`/`isPrimary`/`isUnique` — accept both on read.
+    name = str(p.get("name", p.get("column", ""))).strip()
+    pos = p.get("primaryKeyPosition")
+    return ODCSProperty(
+        name=name,
+        logical_type=str(p.get("logicalType", "")).strip(),
+        physical_type=str(p.get("physicalType", "")).strip(),
+        primary_key=_as_bool(p.get("primaryKey", p.get("isPrimary", False))),
+        primary_key_position=(int(pos) if isinstance(pos, (int, str)) and str(pos).strip()
+                              and str(pos).strip().lstrip("-").isdigit() else None),
+        unique=_as_bool(p.get("unique", p.get("isUnique", False))),
+        required=_as_bool(p.get("required", False)),
+    )
+
+
+def _object_from_dict(o: dict[str, Any]) -> ODCSSchemaObject:
+    # v3: `name` + `properties`; v2: `table` + `columns`.
+    name = str(o.get("name", o.get("table", ""))).strip()
+    props = o.get("properties")
+    if not isinstance(props, list):
+        props = o.get("columns") or []
+    quality = o.get("quality")
+    return ODCSSchemaObject(
+        name=name,
+        physical_name=(str(o["physicalName"]).strip() if o.get("physicalName") else None),
+        properties=[_property_from_dict(p) for p in props if isinstance(p, dict)],
+        quality=list(quality) if isinstance(quality, list) else [],
+    )
+
+
+def parse_odcs_contract(source: str | Any) -> ODCSContract:
+    """Parse a declarative ODCS data contract (path, YAML/JSON string, or dict) into
+    an `ODCSContract`.
+
+    Expects the ODCS v3 shape — `kind: DataContract` + a top-level `schema:` list of
+    objects, each with `properties`. The older v2 spelling (`dataset:` + `columns:`,
+    `isPrimary`/`isUnique`) is accepted on read so an existing contract certifies
+    without a rewrite. GoldenMatch never depends on the `open-data-contract-standard`
+    package — this reads the plain document.
+    """
+    data = _load(source)
+    if not isinstance(data, dict):
+        return ODCSContract()
+    schema = data.get("schema")
+    if not isinstance(schema, list):
+        schema = data.get("dataset") or []
+    cprops = data.get("customProperties")
+    return ODCSContract(
+        api_version=str(data.get("apiVersion", "")).strip(),
+        kind=str(data.get("kind", "DataContract")).strip() or "DataContract",
+        id=str(data.get("id", "")).strip(),
+        version=str(data.get("version", "")).strip(),
+        name=str(data.get("name", data.get("datasetName", ""))).strip(),
+        status=str(data.get("status", "")).strip(),
+        schema_objects=[_object_from_dict(o) for o in schema if isinstance(o, dict)],
+        custom_properties=[c for c in (cprops or []) if isinstance(c, dict)],
+    )
+
+
+def odcs_identity_keys(contract: ODCSContract | str | Any) -> list[dict[str, Any]]:
+    """The declared identity keys each schema object promises — what GoldenMatch
+    should certify. One entry per (object, declared key): the composite primary key
+    (`kind="primary_key"`) plus each standalone `unique` property
+    (`kind="unique"`). `{object, key, kind, measures}`, where `measures` are the
+    object's numeric non-key columns (the fan-out targets)."""
+    contract = contract if isinstance(contract, ODCSContract) else parse_odcs_contract(contract)
+    out: list[dict[str, Any]] = []
+    for obj in contract.schema_objects:
+        measures = obj.numeric_measures()
+        pk = obj.identity_key()
+        if pk:
+            out.append({"object": obj.name, "key": list(pk),
+                        "kind": "primary_key", "measures": list(measures)})
+        for u in obj.unique_keys():
+            out.append({"object": obj.name, "key": [u],
+                        "kind": "unique", "measures": list(measures)})
+    return out
+
+
+# --- emit (produce) ----------------------------------------------------------
+
+
+def emit_odcs_property(p: ODCSProperty) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": p.name}
+    if p.logical_type:
+        out["logicalType"] = p.logical_type
+    if p.physical_type:
+        out["physicalType"] = p.physical_type
+    if p.primary_key:
+        out["primaryKey"] = True
+        if p.primary_key_position is not None:
+            out["primaryKeyPosition"] = p.primary_key_position
+    if p.unique:
+        out["unique"] = True
+    if p.required:
+        out["required"] = True
+    return out
+
+
+def emit_odcs_object(o: ODCSSchemaObject) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": o.name, "logicalType": "object"}
+    if o.physical_name:
+        out["physicalName"] = o.physical_name
+    out["properties"] = [emit_odcs_property(p) for p in o.properties]
+    if o.quality:
+        out["quality"] = list(o.quality)
+    return out
+
+
+def emit_odcs(contract: ODCSContract) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "apiVersion": contract.api_version or "v3.0.0",
+        "kind": contract.kind or "DataContract",
+    }
+    if contract.id:
+        out["id"] = contract.id
+    if contract.version:
+        out["version"] = contract.version
+    if contract.name:
+        out["name"] = contract.name
+    if contract.status:
+        out["status"] = contract.status
+    out["schema"] = [emit_odcs_object(o) for o in contract.schema_objects]
+    if contract.custom_properties:
+        out["customProperties"] = list(contract.custom_properties)
+    return out
+
+
+def emit_odcs_yaml(contract: ODCSContract) -> str:
+    """Render an `ODCSContract` as a declarative ODCS v3 doc. Round-trips through
+    `parse_odcs_contract`."""
+    import yaml
+
+    return yaml.safe_dump(emit_odcs(contract), sort_keys=False, default_flow_style=False)
+
+
+def emit_odcs_from_crosswalk(
+    crosswalk: Any,
+    *,
+    contract_name: str = "resolved_identity",
+    object_name: str = "resolved_entity",
+    source_join_column: str | None = None,
+    resolved_field: str | None = None,
+    version: str = "1.0.0",
+    certificate: Any = None,
+) -> str:
+    """Emit an ODCS v3 data contract for a `ResolvedCrosswalk` (wedge B): a schema
+    object whose GoldenMatch-resolved key is declared `primaryKey: true` — so every
+    consumer that honors the contract joins on resolved identity, not a raw source
+    PK. GoldenMatch provenance (+ an optional key-integrity certificate) rides in the
+    contract's `customProperties` as the `goldenmatch` property.
+    """
+    resolved_field = resolved_field or getattr(crosswalk, "resolved_key", "resolved_entity_id")
+    join_col = source_join_column or resolved_field
+
+    obj = ODCSSchemaObject(
+        name=object_name,
+        properties=[
+            ODCSProperty(name=join_col, logical_type="string",
+                         primary_key=True, primary_key_position=1, unique=True, required=True),
+            ODCSProperty(name="source", logical_type="string"),
+        ],
+    )
+
+    gm: dict[str, Any] = {
+        "generated_by": "goldenmatch.semantic",
+        "resolved_key": resolved_field,
+        "n_records": getattr(crosswalk, "n_records", None),
+        "n_entities": getattr(crosswalk, "n_entities", None),
+        "reduction_ratio": round(getattr(crosswalk, "reduction_ratio", 0.0), 6),
+    }
+    if certificate is not None:
+        from goldenmatch.core.key_integrity_certificate import certificate_verdict
+
+        gm["key_integrity"] = certificate_verdict(certificate)
+
+    contract = ODCSContract(
+        api_version="v3.0.0",
+        kind="DataContract",
+        version=version,
+        name=contract_name,
+        status="draft",
+        schema_objects=[obj],
+        custom_properties=[{"property": "goldenmatch", "value": gm}],
+    )
+    return emit_odcs_yaml(contract)
+
+
+# --- bridge: certify the keys an ODCS contract declares (metric-aware, wedge A) --
+
+
+def certify_odcs_contract(
+    contract: ODCSContract | str | Any,
+    frames: dict[str, Any],
+    *,
+    resolve: bool = False,
+    roles: Any = None,
+) -> list[dict[str, Any]]:
+    """For each declared identity key in a data contract, certify it against the
+    data via wedge A — certifying exactly the promise the contract makes, with the
+    object's **numeric properties as the fan-out measures** whose inflation a
+    duplicated key would cause.
+
+    `frames` maps a schema-object name (or its `physicalName`) to the table backing
+    it (pyarrow / polars / pandas / dict). An object whose frame is absent, or which
+    declares no identity key, is skipped. `resolve=True` also measures identity
+    fragmentation / undercount via ER (fail-open); pass `roles` (a
+    `SemanticFieldRoles`) to make that ER metric-aware — it resolves on the contract's
+    descriptive columns and never on a numeric measure.
+
+    Returns `[{object, key, kind, certificate}]` — one per declared key (the
+    composite primary key plus each standalone `unique` property).
+    """
+    from goldenmatch.semantic.blocking import _frame_columns, metric_aware_attributes
+    from goldenmatch.semantic.key_integrity import certify_key_integrity
+
+    contract = contract if isinstance(contract, ODCSContract) else parse_odcs_contract(contract)
+    out: list[dict[str, Any]] = []
+    for obj in contract.schema_objects:
+        df = frames.get(obj.name)
+        if df is None and obj.physical_name is not None:
+            df = frames.get(obj.physical_name)
+        if df is None:
+            continue
+        cols = _frame_columns(df)
+        measures = [m for m in obj.numeric_measures() if m in cols]
+        attributes = (
+            metric_aware_attributes(roles, cols)
+            if (resolve and roles is not None) else None
+        )
+        for entry in odcs_identity_keys(contract):
+            if entry["object"] != obj.name:
+                continue
+            key = entry["key"]
+            if not key or any(k not in cols for k in key):
+                continue
+            cert = certify_key_integrity(
+                df, key=key, measures=measures, resolve=resolve, attributes=attributes
+            )
+            out.append({
+                "object": obj.name,
+                "key": list(key),
+                "kind": entry["kind"],
+                "certificate": cert,
+            })
+    return out

--- a/packages/python/goldenmatch/scripts/emit_semantic_certify_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_semantic_certify_fixtures.py
@@ -68,11 +68,13 @@ def _bootstrap() -> object:
     _load("goldenmatch.semantic.metricflow", "semantic/metricflow.py")
     _load("goldenmatch.semantic.cube", "semantic/cube.py")
     _load("goldenmatch.semantic.osi", "semantic/osi.py")
-    # certify_semantic_model imports the feast + malloy dialects unconditionally
-    # (both are Python-only / have no TS port, so they add no fixture case — but the
-    # modules must resolve for certify.py to import in this isolated bootstrap).
+    # certify_semantic_model imports the feast + malloy + odcs dialects
+    # unconditionally (all Python-only / no TS port, so they add no fixture case —
+    # but the modules must resolve for certify.py to import in this isolated
+    # bootstrap).
     _load("goldenmatch.semantic.feast", "semantic/feast.py")
     _load("goldenmatch.semantic.malloy", "semantic/malloy.py")
+    _load("goldenmatch.semantic.odcs", "semantic/odcs.py")
     return _load("goldenmatch.semantic.certify", "semantic/certify.py").certify_semantic_model
 
 

--- a/packages/python/goldenmatch/scripts/emit_semantic_roles_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_semantic_roles_fixtures.py
@@ -62,11 +62,12 @@ except ImportError:  # toolkit not installed -> isolated loader (dependency orde
     _load("goldenmatch.semantic.cube", "semantic/cube.py")
     _load("goldenmatch.semantic.osi", "semantic/osi.py")
     _load("goldenmatch.semantic.key_integrity", "semantic/key_integrity.py")
-    # feast + malloy are imported unconditionally by certify.py and (lazily) by
-    # blocking's semantic_field_roles; load them so both resolve in this isolated
+    # feast + malloy + odcs are imported unconditionally by certify.py and (lazily)
+    # by blocking's semantic_field_roles; load them so all resolve in this isolated
     # bootstrap.
     _load("goldenmatch.semantic.feast", "semantic/feast.py")
     _load("goldenmatch.semantic.malloy", "semantic/malloy.py")
+    _load("goldenmatch.semantic.odcs", "semantic/odcs.py")
     _load("goldenmatch.semantic.certify", "semantic/certify.py")
     _blocking = _load("goldenmatch.semantic.blocking", "semantic/blocking.py")
     metric_aware_attributes = _blocking.metric_aware_attributes

--- a/packages/python/goldenmatch/tests/test_odcs.py
+++ b/packages/python/goldenmatch/tests/test_odcs.py
@@ -1,0 +1,208 @@
+"""ODCS (Open Data Contract Standard) data-contract dialect: parse (v3 + v2
+spelling) + certify + emit, and the front-door wiring.
+
+A data contract declares its identity in the schema — `primaryKey: true`
+(ordered by `primaryKeyPosition`) and `unique: true`. These lock the parse of both
+the v3 and legacy-v2 shapes, the composite-key ordering, the bridge to wedge A
+(`certify_odcs_contract`, one entry per declared key), the crosswalk emit (wedge B),
+and that `certify_semantic_model` auto-detects `kind: DataContract` as "odcs".
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from goldenmatch.semantic.certify import certify_semantic_model, detect_dialect
+from goldenmatch.semantic.odcs import (
+    ODCSContract,
+    ODCSProperty,
+    ODCSSchemaObject,
+    certify_odcs_contract,
+    emit_odcs_from_crosswalk,
+    emit_odcs_yaml,
+    odcs_identity_keys,
+    parse_odcs_contract,
+)
+
+# ODCS v3: an orders contract whose composite key is (region, order_id) with an
+# additional standalone unique `email`, plus a numeric `amount` measure.
+_CONTRACT_DOC = {
+    "apiVersion": "v3.0.0",
+    "kind": "DataContract",
+    "id": "abc-123",
+    "version": "1.1.0",
+    "name": "orders_contract",
+    "status": "active",
+    "schema": [
+        {
+            "name": "orders",
+            "physicalName": "orders_v1",
+            "logicalType": "object",
+            "properties": [
+                {"name": "order_id", "logicalType": "string",
+                 "primaryKey": True, "primaryKeyPosition": 2},
+                {"name": "region", "logicalType": "string",
+                 "primaryKey": True, "primaryKeyPosition": 1},
+                {"name": "email", "logicalType": "string", "unique": True},
+                {"name": "amount", "logicalType": "number"},
+            ],
+        },
+    ],
+}
+
+
+def test_parse_v3_composite_key_orders_by_position():
+    contract = parse_odcs_contract(_CONTRACT_DOC)
+    assert contract.kind == "DataContract"
+    assert contract.name == "orders_contract"
+    obj = contract.object_by_name("orders")
+    assert obj.physical_name == "orders_v1"
+    # primaryKeyPosition orders the composite key: region (1) before order_id (2).
+    assert obj.identity_key() == ["region", "order_id"]
+    assert obj.unique_keys() == ["email"]
+    assert obj.numeric_measures() == ["amount"]
+    assert obj.dimensions() == ["email"]
+
+
+def test_parse_v2_spelling_is_accepted():
+    # Legacy ODCS v2: `dataset`/`columns`/`isPrimary`/`isUnique`, no `kind`.
+    v2 = {
+        "apiVersion": "2.2.0",
+        "datasetName": "orders",
+        "dataset": [
+            {"table": "orders", "columns": [
+                {"column": "order_id", "logicalType": "string", "isPrimary": True},
+                {"column": "email", "logicalType": "string", "isUnique": True},
+            ]},
+        ],
+    }
+    contract = parse_odcs_contract(v2)
+    obj = contract.object_by_name("orders")
+    assert obj.identity_key() == ["order_id"]
+    assert obj.unique_keys() == ["email"]
+
+
+def test_identity_keys_lists_pk_and_each_unique():
+    keys = odcs_identity_keys(_CONTRACT_DOC)
+    assert {"object": "orders", "key": ["region", "order_id"],
+            "kind": "primary_key", "measures": ["amount"]} in keys
+    assert {"object": "orders", "key": ["email"],
+            "kind": "unique", "measures": ["amount"]} in keys
+    assert len(keys) == 2
+
+
+def test_certify_trustworthy_when_key_is_unique_at_grain():
+    frames = {
+        "orders": {
+            "region": ["us", "us", "eu"],
+            "order_id": ["1", "2", "1"],   # composite (region, order_id) is unique
+            "email": ["a@x", "b@x", "c@x"],
+            "amount": [10, 20, 30],
+        },
+    }
+    reps = certify_odcs_contract(_CONTRACT_DOC, frames)
+    by_kind = {r["kind"]: r for r in reps}
+    assert by_kind["primary_key"]["key"] == ["region", "order_id"]
+    assert by_kind["primary_key"]["certificate"].is_trustworthy()
+    assert by_kind["unique"]["certificate"].is_trustworthy()
+
+
+def test_certify_catches_a_broken_unique_promise():
+    # email is declared unique but repeats -> the contract's promise is false.
+    frames = {
+        "orders": {
+            "region": ["us", "us", "eu"],
+            "order_id": ["1", "2", "3"],
+            "email": ["dup@x", "dup@x", "c@x"],
+            "amount": [10, 20, 30],
+        },
+    }
+    reps = certify_odcs_contract(_CONTRACT_DOC, frames)
+    by_kind = {r["kind"]: r for r in reps}
+    assert by_kind["primary_key"]["certificate"].is_trustworthy()
+    email_cert = by_kind["unique"]["certificate"]
+    assert not email_cert.is_unique_at_grain
+    assert email_cert.max_fan_out == 2.0
+
+
+def test_certify_resolves_by_physical_name_frame():
+    # A frame keyed on the object's physicalName is found too.
+    frames = {"orders_v1": {"region": ["us"], "order_id": ["1"],
+                            "email": ["a@x"], "amount": [10]}}
+    reps = certify_odcs_contract(_CONTRACT_DOC, frames)
+    assert reps and reps[0]["object"] == "orders"
+
+
+def test_object_with_no_frame_is_skipped():
+    reps = certify_odcs_contract(_CONTRACT_DOC, {})
+    assert reps == []
+
+
+def test_certify_semantic_model_auto_detects_odcs():
+    assert detect_dialect(_CONTRACT_DOC) == "odcs"
+    frames = {
+        "orders": {
+            "region": ["us", "us"],
+            "order_id": ["1", "1"],   # composite key fans out
+            "email": ["a@x", "b@x"],
+            "amount": [10, 20],
+        },
+    }
+    report = certify_semantic_model(_CONTRACT_DOC, frames)
+    assert report.dialect == "odcs"
+    assert report.n_certified == 2
+    pk_entry = next(e for e in report.entries if e.context == "primary key")
+    assert pk_entry.target == "orders"
+    assert pk_entry.key == ["region", "order_id"]
+    assert not pk_entry.certificate.is_trustworthy()
+    assert any(e.context == "unique: email" for e in report.entries)
+
+
+def test_detect_v2_without_kind():
+    v2 = {"apiVersion": "2.2.0", "dataset": [{"table": "t", "columns": []}]}
+    assert detect_dialect(v2) == "odcs"
+
+
+def test_emit_round_trips_through_parser():
+    contract = ODCSContract(
+        api_version="v3.0.0", kind="DataContract", version="1.0.0", name="c",
+        schema_objects=[ODCSSchemaObject(
+            name="orders", physical_name="orders_v1",
+            properties=[
+                ODCSProperty(name="order_id", logical_type="string",
+                             primary_key=True, primary_key_position=1),
+                ODCSProperty(name="amount", logical_type="number"),
+            ],
+        )],
+    )
+    back = parse_odcs_contract(emit_odcs_yaml(contract))
+    obj = back.object_by_name("orders")
+    assert obj.physical_name == "orders_v1"
+    assert obj.identity_key() == ["order_id"]
+    assert obj.numeric_measures() == ["amount"]
+
+
+def test_emit_from_crosswalk_declares_resolved_key_as_pk():
+    crosswalk = SimpleNamespace(
+        resolved_key="resolved_entity_id",
+        n_records=100, n_entities=60, reduction_ratio=0.4,
+    )
+    yaml_text = emit_odcs_from_crosswalk(crosswalk, object_name="resolved_entity")
+    back = parse_odcs_contract(yaml_text)
+    assert back.kind == "DataContract"
+    obj = back.object_by_name("resolved_entity")
+    assert obj.identity_key() == ["resolved_entity_id"]
+    # provenance rides in customProperties
+    gm = next(c for c in back.custom_properties if c["property"] == "goldenmatch")
+    assert gm["value"]["resolved_key"] == "resolved_entity_id"
+    assert gm["value"]["reduction_ratio"] == 0.4
+
+
+def test_semantic_field_roles_reads_odcs():
+    from goldenmatch.semantic.blocking import semantic_field_roles
+
+    roles = semantic_field_roles(_CONTRACT_DOC)
+    assert "region" in roles.keys
+    assert "order_id" in roles.keys
+    assert "amount" in roles.measures          # numeric -> measure, never identity
+    assert "email" in roles.dimensions         # descriptive -> resolve on it
+    assert "amount" not in roles.dimensions


### PR DESCRIPTION
## What and why

Adds a **data-contract** dialect to the semantic-layer key-integrity certifier. A
data contract is the most literal statement of the semantic-layer thesis: it
*asserts* identity right in the schema (ODCS v3 properties carry `primaryKey: true`,
ordered by `primaryKeyPosition` for a composite key, plus `unique: true`) and
nothing checks that promise against the data. A duplicated primary key makes the
contract's own uniqueness guarantee false, and every consumer that trusts the
contract inherits the miscount. ODCS `primaryKey` maps one-to-one onto MetricFlow
`entity (primary)` / Cube / Malloy `primary_key`, so the metric-aware certifier
applies unchanged. Continues the provider-family arc (Cube / Feast / Malloy / OSI /
ontology); decision ADR 0062.

## Changes

- New `goldenmatch.semantic.odcs`, structured like Cube/Feast/Malloy
  (consume / certify / emit):
  - `parse_odcs_contract` reads the v3 `schema:`/`properties:` shape canonically and
    tolerates the legacy v2 `dataset:`/`columns:`/`isPrimary`/`isUnique` spelling on
    read (an existing contract certifies without a rewrite); no
    `open-data-contract-standard` dependency.
  - `odcs_identity_keys` resolves each schema object's declared identity keys: the
    composite primary key (ordered by `primaryKeyPosition`) plus each standalone
    `unique` property.
  - `certify_odcs_contract` (bridge A) certifies every declared key against the data
    -- one certificate per key -- with the object's numeric properties as the fan-out
    measures; matches a frame by `name` or `physicalName`.
  - `emit_odcs_from_crosswalk` (bridge B) emits a v3 `DataContract` declaring the
    resolved key as `primaryKey`, provenance embedded in `customProperties`.
    `parse_odcs_contract(emit_odcs_yaml(...))` round-trips.
- Front-door wiring, no new surface: `certify_semantic_model` auto-detects
  `kind: DataContract` (v3) or `apiVersion` + a `schema`/`dataset` list (kind-less
  v2) as the `"odcs"` dialect; `semantic_field_roles` learns the role split
  (primaryKey = identity, numeric = measures, descriptive = dimensions). Parity-free,
  like Cube/Feast/Malloy.
- Added the odcs module to the two isolated semantic-fixture bootstraps (import-only,
  since certify.py now imports it) -- fixtures regenerate byte-identical, no drift.
- ADR 0062 + planning-doc status; CHANGELOG entry; `agent-codemap.json` regenerated.

## Testing

- `pytest tests/test_odcs.py` -- 12 passed (v3 + v2 parse, composite-key position
  ordering, PK + per-`unique` certification, broken-unique detection, `physicalName`
  frame lookup, front-door auto-detect for v3 and v2, emit round-trip, crosswalk
  emit, roles).
- Semantic regression: `pytest tests/test_malloy.py tests/test_feast.py
  tests/test_cube.py tests/test_certify_semantic_model.py tests/test_dedupe_certify.py
  tests/test_certify_structural_json.py tests/test_cli_certify_keys.py
  tests/test_certificate_verdict.py tests/test_odcs.py` -- 72 passed.
- `ruff check` clean on all changed files.
- `python scripts/regen_docs.py` -- only `agent-codemap.json` changed (new module
  symbols); codemap regen verified byte-deterministic across runs. Semantic parity
  fixtures regenerate byte-identical.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files; no secrets
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (ADR 0062, planning doc, agent-codemap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzd44dcqcr6skiTzmxhYi)_