### PR TITLE
bench(spark): measure Splink on the SAME cluster, because nothing did

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -46,6 +46,21 @@ on:
         required: false
         type: boolean
         default: false
+      runner:
+        description: "Runner for the cluster job. ubuntu-latest is 4 CPU - a TOPOLOGY rig. Use large-new-64GB to measure throughput."
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      worker_cores:
+        description: "Cores per Spark worker (there are 2). Default 1 = 2 executor cores TOTAL, which is correctness sizing, not throughput."
+        required: false
+        type: string
+        default: "1"
+      worker_memory:
+        description: "Memory per Spark worker, e.g. 1g / 6g."
+        required: false
+        type: string
+        default: "1g"
   schedule:
     # Nightly, after the usual working day. Cheap insurance that the topology
     # still works; nothing here gates a merge.
@@ -106,7 +121,11 @@ jobs:
 
   cluster:
     needs: aarch64
-    runs-on: ubuntu-latest
+    # ubuntu-latest (4 CPU) is the DEFAULT because this lane's original job is
+    # proving topology on an 8-row fixture. A throughput run must pass a bigger
+    # runner AND bigger workers -- see `runner` / `worker_cores` above and the
+    # sizing note in docker/spark-cluster/docker-compose.yml.
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
@@ -181,7 +200,16 @@ jobs:
           bash scripts/build_spark_jar.sh
 
       - name: Start the cluster
-        run: docker compose -f docker/spark-cluster/docker-compose.yml up -d
+        env:
+          # Compose reads these; unset they default to the 1-core / 1g topology
+          # sizing baked into the file, so an unparameterised run is unchanged.
+          SPARK_WORKER_CORES: ${{ inputs.worker_cores || '1' }}
+          SPARK_WORKER_MEMORY: ${{ inputs.worker_memory || '1g' }}
+          SPARK_EXECUTOR_CORES: ${{ inputs.worker_cores || '1' }}
+          SPARK_EXECUTOR_MEMORY: ${{ inputs.worker_memory || '1g' }}
+        run: |
+          docker compose -f docker/spark-cluster/docker-compose.yml up -d
+          echo "cluster sized: 2 workers x ${SPARK_WORKER_CORES} core(s) / ${SPARK_WORKER_MEMORY}" >> "$GITHUB_STEP_SUMMARY"
 
       # Readiness is polled HERE rather than by a container healthcheck, so a
       # failure names the condition that was never met instead of surfacing as a

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -99,11 +99,23 @@ services:
     depends_on: [spark-master]
     command: >
       /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker
-      spark://spark-master:7077 --cores 1 --memory 1g
-    # Modest, and deliberately so: a GitHub-hosted runner is 4 CPU / 16 GB and
-    # has to hold the master, both workers, the Connect server AND the client.
-    # The point here is topology, not throughput -- the data is a handful of
-    # rows.
+      spark://spark-master:7077
+      --cores ${SPARK_WORKER_CORES:-1} --memory ${SPARK_WORKER_MEMORY:-1g}
+    # Defaults stay 1 core / 1g: the ORIGINAL point of this cluster is topology,
+    # not throughput -- an 8-row fixture proving the jar-only property on real
+    # executors, on a 4 CPU / 16 GB GitHub runner that also holds the master,
+    # both workers, the Connect server AND the client.
+    #
+    # They are now env-overridable because that default silently became a
+    # PERFORMANCE claim. The FS scale harness runs 5M rows here and its numbers
+    # were being read as throughput; on 2 total executor cores they are not.
+    # Worse, both workers are containers on ONE host, so a shuffle never touches
+    # a network -- which is why a counts-stage profile attributed ~0% to the
+    # GROUP BY exchange. That number is honest for this topology and misleading
+    # as a general claim.
+    #
+    # Set SPARK_WORKER_CORES / SPARK_WORKER_MEMORY (and a bigger runner) when
+    # measuring throughput. Leave them alone when proving topology.
 
   spark-worker-2:
     <<: *worker
@@ -128,8 +140,8 @@ services:
       --conf spark.connect.grpc.binding.address=0.0.0.0
       --conf spark.connect.grpc.binding.port=15002
       --conf spark.driver.host=spark-connect
-      --conf spark.executor.memory=1g
-      --conf spark.executor.cores=1
+      --conf spark.executor.memory=${SPARK_EXECUTOR_MEMORY:-1g}
+      --conf spark.executor.cores=${SPARK_EXECUTOR_CORES:-1}
 
 networks:
   spark:


### PR DESCRIPTION
Every design option on this surface — columnar UDF, Catalyst extension, Arrow C Data Interface — has been sized against *"we are ~5x slower than Splink"*. **That number is nowhere in this repo.**

What exists is a *different* comparison (the JVM path measured 2.4x slower than the **Python-worker** path) and a single-box panel whose Splink lane runs on **DuckDB, not Spark**. Choosing an architecture on an unmeasured gap is how a month goes into the wrong thing.

## What it matches

- **the cluster** — same master, same two workers, whatever sizing the workflow gave them
- **the fixture** — it *imports* `build_fixture` from `spark_fs_train_scale.py` rather than re-implementing it. Two "identical" generators that quietly drift is the classic benchmark lie.
- **the workload** — estimate `u`, then EM per blocking rule. Training only, no scoring or clustering. Same five comparison fields.

## What it does not match, and says so in the output

**Session type.** GM runs over Spark **Connect** (`addArtifact` is Connect-only — the whole reason the jar tier exists). Splink **cannot**: it reaches for `sparkContext`, which Connect does not expose. So Splink gets a classic session on `:7077` while GM gets Connect on `:15002`.

That confound is real, and it is also the honest *product* comparison — it is how each engine actually ships. Anyone wanting to isolate "is our kernel slower" needs a different experiment; anyone asking "GM or Splink on my cluster" wants exactly this one. It's recorded in the JSON as `session_confound` rather than left for a reader to discover.

## Two ways this could have silently mis-measured

- **No executors.** A classic session that never gets one still runs — on the driver — and reports a wall unrelated to the cluster. The script waits for at least one to register and fails with that diagnosis.
- **Unreachable driver.** The driver is on the runner; executors are containers and must connect *back*. `spark.driver.host` has to be the docker bridge gateway, not `localhost`. Getting it wrong doesn't error — the job hangs on *"Initial job has not accepted any resources"* — so the workflow resolves the gateway explicitly and prints it.

Gated behind `splink_compare` (default off), and placed **after** the GM run so both see the same warm cluster. The correctness lane is unaffected.