### PR TITLE
feat(fs): Phase 0 -- the counted EM path in the Rust core, gated

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4155,6 +4155,7 @@
             "_field_score_matrix_dedup",
             "_field_values_for_block",
             "_field_values_from_list",
+            "_fixed_blocking_weights",
             "_fs_arrow_column",
             "_fs_batch_rows",
             "_fs_calibrate_threshold_enabled",

--- a/docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md
+++ b/docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md
@@ -1,0 +1,178 @@
+# Fellegi-Sunter training: one implementation, served everywhere
+
+**Date:** 2026-08-13
+**Status:** design; Phase 0 in progress
+**Supersedes nothing.** Resumes PR-C of
+`docs/superpowers/plans/2026-07-18-fs-rust-arrow-only.md`, which built its
+numeric core and was never wired.
+
+---
+
+## The finding
+
+The Fellegi-Sunter EM loop exists **three times** in this repo, and the copy
+designated as the source of truth is the only one nothing calls.
+
+| implementation | covers | callers |
+| --- | --- | --- |
+| `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` (`train_em`, `_em_iterate`) | NE dims, TF tables, monotonicity guard, missing-value modes, weighted/counted rows | every Python surface, and `bridge::train_em` |
+| `packages/typescript/goldenmatch/src/core/probabilistic.ts` (`trainEM`) | NE dims; no counted path | the TS surface |
+| `packages/rust/extensions/score-core/src/em_core.rs` (`train_em_core`) | the discrete E/M loop only | **none** |
+
+Verified 2026-08-13: `grep -rn "train_em_core\|EmOutput\|EmParams"` across
+`*.rs`, `*.py`, `*.ts` returns nothing outside `em_core.rs` itself.
+`score-core/src/lib.rs` does `pub mod em_core;` and stops there.
+
+Meanwhile `packages/rust/extensions/bridge/src/api.rs::train_em` is a pyo3 shim
+that **embeds CPython** and calls
+`goldenmatch.core.probabilistic.train_em`. Every non-Python surface that wants
+FS training therefore reaches Python, which is the inverse of
+[[project_rust_is_the_reference]]: the Rust kernel is supposed to be the
+reference and Python the lossy fallback.
+
+`em_core.rs`'s own header lists what it does not cover -- "negative-evidence
+dims, TF (Winkler) tables, the monotonicity guard, missing-value modes, and the
+two-table linkage sampling". So the reference is also the **least complete** of
+the three.
+
+### This got worse on 2026-08-13
+
+The distributed-training work (#2550, #2552) added to Python only:
+
+- `pair_weights` on `train_em` (weighted M-step)
+- `train_em_from_counts`
+- `estimate_u_from_counts`
+- `_neutral_u_for`
+- `_combine_em_sessions`
+
+`em_core.rs` already contains `neutral_u` with byte-identical constants
+(`[0.5, 0.5]`, `[0.34, 0.33, 0.33]`, uniform) and already estimates u as
+`(count + SMOOTH) / (observed + n_levels * SMOOTH)`. Both rules now exist twice,
+in two languages, and the second copy was added to the fallback rather than to
+the reference. That is the drift this spec exists to stop.
+
+---
+
+## What belongs where
+
+Not everything should move to Rust, and the line matters.
+
+| layer | belongs in | why |
+| --- | --- | --- |
+| gamma / comparison vectors | **Rust kernel** (already: `score_one` via pyo3 / cabi / jni / wasm) | per-pair math over strings |
+| `GROUP BY` over gammas | **the engine** (Spark, DataFusion, DuckDB) | distributed aggregation is what an engine *is*; a Rust kernel here reimplements Spark badly |
+| EM iteration | **Rust kernel** | pure numerics over a bounded matrix |
+| u from counts | **Rust kernel** | pure numerics |
+| session combination | **Rust kernel** | pure numerics |
+| per-pass orchestration | host language | glue over engine calls |
+
+The bound is what makes this safe: a counted comparison-vector table has at most
+`prod(levels + 1)` rows -- thousands, whatever the pair count -- so the whole
+numeric half fits in one kernel call with no streaming and no I/O.
+
+Everything downstream of the `GROUP BY` is therefore **one kernel's worth of
+code**, and it is exactly the code that currently exists three times.
+
+---
+
+## Parity is decision-level, not bitwise
+
+The 2026-07-18 plan says "byte-parity". That is not achievable and
+`em_core.rs`'s own test helper already says why:
+
+> libm ln/log2/exp differ from CPython in the low mantissa bits
+
+The established tolerances stay: **1e-9 on probabilities, 1e-7 on match
+weights** (weights amplify small `m` near the `1e-10` floor). Any new gate uses
+the same numbers, and a gate claiming exact equality would be a gate that has to
+be loosened the first time it runs on a different libm.
+
+---
+
+## Phases
+
+### Phase 0 -- stop the divergence *(in progress)*
+
+Port the 2026-08-13 Python additions into `em_core.rs`:
+
+- weighted rows (a count per comparison vector)
+- `train_em_from_counts_core`
+- `estimate_u_from_counts_core`
+- `combine_em_sessions_core`
+
+**Gate:** a **committed** Python emitter writes a fixture matrix; a Rust test
+reads it and reproduces it within tolerance. This is deliberately unlike the
+existing `em_core.rs` anchors, which were hand-pasted from "the C1 commit
+message / scratch script" -- an uncommitted scratch script is not a reproducible
+gate ([[feedback_commit_the_measurement_harness]]). The fixture must include the
+#1836 near-unique-blocking case, which is the one that fails silently.
+
+**Non-goal:** wiring. Phase 0 adds no callers. On its own it is a *fourth* copy;
+it is only worth landing because Phase 1 follows immediately.
+
+### Phase 1 -- wire it *(the load-bearing phase)*
+
+- export `train_em_counts` over C-ABI, wasm and JNI
+- `bridge::train_em` stops embedding CPython
+- Python `train_em_from_counts` and TS `trainEM` become thin callers over the
+  kernel, each keeping its pure fallback (the existing `_native_loader` pattern)
+
+**Gate:** the existing FS parity suites pass with the kernel path forced on, and
+with it forced off. **Rollback:** `GOLDENMATCH_FS_EM_NATIVE=0` for one release,
+matching PR-C's stated posture.
+
+Three implementations become one here. Phase 0 without Phase 1 is strictly worse
+than doing neither.
+
+### Phase 2 -- term-frequency adjustment on the distributed path
+
+The largest real gap against Splink. Verified against Splink's
+`internals/term_frequencies.py` on 2026-08-13: a TF table per column
+(`count(*) / total`), left-joined to the input, then
+`log2(u_probability/tf) * tf_adjustment_weight AS log2_bf_tf` -- **all backend
+SQL**. `train_em_distributed` currently refuses TF outright.
+
+**Open question, to settle before designing:** TF is per-*value*, so it does not
+fit the counted-vector key -- collapsing identical vectors discards the values
+the adjustment needs. Splink appears to apply TF as a **scoring-time** Bayes-factor
+term rather than folding it into training, which would make it orthogonal to
+counted training and far cheaper than it looks. **Verify this against their
+source before designing**; if it is wrong, the counting key has to carry
+frequency bands and the cost changes completely.
+
+### Phase 3 -- backends
+
+Once the numerics are one kernel, counting is the only per-engine piece, and
+`spark/em.py::agreement_pattern_counts` is ~40 lines of SQL. DataFusion and
+DuckDB versions are the same `GROUP BY` over the same gamma expressions.
+Splink's five backends stop being five ports of a trainer.
+
+### Phase 4 -- the benchmark
+
+Nothing above earns the words "better" or "faster". Head-to-head against Splink
+on a shared dataset -- accuracy **and** wall-clock -- on DuckDB and Spark.
+Until this exists, no comparative claim about Splink should be made in docs, a
+README, or a release note.
+
+---
+
+## Non-goals
+
+- Moving the `GROUP BY` into Rust. It belongs in the engine.
+- Removing polars from FS candidate generation. That is PR-D of the 2026-07-18
+  plan and is independent of this.
+- Changing any trained model's numbers. Every phase here is a relocation; the
+  gates exist to prove that.
+
+---
+
+## Risks
+
+- **A fourth copy.** Phase 0 in isolation makes the problem worse. Do not land
+  it without Phase 1 following.
+- **Silent calibration drift.** #1835/#1836 are the minefield: a blocking
+  field's `u` collapsing toward the smoothing floor explodes `log2(m/u)` and
+  produces a model that is wrong only in the cells hardest to eyeball
+  (measured F1 0.83 -> 0.57). Every fixture matrix carries that case.
+- **TF may not be orthogonal.** See the open question in Phase 2. If it is not,
+  Phase 2's cost estimate is wrong by a lot.

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1264,6 +1264,32 @@ def estimate_u_from_counts(
     return u_probs
 
 
+def _fixed_blocking_weights(field) -> list[float]:
+    """The bounded ``-3..+3`` ramp a conditioned field's weights take.
+
+    The other half of the #1835 prior (see :func:`_neutral_u_for`, which supplies
+    the ``u`` side). A conditioned field's ``m`` is never updated -- it keeps the
+    exponential initialisation -- so ``log2(m/u)`` for one of these is the ratio
+    of an arbitrary init to a random-pair estimate. It is not a quantity, and it
+    lands in the model looking exactly like every other weight.
+
+    The ramp supplies both properties the estimate would destroy: a real
+    DISAGREEMENT PENALTY at the bottom (drives precision) and an agreement
+    weight BOUNDED at +3 (preserves recall, by denying a near-unique key the
+    20-plus bits that let it dominate every other field).
+
+    One definition, because :func:`train_em`, :func:`train_em_from_counts`,
+    :func:`_combine_em_sessions` and :func:`estimate_m_from_labels` all need it,
+    and it is already implemented a fifth time in Rust
+    (``score-core/src/em_core.rs``). Copies of a calibration rule diverge
+    silently: every variant still produces a plausible weight vector.
+    """
+    n = field.levels
+    if n <= 1:
+        return [3.0]
+    return [-3.0 + 6.0 * k / (n - 1) for k in range(n)]
+
+
 def _neutral_u_for(field) -> list[float]:
     """The fixed ``u`` prior for a field EM must not learn from random pairs.
 
@@ -1345,13 +1371,21 @@ def _combine_em_sessions(
     total_w = sum(w for _, _, w in sessions)
     proportion = sum(em.proportion_matched * w for _, em, w in sessions) / total_w
 
-    match_weights = {
-        name: [
-            math.log2(max(m, 1e-10) / max(u, 1e-10))
-            for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
-        ]
-        for name in m_probs
-    }
+    # Recomputed from the COMBINED m/u rather than averaged from the sessions:
+    # log2 of a mean is not the mean of the log2s, and averaging the weights
+    # would give a model whose weights do not match its own probabilities.
+    match_weights = {}
+    for f in mk.fields:
+        name = f.field
+        if name not in m_probs:
+            continue
+        if name in blocking_union:
+            match_weights[name] = _fixed_blocking_weights(f)
+        else:
+            match_weights[name] = [
+                math.log2(max(m, 1e-10) / max(u, 1e-10))
+                for m, u in zip(m_probs[name], u_probs.get(name, m_probs[name]))
+            ]
     return EMResult(
         m_probs=m_probs,
         u_probs=u_probs,
@@ -1440,6 +1474,16 @@ def train_em_from_counts(
     # from evidence the blocking removed.
     always_conditioned = {f.field for f in mk.fields if f.field in conditioned}
 
+    # The #1835 prior, same as `train_em` applies. This does NOT move the
+    # trained m -- a conditioned field is skipped in the E-step either way --
+    # but `u_probs` is half the persisted model, and a caller reading it off a
+    # model trained here would otherwise see a near-unique random-pair estimate
+    # where `train_em` reports the fixed prior. Found by the Rust parity gate.
+    u_probs = dict(u_probs)
+    for f in mk.fields:
+        if f.field in always_conditioned:
+            u_probs[f.field] = _neutral_u_for(f)
+
     empty_ne = np.zeros((len(pattern_counts), 0), dtype=np.int64)
     m_probs, _m_ne, p_match, converged, iterations = _em_iterate(
         mk, comp_matrix, empty_ne, conditioned_mask,
@@ -1448,14 +1492,15 @@ def train_em_from_counts(
         None, None, max_iterations, convergence,
     )
 
-    match_weights = {
-        f.field: [
-            math.log2(max(m, 1e-10) / max(u, 1e-10))
-            for m, u in zip(m_probs[f.field], u_probs[f.field])
-        ]
-        for f in mk.fields
-        if f.field in m_probs and f.field in u_probs
-    }
+    match_weights = {}
+    for f in mk.fields:
+        if f.field in always_conditioned:
+            match_weights[f.field] = _fixed_blocking_weights(f)
+        elif f.field in m_probs and f.field in u_probs:
+            match_weights[f.field] = [
+                math.log2(max(m, 1e-10) / max(u, 1e-10))
+                for m, u in zip(m_probs[f.field], u_probs[f.field])
+            ]
     logger.info(
         "EM from counts: %d patterns, %.0f pairs, converged=%s in %d iterations",
         len(pattern_counts), total_weight, converged, iterations,
@@ -2010,12 +2055,7 @@ def train_em(
     match_weights = {}
     for f in mk.fields:
         if f.field in always_conditioned:
-            # Fixed weights: linearly increasing from -3 to +3
-            n = f.levels
-            match_weights[f.field] = [
-                -3.0 + 6.0 * k / (n - 1) if n > 1 else 3.0
-                for k in range(n)
-            ]
+            match_weights[f.field] = _fixed_blocking_weights(f)
             logger.debug("Using fixed weights for blocking field '%s'", f.field)
             continue
 
@@ -2304,10 +2344,7 @@ def estimate_m_from_labels(
     match_weights: dict[str, list[float]] = {}
     for f in mk.fields:
         if f.field in blocking_fields:
-            n = f.levels
-            match_weights[f.field] = [
-                -3.0 + 6.0 * k / (n - 1) if n > 1 else 3.0 for k in range(n)
-            ]
+            match_weights[f.field] = _fixed_blocking_weights(f)
             continue
         match_weights[f.field] = [
             math.log2(max(m_probs[f.field][k], 1e-10) / max(u_probs[f.field][k], 1e-10))

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -356,3 +356,110 @@ def test_u_from_counts_excludes_unobserved_from_the_denominator():
     assert u[first.field][0] == pytest.approx(
         (10 + 1e-6) / (10 + first.levels * 1e-6), abs=1e-12
     ), "the 90 unobserved pairs must not be in the denominator"
+
+
+def test_a_conditioned_field_gets_the_FIXED_weights_not_log2_m_over_u():
+    """A blocking field's weights are the bounded -3..+3 ramp, not log2(m/u).
+
+    `train_em` does this (probabilistic.py, "Fixed weights: linearly increasing
+    from -3 to +3"), `estimate_m_from_labels` mirrors it, and the Rust
+    `em_core.rs` implements it. The counted path did not, and the two halves of
+    #1835 both broke:
+
+      * the DISAGREEMENT PENALTY, which drives precision, was more than halved
+        (-1.54 against -3.0 on the fixture below);
+      * the AGREEMENT WEIGHT, bounded at +3.0 to preserve recall, ran to +4.47.
+
+    A conditioned field's `m` is never updated -- it keeps the exponential
+    init -- so `log2(m/u)` there is the ratio of an arbitrary initialisation to
+    a random-pair estimate. It is not a quantity, and it lands in the model
+    looking exactly like every other weight.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="zip", scorer="exact", levels=2),
+        ],
+    )
+    patterns = [((0, 1), 500), ((1, 1), 300), ((0, 0), 150), ((1, 0), 50)]
+    u = {"first": [0.9, 0.1], "zip": [0.97, 0.03]}
+
+    em = train_em_from_counts(mk, patterns, u, conditioned_fields=("zip",))
+
+    assert em.match_weights["zip"] == pytest.approx([-3.0, 3.0], abs=1e-12), (
+        "a conditioned field must carry the bounded fixed ramp; got "
+        f"{em.match_weights['zip']}"
+    )
+    # `first` is free, so it must still be LEARNED -- if it also came back
+    # [-3, 3] the rule is being applied to everything.
+    assert em.match_weights["first"] != pytest.approx([-3.0, 3.0], abs=1e-9)
+
+
+def test_a_three_level_conditioned_field_ramps_across_its_levels():
+    """The ramp is `-3 + 6k/(n-1)`, so 3 levels give -3, 0, +3.
+
+    Hard-coding two levels would pass the test above and silently give a
+    3-level blocking field a 2-element weight vector, which indexes out of
+    range at scoring time or, worse, reads the wrong level's weight.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="city", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.7),
+        ],
+    )
+    patterns = [((0, 2), 400), ((1, 2), 300), ((0, 0), 200), ((1, 1), 100)]
+    u = {"first": [0.9, 0.1], "city": [0.8, 0.15, 0.05]}
+
+    em = train_em_from_counts(mk, patterns, u, conditioned_fields=("city",))
+    assert em.match_weights["city"] == pytest.approx([-3.0, 0.0, 3.0], abs=1e-12)
+
+
+def test_a_conditioned_field_reports_the_NEUTRAL_u_not_the_one_passed_in():
+    """`train_em` neutralises u for conditioned fields; the counted path must too.
+
+    Found by the Rust parity gate (Phase 0), which is the point of having one:
+    `em_core.rs` neutralised and Python did not, and the disagreement is
+    invisible from either side alone.
+
+    It does not change the E-step -- a conditioned field is skipped there -- so
+    nothing about the trained m moves. What it changes is the u vector the
+    persisted EMResult carries, which is half the model: a caller reading
+    `em.u_probs["zip"]` off a model trained this way would see a near-unique
+    random-pair estimate where `train_em` reports the fixed prior.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="zip", scorer="exact", levels=2),
+        ],
+    )
+    em = train_em_from_counts(
+        mk, [((1, 1), 500), ((0, 1), 300)],
+        {"first": [0.9, 0.1], "zip": [0.999, 0.001]},
+        conditioned_fields=("zip",),
+    )
+
+    assert em.u_probs["zip"] == pytest.approx([0.5, 0.5], abs=1e-12), (
+        "the near-unique u handed in must not survive into the model for a "
+        "field the blocking made unrepresentative"
+    )
+    assert em.u_probs["first"] == pytest.approx([0.9, 0.1], abs=1e-12), (
+        "a free field must keep the u it was given"
+    )

