### PR TITLE
fix(fs): gate the calibrated cut on bimodality, with the right mass floor

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -3394,7 +3394,24 @@ def _fs_refit_threshold_enabled() -> bool:
     )
 
 
-def _score_distribution_valley(hist) -> float | None:
+#: Minimum-mode mass for the CALIBRATOR's population, which is not the refit
+#: loop's. `_REFIT_MIN_MODE_MASS` (2%) is tuned for SCORED pairs -- already past
+#: a threshold, so match-rich. The calibrator reads TRAINING pairs: blocked
+#: candidates, overwhelmingly non-matches, where the true-match mode is a thin
+#: sliver by construction. Measured on the 20K person fixture, its posterior
+#: histogram is cleanly bimodal (9,905 pairs in bin 0, 82 in the top two, every
+#: bin between empty) and the match side is 0.82% -- so the 2% floor rejects a
+#: textbook separation and the calibrator falls back to a cut that scores F1
+#: 0.0000.
+#:
+#: 0.2% admits that shape while still refusing a handful of stray pairs as a
+#: "mode". It is a floor on EVIDENCE, not a claim about match rates: below it
+#: the smaller flank is too small for its maximum to mean anything, and the
+#: trough ratio it anchors becomes noise.
+_CALIBRATE_MIN_MODE_MASS = 0.002
+
+
+def _score_distribution_valley(hist, min_mode_mass: float | None = None) -> float | None:
     """Locate the class-separating VALLEY of a [0,1] score histogram: a deep
     density trough with substantial mass on BOTH sides. Returns the valley's cut
     point (the low edge of the deepest qualifying bin, in [0,1]) when the
@@ -3414,14 +3431,18 @@ def _score_distribution_valley(hist) -> float | None:
     total = hist.sum()
     if total <= 0:
         return None
+    # Default preserves the refit loop's behaviour exactly; the calibrator
+    # passes its own floor because it reads a different population (see
+    # `_CALIBRATE_MIN_MODE_MASS`).
+    floor = _REFIT_MIN_MODE_MASS if min_mode_mass is None else min_mode_mass
     nb = len(hist)
     best_idx: int | None = None
     best_ratio = _REFIT_VALLEY_MAX
     for v in range(1, nb - 1):
         left, right = hist[:v], hist[v + 1:]
-        if left.sum() / total < _REFIT_MIN_MODE_MASS:
+        if left.sum() / total < floor:
             continue
-        if right.sum() / total < _REFIT_MIN_MODE_MASS:
+        if right.sum() / total < floor:
             continue
         smaller = min(left.max(), right.max())
         if smaller <= 0:
@@ -3692,18 +3713,40 @@ def _posterior_split(scores) -> float | None:
     from noise, which is the failure mode the refit loop's valley gate exists
     to prevent.
     """
-    x = np.unique(np.asarray(scores, dtype=np.float64))
-    if x.shape[0] < 2:
+    arr = np.asarray(scores, dtype=np.float64)
+    if arr.shape[0] < 2:
         return None
