### PR TITLE
bench(fs): cross-dataset link-threshold sweep, split tune/holdout

### DIFF
--- a/.github/workflows/bench-fs-threshold-sweep.yml
+++ b/.github/workflows/bench-fs-threshold-sweep.yml
@@ -1,0 +1,102 @@
+# Cross-dataset sweep of the FS link threshold.
+#
+# The posterior-calibrated link cut is a hardcoded 0.99 whose own docstring
+# says it was measured on DBLP-ACM, and which every dataset then inherits as
+# `fs_link_thresholds: {source: "fallback"}`. On a person-shaped fixture that
+# cut costs F1 0.8772 -> 0.5406 with precision pinned at 1.0000 the whole way
+# down (scripts/bench_er_headtohead/diagnose_fs_recall.py).
+#
+# This decides whether the fix is a BETTER CONSTANT or a dataset-derived cut,
+# and it is deliberately split tune/holdout: choosing a constant by sweeping
+# every dataset and taking the argmax is how 0.99 happened in the first place.
+# The full grid runs on the tuning panel; the holdout sees exactly two points
+# (the incumbent and the recommendation) so it stays an unbiased check.
+#
+# Dispatch-only. It is a measurement, not a gate, and it pip-installs Splink
+# purely because `datasets.py` loads several fixtures through `splink_datasets`.
+name: bench-fs-threshold-sweep
+
+on:
+  workflow_dispatch:
+    inputs:
+      tune:
+        description: "Tuning datasets (space separated)"
+        required: false
+        default: "historical_50k dblp_acm febrl3 ncvr synthetic_person"
+      holdout:
+        description: "Held-out datasets, two points only"
+        required: false
+        default: "febrl4 dblp_scholar amazon_google"
+      grid:
+        description: "Link thresholds to sweep on the tuning panel"
+        required: false
+        default: "0.50 0.70 0.80 0.85 0.90 0.95 0.99"
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: large-new-64GB
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      # The sweep runs the FS lanes' operating point, which is the NATIVE
+      # kernel. Sweeping the numpy fallback would tune a threshold for a path
+      # the product does not take by default.
+      - name: Build native extension
+        run: uv run python scripts/build_native.py
+
+      # Not a repo dependency -- `datasets.py` reaches several fixtures through
+      # `splink_datasets`, so the loader needs it even though no Splink lane
+      # runs here.
+      - name: Install Splink (dataset loader only) + DuckDB (evaluator)
+        run: |
+          uv pip install splink==4.0.16
+          uv pip install duckdb
+
+      - name: Sweep
+        env:
+          GOLDENMATCH_FS_CALIBRATED: posterior
+          GOLDENMATCH_FS_NATIVE: "1"
+        run: |
+          set -euo pipefail
+          uv run python scripts/bench_er_headtohead/sweep_fs_link_threshold.py \
+            --tune ${{ inputs.tune }} \
+            --holdout ${{ inputs.holdout }} \
+            --grid ${{ inputs.grid }} \
+            --out fs-threshold-sweep.json \
+            --summary-md fs-threshold-sweep.md
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ -f fs-threshold-sweep.md ]; then
+            cat fs-threshold-sweep.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'sweep produced no summary - see the job log' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        if: always()
+        with:
+          name: fs-threshold-sweep
+          path: fs-threshold-sweep.json
+          if-no-files-found: warn

