### PR TITLE
chore(scoreboard): nightly adoption snapshot

### DIFF
--- a/context-network/planning/scoreboard.jsonl
+++ b/context-network/planning/scoreboard.jsonl
@@ -1,3 +1,4 @@
 {"date": "2026-07-29", "stars": 126, "forks": 14, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 3511}
 {"date": "2026-08-10", "stars": 128, "forks": 13, "open_issues_nonmaintainer": 2, "pypi_30d": 96429, "npm_30d": 4949}
 {"date": "2026-08-11", "stars": 128, "forks": 13, "open_issues_nonmaintainer": 2, "pypi_30d": null, "npm_30d": 4949}
+{"date": "2026-08-13", "stars": 128, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 4949}

--- a/context-network/planning/scoreboard.md
+++ b/context-network/planning/scoreboard.md
@@ -5,7 +5,7 @@
 [north-star-roadmap.md](./north-star-roadmap.md): *is GoldenMatch becoming the
 tool developers reach for by default?* Trend > snapshot.
 
-**Latest: 2026-08-11** (vs previous snapshot)
+**Latest: 2026-08-13** (vs previous snapshot)
 
 | Signal | Now | WoW | North Star reading |
 |---|---|---|---|
@@ -13,7 +13,7 @@ tool developers reach for by default?* Trend > snapshot.
 | Forks | 13 | 13 (▬0) | intent-to-use |
 | PyPI downloads (30d, suite) | — | — | actual reach |
 | npm downloads (30d, suite) | 4.9k | 4.9k (▬0) | actual reach (TS) |
-| Open issues, non-maintainer | 2 | 2 (▬0) | "someone reached for it"† |
+| Open issues, non-maintainer | 1 | 1 (▼-1) | "someone reached for it"† |
 
 † Raw count — still needs human triage to exclude badge-marketing bots
 (e.g. MCP-marketplace "live badge" issues). The roadmap's true gate is **≥1
@@ -23,6 +23,7 @@ GENUINE inbound issue from a stranger**; a bot filing a promo badge does not cou
 
 | Date | Stars | Forks | PyPI 30d | npm 30d | Ext. issues |
 |---|---|---|---|---|---|
+| 2026-08-13 | 128 | 13 | — | 4.9k | 1 |
 | 2026-08-11 | 128 | 13 | — | 4.9k | 2 |
 | 2026-08-10 | 128 | 13 | 96.4k | 4.9k | 2 |
 | 2026-07-29 | 126 | 14 | — | 3.5k | 1 |


### PR DESCRIPTION
Nightly North Star adoption snapshot: stars, forks, PyPI/npm 30-day
downloads and non-maintainer inbound issues, appended to the trend.

Generated by `scripts/scoreboard.py` via `.github/workflows/scoreboard.yml`.
The `.md` is rewritten wholesale from the `.jsonl` each run; the new
data is the single appended row.
