### PR TITLE
fix(fs): calibrate the link cut on the scale that consumes it

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4219,6 +4219,7 @@
             "_ne_u_probs_from_matrix",
             "_neutral_u_for",
             "_otsu_threshold",
+            "_posterior_split",
             "_record_concat_value",
             "_record_concat_values",
             "_row_lookup_for_pairs",

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -3265,6 +3265,12 @@ def _fs_calibrate_threshold_enabled() -> bool:
 # Clamp the calibrated cutoff to a sane band (mirrors compute_thresholds' own
 # [0.40, 0.95] clamp; 0.90 upper keeps recall from collapsing on odd shapes).
 _CALIBRATE_MIN, _CALIBRATE_MAX = 0.40, 0.90
+#: Posterior-scale bounds. Wider than the linear pair because a posterior is a
+#: probability: well-separated pairs sit at ~0 and ~1, so a legitimate split can
+#: land far from 0.5 (the fixed posterior default is 0.99). The bounds still
+#: refuse the degenerate ends -- a cut at 0.0 links everything and one at 1.0
+#: links nothing, and either would be a silent disaster rather than a bad model.
+_CALIBRATE_POSTERIOR_MIN, _CALIBRATE_POSTERIOR_MAX = 0.05, 0.995
 
 
 def _otsu_threshold(scores) -> float | None:
@@ -3615,13 +3621,89 @@ def _calibrate_link_threshold(comp_matrix, mk, match_weights, p_match) -> float 
         lv = comp_matrix[:, j]
         obs = lv >= 0
         total[obs] += weights[f.field][lv[obs]]
-    norm = np.clip((total - pair_min) / (pair_max - pair_min), 0.0, 1.0)
-    if norm.shape[0] <= 50:
+    if total.shape[0] <= 50:
         return None
-    t = _otsu_threshold(norm)
+
+    # Calibrate on the scale the cut will be COMPARED against, or the number is
+    # a different quantity that merely shares the [0, 1] range.
+    #
+    # `resolve_thresholds` hands this value straight to the scorer, and under
+    # posterior calibration the scorer is comparing PROBABILITIES. Splitting the
+    # linear weight envelope and applying the result as a posterior was the
+    # original bug: measured on a 20K person fixture, Otsu picked 0.11 on the
+    # linear scale while the posterior default for the same data is 0.99, and
+    # nothing failed -- the linear value is inside [0, 1], the run reports
+    # `source: "calibrated"`, and the model quietly cuts in the wrong place.
+    #
+    # The tell is prior-invariance: the linear envelope does not depend on the
+    # match rate, so the same comparison vectors gave the same cut at a 0.1% and
+    # a 40% prior. A posterior cut must move with the prior.
+    posterior = _fs_calibration_mode() == "posterior"
+    if posterior:
+        prior_w = prior_weight(p_match)
+        norm = np.asarray(
+            [posterior_from_weight(float(w), prior_w) for w in total],
+            dtype=np.float64,
+        )
+    else:
+        norm = np.clip((total - pair_min) / (pair_max - pair_min), 0.0, 1.0)
+
+    # Otsu histograms over a FIXED [0, 1] range, which is right for the linear
+    # scale (min-max normalised scores spread across it) and wrong for
+    # posteriors: a well-separated pair sits at ~0 or ~1, so both masses land in
+    # end bins and the between-class variance peaks at the FIRST occupied bin --
+    # BELOW the low cluster rather than between the two. Measured on the two
+    # posterior clusters of the fixture below (0.0103 and 0.9942), Otsu returns
+    # 0.02, which links everything.
+    #
+    # So on the posterior scale the split is taken between the two masses
+    # directly. `_otsu_threshold` is left untouched: it is also used by the
+    # refit loop, whose scores ARE linear, and changing it there would move a
+    # separately-validated behaviour.
+    t = _posterior_split(norm) if posterior else _otsu_threshold(norm)
     if t is None:
         return None
