### PR TITLE
bench: point the separability question at an instrument that can answer it

### DIFF
--- a/.github/workflows/bench-fs-histograms.yml
+++ b/.github/workflows/bench-fs-histograms.yml
@@ -23,6 +23,15 @@ on:
         description: "Datasets to dump (space separated)"
         required: false
         default: "historical_50k dblp_scholar dblp_acm febrl3"
+      shipped:
+        description: "Probe the SHIPPED config (keep specialised name scorers) instead of the Splink-comparable rewrite"
+        required: false
+        type: boolean
+        default: false
+      synthetic_rows:
+        description: "Row count for synthetic_person / synthetic_biblio (other datasets ignore it)"
+        required: false
+        default: "5000"
 
 permissions:
   contents: read
@@ -106,9 +115,16 @@ jobs:
           GOLDENMATCH_FS_CALIBRATED: posterior
           GOLDENMATCH_FS_NATIVE: "1"
           GOLDENMATCH_FS_CALIBRATE_THRESHOLD: "1"
+          GOLDENMATCH_BENCH_SYNTHETIC_ROWS: ${{ inputs.synthetic_rows }}
         run: |
           set -euo pipefail
-          uv run python scripts/bench_er_headtohead/dump_fs_score_histograms.py             --datasets ${{ inputs.datasets }}             --out fs-histograms.json             --summary-md fs-histograms.md
+          SHIPPED=""
+          if [ "${{ inputs.shipped }}" = "true" ]; then SHIPPED="--shipped"; fi
+          uv run python scripts/bench_er_headtohead/dump_fs_score_histograms.py \
+            --datasets ${{ inputs.datasets }} \
+            $SHIPPED \
+            --out fs-histograms.json \
+            --summary-md fs-histograms.md
 
       - name: Summary
         if: always()

--- a/scripts/bench_er_headtohead/datasets.py
+++ b/scripts/bench_er_headtohead/datasets.py
@@ -13,6 +13,7 @@ tests/benchmarks/datasets/.
 from __future__ import annotations
 
 import logging
+import os
 import tempfile
 from collections.abc import Hashable
 from pathlib import Path
@@ -238,11 +239,25 @@ def _ncvr() -> tuple[pa.Table, pa.Table]:
     )
 
 
-def _synthetic_person() -> tuple[pa.Table, pa.Table]:
-    """Synthetic person rows from the bench fixture generator.
+def _synthetic(shape: str, rows: int) -> tuple[pa.Table, pa.Table]:
+    """Synthetic rows of one head-to-head SHAPE, as a (records, truth) dataset.
 
     Reuses ``generate_fixture.generate`` (writes records + truth parquet to a
     temp dir), then reads both back into the (records, truth) contract shape.
