### PR TITLE
fix(release): goldenmatch-pg publishes no assets (wrong CWD)

### DIFF
--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -173,7 +173,25 @@ jobs:
         # The attestation lives in GitHub's attestation store; also attach it
         # to the release so consumers (and Scorecard) see it next to the
         # artifact.
-        run: cp "${{ steps.attest.outputs.bundle-path }}" "packages/rust/extensions/postgres/${ASSET}.intoto.jsonl"
+        #
+        # `working-directory` is REQUIRED here. The job defaults to
+        # `packages/rust/extensions`, and this step used to omit the override
+        # while writing a repo-root-relative destination -- so the path
+        # resolved to `packages/rust/extensions/packages/rust/extensions/
+        # postgres/...`, which does not exist. Every OTHER step in this job
+        # sets the directory explicitly; this one was missed, and it failed
+        # the whole build matrix at the last step before upload:
+        #
+        #   cp: cannot create regular file '...pg15-linux-x86_64.tar.gz
+        #   .intoto.jsonl': No such file or directory
+        #
+        # That is why goldenmatch-pg has published NO release assets: the
+        # tarballs built fine, then this killed the job before `Upload to
+        # release` ran. `goldenmatch-pg-v0.13.0` is a published release with
+        # zero assets, and it is the only non-skipped run this workflow has
+        # ever had that was not a success.
+        working-directory: packages/rust/extensions/postgres
+        run: cp "${{ steps.attest.outputs.bundle-path }}" "${ASSET}.intoto.jsonl"
 
       - name: Upload to release
         if: github.event_name == 'release'


### PR DESCRIPTION
`goldenmatch-pg-v0.13.0` is a **published GitHub Release with zero assets**. The extension sits at **0.19.0** in `Cargo.toml` against a last-released **0.13.0**, with 14 commits on top.

## Cause

The *Stage provenance bundle* step omits `working-directory` while writing a repo-root-relative destination. The job defaults to `packages/rust/extensions`, so the path resolved to:

```
packages/rust/extensions/packages/rust/extensions/postgres/...
```

and the step died at the last hurdle before upload:

```
cp: cannot create regular file
'goldenmatch_pg-0.13.0-pg15-linux-x86_64.tar.gz.intoto.jsonl':
No such file or directory
```

The tarballs built fine for pg15/16/17. This killed the job before `Upload to release` ran, so the release kept its tag and lost its artifacts.

**Every other step in that job sets `working-directory` explicitly.** This one was missed.

## The run history is unambiguous

| conclusion | count |
|---|---|
| skipped (other packages' release tags) | 96 |
| success | 3 |
| **failure** | **1** |

That single failure is the only time this workflow has ever fired for a real `goldenmatch-pg` release.

## How it surfaced

Found while finishing the repo-wide cut. `goldenmatch-pg` was one of two surfaces left, and checking whether its *last* release actually carried assets — rather than assuming a published release meant a delivered artifact — is what exposed it. Cutting 0.19.0 on top of the bug would have produced another empty release.

Once this lands, `goldenmatch-pg-v0.19.0` can be cut for real.