### PR TITLE
fix(release): publish-goldenmatch ships to PyPI then fails cutting a release

### DIFF
--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -76,6 +76,31 @@ jobs:
       # `packages = ["goldenmatch"]` picks them up. Without this step the
       # wheel ships only `.gitkeep` and `goldenmatch[web]` users can't
       # serve the UI without running build_web.py themselves.
+      # TAG falls back to `github.ref_name` when a dispatch passes no `tag`,
+      # and on a branch dispatch that is the BRANCH ("main"), not a version tag.
+      # Run 31916544559 did exactly that: it published to PyPI and only then
+      # failed at the release step, trying to cut a GitHub Release named `main`
+      # (403 "Resource not accessible by integration"). A published wheel with
+      # no release is the worst outcome of the three, so refuse BEFORE the
+      # publish rather than after it. Mirrors the resolve-the-version step in
+      # publish-goldenmatch-spark-jar.yml.
+      - name: Refuse a ref that is not a version tag
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAG:-}" ]; then
+            echo "::error::No tag resolved. Push a vX.Y.Z tag (this workflow fires on it) or pass 'tag' to the dispatch."
+            exit 1
+          fi
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::TAG='${TAG}' is not a version tag (expected vX.Y.Z). A workflow_dispatch with no 'tag' input falls back to the branch name, which publishes to PyPI and then fails cutting a release named '${TAG}'. Re-run with tag=vX.Y.Z."
+              exit 1
+              ;;
+          esac
+          echo "Publishing tag: $TAG"
+
       - name: Install pnpm workspace deps
         working-directory: ${{ github.workspace }}
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What and why

Found while checking why `main-health` (#2457) reports a red lane. Run [31916544559](https://github.com/benseverndev-oss/goldenmatch/actions/runs/31916544559) published `goldenmatch` to PyPI and **then** failed:

```
⚠️ GitHub release failed with status: 403
⚠️ Unexpected error fetching GitHub release for tag refs/heads/main
   HttpError: Resource not accessible by integration
```

`TAG` is `${{ inputs.tag || github.ref_name }}`. That is correct for the `push` trigger, where `github.ref_name` **is** the pushed tag. On a `workflow_dispatch` with no `tag` input it is the **branch** — `main` — so the workflow tried to cut a GitHub Release named `main`.

That produces the worst of the three possible outcomes: a wheel on PyPI with **no release, no signed assets and no notes**, and an error that points at permissions rather than the real cause. `contents: write` is already declared and is not the problem.

## The fix

Refuse a non-version ref **before** the publish rather than after it, since publishing is the irreversible half. This mirrors the `Resolve the version` step in `publish-goldenmatch-spark-jar.yml`, which already refuses a missing tag with an actionable `::error::` and documents why.

Verified truth table:

| `TAG` | outcome |
|---|---|
| `main` | REFUSED (not vX.Y.Z) — the actual failure |
| `` (empty) | REFUSED (empty) |
| `v3.13.0` | ACCEPTED |
| `goldenmatch-spark-v1.0.0` | REFUSED (different tag namespace) |

The error message names the cause and the remedy, rather than leaving the next person to decode a 403.

## Scope

`publish-goldenmatch.yml` is the **only** workflow carrying this fallback — every other publisher derives its tag from `github.event.release.tag_name` or validates it in a step. Confirmed by grep across all publish workflows, so this is a one-file fix rather than a sweep.

## Not affected

The 3.13.0 release itself is fine. `Cut goldenmatch release` succeeded separately at 00:16 and PyPI carries 3.13.0 — I verified against the PyPI JSON API rather than inferring it. Several other publish runs in that batch failed at 23:57 on an unrelated `Metadata-Version: 2.5` rejection and were retried successfully at 00:09; those are not addressed here, and are worth a separate look if they recur.

This change stops the *next* dispatch from half-publishing.

## Testing

- `scripts/check_workflow_yaml.py` — 127 files parse, no duplicate keys.
- `pytest scripts/test_workflow_yaml.py` — 10 passed.
- Guard logic executed directly against the four ref shapes above.

## Checklist

- [x] Tests added/updated and passing locally for the changed package — workflow YAML validation + the guard's truth table
- [ ] `pre-commit run --all-files` is clean — not run, `pre-commit` is not installed in this environment
- [x] Package `CHANGELOG.md` updated if behavior changed — CI-only change, no runtime behaviour
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — the reasoning is documented inline in the workflow, next to the guard

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_