### PR TITLE
feat(fs): Phase 2 -- term-frequency tables on the distributed path

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -8012,6 +8012,7 @@
             "estimate_u_distributed",
             "gamma_columns",
             "random_pairs",
+            "tf_value_frequencies",
             "train_em_distributed"
           ],
           "imports": [

--- a/docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md
+++ b/docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md
@@ -124,21 +124,47 @@ matching PR-C's stated posture.
 Three implementations become one here. Phase 0 without Phase 1 is strictly worse
 than doing neither.
 
-### Phase 2 -- term-frequency adjustment on the distributed path
+### Phase 2 -- term-frequency adjustment on the distributed path *(done)*
 
-The largest real gap against Splink. Verified against Splink's
-`internals/term_frequencies.py` on 2026-08-13: a TF table per column
-(`count(*) / total`), left-joined to the input, then
-`log2(u_probability/tf) * tf_adjustment_weight AS log2_bf_tf` -- **all backend
-SQL**. `train_em_distributed` currently refuses TF outright.
+**The open question is resolved, and not the way this spec first guessed.**
+Verified 2026-08-14 against both sources rather than inferred:
 
-**Open question, to settle before designing:** TF is per-*value*, so it does not
-fit the counted-vector key -- collapsing identical vectors discards the values
-the adjustment needs. Splink appears to apply TF as a **scoring-time** Bayes-factor
-term rather than folding it into training, which would make it orthogonal to
-counted training and far cheaper than it looks. **Verify this against their
-source before designing**; if it is wrong, the counting key has to carry
-frequency bands and the cost changes completely.
+* **Splink** (`em_training_session.py`): `estimate_without_term_frequencies`
+  defaults to **`False`**, so by default TF *does* join its E-step, through
+  `predict_from_comparison_vectors_sqls(training_mode=True)`. Its
+  agreement-pattern-counts path is the `True` branch. So counted training and
+  TF-in-training are **mutually exclusive there too** -- that flag is the
+  switch between them.
+* **GoldenMatch** (`core/probabilistic.py::_em_iterate`): contains **zero**
+  references to tf. TF is a purely SCORING-time adjustment here; training only
+  *builds* the table (`_build_tf_tables`) and stores it on the `EMResult`,
+  where `backends/score_buckets.py` reads it.
+
+So the earlier framing -- "Splink applies TF at scoring time, which would make
+it orthogonal" -- was half right for the wrong reason. It is not orthogonal for
+Splink. It is orthogonal **for us**, because we never put TF in training at all.
+
+What the counted path actually could not do was narrower than the refusal
+claimed: it cannot *derive* a TF table, because collapsing identical comparison
+vectors is exactly what discards the values. It never needed to. The table is a
+property of the SOURCE column, so `spark.em.tf_value_frequencies` recovers it
+with a separate `GROUP BY` -- the distributed twin of `_build_tf_tables`,
+mirroring `core.tf_tables.value_frequencies` including the detail that the
+denominator counts SURVIVING values, not rows.
+
+`train_em_from_counts` now takes `tf_freqs` / `tf_collision` rather than
+refusing, and refuses only when TF is configured and no table is supplied (and
+rejects a table for a field that never opted in). `train_em_distributed`
+computes them once and carries them onto every session.
+
+**Bound:** a TF table has no `prod(levels + 1)` ceiling -- one entry per
+distinct VALUE -- so it gets its own `MAX_TF_VALUES` (1,000,000) with a message
+saying plainly that this is a driver-memory limit, not a property of the field.
+The one-box builds the same dict from its own frame.
+
+**Still not supported:** negative evidence, which sat in the same guard and is
+a different problem -- it needs a per-pair matrix nothing outside the pair loop
+can reconstruct.
 
 ### Phase 3 -- backends
 
@@ -174,5 +200,10 @@ README, or a release note.
   field's `u` collapsing toward the smoothing floor explodes `log2(m/u)` and
   produces a model that is wrong only in the cells hardest to eyeball
   (measured F1 0.83 -> 0.57). Every fixture matrix carries that case.
-- **TF may not be orthogonal.** See the open question in Phase 2. If it is not,
-  Phase 2's cost estimate is wrong by a lot.
+- ~~**TF may not be orthogonal.**~~ RESOLVED 2026-08-14, and the risk was real:
+  TF is NOT orthogonal for Splink (its `estimate_without_term_frequencies`
+  defaults to `False`, putting TF in the E-step). It is orthogonal for us only
+  because `_em_iterate` never touches tf. Had that not held, the counting key
+  would have needed frequency bands and Phase 2 would have been a different
+  piece of work. Verified against both sources before designing, which is the
+  only reason the cheap answer was trustworthy.

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1320,6 +1320,8 @@ def _train_em_from_counts_native(
     u_probs: dict[str, list[float]],
     *,
     conditioned_fields: Sequence[str],
+    tf_freqs: dict[str, dict[str, float]] | None,
+    tf_collision: dict[str, float] | None,
     max_iterations: int,
     convergence: float,
 ) -> EMResult | None:
@@ -1382,6 +1384,12 @@ def _train_em_from_counts_native(
         converged=bool(converged),
         iterations=int(iterations),
         proportion_matched=float(p_match),
+        # Carried through the kernel path too. The kernel computes only the
+        # numeric half; forgetting these here would drop the TF tables from
+        # every model trained on a box that has the wheel installed, and the
+        # model would look complete.
+        tf_freqs=tf_freqs,
+        tf_collision=tf_collision,
     )
 
 
@@ -1475,6 +1483,8 @@ def train_em_from_counts(
     u_probs: dict[str, list[float]],
     *,
     conditioned_fields: Sequence[str] = (),
+    tf_freqs: dict[str, dict[str, float]] | None = None,
+    tf_collision: dict[str, float] | None = None,
     max_iterations: int = 20,
     convergence: float = 0.001,
 ) -> EMResult:
@@ -1499,10 +1509,27 @@ def train_em_from_counts(
             pass conditioning, constant within a session, which is exactly why
             the counts needed no pass column.
 
-    Not supported here, and refused rather than ignored: negative evidence and
-    term-frequency adjustment. Both need per-pair inputs this function is not
-    given (an NE matrix, and the value frequencies), and silently dropping them
-    would train a different model from the one the config asks for.
+        tf_freqs / tf_collision: per-value frequency tables for fields with
+            ``tf_adjustment``. **Supplied, never derived** -- collapsing
+            identical comparison vectors is exactly what discards the values a
+            TF table is built from. On the one box ``_build_tf_tables`` computes
+            them from the source frame; on a cluster
+            ``spark.em.tf_value_frequencies`` computes the same thing as a
+            distributed ``GROUP BY``. Either way they only have to reach the
+            EMResult, because **TF is a SCORING-time adjustment here**:
+            ``_em_iterate`` contains no reference to tf, so the table never
+            enters the E-step.
+
+            Splink is the other way round by default -- its
+            ``estimate_without_term_frequencies`` is ``False``, so TF joins its
+            E-step via the per-pair path, and its agreement-pattern-counts path
+            is the ``True`` branch. Counted training and TF-in-training are
+            mutually exclusive there too; the difference is that we never put TF
+            in training at all, which is what makes the table separable here.
+
+    Negative evidence remains unsupported and refused rather than ignored: it
+    needs a per-pair NE matrix this function is not given, and silently dropping
+    it would train a different model from the one the config asks for.
     """
     if not pattern_counts:
         raise ValueError("pattern_counts is empty; nothing to train on")
@@ -1512,11 +1539,24 @@ def train_em_from_counts(
             f"per-pair NE matrix that counted comparison vectors do not carry. "
             f"Train it with train_em() on sampled pairs."
         )
-    if any(getattr(f, "tf_adjustment", False) for f in mk.fields):
+    tf_fields = {f.field for f in mk.fields if getattr(f, "tf_adjustment", False)}
+    if tf_fields and not tf_freqs:
         raise NotImplementedError(
-            f"matchkey {mk.name!r} uses term-frequency adjustment, which needs "
-            f"per-value frequencies that counted comparison vectors do not "
-            f"carry. Train it with train_em() on sampled pairs."
+            f"matchkey {mk.name!r} uses term-frequency adjustment on "
+            f"{sorted(tf_fields)}, and counted comparison vectors do not carry "
+            f"the per-value frequencies to build the table from -- collapsing "
+            f"identical vectors is what discards those values. Pass tf_freqs "
+            f"(spark.em.tf_value_frequencies computes it distributed), or train "
+            f"with train_em() on sampled pairs."
+        )
+    # A table for a field that did not opt in means the caller and the config
+    # disagree about which fields are adjusted. The surplus entry would sit in
+    # the persisted model doing nothing until some later scorer honoured it.
+    surplus = set(tf_freqs or {}) - tf_fields
+    if surplus:
+        raise ValueError(
+            f"tf_freqs carries {sorted(surplus)}, which did not opt in to "
+            f"tf_adjustment on matchkey {mk.name!r}"
         )
 
     n_fields = len(mk.fields)
@@ -1533,6 +1573,7 @@ def train_em_from_counts(
     native = _train_em_from_counts_native(
         mk, pattern_counts, u_probs,
         conditioned_fields=conditioned_fields,
+        tf_freqs=tf_freqs, tf_collision=tf_collision,
         max_iterations=max_iterations, convergence=convergence,
     )
     if native is not None:
@@ -1591,6 +1632,8 @@ def train_em_from_counts(
         converged=converged,
         iterations=iterations,
         proportion_matched=p_match,
+        tf_freqs=tf_freqs,
+        tf_collision=tf_collision,
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -272,6 +272,117 @@ def estimate_u_distributed(
     return estimate_u_from_counts(mk, counts)
 
 
+
+# ── term-frequency tables: a GROUP BY over VALUES, not vectors ───────
+
+#: A TF table is one entry per DISTINCT VALUE, so unlike the agreement-pattern
+#: space it has no `prod(levels + 1)` ceiling -- a surname column can carry
+#: millions. Collecting one is the same driver-OOM class `MAX_PATTERNS` guards,
+#: and it is worth a separate, larger bound because the one-box builds exactly
+#: the same dict from its own frame: the ceiling here is the driver's memory,
+#: not a property of the distributed path.
+MAX_TF_VALUES = 1_000_000
+
+
+def tf_value_frequencies(
+    source_df: Any,
+    mk: Any,
+    *,
+    transform_udf: str | None = None,
+    max_tf_values: int = MAX_TF_VALUES,
+) -> tuple[dict[str, dict[str, float]] | None, dict[str, float] | None]:
+    """Per-value relative frequencies for every ``tf_adjustment`` field.
+
+    The distributed twin of ``core.probabilistic._build_tf_tables``. Mirrors
+    ``core.tf_tables.value_frequencies`` exactly: apply the field's transform
+    chain, drop nulls and empties, then ``count / total`` per distinct value --
+    where ``total`` counts the SURVIVING values, not the rows, so a sparse
+    column's frequencies still sum to 1.
+
+    ``tf_collision[field] = sum(freq^2)`` is the expected exact-match collision
+    rate, the baseline an agreement weight is adjusted against.
+
+    ## Why this is separable from the counted trainer
+
+    TF is a SCORING-time adjustment in this engine -- ``_em_iterate`` contains
+    no reference to it -- so the table never enters the E-step. It only has to
+    reach the ``EMResult`` that scoring reads. That is what lets counted
+    training and TF coexist here: the counts discard the values, and this
+    recovers them from the SOURCE, where they were never discarded.
+
+    Splink is the other way round by default (``estimate_without_term_frequencies``
+    is ``False``, so TF joins its E-step through the per-pair path, and its
+    agreement-pattern-counts path is the ``True`` branch). Counted training and
+    TF-in-training are mutually exclusive there too; the difference is that we
+    never put TF in training at all.
+
+    Returns ``(None, None)`` when no field opts in, matching the one-box.
+    """
+    from pyspark.sql import functions as F
+
+    from goldenmatch.spark.config_pipeline import _transformed
+
+    tf_fields = [f for f in mk.fields if getattr(f, "tf_adjustment", False)]
+    if not tf_fields:
+        return None, None
+
+    cols = set(source_df.columns)
+    tf_freqs: dict[str, dict[str, float]] = {}
+    tf_collision: dict[str, float] = {}
+
+    for f in tf_fields:
+        name = f.resolved_field if hasattr(f, "resolved_field") else f.field
+        if name not in cols:
+            # The one-box skips an absent column rather than raising; a matchkey
+            # naming a column this frame lacks is a config problem the scorer
+            # reports, not something to fail training over.
+            continue
+        chain = list(getattr(f, "transforms", None) or [])
+        raw = F.col(name)
+        val = (
+            _transformed(raw, chain, transform_udf=transform_udf)
+            if chain
+            else raw.cast("string")
+        )
+        # Nulls and empties are dropped BEFORE counting, and the transform runs
+        # first: a chain may map a real value to empty (null_if_empty), and the
+        # one-box drops those too. Counting them would put mass on a value no
+        # pair can ever agree on.
+        grouped = (
+            source_df.select(val.alias("__tf_val__"))
+            .where(F.col("__tf_val__").isNotNull() & (F.col("__tf_val__") != F.lit("")))
+            .groupBy("__tf_val__")
+            .agg(F.count(F.lit(1)).alias("__n__"))
+        )
+
+        n_distinct = grouped.count()
+        if n_distinct > max_tf_values:
+            raise ValueError(
+                f"field {name!r} has {n_distinct} distinct values, over "
+                f"max_tf_values={max_tf_values}. A TF table is collected to the "
+                f"driver and stored in the model, so this is a driver-memory "
+                f"bound rather than a property of the field. Raise max_tf_values "
+                f"if the driver can hold it, or drop tf_adjustment for this "
+                f"field."
+            )
+
+        rows = grouped.collect()
+        total = float(sum(int(r["__n__"]) for r in rows))
+        if total <= 0:
+            continue
+        freqs = {str(r["__tf_val__"]): int(r["__n__"]) / total for r in rows}
+        tf_freqs[name] = freqs
+        tf_collision[name] = sum(p * p for p in freqs.values())
+        logger.info(
+            "FS TF: %s -> %d distinct values over %.0f observations "
+            "(collision %.6g)",
+            name, len(freqs), total, tf_collision[name],
+        )
+
+    if not tf_freqs:
+        return None, None
+    return tf_freqs, tf_collision
+
 # ── the caller: every link, strung together ──────────────────────────
 
 
@@ -288,6 +399,9 @@ def train_em_distributed(
     max_iterations: int = 20,
     convergence: float = 0.001,
     max_patterns: int = MAX_PATTERNS,
+    max_tf_values: int = MAX_TF_VALUES,
+    tf_freqs: dict[str, dict[str, float]] | None = None,
+    tf_collision: dict[str, float] | None = None,
 ) -> Any:
     """Train one matchkey's FS model with no pair sample anywhere.
 
@@ -343,6 +457,13 @@ def train_em_distributed(
         max_patterns=max_patterns,
     )
 
+    # A GROUP BY over VALUES, not comparison vectors -- the one thing the counts
+    # threw away. Computed once and carried onto every session, because it is a
+    # property of the source population and not of any blocking pass.
+    tf_freqs, tf_collision = tf_value_frequencies(
+        source_df, mk, transform_udf=transform_udf, max_tf_values=max_tf_values
+    ) if tf_freqs is None else (tf_freqs, tf_collision)
+
     sessions = []
     for i, key_config in enumerate(passes):
         fields = tuple(key_config.fields)
@@ -369,6 +490,7 @@ def train_em_distributed(
             continue
         em = train_em_from_counts(
             mk, counts, u_probs, conditioned_fields=fields,
+            tf_freqs=tf_freqs, tf_collision=tf_collision,
             max_iterations=max_iterations, convergence=convergence,
         )
         # Weighted by the EXACT pair count, which the counts already carry --
@@ -401,9 +523,6 @@ def _refuse_unsupported(mk: Any) -> None:
             f"per-pair NE matrix that counted comparison vectors do not carry. "
             f"Train it with train_em() on sampled pairs."
         )
-    if any(getattr(f, "tf_adjustment", False) for f in mk.fields):
-        raise NotImplementedError(
-            f"matchkey {mk.name!r} uses term-frequency adjustment, which needs "
-            f"per-value frequencies that counted comparison vectors do not "
-            f"carry. Train it with train_em() on sampled pairs."
-        )
+    # NOT refused any more: term-frequency adjustment. The counts cannot derive
+    # a TF table, but `tf_value_frequencies` recovers it from the SOURCE with a
+    # separate GROUP BY, and TF never enters the E-step here anyway.

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -592,3 +592,121 @@ def test_the_kernel_refuses_a_non_positive_count():
     with pytest.raises(ValueError, match="non-positive"):
         fn([2, 2], [[1, 1]], [0.0], [[0.9, 0.1], [0.9, 0.1]], [False, False],
            20, 0.001)
+
+
+# ── Phase 2: term-frequency tables, supplied rather than derived ─────
+
+def _tf_matchkey():
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="last", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+        ],
+    )
+    mk.fields[1].tf_adjustment = True
+    return mk
+
+
+def test_tf_is_still_refused_when_no_table_is_supplied():
+    """The counted vectors cannot DERIVE per-value frequencies.
+
+    Collapsing identical comparison vectors is exactly what discards the values
+    a TF table is built from, so a counted trainer asked for TF with nothing to
+    build it from must refuse. Training without the adjustment would produce a
+    model the config did not ask for, and every weight in it would look normal.
+    """
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    with pytest.raises(NotImplementedError, match="term-frequency"):
+        train_em_from_counts(
+            _tf_matchkey(), [((1, 1), 500), ((0, 1), 300)],
+            {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+        )
+
+
+def test_a_supplied_tf_table_is_accepted_and_carried_onto_the_model():
+    """TF is a SCORING-time adjustment here, so a table computed elsewhere is
+    all the counted trainer needs.
+
+    `_em_iterate` contains no reference to tf at all -- verified, not assumed --
+    so the table never enters the E-step. It is built by `_build_tf_tables` on
+    the one-box and by a distributed GROUP BY on a cluster, and either way it
+    only has to reach the EMResult that scoring reads.
+    """
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    tf_freqs = {"last": {"smith": 0.4, "jones": 0.35, "wong": 0.25}}
+    tf_collision = {"last": sum(p * p for p in tf_freqs["last"].values())}
+
+    em = train_em_from_counts(
+        _tf_matchkey(), [((1, 1), 500), ((0, 1), 300)],
+        {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+        tf_freqs=tf_freqs, tf_collision=tf_collision,
+    )
+
+    assert em.tf_freqs == tf_freqs
+    assert em.tf_collision == tf_collision
+    # And the model is otherwise a normal trained model.
+    assert em.m_probs["first"] and em.match_weights["first"]
+
+
+def test_a_tf_table_for_a_field_that_did_not_ask_for_it_is_refused():
+    """A table keyed on a non-TF field means the caller and the config disagree
+    about which fields are adjusted, and the surplus entry would sit in the
+    persisted model doing nothing -- until some later scorer honoured it."""
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    with pytest.raises(ValueError, match="did not opt in"):
+        train_em_from_counts(
+            _tf_matchkey(), [((1, 1), 500), ((0, 1), 300)],
+            {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+            tf_freqs={"first": {"ann": 1.0}}, tf_collision={"first": 1.0},
+        )
+
+
+def test_tf_tables_are_refused_when_the_matchkey_has_no_tf_field():
+    """Supplying tables nothing asked for is a caller error, not a no-op."""
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    with pytest.raises(ValueError, match="did not opt in"):
+        train_em_from_counts(
+            _make_probabilistic_mk(), [((1, 1, 1), 5)],
+            {"first_name": [0.5, 0.3, 0.2], "last_name": [0.9, 0.1],
+             "zip": [0.9, 0.1]},
+            tf_freqs={"last_name": {"lee": 1.0}}, tf_collision={"last_name": 1.0},
+        )
+
+
+@pytest.mark.parametrize("native", ["0", "auto"])
+def test_the_tf_table_survives_BOTH_the_kernel_and_the_fallback(monkeypatch, native):
+    """The kernel path returns early, so it must carry the tables too.
+
+    Written after finding that it did not: `_train_em_from_counts_native`
+    builds its own EMResult and returned before the tf arguments were read, so
+    on any box with the wheel installed the tables were silently dropped and
+    the model still looked complete. The earlier TF test passed only because it
+    ran under GOLDENMATCH_NATIVE=0 -- which is precisely the environment skew
+    that hides this class of bug.
+
+    Parametrized rather than skipped: `auto` is a no-op where the kernel is
+    absent, so this always exercises at least the fallback and exercises both
+    wherever the kernel is built.
+    """
+    from goldenmatch.core.probabilistic import train_em_from_counts
+
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    tf_freqs = {"last": {"smith": 0.4, "jones": 0.35, "wong": 0.25}}
+    tf_collision = {"last": sum(p * p for p in tf_freqs["last"].values())}
+
+    em = train_em_from_counts(
+        _tf_matchkey(), [((1, 1), 500), ((0, 1), 300)],
+        {"first": [0.9, 0.1], "last": [0.85, 0.15]},
+        tf_freqs=tf_freqs, tf_collision=tf_collision,
+    )
+    assert em.tf_freqs == tf_freqs, f"tf_freqs dropped under NATIVE={native}"
+    assert em.tf_collision == tf_collision

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -774,3 +774,152 @@ def test_a_different_seed_draws_a_different_sample(train_source):
     a = _random_pair_ids(train_source, max_pairs=10, seed=1)
     b = _random_pair_ids(train_source, max_pairs=10, seed=99)
     assert a != b, "the seed does not reach the sample selection"
+
+
+# ── Phase 2: term-frequency tables, computed distributed ─────────────
+#
+# TF is a SCORING-time adjustment in this engine (`_em_iterate` has no
+# reference to it), so the counted trainer does not need it -- but the MODEL
+# does, and the counts are exactly what discards the values it is built from.
+# `tf_value_frequencies` recovers them from the SOURCE with a separate GROUP BY.
+
+def _tf_config():
+    """`last` opts in to tf_adjustment; `first` does not.
+
+    One of each is the point: a builder that adjusted every field, or none,
+    would pass a test that only had opted-in fields in it.
+    """
+    mk = _mk()
+    mk.fields[1].tf_adjustment = True
+    return GoldenMatchConfig(
+        matchkeys=[mk],
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            passes=[
+                BlockingKeyConfig(fields=["city"]),
+                BlockingKeyConfig(fields=["last"]),
+            ],
+        ),
+    )
+
+
+def test_distributed_tf_tables_equal_the_one_box_tables(train_source):
+    """THE gate: the same numbers `core.tf_tables.value_frequencies` produces.
+
+    That function is the reference a locally-trained model's TF table comes
+    from, so comparing against it -- rather than against a re-derived count --
+    is what makes the distributed table the SAME table. A TF adjustment built
+    on a different denominator still yields weights in a plausible range.
+    """
+    import polars as pl
+    from goldenmatch.core.tf_tables import value_frequencies
+    from goldenmatch.spark.em import tf_value_frequencies
+
+    cfg = _tf_config()
+    mk = cfg.get_matchkeys()[0]
+    got_freqs, got_collision = tf_value_frequencies(train_source, mk)
+
+    pdf = pl.DataFrame(
+        {c: [r[i] for r in _TRAIN_ROWS] for i, c in enumerate(_COLS)}
+    )
+    want = value_frequencies(pdf, "last", list(mk.fields[1].transforms or []))
+
+    assert got_freqs is not None
+    assert set(got_freqs) == {"last"}, (
+        f"only the opted-in field may get a table; got {sorted(got_freqs)}"
+    )
+    assert got_freqs["last"] == pytest.approx(want, abs=1e-12)
+    assert got_collision["last"] == pytest.approx(
+        sum(p * p for p in want.values()), abs=1e-12
+    )
+
+
+def test_a_matchkey_with_no_tf_field_builds_no_tables(train_source):
+    """`(None, None)`, matching the one-box -- not an empty dict, which would
+    read as 'computed, and everything is uniform'."""
+    from goldenmatch.spark.em import tf_value_frequencies
+
+    freqs, collision = tf_value_frequencies(train_source, _mk())
+    assert freqs is None and collision is None
+
+
+def test_the_tf_denominator_counts_SURVIVING_values_not_rows(spark):
+    """Nulls and empties are dropped before the division.
+
+    Dividing by the row count instead would make every frequency smaller in
+    proportion to the column's missingness, so the table would no longer sum to
+    1 and every TF adjustment would be scaled by an arbitrary factor -- in the
+    same direction for every value, which is exactly the kind of error that
+    looks like a tuning choice.
+    """
+    from goldenmatch.spark.em import tf_value_frequencies
+
+    rows = [(0, "a", "smith", "x"), (1, "b", "smith", "x"),
+            (2, "c", None, "x"), (3, "d", "", "x")]
+    df = spark.createDataFrame(rows, _COLS)
+    mk = _mk()
+    mk.fields[1].tf_adjustment = True
+
+    freqs, _ = tf_value_frequencies(df, mk)
+    assert freqs is not None
+    # 2 surviving values, both "smith" -> frequency 1.0, not 2/4.
+    assert freqs["last"] == {"smith": pytest.approx(1.0, abs=1e-12)}
+
+
+def test_an_oversized_tf_table_is_refused_not_collected(train_source):
+    """A TF table has no `prod(levels + 1)` ceiling -- one entry per distinct
+    VALUE -- so collecting one is the driver-OOM class `max_patterns` guards,
+    and it needs its own bound."""
+    from goldenmatch.spark.em import tf_value_frequencies
+
+    mk = _mk()
+    mk.fields[1].tf_adjustment = True
+    with pytest.raises(ValueError, match="max_tf_values"):
+        tf_value_frequencies(train_source, mk, max_tf_values=1)
+
+
+def test_train_em_distributed_no_longer_refuses_tf_and_carries_the_table(
+    train_source,
+):
+    """The end of the Phase 2 gap: a TF config trains distributed.
+
+    It used to raise before submitting anything. Now the table is computed by a
+    separate GROUP BY over the source and carried onto the model, while the EM
+    itself still runs on collapsed vectors that never saw the values.
+    """
+    import polars as pl
+    from goldenmatch.core.tf_tables import value_frequencies
+    from goldenmatch.spark.em import train_em_distributed
+
+    cfg = _tf_config()
+    mk = cfg.get_matchkeys()[0]
+    em = train_em_distributed(train_source, cfg, mk, id_col=_ID)
+
+    pdf = pl.DataFrame(
+        {c: [r[i] for r in _TRAIN_ROWS] for i, c in enumerate(_COLS)}
+    )
+    want = value_frequencies(pdf, "last", list(mk.fields[1].transforms or []))
+    assert em.tf_freqs is not None, "the trained model carries no TF table"
+    assert em.tf_freqs["last"] == pytest.approx(want, abs=1e-12)
+    # And it is still a trained model, not just a table carrier.
+    assert em.m_probs["first"] and em.match_weights["first"]
+
+
+def test_the_tf_table_is_jar_only_too(train_source, jvm_registered):
+    """The transform chain a TF field carries must reach the jar as well.
+
+    Building the table needs the field TRANSFORMED exactly as scoring
+    transforms it -- a value normalised one way here and another way at scoring
+    time gets a frequency that belongs to a different string.
+    """
+    from goldenmatch.spark.em import tf_value_frequencies
+    from goldenmatch.spark.jvm import TRANSFORM_UDF_NAME
+
+    mk = _mk()
+    mk.fields[1].tf_adjustment = True
+    want, _ = tf_value_frequencies(train_source, mk)
+    got, _ = tf_value_frequencies(
+        train_source, mk, transform_udf=TRANSFORM_UDF_NAME
+    )
+    assert got is not None and want is not None
+    assert got["last"] == pytest.approx(want["last"], abs=1e-12)

--- a/packages/python/goldenmatch/tests/test_spark_fs_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_unit.py
@@ -349,13 +349,42 @@ def test_negative_evidence_is_refused_before_a_job_is_submitted():
         )
 
 
-def test_term_frequency_adjustment_is_refused_before_a_job_is_submitted():
-    """TF needs per-value frequencies the counts do not carry."""
+def test_term_frequency_adjustment_is_NO_LONGER_refused(monkeypatch):
+    """Phase 2 lifted this refusal, so the pre-flight must let TF through.
+
+    It used to raise NotImplementedError before touching the frame. It cannot
+    any more: the counts still cannot DERIVE a TF table, but the table is not
+    derived from them -- `tf_value_frequencies` recovers it from the SOURCE
+    with a separate GROUP BY, and TF never enters the E-step in this engine
+    anyway (`_em_iterate` has no reference to it).
+
+    Asserted by the frame being USED: `_ExplodingFrame` raises on any attribute
+    access, so reaching it proves the config was accepted rather than refused.
+    A `pytest.raises(NotImplementedError)` that had simply been deleted would
+    leave nothing pinning which way this now goes.
+    """
     from goldenmatch.spark.em import train_em_distributed
 
     mk = _fs_matchkey()
     mk.fields[0].tf_adjustment = True
-    with pytest.raises(NotImplementedError, match="term-frequency"):
+    with pytest.raises(AssertionError, match="before the config was refused"):
+        train_em_distributed(
+            _ExplodingFrame(), _static_config(mk, [["city"]]), mk, id_col="id"
+        )
+
+
+def test_negative_evidence_is_STILL_refused_alongside_tf():
+    """Lifting the TF refusal must not have lifted the NE one with it.
+
+    They sat in the same guard and are not the same problem: NE needs a
+    per-pair matrix that nothing outside the pair loop can reconstruct, whereas
+    a TF table is a property of the source column.
+    """
+    from goldenmatch.spark.em import train_em_distributed
+
+    mk = _ne_matchkey()
+    mk.fields[0].tf_adjustment = True
+    with pytest.raises(NotImplementedError, match="negative-evidence"):
         train_em_distributed(
             _ExplodingFrame(), _static_config(mk, [["city"]]), mk, id_col="id"
         )


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`. Branches off current `main` — **not stacked**.

## The open question resolved the other way

The spec flagged this as *"verify against their source before designing; if it is wrong, the counting key has to carry frequency bands and the cost changes completely."* Verified, and the risk was real:

| | TF in the E-step? |
|---|---|
| **Splink** (`em_training_session.py`) | **Yes by default** — `estimate_without_term_frequencies` defaults to `False`; the agreement-pattern-counts path is the `True` branch |
| **GoldenMatch** (`_em_iterate`) | **No** — zero references to tf; TF is scoring-time only |

So my earlier framing — *"Splink applies TF at scoring time, which makes it orthogonal"* — was **half right for the wrong reason.** It is not orthogonal for Splink; counted training and TF-in-training are mutually exclusive there too. It is orthogonal **for us**, because we never put TF in training at all.

## Which makes the gap much narrower than the refusal claimed

The counted path cannot *derive* a TF table — collapsing identical comparison vectors is exactly what discards the values. **It never needed to.** The table is a property of the SOURCE column, so `tf_value_frequencies` recovers it with a separate `GROUP BY`: the distributed twin of `_build_tf_tables`, mirroring `core.tf_tables.value_frequencies` down to the denominator counting **surviving** values rather than rows. (Dividing by rows would scale every frequency by the column's missingness, in the same direction for every value — an error that reads as a tuning choice.)

`train_em_from_counts` now takes `tf_freqs`/`tf_collision`, refusing only when TF is configured with no table supplied, or when a table names a field that never opted in. `train_em_distributed` computes them once and carries them onto every session.

## A bug this found in Phase 1a

The native fast path builds its own `EMResult` and **returned before the tf arguments were read** — so on any box with the wheel installed, the TF tables were silently dropped and the model still looked complete.

My first TF test passed only because it ran under `GOLDENMATCH_NATIVE=0`. That is the same environment skew that has bitten repeatedly in this arc. The replacement is parametrized over `["0", "auto"]` so it exercises both paths wherever the kernel is built, instead of skipping.

## Bound

A TF table has no `prod(levels + 1)` ceiling — one entry per distinct **value** — so it gets its own `MAX_TF_VALUES` (1,000,000). The message says plainly that this is a driver-memory limit, not a property of the field; the one-box builds the same dict from its own frame.

## Still refused

**Negative evidence**, which sat in the same guard and is a different problem: it needs a per-pair matrix nothing outside the pair loop can reconstruct. A test pins that lifting one refusal did not lift the other.

## Verification

**219 no-Spark tests pass with the kernel present** (not `NATIVE=0`), ruff clean, docs regenerated and `--check` green.

Spark-lane tests run in CI: distributed table equals `value_frequencies`, the denominator semantics, the bound, jar-only transforms, and end-to-end through `train_em_distributed`.

## Spec status after this

Phases 0, 1a/1b/1c and 2 are done. Remaining: **Phase 3** (other backends) and **Phase 4** (the Splink head-to-head). No comparative claim about Splink is supported until Phase 4 exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
