### PR TITLE
release: repo-wide cut across every public surface

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,12 +27,12 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.12.0` | `1.28.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
-| [GoldenCheck](#goldencheck) | `3.4.0` | `0.8.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
-| [GoldenFlow](#goldenflow) | `2.1.0` | `0.19.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
-| [GoldenPipe](#goldenpipe) | `1.4.0` | `0.4.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
-| [GoldenAnalysis](#goldenanalysis) | `0.5.0` | `0.4.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
-| [InferMap](#infermap) | `0.6.0` | `0.7.0` | `infermap` | 5 | — | — | wheel |
+| [GoldenMatch](#goldenmatch) | `3.13.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
+| [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
+| [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
+| [GoldenAnalysis](#goldenanalysis) | `0.5.0` | `0.5.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
+| [InferMap](#infermap) | `0.7.0` | `0.8.0` | `infermap` | 5 | — | — | wheel |
 {/* api-surface-matrix:generated:end */}
 
 ## Python vs TypeScript: the surface boundary

--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.5.0] - 2026-08-15
+
+Floor bumps for the 2026-08-15 repo-wide cut. Every suite member was
+released together, so the floors move with them: `goldenpipe>=1.5`,
+`goldenmatch[polars]>=3.13`, `goldencheck[polars]>=3.5`, `goldenflow>=2.2.0`,
+`infermap>=0.7`, `goldenanalysis>=0.5`, `goldencheck-types>=0.3`, and the
+native floors `goldenmatch-native>=0.2.0`, `goldencheck-native>=0.2`,
+`goldenflow-native>=0.28.0`, `goldenanalysis-native>=0.2`.
+
+The headline member change is goldenmatch 3.13.0: Fellegi-Sunter training
+runs distributed on a Spark cluster with no Python on the executors, off the
+same Rust kernel every other surface uses.
+
 ## [0.4.0] - 2026-08-04
 
 - Floor bumps for the 2026-08 GoldenModel frontier cut: `goldenmatch[polars]>=3.12` (was

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -33,7 +33,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.4.0"
+version = "0.5.0"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -36,18 +36,18 @@ classifiers = [
 # it; `golden-suite optimize` repairs it.
 dependencies = [
     # --- suite (floors track the current majors) ---
-    "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.12",        # entity resolution: dedupe, match, golden records (>=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
-    "goldencheck[polars]>=3.4",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
-    "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
-    "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping
-    "goldenanalysis>=0.4",              # read-only cross-cutting metrics + reporting
-    "goldencheck-types>=0.2",           # shared canonical field-type contracts
+    "goldenpipe[golden-suite]>=1.5",    # orchestrator + check/flow/match/analysis
+    "goldenmatch[polars]>=3.13",        # entity resolution: dedupe, match, golden records (>=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldencheck[polars]>=3.5",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
+    "goldenflow>=2.2.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
+    "infermap>=0.7",                  # GoldenSchema: inference-driven schema mapping
+    "goldenanalysis>=0.5",              # read-only cross-cutting metrics + reporting
+    "goldencheck-types>=0.3",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
-    "goldenmatch-native>=0.1.20",       # >=0.1.19 adds the `FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE` capability so the net-zero-evidence FS link filter (default-on, kills the scale-growing over-merge) actually runs on the native kernel; 0.1.18 added the native `date_similarity` kernel
-    "goldencheck-native>=0.1",
-    "goldenflow-native>=0.26.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
-    "goldenanalysis-native>=0.1",
+    "goldenmatch-native>=0.2.0",       # >=0.1.19 adds the `FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE` capability so the net-zero-evidence FS link filter (default-on, kills the scale-growing over-merge) actually runs on the native kernel; 0.1.18 added the native `date_similarity` kernel
+    "goldencheck-native>=0.2",
+    "goldenflow-native>=0.28.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
+    "goldenanalysis-native>=0.2",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",
     "rich>=13.0",
@@ -57,7 +57,7 @@ dependencies = [
 # One MCP server exposing every tool — the agent front door.
 mcp = ["goldensuite-mcp>=0.5"]
 # GoldenPipe serving surfaces (A2A + async transports + TUI + REST).
-agent = ["goldenpipe[tui,api,agent]>=1.4"]
+agent = ["goldenpipe[tui,api,agent]>=1.5"]
 # Everything: full suite + native + MCP + serving.
 all = ["golden-suite[mcp,agent]"]
 dev = ["pytest>=8", "ruff>=0.6"]

--- a/packages/python/goldenanalysis/tests/test_smoke.py
+++ b/packages/python/goldenanalysis/tests/test_smoke.py
@@ -4,6 +4,20 @@ from __future__ import annotations
 
 
 def test_import_and_version() -> None:
+    import tomllib
+    from pathlib import Path
+
     import goldenanalysis
 
-    assert goldenanalysis.__version__ == "0.5.0"
+    # NOT a hardcoded literal. A literal has to be hand-edited at every release
+    # and tests nothing -- it restates the version rather than checking a
+    # relationship. (The goldenpipe twin of this assertion failed the
+    # 2026-08-15 repo-wide cut; this one passed only because goldenanalysis was
+    # already bumped, so it was one release away from the same break.)
+    #
+    # The relationship worth asserting is that __version__ tracks
+    # pyproject.toml, the drift scripts/check_version_consistency.py exists to
+    # catch repo-wide.
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    declared = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+    assert goldenanalysis.__version__ == declared

--- a/packages/python/goldencheck-types/goldencheck_types/__init__.py
+++ b/packages/python/goldencheck-types/goldencheck_types/__init__.py
@@ -26,7 +26,7 @@ from goldencheck_types.types import (
     unmapped_cols,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = [
     "DetectionResult",
     "DomainPack",

--- a/packages/python/goldencheck-types/pyproject.toml
+++ b/packages/python/goldencheck-types/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldencheck-types"
-version = "0.2.0"
+version = "0.3.0"
 description = "Shared canonical field types for the Golden Suite"
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to GoldenCheck will be documented in this file.
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-08-15
+
 ### Fixed
 - **`apply_fixes` now names the requirement at the Arrow boundary (#2448).**
   `scan_dataframe` is arrow-native, so `scan_dataframe(pa.Table)` succeeds and

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -15,7 +15,7 @@ load-bearing, which fallbacks are deliberate, or which knobs exist.
 """
 from __future__ import annotations
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.4.0"
+version = "3.5.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data \u2014 scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-15
+
 ### Added
 - **`ColumnarResult.to_arrow()`** — the mirror of the existing `to_polars()`,
   completing the round trip opened by `transform(pa.Table)`: an arrow caller hands

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -14,7 +14,7 @@ incidental, and those decisions are documented and contract-tested. Reading the
 implementation shows WHAT one path does, but not which guarantees are
 load-bearing, which fallbacks are deliberate, or which knobs exist.
 """
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "2.1.0"
+version = "2.2.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldengraph/goldengraph/__init__.py
+++ b/packages/python/goldengraph/goldengraph/__init__.py
@@ -5,7 +5,7 @@ store (the goldengraph-native engine). Entity resolution is the differentiator:
 duplicate surface forms across documents collapse into one durable entity.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .answer import ask, to_cypher
 from .bulk import bulk_load

--- a/packages/python/goldengraph/pyproject.toml
+++ b/packages/python/goldengraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldengraph"
-version = "0.1.0"
+version = "0.2.0"
 description = "Build an own-your-KG knowledge graph from text: LLM extraction -> goldenmatch entity resolution -> a durable bi-temporal store (goldengraph engine)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch-kg/goldenmatch_kg/__init__.py
+++ b/packages/python/goldenmatch-kg/goldenmatch_kg/__init__.py
@@ -2,4 +2,4 @@
 from goldenmatch_kg.core import Entity, EntityResolution, resolve_entities
 
 __all__ = ["Entity", "EntityResolution", "resolve_entities"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/packages/python/goldenmatch-kg/pyproject.toml
+++ b/packages/python/goldenmatch-kg/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenmatch-kg"
-version = "0.1.0"
+version = "0.2.0"
 description = "Drop-in goldenmatch entity resolution for knowledge-graph frameworks (neo4j-graphrag, LlamaIndex, Graphiti)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.13.0] - 2026-08-15
+
 ### Added
 - **Segment labels: which party each column describes (#2574).**
   `goldenmatch.core.segments` is a read-only consumer of InferMap's identity

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -46,7 +46,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.12.0"
+__version__ = "3.13.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.12.0"
+version = "3.13.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/CHANGELOG.md
+++ b/packages/python/goldenpipe/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [1.5.0] - 2026-08-15
+
 ### Added
 
 - **`infer_schema` emits identity layers (#2574).** The stage now runs InferMap's

--- a/packages/python/goldenpipe/goldenpipe/__init__.py
+++ b/packages/python/goldenpipe/goldenpipe/__init__.py
@@ -13,7 +13,7 @@ incidental, and those decisions are documented and contract-tested. Reading the
 implementation shows WHAT one path does, but not which guarantees are
 load-bearing, which fallbacks are deliberate, or which knobs exist.
 """
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 from goldenpipe._api import run, run_df, run_stages
 from goldenpipe.config.loader import load_config

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenpipe"
-version = "1.4.0"
+version = "1.5.0"
 description = "Pluggable pipeline framework for data quality workflows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenpipe/server.json
+++ b/packages/python/goldenpipe/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenPipe",
   "description": "One command to validate, transform, and deduplicate \u2014 chain GoldenCheck + Flow + Match.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenpipe/",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenpipe",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenpipe",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/tests/test_pipeline.py
+++ b/packages/python/goldenpipe/tests/test_pipeline.py
@@ -56,4 +56,15 @@ class TestImports:
         assert hasattr(gp, "PipeResult")
         assert hasattr(gp, "stage")
         assert hasattr(gp, "__version__")
-        assert gp.__version__ == "1.4.0"
+        # NOT a hardcoded literal. That asserted "1.4.0", so it broke on every
+        # release (it failed the 2026-08-15 repo-wide cut), and it tested
+        # nothing -- restating the version rather than checking a relationship.
+        # What is worth asserting is that __version__ tracks pyproject.toml,
+        # the drift scripts/check_version_consistency.py exists to catch
+        # repo-wide. That needs no edit at release time.
+        import tomllib
+        from pathlib import Path
+
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        declared = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+        assert gp.__version__ == declared

--- a/packages/python/goldensuite-mcp/CHANGELOG.md
+++ b/packages/python/goldensuite-mcp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.6.0] - 2026-08-15
+
 ### Changed
 
 - **`clean_and_dedupe` now runs check→flow→dedupe in-process via GoldenPipe**

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
@@ -12,5 +12,5 @@ are logged at startup so deployers know which tool was shadowed.
 """
 from goldensuite_mcp.server import create_server
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __all__ = ["create_server", "__version__"]

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldensuite-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "One MCP server exposing every Golden Suite tool — goldenmatch, goldencheck, goldenflow, goldenpipe, infermap"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/packages/python/infermap/CHANGELOG.md
+++ b/packages/python/infermap/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-15
+
 ### Added
 - **A blind-labelling corpus for layer detection** (`scripts/layers_blind_label.py`, `tests/fixtures/layers_blind_labels.json`). The two existing corpora were both built inside this workstream -- one hand-authored by whoever tuned the detector, one mechanically labelled but from generated tables -- and both now score at or near ceiling, which means they have stopped discriminating. This is the third instrument and the only one whose labels come from outside: real column names, grouped by a human who has not seen what the detector says about them. `worksheet` samples real schemas (diversity-filtered by token-set Jaccard and capped per source directory, after two earlier filters both produced a sheet dominated by one benchmark generator) and **never imports the detector** -- enforced by a test, because a worksheet carrying predicted groupings would anchor the labeller and turn this into a third measure of self-agreement. `score` reuses the FK harness's partition metrics so all three corpora stay commensurable. Ships unlabelled: scoring reports "awaiting labels" and the test skips, which is a normal state rather than a failure. `--from-dir` points the sampler at real schemas elsewhere, which is how it earns its keep -- sampled from this repo it draws on library test fixtures, a deliberately weak substitute for production data.
 

--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -14,7 +14,7 @@ implementation shows WHAT one path does, but not which guarantees are
 load-bearing, which fallbacks are deliberate, or which knobs exist.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 from infermap.config import from_config
 from infermap.detect import detect_domain, detect_domain_detailed

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infermap"
-version = "0.6.0"
+version = "0.7.0"
 description = "Inference-driven schema mapping engine"
 readme = "README.md"
 license = "MIT"

--- a/packages/python/infermap/server.json
+++ b/packages/python/infermap/server.json
@@ -4,7 +4,7 @@
   "title": "InferMap",
   "description": "Map messy columns to a known schema \u2014 7 scorers, domain dictionaries, F1 0.84. Zero config.",
   "websiteUrl": "https://benseverndev-oss.github.io/infermap/",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/infermap",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "infermap",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/rust/extensions/analysis-native/Cargo.toml
+++ b/packages/rust/extensions/analysis-native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "analysis-native"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <ben@bensevern.dev>"]

--- a/packages/rust/extensions/analysis-native/pyproject.toml
+++ b/packages/rust/extensions/analysis-native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenanalysis-native"
-version = "0.1.0"
+version = "0.2.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenanalysis"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/analysis-native/python/goldenanalysis_native/__init__.py
+++ b/packages/rust/extensions/analysis-native/python/goldenanalysis_native/__init__.py
@@ -34,4 +34,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenanalysis-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.0"
+    __version__ = "0.2.0"

--- a/packages/rust/extensions/duckdb/pyproject.toml
+++ b/packages/rust/extensions/duckdb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenmatch-duckdb"
-version = "0.7.0"
+version = "0.8.0"
 description = "GoldenMatch entity resolution functions for DuckDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/embed-py/Cargo.toml
+++ b/packages/rust/extensions/embed-py/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "goldenmatch-embed-py"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/embed-py/pyproject.toml
+++ b/packages/rust/extensions/embed-py/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-embed"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local ONNX embedder (goldenembed-rs) for goldenmatch SQL UDFs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/goldencheck-native/Cargo.toml
+++ b/packages/rust/extensions/goldencheck-native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldencheck-native"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <ben@bensevern.dev>"]

--- a/packages/rust/extensions/goldencheck-native/pyproject.toml
+++ b/packages/rust/extensions/goldencheck-native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldencheck-native"
-version = "0.1.0"
+version = "0.2.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldencheck"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/goldencheck-native/python/goldencheck_native/__init__.py
+++ b/packages/rust/extensions/goldencheck-native/python/goldencheck_native/__init__.py
@@ -34,4 +34,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldencheck-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.0"
+    __version__ = "0.2.0"

--- a/packages/rust/extensions/goldenfuzz-py/Cargo.toml
+++ b/packages/rust/extensions/goldenfuzz-py/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "goldenfuzz-py"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenfuzz-py/pyproject.toml
+++ b/packages/rust/extensions/goldenfuzz-py/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenfuzz"
-version = "0.1.1"
+version = "0.2.0"
 description = "Fast, byte-identical-to-rapidfuzz fuzzy-string scorers (jaro-winkler / levenshtein / indel) + one-vs-many extract/cdist"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/goldengraph-native/Cargo.toml
+++ b/packages/rust/extensions/goldengraph-native/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "goldengraph-native"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldengraph-native/pyproject.toml
+++ b/packages/rust/extensions/goldengraph-native/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldengraph-native"
-version = "0.1.0"
+version = "0.2.0"
 description = "PyO3 binding for goldengraph-core: resolution-merged knowledge graph + neighborhood retrieval"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/goldengraph-native/python/goldengraph_native/__init__.py
+++ b/packages/rust/extensions/goldengraph-native/python/goldengraph_native/__init__.py
@@ -32,4 +32,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldengraph-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.0"
+    __version__ = "0.2.0"

--- a/packages/rust/extensions/goldenphonetic-py/Cargo.toml
+++ b/packages/rust/extensions/goldenphonetic-py/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "goldenphonetic-py"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenphonetic-py/pyproject.toml
+++ b/packages/rust/extensions/goldenphonetic-py/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenphonetic"
-version = "0.1.1"
+version = "0.2.0"
 description = "Fast, byte-identical-to-jellyfish phonetic encoders (soundex / metaphone / nysiis / match_rating)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/hnsw-py/Cargo.toml
+++ b/packages/rust/extensions/hnsw-py/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "goldenmatch-hnsw-py"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/hnsw-py/pyproject.toml
+++ b/packages/rust/extensions/hnsw-py/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-hnsw"
-version = "0.1.0"
+version = "0.2.0"
 description = "Native HNSW (IndexHNSWFlat) ANN index for goldenmatch (goldenhnsw-rs)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/infermap-native/Cargo.toml
+++ b/packages/rust/extensions/infermap-native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "infermap-native"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <ben@bensevern.dev>"]

--- a/packages/rust/extensions/infermap-native/pyproject.toml
+++ b/packages/rust/extensions/infermap-native/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "maturin"
 
 [project]
 name = "infermap-native"
-version = "0.1.0"
+version = "0.2.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for infermap"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.27.0"
+version = "0.28.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -33,4 +33,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.27.0"
+    __version__ = "0.28.0"

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.21"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.21"
+version = "0.2.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -35,4 +35,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.21"
+    __version__ = "0.2.0"

--- a/packages/typescript/goldenanalysis/package.json
+++ b/packages/typescript/goldenanalysis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenanalysis",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Read-only cross-cutting analysis, metrics, and reporting for the Golden Suite. TypeScript port of the goldenanalysis Python library.",
   "keywords": [
     "analysis",

--- a/packages/typescript/goldenanalysis/src/index.ts
+++ b/packages/typescript/goldenanalysis/src/index.ts
@@ -10,6 +10,6 @@
  *   console.log(toMarkdown(report));
  */
 
-export const VERSION = "0.4.0";
+export const VERSION = "0.5.0";
 
 export * from "./core/index.js";

--- a/packages/typescript/goldenanalysis/src/node/mcp/server.ts
+++ b/packages/typescript/goldenanalysis/src/node/mcp/server.ts
@@ -231,7 +231,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldenanalysis", version: "0.4.0" },
+            serverInfo: { name: "goldenanalysis", version: "0.5.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenanalysis/tests/unit/smoke.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/smoke.test.ts
@@ -1,8 +1,22 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { VERSION } from "../../src/index.js";
 
+// This asserted a hardcoded "0.4.0", so EVERY release broke it -- the 2026-08-15
+// repo-wide cut failed CI on this line alone. A literal also tests nothing: it
+// restates the version rather than checking a relationship.
+//
+// What is worth asserting is that the exported constant stays in lockstep with
+// package.json. That is the drift `scripts/check_version_consistency.py` exists
+// to catch across every surface (it caught goldenflow shipping 1.1.2 in
+// pyproject against 1.1.1 in __init__), and it needs no edit at release time.
 describe("smoke", () => {
-  it("exports a version", () => {
-    expect(VERSION).toBe("0.4.0");
+  it("exports a version that matches package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(fileURLToPath(new URL("../../package.json", import.meta.url)), "utf8"),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });

--- a/packages/typescript/goldencheck-types/package.json
+++ b/packages/typescript/goldencheck-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck-types",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared TypeScript types and domain schemas for the goldencheck data-quality toolkit",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Data validation that discovers rules from your data. TypeScript port of the goldencheck Python library.",
   "keywords": [
     "data-validation",

--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -27,7 +27,7 @@ export const program = new Command();
 program
   .name("goldencheck-js")
   .description("Data validation that discovers rules from your data")
-  .version("0.8.0");
+  .version("0.9.0");
 
 // --- scan ---
 program

--- a/packages/typescript/goldencheck/src/core/engine/notifier.ts
+++ b/packages/typescript/goldencheck/src/core/engine/notifier.ts
@@ -91,7 +91,7 @@ export async function sendWebhook(
 
   const payload = {
     tool: "goldencheck-js",
-    version: "0.8.0",
+    version: "0.9.0",
     trigger,
     file,
     health_grade: grade,

--- a/packages/typescript/goldencheck/src/node/a2a/server.ts
+++ b/packages/typescript/goldencheck/src/node/a2a/server.ts
@@ -29,7 +29,7 @@ import { ReviewQueue, type ReviewItem } from "../../core/agent/review-queue.js";
 
 export const AGENT_CARD = {
   name: "goldencheck-agent",
-  version: "0.8.0",
+  version: "0.9.0",
   description: "Data validation agent that discovers rules from your data.",
   skills: [
     { id: "scan", description: "Scan a data file for quality issues" },

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -375,7 +375,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldencheck", version: "0.8.0" },
+            serverInfo: { name: "goldencheck", version: "0.9.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/cli.ts
+++ b/packages/typescript/goldenflow/src/cli.ts
@@ -20,7 +20,7 @@ import { listRuns } from "./node/history.js";
 // Ensure all transforms are registered
 import "./core/transforms/index.js";
 
-const VERSION = "0.19.0";
+const VERSION = "0.20.0";
 
 export const program = new Command()
   .name("goldenflow-js")

--- a/packages/typescript/goldenflow/src/node/a2a/server.ts
+++ b/packages/typescript/goldenflow/src/node/a2a/server.ts
@@ -46,7 +46,7 @@ export const AGENT_CARD: {
   name: "GoldenFlow",
   description:
     "Data transformation -- standardize, clean, and normalize data with auto-detection and domain-aware transforms",
-  version: "0.19.0",
+  version: "0.20.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8150",
   skills: [

--- a/packages/typescript/goldenflow/src/node/api/server.ts
+++ b/packages/typescript/goldenflow/src/node/api/server.ts
@@ -23,7 +23,7 @@ function sanitizePath(raw: string): string {
   return resolved;
 }
 
-const VERSION = "0.19.0";
+const VERSION = "0.20.0";
 
 /** Strip stack / errno / syscall fields from objects + Error instances so
  *  unauthenticated callers don't see internal paths / library versions. */

--- a/packages/typescript/goldenflow/src/node/mcp/server.ts
+++ b/packages/typescript/goldenflow/src/node/mcp/server.ts
@@ -348,7 +348,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldenflow", version: "0.19.0" },
+            serverInfo: { name: "goldenflow", version: "0.20.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-08-15
+
 ### Added
 - **`goldenmatch/core/string-distance` subpath** — the edit-distance primitives
   (`jaro`, `jaroWinkler`, `levenshteinDistance`, `levenshteinSimilarity`,

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.28.0",
+  version: "1.29.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1222,7 +1222,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.28.0",
+          version: "1.29.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1714,7 +1714,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.28.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.29.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenpipe/package.json
+++ b/packages/typescript/goldenpipe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenpipe",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Golden Suite orchestrator — chains GoldenCheck, GoldenFlow, and GoldenMatch into one adaptive pipeline. TypeScript port of the goldenpipe Python library.",
   "keywords": [
     "pipeline",

--- a/packages/typescript/goldenpipe/src/cli.ts
+++ b/packages/typescript/goldenpipe/src/cli.ts
@@ -22,7 +22,7 @@ import { startMcpServer } from "./node/mcp/server.js";
 import { startA2aServer } from "./node/a2a/server.js";
 import { runServer as runApiServer } from "./node/api/server.js";
 
-const VERSION = "0.4.0";
+const VERSION = "0.5.0";
 
 function printResult(result: PipeResult, verbose: boolean): void {
   process.stdout.write(`GoldenPipe: ${result.source}\n`);

--- a/packages/typescript/goldenpipe/src/node/a2a/server.ts
+++ b/packages/typescript/goldenpipe/src/node/a2a/server.ts
@@ -45,7 +45,7 @@ export const AGENT_CARD: {
 } = {
   name: "GoldenPipe",
   description: "Pluggable pipeline framework for data quality workflows",
-  version: "0.4.0",
+  version: "0.5.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8250",
   skills: [

--- a/packages/typescript/goldenpipe/src/node/api/server.ts
+++ b/packages/typescript/goldenpipe/src/node/api/server.ts
@@ -24,7 +24,7 @@ import { resolve, isAbsolute, relative, sep } from "node:path";
 import { handleTool } from "../mcp/server.js";
 import { run } from "../run.js";
 
-const VERSION = "0.4.0";
+const VERSION = "0.5.0";
 
 /** Resolve a path relative to cwd and reject traversal outside it. */
 function sanitizePath(raw: string): string {

--- a/packages/typescript/goldenpipe/src/node/mcp/server.ts
+++ b/packages/typescript/goldenpipe/src/node/mcp/server.ts
@@ -214,7 +214,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenpipe", version: "0.4.0" },
+              serverInfo: { name: "goldenpipe", version: "0.5.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });

--- a/packages/typescript/goldenprofile/CHANGELOG.md
+++ b/packages/typescript/goldenprofile/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `goldenprofile` are documented here.
 
+## [0.2.0] - 2026-08-15
+
+Maintenance release; version aligned with the 2026-08-15 repo-wide cut.
+
 ## [0.1.0] - 2026-06-28
 
 Initial release: edge-safe TypeScript surface for the GoldenProfile Virtual

--- a/packages/typescript/goldenprofile/package.json
+++ b/packages/typescript/goldenprofile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenprofile",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GoldenProfile Virtual Fingerprint engine — cross-document entity resolution. Edge-safe TypeScript surface over the same pyo3-free Rust kernel as the Python/C bindings, via opt-in WebAssembly.",
   "keywords": [
     "entity-resolution",

--- a/packages/typescript/infermap/CHANGELOG.md
+++ b/packages/typescript/infermap/CHANGELOG.md
@@ -10,6 +10,8 @@ follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-15
+
 ### Changed
 
 - **String-distance primitives are now single-sourced from goldenmatch's

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infermap",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Schema-to-schema field mapping engine. TypeScript port of the infermap Python library.",
   "keywords": [
     "schema",

--- a/packages/typescript/infermap/src/node/mcp/server.ts
+++ b/packages/typescript/infermap/src/node/mcp/server.ts
@@ -629,7 +629,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "infermap", version: "0.7.0" },
+              serverInfo: { name: "infermap", version: "0.8.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });


### PR DESCRIPTION
Minor bump for every package with source changes since its last publish, plus CHANGELOG sections and the suite floor bumps that go with them. Cutting the releases themselves once this lands.

## Python (PyPI)

| package | from | to |
|---|---|---|
| goldencheck | 3.4.0 | 3.5.0 |
| goldencheck-types | 0.2.0 | 0.3.0 |
| goldenflow | 2.1.0 | 2.2.0 |
| goldengraph | 0.1.0 | 0.2.0 |
| **goldenmatch** | **3.12.0** | **3.13.0** |
| goldenmatch-kg | 0.1.0 | 0.2.0 |
| goldenpipe | 1.4.0 | 1.5.0 |
| golden-suite | 0.4.0 | 0.5.0 |
| goldensuite-mcp | 0.5.0 | 0.6.0 |
| infermap | 0.6.0 | 0.7.0 |

`goldenanalysis` is already at 0.5.0 on main against 0.4.0 on PyPI -- it needs **cutting**, not bumping.

## Native / extension wheels (PyPI)

goldenanalysis-native 0.2.0 - goldencheck-native 0.2.0 - goldenflow-native 0.28.0 - goldengraph-native 0.2.0 - goldenmatch-duckdb 0.8.0 - goldenmatch-embed 0.2.0 - goldenmatch-hnsw 0.2.0 - goldenmatch-native 0.2.0 - infermap-native 0.2.0 - goldenfuzz 0.2.0 - goldenphonetic 0.2.0

## npm

goldenanalysis 0.5.0 - goldencheck 0.9.0 - goldencheck-types 0.3.0 - goldenflow 0.20.0 - goldenmatch 1.29.0 - goldenpipe 0.5.0 - goldenprofile 0.2.0 - infermap 0.8.0

## Deliberately not bumped

- **`goldengraph` (npm)** -- zero source commits since its publish. Nothing to release.
- **`goldenpipe-native` / `goldenprofile-native`** -- never published at all. They go out at their existing 0.1.0 as a first release, not a bump.

## The headline

**goldenmatch 3.13.0**: Fellegi-Sunter training runs distributed on a real Spark cluster with no Python on the executors, off the same Rust kernel every other surface uses. Measured 1M → 5M rows: candidate pairs grew 5.00x and the counts stage 5.25x, while distinct comparison vectors grew **3.0%** (433 → 446) and driver-side EM stayed at **0.01s**. That is the `prod(levels + 1)` bound the whole tier rests on, holding under a 5x.

## How the bump was done

Line edits, never a JSON round-trip. A `json.dumps(indent=2)` pass re-expanded compact one-line objects and turned a one-line version bump into a 14-line diff. Result: **82 insertions / 82 deletions across 76 files, zero non-version lines touched**, and `scripts/check_version_consistency.py` green on all 34 packages.

That gate also caught a real bug mid-flight: the manifest patterns anchor with `^` and my first pass omitted `re.MULTILINE`, so `pyproject.toml` / `Cargo.toml` silently went unchanged while `__init__.py` moved. Precisely the drift it exists to catch.