### PR TITLE
test(parity): re-bless the abt_buy auto-config pin against measured evidence

### DIFF
--- a/packages/python/goldenmatch/tests/parity/autoconfig-classification.json
+++ b/packages/python/goldenmatch/tests/parity/autoconfig-classification.json
@@ -130,48 +130,9 @@
     "name": "abt_buy",
     "rows": 2173,
     "blocking": {
-      "strategy": "multi_pass",
-      "keys": [
-        {
-          "fields": [
-            "manufacturer"
-          ],
-          "transforms": [
-            "lowercase",
-            "soundex"
-          ]
-        }
-      ],
-      "passes": [
-        {
-          "fields": [
-            "manufacturer"
-          ],
-          "transforms": [
-            "lowercase",
-            "substring:0:5"
-          ]
-        },
-        {
-          "fields": [
-            "manufacturer"
-          ],
-          "transforms": [
-            "lowercase",
-            "soundex"
-          ]
-        },
-        {
-          "fields": [
-            "manufacturer"
-          ],
-          "transforms": [
-            "lowercase",
-            "token_sort",
-            "substring:0:8"
-          ]
-        }
-      ]
+      "strategy": "lsh",
+      "keys": [],
+      "passes": []
     },
     "matchkeys": [
       {
@@ -181,15 +142,6 @@
         "fields": [
           {
             "field": "name",
-            "scorer": "token_sort",
-            "weight": 1.5,
-            "transforms": [
-              "lowercase",
-              "strip"
-            ]
-          },
-          {
-            "field": "description",
             "scorer": "token_sort",
             "weight": 1.5,
             "transforms": [
@@ -211,7 +163,7 @@
       {
         "name": "domain_exact_model",
         "type": "exact",
-        "threshold": null,
+        "threshold": 0.5,
         "fields": [
           {
             "field": "__model__",
@@ -226,7 +178,7 @@
       {
         "name": "domain_exact_model_norm",
         "type": "exact",
-        "threshold": null,
+        "threshold": 0.5,
         "fields": [
           {
             "field": "__model_norm__",


### PR DESCRIPTION
## What and why

Closes #2563.

The `abt_buy` parity pin has been stale on main. Three diffs, one cause:

```
- blocking  multi_pass on manufacturer (soundex / substring / token_sort)
+ blocking  lsh, no keys
- fuzzy_match: name, description, manufacturer
+ fuzzy_match: name, manufacturer
- domain_exact_model / _norm  threshold None
+ domain_exact_model / _norm  threshold 0.5
```

**`description` is not dropped by a matchkey decision — the column is removed from the dataframe** before auto-config profiles it:

```
Auto-config exclusion: 'description' (detector=free_text_notes)
  -- free-text notes column (high mean length, routes to fuzzy text
     scoring with no precision signal)
```

The controller receives `['id','name','price','manufacturer']`. No matchkey could reference a column that isn't there. The blocking change is downstream of the same cause: with no bounded structured key left, v0 logs *"no bounded exact blocking key and no blockable structured column; routing the description corpus to near-duplicate blocking"* (#1082) and switches to LSH.

## Why re-bless instead of treating it as a regression

I expected the opposite. A length-keyed rule deleting the product text on a product-matching corpus reads like a defect, and the detector's stated premise — *"no precision signal"* — is the wrong description of a field that carries the product identity. But that was an argument, not a measurement, and the measurement disagrees.

Same v0 base, one variable, scored against the 1097-pair cross-source ground truth:

| arm | fields | all-pairs F1 | cross-only F1 | cross P | R |
|---|---|---|---|---|---|
| WITH `description` (the pinned shape) | name, description, manufacturer | 0.3070 | 0.5743 | 0.9109 | 0.4193 |
| WITHOUT `description` | name, manufacturer | **0.3194** | **0.5775** | 0.9185 | 0.4211 |

Both arms were built on the 5-column frame, so LSH used the description text in **both** — that test only asks "given the column exists and blocks, does also scoring it help?". The config that actually ships never has the column, so LSH cannot use it either; measured separately, that one is the best of the three:

```
ships today (column excluded entirely):  all-F1 0.3578   cross-F1 0.5887   R 0.4704
```

Dropping the field is neutral-to-positive on this benchmark. The pin is recording a real behaviour change that is not a quality regression, so the right action is to record it.

## Changes

- `tests/parity/autoconfig-classification.json`: **only** the `abt_buy` entry rewritten. A full harness re-bless regenerates all three, and `ncvr_10k` is not reproducible without the vendored NCVR dataset — verified intact (10000 rows, 1 matchkey) after the edit.
- The regenerated entry came from `pin_config`, which since #2560 sets `GOLDENMATCH_AUTOCONFIG_DETERMINISTIC` itself and refuses to pin a `BUDGET_TIME` run. So this value is host-independent, unlike the entry it replaces — two independent runs produced byte-identical output.

## Testing

```
pytest tests/test_autoconfig.py::test_autoconfig_parity_pins_unchanged -q
1 passed in 46.70s
```

## Two things this surfaced that are NOT fixed here

Both are recorded on #2563 rather than folded into a pin re-bless:

- **The pinned config is one auto-config itself rates RED** — `committed best-effort RED config (iter=v0, stop_reason=POLICY_SATISFIED, failing_subprofile=cluster)`. The parity gate pins output the system considers unhealthy. That is arguably fine for a drift detector, but it should be a known property rather than a surprise.
- **73.4% of candidate pairs are within-source** (1395 of 1900) while the ground truth is cross-source `(idAbt, idBuy)` only — so most of what the pipeline scores cannot be correct by construction. Same shape as the 48.3% measured on DBLP-ACM. `manufacturer`, which the *old* pin blocked on, exists only in `Buy.csv` and is 50.0% null on the combined frame.

## Checklist

- [x] Tests passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] `CHANGELOG.md` deliberately not touched — this commit changes no behaviour, only records existing behaviour in the pin
- [x] Only the intended pin entry changed; the other two verified intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE)_