### PR TITLE
bench: diagnose WHY zero-config refuses, not just that it does

### DIFF
--- a/.github/workflows/bench-zeroconfig-refusal.yml
+++ b/.github/workflows/bench-zeroconfig-refusal.yml
@@ -1,0 +1,98 @@
+# Why the zero-config controller refuses, per shape and scale.
+#
+# The head-to-head panel records `gm_zeroconfig` as `refused` with one sentence
+# of error text, which reads as a single behaviour ("zero-config gives up at
+# 100k rows"). The four refusals observed disagree with each other:
+#
+#   biblio 100k  sub-profile=cluster   stop_reason=BUDGET_ITERATIONS
+#   biblio 1M    sub-profile=blocking  stop_reason=BLOCKING_DEGENERATE
+#   person 100k  sub-profile=blocking  stop_reason=POLICY_SATISFIED
+#   person 1M    timed out before reporting
+#
+# Three sub-profiles, three stop reasons -- and POLICY_SATISFIED is the SUCCESS
+# reason, so that search converged and the committed config still graded RED.
+# REFUSE_AT_N = 100_000 is the ESCALATION point (below it a RED config
+# warn-and-runs), not the cause. This reports the field values behind each RED
+# verdict so the causes can be separated.
+#
+# Dispatch-only. A measurement, not a gate.
+name: bench-zeroconfig-refusal
+
+on:
+  workflow_dispatch:
+    inputs:
+      shapes:
+        description: "Fixture shapes (space separated)"
+        required: false
+        default: "person biblio"
+      rows:
+        description: "Row counts (space separated)"
+        required: false
+        default: "100000"
+      runner:
+        description: "Runner label"
+        required: false
+        default: "large-new-64GB"
+
+permissions:
+  contents: read
+
+env:
+  ARROW_DEFAULT_MEMORY_POOL: system
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+
+jobs:
+  diagnose:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      # The controller's blocking/scoring profilers have a native path
+      # (native_enabled("autoconfig")). Diagnosing the numpy fallback would
+      # describe a route the product does not take by default.
+      - name: Build native extension
+        run: uv run python scripts/build_native.py
+
+      - name: Diagnose
+        run: |
+          set -euo pipefail
+          uv run python scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py \
+            --shapes ${{ inputs.shapes }} \
+            --rows ${{ inputs.rows }} \
+            --out zeroconfig-refusal.json \
+            --summary-md zeroconfig-refusal.md
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ -f zeroconfig-refusal.md ]; then
+            cat zeroconfig-refusal.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'no summary produced - see the job log' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        if: always()
+        with:
+          name: zeroconfig-refusal
+          path: zeroconfig-refusal.json
+          # NOT `ignore`: a silent empty upload is how a wedged step reported
+          # success earlier in this repo's history.
+          if-no-files-found: error

