### PR TITLE
bench(fs): add an as-shipped control lane, and record every handicap

### DIFF
--- a/.github/workflows/bench-er-headtohead.yml
+++ b/.github/workflows/bench-er-headtohead.yml
@@ -4,7 +4,7 @@
 # machine with an identical per-scale parquet fixture, so wall + peak-RSS are
 # comparable across engines.
 #
-# Lanes (7, selectable via the `lanes` input):
+# Lanes (8, selectable via the `lanes` input):
 #   splink                    - Fellegi-Sunter reference engine (pinned version)
 #   gm_hand_built             - GM fast weighted bucket+native path (speed reference)
 #   gm_probabilistic          - EM-trained FS, numpy fallback (GOLDENMATCH_FS_NATIVE=0)
@@ -15,6 +15,11 @@
 #                               (GOLDENMATCH_FS_EM_COUNTED=1). Differs from
 #                               gm_probabilistic_native ONLY in the trainer, so
 #                               the delta isolates it.
+#   gm_probabilistic_shipped  - the SAME probabilistic path with NO handicap:
+#                               no scorer rewrite, no calibration override, no
+#                               forced threshold. Not comparable to Splink and
+#                               not meant to be -- it is the control that stops
+#                               a handicapped F1 being read as GM's accuracy.
 #   gm_zeroconfig             - zero-effort controller
 #   gm_converted_splink       - GM running Splink's own spec via from_splink
 #
@@ -44,7 +49,7 @@ on:
       lanes:
         description: "Space-separated lanes to run"
         required: false
-        default: "splink gm_hand_built gm_probabilistic gm_probabilistic_native gm_probabilistic_counted gm_zeroconfig gm_converted_splink"
+        default: "splink gm_hand_built gm_probabilistic gm_probabilistic_native gm_probabilistic_counted gm_probabilistic_shipped gm_zeroconfig gm_converted_splink"
       shapes:
         description: "Space-separated fixture shapes (person biblio product)"
         required: false

--- a/scripts/bench_er_headtohead/orchestrate.py
+++ b/scripts/bench_er_headtohead/orchestrate.py
@@ -51,7 +51,7 @@ class Lane:
 # four need --allow-pure-python locally (CI builds native and passes False).
 _GM_RUN_LANES = {"gm_hand_built", "gm_probabilistic",
                  "gm_probabilistic_native", "gm_probabilistic_counted",
-                 "gm_zeroconfig"}
+                 "gm_probabilistic_shipped", "gm_zeroconfig"}
 
 LANES: dict[str, Lane] = {
     "splink": Lane("splink", "run_splink.py"),
@@ -92,6 +92,25 @@ LANES: dict[str, Lane] = {
                                           "GOLDENMATCH_FS_CALIBRATED": "posterior",
                                           "GOLDENMATCH_FS_EM_COUNTED": "1"},
                                      extra_args=("--fs-basic-scorers",)),
+    # GM AS SHIPPED. Every other FS lane is deliberately handicapped for
+    # comparability -- `--fs-basic-scorers` forces the specialised name scorers
+    # (given_name_aliased_jw, name_freq_weighted_jw) down to plain jaro_winkler
+    # so GM and Splink run the same comparison model, and
+    # GOLDENMATCH_FS_CALIBRATED=posterior overrides GM's `linear` default so a
+    # shared --threshold means the same thing to both engines.
+    #
+    # Both are RIGHT for a Splink comparison and WRONG as a statement of what
+    # GoldenMatch does. Without this lane the panel's only FS numbers are
+    # handicapped ones, and they read as GM's accuracy -- which is exactly how
+    # I misread them: on a 20K person fixture the handicapped config scores
+    # F1 0.0000 where the shipped default scores 0.9964, same data, same engine.
+    #
+    # So this lane runs the probabilistic path with NO rewrite and NO
+    # calibration override. It is not comparable to Splink and is not meant to
+    # be; it is the control that keeps the handicapped lanes honest.
+    "gm_probabilistic_shipped": Lane("gm_probabilistic_shipped",
+                                     "run_goldenmatch.py",
+                                     mode="probabilistic"),
     "gm_zeroconfig": Lane("gm_zeroconfig", "run_goldenmatch.py", mode="zeroconfig"),
     "gm_converted_splink": Lane("gm_converted_splink", "run_gm_converted.py"),
 }

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -241,8 +241,16 @@ def main() -> None:
             # Measured on a 20K person fixture, the cut alone is worth
             # F1 0.5406 (at 0.95) -> 0.8772 (at 0.85) with precision staying
             # 1.0000 throughout -- see `diagnose_fs_recall.py`.