+
+    Exposing the head-to-head shapes as datasets is what lets the score-histogram
+    probe run on them. That probe answers whether a shape's matches and
+    non-matches are SEPARABLE, and separability is the property that decides
+    whether the calibration choice matters at all: linear and posterior are both
+    monotone in match weight, so they rank pairs identically and can only differ
+    where the cut lands. The head-to-head panel shows exactly that split --
+    biblio's linear and posterior lanes are byte-identical at both scales, while
+    person's differ by 0.078 F1 -- and the probe is the instrument that can say
+    whether an empty band is the reason.
+
+    ``rows`` is a parameter because the effect is scale-dependent: the person
+    shape's over-merge is mild at 100k and catastrophic at 1M, so a probe fixed
+    at one small size could report "separable" for a shape that stops being so.
     """
     try:
         from generate_fixture import generate  # type: ignore
@@ -259,20 +274,48 @@ def _synthetic_person() -> tuple[pa.Table, pa.Table]:
         spec.loader.exec_module(gen_mod)
         generate = gen_mod.generate  # type: ignore
 
-    with tempfile.TemporaryDirectory(prefix="gm_synth_person_") as td:
+    with tempfile.TemporaryDirectory(prefix=f"gm_synth_{shape}_") as td:
         out = Path(td) / "records.parquet"
         truth_path = Path(td) / "truth.parquet"
         generate(
-            rows=5_000,
+            rows=rows,
             dupe_rate=0.20,
             out=out,
             truth=truth_path,
             seed=42,
             batch=1_000_000,
+            shape=shape,
         )
         records = pq.read_table(out)
         truth = pq.read_table(truth_path)
     return records, truth
+
+
+def _synthetic_rows(default: int = 5_000) -> int:
+    """Row count for the synthetic shapes, overridable per run.
+
+    Env rather than a loader argument because `load_dataset(name)` is a
+    single-string contract shared with the real benchmark datasets, and widening
+    it for two synthetic entries would touch every caller.
+    """
+    raw = os.environ.get("GOLDENMATCH_BENCH_SYNTHETIC_ROWS", "").strip()
+    if not raw:
+        return default
+    try:
+        n = int(raw)
+    except ValueError:
+        return default
+    return n if n > 0 else default
+
+
+def _synthetic_person() -> tuple[pa.Table, pa.Table]:
+    """Synthetic person rows. See :func:`_synthetic`."""
+    return _synthetic("person", _synthetic_rows())
+
+
+def _synthetic_biblio() -> tuple[pa.Table, pa.Table]:
+    """Synthetic biblio rows. See :func:`_synthetic`."""
+    return _synthetic("biblio", _synthetic_rows())
 
 
 def _two_source_leipzig(
@@ -400,6 +443,11 @@ _LOADERS = {
     "febrl3": _febrl3,
     "ncvr": _ncvr,
     "synthetic_person": _synthetic_person,
+    # The head-to-head panel's OTHER shape. Present so the score-histogram probe
+    # can compare the two: the panel shows biblio's linear and posterior lanes
+    # agreeing byte-for-byte while person's diverge, and only a labelled score
+    # distribution can say whether an empty band is why.
+    "synthetic_biblio": _synthetic_biblio,
     # Held-out (never in the FS-lever tuning panel) -- generalisation tests.
     "febrl4": _febrl4,
     "dblp_scholar": _dblp_scholar,

--- a/scripts/bench_er_headtohead/dump_fs_score_histograms.py
+++ b/scripts/bench_er_headtohead/dump_fs_score_histograms.py
@@ -73,8 +73,17 @@ def truth_pairs(truth) -> set[tuple[str, str]]:
     return out
 
 
-def collect(name: str) -> dict:
-    """Score every blocked training pair, and label it against ground truth."""
+def collect(name: str, *, basic_scorers: bool = True) -> dict:
+    """Score every blocked training pair, and label it against ground truth.
+
+    ``basic_scorers`` rewrites the specialised name scorers down to plain
+    ``jaro_winkler``, which is right for a Splink-comparable measurement and
+    WRONG as a statement of what GoldenMatch does -- on the head-to-head panel
+    that rewrite alone costs the person shape 0.078 F1, all of it recall. Pass
+    ``False`` to probe the distribution the shipped configuration actually
+    produces. Recorded in the output either way so a reader never has to infer
+    which one they are looking at.
+    """
     import datasets as datasets_mod
     import numpy as np
     from goldenmatch.core import probabilistic as P
@@ -85,9 +94,12 @@ def collect(name: str) -> dict:
 
     cfg = auto_configure_probabilistic_df(records)
     mk = cfg.get_matchkeys()[0]
-    for f in getattr(mk, "fields", None) or []:
-        if f.scorer and f.scorer not in _BASIC:
-            f.scorer = "jaro_winkler"
+    rewritten = []
+    if basic_scorers:
+        for f in getattr(mk, "fields", None) or []:
+            if f.scorer and f.scorer not in _BASIC:
+                rewritten.append(f"{f.field}:{f.scorer}->jaro_winkler")
+                f.scorer = "jaro_winkler"
 
     # Intercept the exact array the calibrator is handed. Reaching in like this
     # is deliberate: re-deriving the scores here would measure a lookalike, and
@@ -108,7 +120,10 @@ def collect(name: str) -> dict:
         P._posterior_split = orig
 
     out: dict = {"dataset": name, "n_records": records.num_rows,
-                 "n_true_pairs": len(tp)}
+                 "n_true_pairs": len(tp),
+                 "basic_scorers": bool(basic_scorers),
+                 "scorers_rewritten": rewritten,
+                 "comparable_to_splink": bool(basic_scorers)}
     stats = (getattr(res, "stats", None) or {}).get("fs_link_thresholds") or {}
     first = next(iter(stats.values()), {}) if isinstance(stats, dict) else {}
     out["chosen_threshold"] = first.get("link_threshold")
@@ -276,18 +291,30 @@ def main() -> int:
                     default=["historical_50k", "dblp_scholar"])
     ap.add_argument("--out", default="fs-histograms.json")
     ap.add_argument("--summary-md", default="")
+    ap.add_argument(
+        "--shipped", action="store_true",
+        help="probe the SHIPPED configuration: keep the specialised name "
+             "scorers instead of rewriting them to jaro_winkler. The rewrite "
+             "is right for a Splink-comparable number and wrong as a statement "
+             "of what GoldenMatch does; on the head-to-head panel it alone "
+             "costs the person shape 0.078 F1, all of it recall.")
     args = ap.parse_args()
 
     os.environ.setdefault("GOLDENMATCH_FS_CALIBRATED", "posterior")
     os.environ.setdefault("GOLDENMATCH_FS_NATIVE", "1")
     os.environ.setdefault("GOLDENMATCH_FS_CALIBRATE_THRESHOLD", "1")
 
-    reports = []
+    mode = "SHIPPED" if args.shipped else "splink-comparable"
+    print(f"[hist] scorer mode: {mode}", flush=True)
+
+    reports: list[dict] = []
     for name in args.datasets:
+        r: dict
         try:
-            r = collect(name)
+            r = collect(name, basic_scorers=not args.shipped)
         except Exception as exc:  # noqa: BLE001 - one dataset must not lose the rest
-            r = {"dataset": name, "error": str(exc)[:300]}
+            r = {"dataset": name, "error": str(exc)[:300],
+                 "basic_scorers": not args.shipped}
         reports.append(r)
         if r.get("error"):
             print(f"[hist] {name}: ERROR {r['error']}", flush=True)

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -36,13 +36,24 @@ def _score_histogram(ded, bins: int = 100) -> dict:
     this same file reports two lines later. Telemetry that moves the number it
     is printed next to is worse than no telemetry.
 
-    ``largest_gap`` is the point of this. Linear and posterior calibration are
-    both monotone in total match weight, so they rank pairs IDENTICALLY and
-    differ only in where a fixed threshold cuts. Two calibrations therefore
-    agree exactly when the cut falls inside an empty band and diverge when it
-    does not -- which is the difference between a dataset where the threshold
-    choice is free and one where it decides the answer. The bench has been
-    reporting the consequence (F1) without ever measuring the cause.
+    **This is the RETAINED-pair distribution, truncated at the cut.** It is not
+    the distribution the calibrator sees and it CANNOT answer whether a dataset
+    is separable. `DedupeResult.scored_pairs` holds the pairs the scorer
+    emitted, which are the ones that already passed; the first version of this
+    docstring claimed `largest_gap` measured separability, and the first run
+    disproved it -- `gm_probabilistic` on biblio carries `link_threshold=0.85`
+    and a minimum retained score of 0.9917, so all 22,767 pairs land in one
+    0.01-wide bin. A gap detector fed a truncated distribution reports the
+    truncation, not the structure.
+
+    Separability is answered by `dump_fs_score_histograms.py`, which spies on
+    `_posterior_split` to capture the untruncated training-pair scores AND
+    splits them by ground truth. Use that; this is not a substitute.
+
+    What this DOES show is where the retained mass sits relative to the cut,
+    which is how the posterior scale's saturation became visible: everything
+    accepted piles into [0.9917, 1.0] with nothing between it and the nominal
+    0.85 threshold.
     """
     try:
         import numpy as np