--- a/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
+++ b/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Why the zero-config controller refuses, per shape and scale.
+
+## Why this exists
+
+The head-to-head panel records `gm_zeroconfig` as `refused` with one sentence of
+error text, and that reads as a single behaviour -- "zero-config gives up at
+100k rows". The four refusals actually observed disagree with each other:
+
+    biblio  100k   sub-profile=cluster    stop_reason=BUDGET_ITERATIONS
+    biblio  1M     sub-profile=blocking   stop_reason=BLOCKING_DEGENERATE
+    person  100k   sub-profile=blocking   stop_reason=POLICY_SATISFIED
+    person  1M     (timed out before reporting)
+
+Three different sub-profiles and three different stop reasons. `POLICY_SATISFIED`
+is the SUCCESS reason -- that search converged and the committed config still
+graded RED -- so the stop reason is not the cause either.
+
+`REFUSE_AT_N = 100_000` is real, but it is the ESCALATION point, not the cause:
+below it a RED config warn-and-runs, at or above it the same RED config refuses.
+So the question this answers is not "why 100k" but "why is the committed config
+RED", which is a different question per shape.
+
+## What it reports
+
+The controller returns `(config, profile, history)`. This runs it with
+`allow_red_config=True` so it hands the profile back instead of raising, then
+prints each sub-profile's health verdict beside THE FIELD VALUES THAT DECIDE IT,
+and names the rule that fired. The rules (complexity_profile.py):
+
+    blocking RED  <- n_blocks == 0
+                  <- block_sizes_p99 > 10 * (n_rows / n_blocks)   [skew]
+                  <- reduction_ratio < 0.5
+    cluster  RED  <- cluster_size_max > 0.1 * n_rows
+                  <- transitivity_rate < 0.85
+
+`cluster_size_max > 0.1 * n_rows` is worth watching on the person shape: the
+head-to-head measured non-singleton clusters averaging 7.98 members against a
+truth of 2.40 at 1M, which is the same over-merge this rule exists to catch. If
+it fires, the refusal is the guard working rather than a false alarm, and the
+two open questions are one question.
+
+Usage:
+    python scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py \\
+        --shapes person biblio --rows 100000 --out zeroconfig-refusal.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _fixture(shape: str, rows: int, seed: int, workdir: Path):
+    """Records for one head-to-head shape, via the bench's own generator."""
+    from generate_fixture import generate  # type: ignore
+
+    out = workdir / f"{shape}_{rows}.parquet"
+    truth = workdir / f"{shape}_{rows}_truth.parquet"
+    if not out.exists():
+        generate(rows=rows, dupe_rate=0.20, out=out, truth=truth,
+                 seed=seed, batch=1_000_000, shape=shape)
+    import pyarrow.parquet as pq
+
+    return pq.read_table(out), pq.read_table(truth)
+
+
+def _blocking_report(bp, n_rows: int) -> dict:
+    n_blocks = getattr(bp, "n_blocks", 0)
+    avg = n_rows / max(n_blocks, 1)
+    p99 = getattr(bp, "block_sizes_p99", 0)
+    rr = getattr(bp, "reduction_ratio", 0.0)
+    singles = getattr(bp, "singleton_block_count", 0)
+    fired = []
+    if n_blocks == 0:
+        fired.append("n_blocks == 0")
+    if p99 > 10 * avg:
+        fired.append(f"block_sizes_p99 {p99} > 10*avg {10 * avg:.1f}  [SKEW]")
+    if rr < 0.5:
+        fired.append(f"reduction_ratio {rr:.4f} < 0.5")
+    return {
+        "n_blocks": n_blocks, "avg_block_size": round(avg, 2),
+        "block_sizes_p50": getattr(bp, "block_sizes_p50", 0),
+        "block_sizes_p95": getattr(bp, "block_sizes_p95", 0),
+        "block_sizes_p99": p99,
+        "block_sizes_max": getattr(bp, "block_sizes_max", 0),
+        "reduction_ratio": round(rr, 6),
+        "singleton_block_count": singles,
+        "singleton_fraction": round(singles / max(n_blocks, 1), 4),
+        "red_rules_fired": fired,
+    }
+
+
+def _cluster_report(cp, n_rows: int) -> dict:
+    cmax = getattr(cp, "cluster_size_max", 0)
+    tr = getattr(cp, "transitivity_rate", 1.0)
+    fired = []
+    if n_rows > 0 and cmax > 0.1 * n_rows:
+        fired.append(f"cluster_size_max {cmax} > 10% of n_rows ({0.1 * n_rows:.0f})")
+    if tr < 0.85:
+        fired.append(f"transitivity_rate {tr:.4f} < 0.85")
+    return {
+        "n_clusters": getattr(cp, "n_clusters", 0),
+        "cluster_size_max": cmax,
+        "cluster_size_max_pct_of_rows": round(100 * cmax / max(n_rows, 1), 3),
+        "transitivity_rate": round(tr, 6),
+        "oversized_cluster_count": getattr(cp, "oversized_cluster_count", 0),
+        "bridge_edge_count": getattr(cp, "bridge_edge_count", 0),
+        "measured_bridge_risk": getattr(cp, "measured_bridge_risk", None),
+        "red_rules_fired": fired,
+    }
+
+
+def collect(shape: str, rows: int, seed: int, workdir: Path) -> dict:
+    import polars as pl
+    from goldenmatch.core.autoconfig_controller import (
+        REFUSE_AT_N,
+        AutoConfigController,
+        ControllerBudget,
+        _first_red_subprofile,
+        resolve_planning_effort,
+    )
+    from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+
+    records, _truth = _fixture(shape, rows, seed, workdir)
+    df = pl.from_arrow(records)
+
+    out: dict = {"shape": shape, "rows": rows, "refuse_at_n": REFUSE_AT_N,
+                 "would_refuse_by_size": rows >= REFUSE_AT_N}
+    t = time.perf_counter()
+    # allow_red_config=True is the point: it makes the controller HAND BACK the
+    # RED profile instead of raising, which is the only way to see the numbers
+    # behind a refusal. It does not change what the controller decided.
+    # Constructed the way `auto_configure_df` constructs it (heuristic policy,
+    # dataset-sized budget) so the profile this reports is the one the shipped
+    # path would produce. The LLM policy branch is deliberately skipped: it is
+    # env-gated and non-deterministic, and a diagnosis has to be reproducible.
+    ctrl = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget.for_dataset(df.height, resolve_planning_effort("normal")),
+    )
+    try:
+        _cfg, profile, history = ctrl.run(df, allow_red_config=True)
+    except Exception as e:  # noqa: BLE001 - one shape must not lose the rest
+        out["error"] = f"{type(e).__name__}: {str(e)[:400]}"
+        out["seconds"] = round(time.perf_counter() - t, 2)
+        return out
+    out["seconds"] = round(time.perf_counter() - t, 2)
+
+    n = profile.data.n_rows
+    healths = {
+        "data": profile.data.health().name,
+        "domain": profile.domain.health().name,
+        "matchkey": profile.matchkey.health().name,
+        "blocking": profile.blocking.health(n_rows=n).name,
+        "scoring": profile.scoring.health().name,
+        "cluster": profile.cluster.health(n_rows=n).name,
+    }
+    out["profiled_n_rows"] = n
+    out["health"] = healths
+    out["rollup"] = profile.health().name
+    out["first_red_subprofile"] = _first_red_subprofile(profile)
+    out["red_subprofiles"] = [k for k, v in healths.items() if v == "RED"]
+    out["stop_reason"] = history.stop_reason.name if history.stop_reason else None
+    out["iterations"] = len(getattr(history, "entries", []) or [])
+    out["blocking"] = _blocking_report(profile.blocking, n)
+    out["cluster"] = _cluster_report(profile.cluster, n)
+    out["scoring"] = {
+        "n_pairs_scored": getattr(profile.scoring, "n_pairs_scored", 0),
+        "dip_statistic": round(getattr(profile.scoring, "dip_statistic", 0.0), 6),
+        "mass_above_threshold": round(getattr(profile.scoring, "mass_above_threshold", 0.0), 6),
+        "random_pair_above_threshold_rate":
+            getattr(profile.scoring, "random_pair_above_threshold_rate", None),
+    }
+    return out
+
+
+def render(reports: list[dict]) -> str:
+    lines = ["# Zero-config refusal diagnosis", ""]
+    lines.append("| shape | rows | rollup | RED sub-profiles | first RED | stop reason |")
+    lines.append("|---|---:|---|---|---|---|")
+    for r in reports:
+        if r.get("error"):
+            lines.append(f"| {r['shape']} | {r['rows']:,} | ERROR | - | - | {r['error'][:60]} |")
+            continue
+        lines.append(
+            f"| {r['shape']} | {r['rows']:,} | {r['rollup']} | "
+            f"{', '.join(r['red_subprofiles']) or 'none'} | {r['first_red_subprofile']} | "
+            f"{r['stop_reason']} |"
+        )
+    lines.append("")
+    for r in reports:
+        if r.get("error"):
+            continue
+        lines.append(f"## {r['shape']} @ {r['rows']:,}")
+        for key in ("blocking", "cluster"):
+            fired = r[key]["red_rules_fired"]
+            lines.append(f"- **{key}**: {'RED -> ' + '; '.join(fired) if fired else 'no RED rule fired'}")
+            lines.append(f"  - `{json.dumps({k: v for k, v in r[key].items() if k != 'red_rules_fired'})}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shapes", nargs="+", default=["person", "biblio"])
+    ap.add_argument("--rows", nargs="+", type=int, default=[100000])
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--workdir", default=".zeroconfig_diag")
+    ap.add_argument("--out", default="zeroconfig-refusal.json")
+    ap.add_argument("--summary-md", default="")
+    args = ap.parse_args()
+
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    reports = []
+    for rows in args.rows:
+        for shape in args.shapes:
+            r = collect(shape, rows, args.seed, workdir)
+            reports.append(r)
+            if r.get("error"):
+                print(f"[zc] {shape}@{rows:,}: ERROR {r['error'][:160]}", flush=True)
+            else:
+                print(f"[zc] {shape}@{rows:,}: rollup={r['rollup']} "
+                      f"RED={r['red_subprofiles']} stop={r['stop_reason']} "
+                      f"({r['seconds']}s)", flush=True)
+                for key in ("blocking", "cluster"):
+                    for f in r[key]["red_rules_fired"]:
+                        print(f"       {key} RED: {f}", flush=True)
+
+    Path(args.out).write_text(json.dumps(reports, indent=2), encoding="utf-8")
+    print(f"[zc] wrote {args.out}", flush=True)
+    if args.summary_md:
+        Path(args.summary_md).write_text(render(reports), encoding="utf-8")
+        print(f"[zc] wrote {args.summary_md}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The panel records `gm_zeroconfig` as `refused` with one sentence of error text, which reads as a single behaviour: *zero-config gives up at 100k rows*. The four refusals actually observed disagree with each other.

| shape | rows | failing sub-profile | stop_reason |
|---|---:|---|---|
| biblio | 100k | `cluster` | `BUDGET_ITERATIONS` |
| biblio | 1M | `blocking` | `BLOCKING_DEGENERATE` |
| person | 100k | `blocking` | **`POLICY_SATISFIED`** |
| person | 1M | — | timed out before reporting |

Three sub-profiles, three stop reasons. And `POLICY_SATISFIED` is the **success** reason -- that search converged and the committed config still graded RED -- so the stop reason is not the cause either.

## The threshold is not the cause

Reading `autoconfig_controller.py`: `REFUSE_AT_N = 100_000` is the **escalation point**. Below it a RED config warn-and-runs; at or above it the *same* RED config refuses. So "refuses at ≥100k" names the trigger, not the failure. The real question is why each config grades RED — and that has a different answer per shape.

## What this reports

Runs the controller with `allow_red_config=True`, which makes it hand the profile back instead of raising, then prints each sub-profile's verdict **beside the field values that decide it**, naming the rule that fired:

```
blocking RED  <- n_blocks == 0
              <- block_sizes_p99 > 10 * (n_rows / n_blocks)   [skew]
              <- reduction_ratio < 0.5
cluster  RED  <- cluster_size_max > 0.1 * n_rows
              <- transitivity_rate < 0.85
```

## Why this may collapse two open questions into one

`cluster_size_max > 0.1 * n_rows` is the rule to watch. The head-to-head measured person@1M non-singleton clusters averaging **7.98** members against a truth of **2.40** — the same over-merge this rule exists to catch.

If it fires, the refusal is **the guard working**, not a false alarm, and the person-shape-at-1M degradation and the zero-config refusal are the same finding.

## Fidelity notes

- The controller is constructed the way `auto_configure_df` constructs it (heuristic policy, dataset-sized budget), so the profile reported is the one the shipped path produces.
- The LLM policy branch is skipped deliberately: env-gated and non-deterministic, and a diagnosis has to be reproducible.
- `if-no-files-found: error` on the upload — a silent empty upload is how a wedged step reported success earlier in this repo's history.