### PR TITLE
release: goldenmatch-pg 0.20.0 (0.19.0 is unusable)

### DIFF
--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.19.0'
+default_version = '0.20.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.19.0--0.20.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.19.0--0.20.0.sql
@@ -1,0 +1,18 @@
+-- Upgrade goldenmatch_pg 0.19.0 -> 0.20.0
+--
+-- INTENTIONALLY EMPTY. No schema change, no new function, no behaviour change:
+-- 0.20.0 exists only because the 0.19.0 tag is unusable.
+--
+-- goldenmatch-pg-v0.19.0 was created with `gh release create`, which publishes
+-- immediately. This repo has immutable releases enabled, so that sealed the
+-- release the moment it existed and its assets could never be attached -- and a
+-- tag consumed by a published immutable release is burned permanently
+-- (`gh release delete --cleanup-tag` does not free it). The release is still
+-- there, published, carrying zero assets.
+--
+-- The publish workflow was rebuilt in #2602 to own its release (draft -> attach
+-- -> publish, the shape publish-goldenmatch-spark-jar.yml already used), and it
+-- needs an unburned version to cut. Hence 0.20.0.
+--
+-- The extension itself is byte-identical to 0.19.0; sql/goldenmatch_pg--0.20.0.sql
+-- is a copy of the 0.19.0 base.

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.20.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.20.0.sql
@@ -1,0 +1,972 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+-- In-DB stateful identity resolution (#1913 P1). Resolves a job's table into a
+-- Postgres-native identity dataset (create/absorb/merge, incremental across
+-- runs). Writes go to the DSN from the goldenmatch.identity_dsn GUC.
+CREATE FUNCTION "gm_resolve"(
+    "job_name" TEXT,
+    "table_name" TEXT,
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_resolve_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- Two-table record linkage: match a target table against a reference table,
+-- returning the (target_id, reference_id, score) linkage as rows. target_id /
+-- reference_id are 0-based row indices into the respective input tables.
+CREATE FUNCTION "goldenmatch_match_pairs"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("target_id" BIGINT, "reference_id" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_pairs_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+-- `mode` selects the strategy: 'standard' (default, iterative controller) or
+-- 'probabilistic' (Fellegi-Sunter matchkeys). The DEFAULT keeps 1-arg calls.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir)
+-- via goldenembed-rs (pure Rust, no embedded CPython). Returns the vector as
+-- float8[].
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS double precision[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';
+
+-- goldenmatch_hnsw_pairs (added in 0.10.0): native HNSW ANN blocking over a
+-- row-major flat real[] corpus. See the 0.9.0->0.10.0 migration for details.
+CREATE FUNCTION "goldenmatch_hnsw_pairs"(
+    "flat_vecs" real[],
+    "dim" INT,
+    "k" INT,
+    "threshold" DOUBLE PRECISION
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_hnsw_pairs_wrapper';
+
+-- goldenmatch_lsh_pairs (added in 0.11.0): native MinHash-LSH token blocking
+-- over a text[] corpus. See the 0.10.0->0.11.0 migration for details.
+CREATE FUNCTION "goldenmatch_lsh_pairs"(
+    "texts" TEXT[],
+    "mode" TEXT,
+    "k" INT,
+    "num_perms" INT,
+    "num_bands" INT,
+    "seed" BIGINT
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_lsh_pairs_wrapper';
+
+-- goldenmatch_perceptual_phash (added in 0.12.0): native-direct (no CPython)
+-- 64-bit DCT perceptual image hash over a row-major flat luma grid + its row
+-- width. The kernel resizes to 32x32 internally. The unsigned 64-bit hash is
+-- returned bit-reinterpreted as BIGINT. See the 0.11.0->0.12.0 migration.
+CREATE FUNCTION "goldenmatch_perceptual_phash"(
+    "grid" double precision[],
+    "ncols" INT
+) RETURNS BIGINT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_phash_wrapper';
+
+-- goldenmatch_perceptual_hamming (added in 0.12.0): Hamming distance between two
+-- 64-bit pHashes (the near-duplicate blocking predicate). Correct on the BIGINT
+-- bit patterns goldenmatch_perceptual_phash returns.
+CREATE FUNCTION "goldenmatch_perceptual_hamming"(
+    "a" BIGINT,
+    "b" BIGINT
+) RETURNS INT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_hamming_wrapper';
+
+-- ── GoldenCheck deep-profiling surface (added in 0.13.0) ────────────────────
+-- Native-direct (no CPython) over the pyo3-free goldencheck-core kernels — the
+-- same reference kernel the goldencheck[native] wheel + the DuckDB goldencheck_*
+-- UDFs run (cross-surface parity roadmap P5). The multi-column functions take a
+-- column-major flat text[] (all of column 0's rows, then column 1's, …) + n_cols.
+
+-- goldencheck_benford: leading-digit (1..9) histogram; element d-1 is the count
+-- of values whose first significant digit is d (non-positive/non-finite skipped).
+CREATE FUNCTION "goldencheck_benford"(
+    "values" double precision[]
+) RETURNS BIGINT[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_benford_wrapper';
+
+-- goldencheck_near_duplicates: cluster near-duplicate string values; one
+-- (cluster, member) row per clustered element (member = 0-based position);
+-- singletons omitted; NULL elements treated as the empty string.
+CREATE FUNCTION "goldencheck_near_duplicates"(
+    "values" TEXT[],
+    "min_similarity" DOUBLE PRECISION
+) RETURNS TABLE ("cluster" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_near_duplicates_wrapper';
+
+-- goldencheck_discover_fds: strict single-column functional dependencies among
+-- n_cols equal-length columns; (det, dep) 0-based column-index pairs.
+CREATE FUNCTION "goldencheck_discover_fds"(
+    "flat" TEXT[],
+    "n_cols" INT
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_fds_wrapper';
+
+-- goldencheck_discover_approx_fds: near-strict FDs + their violation counts;
+-- (det, dep, violations) where det->dep holds for >= min_confidence of rows.
+CREATE FUNCTION "goldencheck_discover_approx_fds"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "min_confidence" DOUBLE PRECISION
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT, "violations" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_approx_fds_wrapper';
+
+-- goldencheck_composite_keys: minimal composite keys (column subsets of size
+-- 2..max_size whose tuples are all distinct); one (key_id, col_index) row per
+-- column in each key. Constant + individually-unique columns are excluded first.
+CREATE FUNCTION "goldencheck_composite_keys"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "max_size" INT
+) RETURNS TABLE ("key_id" BIGINT, "col_index" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_composite_keys_wrapper';
+
+CREATE FUNCTION "gm_identity_merge"(
+    "dataset" TEXT,
+    "entity_a" TEXT,
+    "entity_b" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_merge_wrapper';
+
+CREATE FUNCTION "gm_identity_split"(
+    "dataset" TEXT,
+    "entity_id" TEXT,
+    "record_id" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_split_wrapper';
+
+-- ── Identity audit / mediation / MDM SQL surface (added in 0.16.0) ──
+CREATE FUNCTION "gm_identity_audit"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_wrapper';
+
+CREATE FUNCTION "gm_identity_audit_verify"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_verify_wrapper';
+
+CREATE FUNCTION "gm_identity_profile"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_profile_wrapper';
+
+CREATE FUNCTION "gm_identity_stats"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_stats_wrapper';
+
+CREATE FUNCTION "gm_identity_worklist"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_worklist_wrapper';
+
+CREATE FUNCTION "gm_identity_audit_seal"(
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_seal_wrapper';
+
+CREATE FUNCTION "gm_identity_resolve_conflict"(
+    "dataset" TEXT,
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "resolution" TEXT,
+    "reason" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_resolve_conflict_wrapper';
+
+CREATE FUNCTION "gm_identity_claim"(
+    "entity_id" TEXT,
+    "record_id" TEXT,
+    "reason" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_claim_wrapper';
+
+-- 0.17.0: structural key-integrity certifier (the semantic-layer wedge).
+CREATE FUNCTION "goldenmatch_certify_structural"(
+    "input_json" TEXT
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_certify_structural_wrapper';
+
+-- 0.18.0: in-SQL orientation. Returns the extension's llms.txt (compiled in via
+-- include_str!), so an agent on a bare connection -- no filesystem, no package
+-- to import -- can find the authoritative docs instead of inferring behaviour
+-- from eighty function signatures. Zero-arg and dependency-free: it answers
+-- even in a backend where the Python bridge would fail to initialise.
+CREATE FUNCTION "goldenmatch_docs"() RETURNS TEXT
+IMMUTABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_docs_wrapper';
+
+-- 0.19.0: Fellegi-Sunter training from COUNTED comparison vectors, native-direct.
+--
+-- goldenmatch_train_em(rows, matchkey, params) trains through the embedded
+-- CPython bridge because it samples pairs and bins them into comparison
+-- vectors, and neither of those is ported. This function starts one step later
+-- -- from vectors the engine has already counted -- and so needs no Python at
+-- all: it calls the pyo3-free score-core::em_core kernel directly, the same
+-- shape as goldenmatch_hnsw_pairs / goldenmatch_lsh_pairs.
+--
+-- That split is the design, not a shortcut. Counting agreement patterns is
+-- GROUP BY over the gamma columns, which is what a SQL engine is for, and the
+-- number of distinct vectors is bounded by prod(levels + 1) -- thousands of
+-- rows however many pairs were compared. So Postgres can now do both halves of
+-- FS training with no interpreter in the backend.
+--
+-- Flat arrays because pgrx flattens multidimensional ones (the
+-- goldenmatch_hnsw_pairs(flat_vecs, dim) idiom): `patterns` is row-major
+-- n_patterns x n_fields with -1 meaning unobserved, and `u_probs` is RAGGED --
+-- field j contributes n_levels[j] entries -- so it is flattened in field order
+-- and split back by n_levels.
+--
+-- Fail-soft to a {"error": ...} envelope, like goldenmatch_certify_structural:
+-- a training call inside a larger query must not abort the transaction.
+--
+--   SELECT goldenmatch.goldenmatch_train_em_from_counts(
+--       ARRAY[2,2], ARRAY[1,1, 0,1, 1,0, 0,0],
+--       ARRAY[500,300,150,50]::float8[],
+--       ARRAY[0.9,0.1, 0.85,0.15]::float8[],
+--       ARRAY[false,false]);
+CREATE FUNCTION "goldenmatch_train_em_from_counts"(
+    "n_levels" INT[],
+    "patterns" INT[],
+    "counts" DOUBLE PRECISION[],
+    "u_probs" DOUBLE PRECISION[],
+    "conditioned" BOOL[],
+    "max_iterations" INT DEFAULT 20,
+    "convergence" DOUBLE PRECISION DEFAULT 0.001
+) RETURNS TEXT
+IMMUTABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_from_counts_wrapper';


### PR DESCRIPTION
Pure version bump. **No schema change, no new function, no behaviour change** — the extension is byte-identical to 0.19.0 and `sql/goldenmatch_pg--0.20.0.sql` is a copy of the 0.19.0 base.

## Why 0.19.0 cannot be used

I created its release with `gh release create`, which publishes immediately. This repo has immutable releases enabled, so the release sealed the moment it existed and its assets could never be attached. A tag consumed by a published immutable release is **burned permanently** — `gh release delete --cleanup-tag` does not free it. `goldenmatch-pg-v0.19.0` is still there: published, zero assets, unrecoverable.

The publish workflow was rebuilt in #2602 to own its release (draft → attach → publish, the shape `publish-goldenmatch-spark-jar.yml` already used successfully under the same setting). It needs an unburned version to cut against.

## Contents

- `Cargo.toml` and `goldenmatch_pg.control` `default_version` → 0.20.0
- new base SQL (copy of 0.19.0)
- `goldenmatch_pg--0.19.0--0.20.0.sql`, **deliberately empty**, with a comment explaining why — so a reader who finds a no-op upgrade script does not go hunting for a change that is not there

`check_pgrx_sql_sync.py` green: 82 `#[pg_extern]` vs 82 `CREATE FUNCTION`.

Once merged I will push `goldenmatch-pg-v0.20.0` and verify the release carries **9 assets** (3 PG versions x tarball + sigstore + intoto) rather than trusting a green run.