-    gaps = np.diff(x)
-    k = int(np.argmax(gaps))
-    widest = float(gaps[k])
-    # The gap has to dominate the spread, or this is a continuum and any cut is
-    # arbitrary. 0.10 of the full [0,1] range is deliberately coarse: it admits
-    # the clean two-cluster case this exists for and declines the rest.
-    if widest < 0.10:
+
+    # BIMODALITY GATE, not a gap rule. The first version of this took the
+    # midpoint of the widest gap between sorted scores, which finds *a*
+    # separation in any distribution -- including one that has none. The
+    # cross-dataset sweep (run 31844730947) measured the cost: on
+    # `historical_50k` it cut at 0.348 where that dataset's optimum is 0.99,
+    # taking F1 0.7462 -> 0.0005 while reporting `source: "calibrated"` and
+    # returning clusters the whole way. Its shape is one non-match mass
+    # decaying into the matches -- no valley, so the widest gap sits inside the
+    # tail.
+    #
+    # `_score_distribution_valley` is the refit loop's answer to exactly this
+    # problem, and its own comment names the same dataset as the reason it
+    # exists ("historical_50k ... valley_ratio 0.55 (NO valley) -> keep 0.50").
+    # Reusing it means one bimodality rule rather than two that can disagree
+    # about what a class boundary is.
+    #
+    # It is deliberately reused rather than reimplemented on the posterior
+    # scale: the detector reads a [0, 1] histogram and both scales are [0, 1],
+    # so the only thing that changes is which quantity fills the bins.
+    hist, _ = np.histogram(arr, bins=_REFIT_BINS, range=(0.0, 1.0))
+    valley = _score_distribution_valley(
+        hist.astype(np.float64), min_mode_mass=_CALIBRATE_MIN_MODE_MASS
+    )
+    if valley is None:
         return None
