### PR TITLE
feat(autoconfig): detect concatenated sources + bless the two ungated datasets (#2540 items 1 and 3)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 475,
+      "module_count": 476,
       "modules": [
         {
           "module": "goldenmatch",
@@ -1989,6 +1989,7 @@
             "goldenmatch.core.blocking_pass_selection",
             "goldenmatch.core.blocking_union_core",
             "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.concat_sources",
             "goldenmatch.core.domain",
             "goldenmatch.core.embedder",
             "goldenmatch.core.execution_plan",
@@ -2758,6 +2759,21 @@
           "imports": [
             "goldenmatch.core._native_loader",
             "goldenmatch.core.autoconfig_native"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.concat_sources",
+          "file": "packages/python/goldenmatch/goldenmatch/core/concat_sources.py",
+          "purpose": "Detect a frame that is several sources concatenated together (#2540).",
+          "defines": [
+            "ConcatenationEvidence",
+            "_best_step",
+            "_signature",
+            "detect_concatenated_sources",
+            "warn_if_concatenated_sources"
+          ],
+          "imports": [
+            "goldenmatch.core.frame"
           ]
         },
         {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Zero-config now says when a frame looks like several sources concatenated
+  together, and routes to `match_df` (#2540).** `dedupe_df` compares candidate
+  pairs WITHIN one frame. When that frame is two catalogues stacked with
+  `pl.concat`, most of the candidate set is wrong by construction -- pairs drawn
+  from a single source, which a cross-source ground truth can never mark correct.
+  Measured on the repo's own benchmarks: **48.3%** of DBLP-ACM's candidate pairs
+  and **73.4%** of Abt-Buy's are within-source. The failure was entirely silent.
+
+  New `core/concat_sources.py` detects the shape and logs a warning naming
+  `match_df`. It deliberately does **not** constrain matching: `match_df` already
+  owns cross-source linkage, so a source constraint in dedupe would be a second
+  authoritative owner for one capability, against the architecture frame -- this
+  routes rather than duplicates. Inferring a source and silently dropping pairs
+  would also turn a heuristic into a correctness dependency; a warning costs a
+  log line when wrong, a dropped true match costs recall invisibly.
+
+  **Contiguity is the entire signal.** `pl.concat` lays source A's rows down
+  first, so a genuine concatenation leaves a step -- a column goes null, or
+  changes value-shape, at one row boundary and stays that way. Real single-source
+  messiness is scattered, not contiguous, which is what keeps this from being
+  another plausible-but-wrong heuristic. The step test is tolerant (97% purity),
+  because an exact two-run test missed abt_buy: `manufacturer` is null for all
+  1081 Abt rows AND 6 Buy rows.
+
+  Validated against the benchmark corpus before shipping -- it fires on all three
+  known concatenated benchmarks at exactly the true source boundary, and stays
+  silent on all four genuine single-source corpora:
+
+  | corpus | result | boundary | true split |
+  |---|---|---|---|
+  | `dblp_acm` | fires (format step on `id`) | 2616 | DBLP2 = 2616 rows |
+  | `abt_buy` | fires (null step on `manufacturer`) | 1081 | Abt = 1081 rows |
+  | `amazon_google` | fires (null step on `title`/`name`) | 1363 | Amazon = 1363 rows |
+  | `person` / `household_hardneg` / `cotenant_hardneg` / `ncvr_synthetic` | silent | -- | genuine single-source |
+
+  Advisory and fail-open: any error returns `None`, and large frames are strided
+  (a step survives uniform striding; head-sampling would see only one source).
 - **ODCS (Open Data Contract Standard) dialect for the semantic-layer certifier
   (`goldenmatch.semantic.odcs`).** A data contract declares its identity right in
   the schema — `primaryKey: true` (ordered by `primaryKeyPosition` for a composite

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4863,6 +4863,15 @@ def auto_configure_df(
         force_exclude_list, force_include_list = (
             _resolve_effective_exclusion_overrides(config=None)
         )
+        # #2540: a frame that is several sources CONCATENATED (no source column)
+        # is a different shape from #858's below, which needs a source-indicator
+        # column to key on -- measured: `_detect_source_partition` returns None
+        # on abt_buy even though it is Abt+Buy stacked. Report it and route to
+        # `match_df`; deliberately do NOT constrain matching here, since
+        # `match_df` already owns cross-source linkage and a second owner for
+        # one capability is against the architecture frame. Advisory + fail-open.
+        from goldenmatch.core.concat_sources import warn_if_concatenated_sources
+        warn_if_concatenated_sources(df)
         # #858: multi-source source-correlated over-merge guard (spec §0-§4).
         # Detect the source partition on the FULL frame, then exclude the
         # source-indicator column + every 0-cross-source-overlap column from

--- a/packages/python/goldenmatch/goldenmatch/core/concat_sources.py
+++ b/packages/python/goldenmatch/goldenmatch/core/concat_sources.py
@@ -1,0 +1,198 @@
+"""Detect a frame that is several sources concatenated together (#2540).
+
+``dedupe_df`` compares every candidate pair inside one frame. When that frame is
+actually two catalogues stacked with ``pl.concat``, most of the candidate set is
+**wrong by construction** -- pairs drawn from within a single source, which a
+cross-source ground truth can never mark correct. Measured on the repo's own
+benchmarks: 48.3% of DBLP-ACM's candidate pairs and 73.4% of Abt-Buy's are
+within-source. Today that failure is entirely silent.
+
+This module only *detects and reports*. It deliberately does NOT constrain
+matching:
+
+* ``match_df`` already owns cross-source linkage. Teaching dedupe a source
+  constraint would create a second authoritative owner for one capability,
+  against the architecture frame -- so this **routes** to ``match_df`` instead of
+  duplicating it.
+* Inferring a source and silently dropping pairs would turn a heuristic into a
+  correctness dependency. A wrong inference would discard true matches with no
+  way for the caller to see it. A warning costs a log line when wrong.
+
+**Why contiguity is the whole signal.** ``pl.concat`` lays source A's rows down
+first, then source B's, so a genuine concatenation leaves a *step* in the data:
+some column goes null, or changes value-shape, at one row boundary and stays
+that way. Real single-source messiness is scattered, not contiguous, which is
+what keeps this from being another plausible-but-wrong heuristic. Validated on
+the benchmark corpus -- it fires on all three known concatenated benchmarks, at
+exactly the true source boundary, and stays silent on all four genuine
+single-source corpora:
+
+    dblp_acm       FIRES  row 2616  (DBLP2 is 2616 rows)   format step on `id`
+    abt_buy        FIRES  row 1081  (Abt is 1081 rows)     null step on `manufacturer`
+    amazon_google  FIRES  row 1363  (Amazon is 1363 rows)  null step on `title`/`name`
+    person / household_hardneg / cotenant_hardneg / ncvr_synthetic   silent
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# A step with a few exceptions is still a step: abt_buy's `manufacturer` is null
+# for all 1081 Abt rows AND 6 Buy rows, so an exact two-run test misses the real
+# concatenation. Tolerance is what makes the signal usable.
+_STEP_PURITY = 0.97
+
+# Each side must be a real block. Without this a column that is 3% null anywhere
+# would read as a step whose short side is noise.
+_MIN_BLOCK_FRAC = 0.10
+
+# Python-level per-value work is O(rows x columns); stride large frames instead.
+# A step function stays a step function under uniform striding, so contiguity --
+# the entire signal -- survives, unlike head-sampling which would see one source.
+_SCAN_ROWS = 20_000
+
+
+@dataclass(frozen=True)
+class ConcatenationEvidence:
+    """A detected source boundary and the columns that show it."""
+
+    boundary: int          # approximate row index where the second source starts
+    n_rows: int
+    columns: tuple[str, ...]   # columns exhibiting the step
+    kinds: tuple[str, ...]     # "null" / "format", aligned with `columns`
+
+    def describe(self) -> str:
+        parts = [f"{c} ({k} step)" for c, k in zip(self.columns, self.kinds)]
+        return ", ".join(parts)
+
+
+def _best_step(flags: list[bool]) -> tuple[int, float] | None:
+    """Boundary that best explains ``flags`` as a step, with its purity.
+
+    Returns ``None`` when either class is too small to be a source block.
+    """
+    n = len(flags)
+    if n < 4:
+        return None
+    trues = sum(flags)
+    floor = _MIN_BLOCK_FRAC * n
+    if min(trues, n - trues) < floor:
+        return None
+    prefix = [0] * (n + 1)
+    for i, f in enumerate(flags):
+        prefix[i + 1] = prefix[i] + (1 if f else 0)
+    lo, hi = int(floor), int(n - floor)
+    best_at, best_agree = -1, -1
+    for b in range(lo, hi + 1):
+        left_true = prefix[b]
+        right_true = prefix[n] - prefix[b]
+        true_then_false = left_true + ((n - b) - right_true)
+        false_then_true = (b - left_true) + right_true
+        agree = true_then_false if true_then_false > false_then_true else false_then_true
+        if agree > best_agree:
+            best_at, best_agree = b, agree
+    if best_at < 0:
+        return None
+    return best_at, best_agree / n
+
+
+def _signature(value: Any) -> str:
+    """Coarse value shape. Distinguishes id families (``conf/vldb/x`` vs ``12345``)
+    without pretending to parse them."""
+    if value is None:
+        return "null"
+    s = str(value)
+    if not s:
+        return "null"
+    if s.isdigit():
+        return "digits"
+    if "/" in s:
+        return "path"
+    return "alpha"
+
+
+def detect_concatenated_sources(df: Any) -> ConcatenationEvidence | None:
+    """Return evidence that ``df`` is concatenated sources, or ``None``.
+
+    Fail-open: any error returns ``None``. This is advisory, and must never be
+    able to break a run it only meant to comment on.
+    """
+    try:
+        from goldenmatch.core.frame import to_frame
+
+        frame = to_frame(df)
+        n_full = frame.height
+        if n_full < 20:
+            return None
+        stride = max(1, n_full // _SCAN_ROWS)
+
+        hits_col: list[str] = []
+        hits_kind: list[str] = []
+        boundaries: list[int] = []
+
+        for col in frame.columns:
+            try:
+                values = frame.column(col).to_list()
+            except Exception:
+                continue
+            if stride > 1:
+                values = values[::stride]
+            if len(values) < 20:
+                continue
+
+            null_flags = [v is None for v in values]
+            got = _best_step(null_flags)
+            if got is not None and got[1] >= _STEP_PURITY:
+                hits_col.append(col)
+                hits_kind.append("null")
+                boundaries.append(got[0] * stride)
+                continue  # one signal per column is enough
+
+            sigs = [_signature(v) for v in values]
+            if len(set(sigs)) < 2:
+                continue
+            first = sigs[0]
+            got = _best_step([s == first for s in sigs])
+            if got is not None and got[1] >= _STEP_PURITY:
+                hits_col.append(col)
+                hits_kind.append("format")
+                boundaries.append(got[0] * stride)
+
+        if not hits_col:
+            return None
+        # Agreeing columns should agree on WHERE the split is; take the median so
+        # one odd column cannot move it.
+        boundaries.sort()
+        boundary = boundaries[len(boundaries) // 2]
+        return ConcatenationEvidence(
+            boundary=boundary,
+            n_rows=n_full,
+            columns=tuple(hits_col),
+            kinds=tuple(hits_kind),
+        )
+    except Exception:  # advisory only -- never break the caller
+        return None
+
+
+def warn_if_concatenated_sources(df: Any) -> ConcatenationEvidence | None:
+    """Detect and log. Returns the evidence so callers can surface it too."""
+    evidence = detect_concatenated_sources(df)
+    if evidence is None:
+        return None
+    pct = 100.0 * evidence.boundary / max(evidence.n_rows, 1)
+    logger.warning(
+        "This frame looks like %d sources concatenated together: %s change at "
+        "row ~%d of %d (%.0f%% / %.0f%%). Dedupe compares records WITHIN this "
+        "frame, so pairs drawn from the same source are included -- on a "
+        "two-source linkage those cannot be true matches, and they dominated "
+        "the candidate set on the benchmarks this was measured against "
+        "(48-73%%). If these are distinct sources, use match_df(left, right) "
+        "for cross-source linkage. If it is genuinely one population, ignore "
+        "this.",
+        2, evidence.describe(), evidence.boundary, evidence.n_rows,
+        pct, 100.0 - pct,
+    )
+    return evidence

--- a/packages/python/goldenmatch/tests/test_concat_sources_2540.py
+++ b/packages/python/goldenmatch/tests/test_concat_sources_2540.py
@@ -1,0 +1,147 @@
+"""#2540: detecting a frame that is several sources concatenated together.
+
+`dedupe_df` compares pairs WITHIN one frame, so when that frame is two catalogues
+stacked the within-source pairs can never be true matches -- 48.3% of DBLP-ACM's
+candidate set and 73.4% of Abt-Buy's, measured. The detector reports that shape
+and routes to `match_df`; it must never constrain matching itself.
+
+The load-bearing property is CONTIGUITY. A genuine `pl.concat` leaves a step:
+some column goes null, or changes value-shape, at one row boundary and stays
+that way. Scattered single-source messiness must NOT look like that, or the
+warning becomes noise on exactly the datasets dedupe is right for.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.core.concat_sources import (
+    detect_concatenated_sources,
+    warn_if_concatenated_sources,
+)
+
+
+def _stacked(n_a: int = 60, n_b: int = 40) -> pl.DataFrame:
+    """Two sources with disjoint schemas, as `diagonal_relaxed` leaves them."""
+    a = pl.DataFrame({
+        "id": [f"a{i}" for i in range(n_a)],
+        "name": [f"widget {i}" for i in range(n_a)],
+    })
+    b = pl.DataFrame({
+        "id": [f"b{i}" for i in range(n_b)],
+        "name": [f"widget {i}" for i in range(n_b)],
+        "vendor": [f"vendor{i % 5}" for i in range(n_b)],
+    })
+    return pl.concat([a, b], how="diagonal_relaxed")
+
+
+# ── it fires on the real shape ────────────────────────────────────────────────
+
+def test_detects_a_null_step_from_disjoint_schemas():
+    ev = detect_concatenated_sources(_stacked(60, 40))
+    assert ev is not None
+    assert "vendor" in ev.columns
+    assert ev.kinds[ev.columns.index("vendor")] == "null"
+    assert ev.boundary == 60, f"boundary should be the true split, got {ev.boundary}"
+
+
+def test_detects_a_format_step_when_schemas_are_identical():
+    """DBLP-ACM's shape: same columns, different id families."""
+    df = pl.DataFrame({
+        "id": [f"conf/vldb/p{i}" for i in range(70)] + [str(100000 + i) for i in range(50)],
+        "title": [f"paper about topic {i}" for i in range(120)],
+    })
+    ev = detect_concatenated_sources(df)
+    assert ev is not None
+    assert "id" in ev.columns
+    assert ev.kinds[ev.columns.index("id")] == "format"
+    assert ev.boundary == 70
+
+
+def test_tolerates_exceptions_within_a_block():
+    """abt_buy's actual shape: `manufacturer` is null for every Abt row AND a
+    handful of Buy rows. An exact two-run test misses that -- and did."""
+    vendor = [None] * 60 + [f"v{i}" for i in range(40)]
+    vendor[65], vendor[77], vendor[91] = None, None, None  # 3 stragglers past the split
+    df = pl.DataFrame({"id": [f"r{i}" for i in range(100)], "vendor": vendor})
+    ev = detect_concatenated_sources(df)
+    assert ev is not None
+    assert "vendor" in ev.columns
+    assert abs(ev.boundary - 60) <= 2
+
+
+# ── it stays silent where dedupe is the right tool ────────────────────────────
+
+def test_silent_on_a_genuine_single_source_frame():
+    df = pl.DataFrame({
+        "id": [f"r{i}" for i in range(200)],
+        "name": [f"person {i % 50}" for i in range(200)],
+        "city": [["Boston", "Denver", "Austin"][i % 3] for i in range(200)],
+    })
+    assert detect_concatenated_sources(df) is None
+
+
+def test_silent_on_scattered_nulls():
+    """The tolerance must not turn ordinary sparsity into a step. A column that
+    is ~25% null at random is the common case dedupe is FOR."""
+    df = pl.DataFrame({
+        "id": [f"r{i}" for i in range(200)],
+        "phone": [None if i % 4 == 0 else f"555-{i:04d}" for i in range(200)],
+    })
+    assert detect_concatenated_sources(df) is None
+
+
+def test_silent_when_one_side_is_too_small_to_be_a_source():
+    """A 3-row tail is a data-entry artifact, not a second catalogue."""
+    vendor = [None] * 197 + ["v1", "v2", "v3"]
+    df = pl.DataFrame({"id": [f"r{i}" for i in range(200)], "vendor": vendor})
+    assert detect_concatenated_sources(df) is None
+
+
+def test_silent_on_a_tiny_frame():
+    df = pl.DataFrame({"id": ["a", "b", "c"], "v": [None, None, "x"]})
+    assert detect_concatenated_sources(df) is None
+
+
+# ── it is advisory, and cannot break the caller ───────────────────────────────
+
+def test_fail_open_on_garbage_input():
+    assert detect_concatenated_sources(object()) is None
+    assert detect_concatenated_sources(None) is None
+
+
+def test_warn_logs_and_names_match_df(caplog):
+    import logging
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.core.concat_sources"):
+        ev = warn_if_concatenated_sources(_stacked(60, 40))
+    assert ev is not None
+    msg = " ".join(r.getMessage() for r in caplog.records
+                   if r.name == "goldenmatch.core.concat_sources")
+    assert "match_df" in msg, "the warning must route to the tool that owns linkage"
+    assert "concatenated" in msg
+
+
+def test_warn_is_silent_on_single_source(caplog):
+    import logging
+    df = pl.DataFrame({
+        "id": [f"r{i}" for i in range(200)],
+        "name": [f"person {i % 50}" for i in range(200)],
+    })
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.core.concat_sources"):
+        assert warn_if_concatenated_sources(df) is None
+    assert not [r for r in caplog.records if r.name == "goldenmatch.core.concat_sources"]
+
+
+# ── striding must not lose the signal ─────────────────────────────────────────
+
+def test_survives_striding_on_a_large_frame():
+    """Large frames are strided to bound Python-level work. A step stays a step
+    under uniform striding -- unlike head-sampling, which would see one source."""
+    n_a, n_b = 30_000, 20_000
+    df = pl.DataFrame({
+        "id": [f"r{i}" for i in range(n_a + n_b)],
+        "vendor": [None] * n_a + [f"v{i}" for i in range(n_b)],
+    })
+    ev = detect_concatenated_sources(df)
+    assert ev is not None
+    assert "vendor" in ev.columns
+    # boundary is reported in original row space, within one stride
+    assert abs(ev.boundary - n_a) <= (n_a + n_b) // 20_000 + 1

--- a/scripts/suggest_quality/baselines/scorecard.json
+++ b/scripts/suggest_quality/baselines/scorecard.json
@@ -53,23 +53,6 @@
       ],
       "suggester_prec": 1.0
     },
-    "dblp_acm": {
-      "baseline_f1": 0.564539,
-      "convergence_final_f1": 0.729595,
-      "convergence_steps": 1,
-      "error": null,
-      "gt_pairs": 2224,
-      "kind": "real",
-      "n_suggestions": 1,
-      "name": "dblp_acm",
-      "native_available": true,
-      "rank_corr": null,
-      "rows": 4910,
-      "suggested_order_lifts": [
-        0.165055
-      ],
-      "suggester_prec": 1.0
-    },
     "historical_50k": {
       "baseline_f1": 0.812209,
       "convergence_final_f1": 0.812209,

--- a/scripts/suggest_quality/baselines/scorecard.json
+++ b/scripts/suggest_quality/baselines/scorecard.json
@@ -1,9 +1,9 @@
 {
   "datasets": {
     "anchor_person_match": {
-      "baseline_f1": 0.989556,
+      "baseline_f1": 1.0,
       "convergence_final_f1": 1.0,
-      "convergence_steps": 1,
+      "convergence_steps": 0,
       "error": null,
       "gt_pairs": 379,
       "kind": "anchor",
@@ -13,7 +13,7 @@
       "rank_corr": null,
       "rows": 706,
       "suggested_order_lifts": [
-        0.010444
+        0.0
       ],
       "suggester_prec": 1.0
     },
@@ -42,19 +42,52 @@
       "error": null,
       "gt_pairs": 0,
       "kind": "anchor",
-      "n_suggestions": 1,
+      "n_suggestions": 2,
       "name": "anchor_sparse_zip",
       "native_available": true,
       "rank_corr": null,
       "rows": 20000,
       "suggested_order_lifts": [
+        null,
         null
       ],
       "suggester_prec": 1.0
     },
+    "dblp_acm": {
+      "baseline_f1": 0.564539,
+      "convergence_final_f1": 0.729595,
+      "convergence_steps": 1,
+      "error": null,
+      "gt_pairs": 2224,
+      "kind": "real",
+      "n_suggestions": 1,
+      "name": "dblp_acm",
+      "native_available": true,
+      "rank_corr": null,
+      "rows": 4910,
+      "suggested_order_lifts": [
+        0.165055
+      ],
+      "suggester_prec": 1.0
+    },
+    "historical_50k": {
+      "baseline_f1": 0.812209,
+      "convergence_final_f1": 0.812209,
+      "convergence_steps": 0,
+      "error": null,
+      "gt_pairs": 303961,
+      "kind": "real",
+      "n_suggestions": 0,
+      "name": "historical_50k",
+      "native_available": true,
+      "rank_corr": null,
+      "rows": 50578,
+      "suggested_order_lifts": [],
+      "suggester_prec": 1.0
+    },
     "ncvr_synthetic": {
-      "baseline_f1": 0.982804,
-      "convergence_final_f1": 0.982804,
+      "baseline_f1": 0.984677,
+      "convergence_final_f1": 0.984677,
       "convergence_steps": 0,
       "error": null,
       "gt_pairs": 2500,
@@ -68,18 +101,20 @@
       "suggester_prec": 1.0
     },
     "synthetic": {
-      "baseline_f1": 0.988662,
-      "convergence_final_f1": 0.988662,
+      "baseline_f1": 1.0,
+      "convergence_final_f1": 1.0,
       "convergence_steps": 0,
       "error": null,
       "gt_pairs": 218,
       "kind": "real",
-      "n_suggestions": 0,
+      "n_suggestions": 1,
       "name": "synthetic",
       "native_available": true,
       "rank_corr": null,
       "rows": 373,
-      "suggested_order_lifts": [],
+      "suggested_order_lifts": [
+        0.0
+      ],
       "suggester_prec": 1.0
     }
   },
@@ -88,11 +123,16 @@
       "anchor_person_match",
       "anchor_shared_email",
       "anchor_sparse_zip",
+      "dblp_acm",
+      "historical_50k",
       "ncvr_synthetic",
       "synthetic"
     ],
-    "datasets_skipped": {},
-    "git_sha": "db0c761cdc69c3bc60a07608ec7f974e65cce531",
-    "native_version": "0.1.5"
+    "datasets_skipped": {
+      "febrl3": "absent",
+      "ncvr_real": "absent"
+    },
+    "git_sha": "1ab9fb43eea8769d5436c8d3fdea9be65c2df0a3",
+    "native_version": "0.1.20"
   }
 }


### PR DESCRIPTION
## What and why

Closes #2540 items **1** and **3**. Item 2 stays open by design — see the bottom.

Two commits, separable on purpose:

| commit | item |
|---|---|
| `feat(autoconfig): say when a frame is concatenated sources…` | 1 — the code change |
| `test(suggest-quality): bless dblp_acm + historical_50k…` | 3 — the baseline update |

The bless is **not** caused by the detector (which only logs); they ride together because both belong to this issue.

---

## Item 1 — detect concatenated sources, route to `match_df`

`dedupe_df` compares candidate pairs **within** one frame. When that frame is two catalogues stacked with `pl.concat`, most of the candidate set is wrong by construction — pairs drawn from a single source, which a cross-source ground truth can never mark correct:

- **48.3%** of DBLP-ACM's candidate pairs are within-source
- **73.4%** of Abt-Buy's are

The failure was entirely silent. Auto-config already has guards that detect a shape and explain it (*"col_type=zip is a blocking signal, not an identity claim"*); this is that pattern.

This is a **different shape** from the `#858` multi-source guard immediately below it in the same function, which needs a source-indicator *column* to key on — measured: `_detect_source_partition` returns `None` on `abt_buy` even though it is Abt+Buy stacked.

### What it deliberately does not do

- **It does not constrain matching.** `match_df` already owns cross-source linkage; a source constraint inside dedupe would be a second authoritative owner for one capability, against the architecture frame. This *routes* rather than duplicates — the issue's own decision.
- **It does not infer a source and drop pairs.** A wrong inference costs recall invisibly; a wrong warning costs a log line.

### Contiguity is the entire signal

`pl.concat` lays source A's rows down first, so a genuine concatenation leaves a **step**: a column goes null, or changes value-shape, at one row boundary and stays that way. Real single-source messiness is scattered, not contiguous — that is what keeps this from being another plausible-but-wrong heuristic.

The step test is **tolerant (97% purity)** because an exact two-run test **missed `abt_buy`**: `manufacturer` is null for all 1081 Abt rows *and* 6 Buy rows. Found by validating against the benchmark corpus *before* writing the module rather than after.

### Validation

| corpus | result | boundary | true split |
|---|---|---|---|
| `dblp_acm` | fires — format step on `id` | 2616 | DBLP2 = 2616 rows |
| `abt_buy` | fires — null step on `manufacturer` | 1081 | Abt = 1081 rows |
| `amazon_google` | fires — null step on `title`/`name` | 1363 | Amazon = 1363 rows |
| `person` / `household_hardneg` / `cotenant_hardneg` / `ncvr_synthetic` | silent | — | genuine single-source |

3/3 positives at the exact boundary, 4/4 negatives silent.

---

## Item 3 — bless the two datasets that gated nothing

`dblp_acm` and `historical_50k` ran on every gate invocation and gated nothing (`+ (NEW)` each run). Blessing was blocked on #2532 — `dblp_acm`'s controller stopped on `BUDGET_TIME` in some runs and `BUDGET_ITERATIONS` in others, so `convergence_final_f1` varied with machine load and blessing it would have manufactured a flaky gate. #2560 fixed that; both quality gates now set `GOLDENMATCH_AUTOCONFIG_DETERMINISTIC=1` themselves, so the recorded number is host-independent. That is the only reason this is safe to take now.

```
dblp_acm        baseline_f1 0.5645 -> convergence_final_f1 0.7296  (1 suggestion)
historical_50k  baseline_f1 0.8122 -> convergence_final_f1 0.8122  (0 suggestions)
```

I ran `gate` **before** `bless` so the bless could not silently absorb a regression: `7 ok, 0 fail, 4 new, 0 missing`.

**But `0 fail` means "no regression", not "no change"** — and five existing metrics did move. All upward, consistent with the fixes merged this session (#2527, #2535, #2546, #2497, #2560). This PR records them:

| dataset | metric | old | new |
|---|---|---|---|
| `anchor_person_match` | baseline_f1 | 0.989556 | 1.0 |
| `anchor_person_match` | convergence_steps | 1 | 0 |
| `anchor_sparse_zip` | n_suggestions | 1 | 2 |
| `ncvr_synthetic` | baseline_f1 / conv_f1 | 0.982804 | 0.984677 |
| `synthetic` | baseline_f1 / conv_f1 | 0.988662 | 1.0 |
| `synthetic` | n_suggestions | 0 | 1 |

## Testing

```
pytest tests/test_concat_sources_2540.py -q                    # 11 passed
pytest tests/test_autoconfig.py tests/test_autoconfig_regressions.py \
       tests/test_concat_sources_2540.py -q                    # 146 passed, 1 skipped
python -m scripts.suggest_quality gate                         # 7 ok, 0 fail, 4 new
python -m scripts.suggest_quality bless                        # 7 blessed, 2 skipped
```

The 11 tests pin the properties that make the detector safe, not just the happy path: the tolerance must not turn a 25%-scattered-null column into a step; a 3-row tail must not read as a second catalogue; garbage input must fail open; and the striding used to bound Python work on large frames must not lose the signal (a step survives uniform striding — head-sampling would see only one source).

`ruff` + `pyright` clean. `scripts/regen_docs.py` picked up only the new module in the codemap.

## Honest limits

- **The detector is advisory.** It changes no config and no output. It makes a silent failure audible; it does not improve a single benchmark number. DBLP-ACM's candidate set is still ~half impossible pairs after this lands.
- **Contiguity is required.** Sources interleaved or shuffled after concatenation are not detected — the deliberate trade for a low false-positive rate.
- **`historical_50k` gates less than it appears to.** It produces **zero** suggestions, so its `suggester_prec: 1.0` is vacuous and `convergence_final_f1 == baseline_f1`. The row gates the config/pipeline, not the suggester.
- **A green `dblp_acm` gate means "has not drifted", never "is good"** — the number sits on the 48.3%-within-source candidate set item 1 is about.

## Item 2 is deliberately still open

Whether dedupe should accept a *declared* source column as a negative constraint is the one piece that changes matching behaviour rather than reporting it. The issue rated it "probably" and I am not guessing at intent. Item 1 is the prerequisite either way: users now get told the shape exists, and the detector is the natural place to hang a `source_column` hint off if the answer is yes.

## Checklist

- [x] Tests added and passing locally for the changed package
- [x] `ruff` + `pyright` clean on the changed files; no secrets
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] Derived-docs battery regenerated (`scripts/regen_docs.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5YPsy6vTJ7Ca5kfjrSVgE