### PR TITLE
docs(probabilistic): the refit comment still says default off; it is on (#2483)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -978,15 +978,22 @@ def _score_probabilistic_matchkey(
                 n_buckets=config.n_buckets,
                 em_result=em_result,
             )
-            # Phase 3a threshold refit (GOLDENMATCH_FS_REFIT_THRESHOLD, default off):
+            # Phase 3a threshold refit (GOLDENMATCH_FS_REFIT_THRESHOLD, default ON
+            # since #2522; `=0` is the byte-identical kill-switch):
             # pick the link cutoff from the actual scored-pair distribution -- the
             # class-separating valley -- but COMMIT it only when re-clustering there
-            # reduces over-merge (max cluster size), correcting the over-merge the
-            # non-iterated FS path can't see WITHOUT regressing clean data (a bare
-            # valley cut removes low-scoring true matches on person/ncvr; the
-            # cluster-shape guard rejects it there). No-op unless the flag is on and
-            # no explicit user threshold. Scores are already computed (re-cluster
-            # only, no re-scoring); only the cutoff used for the split moves.
+            # both (a) reduces over-merge (max cluster size) AND (b) strands at most
+            # `_REFIT_MAX_EXPELLED_SHARE` of already-matched records as singletons.
+            # Criterion (b) is not decoration: (a) alone is a single-outlier
+            # statistic, so it accepts a cutoff that shatters many correct
+            # clusters as long as the largest shrinks -- the #2387 ncvr regression.
+            # See `_expelled_share` in probabilistic.py for why the two regimes
+            # separate (repair regroups records; shattering expels them).
+            #
+            # No-op unless the flag is on and no explicit user threshold -- note
+            # that a caller-set `link_threshold` short-circuits this, which is why
+            # #2483 declined to have auto-config write one in. Scores are already
+            # computed (re-cluster only, no re-scoring); only the cutoff moves.
             link_threshold = _maybe_refit_link_threshold(
                 mk, link_threshold, table=_pair_table
             )


### PR DESCRIPTION
## What and why

`pipeline.py` describes the Phase 3a threshold refit as:

```python
# Phase 3a threshold refit (GOLDENMATCH_FS_REFIT_THRESHOLD, default off):
```

It has been **on** since #2522. Verified at runtime rather than by reading — with the variable unset, `_fs_refit_threshold_enabled()` returns `True` and the resolver defaults to `"1"`.

This matters more than a typo would. The refit is the mechanism that resolves **#2483**'s headline symptom — the blind 0.50 fallback that admitted 94.4% of scored pairs — so a comment claiming it is off points the next reader away from the thing that fixes their problem. And "the text says one thing, the code does another" is the exact failure mode #2483 is about, which makes it a poor place to carry a stale claim.

## Two more corrections in the same comment

**The accept criterion was described as half of itself.** The comment said the refit commits only when re-clustering "reduces over-merge (max cluster size)". That was true until #2518 ANDed it with `_expelled_share` — and the missing half is the load-bearing one. The max test alone is a single-outlier statistic: it accepts a cutoff that shatters many correct clusters so long as the largest one shrinks, which is precisely the #2387 ncvr regression (−0.0966 F1). Both criteria are now described, with a pointer to `_expelled_share` for why the two regimes separate (repair *regroups* records, shattering *expels* them).

**A caller-set `link_threshold` short-circuits the refit.** Now recorded inline, because it is the mechanical reason #2483 suggestion 3 was declined — writing a threshold in to make the config self-describing would disable the fix — and it was previously only discoverable by reading the resolver.

## Scope

Comment-only, no behaviour change.

Checked the other references and deliberately left them: `docs/context/code-patterns.md` already documents the final flip correctly (it carries the whole flip → revert → re-flip history), and the two CHANGELOG mentions of default-off are historical entries for the versions where that *was* true. `pipeline.py:981` was the only live claim contradicting the code.

## Testing

- `pytest tests/test_fs_refit_threshold.py tests/test_probabilistic_cutoff_2483.py` — **36 passed**.
- `ruff check` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package — comment-only; the surrounding suites are run above
- [ ] `pre-commit run --all-files` is clean — not run, `pre-commit` is not installed in this environment; `ruff check` was run directly and is clean
- [x] Package `CHANGELOG.md` updated if behavior changed — no behaviour change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — this *is* the doc correction

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_