### PR TITLE
fix(spark): stop the scale fixture collapsing a blocking field to one key

### DIFF
--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -87,9 +87,17 @@ def build_fixture(spark, rows: int, dup: int, blocks_per_key: int):
 
     def perturbed(base, seed: int):
         h = F.pmod(F.xxhash64(F.col("id"), F.lit(seed)), F.lit(10))
+        # The truncation drops the LAST character, not everything after the
+        # third. `substring(base, 1, 3)` collapsed every truncated value to the
+        # field's shared literal prefix -- every truncated `last` became "lee",
+        # so blocking pass 1 (keyed on `last`) put 20% of the table in ONE
+        # block: 200k rows at 1M => ~20 BILLION pairs, and the run wedged for
+        # 24 minutes before the step timeout killed it. Dropping the trailing
+        # character is the typo the docstring above describes and preserves the
+        # field's cardinality.
         return (
             F.when(h < F.lit(6), base)                                    # 60% clean
-             .when(h < F.lit(8), F.substring(base, 1, 3))                 # 20% truncated
+             .when(h < F.lit(8), F.regexp_replace(base, ".$", ""))        # 20% truncated
              .when(h < F.lit(9), F.concat(base, F.lit("x")))              # 10% typo
              .otherwise(F.lit(None).cast("string"))                       # 10% missing
         )
@@ -115,6 +123,38 @@ def build_fixture(spark, rows: int, dup: int, blocks_per_key: int):
                  (ent / F.lit(max(blocks_per_key, 1))).cast("int").cast("string"))
          .alias("blk"),
     )
+
+
+def largest_block(source_df, key_config, transform_udf=None):
+    """``(key, rows)`` for the biggest block one pass would build.
+
+    Blocking skew is the failure mode this harness is least able to report on
+    its own: a skewed key does not raise, it just makes the self-join quadratic
+    in the size of one block and the run sits there producing nothing. The
+    fixture's own truncation bug did exactly that (see `perturbed`), and the
+    only evidence was a 24-minute gap between two log lines.
+
+    Deliberately reuses the product's `_block_key_column` / `_valid_key` rather
+    than grouping by the raw fields. Those privates are what `pass_candidates`
+    joins on, so a guard built on anything else could measure a key the join
+    never uses and clear a pass that then hangs anyway.
+    """
+    from goldenmatch.spark.config_pipeline import _block_key_column, _valid_key
+    from pyspark.sql import functions as F
+
+    key_col, _fields = _block_key_column(key_config, transform_udf)
+    top = (
+        source_df.withColumn("__block_key__", key_col)
+        .where(_valid_key(F.col("__block_key__")))
+        .groupBy("__block_key__")
+        .agg(F.count(F.lit(1)).alias("n"))
+        .orderBy(F.col("n").desc())
+        .limit(1)
+        .collect()
+    )
+    if not top:
+        return None, 0
+    return top[0]["__block_key__"], int(top[0]["n"])
 
 
 def make_config():
@@ -171,6 +211,14 @@ def main() -> int:
     ap.add_argument("--remote", default=os.environ.get(
         "GOLDENMATCH_SPARK_REMOTE", "sc://localhost:15002"))
     ap.add_argument("--u-max-pairs", type=int, default=1_000_000)
+    ap.add_argument(
+        "--max-block-pairs", type=int, default=50_000_000,
+        help="refuse a pass whose LARGEST single block would emit more pairs "
+             "than this. A skewed blocking key does not fail, it hangs -- the "
+             "constant-prefix truncation bug put 20%% of the table in one "
+             "block and the run sat in the join for 24 minutes until the step "
+             "timeout killed it, with no output naming the cause. This turns "
+             "that into a fast, specific refusal.")
     ap.add_argument("--out", default="")
     args = ap.parse_args()
 
@@ -243,6 +291,26 @@ def main() -> int:
     train_wall = 0.0
     for i, key_config in enumerate(blocking_passes(cfg)):
         fields = tuple(key_config.fields)
