### PR TITLE
feat(spark): give the scale fixture real entropy

### DIFF
--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -50,32 +50,70 @@ import time
 def build_fixture(spark, rows: int, dup: int, blocks_per_key: int):
     """A person-shaped frame with a known duplicate structure, built in-engine.
 
-    ``dup`` rows per entity, so the true-match count is known:
-    ``n_entities * C(dup, 2)``. Blocking keys are derived from the entity id so
-    duplicates land in the same block -- a fixture whose duplicates never block
-    together would measure an empty candidate set very quickly and prove
-    nothing.
+    ``dup`` rows per entity, so the true-match count is known. Blocking keys are
+    derived from the entity id so duplicates land in the same block -- a fixture
+    whose duplicates never block together would measure an empty candidate set
+    very quickly and prove nothing.
+
+    ## Entropy is the point, and the first version of this had none
+
+    The original generator perturbed ONE field with ONE of two spellings, so
+    9.5M candidate pairs collapsed to **3 and 2 distinct comparison vectors**.
+    That measured the collapse mechanism working on data with nothing to
+    collapse -- it proved `prod(levels + 1)` bounds the driver-side EM without
+    ever approaching the bound.
+
+    Every field is now perturbed INDEPENDENTLY, by a per-(row, field) hash:
+
+      * a character dropped (a truncation typo),
+      * a character appended (a fat-finger typo),
+      * nulled entirely (missing data -> the `-1` unobserved level),
+      * left alone.
+
+    Independence is what produces variety: with five fields each landing on
+    agree / partial / unobserved, the reachable vector space is in the hundreds,
+    and which of them actually occur is a property of the data rather than of
+    the generator's single knob.
+
+    Deterministic despite being pseudo-random: `xxhash64(id, field_seed)` is a
+    pure function of the row, so two runs at the same scale produce byte-
+    identical fixtures and a regression is a real change rather than a reroll.
     """
     from pyspark.sql import functions as F
 
     n_entities = max(rows // max(dup, 1), 1)
     ent = F.col("id") % F.lit(n_entities)
-    # A cheap deterministic perturbation: one row in `dup` gets a variant
-    # spelling, so comparison vectors are not all "agree on everything".
-    variant = (F.col("id") / F.lit(n_entities)).cast("int") % F.lit(max(dup, 1))
+    ent_s = ent.cast("string")
+
+    def perturbed(base, seed: int):
+        h = F.pmod(F.xxhash64(F.col("id"), F.lit(seed)), F.lit(10))
+        return (
+            F.when(h < F.lit(6), base)                                    # 60% clean
+             .when(h < F.lit(8), F.substring(base, 1, 3))                 # 20% truncated
+             .when(h < F.lit(9), F.concat(base, F.lit("x")))              # 10% typo
+             .otherwise(F.lit(None).cast("string"))                       # 10% missing
+        )
+
+    first = F.concat(F.lit("ann"), ent_s)
+    last = F.concat(F.lit("lee"), (ent % F.lit(max(n_entities // 3, 1))).cast("string"))
+    dob = F.concat(F.lit("19"), F.lpad((ent % F.lit(80)).cast("string"), 2, "0"),
+                   F.lit("-01-01"))
+    zipc = F.concat(F.lit("z"), F.lpad((ent % F.lit(500)).cast("string"), 3, "0"))
+    city = F.concat(F.lit("city"), (ent % F.lit(40)).cast("string"))
 
     return spark.range(rows).select(
         F.col("id").alias("__row_id__"),
-        F.when(variant == 0, F.concat(F.lit("ann"), ent.cast("string")))
-         .otherwise(F.concat(F.lit("anna"), ent.cast("string"))).alias("first"),
-        F.concat(F.lit("lee"), (ent % F.lit(max(n_entities // 3, 1))).cast("string"))
-         .alias("last"),
-        # The blocking key: `blocks_per_key` entities share one value, so block
-        # size is about `dup * blocks_per_key` and the candidate count stays
-        # linear in rows rather than quadratic.
-        F.concat(F.lit("k"), (ent / F.lit(max(blocks_per_key, 1))).cast("int").cast("string"))
+        perturbed(first, 101).alias("first"),
+        perturbed(last, 202).alias("last"),
+        perturbed(dob, 303).alias("dob"),
+        perturbed(zipc, 404).alias("zip"),
+        perturbed(city, 505).alias("city"),
+        # The blocking key is NEVER perturbed: it decides which pairs are
+        # compared at all, so corrupting it would silently shrink the candidate
+        # set and make a smaller run look like a faster one.
+        F.concat(F.lit("k"),
+                 (ent / F.lit(max(blocks_per_key, 1))).cast("int").cast("string"))
          .alias("blk"),
-        F.concat(F.lit("z"), (ent % F.lit(500)).cast("string")).alias("zip"),
     )
 
 
@@ -100,13 +138,24 @@ def make_config():
             ],
         ),
         matchkeys=[
+            # FIVE fields at three levels each. The comparison-vector space is
+            # `prod(levels + 1)` = 4^5 = 1,024, so the driver-side EM has a
+            # bound worth testing. The previous two-field / two-level config
+            # capped it at 9 -- the run reported 3 and 2 distinct patterns and
+            # could not have reported more than 9 whatever the data looked like.
             MatchkeyConfig(
                 name="fs", type="probabilistic",
                 fields=[
                     MatchkeyField(field="first", scorer="jaro_winkler",
-                                  levels=2, partial_threshold=0.8),
+                                  levels=3, partial_threshold=0.7),
                     MatchkeyField(field="last", scorer="jaro_winkler",
-                                  levels=2, partial_threshold=0.8),
+                                  levels=3, partial_threshold=0.7),
+                    MatchkeyField(field="dob", scorer="levenshtein",
+                                  levels=3, partial_threshold=0.7),
+                    MatchkeyField(field="zip", scorer="jaro_winkler",
+                                  levels=3, partial_threshold=0.7),
+                    MatchkeyField(field="city", scorer="jaro_winkler",
+                                  levels=3, partial_threshold=0.7),
                 ],
             ),
         ],


### PR DESCRIPTION
The 1M-row cluster run passed and **proved less than it appeared to**. Its two blocking passes reported **3 and 2 distinct comparison vectors** from 9.5M candidate pairs — so the driver-side EM was 0.00s because there was almost nothing to iterate over, not because the collapse handled a realistic load.

## Two causes, and I'd only noticed one

**1. The data had no variety.** One field perturbed, one of two spellings. Every other field agreed on every pair by construction.

**2. The config could not express variety.** Two fields at two levels caps the vector space at `prod(levels + 1)` = **9**. The run could not have reported more than 9 patterns whatever the data looked like — so fixing only the generator would have raised 3 to at most 9.

Both change together: every field perturbed **independently** by a per-(row, field) hash (60% clean, 20% truncated, 10% typo, 10% nulled → the `-1` unobserved level), and the matchkey is five fields at three levels — a space of 4⁵ = 1,024.

## Pre-flighted without Spark

Simulated the perturbation and level ladder in pure Python: **243 distinct vectors** over 60K simulated pairs, against the previous 3.

Not a parity check (Spark's `xxhash64` isn't Python's `blake2b`) and not meant to be — it answers the only question worth answering before spending a cluster run: does independent per-field perturbation produce variety at all? It does, and it lands **well under** the ceiling rather than saturating it, so the bound stays a bound rather than becoming the answer.

## Details

- **Deterministic** despite being pseudo-random — the hash is a pure function of the row id, so two runs at the same scale are byte-identical and a regression is a real change rather than a reroll.
- **The blocking key is never perturbed.** It decides which pairs are compared at all; corrupting it would silently shrink the candidate set and make a smaller run look like a faster one.
- Removed 18 dead lines — a first attempt that tried to read a Column's expression via `_jc.toString()`. Unreachable, and shipping a broken draft beside the working one is how a reader ends up believing the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5KmXAPkZ8FBLYfxb9hXFZ