### PR TITLE
feat(fs): Phase 1a -- Python trains FS through the Rust kernel

### DIFF
--- a/docs-site/goldenmatch/native.mdx
+++ b/docs-site/goldenmatch/native.mdx
@@ -43,6 +43,7 @@ Each component maps to the native kernel symbol(s) its `auto` call site invokes 
 | `perceptual` | `perceptual_phash_image` |  |
 | `documents` | `documents_parse_message_text`, `documents_schema_validate`, `documents_extract_instruction`, `documents_normalize_record`, `documents_template`, `documents_template_list`, `documents_classify_prompt`, `documents_parse_classify`, `documents_parse_structured` |  |
 | `sail_scoring` | `score_field_pairwise` |  |
+| `fs_em` | `train_em_from_counts_native`, `estimate_u_from_counts_native` |  |
 
 ## How parity stays honest
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4211,6 +4211,7 @@
             "_scalar_tf_contribution",
             "_score_distribution_valley",
             "_score_fs_native_frame",
+            "_train_em_from_counts_native",
             "_training_config_manifest",
             "_training_pair_conditioning",
             "_transform_field_value",

--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -199,6 +199,18 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # DTYPE is f64 and falls back otherwise -- an older installed wheel must not
     # silently reintroduce the flips.
     "sail_scoring": ("score_field_pairwise",),
+    # fs_em: the COUNTED Fellegi-Sunter trainer (spec
+    # 2026-08-13-fs-em-rust-single-source-design). The kernel is
+    # `score-core::em_core`, which until Phase 1 had no callers at all while the
+    # same loop was maintained separately in Python and TypeScript.
+    #
+    # Parity is DECISION-LEVEL, not bitwise: libm's ln/log2/exp differ from
+    # CPython's in the low mantissa bits, so a model trained native and one
+    # trained pure-Python agree to ~1e-9 on probabilities rather than exactly.
+    # That is the same posture every other float kernel here takes, and the
+    # per-case tolerances are pinned in
+    # packages/rust/extensions/score-core/tests/fixtures/em_counts_parity.json.
+    "fs_em": ("train_em_from_counts_native", "estimate_u_from_counts_native"),
 }
 
 # Components with a native symbol that is KNOWN to diverge from the Python

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1314,6 +1314,77 @@ def _neutral_u_for(field) -> list[float]:
     return [1.0 / field.levels] * field.levels
 
 