--- a/scripts/bench_er_headtohead/sweep_fs_link_threshold.py
+++ b/scripts/bench_er_headtohead/sweep_fs_link_threshold.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Cross-dataset sweep of the FS link threshold: is one constant defensible?
+
+## Why
+
+Under posterior calibration `core.probabilistic.compute_thresholds` returns a
+hardcoded `(0.99, 0.50)`. Its docstring says 0.99 is the measured-best cut **on
+DBLP-ACM**, and with no `mk.link_threshold` and no `calibrated_link_threshold`
+that constant is what every dataset gets -- reported honestly as
+`fs_link_thresholds: {source: "fallback"}`.
+
+Measured on a 20K person fixture (`diagnose_fs_recall.py`) that cut costs
+F1 0.8772 -> 0.5406 with precision pinned at 1.0000 the whole way down: the
+model separates cleanly and the knife is simply in the wrong place.
+
+The open question this answers: is the fix a BETTER CONSTANT, or does the
+optimum move enough between datasets that only a dataset-derived cut will do?
+
+## Methodology, and why it is split
+
+0.99 was chosen by looking at one dataset. Sweeping every dataset and taking
+the argmax would repeat that mistake with more steps -- it would report the
+best constant *for the datasets I looked at*, which is not evidence it
+generalises.
+
+So the panel is split the way `datasets.py` already splits it:
+
+* **tune**    -- historical_50k, dblp_acm, febrl3, ncvr, synthetic_person.
+  The full grid runs here, and the recommended constant is chosen here.
+* **holdout** -- febrl4, dblp_scholar, amazon_google, marked in `datasets.py`
+  as "never in the FS-lever tuning panel". Only TWO points run here: the
+  incumbent 0.99 and whatever the tuning panel recommended. Sweeping the
+  holdout would destroy the only unbiased estimate available.
+
+The verdict is decided on the holdout delta, not the tuning-panel argmax.
+
+## Cost
+
+One full `dedupe_df` per (dataset, threshold) -- not a score-once-then-recluster
+shortcut, because clustering can auto-split and a shortcut would report a
+pipeline that does not exist. That is why the grid is small and the holdout is
+two points.
+
+Usage:
+    python scripts/bench_er_headtohead/sweep_fs_link_threshold.py \\
+        --out fs-threshold-sweep.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+TUNE = ["historical_50k", "dblp_acm", "febrl3", "ncvr", "synthetic_person"]
+HOLDOUT = ["febrl4", "dblp_scholar", "amazon_google"]
+GRID = [0.50, 0.70, 0.80, 0.85, 0.90, 0.95, 0.99]
+INCUMBENT = 0.99
+_BASIC = {"jaro_winkler", "levenshtein", "token_sort", "exact"}
+
+
+def _write_truth(truth, path: Path):
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+
+    idx = truth.schema.get_field_index("record_id")
+    t = truth.set_column(idx, "record_id", pc.cast(truth.column("record_id"), pa.string()))
+    pq.write_table(t, path, compression="zstd")
+
+
+def run_one(records, truth_path: Path, out_dir: Path, thr: float) -> dict:
+    """One full dedupe at `thr`, scored by the shared evaluator."""
+    import evaluate as evaluate_mod
+    import numpy as np
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    from goldenmatch import dedupe_df
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
+    rid = records.column("record_id").to_pylist()
+    cfg = auto_configure_probabilistic_df(records)
+    for mk in cfg.get_matchkeys():
+        # Same basic-scorer rewrite the FS bench lanes apply, so this sweep
+        # measures the model those lanes measure and not a different one.
+        for f in getattr(mk, "fields", None) or []:
+            if f.scorer and f.scorer not in _BASIC:
+                f.scorer = "jaro_winkler"
+        mk.link_threshold = thr
+
+    t0 = time.perf_counter()
+    ded = dedupe_df(records, config=cfg)
+    wall = time.perf_counter() - t0
+
+    rec_ids, pred_cids = [], []
+    for cid, c in (getattr(ded, "clusters", None) or {}).items():
+        members = c["members"] if isinstance(c, dict) else c.members
+        for m in members:
+            rec_ids.append(str(rid[m]))
+            pred_cids.append(cid)
+
+    pred_path = out_dir / f"pred_{thr}.parquet"
+    pq.write_table(
+        pa.table({
+            "record_id": pa.array(rec_ids, pa.string()),
+            "pred_cluster_id": pa.array(np.asarray(pred_cids, dtype=np.int64)),
+        }),
+        pred_path, compression="zstd",
+    )
+    m = evaluate_mod.evaluate(pred_path, truth_path)
+    pw = m.get("pairwise") or {}
+    return {
+        "threshold": thr, "wall_seconds": round(wall, 2),
+        "precision": pw.get("precision"), "recall": pw.get("recall"),
+        "f1": pw.get("f1"),
+    }
+
+
+def sweep(name: str, thresholds: list[float], out_dir: Path) -> list[dict]:
+    import datasets as datasets_mod
+
+    records, truth = datasets_mod.load_dataset(name)
+    d = out_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    truth_path = d / "truth.parquet"
+    _write_truth(truth, truth_path)
+
+    rows = []
+    for thr in thresholds:
+        try:
+            r = run_one(records, truth_path, d, thr)
+        except Exception as exc:  # noqa: BLE001 - one bad point must not lose the rest
+            r = {"threshold": thr, "error": str(exc)[:200]}
+        r["dataset"] = name
+        rows.append(r)
+        if "error" in r:
+            note = f"ERROR {r['error']}"
+        else:
+            note = (f"F1={r['f1']:.4f} P={r['precision']:.4f} "
+                    f"R={r['recall']:.4f} ({r['wall_seconds']}s)")
+        print(f"[sweep] {name} thr={thr}: {note}", flush=True)
+    return rows
+
+
+def best_constant(rows: list[dict]) -> tuple[float, float]:
+    """The threshold maximising MEAN F1 across the tuning datasets.
+
+    Mean, not sum-of-argmax: a constant has to serve every dataset at once, so
+    the thing to maximise is what a single knob delivers on average. Datasets
+    that errored contribute nothing rather than a zero, which would let one
+    failure pick the constant.
+    """
+    by_thr: dict[float, list[float]] = {}
+    for r in rows:
+        if r.get("f1") is not None:
+            by_thr.setdefault(r["threshold"], []).append(float(r["f1"]))
+    if not by_thr:
+        return INCUMBENT, 0.0
+    scored = {t: sum(v) / len(v) for t, v in by_thr.items()}
+    best = max(scored, key=lambda t: scored[t])
+    return best, scored[best]
+
+
+def render_markdown(report: dict) -> str:
+    """The job-summary table.
+
+    Rendered here rather than in a YAML heredoc: a heredoc terminator has to sit
+    at column 0, which is easy to get wrong inside an indented `run:` block and
+    fails at job time rather than at lint time. Formatting in the script also
+    means it can be exercised without a runner.
+    """
+    out = ["## FS link-threshold sweep", ""]
+    out.append(
+        f"Incumbent **{report.get('incumbent')}** mean F1 "
+        f"`{report.get('incumbent_mean_f1')}`  ·  recommended "
+        f"**{report.get('recommended')}** mean F1 "
+        f"`{report.get('recommended_mean_f1')}`"
+    )
+    out.append("")
+    for section in ("tune", "holdout"):
+        rows = report.get(section) or []
+        if not rows:
+            continue
+        out += [f"### {section}", "", "| dataset | thr | P | R | F1 |",
+                "|---|---|---|---|---|"]
+        for r in rows:
+            if r.get("f1") is None:
+                out.append(f"| {r.get('dataset')} | {r.get('threshold', '-')} "
+                           f"| - | - | ERROR |")
+            else:
+                out.append(f"| {r['dataset']} | {r['threshold']} "
+                           f"| {r['precision']:.4f} | {r['recall']:.4f} "
+                           f"| {r['f1']:.4f} |")
+        out.append("")
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tune", nargs="*", default=TUNE)
+    ap.add_argument("--holdout", nargs="*", default=HOLDOUT)
+    ap.add_argument("--grid", nargs="*", type=float, default=GRID)
+    ap.add_argument("--out", default="fs-threshold-sweep.json")
+    ap.add_argument("--work", default="fs_sweep_work")
+    ap.add_argument("--summary-md", default="",
+                    help="also render a markdown table here (CI job summary)")
+    args = ap.parse_args()
+
+    os.environ.setdefault("GOLDENMATCH_FS_CALIBRATED", "posterior")
+    os.environ.setdefault("GOLDENMATCH_FS_NATIVE", "1")
+
+    out_dir = Path(args.work)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report: dict = {"grid": args.grid, "incumbent": INCUMBENT,
+                    "tune": [], "holdout": []}
+
+    for name in args.tune:
+        try:
+            report["tune"].extend(sweep(name, args.grid, out_dir))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[sweep] {name}: LOAD FAILED {exc}", flush=True)
+            report["tune"].append({"dataset": name, "error": str(exc)[:200]})
+
+    rec, mean_f1 = best_constant(report["tune"])
+    report["recommended"] = rec
+    report["recommended_mean_f1"] = round(mean_f1, 4)
+    inc_rows = [r for r in report["tune"]
+                if r.get("threshold") == INCUMBENT and r.get("f1") is not None]
+    report["incumbent_mean_f1"] = (
+        round(sum(r["f1"] for r in inc_rows) / len(inc_rows), 4) if inc_rows else None
+    )
+    print(f"\n[sweep] tuning panel recommends {rec} "
+          f"(mean F1 {report['recommended_mean_f1']}) vs incumbent "
+          f"{INCUMBENT} (mean F1 {report['incumbent_mean_f1']})\n", flush=True)
+
+    # Holdout: TWO points only. Sweeping here would spend the only unbiased
+    # estimate available and leave nothing to check the recommendation against.
+    hold_grid = sorted({INCUMBENT, rec})
+    for name in args.holdout:
+        try:
+            report["holdout"].extend(sweep(name, hold_grid, out_dir))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[sweep] {name}: LOAD FAILED {exc}", flush=True)
+            report["holdout"].append({"dataset": name, "error": str(exc)[:200]})
+
+    Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"[sweep] wrote {args.out}", flush=True)
+    if args.summary_md:
+        Path(args.summary_md).write_text(render_markdown(report), encoding="utf-8")
+        print(f"[sweep] wrote {args.summary_md}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Answers the question the person-shape diagnosis (#2571) left open: is the fix a **better constant**, or does the optimum move enough between datasets that only a **dataset-derived** cut will do?

## The methodology is the point

`0.99` became the default by being measured on one dataset — DBLP-ACM, per `compute_thresholds`' own docstring. **Sweeping every dataset and taking the argmax would repeat exactly that mistake with more arithmetic**: it reports the best constant *for the datasets I looked at*, which is not evidence it generalises.

So the panel is split the way `datasets.py` already splits it:

| panel | datasets | points |
|---|---|---|
| **tune** | historical_50k, dblp_acm, febrl3, ncvr, synthetic_person | full 7-point grid |
| **holdout** | febrl4, dblp_scholar, amazon_google — that file marks these *"never in the FS-lever tuning panel"* | **exactly 2** (incumbent + recommendation) |

Sweeping the holdout would spend the only unbiased estimate available. **The verdict is the holdout delta, not the tuning argmax.**

## Deliberate cost choice

One full `dedupe_df` per (dataset, threshold) — *not* a score-once-then-recluster shortcut. Clustering can auto-split, and the shortcut would report a pipeline that doesn't exist. That's why the grid is seven points and the holdout is two.

The recommendation maximises **mean** F1 across the tuning datasets rather than counting per-dataset wins, since a single knob has to serve every dataset at once. Datasets that error contribute nothing rather than a zero, so one load failure can't pick the constant.

## Two bugs caught before pushing

Both from patching files through nested heredocs: a literal `\n` landed mid-line in the workflow, and the renderer's join string got split across real newlines. Fixed directly rather than with more string surgery.

The markdown rendering also moved **out** of a YAML heredoc into the script — a heredoc terminator must sit at column 0, which is easy to get wrong inside an indented `run:` block and fails at job time rather than lint time. In the script it's exercisable, and I exercised it (including the error row and the constant selection).

## Scope

Dispatch-only, a measurement rather than a gate. Splink is installed purely because `datasets.py` reaches several fixtures through `splink_datasets`; no Splink lane runs here.

**This does not change the 0.99 default.** It produces the evidence needed to change it defensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