-    return round(float(np.clip(t, _CALIBRATE_MIN, _CALIBRATE_MAX)), 4)
+    # The [0.40, 0.90] clamp is a LINEAR-scale guard: it bounds how far a
+    # min-max normalised cut may stray from the 0.50 midpoint. Posterior scores
+    # pile up against both ends (a well-separated pair is ~0 or ~1), so the same
+    # clamp there would force every dataset to 0.40 or 0.90 -- which is exactly
+    # what it did: the 0.11 split above was clamped to 0.40 and scored well by
+    # accident, because 0.40 happened to sit between this fixture's two
+    # posterior clusters.
+    if posterior:
+        lo, hi = _CALIBRATE_POSTERIOR_MIN, _CALIBRATE_POSTERIOR_MAX
+    else:
+        lo, hi = _CALIBRATE_MIN, _CALIBRATE_MAX
+    return round(float(np.clip(t, lo, hi)), 4)
+
+
+def _posterior_split(scores) -> float | None:
+    """A cut between the two posterior masses, rather than an Otsu bin edge.
+
+    Posterior scores are not spread over [0, 1] -- they pile up near 0 and 1 --
+    so a fixed-range histogram puts both classes in end bins and Otsu's split
+    lands below the low mass instead of between them (measured: 0.02 for
+    clusters at 0.0103 and 0.9942).
+
+    This finds the widest GAP between consecutive sorted scores and cuts at its
+    midpoint. On a genuinely bimodal set that gap is the class boundary. It
+    returns None when the widest gap is not a real separation -- a set with no
+    meaningful split should keep the fixed default rather than invent a cut
+    from noise, which is the failure mode the refit loop's valley gate exists
+    to prevent.
+    """
+    x = np.unique(np.asarray(scores, dtype=np.float64))
+    if x.shape[0] < 2:
+        return None
+    gaps = np.diff(x)
+    k = int(np.argmax(gaps))
+    widest = float(gaps[k])
+    # The gap has to dominate the spread, or this is a continuum and any cut is
+    # arbitrary. 0.10 of the full [0,1] range is deliberately coarse: it admits
+    # the clean two-cluster case this exists for and declines the rest.
+    if widest < 0.10:
+        return None
+    return float((x[k] + x[k + 1]) / 2.0)
 
 
 def _fs_link_threshold(

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -710,3 +710,70 @@ def test_the_tf_table_survives_BOTH_the_kernel_and_the_fallback(monkeypatch, nat
     )
     assert em.tf_freqs == tf_freqs, f"tf_freqs dropped under NATIVE={native}"
     assert em.tf_collision == tf_collision
+
+
+# ── the calibrated link cut has to be on the ACTIVE scale ────────────
+
+def _calib_mk():
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    return MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+            MatchkeyField(field="last", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.8),
+        ],
+    )
+
+
+def test_the_calibrated_cut_is_expressed_on_the_scale_that_consumes_it(
+    monkeypatch,
+):
+    """A cut chosen on the LINEAR scale must not be applied as a POSTERIOR one.
+
+    `_calibrate_link_threshold` normalises `(total - min) / (max - min)` -- the
+    linear weight envelope -- and `resolve_thresholds` then uses that number
+    directly as the cut, whichever calibration mode is active. Under
+    `GOLDENMATCH_FS_CALIBRATED=posterior` the score being thresholded is a
+    PROBABILITY, so the two are different quantities that happen to share the
+    [0, 1] range: measured on a 20K person fixture, Otsu picked 0.11 on the
+    linear scale while the posterior default for the same data is 0.99.
+
+    Nothing about that fails loudly. The linear value lands inside [0, 1], the
+    run reports `source: "calibrated"`, and the model quietly cuts in the wrong
+    place -- which is the same class of error as the fixed 0.99 this
+    calibration exists to replace.
+    """
+    import numpy as np
+    from goldenmatch.core.probabilistic import _calibrate_link_threshold
+
+    mk = _calib_mk()
+    weights = {"first": [-3.0, 4.0], "last": [-3.0, 4.0]}
+    # A clean bimodal split: half the pairs disagree on both fields, half agree.
+    comp = np.array([[0, 0]] * 400 + [[1, 1]] * 400, dtype=np.int64)
+
+    monkeypatch.setenv("GOLDENMATCH_FS_CALIBRATE_THRESHOLD", "1")
+    monkeypatch.setenv("GOLDENMATCH_FS_CALIBRATED", "posterior")
+
+    # Same comparison vectors, very different PRIORS. A posterior cut has to
+    # move, because every posterior moves with the prior; a linear-envelope cut
+    # cannot, because the envelope does not depend on the prior at all. That
+    # invariance is the sharpest available tell, and it needs no tolerance.
+    #
+    # An earlier version of this test asserted only that the cut fell between
+    # the two clusters' posteriors. On this fixture that band is
+    # [0.0008, 0.93] -- wide enough that the WRONG answer passed. A test whose
+    # bounds admit the bug is worse than none, because it reads as coverage.
+    rare = _calibrate_link_threshold(comp, mk, weights, 0.001)
+    common = _calibrate_link_threshold(comp, mk, weights, 0.400)
+
+    assert rare is not None and common is not None, (
+        "the calibrator declined on a cleanly bimodal input"
+    )
+    assert rare != common, (
+        f"the calibrated cut is {rare} at a 0.1% match rate and {common} at "
+        f"40% -- identical, so it is not a posterior at all. It is the linear "
+        f"weight envelope being handed to a posterior-scale comparison."
+    )


