### PR TITLE
fix(release): bump the last stale PyPI publish pin

### DIFF
--- a/.github/workflows/publish-goldenpipe-native.yml
+++ b/.github/workflows/publish-goldenpipe-native.yml
@@ -144,7 +144,7 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
`publish-goldenpipe-native.yml` was created in #2598 by cloning a sibling, so it inherited the `cef22109` pin that #2599 was replacing everywhere else. The two PRs were in flight together and passed each other: #2599 updated the 16 workflows that existed when it branched, and this one was the 17th, landing after.

Called out in #2599's body as the known gap rather than left to be discovered. No stale pin remains repo-wide.