### PR TITLE
perf(spark): the cluster is a topology rig, and its numbers were being read as throughput

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -46,6 +46,21 @@ on:
         required: false
         type: boolean
         default: false
+      runner:
+        description: "Runner for the cluster job. ubuntu-latest is 4 CPU - a TOPOLOGY rig. Use large-new-64GB to measure throughput."
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      worker_cores:
+        description: "Cores per Spark worker (there are 2). Default 1 = 2 executor cores TOTAL, which is correctness sizing, not throughput."
+        required: false
+        type: string
+        default: "1"
+      worker_memory:
+        description: "Memory per Spark worker, e.g. 1g / 6g."
+        required: false
+        type: string
+        default: "1g"
   schedule:
     # Nightly, after the usual working day. Cheap insurance that the topology
     # still works; nothing here gates a merge.
@@ -106,7 +121,11 @@ jobs:
 
   cluster:
     needs: aarch64
-    runs-on: ubuntu-latest
+    # ubuntu-latest (4 CPU) is the DEFAULT because this lane's original job is
+    # proving topology on an 8-row fixture. A throughput run must pass a bigger
+    # runner AND bigger workers -- see `runner` / `worker_cores` above and the
+    # sizing note in docker/spark-cluster/docker-compose.yml.
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
@@ -181,7 +200,16 @@ jobs:
           bash scripts/build_spark_jar.sh
 
       - name: Start the cluster
-        run: docker compose -f docker/spark-cluster/docker-compose.yml up -d
+        env:
+          # Compose reads these; unset they default to the 1-core / 1g topology
+          # sizing baked into the file, so an unparameterised run is unchanged.
+          SPARK_WORKER_CORES: ${{ inputs.worker_cores || '1' }}
+          SPARK_WORKER_MEMORY: ${{ inputs.worker_memory || '1g' }}
+          SPARK_EXECUTOR_CORES: ${{ inputs.worker_cores || '1' }}
+          SPARK_EXECUTOR_MEMORY: ${{ inputs.worker_memory || '1g' }}
+        run: |
+          docker compose -f docker/spark-cluster/docker-compose.yml up -d
+          echo "cluster sized: 2 workers x ${SPARK_WORKER_CORES} core(s) / ${SPARK_WORKER_MEMORY}" >> "$GITHUB_STEP_SUMMARY"
 
       # Readiness is polled HERE rather than by a container healthcheck, so a
       # failure names the condition that was never met instead of surfacing as a

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -99,11 +99,23 @@ services:
     depends_on: [spark-master]
     command: >
       /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker
-      spark://spark-master:7077 --cores 1 --memory 1g
-    # Modest, and deliberately so: a GitHub-hosted runner is 4 CPU / 16 GB and
-    # has to hold the master, both workers, the Connect server AND the client.
-    # The point here is topology, not throughput -- the data is a handful of
-    # rows.
+      spark://spark-master:7077
+      --cores ${SPARK_WORKER_CORES:-1} --memory ${SPARK_WORKER_MEMORY:-1g}
+    # Defaults stay 1 core / 1g: the ORIGINAL point of this cluster is topology,
+    # not throughput -- an 8-row fixture proving the jar-only property on real
+    # executors, on a 4 CPU / 16 GB GitHub runner that also holds the master,
+    # both workers, the Connect server AND the client.
+    #
+    # They are now env-overridable because that default silently became a
+    # PERFORMANCE claim. The FS scale harness runs 5M rows here and its numbers
+    # were being read as throughput; on 2 total executor cores they are not.
+    # Worse, both workers are containers on ONE host, so a shuffle never touches
+    # a network -- which is why a counts-stage profile attributed ~0% to the
+    # GROUP BY exchange. That number is honest for this topology and misleading
+    # as a general claim.
+    #
+    # Set SPARK_WORKER_CORES / SPARK_WORKER_MEMORY (and a bigger runner) when
+    # measuring throughput. Leave them alone when proving topology.
 
   spark-worker-2:
     <<: *worker
@@ -128,8 +140,8 @@ services:
       --conf spark.connect.grpc.binding.address=0.0.0.0
       --conf spark.connect.grpc.binding.port=15002
       --conf spark.driver.host=spark-connect
-      --conf spark.executor.memory=1g
-      --conf spark.executor.cores=1
+      --conf spark.executor.memory=${SPARK_EXECUTOR_MEMORY:-1g}
+      --conf spark.executor.cores=${SPARK_EXECUTOR_CORES:-1}
 
 networks:
   spark:


### PR DESCRIPTION
The FS scale harness runs **5M rows** against this cluster and I have been quoting its stage timings as performance. The cluster is:

- `runs-on: ubuntu-latest` — 4 CPU, also hosting master + Connect server + client
- two workers at `--cores 1 --memory 1g`

**Two executor cores. One host.** Its own compose comment says it plainly: *"the point here is topology, not throughput."*

## What this corrects

The counts-stage profile attributed **~0% to the GROUP BY exchange**, and I generalised that into "pre-aggregating patterns in the JVM targets only 3% — Spark already does it."

Both workers are containers on **one host**, so a shuffle never crosses a network. That ~0% is honest for this topology and **misleading as a general claim** — on a real cluster the exchange is network I/O. Anyone choosing between design options on that number would be choosing on an artifact of the rig.

Notably, this makes **version 2** (partition-level UDF returning `map<pattern,count>`) the more robust bet either way: it removes the per-pair crossings *and* shrinks the exchange, so it wins under both topologies rather than betting on one.

## What it does NOT change

**#2607's 48%** (counts 443.32s → 224.26s, byte-identical output). Doing the same work twice is waste at any topology.

## The change

Defaults are **untouched**, so every existing correctness run behaves exactly as before:

- compose reads `SPARK_WORKER_CORES` / `SPARK_WORKER_MEMORY` / `SPARK_EXECUTOR_CORES` / `SPARK_EXECUTOR_MEMORY`, defaulting to `1` / `1g`
- the workflow gains `runner`, `worker_cores`, `worker_memory`; the cluster job's `runs-on` follows `runner`
- the sizing is echoed into the job summary, so a reader of any future measurement sees what it ran on instead of assuming

## Why now

This is a precondition for benchmarking GM against Splink on one cluster. A 2-core single-host rig cannot answer whether we are slower than Splink, and running that comparison on it would produce a number exactly as misleading as the one this commit is correcting.