### PR TITLE
bench(spark): measure Splink on the SAME cluster (re-land)

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -66,6 +66,11 @@ on:
         required: false
         type: string
         default: "0"
+      splink_compare:
+        description: "Also run Splink FS training on the SAME cluster and print both walls. Nothing currently measures the GM-vs-Splink gap on Spark."
+        required: false
+        type: boolean
+        default: false
       train_fields:
         description: "Comparison fields for the FS scale run (max 5). Run 5 vs 2 with profile_counts to separate per-CALL from per-BYTE scoring cost."
         required: false
@@ -471,6 +476,34 @@ jobs:
         with:
           name: spark-fs-train-scale
           path: spark-fs-train-scale.json
+
+      # Splink on the SAME cluster. Deliberately AFTER the GM run so both see an
+      # identical warm cluster, and gated so the correctness lane is unaffected.
+      - name: Splink FS training on the same cluster
+        if: inputs.splink_compare && inputs.train_rows != '0' && inputs.train_rows != ''
+        continue-on-error: true
+        timeout-minutes: 45
+        run: |
+          set -euo pipefail
+          pip install "splink==4.0.16" >/dev/null
+          # The driver runs HERE; the executors are containers. They must route
+          # back to the driver, so `spark.driver.host` has to be the docker
+          # bridge gateway, not localhost. Getting this wrong does not error --
+          # the job hangs on "Initial job has not accepted any resources" -- so
+          # it is resolved explicitly and printed.
+          GW=$(docker network inspect spark-cluster_spark                  --format '{{ (index .IPAM.Config 0).Gateway }}' 2>/dev/null || true)
+          if [ -z "$GW" ]; then
+            GW=$(docker network inspect bridge                    --format '{{ (index .IPAM.Config 0).Gateway }}')
+          fi
+          echo "driver host (docker bridge gateway): $GW"
+          python scripts/spark_splink_train_scale.py             --rows "${{ inputs.train_rows || '1000000' }}"             --master spark://localhost:7077             --driver-host "$GW"             --out splink-train-scale.json
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        if: always() && inputs.splink_compare
+        with:
+          name: splink-train-scale
+          path: splink-train-scale.json
+          if-no-files-found: warn
           if-no-files-found: ignore
 
       # Python worker" fails on its own rather than because an empty virtualenv

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -476,6 +476,7 @@ jobs:
         with:
           name: spark-fs-train-scale
           path: spark-fs-train-scale.json
+          if-no-files-found: ignore
 
       # Splink on the SAME cluster. Deliberately AFTER the GM run so both see an
       # identical warm cluster, and gated so the correctness lane is unaffected.
@@ -491,9 +492,10 @@ jobs:
           # bridge gateway, not localhost. Getting this wrong does not error --
           # the job hangs on "Initial job has not accepted any resources" -- so
           # it is resolved explicitly and printed.
-          GW=$(docker network inspect spark-cluster_spark                  --format '{{ (index .IPAM.Config 0).Gateway }}' 2>/dev/null || true)
+          FMT='{{ (index .IPAM.Config 0).Gateway }}'
+          GW=$(docker network inspect spark-cluster_spark --format "$FMT" 2>/dev/null || true)
           if [ -z "$GW" ]; then
-            GW=$(docker network inspect bridge                    --format '{{ (index .IPAM.Config 0).Gateway }}')
+            GW=$(docker network inspect bridge --format "$FMT")
           fi
           echo "driver host (docker bridge gateway): $GW"
           python scripts/spark_splink_train_scale.py             --rows "${{ inputs.train_rows || '1000000' }}"             --master spark://localhost:7077             --driver-host "$GW"             --out splink-train-scale.json
@@ -504,7 +506,6 @@ jobs:
           name: splink-train-scale
           path: splink-train-scale.json
           if-no-files-found: warn