+def _train_em_from_counts_native(
+    mk: MatchkeyConfig,
+    pattern_counts: list[tuple[tuple[int, ...], int]],
+    u_probs: dict[str, list[float]],
+    *,
+    conditioned_fields: Sequence[str],
+    max_iterations: int,
+    convergence: float,
+) -> EMResult | None:
+    """Run the counted trainer in the Rust kernel, or ``None`` to fall back.
+
+    Phase 1 of the FS-EM single-source spec. The same loop was maintained in
+    Python, TypeScript and Rust; this is what makes the Rust one load-bearing
+    for Python rather than a fourth copy nothing runs.
+
+    Returns ``None`` -- never a partial result -- when the kernel is absent, the
+    component is gated off, or the symbol is missing from an older published
+    wheel. Symbol presence is checked at the call site and not only through the
+    component gate, because a wheel predating this symbol is the normal state of
+    every environment until the wheel is republished (#688's secondary bug).
+
+    Parity is DECISION-LEVEL, not bitwise: libm's ``ln``/``log2``/``exp`` differ
+    from CPython's in the low mantissa bits, so which path ran moves the trained
+    numbers in the last ~1e-9. That is the same posture every other float kernel
+    here takes; it is stated because "the model differs by environment" is
+    otherwise a surprising thing to discover.
+    """
+    from goldenmatch.core._native_loader import native_enabled, native_module
+
+    if not native_enabled("fs_em", "train_em_from_counts_native"):
+        return None
+    mod = native_module()
+    fn = getattr(mod, "train_em_from_counts_native", None)
+    if fn is None:
+        return None
+
+    conditioned = set(conditioned_fields)
+    n_levels = [f.levels for f in mk.fields]
+    try:
+        u_in = [list(u_probs[f.field]) for f in mk.fields]
+    except KeyError as exc:
+        raise ValueError(
+            f"u_probs is missing field {exc.args[0]!r}; the counted trainer "
+            f"needs one u vector per matchkey field"
+        ) from None
+
+    m_tab, u_tab, w_tab, converged, iterations, p_match = fn(
+        n_levels,
+        [list(vec) for vec, _ in pattern_counts],
+        [float(c) for _, c in pattern_counts],
+        u_in,
+        [f.field in conditioned for f in mk.fields],
+        int(max_iterations),
+        float(convergence),
+    )
+
+    names = [f.field for f in mk.fields]
+    logger.info(
+        "EM from counts (native): %d patterns, converged=%s in %d iterations",
+        len(pattern_counts), converged, iterations,
+    )
+    return EMResult(
+        m_probs={n: list(v) for n, v in zip(names, m_tab)},
+        u_probs={n: list(v) for n, v in zip(names, u_tab)},
+        match_weights={n: list(v) for n, v in zip(names, w_tab)},
+        converged=bool(converged),
+        iterations=int(iterations),
+        proportion_matched=float(p_match),
+    )
+
+
 def _combine_em_sessions(
     mk: MatchkeyConfig,
     sessions: list[tuple[tuple[str, ...], EMResult, float]],
@@ -1458,6 +1529,14 @@ def train_em_from_counts(
             )
         if count <= 0:
             raise ValueError(f"pattern {vec} has non-positive count {count}")
+
+    native = _train_em_from_counts_native(
+        mk, pattern_counts, u_probs,
+        conditioned_fields=conditioned_fields,
+        max_iterations=max_iterations, convergence=convergence,
+    )
+    if native is not None:
+        return native
 
     comp_matrix = np.asarray([v for v, _ in pattern_counts], dtype=np.int64)
     w = np.asarray([float(c) for _, c in pattern_counts], dtype=np.float64)

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -463,3 +463,132 @@ def test_a_conditioned_field_reports_the_NEUTRAL_u_not_the_one_passed_in():
     assert em.u_probs["first"] == pytest.approx([0.9, 0.1], abs=1e-12), (
         "a free field must keep the u it was given"
     )
+
+
+# ── Phase 1: the Rust kernel is the one that runs ────────────────────
+
+def _native_em_available() -> bool:
+    from goldenmatch.core._native_loader import native_module
+
+    mod = native_module()
+    return mod is not None and hasattr(mod, "train_em_from_counts_native")
+
+
+def _counted_case():
+    """A case with a learnable field AND a conditioned one.
+
+    Both calibration rules the Rust port had to reproduce (`_neutral_u_for`,
+    `_fixed_blocking_weights`) only fire for a conditioned field, so a fixture
+    without one would compare the two paths on the half that never diverged.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="city", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.7),
+        ],
+    )
+    patterns = [((1, 2), 500), ((0, 2), 300), ((1, 0), 150), ((0, 1), 50)]
+    u = {"first": [0.9, 0.1], "city": [0.8, 0.15, 0.05]}
+    return mk, patterns, u
+
+
+@pytest.mark.skipif(not _native_em_available(),
+                    reason="the native FS-EM kernel is not built here")
+@pytest.mark.parametrize("conditioned", [(), ("city",)])
+def test_the_native_kernel_and_the_python_fallback_agree(monkeypatch, conditioned):
+    """THE Phase 1 gate: which path ran must not change the model.
+
+    Decision-level, not bitwise. libm's ln/log2/exp differ from CPython's in the
+    low mantissa bits, so 1e-9 on probabilities and 1e-7 on match weights -- the
+    same tolerances the Rust-side fixture carries, and for the same reason.
+    Asserting equality would fail on the first machine with a different libm and
+    teach everyone to loosen it, which is how a real divergence gets waved
+    through.
+    """
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk, patterns, u = _counted_case()
+    native = train_em_from_counts(mk, patterns, u, conditioned_fields=conditioned)
+
+    # Force the fallback by gating the component off, which is the same switch
+    # an operator has. Patching the module out would test a code path no
+    # deployment can reach.
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    fallback = train_em_from_counts(mk, patterns, u, conditioned_fields=conditioned)
+
+    for f in mk.fields:
+        n = f.field
+        assert native.m_probs[n] == pytest.approx(fallback.m_probs[n], abs=1e-9), n
+        assert native.u_probs[n] == pytest.approx(fallback.u_probs[n], abs=1e-9), n
+        assert native.match_weights[n] == pytest.approx(
+            fallback.match_weights[n], abs=1e-7
+        ), n
+    assert native.proportion_matched == pytest.approx(
+        fallback.proportion_matched, abs=1e-9
+    )
+    assert native.converged == fallback.converged
+    assert native.iterations == fallback.iterations, (
+        "the two loops took a different number of iterations, so they are not "
+        "the same loop even if the numbers landed close"
+    )
+
+
+@pytest.mark.skipif(not _native_em_available(),
+                    reason="the native FS-EM kernel is not built here")
+def test_the_native_path_is_actually_taken_when_available(monkeypatch):
+    """A skipif-guarded parity test proves nothing if the native path never ran.
+
+    This asserts the dispatch, not the numbers: without it, a call site that
+    quietly returned `None` on every input would leave the test above comparing
+    the fallback against itself and passing forever.
+    """
+    from goldenmatch.core._native_loader import (
+        native_dispatch_report,
+        reset_native_dispatch_log,
+    )
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    mk, patterns, u = _counted_case()
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+    reset_native_dispatch_log()
+    train_em_from_counts(mk, patterns, u, conditioned_fields=("city",))
+
+    report = native_dispatch_report().get("fs_em", {})
+    assert report.get("native", 0) >= 1, (
+        f"fs_em did not dispatch native: {report}. The parity test above is "
+        f"comparing the fallback with itself."
+    )
+
+
+@pytest.mark.skipif(not _native_em_available(),
+                    reason="the native FS-EM kernel is not built here")
+def test_the_kernel_refuses_a_level_outside_the_field_range():
+    """A corrupt vector must raise, not index the wrong weight.
+
+    The kernel range-checks rather than casting: a level of 7 on a 2-level field
+    would otherwise read past the weight table or wrap, and both produce a
+    number rather than an error.
+    """
+    from goldenmatch.core._native_loader import native_module
+
+    fn = native_module().train_em_from_counts_native
+    with pytest.raises(ValueError, match="outside"):
+        fn([2, 2], [[1, 7]], [10.0], [[0.9, 0.1], [0.9, 0.1]], [False, False],
+           20, 0.001)
+
+
+@pytest.mark.skipif(not _native_em_available(),
+                    reason="the native FS-EM kernel is not built here")
+def test_the_kernel_refuses_a_non_positive_count():
+    """A zero-count pattern is a row that should not have been emitted."""
+    from goldenmatch.core._native_loader import native_module
+
+    fn = native_module().train_em_from_counts_native
+    with pytest.raises(ValueError, match="non-positive"):
+        fn([2, 2], [[1, 1]], [0.0], [[0.9, 0.1], [0.9, 0.1]], [False, False],
+           20, 0.001)

--- a/packages/rust/extensions/native/src/em.rs
+++ b/packages/rust/extensions/native/src/em.rs
@@ -1,0 +1,198 @@
+//! Fellegi-Sunter training over COUNTED comparison vectors, exposed to Python.
+//!
+//! Phase 1 of `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`.
+//! Phase 0 put the counted EM math in `goldenmatch-score-core::em_core`; this is
+//! the first caller. Before it, `em_core` had none at all — the copy designated
+//! as the source of truth was the only one nothing ran, while
+//! `bridge::train_em` embedded CPython to reach the Python trainer.
+//!
+//! This module is deliberately thin: marshalling only, no arithmetic. Every
+//! constant, every accumulation order and every calibration rule lives in
+//! `em_core`, because a second place to get `1e-6` or the `-3..+3` ramp wrong is
+//! exactly what this phase exists to remove. If you find yourself computing
+//! something here, it belongs one crate down.
+//!
+//! ## Shapes
+//!
+//! `patterns` is `n_patterns x n_fields` of levels (`-1` = unobserved) and
+//! `counts` is one weight per pattern. `conditioned` is per FIELD, not per row:
+//! within one blocking pass the conditioning is constant, which is why the
+//! counts can come from a `GROUP BY` with no pass column.
+//!
+//! Levels arrive as `i64` because that is what a Python list of ints marshals to
+//! without a lossy narrowing step; they are range-checked into `i32` here rather
+//! than cast, so a corrupt vector is an error and not a wrapped level that
+//! silently reads the wrong weight.
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use goldenmatch_score_core::em_core::{
+    estimate_u_from_counts as core_estimate_u, train_em_from_counts as core_train, EmField,
+    EmParams,
+};
+
+/// The numeric subset of the Python `EMResult`, as a plain tuple-friendly struct.
+type EmTuple = (
+    Vec<Vec<f64>>, // m_probs
+    Vec<Vec<f64>>, // u_probs
+    Vec<Vec<f64>>, // match_weights
+    bool,          // converged
+    usize,         // iterations
+    f64,           // proportion_matched
+);
+
+fn build_fields(n_levels: &[usize]) -> Vec<EmField> {
+    n_levels
+        .iter()
+        .map(|&n| EmField {
+            n_levels: n,
+            // `is_blocking` stays false: the counted path expresses conditioning
+            // through the per-field `conditioned` mask the caller passes, which
+            // is the per-PASS signal. Setting both would make it impossible to
+            // tell which one produced a fixed field.
+            is_blocking: false,
+        })
+        .collect()
+}
+
+fn check_shapes(
+    n_levels: &[usize],
+    patterns: &[Vec<i64>],
+    counts: &[f64],
+    conditioned: &[bool],
+) -> PyResult<Vec<Vec<i32>>> {
+    let nf = n_levels.len();
+    if nf == 0 {
+        return Err(PyValueError::new_err(
+            "n_levels is empty; no fields to train",
+        ));
+    }
+    if conditioned.len() != nf {
+        return Err(PyValueError::new_err(format!(
+            "conditioned has {} entries but there are {nf} fields",
+            conditioned.len()
+        )));
+    }
+    if patterns.len() != counts.len() {
+        return Err(PyValueError::new_err(format!(
+            "{} patterns but {} counts",
+            patterns.len(),
+            counts.len()
+        )));
+    }
+    if patterns.is_empty() {
+        return Err(PyValueError::new_err("no patterns; nothing to train on"));
+    }
+
+    let mut out = Vec::with_capacity(patterns.len());
+    for (i, row) in patterns.iter().enumerate() {
+        if row.len() != nf {
+            return Err(PyValueError::new_err(format!(
+                "pattern {i} has {} entries but there are {nf} fields -- the \
+                 vectors must be ordered by the matchkey's fields",
+                row.len()
+            )));
+        }
+        let mut r = Vec::with_capacity(nf);
+        for (j, &lvl) in row.iter().enumerate() {
+            // Range-checked, not cast. A level outside its field's range would
+            // otherwise index the wrong weight or panic deep in the loop, and
+            // the caller would see neither.
+            if lvl < -1 || lvl >= n_levels[j] as i64 {
+                return Err(PyValueError::new_err(format!(
+                    "pattern {i} field {j} has level {lvl}, outside -1..{}",
+                    n_levels[j] - 1
+                )));
+            }
+            r.push(lvl as i32);
+        }
+        out.push(r);
+    }
+    for (i, &c) in counts.iter().enumerate() {
+        // NaN is rejected explicitly rather than via `!(c > 0.0)`: NaN fails
+        // every comparison, so it would slip through a bare `c <= 0.0` and then
+        // poison every weighted sum downstream into NaN -- which compares false
+        // against the convergence threshold, so EM would silently run to the
+        // iteration cap and return a model of NaNs.
+        if c.is_nan() || c <= 0.0 {
+            return Err(PyValueError::new_err(format!(
+                "pattern {i} has non-positive count {c}"
+            )));
+        }
+    }
+    Ok(out)
+}
+
+/// Train FS from counted comparison vectors. Mirrors
+/// `goldenmatch.core.probabilistic.train_em_from_counts`'s numeric half.
+///
+/// Returns `(m_probs, u_probs, match_weights, converged, iterations,
+/// proportion_matched)` with each table ordered by field, matching the order the
+/// caller passed `n_levels` in.
+#[pyfunction]
+#[pyo3(signature = (n_levels, patterns, counts, u_probs, conditioned,
+                    max_iterations=20, convergence=0.001))]
+#[allow(clippy::too_many_arguments)]
+pub fn train_em_from_counts_native(
+    py: Python<'_>,
+    n_levels: Vec<usize>,
+    patterns: Vec<Vec<i64>>,
+    counts: Vec<f64>,
+    u_probs: Vec<Vec<f64>>,
+    conditioned: Vec<bool>,
+    max_iterations: usize,
+    convergence: f64,
+) -> PyResult<EmTuple> {
+    let levels = check_shapes(&n_levels, &patterns, &counts, &conditioned)?;
+    if u_probs.len() != n_levels.len() {
+        return Err(PyValueError::new_err(format!(
+            "u_probs has {} vectors but there are {} fields",
+            u_probs.len(),
+            n_levels.len()
+        )));
+    }
+    for (j, u) in u_probs.iter().enumerate() {
+        if u.len() != n_levels[j] {
+            return Err(PyValueError::new_err(format!(
+                "u_probs[{j}] has {} levels but the field has {}",
+                u.len(),
+                n_levels[j]
+            )));
+        }
+    }
+
+    let fields = build_fields(&n_levels);
+    let params = EmParams {
+        max_iterations,
+        convergence,
+    };
+    // The loop touches no Python objects, so the GIL is released for it. The
+    // work is bounded by the distinct-vector count rather than the pair count,
+    // so this is rarely long -- but holding the GIL over a pure-numeric loop is
+    // the habit that makes a threaded caller serial for no reason.
+    let out =
+        py.detach(move || core_train(&fields, &levels, &counts, &u_probs, &conditioned, &params));
+
+    Ok((
+        out.m_probs,
+        out.u_probs,
+        out.match_weights,
+        out.converged,
+        out.iterations,
+        out.proportion_matched,
+    ))
+}
+
+/// `u` from counted comparison vectors over RANDOM pairs. Mirrors
+/// `goldenmatch.core.probabilistic.estimate_u_from_counts`.
+#[pyfunction]
+pub fn estimate_u_from_counts_native(
+    n_levels: Vec<usize>,
+    patterns: Vec<Vec<i64>>,
+    counts: Vec<f64>,
+) -> PyResult<Vec<Vec<f64>>> {
+    let conditioned = vec![false; n_levels.len()];
+    let levels = check_shapes(&n_levels, &patterns, &counts, &conditioned)?;
+    let fields = build_fields(&n_levels);
+    Ok(core_estimate_u(&fields, &levels, &counts))
+}

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -12,6 +12,7 @@ mod block;
 mod bloom;
 mod cluster;
 mod documents;
+mod em;
 mod featurize;
 mod fused;
 mod golden;
@@ -125,6 +126,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fused::match_fused, m)?)?;
     m.add_function(wrap_pyfunction!(fused::match_fused_fs, m)?)?;
     m.add_function(wrap_pyfunction!(golden::golden_fused, m)?)?;
+    m.add_function(wrap_pyfunction!(em::train_em_from_counts_native, m)?)?;
+    m.add_function(wrap_pyfunction!(em::estimate_u_from_counts_native, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_features, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_project, m)?)?;
     m.add_function(wrap_pyfunction!(score::jaro_winkler_similarity, m)?)?;


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`. **Stacked on #2555.**

Phase 0 put the counted EM math in `score-core::em_core` and left it with **zero callers** — a fourth copy of a loop that already existed three times. This is the first caller, and it makes the Rust core load-bearing for Python rather than decorative.

## What it does

`native/src/em.rs` is a pyo3 wrapper and nothing more: marshalling, shape checks, a `py.detach` around the call. **No arithmetic.** Every constant, accumulation order and calibration rule stays one crate down — a second place to get `1e-6` or the `-3..+3` ramp wrong is exactly what this arc removes.

`train_em_from_counts` calls the kernel and falls back to the numpy path.

## Failure modes it closes deliberately

**Wheel/caller symbol skew.** The symbol is checked at the *call site*, not only through the component gate. A published wheel predating this symbol is the normal state of every environment until the wheel is republished — #688's secondary bug was a call site that assumed otherwise. Returns `None`, never a partial result, so a missing kernel is a fallback rather than a half-trained model.

**Level range.** Levels are range-checked into `i32`, not cast. A level outside its field's range would otherwise index the wrong weight or panic deep in the loop, and the caller would see neither.

**NaN counts.** Rejected explicitly rather than via `c <= 0.0`. NaN fails every comparison, so it slips past that check, poisons every weighted sum, and — because a NaN delta compares false against the convergence threshold — EM runs silently to the iteration cap and returns a model of NaNs.

## A behaviour change worth stating

**Parity is decision-level, not bitwise.** libm's `ln`/`log2`/`exp` differ from CPython's in the low mantissa bits, so a model trained with the kernel present differs from one trained without it in the last ~1e-9. Same posture as every other float kernel here, but "the model differs by environment" is a surprising thing to discover by accident.

## Verification

I **built the extension and ran both paths** rather than asserting the wiring compiles.

- **212 tests pass** with the kernel present
- a parity pair trains each way (native, then `GOLDENMATCH_NATIVE=0`) and compares within 1e-9 / 1e-7 — the same tolerances the Rust-side fixture carries
- a **dispatch assertion** that fails if the native path silently stops being taken; without it the parity test would compare the fallback against itself and pass forever
- two refusal tests driving the kernel directly (out-of-range level, non-positive count)
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean

One test, `TestNativeFSGating::test_soundex_declines_tf_now_native`, fails when the whole suite is forced to `GOLDENMATCH_NATIVE=0` — it is a test that *requires* native, unrelated to this change, and passes with the kernel on.

`cargo fmt` reformatted `fused.rs`, which this PR does not touch; reverted.

## Phase 1 is not done

TypeScript still carries its own `trainEM`, and `bridge::train_em` still embeds CPython to reach the Python trainer. Those are slices **1b** and **1c**. Until 1c lands, non-Python surfaces still reach FS training through CPython, which is the thing the spec is ultimately about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