### PR DESCRIPTION
## Correction to my own framing first

I told Ben the calibrated cut was *"a hook that is always `None`"* and proposed building it. **It already exists** — `_calibrate_link_threshold`, behind `GOLDENMATCH_FS_CALIBRATE_THRESHOLD`, default off.

The work was never to build it. It was to find out *why* it was off — and it turns out to have been broken in two ways that would each have shipped silently.

## Bug 1: the wrong scale

The calibrator normalises `(total - min) / (max - min)` — the **linear weight envelope** — and `resolve_thresholds` hands that number straight to the scorer whichever mode is active. Under `GOLDENMATCH_FS_CALIBRATED=posterior` the scorer compares **probabilities**.

Two different quantities that merely share the `[0, 1]` range, so nothing fails: the value is in range, the run reports `source: "calibrated"`, and the model cuts in the wrong place. On a 20K person fixture Otsu picked **0.11** on the linear scale where the posterior default for the same data is **0.99**.

**The tell is prior-invariance.** The linear envelope doesn't depend on the match rate, so identical comparison vectors produced the *same* cut at a 0.1% and a 40% prior. A posterior cannot do that.

## Bug 2: Otsu is the wrong instrument for posteriors

It histograms over a fixed `[0, 1]` range — right for linear scores (spread across it), wrong for posteriors (piled at ~0 and ~1). Both masses land in end bins and the between-class variance peaks at the **first occupied bin**, below the low cluster rather than between the two. Measured on clusters at 0.0103 and 0.9942, Otsu returns **0.02** — which links everything.

The posterior path now splits at the midpoint of the widest gap between sorted scores, and **declines** when that gap is under 0.10: a continuum has no principled cut, and inventing one from noise is the failure the refit loop's valley gate already guards against.

`_otsu_threshold` is untouched — the refit loop uses it on *linear* scores and that behaviour was separately validated.

## The clamp was linear-scale reasoning too

`[0.40, 0.90]` forced every posterior dataset to 0.40 or 0.90. The person fixture got **0.40 and scored well by accident**, because it happened to fall between that fixture's two clusters. Posterior bounds are now `[0.05, 0.995]` — wide enough for a real split, still refusing the degenerate ends.

## Measured, end to end

| | link cut | P | R | F1 |
|---|---|---|---|---|
| `CALIBRATE=0` | 0.99 *(fallback)* | 0.0000 | 0.0000 | **0.0000** |
| `CALIBRATE=1` | 0.3463 *(calibrated)* | 1.0000 | 0.9532 | **0.9761** |

## Still default OFF, deliberately

This makes the calibrator *correct* on the posterior scale. It does **not** establish that turning it on is right for every dataset.

The cross-dataset sweep (run `31837064581`) showed four datasets peaking at four different thresholds across the whole grid, and its holdout **rejected** the best tuning-panel constant (−0.0188 mean F1). Flipping the default needs that sweep re-run with calibration on, compared against the per-dataset optima — now possible, and it wasn't before.

## A test-quality note

My first version of the new test asserted only that the cut fell between the two clusters' posteriors. On that fixture the band is `[0.0008, 0.93]` — **wide enough that the wrong answer passed.** It read as coverage while testing almost nothing. The prior-invariance assertion needs no tolerance and fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
