### PR TITLE
fix(bench): the threshold sweep could not load six of its eight datasets

### DIFF
--- a/.github/workflows/bench-fs-threshold-sweep.yml
+++ b/.github/workflows/bench-fs-threshold-sweep.yml
@@ -22,7 +22,7 @@ on:
       tune:
         description: "Tuning datasets (space separated)"
         required: false
-        default: "historical_50k dblp_acm febrl3 ncvr synthetic_person"
+        default: "historical_50k dblp_acm febrl3 synthetic_person"
       holdout:
         description: "Held-out datasets, two points only"
         required: false
@@ -71,6 +71,43 @@ jobs:
         run: |
           uv pip install splink==4.0.16
           uv pip install duckdb
+
+      # febrl3/febrl4 ship INSIDE recordlinkage, which is not a goldenmatch
+      # dependency (`benchmarks.yml` installs it the same way). Without it both
+      # the tuning panel and the holdout lose a dataset each.
+      - name: Install recordlinkage (febrl3 / febrl4 fixtures)
+        continue-on-error: true
+        run: uv pip install recordlinkage
+
+      # The Leipzig benchmarks are gitignored; fetch them best-effort, exactly
+      # as `bench-probabilistic.yml` does. A failure here costs one dataset,
+      # not the run -- but silently losing all three (as the first run did)
+      # empties the holdout, so the sweep step below hard-fails on an empty
+      # holdout rather than reporting a recommendation nothing checked.
+      - name: Fetch Leipzig benchmarks (best-effort)
+        continue-on-error: true
+        run: |
+          BASE=packages/python/goldenmatch/tests/benchmarks/datasets
+          fetch() {
+            local name="$1" url="$2"; shift 2
+            local dest="$BASE/$name"
+            mkdir -p "$dest"
+            if curl -fsSL --retry 3 -o "/tmp/$name.zip" "$url"; then
+              mkdir -p "/tmp/$name" && unzip -o "/tmp/$name.zip" -d "/tmp/$name"
+              for f in "$@"; do
+                found=$(find "/tmp/$name" -name "$f" | head -1)
+                if [ -n "$found" ]; then cp "$found" "$dest/$f"
+                else echo "::warning::$name: $f not in archive"; fi
+              done
+              ls -la "$dest"
+            else
+              echo "::warning::$name download failed; it will be skipped"
+            fi
+          }
+          L=https://dbs.uni-leipzig.de/file
+          fetch DBLP-ACM "$L/DBLP-ACM.zip" DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv
+          fetch DBLP-Scholar "$L/DBLP-Scholar.zip" DBLP1.csv Scholar.csv DBLP-Scholar_perfectMapping.csv
+          fetch Amazon-GoogleProducts "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
 
       - name: Sweep
         env:

--- a/scripts/bench_er_headtohead/sweep_fs_link_threshold.py
+++ b/scripts/bench_er_headtohead/sweep_fs_link_threshold.py
@@ -25,8 +25,10 @@ generalises.
 
 So the panel is split the way `datasets.py` already splits it:
 
-* **tune**    -- historical_50k, dblp_acm, febrl3, ncvr, synthetic_person.
-  The full grid runs here, and the recommended constant is chosen here.
+* **tune**    -- historical_50k, dblp_acm, febrl3, synthetic_person. The full
+  grid runs here, and the recommended constant is chosen here. NCVR is NOT in
+  this list: its loader refuses by design (the raw sample's `ncid` is unique
+  per row, so there is no true-entity grouping and it will not fabricate one).
 * **holdout** -- febrl4, dblp_scholar, amazon_google, marked in `datasets.py`
   as "never in the FS-lever tuning panel". Only TWO points run here: the
   incumbent 0.99 and whatever the tuning panel recommended. Sweeping the
@@ -57,7 +59,8 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
-TUNE = ["historical_50k", "dblp_acm", "febrl3", "ncvr", "synthetic_person"]
+# NCVR omitted deliberately -- see the module docstring; its loader refuses.
+TUNE = ["historical_50k", "dblp_acm", "febrl3", "synthetic_person"]
 HOLDOUT = ["febrl4", "dblp_scholar", "amazon_google"]
 GRID = [0.50, 0.70, 0.80, 0.85, 0.90, 0.95, 0.99]
 INCUMBENT = 0.99
@@ -209,6 +212,10 @@ def main() -> int:
     ap.add_argument("--work", default="fs_sweep_work")
     ap.add_argument("--summary-md", default="",
                     help="also render a markdown table here (CI job summary)")