@@ -121,8 +132,25 @@ def _config_telemetry(cfg) -> dict:
     except Exception as e:  # noqa: BLE001
         out["matchkeys_error"] = f"{type(e).__name__}: {e}"
     try:
-        passes = getattr(getattr(cfg, "blocking", None), "passes", None) or []
-        out["blocking_passes"] = [list(getattr(p, "fields", []) or []) for p in passes]
+        # `BlockingConfig.keys`, NOT `.passes`. The first version of this read
+        # `.passes` and got `[]` for every lane at both scales -- a plausible
+        # empty list rather than an error, which is the worst way for telemetry
+        # to be wrong. `.passes` is kept as a fallback only because some callers
+        # construct with that alias.
+        blocking = getattr(cfg, "blocking", None)
+        keys = getattr(blocking, "keys", None)
+        if keys is None:
+            keys = getattr(blocking, "passes", None)
+        if keys is None:
+            out["blocking_error"] = (
+                "resolved config exposed neither blocking.keys nor .passes"
+            )
+        else:
+            out["blocking_passes"] = [
+                list(getattr(k, "fields", []) or []) for k in keys
+            ]
+            out["blocking_strategy"] = getattr(blocking, "strategy", None)
+            out["blocking_max_block_size"] = getattr(blocking, "max_block_size", None)
     except Exception as e:  # noqa: BLE001
         out["blocking_error"] = f"{type(e).__name__}: {e}"
     return out


