### PR TITLE
perf(spark): the counts stage evaluated its whole DAG twice

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -116,11 +116,27 @@ def agreement_pattern_counts(
         .agg(F.count(F.lit(1)).alias("agreement_pattern_count"))
     )
 
-    # Bound BEFORE collecting. `count()` on the grouped frame is one more
-    # distributed pass and costs a fraction of what materialising an
-    # unexpectedly large result on the driver would.
-    n = grouped.count()
-    if n > max_patterns:
+    # ONE evaluation, not two. This used to be `grouped.count()` followed by
+    # `grouped.collect()`, on the reasoning that the count "costs a fraction of"
+    # the collect. It does not: Spark caches nothing here, so `count()` re-ran
+    # the ENTIRE upstream DAG -- the candidate join, the per-pair scorer UDF over
+    # every pair, and the groupBy -- and then `collect()` ran all of it again.
+    #
+    # MEASURED: at 5M rows / 49.2M candidate pairs this stage was 443.32s, 94.0%
+    # of the whole distributed training wall (fixture 2.3%, u 3.7%, driver EM
+    # 0.0%). Halving a stage that IS the wall is the single biggest lever on this
+    # surface.
+    #
+    # `limit(max_patterns + 1)` keeps the guard exactly as strong. Under the
+    # bound it returns every row (the point of the +1 is that overflow is
+    # detectable), and it never materialises more than max_patterns + 1 rows on
+    # the driver, which is what the guard existed to prevent.
+    rows = grouped.limit(max_patterns + 1).collect()
+    if len(rows) > max_patterns:
+        # Only on the failure path, which is about to raise anyway: pay for one
+        # more pass to report the EXACT count, so the error stays as actionable
+        # as it was before (it names the number the model actually produced).
+        n = grouped.count()
         raise ValueError(
             f"{n} distinct agreement patterns exceeds max_patterns="
             f"{max_patterns}. The bound is prod(levels + 1) over the "
@@ -130,7 +146,6 @@ def agreement_pattern_counts(
             f"path exists to avoid."
         )
 
-    rows = grouped.collect()
     out = [
         (tuple(int(r[name]) for name in names), int(r["agreement_pattern_count"]))
         for r in rows

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -435,11 +435,45 @@ def test_pattern_counts_are_identical_jar_only(source, jvm_registered):
 
 def test_an_oversized_pattern_space_is_refused_not_collected(source):
     """`collect()` of an unexpectedly large frame is a driver OOM, which is the
-    failure this whole path exists to avoid -- so the bound is checked against
-    the real row count before anything is materialised."""
+    failure this whole path exists to avoid -- so the bound is enforced before
+    anything unbounded is materialised.
+
+    The counts stage now takes ONE pass (`limit(max_patterns + 1).collect()`)
+    instead of `count()` then `collect()`, which re-ran the whole upstream DAG.
+    That rewrite could plausibly have weakened this guard, so the guard is what
+    this asserts: at most `max_patterns + 1` rows ever reach the driver, and
+    exceeding the bound still raises."""
     cfg = _config()
     with pytest.raises(ValueError, match="max_patterns"):
         _spark_pattern_counts(source, cfg, max_patterns=1)
+
+
+def test_the_oversized_refusal_still_names_the_real_pattern_count(source):
+    """The error reports the ACTUAL number of distinct patterns, not just
+    "more than the bound".
+
+    Worth pinning: the single-pass rewrite only knows `> max_patterns` from the
+    truncated collect, so it pays for one extra pass ON THE FAILURE PATH to
+    recover the exact figure. If that were dropped as an optimisation the error
+    would silently degrade from "N patterns exceeds max_patterns=M" to
+    something a reader cannot size, and no other test would notice."""
+    cfg = _config()
+    exact = len(_driver_pattern_counts(source, cfg))
+    assert exact > 1, "fixture must exceed the bound for this to mean anything"
+    with pytest.raises(ValueError, match=rf"^{exact} distinct agreement patterns"):
+        _spark_pattern_counts(source, cfg, max_patterns=1)
+
+
+def test_counts_under_the_bound_return_every_pattern(source):
+    """`limit(max_patterns + 1)` must not truncate a legitimate result.
+
+    The +1 exists so overflow is detectable; the risk it introduces is silently
+    dropping rows when the result is legal. With the bound set to exactly the
+    real pattern count, every pattern must still come back."""
+    cfg = _config()
+    expected = _driver_pattern_counts(source, cfg)
+    got = _spark_pattern_counts(source, cfg, max_patterns=len(expected))
+    assert got == expected
 
 
 # ── distributed training: u, the per-pass sessions, the combination ──


### PR DESCRIPTION
## Where the time is

At 5M rows the distributed FS counting stage is **443.32s of a 471.53s wall — 94.0%**:

| stage | seconds | share |
|---|---:|---:|
| fixture | 10.71 | 2.3% |
| u | 17.49 | 3.7% |
| **counts** | **443.32** | **94.0%** |
| driver EM | 0.01 | 0.0% |

So this stage *is* the wall. Everything else is noise.

## It was doing the work twice

```python
n = grouped.count()       # full evaluation
...
rows = grouped.collect()  # full evaluation AGAIN
```

Spark caches nothing here, so `count()` re-ran the **entire upstream DAG** — the candidate join, the per-pair scorer UDF over all **49.2M pairs**, and the groupBy — and then `collect()` ran all of it again. The comment justified the extra pass as costing "a fraction of" the collect. It costs everything upstream of it.

## The fix

`grouped.limit(max_patterns + 1).collect()` — one pass. Under the bound it returns every row; over it, the extra row makes overflow detectable. At most `max_patterns + 1` rows ever reach the driver, which is precisely what the guard existed to prevent, so **the guard is not weakened**.

The error still names the real number: the truncated collect only knows `> max_patterns`, so the exact count is recovered with one more pass **on the failure path**, which is about to raise anyway. Silently degrading that message to "more than the bound" would have been a hidden cost of the optimisation.

## Tests aimed at the failure modes, not the happy path

- the existing oversized-refusal test, re-documented so the next reader knows it is load-bearing against this rewrite;
- **the refusal still names the actual pattern count** — pins the failure-path pass so a later "optimisation" cannot quietly drop it;
- **a legal result at exactly the bound returns every pattern** — silent truncation is the risk `limit` introduces, and nothing else would have caught it.

## Not claiming the number yet

Expected saving is up to half of a stage that is 94% of the wall. I will A/B it on the cluster against run `31903675803` (5M, same fixture and seed) and report the measured delta rather than asserting it here.