### PR TITLE
feat(duckdb): Phase 3 -- the counted trainer on DuckDB, and a spec correction

### DIFF
--- a/docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md
+++ b/docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md
@@ -166,12 +166,36 @@ The one-box builds the same dict from its own frame.
 a different problem -- it needs a per-pair matrix nothing outside the pair loop
 can reconstruct.
 
-### Phase 3 -- backends
+### Phase 3 -- backends *(partially done; the premise was wrong)*
 
-Once the numerics are one kernel, counting is the only per-engine piece, and
-`spark/em.py::agreement_pattern_counts` is ~40 lines of SQL. DataFusion and
-DuckDB versions are the same `GROUP BY` over the same gamma expressions.
-Splink's five backends stop being five ports of a trainer.
+**Correction to this spec.** Phase 3 was written as "counting is the only
+per-engine piece, and `agreement_pattern_counts` is ~40 lines of SQL --
+DataFusion and DuckDB versions are the same `GROUP BY` over the same gamma
+expressions". Checked 2026-08-14: **the gamma expressions do not exist outside
+Spark.** `fs_level_expr` and `_field_similarity_and_observed` live only in
+`goldenmatch/spark/probabilistic.py`; there is no engine-neutral SQL form of the
+level ladder anywhere in the repo.
+
+So porting the counting to another engine is not a `GROUP BY` -- it is writing a
+**second implementation of what a level MEANS**, which is exactly what
+`gamma_columns`'s own docstring warns against ("a training run that disagreed
+with scoring about levels would produce weights for a partition of the data that
+scoring never reproduces"). That is the duplication this whole arc exists to
+remove, so doing it per engine would be self-defeating.
+
+**Delivered instead:** the counted TRAINER on DuckDB
+(`goldenmatch_train_em_from_counts`), matching the Postgres surface from Phase
+1c. Both SQL backends now train from vectors their own engine counted, using
+whatever `GROUP BY` the caller writes. The DuckDB UDF is Python (every UDF in
+that package is, by construction) -- what it gains is the counted SHAPE, an
+input that is not a sample, not freedom from the interpreter.
+
+**What a full Phase 3 still needs**, and it is a design job rather than a port:
+extract the level ladder + per-field similarity into an engine-neutral form both
+`spark/probabilistic.py` and a DuckDB/DataFusion emitter can render, so
+`gamma_columns` has one definition per surface instead of one per engine. Until
+that exists, "counting on N backends" means N copies of the calibration rules
+this arc keeps finding bugs in.
 
 ### Phase 4 -- the benchmark
 

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py
@@ -105,6 +105,11 @@ def register_core_api_functions(con: duckdb.DuckDBPyConnection) -> None:
         ["VARCHAR", "VARCHAR", "VARCHAR"], "VARCHAR",
     )
     con.create_function(
+        "goldenmatch_train_em_from_counts", _train_em_from_counts,
+        # matchkey_json, counts_json, u_probs_json, params_json
+        ["VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
         "goldenmatch_score_probabilistic", _score_probabilistic,
         # rows_json, matchkey_json, em_result_json
         ["VARCHAR", "VARCHAR", "VARCHAR"], "VARCHAR",
@@ -459,6 +464,86 @@ def _train_em(rows_json: str, matchkey_json: str, params_json: str) -> str:
         }
         kwargs = {k: v for k, v in params.items() if k in allowed}
         em = train_em(df, mk, **kwargs)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(dataclasses.asdict(em), default=str)
+
+
+def _train_em_from_counts(
+    matchkey_json: str, counts_json: str, u_probs_json: str, params_json: str,
+) -> str:
+    """Wrap Fellegi-Sunter ``train_em_from_counts`` -- the COUNTED shape.
+
+    ``goldenmatch_train_em`` takes ROWS and samples pairs from them, so its
+    training set is capped by the sampler no matter how much data exists. This
+    one starts from comparison vectors the ENGINE has already counted, which is
+    the shape a ``GROUP BY`` produces:
+
+    .. code-block:: sql
+
+        SELECT goldenmatch_train_em_from_counts(
+            :matchkey,
+            (SELECT json_group_array(json_array(gamma_first, gamma_last, n))
+               FROM (SELECT gamma_first, gamma_last, count(*) AS n
+                       FROM candidate_gammas
+                      GROUP BY gamma_first, gamma_last)),
+            :u_probs, '{}');
+
+    The E-step reads only the comparison vector, so pairs sharing one are
+    interchangeable and every M-step quantity is a sum linear in how many pairs
+    share it -- collapsing is EXACT, not a sample. The distinct-vector count is
+    bounded by ``prod(levels + 1)``, so what crosses the boundary is thousands
+    of rows however many pairs were compared.
+
+    Args:
+        matchkey_json: a probabilistic ``MatchkeyConfig``.
+        counts_json: ``[[l0, l1, ..., count], ...]`` -- one row per distinct
+            comparison vector, levels ordered by the matchkey's fields
+            (``-1`` = unobserved), with the pair COUNT last. A count, not a
+            proportion: EM's smoothing is additive, so rescaling moves the model.
+        u_probs_json: ``{"field": [p0, p1, ...]}`` estimated from RANDOM
+            (unblocked) pairs. Required, not defaulted -- u is half the
+            likelihood ratio and this function never sees the pairs it comes
+            from.
+        params_json: optional ``conditioned_fields`` / ``max_iterations`` /
+            ``convergence`` / ``tf_freqs`` / ``tf_collision``. Empty -> defaults.
+
+    Returns the ``EMResult`` as JSON, or ``{"error": ...}``.
+
+    NOTE this is a PYTHON UDF, unlike the Postgres
+    ``goldenmatch_train_em_from_counts`` which reaches the pyo3-free kernel
+    native-direct. Every UDF in this package is Python by construction. What
+    DuckDB gains here is the counted SHAPE -- training whose input is not a
+    sample -- not freedom from the interpreter.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig
+    from goldenmatch.core.probabilistic import train_em_from_counts
+    try:
+        mk = MatchkeyConfig.model_validate_json(matchkey_json)
+        raw = _parse_json(counts_json, [])
+        if not raw:
+            raise ValueError("counts_json is empty; nothing to train on")
+        pattern_counts = []
+        for row in raw:
+            if not isinstance(row, list) or len(row) < 2:
+                raise ValueError(
+                    f"each counts row must be [levels..., count]; got {row!r}"
+                )
+            pattern_counts.append((tuple(int(x) for x in row[:-1]), int(row[-1])))
+        u_probs = _parse_json(u_probs_json, {})
+        if not u_probs:
+            raise ValueError(
+                "u_probs_json is required: u is estimated from RANDOM pairs, "
+                "which counted vectors do not contain"
+            )
+        u_probs = {k: [float(x) for x in v] for k, v in u_probs.items()}
+        params = _parse_json(params_json, {})
+        allowed = {
+            "conditioned_fields", "max_iterations", "convergence",
+            "tf_freqs", "tf_collision",
+        }
+        kwargs = {k: v for k, v in params.items() if k in allowed}
+        em = train_em_from_counts(mk, pattern_counts, u_probs, **kwargs)
     except Exception as exc:  # noqa: BLE001
         return json.dumps({"error": str(exc)})
     return json.dumps(dataclasses.asdict(em), default=str)

--- a/packages/rust/extensions/duckdb/tests/test_train_em_from_counts.py
+++ b/packages/rust/extensions/duckdb/tests/test_train_em_from_counts.py
@@ -1,0 +1,160 @@
+"""DuckDB trains Fellegi-Sunter from COUNTED comparison vectors.
+
+Phase 3 of docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md.
+
+`goldenmatch_train_em` takes ROWS and samples pairs from them, so its training
+set is capped by the sampler no matter how much data exists. This one starts
+from vectors the engine has already counted -- the shape a `GROUP BY` produces
+-- so the input stops being a sample.
+
+The anchors are the SAME numbers
+`packages/rust/extensions/score-core/tests/fixtures/em_counts_parity.json`
+carries, emitted from the Python reference. Every surface that trains from
+counts asserts against those, so they cannot each agree with their own copy and
+nothing else.
+"""
+from __future__ import annotations
+
+import json
+
+import duckdb
+import goldenmatch_duckdb
+import pytest
+
+MK = json.dumps(
+    {
+        "name": "fs",
+        "type": "probabilistic",
+        "fields": [
+            {"field": "first", "scorer": "jaro_winkler", "levels": 2,
+             "partial_threshold": 0.8},
+            {"field": "last", "scorer": "jaro_winkler", "levels": 2,
+             "partial_threshold": 0.8},
+        ],
+    }
+)
+U = json.dumps({"first": [0.9, 0.1], "last": [0.85, 0.15]})
+
+
+@pytest.fixture()
+def con():
+    c = duckdb.connect()
+    goldenmatch_duckdb.register(c)
+    return c
+
+
+def _train(con, counts, u=U, params="{}", mk=MK):
+    (out,) = con.execute(
+        "SELECT goldenmatch_train_em_from_counts(?, ?, ?, ?)",
+        [mk, json.dumps(counts), u, params],
+    ).fetchone()
+    return json.loads(out)
+
+
+def test_counted_training_matches_the_shared_anchors(con):
+    """Fixture case `two_level_learnable_only`."""
+    em = _train(con, [[1, 1, 500], [0, 1, 300], [1, 0, 150], [0, 0, 50]])
+
+    assert "error" not in em, em
+    assert em["match_weights"]["first"][0] == pytest.approx(-1.374233, abs=1e-5)
+    assert em["match_weights"]["first"][1] == pytest.approx(2.706681, abs=1e-5)
+    # Field 1 too: asserting only field 0 would pass with the second field's
+    # weights dropped or copied from the first.
+    assert em["match_weights"]["last"][0] == pytest.approx(-2.111677, abs=1e-5)
+    assert em["match_weights"]["last"][1] == pytest.approx(2.421028, abs=1e-5)
+
+
+def test_a_conditioned_field_takes_the_bounded_ramp(con):
+    """Fixture case `near_unique_blocking_field_1836`.
+
+    A near-unique blocking key whose u is LEARNED collapses toward the smoothing
+    floor, which explodes log2(m/u) past 20 bits and lets one field dominate
+    every other (measured F1 0.83 -> 0.57). Every wrong variant still returns a
+    valid probability vector, which is what makes it worth pinning here rather
+    than trusting it to hold across a JSON boundary.
+    """
+    em = _train(
+        con, [[1, 1, 500], [0, 1, 300]],
+        u=json.dumps({"first": [0.9, 0.1], "last": [0.999, 0.001]}),
+        params=json.dumps({"conditioned_fields": ["last"]}),
+    )
+
+    assert "error" not in em, em
+    assert em["match_weights"]["last"] == [-3.0, 3.0]
+    assert em["u_probs"]["last"] == [0.5, 0.5]
+    assert em["match_weights"]["first"] != [-3.0, 3.0]
+
+
+def test_the_counts_are_counts_not_proportions(con):
+    """The same SHAPE at 1/100th the counts must NOT give the same model.
+
+    EM's 1e-6 smoothing is additive, so its pull shrinks as the totals grow. A
+    boundary that normalised the counts on the way through would pass every
+    other test here and shift the low-probability cells -- which is where FS
+    weights are largest.
+    """
+    big = _train(con, [[1, 1, 500], [0, 1, 300], [1, 0, 150], [0, 0, 50]])
+    small = _train(con, [[1, 1, 5], [0, 1, 3], [1, 0, 1], [0, 0, 1]])
+
+    assert big["match_weights"]["first"][0] != pytest.approx(
+        small["match_weights"]["first"][0], abs=1e-6
+    )
+
+
+def test_it_trains_from_a_real_GROUP_BY(con):
+    """The shape this exists for: counts produced by the engine, not by hand.
+
+    Hand-written literals would never catch a boundary that mis-parses what
+    `json_group_array` actually emits, which is the only thing standing between
+    a DuckDB aggregation and the trainer.
+    """
+    con.execute(
+        "CREATE TABLE gammas AS SELECT * FROM (VALUES "
+        "(1,1),(1,1),(1,1),(0,1),(0,1),(1,0),(0,0)) AS t(g_first, g_last)"
+    )
+    (counts_json,) = con.execute(
+        "SELECT json_group_array(json_array(g_first, g_last, n)) FROM ("
+        "  SELECT g_first, g_last, count(*) AS n FROM gammas"
+        "  GROUP BY g_first, g_last)"
+    ).fetchone()
+    (out,) = con.execute(
+        "SELECT goldenmatch_train_em_from_counts(?, ?, ?, '{}')",
+        [MK, counts_json, U],
+    ).fetchone()
+    em = json.loads(out)
+
+    assert "error" not in em, em
+    assert set(em["m_probs"]) == {"first", "last"}
+    assert len(em["match_weights"]["first"]) == 2
+
+
+def test_missing_u_is_refused_rather_than_invented(con):
+    """u comes from RANDOM unblocked pairs, which counted vectors never contain.
+
+    Defaulting it would produce weights wrong in a direction nobody could spot
+    from the m estimates.
+    """
+    em = _train(con, [[1, 1, 5]], u="{}")
+    assert "u_probs_json is required" in em["error"]
+
+
+def test_a_malformed_counts_row_is_an_envelope_not_a_crash(con):
+    """Fail-soft, like every other UDF in this package: a bad call inside a
+    larger query returns an error object rather than aborting it."""
+    em = _train(con, [[1]])
+    assert "each counts row" in em["error"]
+
+
+def test_negative_evidence_is_still_refused(con):
+    """NE needs a per-pair matrix nothing outside the pair loop can rebuild.
+
+    The refusal has to survive the JSON boundary -- a config whose NE fields
+    were dropped in parsing would train silently and return a model the config
+    never asked for.
+    """
+    mk = json.loads(MK)
+    mk["negative_evidence"] = [
+        {"field": "dob", "scorer": "exact", "threshold": 0.9}
+    ]
+    em = _train(con, [[1, 1, 5]], mk=json.dumps(mk))
+    assert "negative-evidence" in em["error"]

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -598,4 +598,5 @@ duckdb:
   - goldenmatch_score_probabilistic
   - goldenmatch_suggest_threshold
   - goldenmatch_train_em
+  - goldenmatch_train_em_from_counts
   - goldenmatch_validate_table


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-08-13-fs-em-rust-single-source-design.md`. **Stacked on #2565** (Phase 2).

## The spec's Phase 3 premise was wrong

It read: *"counting is the only per-engine piece, and `agreement_pattern_counts` is ~40 lines of SQL — DataFusion and DuckDB versions are the same `GROUP BY` over the same gamma expressions."*

I wrote that. Checked before building on it: **the gamma expressions do not exist outside Spark.** `fs_level_expr` and `_field_similarity_and_observed` live only in `goldenmatch/spark/probabilistic.py`, and there is no engine-neutral SQL form of the level ladder anywhere in the repo.

So porting the counting isn't a `GROUP BY` — it's writing a **second implementation of what a level means**. That's exactly what `gamma_columns`'s own docstring warns against:

> a training run that disagreed with scoring about levels would produce weights for a partition of the data that scoring never reproduces

Doing that per engine would be self-defeating for an arc whose entire point is removing duplicated calibration — and this arc has already found four bugs of precisely that class.

## Delivered instead

`goldenmatch_train_em_from_counts` on DuckDB, matching the Postgres surface from Phase 1c. Both SQL backends now train from vectors their own engine counted, using whatever `GROUP BY` the caller writes.

**Stated plainly, because the Postgres framing does not carry over: this is a Python UDF.** Every UDF in that package is, by construction. What DuckDB gains is the counted *shape* — an input that is not a sample — **not** freedom from the interpreter. The Postgres sibling reaches the pyo3-free kernel native-direct; this one does not.

## Boundary contract

- `counts_json` is `[[levels..., count], ...]` with the **count last**. EM's smoothing is additive, so a boundary that normalised on the way through would shift the low-probability cells where FS weights are largest.
- `u_probs_json` is **required, not defaulted** — u comes from random unblocked pairs the counted vectors never contain.
- Fail-soft to `{"error": ...}`, like every other UDF here.

## Tests actually ran locally

DuckDB is light enough to install, unlike most of this arc's surfaces — so for once these are verified by me rather than by CI.

**7 new tests**, including one that trains from a real `json_group_array(json_array(...)) … GROUP BY` rather than hand-written literals: a boundary that mis-parses what DuckDB actually emits is the only thing standing between an aggregation and the trainer. Anchors are the **same** numbers `score-core/tests/fixtures/em_counts_parity.json` carries.

Full DuckDB suite: **113 passed, 1 skipped**. (`ruff --fix` touched two unrelated test files; reverted — their lint findings pre-exist on `main`.)

## What a full Phase 3 still needs

A design job, not a port: extract the level ladder and per-field similarity into an engine-neutral form that both `spark/probabilistic.py` and a DuckDB/DataFusion emitter render, so `gamma_columns` has one definition per *surface* instead of one per *engine*. Until that exists, "counting on N backends" means N copies of the calibration rules this arc keeps finding bugs in.

## Spec status

Phases 0, 1a/1b/1c, 2 done; 3 partially, with the premise corrected in the spec itself. **Phase 4 — the Splink head-to-head — remains, and no comparative claim about Splink is supported until it exists.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
