### PR TITLE
bench: resume must never span a code change

### DIFF
--- a/.github/workflows/bench-er-headtohead.yml
+++ b/.github/workflows/bench-er-headtohead.yml
@@ -170,17 +170,28 @@ jobs:
       # signal"); orchestrate.py flushes bench_results.json after every datapoint
       # and skips datapoints already recorded, so restoring .bench_er lets a
       # re-run continue instead of recomputing from zero. Unique primary key per
-      # (shape, tag, run, attempt) => the post-job save always writes; the
-      # prefix restore-keys pick up the most recent partial for this shape+tag
-      # (previous attempt first, then any earlier dispatch with the same tag).
+      # (shape, tag, sha, run, attempt) => the post-job save always writes; the
+      # prefix restore-keys pick up the most recent partial for this
+      # shape+tag+SHA (previous attempt first, then any earlier dispatch of the
+      # SAME COMMIT with the same tag).
+      #
+      # `github.sha` is load-bearing, not decoration. Without it the resume key
+      # was (shape, tag) alone, so a dispatch on new code with the default tag
+      # restored the PREVIOUS dispatch's `.bench_er` and orchestrate.py skipped
+      # every datapoint as "already recorded". A run added to measure new
+      # per-lane telemetry came back with none of it and a `git_sha` in the
+      # header naming a commit from before the change -- a green run reporting
+      # stale numbers, with the only tell buried in a field nobody reads.
+      # Resume is for the same code being interrupted; it must never span a
+      # code change.
       - name: Restore partial sweep progress
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: .bench_er
-          key: er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-${{ github.run_id }}-
-            er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-
+            er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-${{ github.sha }}-${{ github.run_id }}-
+            er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-${{ github.sha }}-
 
       - name: Run head-to-head sweep
         run: |

--- a/scripts/bench_er_headtohead/orchestrate.py
+++ b/scripts/bench_er_headtohead/orchestrate.py
@@ -442,12 +442,31 @@ def _load_resume_state(agg_path: Path) -> tuple[dict | None, list[dict], set[tup
     the workflow restores the workdir across runner attempts/dispatches (the cache
     step in bench-er-headtohead.yml), and the per-datapoint flush below means we
     resume from the last datapoint that completed before the runner was reclaimed.
-    A corrupt/half-written aggregate is treated as no prior state (start clean)."""
+    A corrupt/half-written aggregate is treated as no prior state (start clean).
+
+    A prior aggregate built from a DIFFERENT commit is discarded, loudly. Resume
+    means "the same code was interrupted", never "reuse results from other code":
+    every recorded datapoint would be skipped, so a sweep dispatched to measure a
+    bench change comes back reporting the numbers it was meant to replace. That
+    happened -- the workflow's cache key was (shape, tag) with no SHA, so a
+    re-dispatch on new code restored the previous dispatch's workdir and skipped
+    all 16 datapoints. The run was green, the artifact had none of the new fields,
+    and the only tell was a `git_sha` in the header naming the older commit."""
     if not agg_path.exists():
         return None, [], set()
     try:
         obj = json.loads(agg_path.read_text())
     except Exception:
+        return None, [], set()
+    prior_header = obj.get("header") or {}
+    prior_sha, now_sha = prior_header.get("git_sha"), _git_sha()
+    if prior_sha and now_sha and prior_sha != now_sha:
+        print(
+            f"[orchestrate] DISCARDING resume state: it was built at "
+            f"{prior_sha[:12]}, this is {now_sha[:12]}. Resume never spans a "
+            f"code change -- re-running all datapoints from scratch.",
+            flush=True,
+        )
         return None, [], set()
     results = [r for r in (obj.get("results") or [])
                if _datapoint_key(r) != (None, None, None)]


### PR DESCRIPTION
## What happened

I dispatched the head-to-head panel on `main` right after #2590 merged, to collect the per-lane telemetry that PR added. The run went green and the artifact contained **none of the new fields**.

It had not run. `headSha` was `6fff95f0e` (the right code), but the artifact's header said:

```
git_sha: f92b43b4878aff067eb119d3020aa51b8c611298   <- the PREVIOUS run's commit
```

## Cause

The resume cache key carried no code identity:

```yaml
restore-keys: |
  er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-${{ github.run_id }}-
  er-h2h-${{ matrix.shape }}-${{ inputs.run_tag }}-        # <- matches ANY earlier dispatch
```

`run_tag` defaults to `manual`, so the second key matched the previous dispatch and restored its `.bench_er`. `orchestrate.py` treats every recorded `(shape, lane, rows)` triple as done, so all 16 datapoints were skipped and the sweep finished in ~2 minutes having measured nothing.

Nothing failed. A green run reported stale numbers, and the only tell was a field nobody reads.

## Fix

Two independent changes, because either alone leaves a hole:

1. **`github.sha` in the cache key and both restore-keys.** Resume can now only pick up an interrupted run of the same commit.
2. **`_load_resume_state` compares the prior header's `git_sha` to HEAD** and discards the state loudly on mismatch. This covers routes the cache key cannot: a local `.bench_er`, a hand-copied workdir, a future workflow restoring under a different key.

Resume exists so a preempted `large-new-64GB` runner continues instead of recomputing from zero. That is about the same code being interrupted. It must never mean reusing results produced by different code.

## Note

The measurement run is already in flight under `run_tag=telemetry1` (run `31909224461`), which sidesteps the stale cache by using a tag no prior dispatch used.