--- a/packages/rust/extensions/score-core/Cargo.toml
+++ b/packages/rust/extensions/score-core/Cargo.toml
@@ -52,3 +52,11 @@ alias = ["dep:regex"]
 # The strsim primitives + their rapidfuzz parity oracle moved to the
 # `goldenfuzz-core` crate (see [dependencies]); the rapidfuzz dev-dep went with
 # them. score-core no longer references rapidfuzz at all.
+
+[dev-dependencies]
+# Reads the committed FS-EM parity fixture (tests/fixtures/em_counts_parity.json,
+# emitted by scripts/gen_fs_em_parity_fixture.py). A DEV-dependency on purpose:
+# it never reaches the shipped rlib, so the wasm surface's bundle budget and this
+# crate's minimal-dependency posture are both untouched. Same version the rest of
+# the workspace already pins.
+serde_json = "1"

--- a/packages/rust/extensions/score-core/src/em_core.rs
+++ b/packages/rust/extensions/score-core/src/em_core.rs
@@ -23,6 +23,24 @@
 //! NOT yet ported (later C1/C2 slices, tracked in the design doc): negative-evidence
 //! dims, TF (Winkler) tables, the monotonicity guard, missing-value modes, and the
 //! two-table linkage sampling. Those are additive and do not change this core.
