### PR TITLE
feat(infermap): identity layers reach the consumers (#2574 Wave 4)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 476,
+      "module_count": 477,
       "modules": [
         {
           "module": "goldenmatch",
@@ -4685,6 +4685,23 @@
             "goldenmatch.config.schemas",
             "goldenmatch.core.match_one",
             "goldenmatch.core.scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.segments",
+          "file": "packages/python/goldenmatch/goldenmatch/core/segments.py",
+          "purpose": "Segment labels — which *party* each column describes.",
+          "defines": [
+            "Segment",
+            "_to_segment",
+            "column_segments",
+            "detect_segments",
+            "is_heterogeneous",
+            "segments_from_layers",
+            "segments_from_schema"
+          ],
+          "imports": [
+            "infermap"
           ]
         },
         {

--- a/docs/superpowers/specs/2026-08-14-infermap-identity-layers-detector-design.md
+++ b/docs/superpowers/specs/2026-08-14-infermap-identity-layers-detector-design.md
@@ -1,8 +1,8 @@
 # Identity-layers detector — detect the entity roles present in a dataset
 
 **Date:** 2026-08-14
-**Status:** Design (draft, pre-approval). Tracks [#2574](https://github.com/benseverndev-oss/goldenmatch/issues/2574).
-**Scope:** `packages/python/infermap/` + `packages/python/goldencheck-types/` (and their TS mirrors).
+**Status:** Approved; Waves 1, 2 and 4 landed (#2578, #2581, and this change). Wave 3 open. Tracks [#2574](https://github.com/benseverndev-oss/goldenmatch/issues/2574).
+**Scope:** `packages/python/infermap/` + `packages/python/goldencheck-types/` (and their TS mirrors), plus the Wave 4 consumers in `goldenpipe/` and `goldenmatch/`.
 **Feeds:** [#2575](https://github.com/benseverndev-oss/goldenmatch/issues/2575) (per-block / per-partition config) — you cannot vary matching config per segment until you can detect the segments.
 
 ## The gap
@@ -248,6 +248,17 @@ common path stays name-only and free: a 9-digit numeric column named `aba`
 
 **Wave 4 — consumers.** `goldenpipe.stages.infer_schema` emits layers into
 `InferredSchema`; goldenmatch consumes them as the segment labels for #2575.
+
+> **Landed.** `InferredSchema` gained `layers` (inside the v4 contract, which
+> already declared that layers travel InferMap → GoldenPipe → GoldenMatch, so no
+> further bump); the stage detects unconditionally because name-only detection
+> costs what `detect_domain` costs. `goldenmatch.core.segments` is the consumer:
+> read-only, structurally adapted (no `goldencheck_types` import, so that stays
+> an optional dependency), fail-open to `[]`. It **labels and stops** — it does
+> not vary scorers, thresholds or blocking, and touches neither the vectorized
+> fast paths nor the global-EM / single-score-space assumptions. Those are
+> #2575's subject, behind its measured-quality-win gate; landing the labels
+> separately is what makes that work testable.
 
 ### Why the kernel is Wave 1, not a deferred optimization
 

--- a/packages/python/goldencheck-types/goldencheck_types/types.py
+++ b/packages/python/goldencheck-types/goldencheck_types/types.py
@@ -154,12 +154,20 @@ class FieldMapping:
 
 @dataclass(frozen=True)
 class InferredSchema:
-    """Result of running InferMap with a domain pack as target."""
+    """Result of running InferMap with a domain pack as target.
+
+    ``layers`` carries the identity layers (parties) detected over the same
+    frame — the *who is in this table* axis, orthogonal to ``fields``' *what
+    is this column* axis. It is empty when layer detection was skipped or
+    found nothing, so consumers that predate layers are unaffected: absence
+    means "no layer information", never "one anonymous population".
+    """
 
     domain: str
     fields: dict[str, FieldMapping]
     confidence: float
     schema_version: int = SCHEMA_VERSION
+    layers: list[IdentityLayer] = field(default_factory=list)
 
     @property
     def unmapped(self) -> list[str]:

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Segment labels: which party each column describes (#2574).**
+  `goldenmatch.core.segments` is a read-only consumer of InferMap's identity
+  layers — `segments_from_schema` reads them off an `InferredSchema` GoldenPipe
+  already produced (free), `detect_segments` detects on demand, and
+  `column_segments` / `is_heterogeneous` are the helpers per-block configuration
+  (#2575) needs as its input. Deliberately inert with respect to matching: it
+  labels, it does not vary scorers, thresholds or blocking, and nothing here
+  reaches the vectorized fast paths or the global-EM assumptions. InferMap stays
+  an optional dependency (lazy import, structural adaptation, fail-open to `[]`).
 - **Zero-config now says when a frame looks like several sources concatenated
   together, and routes to `match_df` (#2540).** `dedupe_df` compares candidate
   pairs WITHIN one frame. When that frame is two catalogues stacked with

--- a/packages/python/goldenmatch/goldenmatch/core/segments.py
+++ b/packages/python/goldenmatch/goldenmatch/core/segments.py
@@ -1,0 +1,148 @@
+"""Segment labels — which *party* each column describes.
+
+InferMap's identity-layer detector answers "who is in this table": a loan tape
+refers to a lender, a borrower and a servicer, each its own entity population.
+This module is GoldenMatch's **read-only consumer** of that answer, turning
+layers into the segment labels that per-block configuration (#2575) needs as
+its input.
+
+Deliberately inert with respect to matching. It labels; it does not vary
+scorers, thresholds, weights or blocking, and nothing here reaches the
+vectorized fast paths, the global EM, or the single-score-space clustering
+assumption. Those are #2575's subject, behind its measured-quality-win gate.
+Landing the labels first is what makes that work testable.
+
+**Two entry points, one shape.** When GoldenPipe already ran InferMap, the
+layers ride on ``InferredSchema.layers`` and cost nothing to read
+(:func:`segments_from_schema`). Standalone callers detect on demand
+(:func:`detect_segments`), which is name-only and so costs what
+``detect_domain`` costs.
+
+**Optional dependency, fail-open.** InferMap is not a GoldenMatch runtime
+dependency — the import is lazy and every failure degrades to ``[]``, the same
+posture ``core/survivorship/groups.py`` uses for its InferMap-fed detection.
+An empty list means "no segment information", never "one anonymous
+population": callers must not read absence as a claim about the data.
+
+Layer objects are consumed **structurally** (``role`` / ``kind`` / ``columns``
+/ ``score`` / ``reason``) rather than by importing ``goldencheck_types``, which
+keeps GoldenMatch free of a hard dependency on the wire package.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Label carried by a segment whose party is clearly present but unrecognised.
+#: Mirrors ``goldencheck_types.UNKNOWN_ROLE`` structurally (see module docstring
+#: on why the constant is not imported).
+UNKNOWN_SEGMENT: str = "unknown"
+
+
+@dataclass(frozen=True)
+class Segment:
+    """One party present in a frame, and the columns describing it.
+
+    A *segment* is GoldenMatch's name for what InferMap calls an identity
+    layer. Same grouping, consumer-side vocabulary: #2575 partitions work by
+    segment, so the label is the thing that travels.
+
+    ``score`` and ``reason`` are carried through from detection unchanged so a
+    consumer can gate on detection confidence rather than trusting every label
+    equally — the never-black-box commitment applied to this surface.
+    """
+
+    label: str
+    kind: str
+    columns: list[str] = field(default_factory=list)
+    score: float = 0.0
+    reason: str = ""
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.label == UNKNOWN_SEGMENT
+
+
+def _to_segment(layer: Any) -> Segment | None:
+    """Structurally adapt one identity layer. Returns None if it is not one."""
+    role = getattr(layer, "role", None)
+    columns = getattr(layer, "columns", None)
+    if not isinstance(role, str) or columns is None:
+        return None
+    return Segment(
+        label=role,
+        kind=str(getattr(layer, "kind", "unknown")),
+        columns=[str(c) for c in columns],
+        score=float(getattr(layer, "score", 0.0) or 0.0),
+        reason=str(getattr(layer, "reason", "")),
+    )
+
+
+def segments_from_layers(layers: Any) -> list[Segment]:
+    """Adapt InferMap identity layers into segments. Fail-open: bad input -> []."""
+    if not layers:
+        return []
+    try:
+        return [s for s in (_to_segment(lyr) for lyr in layers) if s is not None]
+    except Exception as exc:  # fail-open
+        logger.warning("segment adaptation failed (%s); no segments", exc)
+        return []
+
+
+def segments_from_schema(schema: Any) -> list[Segment]:
+    """Read segments off an ``InferredSchema`` GoldenPipe already produced.
+
+    The free path: InferMap ran in the pipeline's ``infer_schema`` stage, so
+    this is a field read, not a detection. Schemas predating layers carry no
+    ``layers`` attribute and yield ``[]``.
+    """
+    if schema is None:
+        return []
+    return segments_from_layers(getattr(schema, "layers", None))
+
+
+def detect_segments(df: Any, *, domain: str | None = None) -> list[Segment]:
+    """Detect segments directly, for callers with no ``InferredSchema`` in hand.
+
+    Name-only detection via InferMap. Fail-open on everything, ``ImportError``
+    included: InferMap is optional here.
+    """
+    if df is None:
+        return []
+    try:
+        import infermap
+
+        result = infermap.detect_identity_layers(df, domain=domain)
+    except Exception as exc:  # fail-open (incl. ImportError)
+        logger.debug("segment detection unavailable (%s); no segments", exc)
+        return []
+    return segments_from_layers(getattr(result, "layers", None))
+
+
+def column_segments(segments: list[Segment]) -> dict[str, str]:
+    """Column name -> segment label, for the columns that belong to one.
+
+    First segment wins a contested column, matching detection order (segments
+    arrive best-scored-first). Columns in no segment are simply absent — the
+    caller decides what unlabelled means rather than being handed a guess.
+    """
+    out: dict[str, str] = {}
+    for seg in segments:
+        for col in seg.columns:
+            out.setdefault(col, seg.label)
+    return out
+
+
+def is_heterogeneous(segments: list[Segment]) -> bool:
+    """True when a frame describes more than one party.
+
+    The precondition for per-block configuration being worth anything: a
+    single-segment frame is exactly the uniform case one global config already
+    serves well. No segments detected is **not** heterogeneous — absence of
+    evidence is not evidence of uniformity, but it is also not a licence to
+    partition.
+    """
+    return len(segments) > 1

--- a/packages/python/goldenmatch/tests/test_segments.py
+++ b/packages/python/goldenmatch/tests/test_segments.py
@@ -169,9 +169,9 @@ def test_heterogeneity_needs_more_than_one_segment():
 def test_module_imports_without_goldencheck_types():
     """The structural adapter is what keeps that dependency optional."""
     import pathlib
+    import sys
 
-    import goldenmatch.core.segments as mod
-
+    mod = sys.modules[detect_segments.__module__]
     src = pathlib.Path(mod.__file__).read_text(encoding="utf-8")
     assert "import goldencheck_types" not in src
     assert "from goldencheck_types" not in src

--- a/packages/python/goldenmatch/tests/test_segments.py
+++ b/packages/python/goldenmatch/tests/test_segments.py
@@ -1,0 +1,177 @@
+"""Segment labels (#2574 Wave 4) — GoldenMatch's read-only consumer of layers.
+
+Two properties carry the weight here: the adapter is structural (no
+goldencheck_types import, so an optional dependency stays optional), and
+every path fails open to ``[]`` rather than raising into a matching run.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+import pytest
+from goldenmatch.core.segments import (
+    UNKNOWN_SEGMENT,
+    Segment,
+    column_segments,
+    detect_segments,
+    is_heterogeneous,
+    segments_from_layers,
+    segments_from_schema,
+)
+
+
+@dataclass(frozen=True)
+class _Layer:
+    """Structural stand-in for goldencheck_types.IdentityLayer."""
+
+    role: str
+    kind: str
+    columns: list[str]
+    score: float = 0.9
+    reason: str = "affix"
+
+
+@dataclass(frozen=True)
+class _Schema:
+    layers: list
+
+
+def _loan_tape() -> pl.DataFrame:
+    return pl.DataFrame({
+        "lender_name": ["Acme Bank"],
+        "lender_id": ["L1"],
+        "borrower_name": ["Jane Roe"],
+        "borrower_ssn": ["123456789"],
+    })
+
+
+# ── adaptation ────────────────────────────────────────────────────────────
+
+def test_layers_adapt_to_segments():
+    segs = segments_from_layers([
+        _Layer("lender", "organization", ["lender_name", "lender_id"]),
+        _Layer("borrower", "person", ["borrower_name"], score=0.7, reason="role_hint"),
+    ])
+    assert [s.label for s in segs] == ["lender", "borrower"]
+    assert segs[0].kind == "organization"
+    assert segs[0].columns == ["lender_name", "lender_id"]
+    assert segs[1].score == 0.7
+    assert segs[1].reason == "role_hint"
+
+
+def test_unknown_role_is_flagged_not_dropped():
+    segs = segments_from_layers([_Layer(UNKNOWN_SEGMENT, "unknown", ["zz_id"])])
+    assert len(segs) == 1
+    assert segs[0].is_unknown
+
+
+def test_non_layer_objects_are_skipped_not_raised():
+    segs = segments_from_layers([object(), _Layer("lender", "organization", ["a"])])
+    assert [s.label for s in segs] == ["lender"]
+
+
+def test_empty_and_none_layers():
+    assert segments_from_layers([]) == []
+    assert segments_from_layers(None) == []
+
+
+# ── schema path (the free one) ────────────────────────────────────────────
+
+def test_segments_read_off_a_schema():
+    schema = _Schema(layers=[_Layer("lender", "organization", ["lender_id"])])
+    assert [s.label for s in segments_from_schema(schema)] == ["lender"]
+
+
+def test_schema_without_layers_yields_none():
+    """A schema predating layers must not raise."""
+    assert segments_from_schema(object()) == []
+    assert segments_from_schema(None) == []
+
+
+# ── detection path ────────────────────────────────────────────────────────
+
+def test_detect_segments_on_a_multiparty_frame():
+    pytest.importorskip("infermap")
+    segs = detect_segments(_loan_tape(), domain="finance")
+    labels = {s.label for s in segs}
+    assert len(segs) >= 2
+    assert {"lender", "borrower"} & labels
+
+
+def test_detect_segments_matches_the_schema_path():
+    """Both entry points must produce the same shape for the same frame."""
+    infermap = pytest.importorskip("infermap")
+    df = _loan_tape()
+    direct = detect_segments(df, domain="finance")
+    via_schema = segments_from_schema(
+        _Schema(layers=list(infermap.detect_identity_layers(df, domain="finance").layers))
+    )
+    assert direct == via_schema
+
+
+def test_detect_segments_fails_open_on_bad_input():
+    assert detect_segments(None) == []
+    assert detect_segments("not a frame") == []
+
+
+def test_detect_segments_fails_open_when_infermap_is_absent(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_infermap(name, *args, **kwargs):
+        if name == "infermap":
+            raise ImportError("infermap is optional here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_infermap)
+    assert detect_segments(_loan_tape()) == []
+
+
+# ── consumer helpers (#2575's inputs) ─────────────────────────────────────
+
+def test_column_segments_maps_columns_to_labels():
+    segs = [
+        Segment("lender", "organization", ["lender_name", "lender_id"]),
+        Segment("borrower", "person", ["borrower_name"]),
+    ]
+    assert column_segments(segs) == {
+        "lender_name": "lender",
+        "lender_id": "lender",
+        "borrower_name": "borrower",
+    }
+
+
+def test_contested_column_goes_to_the_first_segment():
+    segs = [
+        Segment("lender", "organization", ["shared_id"]),
+        Segment("borrower", "person", ["shared_id"]),
+    ]
+    assert column_segments(segs)["shared_id"] == "lender"
+
+
+def test_unlabelled_columns_are_absent_not_guessed():
+    segs = [Segment("lender", "organization", ["lender_id"])]
+    assert "amount" not in column_segments(segs)
+
+
+def test_heterogeneity_needs_more_than_one_segment():
+    one = [Segment("customer", "person", ["name"])]
+    two = one + [Segment("lender", "organization", ["lender_id"])]
+    assert is_heterogeneous(two)
+    assert not is_heterogeneous(one)
+    # No detection is not a claim of uniformity — but it is not a licence to
+    # partition either.
+    assert not is_heterogeneous([])
+
+
+def test_module_imports_without_goldencheck_types():
+    """The structural adapter is what keeps that dependency optional."""
+    import pathlib
+
+    import goldenmatch.core.segments as mod
+
+    src = pathlib.Path(mod.__file__).read_text(encoding="utf-8")
+    assert "import goldencheck_types" not in src
+    assert "from goldencheck_types" not in src

--- a/packages/python/goldenpipe/CHANGELOG.md
+++ b/packages/python/goldenpipe/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **`infer_schema` emits identity layers (#2574).** The stage now runs InferMap's
+  layer detector over the same frame and puts the result on
+  `InferredSchema.layers`, so downstream consumers get the *who is in this table*
+  axis without re-detecting. Detection is name-only, so it costs what
+  `detect_domain` costs. `infer_schema_evidence` gains `layer_roles` /
+  `layer_unassigned`. The pre-existing mapping and detection outputs are
+  unchanged; a user-supplied `schema` still passes through untouched.
+
 ## 1.4.0 (2026-07-16)
 
 ### Added

--- a/packages/python/goldenpipe/goldenpipe/stages/infer_schema.py
+++ b/packages/python/goldenpipe/goldenpipe/stages/infer_schema.py
@@ -4,6 +4,11 @@ Produces ``ctx.artifacts['inferred_schema']`` (a goldencheck_types.InferredSchem
 or None when InferMap is skipped). Consumes nothing — must run before any
 other stage that wants typed columns.
 
+The schema carries two axes: ``fields`` (what each column *is*) and ``layers``
+(which *party* the frame describes — see ``infermap.detect_identity_layers``).
+Layer detection is name-only and unconditional; it never perturbs the mapping
+or domain-detection outputs.
+
 Configuration via ``ctx.stage_config``:
     domain: str | None    Force a specific domain pack name.
     schema: InferredSchema | None    User-provided schema; skip InferMap.
@@ -133,11 +138,24 @@ def infer_schema_stage(ctx: PipeContext) -> StageResult:
     target = infermap.DomainPackTarget(pack)
     map_result = infermap.map(ctx.df, target, soft=True)
     inferred = _result_to_inferred_schema(map_result, domain)
+
+    # Identity layers: the *who is in this table* axis, detected over the same
+    # frame with the domain we just resolved. Name-only, so it costs what
+    # detect_domain costs -- cheap enough to be unconditional, which is what
+    # keeps it zero-config for downstream consumers (goldenmatch segments).
+    layer_result = infermap.detect_identity_layers(ctx.df, domain=domain)
     # Confidence reflects detection quality (was always min() of mapping
     # confidences before, regardless of whether detection was confident).
     # Replace because InferredSchema is frozen.
     from dataclasses import replace
-    inferred = replace(inferred, confidence=detect_score)
+    inferred = replace(
+        inferred, confidence=detect_score, layers=list(layer_result.layers)
+    )
     ctx.artifacts["inferred_schema"] = inferred
+    detect_evidence = {
+        **detect_evidence,
+        "layer_roles": list(layer_result.roles),
+        "layer_unassigned": list(layer_result.unassigned),
+    }
     ctx.artifacts.setdefault("infer_schema_evidence", detect_evidence)
     return StageResult(status=StageStatus.SUCCESS)

--- a/packages/python/goldenpipe/tests/test_infer_schema_stage.py
+++ b/packages/python/goldenpipe/tests/test_infer_schema_stage.py
@@ -70,3 +70,74 @@ def test_conflict_no_infer_and_schema_raises():
     ctx = _ctx(no_infer=True, schema=user)
     with pytest.raises(ValueError, match="conflict"):
         infer_schema_stage.run(ctx)
+
+
+# ── Identity layers (#2574 Wave 4) ────────────────────────────────────────
+#
+# The stage emits layers onto InferredSchema so downstream consumers
+# (goldenmatch segments) get them without re-detecting.
+
+
+def _multiparty_ctx(**stage_config) -> PipeContext:
+    df = pl.DataFrame({
+        "lender_name": ["Acme Bank"],
+        "lender_id": ["L1"],
+        "borrower_name": ["Jane Roe"],
+        "borrower_ssn": ["123456789"],
+    })
+    return PipeContext(df=df, stage_config=stage_config)
+
+
+def test_layers_emitted_on_inferred_schema():
+    ctx = _multiparty_ctx()
+    infer_schema_stage.run(ctx)
+    layers = ctx.artifacts["inferred_schema"].layers
+    assert len(layers) >= 2
+    cols = {c for lyr in layers for c in lyr.columns}
+    assert "lender_name" in cols and "borrower_name" in cols
+
+
+def test_layers_match_a_direct_detector_call():
+    """The stage must not transform what the detector returned."""
+    import infermap
+
+    ctx = _multiparty_ctx(domain="finance")
+    infer_schema_stage.run(ctx)
+    emitted = ctx.artifacts["inferred_schema"].layers
+    direct = infermap.detect_identity_layers(ctx.df, domain="finance").layers
+    assert [(x.role, x.columns, x.score) for x in emitted] == [
+        (x.role, x.columns, x.score) for x in direct
+    ]
+
+
+def test_layer_roles_recorded_in_evidence():
+    ctx = _multiparty_ctx()
+    infer_schema_stage.run(ctx)
+    ev = ctx.artifacts["infer_schema_evidence"]
+    assert "layer_roles" in ev and "layer_unassigned" in ev
+    assert ev["layer_roles"] == [lyr.role for lyr in ctx.artifacts["inferred_schema"].layers]
+
+
+def test_single_party_frame_yields_one_layer():
+    """The common case, not a degenerate one."""
+    ctx = _ctx()
+    infer_schema_stage.run(ctx)
+    assert len(ctx.artifacts["inferred_schema"].layers) == 1
+
+
+def test_user_supplied_schema_layers_untouched():
+    """schema > everything: a pinned schema is passed through, layers and all."""
+    user = InferredSchema(domain="user", fields={}, confidence=1.0)
+    ctx = _multiparty_ctx(schema=user)
+    infer_schema_stage.run(ctx)
+    assert ctx.artifacts["inferred_schema"].layers == []
+
+
+def test_detect_domain_path_is_unperturbed():
+    """Guardrail from the design: the pre-existing fields must not move."""
+    ctx = _ctx()
+    infer_schema_stage.run(ctx)
+    inferred = ctx.artifacts["inferred_schema"]
+    assert inferred.domain == "finance"
+    assert set(inferred.fields) == {"account_number", "currency"}
+    assert inferred.confidence > 0.0

--- a/packages/typescript/goldencheck-types/src/types.ts
+++ b/packages/typescript/goldencheck-types/src/types.ts
@@ -168,6 +168,11 @@ export interface InferredSchema {
   readonly fields: Record<string, FieldMapping>;
   readonly confidence: number;
   readonly schema_version?: number;
+  /** Identity layers (parties) detected over the same frame — the *who is in
+   *  this table* axis, orthogonal to `fields`' *what is this column* axis.
+   *  Empty/absent when layer detection was skipped or found nothing: that
+   *  means "no layer information", never "one anonymous population". */
+  readonly layers?: readonly IdentityLayer[];
 }
 
 export const isUnknown = (m: FieldMapping): boolean => m.type === UNMAPPED_TYPE;


### PR DESCRIPTION
## What and why

Waves 1-2 (#2578, #2581) shipped identity-layer detection as a library, CLI and MCP capability that nothing consumed. Wave 4 of #2574 wires it into the two places that make it actionable: GoldenPipe emits layers on the schema it already produces, and GoldenMatch reads them as segment labels, which is the input per-block configuration (#2575) needs.

This labels and stops. It does not vary scorers, thresholds, weights or blocking, and it touches neither the vectorized fast paths nor the global-EM / single-score-space assumptions. Those are #2575's subject, behind its measured-quality-win gate; landing the labels separately is what makes that work testable.

## Changes

- **`goldencheck_types.InferredSchema` gains `layers`** (default empty), mirrored in `packages/typescript/goldencheck-types/src/types.ts` in the same commit per the cross-language parity contract. No `SCHEMA_VERSION` bump: the v4 contract cut in Wave 1 already declares that layers travel InferMap to GoldenPipe to GoldenMatch, and the field is additive with a default. Empty means "no layer information", never "one anonymous population".
- **`goldenpipe.stages.infer_schema` populates it** from `detect_identity_layers` over the frame it already has, using the domain it just resolved. Unconditional, because name-only detection costs what `detect_domain` costs, so a flag would be zero-config tax for no saving. `infer_schema_evidence` gains `layer_roles` / `layer_unassigned`. The mapping and domain-detection outputs are unchanged, and a user-supplied `schema` still passes through untouched (covered by a guardrail test).
- **New `goldenmatch/core/segments.py`**, the read-only consumer. `segments_from_schema` reads layers GoldenPipe already produced (a field read, not a detection); `detect_segments` detects on demand; `column_segments` and `is_heterogeneous` are the helpers #2575 consumes. Layers are adapted **structurally** rather than by importing `goldencheck_types`, so neither it nor infermap becomes a hard GoldenMatch dependency, and every path fails open to `[]` - the posture `core/survivorship/groups.py` already uses for its InferMap-fed detection.
- Spec status updated (Waves 1, 2, 4 landed; Wave 3 open), both CHANGELOGs, and the regenerated `docs/agent-codemap.json`.

## Testing

- `pytest packages/python/goldenpipe/ packages/python/goldencheck-types/` - 314 passed, 21 skipped, matching the pre-change baseline exactly. The 3 `test_a2a` collection errors are pre-existing (a starlette/httpx deprecation), confirmed identical on stashed code.
- `pytest packages/python/goldenmatch/tests/test_segments.py` - 18 passed, covering structural adaptation, both entry points agreeing on the same frame, fail-open on bad input and on a simulated missing infermap, and the consumer helpers.
- `ruff check` clean across the three changed Python packages; `pnpm --filter goldencheck-types typecheck` clean.
- `python scripts/regen_docs.py --check` clean after committing the regenerated codemap.

Note for the record: running goldenpipe, goldencheck-types and infermap test dirs in a **single** pytest invocation makes 6 `test_tui` tests fail through cross-package import pollution. That is pre-existing (identical failure set on stashed code) and CI never hits it, since the Python matrix runs one package per job. Not introduced here, and not fixed here.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean - not run, `pre-commit` is not installed in this environment; `ruff check` was run directly and is clean
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_