### PR DESCRIPTION
## The instrument in #2590 was wrong

#2590 added `score_histogram` with a `largest_gap` statistic and claimed it measured separability. The first run disproved it.

`DedupeResult.scored_pairs` holds the pairs the scorer **emitted** -- the ones that already passed the cut. The distribution is truncated at the threshold by construction:

```
gm_probabilistic, biblio 100k:  link_threshold = 0.85
                                min retained score = 0.9917
                                all 22,767 pairs in ONE 0.01-wide bin
```

A gap detector fed a truncated distribution reports the truncation, not the structure. The falsification test I set up did not run.

## The right instrument already existed

`dump_fs_score_histograms.py` spies on `_posterior_split` to capture the **untruncated training-pair scores** and splits them by ground truth -- the only way to distinguish "one mode" from "two modes that overlap". It already emits an `overlap.separable` verdict. It just could not see the shapes where the question lives.

- **`synthetic_biblio`** joins `synthetic_person` in `datasets.py`, both through a shared `_synthetic(shape, rows)` over the bench's own fixture generator.
- **Row count is env-overridable.** Scale matters: the person shape's over-merge is mild at 100k (cluster size 2.54 vs truth 2.40) and catastrophic at 1M (7.98), so a probe pinned at one small size could report "separable" for a shape that stops being so.
- **`--shipped`** keeps the specialised name scorers instead of rewriting them to `jaro_winkler`. That rewrite is right for a Splink-comparable number and wrong as a statement of what GoldenMatch does; on the panel it alone costs the person shape 0.078 F1, all of it recall. The mode is recorded in the output either way.
- Workflow gains `shipped` and `synthetic_rows` inputs.

## Two fixes to #2590

**`blocking_passes` read the wrong field.** `BlockingConfig` has `keys`, not `passes`, so it returned `[]` for every lane at both scales -- a plausible empty list rather than an error, which is the worst way for telemetry to be wrong. Now reads `keys` (with `passes` as fallback), records an explicit error when neither exists, and adds `strategy` + `max_block_size`.

**`_score_histogram`'s docstring now says what it is:** the retained-pair distribution, truncated at the cut, which cannot answer separability -- and points at the probe that can. Kept, because it did show something real: the posterior scale **saturates**, with everything accepted piled into [0.9917, 1.0] and nothing between there and the nominal 0.85 cut.