+//!
+//! # The counted (distributed) entry points
+//!
+//! Phase 0 of `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`
+//! adds [`train_em_from_counts`], [`estimate_u_from_counts`] and
+//! [`combine_em_sessions`] — the shape distributed training produces, where
+//! identical comparison vectors have already been collapsed to one row carrying a
+//! count. The E-step reads only the vector, so those rows are interchangeable and
+//! every M-step quantity is a sum linear in the count: aggregating is EXACT, not a
+//! sample.
+//!
+//! **These have no callers yet.** Phase 1 wires them over the C-ABI / wasm / JNI
+//! so Python and TypeScript stop carrying their own copies of this loop. Until
+//! then `tests/em_counts_parity.rs` is the only thing keeping this file honest,
+//! and it is what found two divergences on its first run: Python was reporting
+//! `log2(m/u)` where a conditioned field must take the bounded ramp, and was
+//! reporting the random-pair `u` where it must take the neutral prior. Both
+//! produced entirely plausible models.
 
 /// A comparison field's shape for EM. `is_blocking` marks a configured blocking
 /// field, which — mirroring the shipped #1836 posture — always takes the fixed
@@ -69,6 +87,293 @@ fn neutral_u(n_levels: usize) -> Vec<f64> {
         2 => vec![0.5, 0.5],
         3 => vec![0.34, 0.33, 0.33],
         n => vec![1.0 / n as f64; n],
+    }
+}
+
+/// The bounded `-3..+3` ramp a conditioned (blocking) field's weights take.
+///
+/// The other half of the #1835 prior; [`neutral_u`] supplies the `u` side. A
+/// conditioned field's `m` is never updated -- it keeps the exponential
+/// initialisation -- so `log2(m/u)` for one of these is the ratio of an
+/// arbitrary init to a random-pair estimate. It is not a quantity, and it lands
+/// in the model looking exactly like every other weight.
+///
+/// The ramp supplies both properties that estimate would destroy: a real
+/// DISAGREEMENT PENALTY at the bottom (drives precision) and an agreement weight
+/// BOUNDED at `+3` (preserves recall, by denying a near-unique key the 20-plus
+/// bits that let it dominate every other field).
+pub fn fixed_blocking_weights(n_levels: usize) -> Vec<f64> {
+    if n_levels <= 1 {
+        return vec![3.0];
+    }
+    (0..n_levels)
+        .map(|k| -3.0 + 6.0 * k as f64 / (n_levels - 1) as f64)
+        .collect()
+}
+
+/// `u` from COUNTED comparison vectors over random pairs.
+///
+/// `patterns[i]` is one distinct comparison vector and `counts[i]` how many
+/// random pairs had it. Mirrors the Python `estimate_u_from_counts`:
+/// `(count + 1e-6) / (observed + n_levels * 1e-6)`, with `observed` excluding
+/// unobserved (`-1`) entries -- a field null on one side is missing data, not a
+/// disagreement, and putting those pairs in the denominator would shrink every
+/// level of a sparse field and inflate its `log2(m/u)` in proportion to how
+/// little data supports it.
+pub fn estimate_u_from_counts(
+    fields: &[EmField],
+    patterns: &[Vec<i32>],
+    counts: &[f64],
+) -> Vec<Vec<f64>> {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(j, f)| {
+            let mut level_counts = vec![0.0f64; f.n_levels];
+            let mut observed = 0.0f64;
+            for (row, &c) in patterns.iter().zip(counts) {
+                let lvl = row[j];
+                if lvl >= 0 {
+                    observed += c;
+                    let l = lvl as usize;
+                    if l < f.n_levels {
+                        level_counts[l] += c;
+                    }
+                }
+            }
+            let total = observed + f.n_levels as f64 * SMOOTH;
+            level_counts.iter().map(|c| (c + SMOOTH) / total).collect()
+        })
+        .collect()
+}
+
+/// Train from COUNTED comparison vectors -- the distributed shape.
+///
+/// The E-step reads only the comparison vector, so pairs sharing one are
+/// interchangeable and every M-step quantity is a sum linear in how many pairs
+/// share it. Identical rows therefore collapse to one row carrying a count, and
+/// the count multiplies through every sum. **Exact, not a sample.**
+///
+/// `conditioned` is per-FIELD, not per-row: within one blocking pass the
+/// conditioning is constant, which is exactly why the counts need no pass
+/// column and can be produced by a `GROUP BY` on a cluster.
+///
+/// `u_probs` is required rather than derived here: `u` comes from RANDOM
+/// (unblocked) pairs, which this function never sees.
+pub fn train_em_from_counts(
+    fields: &[EmField],
+    patterns: &[Vec<i32>],
+    counts: &[f64],
+    u_probs: &[Vec<f64>],
+    conditioned: &[bool],
+    params: &EmParams,
+) -> EmOutput {
+    let nf = fields.len();
+    let nrows = patterns.len();
+    let total_weight: f64 = counts.iter().sum();
+
+    let always: Vec<bool> = (0..nf)
+        .map(|j| fields[j].is_blocking || conditioned[j])
+        .collect();
+
+    let mut u_probs: Vec<Vec<f64>> = u_probs.to_vec();
+    for j in 0..nf {
+        if always[j] {
+            u_probs[j] = neutral_u(fields[j].n_levels);
+        }
+    }
+
+    let mut m_probs: Vec<Vec<f64>> = fields
+        .iter()
+        .map(|f| {
+            let raw: Vec<f64> = (0..f.n_levels).map(|k| (1u64 << k) as f64).collect();
+            let s: f64 = raw.iter().sum();
+            raw.iter().map(|r| r / s).collect()
+        })
+        .collect();
+
+    let mut p_match = P_MATCH_INIT;
+    let mut converged = false;
+    let mut iterations = 0usize;
+
+    for it in 0..params.max_iterations {
+        iterations = it + 1;
+        let old_m = m_probs.clone();
+
+        // E-step, then weight each row's posterior by its count.
+        let mut wp = vec![0.0f64; nrows];
+        for i in 0..nrows {
+            let mut log_m = 0.0f64;
+            let mut log_u = 0.0f64;
+            for j in 0..nf {
+                let lvl = patterns[i][j];
+                if lvl >= 0 && !conditioned[j] {
+                    let l = lvl as usize;
+                    log_m += m_probs[j][l].max(FLOOR).ln();
+                    log_u += u_probs[j][l].max(FLOOR).ln();
+                }
+            }
+            let log_match = p_match.max(FLOOR).ln() + log_m;
+            let log_non = (1.0 - p_match).max(FLOOR).ln() + log_u;
+            let mx = log_match.max(log_non);
+            let e_m = (log_match - mx).exp();
+            let e_n = (log_non - mx).exp();
+            wp[i] = (e_m / (e_m + e_n)) * counts[i];
+        }
+
+        let total_match: f64 = wp.iter().sum();
+        p_match = (total_match / total_weight).max(SMOOTH);
+
+        for j in 0..nf {
+            if always[j] {
+                continue;
+            }
+            let nl = fields[j].n_levels;
+            let mut elig_match = 0.0f64;
+            for i in 0..nrows {
+                if patterns[i][j] >= 0 {
+                    elig_match += wp[i];
+                }
+            }
+            let mut new_m = vec![0.0f64; nl];
+            for (lvl, slot) in new_m.iter_mut().enumerate() {
+                let mut s = 0.0f64;
+                for i in 0..nrows {
+                    if patterns[i][j] >= 0 && patterns[i][j] as usize == lvl {
+                        s += wp[i];
+                    }
+                }
+                *slot = (s + SMOOTH) / (elig_match + nl as f64 * SMOOTH);
+            }
+            m_probs[j] = new_m;
+        }
+
+        let mut max_delta = 0.0f64;
+        for j in 0..nf {
+            if always[j] {
+                continue;
+            }
+            for k in 0..fields[j].n_levels {
+                max_delta = max_delta.max((m_probs[j][k] - old_m[j][k]).abs());
+            }
+        }
+        if max_delta < params.convergence {
+            converged = true;
+            break;
+        }
+    }
+
+    let match_weights = weights_from(fields, &always, &m_probs, &u_probs);
+    EmOutput {
+        m_probs,
+        u_probs,
+        match_weights,
+        converged,
+        iterations,
+        proportion_matched: p_match,
+    }
+}
+
+fn weights_from(
+    fields: &[EmField],
+    always: &[bool],
+    m_probs: &[Vec<f64>],
+    u_probs: &[Vec<f64>],
+) -> Vec<Vec<f64>> {
+    (0..fields.len())
+        .map(|j| {
+            if always[j] {
+                fixed_blocking_weights(fields[j].n_levels)
+            } else {
+                (0..fields[j].n_levels)
+                    .map(|k| (m_probs[j][k].max(FLOOR) / u_probs[j][k].max(FLOOR)).log2())
+                    .collect()
+            }
+        })
+        .collect()
+}
+
+/// One trained per-pass session: which fields its pass conditioned, its result,
+/// and how many pairs it saw.
+#[derive(Debug, Clone)]
+pub struct EmSession {
+    pub conditioned: Vec<bool>,
+    pub out: EmOutput,
+    pub weight: f64,
+}
+
+/// Combine independent per-pass sessions into one model.
+///
+/// `m` is the pair-weighted mean over the sessions that COULD estimate the field
+/// (those whose pass does not block on it), weighted because a pass contributing
+/// 10 pairs and one contributing 10,000 are not equal evidence.
+///
+/// `u` is neutralised for the UNION of every pass's blocking fields. Taking one
+/// session's `u` wholesale is wrong even though all sessions share a random-pair
+/// sample: each neutralises only its OWN blocking fields, so lifting the vector
+/// from session 0 leaves every other pass's blocking field carrying the
+/// random-pair estimate and re-opens #1835 for it.
+pub fn combine_em_sessions(fields: &[EmField], sessions: &[EmSession]) -> EmOutput {
+    let nf = fields.len();
+    let base = &sessions[0].out;
+
+    let union: Vec<bool> = (0..nf)
+        .map(|j| {
+            sessions
+                .iter()
+                .any(|s| s.conditioned[j] || fields[j].is_blocking)
+        })
+        .collect();
+
+    let mut m_probs: Vec<Vec<f64>> = Vec::with_capacity(nf);
+    for (j, field) in fields.iter().enumerate() {
+        let estimable: Vec<&EmSession> = sessions
+            .iter()
+            .filter(|s| !s.conditioned[j] && !field.is_blocking)
+            .collect();
+        if estimable.is_empty() {
+            // No pass leaves this field free, so every session fell back to the
+            // fixed prior and they agree; the first is as good as any.
+            m_probs.push(base.m_probs[j].clone());
+            continue;
+        }
+        let total: f64 = estimable.iter().map(|s| s.weight).sum();
+        let nl = field.n_levels;
+        m_probs.push(
+            (0..nl)
+                .map(|k| {
+                    estimable
+                        .iter()
+                        .map(|s| s.out.m_probs[j][k] * s.weight)
+                        .sum::<f64>()
+                        / total
+                })
+                .collect(),
+        );
+    }
+
+    let mut u_probs = base.u_probs.clone();
+    for j in 0..nf {
+        if union[j] {
+            u_probs[j] = neutral_u(fields[j].n_levels);
+        }
+    }
+
+    let total_w: f64 = sessions.iter().map(|s| s.weight).sum();
+    let proportion_matched = sessions
+        .iter()
+        .map(|s| s.out.proportion_matched * s.weight)
+        .sum::<f64>()
+        / total_w;
+
+    let match_weights = weights_from(fields, &union, &m_probs, &u_probs);
+    EmOutput {
+        m_probs,
+        u_probs,
+        match_weights,
+        converged: sessions.iter().all(|s| s.out.converged),
+        iterations: sessions.iter().map(|s| s.out.iterations).max().unwrap_or(0),
+        proportion_matched,
     }
 }
 