+
+        # Skew check BEFORE the join, because after it there is nothing to
+        # report -- the join is where a skewed key spends forever.
+        t = time.perf_counter()
+        top_key, top_rows = largest_block(df, key_config)
+        skew_dt = time.perf_counter() - t
+        top_pairs = top_rows * (top_rows - 1) // 2
+        print(f"[scale] pass {i} on {list(fields)}: largest block "
+              f"{top_key!r} has {top_rows:,} rows -> {top_pairs:,} pairs "
+              f"({skew_dt:.2f}s)", flush=True)
+        if top_pairs > args.max_block_pairs:
+            raise SystemExit(
+                f"[scale] pass {i} on {list(fields)} REFUSED: block "
+                f"{top_key!r} holds {top_rows:,} rows, which is "
+                f"{top_pairs:,} pairs on its own -- over --max-block-pairs="
+                f"{args.max_block_pairs:,}. This is a skewed blocking key, "
+                f"not a scale limit. Raise the flag only if the skew is the "
+                f"thing under test."
+            )
+
         cands = pass_candidates(df, key_config, id_col="__row_id__")
         joined = join_candidates_to_sources(cands, df, id_col="__row_id__")
 
@@ -264,6 +332,12 @@ def main() -> int:
             "pass": i, "blocking_fields": list(fields),
             "pairs": n_pairs, "distinct_patterns": len(counts),
             "count_seconds": round(dt, 2),
+            # Recorded even when it passes the guard: skew that is merely bad
+            # is invisible in the totals, and this is the number that moves
+            # when a fixture change quietly reshapes the candidate set.
+            "largest_block_rows": top_rows,
+            "largest_block_key": top_key,
+            "largest_block_pairs": top_pairs,
         })
         print(f"[scale] pass {i} on {list(fields)}: {n_pairs:,} pairs -> "
               f"{len(counts)} distinct patterns in {dt:.2f}s", flush=True)


### PR DESCRIPTION
## What happened

The 1M-row cluster scale run (`31901520923`) reported **success** and published **no artifact**. It had actually wedged:

```
[scale] fixture: 1,000,000 rows in 3.43s
[scale] u in 10.99s -> {...}
[scale] pass 0 on ['blk']: 5,499,993 pairs -> 516 distinct patterns in 54.22s
##[error]The action 'Distributed FS training at scale' has timed out after 25 minutes.
```

24 minutes between the last two lines, all of it inside pass 1's join.

## Cause

#2587's truncation branch was `substring(base, 1, 3)` -- keep the first three characters. Every field's base value starts with a shared literal prefix (`last = "lee" + digits`), so **every truncated `last` became the string `"lee"`**.

Pass 1 blocks on `last`. Simulating the exact fixture:

| | distinct keys | largest block | pairs from that block | total pass-1 pairs |
|---|---|---|---|---|
| `substring(base,1,3)` | 211,112 | **200,000 rows** (`'lee'`) | **19,999,900,000** | 20,001,233,335 |
| drop-last-char | 211,112 | 24 rows | 276 | **4,113,221** |

It would never have finished at any timeout.

The failure was silent at three layers: `continue-on-error` made the step report `success`, `gh run view --json` reports `success` for such steps regardless of exit code, and the upload step's `if-no-files-found: ignore` published nothing without complaint.

## Fix

Drop the **last** character instead. That is the typo the docstring already claimed (\"a character dropped (a truncation typo)\") and it preserves the field's cardinality.

## Guard

A skewed blocking key does not raise, it hangs. `largest_block()` computes the biggest block a pass would build **before** the join and refuses above `--max-block-pairs` (default 50M). It reuses the product's `_block_key_column`/`_valid_key` rather than grouping the raw fields, so it cannot clear a key the join does not actually use. The default sits four orders of magnitude clear of both the bug (20B) and the fixed fixture (276).

`largest_block_rows` / `largest_block_key` / `largest_block_pairs` land in the JSON per pass even when the guard passes -- skew that is merely bad is invisible in the totals.

## Not verified here

The fixed run itself. Pyspark is not installed locally by design; this needs the cluster lane. I will dispatch `spark-cluster.yml -f train_rows=1000000` once this merges and report the per-stage numbers.