### PR TITLE
perf(spark): separate per-CALL from per-BYTE scoring cost before building a UDF

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -61,6 +61,11 @@ on:
         required: false
         type: string
         default: "1g"
+      train_fields:
+        description: "Comparison fields for the FS scale run (max 5). Run 5 vs 2 with profile_counts to separate per-CALL from per-BYTE scoring cost."
+        required: false
+        type: string
+        default: "5"
   schedule:
     # Nightly, after the usual working day. Cheap insurance that the topology
     # still works; nothing here gates a merge.
@@ -452,7 +457,8 @@ jobs:
           ROWS="${{ inputs.train_rows || '1000000' }}"
           PROFILE=""
           if [ "${{ inputs.profile_counts }}" = "true" ]; then PROFILE="--profile-counts"; fi
-          python scripts/spark_fs_train_scale.py --rows "$ROWS" $PROFILE --out spark-fs-train-scale.json
+          FIELDS="${{ inputs.train_fields || '5' }}"
+          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS" $PROFILE --out spark-fs-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         if: always()

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -248,7 +248,37 @@ def profile_counts(joined, mk, *, scorer_udf, transform_udf, cands):
     return out
 
 
-def make_config():
+def make_config(n_fields: int = 5):
+    """The scale config. ``n_fields`` trims the COMPARISON fields only.
+
+    ## Why this is a knob
+
+    The counts stage is ~87% scoring, and scoring is the ONE thing that crosses
+    into the kernel -- `_field_similarity_and_observed` is explicit that levels,
+    the weight lookup, the sum and the posterior are all already Spark SQL. So
+    the question that picks the next optimisation is whether that 87% scales
+    with the NUMBER of calls or with the BYTES marshalled:
+
+      per-CALL  -> one call per pair instead of one per field is a ~5x cut, and
+                   no columnar/FFI rewrite is needed to get most of it.
+      per-BYTE  -> fewer, fatter calls move nothing, and the Arrow C Data
+                   Interface (or leaving Spark Connect) is the only real lever.
+
+    That matters because the jar's own `GoldenScoreRowUdf` documents why the
+    previous batching attempt LOST: Spark arrays are `ArrayData` of
+    `InternalRow`, so array-shaped UDF I/O pays row-wise object churn. A fatter
+    UDF would reintroduce some of that, and is only worth building if the cost
+    is per-call.
+
+    Varying the field count over the SAME pairs separates the two, and costs a
+    config change instead of a JNI rewrite. Blocking is untouched, so the
+    candidate set is identical across arms and only the per-pair crossing count
+    moves.
+
+    Trimming from the END keeps `first` and `last` -- the high-cardinality
+    jaro-winkler fields -- in every arm, so a smaller arm is never accidentally
+    cheaper because it dropped the expensive scorers.
+    """
     from goldenmatch.config.schemas import (
         BlockingConfig,
         BlockingKeyConfig,
@@ -257,6 +287,19 @@ def make_config():
         MatchkeyField,
     )
 
+    cfg = _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
+                        MatchkeyConfig, MatchkeyField)
+    mk = cfg.get_matchkeys()[0]
+    if n_fields < len(mk.fields):
+        # Trim in place. Rebuilding a shorter literal risks the arms differing
+        # in something other than field count, which is the one variable this
+        # experiment must isolate.
+        mk.fields = mk.fields[:n_fields]
+    return cfg
+
+
+def _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
+                  MatchkeyConfig, MatchkeyField):
     return GoldenMatchConfig(
         blocking=BlockingConfig(
             strategy="multi_pass",
@@ -302,6 +345,13 @@ def main() -> int:
     ap.add_argument("--remote", default=os.environ.get(
         "GOLDENMATCH_SPARK_REMOTE", "sc://localhost:15002"))
     ap.add_argument("--u-max-pairs", type=int, default=1_000_000)
+    ap.add_argument(
+        "--fields", type=int, default=5,
+        help="Number of COMPARISON fields (max 5). Same blocking, same "
+             "candidate pairs -- only the per-pair crossing count changes. "
+             "Run 5 vs 2 and compare `scoring_udf`: linear in field count "
+             "means the cost is per-CALL (fewer, fatter calls win); flat means "
+             "per-BYTE (only columnar/FFI moves it).")
     ap.add_argument(
         "--profile-counts", action="store_true",
         help="Attribute the counts stage across pair generation / record "
@@ -350,7 +400,7 @@ def main() -> int:
         "rows": args.rows, "dup": args.dup,
         "blocks_per_key": args.blocks_per_key,
         "kernel_impl": impl, "kernel_runtime": runtime,
-        "stages": {}, "passes": [],
+        "stages": {}, "passes": [], "n_fields": args.fields,
     }
 
     t0 = time.perf_counter()
@@ -364,7 +414,7 @@ def main() -> int:
     print(f"[scale] fixture: {actual:,} rows in "
           f"{out['stages']['fixture_seconds']}s", flush=True)
 
-    cfg = make_config()
+    cfg = make_config(args.fields)
     mk = cfg.get_matchkeys()[0]
 
     # ── u: sampled self-join. Cost tracks the SAMPLE, not the table. ──


### PR DESCRIPTION
The counts stage is **~87% scoring**, and scoring is the *only* thing that crosses into the kernel — `_field_similarity_and_observed` is explicit that levels, the weight lookup, the sum and the posterior are already Spark SQL.

The obvious next move is a fatter UDF: one call per **pair** instead of one per **field**, ~5x fewer crossings. Before building it, I read why the previous batching attempt lost — and it isn't what I assumed. From `GoldenScoreRowUdf`'s own docs:

> Spark's arrays are `ArrayData` of `InternalRow` objects, not columnar vectors … **Batching pays row-wise object churn to avoid a columnar Arrow transfer that is cheaper than the churn.**

A fatter UDF reintroduces some of that churn. So it is only worth building if the 87% is **per-call**. If it is **per-byte**, fewer/fatter calls move nothing and only a columnar/FFI path helps — a far larger commitment, since it leaves Spark Connect, and Connect is the entire deployment story of the jar tier.

## The experiment

`--fields N` separates the two for the price of a config change instead of a JNI rewrite. **Blocking is untouched**, so the candidate set is identical across arms and only the per-pair crossing count moves.

| result | meaning | next move |
|---|---|---|
| scoring **linear** in field count | per-CALL | build the fatter UDF |
| scoring **flat** in field count | per-BYTE | only columnar/FFI moves it |

Two details that keep the arms honest:

- **Trimming takes fields from the end**, keeping `first` and `last` — the high-cardinality jaro-winkler fields — in every arm. Otherwise a smaller arm could look cheaper simply because it dropped the expensive scorers.
- **The trim happens on the built config**, not by rebuilding a shorter literal, so the 5-field arm stays byte-identical to what shipped.

`n_fields` is recorded in the JSON so an artifact is self-describing; `train_fields` is a workflow input.