@@ -208,25 +513,8 @@ pub fn train_em_core(
         }
     }
 
-    // ── Match weights: log2(m/u) for learnable fields; linear -3..+3 for fixed ──
-    let match_weights: Vec<Vec<f64>> = (0..nf)
-        .map(|j| {
-            let nl = fields[j].n_levels;
-            if always[j] {
-                if nl > 1 {
-                    (0..nl)
-                        .map(|k| -3.0 + 6.0 * k as f64 / (nl - 1) as f64)
-                        .collect()
-                } else {
-                    vec![3.0]
-                }
-            } else {
-                (0..nl)
-                    .map(|k| (m_probs[j][k].max(FLOOR) / u_probs[j][k].max(FLOOR)).log2())
-                    .collect()
-            }
-        })
-        .collect();
+    // ── Match weights: log2(m/u) for learnable fields; the fixed ramp otherwise ──
+    let match_weights = weights_from(fields, &always, &m_probs, &u_probs);
 
     EmOutput {
         m_probs,

--- a/packages/rust/extensions/score-core/tests/em_counts_parity.rs
+++ b/packages/rust/extensions/score-core/tests/em_counts_parity.rs
@@ -1,0 +1,228 @@
+//! The Rust FS EM core reproduces the Python reference, case for case.
+//!
+//! Phase 0 of `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`.
+//! The Fellegi-Sunter EM loop exists three times in this repo (Python, TypeScript,
+//! and here) and this crate's copy is the one designated as the source of truth.
+//! Until it is wired (Phase 1) it is also the one nothing calls, so without a gate
+//! it drifts from the behaviour it is supposed to define and nobody finds out.
+//!
+//! The anchors come from `scripts/gen_fs_em_parity_fixture.py`, which is
+//! COMMITTED. The older anchors inlined in `em_core.rs` came from an uncommitted
+//! scratch script: when one of those goes red there is no way to tell a Python
+//! behaviour change from a bad port, because the numbers cannot be re-derived.
+//! Here, re-running the emitter and reading `git diff` is the whole diagnosis.
+//!
+//! Parity is decision-level, not bitwise -- libm's `ln`/`log2`/`exp` differ from
+//! CPython's in the low mantissa bits. Tolerances travel IN the fixture so the
+//! two sides cannot disagree about what "parity" means.
+
+use goldenmatch_score_core::em_core::{
+    estimate_u_from_counts, train_em_from_counts, EmField, EmParams,
+};
+use serde_json::Value;
+
+fn fixture() -> Value {
+    let raw = include_str!("fixtures/em_counts_parity.json");
+    serde_json::from_str(raw).expect("the parity fixture is not valid JSON")
+}
+
+fn floats(v: &Value) -> Vec<f64> {
+    v.as_array()
+        .expect("expected an array of numbers")
+        .iter()
+        .map(|x| x.as_f64().expect("expected a number"))
+        .collect()
+}
+
+fn table(v: &Value) -> Vec<Vec<f64>> {
+    v.as_array()
+        .expect("expected an array of arrays")
+        .iter()
+        .map(floats)
+        .collect()
+}
+
+/// Compare two nested tables, reporting the case, field and level on failure.
+///
+/// The message carries `why` -- the fixture's own statement of what the case is
+/// for -- because a bare numeric mismatch three months from now says nothing
+/// about which property broke.
+fn assert_table(got: &[Vec<f64>], want: &[Vec<f64>], tol: f64, case: &str, what: &str, why: &str) {
+    assert_eq!(got.len(), want.len(), "{case}/{what}: field count");
+    for (j, (g, w)) in got.iter().zip(want).enumerate() {
+        assert_eq!(g.len(), w.len(), "{case}/{what}: field {j} level count");
+        for (k, (a, b)) in g.iter().zip(w).enumerate() {
+            assert!(
+                (a - b).abs() <= tol,
+                "{case}/{what}: field {j} level {k}: rust {a} vs python {b} \
+                 (delta {}, tol {tol})\n  this case exists because: {why}",
+                (a - b).abs()
+            );
+        }
+    }
+}
+
+#[test]
+fn the_rust_core_reproduces_the_python_reference() {
+    let fx = fixture();
+    let tol_p = fx["_tolerances"]["probabilities"].as_f64().unwrap();
+    let tol_w = fx["_tolerances"]["match_weights"].as_f64().unwrap();
+
+    let cases = fx["cases"].as_array().expect("cases");
+    assert!(!cases.is_empty(), "the fixture carries no cases");
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let why = case["why"].as_str().unwrap();
+
+        let fields: Vec<EmField> = case["fields"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .zip(case["conditioned"].as_array().unwrap())
+            .map(|(f, _)| EmField {
+                n_levels: f["n_levels"].as_u64().unwrap() as usize,
+                // `is_blocking` stays false: the fixture expresses conditioning
+                // through `conditioned`, which is the per-PASS signal the
+                // counted path carries. Setting both would make it impossible
+                // to tell which one the port is honouring.
+                is_blocking: false,
+            })
+            .collect();
+        let conditioned: Vec<bool> = case["conditioned"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_bool().unwrap())
+            .collect();
+
+        let patterns: Vec<Vec<i32>> = case["patterns"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| {
+                row.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|x| x.as_i64().unwrap() as i32)
+                    .collect()
+            })
+            .collect();
+        let counts = floats(&case["counts"]);
+        let u_in = table(&case["u_probs_in"]);
+
+        let out = train_em_from_counts(
+            &fields,
+            &patterns,
+            &counts,
+            &u_in,
+            &conditioned,
+            &EmParams::default(),
+        );
+
+        let expect = &case["expect"];
+        assert_table(
+            &out.m_probs,
+            &table(&expect["m_probs"]),
+            tol_p,
+            name,
+            "m_probs",
+            why,
+        );
+        assert_table(
+            &out.u_probs,
+            &table(&expect["u_probs"]),
+            tol_p,
+            name,
+            "u_probs",
+            why,
+        );
+        assert_table(
+            &out.match_weights,
+            &table(&expect["match_weights"]),
+            tol_w,
+            name,
+            "match_weights",
+            why,
+        );
+        let want_p = expect["proportion_matched"].as_f64().unwrap();
+        assert!(
+            (out.proportion_matched - want_p).abs() <= tol_p,
+            "{name}/proportion_matched: rust {} vs python {want_p}",
+            out.proportion_matched
+        );
+        assert_eq!(
+            out.converged,
+            expect["converged"].as_bool().unwrap(),
+            "{name}: converged flag"
+        );
+        assert_eq!(
+            out.iterations,
+            expect["iterations"].as_u64().unwrap() as usize,
+            "{name}: iteration count -- the loops diverged even if the numbers \
+             happened to land close"
+        );
+
+        // u-from-counts has no other gate: the trainer is handed `u` rather than
+        // estimating it, so a broken estimator would never show up above.
+        let u_est = estimate_u_from_counts(&fields, &patterns, &counts);
+        assert_table(
+            &u_est,
+            &table(&case["expect_u_from_counts"]),
+            tol_p,
+            name,
+            "estimate_u_from_counts",
+            why,
+        );
+    }
+}
+
+#[test]
+fn a_conditioned_field_takes_the_bounded_ramp_not_an_estimate() {
+    // Stated separately from the fixture sweep because it is the #1835/#1836
+    // failure and it is worth being able to read the rule off a test rather
+    // than off a JSON blob. A near-unique blocking key whose `u` is learned
+    // collapses toward the smoothing floor, which explodes log2(m/u) past 20
+    // bits and lets one field dominate every other (measured F1 0.83 -> 0.57).
+    let fields = vec![
+        EmField {
+            n_levels: 2,
+            is_blocking: false,
+        },
+        EmField {
+            n_levels: 2,
+            is_blocking: false,
+        },
+    ];
+    let patterns = vec![vec![1, 1], vec![0, 1]];
+    let counts = vec![500.0, 300.0];
+    // A deliberately near-unique u for field 1 -- the shape that explodes.
+    let u_in = vec![vec![0.9, 0.1], vec![0.999, 0.001]];
+
+    let out = train_em_from_counts(
+        &fields,
+        &patterns,
+        &counts,
+        &u_in,
+        &[false, true],
+        &EmParams::default(),
+    );
+
+    assert_eq!(
+        out.match_weights[1],
+        vec![-3.0, 3.0],
+        "a conditioned field must take the bounded ramp; the near-unique u it \
+         was handed must not reach the weights at all"
+    );
+    assert_eq!(
+        out.u_probs[1],
+        vec![0.5, 0.5],
+        "and its u must be neutralised"
+    );
+    assert_ne!(
+        out.match_weights[0],
+        vec![-3.0, 3.0],
+        "field 0 is free and must still be LEARNED -- if it also came back \
+         [-3, 3] the rule is being applied to everything"
+    );
+}