-          if-no-files-found: ignore
 
       # Python worker" fails on its own rather than because an empty virtualenv
       # was shipped to make it fail. The local lane can only simulate this.

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Splink FS training on the SAME Spark cluster, for a like-for-like wall.
+
+## Why this exists
+
+Every performance decision on the Spark tier has been sized against "we are ~5x
+slower than Splink", and that number does not exist anywhere in this repo. What
+does exist is a different comparison (the JVM path measured 2.4x slower than the
+PYTHON-WORKER path) and a single-box panel whose Splink lane runs on **DuckDB**,
+not Spark. Choosing between a columnar UDF, a Catalyst extension and an Arrow
+C-Data-Interface rewrite on the strength of an unmeasured gap is how a month
+goes into the wrong thing.
+
+This runs Splink's Fellegi-Sunter TRAINING against the same standalone cluster,
+on the same fixture, so the two numbers are comparable.
+
+## What is matched, and what is not
+
+MATCHED: the cluster (one master, two workers, whatever sizing the workflow
+gave them), the fixture (`build_fixture` from `spark_fs_train_scale.py` --
+literally the same function, same seed, same row count), and the workload
+(estimate u, then EM parameter estimation -- model training, not scoring or
+clustering).
+
+NOT MATCHED, deliberately and unavoidably: the SESSION TYPE. GoldenMatch's tier
+runs over Spark **Connect** because `addArtifact` is Connect-only and that is
+the deployment story the jar exists for. Splink cannot run over Connect -- it
+reaches for `sparkContext`, which Connect does not expose. So Splink gets a
+CLASSIC session against `spark://...:7077` while GM gets Connect against
+`sc://...:15002`.
+
+That confound is real and is reported in the output rather than smoothed over.
+It is also the honest product comparison: this is how each engine actually
+ships. A reader wanting to isolate "is our kernel slower" needs a different
+experiment; a reader asking "should I use GM or Splink on my cluster" wants
+exactly this one.
+
+## Read the cluster sizing before reading the number
+
+The default rig is two workers at one core each on a 4-CPU runner -- two
+executor cores, one host. That is a TOPOLOGY rig, and a wall measured on it is
+not throughput for either engine. The workflow's `runner` / `worker_cores` /
+`worker_memory` inputs exist to size it up; this script records the executor
+count it actually saw so an artifact cannot be read out of context.
+
+## The driver has to be reachable
+
+A classic session driven from the runner puts the DRIVER on the host while the
+executors are containers. The workers must connect BACK to the driver, so
+`spark.driver.host` has to be an address they can route to -- the docker bridge
+gateway, not `localhost`. Get it wrong and the symptom is not an error: the job
+sits at "Initial job has not accepted any resources" until something times out.
+`--driver-host` is therefore explicit, and the script fails loudly with that
+diagnosis if no executor registers inside `--executor-wait`.
+
+Usage:
+    python scripts/spark_splink_train_scale.py --rows 1000000 \\
+        --master spark://localhost:7077 --driver-host 172.17.0.1 \\
+        --out splink-train-scale.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+
+def _fixture_module():
+    """Import `build_fixture` from the GM harness, so the data is identical.
+
+    Re-implementing the generator here would be the classic benchmark lie: two
+    "same" fixtures that drift apart, and a comparison that quietly measures the
+    difference between them instead of the difference between the engines.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "spark_fs_train_scale.py"
+    spec = importlib.util.spec_from_file_location("spark_fs_train_scale", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def build_session(master: str, driver_host: str | None, wait_s: int):
+    from pyspark.sql import SparkSession
+
+    b = (
+        SparkSession.builder.master(master)
+        .appName("splink-train-scale")
+        # Splink materialises many intermediate tables; the default 200 shuffle
+        # partitions on a small cluster is pure scheduling overhead.
+        .config("spark.sql.shuffle.partitions", "8")
+        .config("spark.driver.bindAddress", "0.0.0.0")
+    )
+    if driver_host:
+        b = b.config("spark.driver.host", driver_host)
+    spark = b.getOrCreate()
+
+    # Refuse to measure a cluster that never gave us executors. Without this the
+    # run "works" -- it just runs everything on the driver and reports a wall
+    # that has nothing to do with the cluster, which is a worse outcome than a
+    # failure because it looks like data.
+    deadline = time.time() + wait_s
+    n = 0
+    while time.time() < deadline:
+        try:
+            n = spark.sparkContext._jsc.sc().getExecutorMemoryStatus().size() - 1
+        except Exception:  # noqa: BLE001 - probe only
+            n = 0
+        if n > 0:
+            break
+        time.sleep(2)
+    if n <= 0:
+        raise SystemExit(
+            f"::error::no executor registered within {wait_s}s on {master}. "
+            f"The usual cause is driver reachability: the driver runs on this "
+            f"host and the workers are containers, so `spark.driver.host` must "
+            f"be an address they can route to (the docker bridge gateway), not "
+            f"localhost. Pass --driver-host."
+        )
+    print(f"[splink] {n} executor(s) registered on {master}", flush=True)
+    return spark, n
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, default=1_000_000)
+    ap.add_argument("--dup", type=int, default=3, help="rows per entity")
+    ap.add_argument("--blocks-per-key", type=int, default=4)
+    ap.add_argument("--master", default=os.environ.get(
+        "SPLINK_SPARK_MASTER", "spark://localhost:7077"))
+    ap.add_argument("--driver-host", default=os.environ.get("SPLINK_DRIVER_HOST", ""))
+    ap.add_argument("--executor-wait", type=int, default=120)
+    ap.add_argument("--max-pairs", type=int, default=1_000_000,
+                    help="Splink's u-estimation sample. Matches the GM harness's "
+                         "--u-max-pairs so the u stage is comparable.")
+    ap.add_argument("--out", default="splink-train-scale.json")
+    args = ap.parse_args()
+
+    out: dict = {
+        "engine": "splink", "rows_requested": args.rows, "master": args.master,
+        "stages": {}, "session_type": "classic",
+        "session_confound": (
+            "GM runs over Spark Connect (addArtifact is Connect-only); Splink "
+            "cannot (it uses sparkContext). Same cluster, different front door."
+        ),
+    }
+    t_all = time.perf_counter()
+
+    spark, n_exec = build_session(args.master, args.driver_host or None,
+                                  args.executor_wait)
+    out["executors"] = n_exec
+
+    fx = _fixture_module()
+    t = time.perf_counter()
+    df = fx.build_fixture(spark, args.rows, args.dup, args.blocks_per_key)
+    df = df.withColumnRenamed("__row_id__", "record_id")
+    actual = df.count()
+    out["stages"]["fixture_seconds"] = round(time.perf_counter() - t, 2)
+    out["actual_rows"] = int(actual)
+    print(f"[splink] fixture: {actual:,} rows in "
+          f"{out['stages']['fixture_seconds']}s", flush=True)
+
+    from splink import Linker, SettingsCreator, block_on
+    from splink import comparison_library as cl
+    from splink.backends.spark import SparkAPI
+
+    # The SAME five fields the GM harness compares, at the same shape: two
+    # jaro-winkler name fields, a levenshtein date, and two more jaro-winkler.
+    # Splink expresses levels as thresholds and GM as `levels=3` with a partial
+    # cut; both give three informative levels per field.
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        blocking_rules_to_generate_predictions=[block_on("blk"), block_on("last")],
+        comparisons=[
+            cl.JaroWinklerAtThresholds("first", [0.9, 0.7]),
+            cl.JaroWinklerAtThresholds("last", [0.9, 0.7]),
+            cl.DamerauLevenshteinAtThresholds("dob", [1, 2]),
+            cl.JaroWinklerAtThresholds("zip", [0.9, 0.7]),
+            cl.JaroWinklerAtThresholds("city", [0.9, 0.7]),
+        ],
+    )
+    linker = Linker(df, settings, db_api=SparkAPI(spark_session=spark))
+
+    # u, from random pairs -- the same quantity the GM harness times as `u`.
+    t = time.perf_counter()
+    linker.training.estimate_u_using_random_sampling(max_pairs=args.max_pairs)
+    out["stages"]["u_seconds"] = round(time.perf_counter() - t, 2)
+    print(f"[splink] u in {out['stages']['u_seconds']}s", flush=True)
+
+    # m, by EM, once per blocking rule -- the GM harness's per-pass sessions.
+    t = time.perf_counter()
+    for rule in (block_on("blk"), block_on("last")):
+        linker.training.estimate_parameters_using_expectation_maximisation(rule)
+    out["stages"]["em_seconds"] = round(time.perf_counter() - t, 2)
+    print(f"[splink] EM in {out['stages']['em_seconds']}s", flush=True)
+
+    out["stages"]["total_seconds"] = round(time.perf_counter() - t_all, 2)
+    # `train_total` is the number to put beside GM's u + counts + train. The
+    # fixture build is excluded from BOTH: it is the harness, not the engine.
+    out["train_total_seconds"] = round(
+        out["stages"]["u_seconds"] + out["stages"]["em_seconds"], 2
+    )
+    print(f"[splink] DONE rows={actual:,} executors={n_exec} train_total="
+          f"{out['train_total_seconds']}s stages={out['stages']}", flush=True)
+
+    Path(args.out).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"[splink] wrote {args.out}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## This was written once and never landed

I opened **two PRs from one branch** (`perf/cluster-sizing`): #2611 for the cluster sizing, then committed this on top and opened #2613. #2613 squash-merged as `752cb540f` — with **#2611's title and 2 files**, the sizing change re-applied. The Splink lane was never in any commit; it is absent from main *and* from the branch.

Two mistakes, both mine: reusing a branch that already had a PR, and not verifying the commit landed before opening a PR on it. This time the commit is verified (2 files, 250 insertions) before the PR exists.

## The work

Every design option on this surface — columnar UDF, Catalyst extension, Arrow C Data Interface — has been sized against *"we are ~5x slower than Splink"*. **That number is nowhere in this repo.** What exists is a *different* comparison (JVM path 2.4x slower than the **Python-worker** path) and a single-box panel whose Splink lane runs on **DuckDB, not Spark**.

**Matched:** the cluster, the fixture (it *imports* `build_fixture` rather than re-implementing it — two "identical" generators that drift is the classic benchmark lie), the workload (estimate `u`, then EM per blocking rule; training only), and the five comparison fields.

**Not matched, recorded in the JSON:** session type. GM runs over Connect (`addArtifact` is Connect-only); Splink cannot (it uses `sparkContext`). Splink gets classic on `:7077`, GM gets Connect on `:15002`. A real confound *and* the honest product comparison — it is how each ships.

## Two silent mis-measures it refuses

- **No executors.** A classic session that never gets one still runs — on the driver — and reports a wall unrelated to the cluster. It waits, then fails with that diagnosis.
- **Unreachable driver.** Executors must connect *back* to a driver on the host, so `spark.driver.host` must be the docker bridge gateway. A wrong value doesn't error — it hangs on *"Initial job has not accepted any resources"*. The workflow resolves the gateway explicitly and prints it.

The **executor count is recorded**, because the default rig is two executor cores on one host and a wall measured there is not throughput for either engine.

Gated behind `splink_compare` (default off), placed after the GM run so both see the same warm cluster.