### PR TITLE
release: give goldenpipe-native a publish workflow at all

### DIFF
--- a/.github/workflows/publish-goldenpipe-native.yml
+++ b/.github/workflows/publish-goldenpipe-native.yml
@@ -1,0 +1,151 @@
+name: Publish goldenpipe-native to PyPI
+
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI. goldenpipe-native is the optional Rust/PyO3 binding that
+# exposes the pyo3-free `goldenpipe-core` planner kernel to Python
+# (`pip install goldenpipe[native]`). Per its own README it is NOT an
+# accelerator -- it makes the Rust core the reference the pure-Python planner is
+# gated against. Mirrors publish-goldenprofile-native.yml exactly.
+#
+# This workflow did not exist until the 2026-08-15 repo-wide cut, and that is
+# WHY goldenpipe-native had never been published. The crate has carried a
+# Cargo.toml + pyproject.toml at 0.1.0 for months with no pipeline to build it,
+# so there was no tag to miss and no red run to notice -- it was absent from
+# PyPI silently. Every sibling (goldenprofile-native, infermap-native,
+# goldenanalysis-native, goldencheck-native, goldengraph-native,
+# goldenflow-native) already had one.
+#
+# Fires on a release tagged `goldenpipe-native-v*` (kept distinct from every
+# other Python/TS/native tag so the publishers never cross-trigger).
+# workflow_dispatch with a `ref` allows a manual/retro build; leave `publish`
+# unchecked for a build-matrix dry run.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      publish:
+        description: "Upload to PyPI (uncheck for a build-matrix dry run)"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
+  MANIFEST: packages/rust/extensions/goldenpipe-native/Cargo.toml
+
+jobs:
+  linux:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheels (maturin, abi3, manylinux)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: "2_28"
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: x64
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  macos:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
+    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile.
+    # macos-13 (Intel) runners queue indefinitely in this org, so we don't use them.
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          command: sdist
+          args: --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    needs: [linux, windows, macos, sdist]
+    # Release events always publish; a workflow_dispatch publishes only when the
+    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
+    if: github.event_name != 'workflow_dispatch' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          # Merge every wheels-* artifact into a single dist/ for upload.
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
`goldenpipe-native` is absent from PyPI, and the reason is not a missed tag: **it has no publish workflow**. The crate has carried a `Cargo.toml` + `pyproject.toml` at 0.1.0 for months with nothing to build it, so there was no tag to miss and no red run to notice. It was silently absent.

Found while dispatching the repo-wide cut — every other publish workflow accepted `gh workflow run`, and this one failed because the file does not exist. Every sibling has one: `goldenprofile-native`, `infermap-native`, `goldenanalysis-native`, `goldencheck-native`, `goldengraph-native`, `goldenflow-native`.

## What this adds

Cloned from `publish-goldenprofile-native.yml` — same maturin/abi3 matrix (linux x86_64 + aarch64, windows x64, macOS both arches on `macos-14`, sdist), then a merged PyPI upload with `skip-existing: true`.

## The header is rewritten, not inherited

A blind clone described `goldenpipe-native` as the *"Semantic-Signature resolution engine that goldengraph gates on"* — that is goldenprofile's job — and left an `import goldenprofile_native` behind, because that spelling uses an underscore and survived the hyphenated rename.

Per its own README, goldenpipe-native is the optional Rust/PyO3 binding exposing the pyo3-free `goldenpipe-core` planner kernel, and is explicitly **not** an accelerator: it makes the Rust core the reference the pure-Python planner is gated against.