+    # Floors, not preferences. Below these the run cannot answer the question
+    # it was dispatched to answer.
+    ap.add_argument("--min-tune", type=int, default=3)
+    ap.add_argument("--min-holdout", type=int, default=2)
     args = ap.parse_args()
 
     os.environ.setdefault("GOLDENMATCH_FS_CALIBRATED", "posterior")
@@ -253,6 +260,31 @@ def main() -> int:
     if args.summary_md:
         Path(args.summary_md).write_text(render_markdown(report), encoding="utf-8")
         print(f"[sweep] wrote {args.summary_md}", flush=True)
+
+    # A recommendation nothing checked is worse than no recommendation: the
+    # FIRST run of this sweep lost six of eight datasets to missing loaders and
+    # still printed "recommended 0.5", fitted on two datasets that disagreed
+    # with each other, with an EMPTY holdout. The artifact looked like a result.
+    #
+    # So the exit code now reflects whether the methodology held, not whether
+    # the process crashed. `--min-tune` / `--min-holdout` are the floor; the
+    # numbers stay in the artifact either way for diagnosis.
+    ok_tune = {r["dataset"] for r in report["tune"] if r.get("f1") is not None}
+    ok_hold = {r["dataset"] for r in report["holdout"] if r.get("f1") is not None}
+    report["usable_tune_datasets"] = sorted(ok_tune)
+    report["usable_holdout_datasets"] = sorted(ok_hold)
+    Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if len(ok_tune) < args.min_tune or len(ok_hold) < args.min_holdout:
+        print(
+            f"[sweep] REFUSING the recommendation: {len(ok_tune)} usable tuning "
+            f"dataset(s) (need {args.min_tune}) and {len(ok_hold)} usable "
+            f"holdout dataset(s) (need {args.min_holdout}). A constant chosen "
+            f"on too few datasets, or with nothing held out to check it, is "
+            f"how the incumbent 0.99 happened in the first place.",
+            flush=True,
+        )
+        return 1
     return 0
 
 


### PR DESCRIPTION
The first sweep run (`31831632084`) **completed "successfully" and produced a recommendation that is not usable.** Six of eight datasets failed to load:

| dataset | failure |
|---|---|
| `dblp_acm` | DBLP-ACM source CSVs not found |
| `febrl3` | recordlinkage not installed |
| `ncvr` | refuses by design (see below) |
| `febrl4` | recordlinkage not installed |
| `dblp_scholar` | DBLP-Scholar source CSVs not found |
| `amazon_google` | Amazon-Google source CSVs not found |

So **"recommended 0.50" was fitted on two datasets that disagree with each other** — `historical_50k` peaks at 0.99 (F1 0.7462), `synthetic_person` peaks at 0.50 (F1 0.9718) — and the **entire holdout panel was empty**. There was nothing unbiased to check it against, which is the one thing that sweep exists to provide. The artifact looked like a result.

## Three causes, three fixes

**1. `recordlinkage` is not a goldenmatch dependency.** febrl3/febrl4 ship inside it; `benchmarks.yml` pip-installs it and I didn't copy that.

**2. The Leipzig CSVs are gitignored.** `bench-probabilistic.yml` curl-fetches them best-effort; I didn't copy that either. Added as one `fetch` helper covering all three archives.

**3. NCVR was never loadable and shouldn't have been in the panel.** Its loader raises unconditionally and says why: the raw sample's `ncid` is unique per row, so there's no true-entity grouping and it refuses to fabricate one rather than emit an all-singletons truth. **That's correct behaviour.** I copied the `_LOADERS` list without checking which entries can actually load. Removed from the default panel and from the module docstring, which claimed it was there.

## The deeper fix: the sweep now refuses to recommend

`--min-tune` (3) and `--min-holdout` (2) are floors. Below them it prints why and **exits 1**.

A recommendation nothing checked is worse than no recommendation — choosing a constant from too few datasets with nothing held out is *precisely* how the incumbent 0.99 came to be. The rows stay in the artifact for diagnosis either way, and `usable_tune_datasets` / `usable_holdout_datasets` are now recorded so the next reader sees the panel that actually ran rather than the one requested.

## Also

The fetch step's line continuations collapsed into one line when I patched the file through a heredoc — third time this session. Rewritten with a `$L` base-URL variable so each command fits on one line.

**Not re-dispatched yet:** `workflow_dispatch` only sees workflows on the default branch, so the corrected sweep can't run until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