--- a/packages/rust/extensions/score-core/tests/fixtures/em_counts_parity.json
+++ b/packages/rust/extensions/score-core/tests/fixtures/em_counts_parity.json
@@ -1,0 +1,491 @@
+{
+  "_generated_by": "scripts/gen_fs_em_parity_fixture.py",
+  "_reference": "goldenmatch.core.probabilistic",
+  "_tolerances": {
+    "probabilities": 1e-09,
+    "match_weights": 1e-07
+  },
+  "_tolerance_reason": "libm ln/log2/exp differ from CPython in the low mantissa bits, so parity is decision-level rather than bitwise. Weights get the looser bound because they amplify small m near the 1e-10 floor.",
+  "cases": [
+    {
+      "name": "two_level_learnable_only",
+      "why": "the base case: both fields free, so every weight is log2(m/u)",
+      "fields": [
+        {
+          "name": "first",
+          "n_levels": 2
+        },
+        {
+          "name": "last",
+          "n_levels": 2
+        }
+      ],
+      "patterns": [
+        [
+          1,
+          1
+        ],
+        [
+          0,
+          1
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "counts": [
+        500,
+        300,
+        150,
+        50
+      ],
+      "u_probs_in": [
+        [
+          0.9,
+          0.1
+        ],
+        [
+          0.85,
+          0.15
+        ]
+      ],
+      "conditioned": [
+        false,
+        false
+      ],
+      "expect": {
+        "m_probs": [
+          [
+            0.34718191289321637,
+            0.6528180871067837
+          ],
+          [
+            0.1966712071449673,
+            0.8033287928550328
+          ]
+        ],
+        "u_probs": [
+          [
+            0.9,
+            0.1
+          ],
+          [
+            0.85,
+            0.15
+          ]
+        ],
+        "match_weights": [
+          [
+            -1.3742332116638434,
+            2.706681029456731
+          ],
+          [
+            -2.111677080124582,
+            2.4210280856960886
+          ]
+        ],
+        "proportion_matched": 0.9944466076137125,
+        "converged": true,
+        "iterations": 15
+      },
+      "expect_u_from_counts": [
+        [
+          0.3500000003,
+          0.6499999997
+        ],
+        [
+          0.2000000006,
+          0.7999999994
+        ]
+      ]
+    },
+    {
+      "name": "near_unique_blocking_field_1836",
+      "why": "THE #1836 case. `zip` is near-unique, so a learned u collapses toward the smoothing floor and log2(m/u) explodes past 20 bits, letting one field dominate every other. It must come back neutral-u with the bounded -3..+3 ramp instead. This is the case that fails silently.",
+      "fields": [
+        {
+          "name": "first",
+          "n_levels": 2
+        },
+        {
+          "name": "zip",
+          "n_levels": 2
+        }
+      ],
+      "patterns": [
+        [
+          1,
+          1
+        ],
+        [
+          0,
+          1
+        ]
+      ],
+      "counts": [
+        500,
+        300
+      ],
+      "u_probs_in": [
+        [
+          0.9,
+          0.1
+        ],
+        [
+          0.999,
+          0.001
+        ]
+      ],
+      "conditioned": [
+        false,
+        true
+      ],
+      "expect": {
+        "m_probs": [
+          [
+            0.001068680567278574,
+            0.9989313194327214
+          ],
+          [
+            0.3333333333333333,
+            0.6666666666666666
+          ]
+        ],
+        "u_probs": [
+          [
+            0.9,
+            0.1
+          ],
+          [
+            0.5,
+            0.5
+          ]
+        ],
+        "match_weights": [
+          [
+            -9.717950500806209,
+            3.3203854903099943
+          ],
+          [
+            -3.0,
+            3.0
+          ]
+        ],
+        "proportion_matched": 0.5683114341681318,
+        "converged": true,
+        "iterations": 4
+      },
+      "expect_u_from_counts": [
+        [
+          0.3750000003125,
+          0.6249999996875
+        ],
+        [
+          1.249999996875e-09,
+          0.99999999875
+        ]
+      ]
+    },
+    {
+      "name": "three_level_conditioned",
+      "why": "a 3-level conditioned field must ramp -3, 0, +3 across ITS levels; a hard-coded two-element ramp would index wrong at scoring time",
+      "fields": [
+        {
+          "name": "first",
+          "n_levels": 2
+        },
+        {
+          "name": "city",
+          "n_levels": 3
+        }
+      ],
+      "patterns": [
+        [
+          1,
+          2
+        ],
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          1
+        ]
+      ],
+      "counts": [
+        400,
+        300,
+        200,
+        100
+      ],
+      "u_probs_in": [
+        [
+          0.9,
+          0.1
+        ],
+        [
+          0.8,
+          0.15,
+          0.05
+        ]
+      ],
+      "conditioned": [
+        false,
+        true
+      ],
+      "expect": {
+        "m_probs": [
+          [
+            0.0013403384468370417,
+            0.998659661553163
+          ],
+          [
+            0.14285714285714285,
+            0.2857142857142857,
+            0.5714285714285714
+          ]
+        ],
+        "u_probs": [
+          [
+            0.9,
+            0.1
+          ],
+          [
+            0.34,
+            0.33,
+            0.33
+          ]
+        ],
+        "match_weights": [
+          [
+            -9.391183851786712,
+            3.3199930981918846
+          ],
+          [
+            -3.0,
+            0.0,
+            3.0
+          ]
+        ],
+        "proportion_matched": 0.5396783640662413,
+        "converged": true,
+        "iterations": 4
+      },
+      "expect_u_from_counts": [
+        [
+          0.4000000002,
+          0.5999999998
+        ],
+        [
+          0.2000000004,
+          0.1000000007,
+          0.6999999989
+        ]
+      ]
+    },
+    {
+      "name": "unobserved_entries",
+      "why": "-1 is UNOBSERVED: it must carry no evidence and stay out of the denominator, not be read as level -1 or as a disagreement",
+      "fields": [
+        {
+          "name": "first",
+          "n_levels": 2
+        },
+        {
+          "name": "last",
+          "n_levels": 2
+        }
+      ],
+      "patterns": [
+        [
+          1,
+          -1
+        ],
+        [
+          -1,
+          1
+        ],
+        [
+          1,
+          1
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "counts": [
+        400,
+        300,
+        200,
+        100
+      ],
+      "u_probs_in": [
+        [
+          0.9,
+          0.1
+        ],
+        [
+          0.85,
+          0.15
+        ]
+      ],
+      "conditioned": [
+        false,
+        false
+      ],
+      "expect": {
+        "m_probs": [
+          [
+            1.7454676659281926e-09,
+            0.9999999982545325
+          ],
+          [
+            2.124773663420994e-09,
+            0.9999999978752263
+          ]
+        ],
+        "u_probs": [
+          [
+            0.9,
+            0.1
+          ],
+          [
+            0.85,
+            0.15
+          ]
+        ],
+        "match_weights": [
+          [
+            -28.94173612873626,
+            3.321928092369185
+          ],
+          [
+            -28.575578430652385,
+            2.7369655911008057
+          ]
+        ],
+        "proportion_matched": 0.8455727647293606,
+        "converged": true,
+        "iterations": 3
+      },
+      "expect_u_from_counts": [
+        [
+          0.14285714387755102,
+          0.857142856122449
+        ],
+        [
+          0.16666666777777778,
+          0.8333333322222223
+        ]
+      ]
+    },
+    {
+      "name": "weights_are_counts_not_proportions",
+      "why": "the same shape as case 1 at 1/100th the counts. The 1e-6 smoothing is ADDITIVE, so this must NOT equal case 1 -- if a port normalises the weights it will, and the difference lands in the low-probability cells where FS weights are largest",
+      "fields": [
+        {
+          "name": "first",
+          "n_levels": 2
+        },
+        {
+          "name": "last",
+          "n_levels": 2
+        }
+      ],
+      "patterns": [
+        [
+          1,
+          1
+        ],
+        [
+          0,
+          1
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "counts": [
+        5,
+        3,
+        1,
+        1
+      ],
+      "u_probs_in": [
+        [
+          0.9,
+          0.1
+        ],
+        [
+          0.85,
+          0.15
+        ]
+      ],
+      "conditioned": [
+        false,
+        false
+      ],
+      "expect": {
+        "m_probs": [
+          [
+            0.36570669826296015,
+            0.63429330173704
+          ],
+          [
+            0.1553117994961843,
+            0.8446882005038158
+          ]
+        ],
+        "u_probs": [
+          [
+            0.9,
+            0.1
+          ],
+          [
+            0.85,
+            0.15
+          ]
+        ],
+        "match_weights": [
+          [
+            -1.2992379502012152,
+            2.6651501071057044
+          ],
+          [
+            -2.4522954015575333,
+            2.493456397360316
+          ]
+        ],
+        "proportion_matched": 0.9352765747639333,
+        "converged": true,
+        "iterations": 18
+      },
+      "expect_u_from_counts": [
+        [
+          0.400000019999996,
+          0.599999980000004
+        ],
+        [
+          0.20000005999998802,
+          0.799999940000012
+        ]
+      ]
+    }
+  ]
+}

--- a/scripts/gen_fs_em_parity_fixture.py
+++ b/scripts/gen_fs_em_parity_fixture.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Emit the Python-side anchors for the Rust FS EM parity gate.
+
+The Rust `score-core/src/em_core.rs` is the designated single source of truth
+for Fellegi-Sunter training math (see
+`docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`), but the
+behaviour it must reproduce is defined by
+`goldenmatch.core.probabilistic`. This script writes that behaviour down as data
+so a Rust test can assert against it without embedding Python.
+
+**Why a committed emitter and not pasted numbers.** The existing anchors in
+`em_core.rs` came from "the C1 commit message / scratch script" -- a script that
+was never committed. Nobody can re-derive those numbers, so nobody can tell a
+Python behaviour change from a bad port: the test just goes red with no way to
+decide which side moved. This script is the harness, and re-running it is the
+whole diff.
+
+Regenerate:
+
+    PYTHONPATH=packages/python/goldenmatch \\
+      python scripts/gen_fs_em_parity_fixture.py
+
+Then `git diff` on the fixture shows any drift. A change there is a change to
+trained models and must be justified in the PR, not waved through.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+OUT = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "packages/rust/extensions/score-core/tests/fixtures/em_counts_parity.json"
+)
+
+
+def _mk(fields):
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    return MatchkeyConfig(
+        name="fs",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(
+                field=name,
+                scorer="jaro_winkler",
+                levels=levels,
+                partial_threshold=0.8,
+            )
+            for name, levels in fields
+        ],
+    )
+
+
+#: Each case is (name, fields, patterns, u_probs, conditioned, why).
+#:
+#: These are chosen for the ways the port can be wrong while still returning a
+#: valid model, not for realism.
+CASES = [
+    (
+        "two_level_learnable_only",
+        [("first", 2), ("last", 2)],
+        [[[1, 1], 500], [[0, 1], 300], [[1, 0], 150], [[0, 0], 50]],
+        {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+        [],
+        "the base case: both fields free, so every weight is log2(m/u)",
+    ),
+    (
+        "near_unique_blocking_field_1836",
+        [("first", 2), ("zip", 2)],
+        # Blocked ON zip, so every candidate agrees on it: level 1 throughout.
+        [[[1, 1], 500], [[0, 1], 300]],
+        {"first": [0.9, 0.1], "zip": [0.999, 0.001]},
+        ["zip"],
+        "THE #1836 case. `zip` is near-unique, so a learned u collapses toward "
+        "the smoothing floor and log2(m/u) explodes past 20 bits, letting one "
+        "field dominate every other. It must come back neutral-u with the "
+        "bounded -3..+3 ramp instead. This is the case that fails silently.",
+    ),
+    (
+        "three_level_conditioned",
+        [("first", 2), ("city", 3)],
+        [[[1, 2], 400], [[0, 2], 300], [[1, 0], 200], [[0, 1], 100]],
+        {"first": [0.9, 0.1], "city": [0.8, 0.15, 0.05]},
+        ["city"],
+        "a 3-level conditioned field must ramp -3, 0, +3 across ITS levels; a "
+        "hard-coded two-element ramp would index wrong at scoring time",
+    ),
+    (
+        "unobserved_entries",
+        [("first", 2), ("last", 2)],
+        [[[1, -1], 400], [[-1, 1], 300], [[1, 1], 200], [[0, 0], 100]],
+        {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+        [],
+        "-1 is UNOBSERVED: it must carry no evidence and stay out of the "
+        "denominator, not be read as level -1 or as a disagreement",
+    ),
+    (
+        "weights_are_counts_not_proportions",
+        [("first", 2), ("last", 2)],
+        [[[1, 1], 5], [[0, 1], 3], [[1, 0], 1], [[0, 0], 1]],
+        {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+        [],
+        "the same shape as case 1 at 1/100th the counts. The 1e-6 smoothing is "
+        "ADDITIVE, so this must NOT equal case 1 -- if a port normalises the "
+        "weights it will, and the difference lands in the low-probability "
+        "cells where FS weights are largest",
+    ),
+]
+
+
+def main() -> int:
+    from goldenmatch.core.probabilistic import (
+        estimate_u_from_counts,
+        train_em_from_counts,
+    )
+
+    out = {
+        "_generated_by": "scripts/gen_fs_em_parity_fixture.py",
+        "_reference": "goldenmatch.core.probabilistic",
+        "_tolerances": {"probabilities": 1e-9, "match_weights": 1e-7},
+        "_tolerance_reason": (
+            "libm ln/log2/exp differ from CPython in the low mantissa bits, so "
+            "parity is decision-level rather than bitwise. Weights get the "
+            "looser bound because they amplify small m near the 1e-10 floor."
+        ),
+        "cases": [],
+    }
+
+    for name, fields, patterns, u_probs, conditioned, why in CASES:
+        mk = _mk(fields)
+        pattern_counts = [(tuple(vec), int(c)) for vec, c in patterns]
+        em = train_em_from_counts(
+            mk, pattern_counts, u_probs, conditioned_fields=tuple(conditioned)
+        )
+        # u-from-counts is exercised on the SAME patterns. It is not what the
+        # trainer was handed (that is `u_probs`, from random pairs) -- this pins
+        # the estimator itself, which has no other gate.
+        u_est = estimate_u_from_counts(mk, pattern_counts)
+
+        out["cases"].append(
+            {
+                "name": name,
+                "why": why,
+                "fields": [{"name": n, "n_levels": lv} for n, lv in fields],
+                "patterns": [vec for vec, _ in patterns],
+                "counts": [c for _, c in patterns],
+                "u_probs_in": [u_probs[n] for n, _ in fields],
+                "conditioned": [n in conditioned for n, _ in fields],
+                "expect": {
+                    "m_probs": [list(em.m_probs[n]) for n, _ in fields],
+                    "u_probs": [list(em.u_probs[n]) for n, _ in fields],
+                    "match_weights": [list(em.match_weights[n]) for n, _ in fields],
+                    "proportion_matched": em.proportion_matched,
+                    "converged": em.converged,
+                    "iterations": em.iterations,
+                },
+                "expect_u_from_counts": [list(u_est[n]) for n, _ in fields],
+            }
+        )
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(out, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    print(f"wrote {OUT} ({len(out['cases'])} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`.

**Stacked on #2552.** Its commits are the first four here and drop out on rebase.

## The finding

The Fellegi-Sunter EM loop exists **three times**:

| implementation | covers | callers |
|---|---|---|
| `probabilistic.py` (`train_em`, `_em_iterate`) | NE, TF, monotonicity, missing modes, counted path | everything |
| `probabilistic.ts` (`trainEM`) | NE; no counted path | the TS surface |
| **`score-core/src/em_core.rs`** | the discrete E/M loop only | **none** |

The copy designated as the source of truth is the least complete *and* has zero callers — `grep -rn "train_em_core\|EmOutput\|EmParams"` across `*.rs`/`*.py`/`*.ts` returns nothing outside the file itself. Meanwhile `bridge::train_em` **embeds CPython** and calls the Python trainer, so every non-Python surface reaches Python for FS training. It's a PR-C that built its numeric core and was never wired.

And #2550/#2552 made it worse: `pair_weights`, `train_em_from_counts`, `estimate_u_from_counts`, `_neutral_u_for`, `_combine_em_sessions` all went into Python only. `em_core.rs` already had `neutral_u` with byte-identical constants.

## What this PR does

Ports the counted shape into the Rust core — `train_em_from_counts`, `estimate_u_from_counts`, `combine_em_sessions`, `fixed_blocking_weights` — and puts a parity gate under it.

**It adds no callers.** On its own it is a *fourth* copy; it is only worth landing because Phase 1 (wiring it over C-ABI/wasm/JNI, so Python and TS stop carrying their own loops) follows immediately. That is stated in the spec's risks section too.

## The gate found two real bugs in #2552

Both in code queued to merge, both #1835-family, both invisible from either side alone.

**1. A conditioned field got `log2(m/u)` instead of the bounded ramp.** Its `m` is never updated — it keeps the exponential init — so that ratio is an arbitrary initialisation divided by a random-pair estimate. Measured on a 2-level blocking field:

| | disagree | agree |
|---|---|---|
| `train_em` (correct) | **-3.0** | **+3.0** |
| counted path | -1.54 | +4.47 |

The disagreement penalty that drives precision was more than halved; the agreement weight bounded to preserve recall ran 49% over. On a near-unique key this is the mechanism behind the measured F1 0.83 → 0.57.

**2. It reported the random-pair `u` it was handed, not the neutral prior.** Doesn't move the trained `m` (a conditioned field is skipped in the E-step), but `u_probs` is half the persisted model.

Both now route through single definitions — `_fixed_blocking_weights` and `_neutral_u_for` — which `train_em` and `estimate_m_from_labels` were also duplicating.

Bug 2 was found *by the Rust gate on its first run*, which is the entire argument for the spec.

## The gate

Anchors come from `scripts/gen_fs_em_parity_fixture.py`, which is **committed**. The existing `em_core.rs` anchors came from "the C1 commit message / scratch script" — uncommitted, so when one goes red there is no way to tell a Python behaviour change from a bad port. Here, re-running the emitter and reading `git diff` is the whole diagnosis.

Five cases: the base case, the **#1836 near-unique-blocking** one, a 3-level conditioned field (a hard-coded 2-element ramp would index wrong at scoring time), unobserved `-1` handling, and one pinning that weights are **counts** — the `1e-6` smoothing is additive, so rescaling them moves the model.

Tolerances travel *in* the fixture. Parity is decision-level, not bitwise: libm's `ln`/`log2`/`exp` differ from CPython's in the low mantissa bits. The 2026-07-18 plan's "byte-parity" wording was wrong, and `em_core.rs`'s own test helper already said so.

`serde_json` is a **dev**-dependency, so the wasm bundle budget and the crate's minimal-dep posture are untouched.

## Verification

- `cargo test` (score-core): 36 passed
- `cargo clippy --all-targets -- -D warnings`: clean; `cargo fmt --check`: clean
- Python FS/EM/probabilistic suites: 160 passed
- `regen_docs.py --check`: current

`cargo fmt` reformatted three files this PR does not touch (`examples/bench_*.rs`, `src/lib.rs`); those were reverted.

## Not in this PR

Phases 1-4 of the spec: wiring (the load-bearing one), TF adjustment on the distributed path, other backends, and the Splink head-to-head benchmark. **No comparative claim about Splink is supported until Phase 4 exists.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