-    return float((x[k] + x[k + 1]) / 2.0)
+
+    # The valley is the LOW EDGE of the trough bin. Return the bin's midpoint so
+    # the cut sits inside the empty region rather than on the shoulder of the
+    # mass below it.
+    return float(valley + 0.5 / _REFIT_BINS)
 
 
 def _fs_link_threshold(

--- a/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
+++ b/packages/python/goldenmatch/tests/test_fs_em_weighted_pairs.py
@@ -747,7 +747,11 @@ def test_the_calibrated_cut_is_expressed_on_the_scale_that_consumes_it(
     calibration exists to replace.
     """
     import numpy as np
-    from goldenmatch.core.probabilistic import _calibrate_link_threshold
+    from goldenmatch.core.probabilistic import (
+        _calibrate_link_threshold,
+        posterior_from_weight,
+        prior_weight,
+    )
 
     mk = _calib_mk()
     weights = {"first": [-3.0, 4.0], "last": [-3.0, 4.0]}
@@ -757,23 +761,97 @@ def test_the_calibrated_cut_is_expressed_on_the_scale_that_consumes_it(
     monkeypatch.setenv("GOLDENMATCH_FS_CALIBRATE_THRESHOLD", "1")
     monkeypatch.setenv("GOLDENMATCH_FS_CALIBRATED", "posterior")
 
-    # Same comparison vectors, very different PRIORS. A posterior cut has to
-    # move, because every posterior moves with the prior; a linear-envelope cut
-    # cannot, because the envelope does not depend on the prior at all. That
-    # invariance is the sharpest available tell, and it needs no tolerance.
+    # The cut must SEPARATE the posterior clusters, and the posteriors move
+    # with the prior -- so the test is that the cut tracks them.
     #
-    # An earlier version of this test asserted only that the cut fell between
-    # the two clusters' posteriors. On this fixture that band is
-    # [0.0008, 0.93] -- wide enough that the WRONG answer passed. A test whose
-    # bounds admit the bug is worse than none, because it reads as coverage.
-    rare = _calibrate_link_threshold(comp, mk, weights, 0.001)
-    common = _calibrate_link_threshold(comp, mk, weights, 0.400)
+    # Two earlier versions of this assertion were wrong in opposite ways, and
+    # both are worth recording:
+    #
+    #   1. "cut falls between the clusters" -- on this fixture that band is
+    #      [0.0008, 0.93], wide enough that the WRONG answer passed.
+    #   2. "cut differs between two priors" -- sharper, and it did catch the
+    #      linear-scale bug. But it asserts an implementation detail, not the
+    #      property: the split is now histogram-based over 20 bins, and a
+    #      two-point fixture puts the low mass in bin 0 under BOTH priors, so
+    #      the trough bin is identical and the cut is legitimately the same.
+    #      That version failed on correct code.
+    #
+    # What actually distinguishes right from wrong is whether the cut lands
+    # between THIS prior's two masses. A linear-envelope number cannot, because
+    # it knows nothing about the prior that produced them.
+    for p_match in (0.001, 0.400):
+        cut = _calibrate_link_threshold(comp, mk, weights, p_match)
+        assert cut is not None, (
+            f"the calibrator declined on a cleanly bimodal input at "
+            f"prior={p_match}"
+        )
+        prior_w = prior_weight(p_match)
+        lo = posterior_from_weight(-6.0, prior_w)   # both fields disagree
+        hi = posterior_from_weight(8.0, prior_w)    # both fields agree
+        assert lo < cut < hi, (
+            f"prior={p_match}: cut {cut} does not separate the posterior "
+            f"masses [{lo:.6f}, {hi:.6f}] -- a linear-envelope cut cannot "
+            f"track a prior it never saw"
+        )
 
-    assert rare is not None and common is not None, (
-        "the calibrator declined on a cleanly bimodal input"
+
+def test_the_calibrator_DECLINES_on_a_unimodal_with_tail_distribution():
+    """No genuine class boundary -> keep the fixed default, do not invent a cut.
+
+    The cross-dataset sweep (run 31844730947) measured what happens without this
+    guard. Calibration tied or beat a per-dataset ORACLE on three of six
+    datasets, and then destroyed `historical_50k`:
+
+        oracle 0.99 -> F1 0.7462     calibrated chose 0.348 -> F1 0.0005
+
+    A -0.7457 delta, reported as `source: "calibrated"`, returning clusters the
+    whole way. That shape is one non-match mass with a declining tail into the
+    matches -- there is no valley, so the widest-gap rule finds *a* gap inside
+    the tail and cuts there.
+
+    The refit loop already solved this exact problem with a bimodality gate, and
+    its own comment records the same dataset as the reason
+    (`historical_50k ... valley_ratio 0.55 (NO valley) -> keep 0.50`). So the
+    calibrator now uses that detector: it must return None on a distribution
+    with no deep trough, whatever gap happens to exist inside the tail.
+    """
+    import numpy as np
+    from goldenmatch.core.probabilistic import _posterior_split
+
+    rng = np.random.default_rng(11)
+    # A CONTINUUM: one dominant low mass decaying smoothly all the way up, with
+    # no empty band anywhere. That is the historical_50k shape -- its calibrated
+    # run cut at 0.348 and returned precision 0.0003 at recall 0.9796, i.e. it
+    # linked essentially everything.
+    #
+    # My first version of this fixture put a hard empty gap at 0.45-0.60 and
+    # then asserted the calibrator must decline. That fixture is BIMODAL: bins
+    # 9 and 10 were genuinely empty with mass on both sides, so declining would
+    # have been the wrong answer and the test was demanding a bug. Modelling
+    # the failing shape means no gap at all.
+    scores = np.clip(rng.exponential(0.12, 4000), 0.0, 1.0)
+
+    assert _posterior_split(scores) is None, (
+        "the calibrator found a cut in a unimodal-with-tail distribution; that "
+        "is the historical_50k shape that took F1 0.7462 -> 0.0005"
     )
-    assert rare != common, (
-        f"the calibrated cut is {rare} at a 0.1% match rate and {common} at "
-        f"40% -- identical, so it is not a posterior at all. It is the linear "
-        f"weight envelope being handed to a posterior-scale comparison."
-    )
+
+
+def test_the_calibrator_still_fires_on_a_genuinely_bimodal_distribution():
+    """The gate must not turn calibration into a no-op everywhere.
+
+    Stated separately because a guard that declines on EVERYTHING would also
+    make the test above pass, and would silently revert the datasets where
+    calibration matched the oracle exactly (synthetic_person +0.0000,
+    febrl3 +0.0001, febrl4 +0.0012).
+    """
+    import numpy as np
+    from goldenmatch.core.probabilistic import _posterior_split
+
+    rng = np.random.default_rng(11)
+    lo = np.clip(rng.normal(0.05, 0.02, 2000), 0.0, 1.0)
+    hi = np.clip(rng.normal(0.95, 0.02, 2000), 0.0, 1.0)
+    cut = _posterior_split(np.concatenate([lo, hi]))
+
+    assert cut is not None, "declined on a cleanly bimodal distribution"
+    assert 0.10 < cut < 0.90, f"cut {cut} is not between the two modes"


### PR DESCRIPTION
The sweep (run `31844730947`) measured the calibrator against a per-dataset **oracle** and found it unsafe:

| dataset | oracle | oracle F1 | calibrated F1 | delta |
|---|---|---|---|---|
| `synthetic_person` | 0.50 | 0.9718 | 0.9718 | **+0.0000** |
| `febrl3` | 0.70 | 0.9991 | 0.9992 | **+0.0001** |
| `febrl4` *(holdout)* | 0.90 | 0.9948 | 0.9960 | **+0.0012** |
| `dblp_acm` | 0.90 | 0.8613 | 0.8050 | −0.0563 |
| `dblp_scholar` *(holdout)* | 0.99 | 0.3902 | 0.3521 | −0.0381 |
| **`historical_50k`** | 0.99 | 0.7462 | **0.0005** | **−0.7457** |

The tail is the finding. `historical_50k` cut at 0.348 and returned **precision 0.0003 at recall 0.9796** — it linked essentially everything — while reporting `source: "calibrated"` and producing clusters the whole way.

## Root cause

The widest-gap rule finds a separation in **any** distribution, including one that has none. `historical_50k` is a continuum — one non-match mass decaying into the matches — so the widest gap sits arbitrarily inside the tail.

The refit loop already solved this with `_score_distribution_valley`, and its own comment names the same dataset: *"historical_50k … valley_ratio 0.55 (NO valley) → keep 0.50"*. The calibrator now uses that detector, so there's **one** bimodality rule rather than two that can disagree about what a class boundary is.

## The wrong turn, worth recording

Routing through it unchanged made the calibrator decline on the person fixture too — **F1 0.9761 → 0.0000**. I'd traded one failure for another.

`_REFIT_MIN_MODE_MASS` (2%) is tuned for **scored** pairs: already past a threshold, match-rich. The calibrator reads **training** pairs: blocked candidates, overwhelmingly non-matches. Measured, that fixture's posterior histogram is textbook bimodal — 9,905 pairs in bin 0, 82 in the top two, every bin between empty — and its match side is **0.82%**, so a 2% floor rejects a clean separation.

So `_score_distribution_valley` takes an optional floor (default unchanged — the refit loop is untouched) and the calibrator passes `_CALIBRATE_MIN_MODE_MASS` = 0.2%. That's a floor on **evidence**, not a claim about match rates.

## Result on the person fixture

| | F1 | |
|---|---|---|
| 0.99 | 0.0000 | the shipped fallback |
| 0.50 | 0.9761 | this dataset's oracle |
| **calibrated** | **0.9965** | chose 0.075, `src=calibrated` |

**`delta_vs_oracle +0.0204`** — calibration now *beats* the best fixed cut that dataset could have had.

## Two of my own fixtures were wrong, in opposite directions

- The **decline test** built a hard empty band at 0.45–0.60 and demanded the calibrator refuse it. That fixture is *bimodal* (bins 9–10 empty with mass on both sides), so declining would have been wrong — **the test was demanding a bug**. It now models a continuum, the shape that actually fails.
- The **prior-invariance test** asserted the cut must *differ* between two priors. That caught the linear-scale bug, but asserts an implementation detail: the split is histogram-based over 20 bins, and a two-point fixture puts the low mass in bin 0 under both priors, so an identical cut is correct. It now asserts the property.

## Scope

**Still default OFF.** This makes the calibrator safe on the shape that broke it. Whether it's right everywhere is what the re-run sweep decides — 192 tests pass, including the refit loop's own, which this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ
