### PR TITLE
fix(release): PyPI publish rejects Metadata-Version 2.5

### DIFF
--- a/.github/workflows/_publish-pypi.yml
+++ b/.github/workflows/_publish-pypi.yml
@@ -56,7 +56,7 @@ jobs:
       - run: python -m build
       - name: Publish to PyPI
         if: inputs.dry_run != 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/python/${{ inputs.package }}/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-golden-suite.yml
+++ b/.github/workflows/publish-golden-suite.yml
@@ -50,7 +50,7 @@ jobs:
 
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/python/golden-suite/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenanalysis-native.yml
+++ b/.github/workflows/publish-goldenanalysis-native.yml
@@ -135,7 +135,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldencheck-native.yml
+++ b/.github/workflows/publish-goldencheck-native.yml
@@ -135,7 +135,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenflow-native.yml
+++ b/.github/workflows/publish-goldenflow-native.yml
@@ -136,7 +136,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenfuzz.yml
+++ b/.github/workflows/publish-goldenfuzz.yml
@@ -135,7 +135,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldengraph-native.yml
+++ b/.github/workflows/publish-goldengraph-native.yml
@@ -149,7 +149,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenmatch-duckdb.yml
+++ b/.github/workflows/publish-goldenmatch-duckdb.yml
@@ -54,7 +54,7 @@ jobs:
 
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/rust/extensions/duckdb/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenmatch-embed.yml
+++ b/.github/workflows/publish-goldenmatch-embed.yml
@@ -147,7 +147,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenmatch-hnsw.yml
+++ b/.github/workflows/publish-goldenmatch-hnsw.yml
@@ -139,7 +139,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenmatch-native.yml
+++ b/.github/workflows/publish-goldenmatch-native.yml
@@ -146,7 +146,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -84,7 +84,7 @@ jobs:
         run: python packages/python/goldenmatch/scripts/build_web.py
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/python/goldenmatch/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenphonetic.yml
+++ b/.github/workflows/publish-goldenphonetic.yml
@@ -135,7 +135,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenprofile-native.yml
+++ b/.github/workflows/publish-goldenprofile-native.yml
@@ -135,7 +135,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldensuite-mcp.yml
+++ b/.github/workflows/publish-goldensuite-mcp.yml
@@ -49,7 +49,7 @@ jobs:
 
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/python/goldensuite-mcp/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-infermap-native.yml
+++ b/.github/workflows/publish-infermap-native.yml
@@ -135,7 +135,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Every pure-Python PyPI publish in the repo-wide cut failed identically:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Ten packages, plus goldenmatch's own bespoke cutter. **Not the packages and not the version bumps.** `pip install build` is unpinned, so the builder now emits `Metadata-Version: 2.5`, and the pinned publish action cannot parse it.

## What localises it

Every maturin/native wheel published **fine** in the same wave. maturin emits older metadata, so those never touched the rejecting code path. The split is the diagnosis:

| build backend | result |
|---|---|
| `python -m build` (10 packages) | all failed, `Metadata-Version 2.5` |
| maturin/abi3 (9 packages) | all succeeded |

## The fix

The rejection string comes from `packaging`'s metadata validator, and the two action pins differ exactly there — checked against the action's own `requirements/runtime.txt` at both SHAs rather than inferred from version numbers:

| pin | date | twine | packaging |
|---|---|---|---|
| `cef22109` (current) | 2026-02-18 | 6.1.0 | **25.0** |
| `dc37677b` (v1.14.2) | 2026-07-29 | 7.0.0 | **26.2** |

Bumps `pypa/gh-action-pypi-publish` to v1.14.2 across all **16** workflows carrying the stale pin, resolved through the annotated tag to its commit SHA rather than a moving ref.

## State after the failed wave

No tag name is tombstoned. `v3.13.0` and `goldenmatch-native-v0.2.0` exist as tags but **no release was created** for either — the failure landed before the release step. So the retry path is clean, and neither version is burned.

## Not covered here

`publish-goldenpipe-native.yml` is still in flight in its own PR (#2598) and carries the old pin. It needs the same bump once that lands.