-            for mk in cfg.get_matchkeys():
-                mk.link_threshold = args.threshold
+            #
+            # Tied to `--fs-basic-scorers` because both adjustments serve the
+            # SAME purpose -- making this lane comparable to Splink -- and a
+            # lane that is not being compared to Splink should not inherit
+            # either. `gm_probabilistic_shipped` runs without the flag and so
+            # keeps GM's own threshold decision, which is the point of having
+            # it: a control that shows what GoldenMatch actually does.
+            if args.fs_basic_scorers:
+                for mk in cfg.get_matchkeys():
+                    mk.link_threshold = args.threshold
             # Force rerank off so a 3+ field weighted matchkey can't pull a
             # cross-encoder model down from HuggingFace at dedupe time.
             for mk in cfg.get_matchkeys():
@@ -275,6 +283,20 @@ def main() -> None:
                             rewritten.append((getattr(f, "field", None), sc))
                             f.scorer = "jaro_winkler"
             result["fs_basic_scorers_rewritten"] = rewritten
+            # ALWAYS recorded, present or absent, so a reader never has to infer
+            # from a missing key whether this number is comparable-to-Splink or
+            # as-shipped. Reading a handicapped F1 as "GoldenMatch's accuracy"
+            # is a real failure mode -- it cost this repo a five-session detour
+            # on a 20K person fixture where the handicapped config scores
+            # F1 0.0000 and the shipped default scores 0.9964.
+            result["handicaps"] = {
+                "fs_basic_scorers": bool(args.fs_basic_scorers),
+                "forced_link_threshold": (
+                    args.threshold if args.fs_basic_scorers else None
+                ),
+                "fs_calibrated": os.environ.get("GOLDENMATCH_FS_CALIBRATED"),
+                "comparable_to_splink": bool(args.fs_basic_scorers),
+            }
             # FS-native per-matchkey eligibility telemetry (spec section 8): count
             # how many resolved matchkeys the native FS kernel could score. Under
             # the numpy lane (GOLDENMATCH_FS_NATIVE=0) _fs_native_enabled()


### PR DESCRIPTION
**Correction to my own earlier claim first.** I said the FS lanes and `gm_converted_splink` were unequally handicapped *on scorers*, and that this explained their gap. **That's wrong** — Splink's spec uses `JaroWinklerAtThresholds`, so the converted lane lands on `jaro_winkler` anyway. The asymmetry that did matter was the link threshold, and #2571 already fixed it.

## The real problem is reporting, not fairness

Every FS lane is deliberately handicapped for Splink comparability:

- `--fs-basic-scorers` forces the specialised name scorers (`given_name_aliased_jw`, `name_freq_weighted_jw`) down to plain `jaro_winkler`
- `GOLDENMATCH_FS_CALIBRATED=posterior` overrides GM's `linear` default

Both are **right for the comparison** and **wrong as a statement of what GoldenMatch does** — and until now the panel's only FS numbers were the handicapped ones, with nothing saying so.

Measured on a 20K person fixture, same data, same engine:

| config | F1 |
|---|---|
| shipped default `dedupe_df(df)` | **0.9964** |
| handicapped (forced FS + posterior + basic scorers) | **0.0000** |

I read the handicapped number as GM's accuracy and spent five sessions chasing a threshold problem **in a configuration nobody runs**. The canonical benchmark (plain `dedupe_df`) says Febrl3 0.9912, NCVR 0.9932.

## Two changes

**1. `gm_probabilistic_shipped`** — the same path with no rewrite, no calibration override, no forced threshold. Not comparable to Splink and not meant to be; it's the control that keeps the handicapped lanes honest.

**2. `result["handicaps"]`, always present** — which handicaps applied, what threshold was forced, which calibration was active, and `comparable_to_splink` stated outright. Recorded even when nothing applied, so a reader never infers from a *missing* key which kind of number they're looking at.

Threshold forcing is now tied to `--fs-basic-scorers` rather than unconditional: a lane not being compared to Splink should inherit neither adjustment.

Verified by running the real lane script both ways — handicapped reports `comparable_to_splink: True` with the threshold forced to 0.85; shipped reports `False` with none applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