### PR TITLE
diag(zeroconfig): record the number the blocking RED rule should be using

### DIFF
--- a/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
+++ b/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
@@ -83,15 +83,38 @@ def _blocking_report(bp, n_rows: int) -> dict:
         fired.append(f"block_sizes_p99 {p99} > 10*avg {10 * avg:.1f}  [SKEW]")
     if rr < 0.5:
         fired.append(f"reduction_ratio {rr:.4f} < 0.5")
+    # Pair-share of the biggest block: the measure the RED rule arguably should
+    # be using. `p99 > 10 * avg` compares a tail percentile to a MEAN that is
+    # pinned near 1 whenever blocking is fine-grained (n_blocks -> n_rows), so
+    # it fires on configs with excellent reduction and no singletons. What
+    # actually makes skew dangerous is that a few blocks own most of the WORK,
+    # and work is quadratic in block size -- so the honest question is what
+    # fraction of total candidate pairs the largest block contributes.
+    #
+    # Recorded, not acted on: changing a RED rule needs this number first, and
+    # the first version of this diagnostic did not capture it.
+    total_pairs = getattr(bp, "total_comparisons", 0) or 0
+    biggest = getattr(bp, "block_sizes_max", 0) or 0
+    biggest_pairs = biggest * (biggest - 1) // 2
     return {
         "n_blocks": n_blocks, "avg_block_size": round(avg, 2),
         "block_sizes_p50": getattr(bp, "block_sizes_p50", 0),
         "block_sizes_p95": getattr(bp, "block_sizes_p95", 0),
         "block_sizes_p99": p99,
-        "block_sizes_max": getattr(bp, "block_sizes_max", 0),
+        "block_sizes_max": biggest,
         "reduction_ratio": round(rr, 6),
         "singleton_block_count": singles,
         "singleton_fraction": round(singles / max(n_blocks, 1), 4),
+        "total_comparisons": int(total_pairs),
+        "largest_block_pairs": int(biggest_pairs),
+        "largest_block_pair_share": (
+            round(biggest_pairs / total_pairs, 6) if total_pairs else None
+        ),
+        "p99_over_avg": round(p99 / avg, 2) if avg else None,
+        "p99_over_p50": (
+            round(p99 / getattr(bp, "block_sizes_p50", 0), 2)
+            if getattr(bp, "block_sizes_p50", 0) else None
+        ),
         "red_rules_fired": fired,
     }
 


### PR DESCRIPTION
The blocking RED rule is:

```python
avg = n_rows / max(n_blocks, 1)
if block_sizes_p99 > 10 * avg:   # RED
```

That denominator is a **mean**, and it is pinned near 1 whenever blocking is fine-grained. Measured on person@100k:

| | |
|---|---:|
| n_blocks | 84,293 |
| n_rows | 100,000 |
| **avg** | **1.19** |
| bar (10 x avg) | 11.9 |
| p99 | 72 |
| reduction_ratio | **0.9757** |
| singleton_fraction | **0.0** |

Any block over a dozen rows trips it. That config has *excellent* reduction and *zero* singletons, and it grades RED — which is why zero-config refuses it.

## Why this PR does not fix the rule

Because the first version of this diagnostic did not capture the quantity a better rule would use. Skew is dangerous when a few blocks own most of the **work**, and work is quadratic in block size — so the honest measure is what fraction of total candidate pairs the largest block contributes, not a tail percentile over a mean.

Now recorded, all from fields `BlockingProfile` already carries:

- `total_comparisons` — the denominator that was missing
- `largest_block_pairs` — `max*(max-1)/2`
- `largest_block_pair_share` — the candidate replacement signal
- `p99_over_avg` — the current rule's ratio, made explicit
- `p99_over_p50` — the obvious alternative denominator

**Recorded, not acted on.** A RED rule decides whether zero-config refuses a user's run. Swapping one heuristic for another on reasoning rather than evidence is presumably how the current rule got here. Re-run the diagnostic, read the share, then change the rule.