### PR TITLE
perf(spark): --fields cannot separate per-CALL from per-BYTE; --value-pad can

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -61,6 +61,11 @@ on:
         required: false
         type: string
         default: "1g"
+      value_pad:
+        description: "Append N chars to every comparison value. Same crossing COUNT, more bytes per crossing - the arm that separates per-CALL from per-BYTE scoring cost."
+        required: false
+        type: string
+        default: "0"
       train_fields:
         description: "Comparison fields for the FS scale run (max 5). Run 5 vs 2 with profile_counts to separate per-CALL from per-BYTE scoring cost."
         required: false
@@ -458,7 +463,8 @@ jobs:
           PROFILE=""
           if [ "${{ inputs.profile_counts }}" = "true" ]; then PROFILE="--profile-counts"; fi
           FIELDS="${{ inputs.train_fields || '5' }}"
-          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS" $PROFILE --out spark-fs-train-scale.json
+          PAD="${{ inputs.value_pad || '0' }}"
+          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS" --value-pad "$PAD" $PROFILE --out spark-fs-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         if: always()

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -47,7 +47,7 @@ import os
 import time
 
 
-def build_fixture(spark, rows: int, dup: int, blocks_per_key: int):
+def build_fixture(spark, rows: int, dup: int, blocks_per_key: int, value_pad: int = 0):
     """A person-shaped frame with a known duplicate structure, built in-engine.
 
     ``dup`` rows per entity, so the true-match count is known. Blocking keys are
@@ -109,13 +109,34 @@ def build_fixture(spark, rows: int, dup: int, blocks_per_key: int):
     zipc = F.concat(F.lit("z"), F.lpad((ent % F.lit(500)).cast("string"), 3, "0"))
     city = F.concat(F.lit("city"), (ent % F.lit(40)).cast("string"))
 
+    # `value_pad` lengthens every COMPARISON value by a constant suffix without
+    # changing cardinality, which fields exist, or which pairs block together.
+    # It is the knob that separates per-CALL from per-BYTE scoring cost:
+    # crossing COUNT is identical across pad settings, only the bytes marshalled
+    # per crossing move. (Varying the FIELD COUNT cannot do this -- adding a
+    # field adds a call AND its bytes, so both hypotheses predict the same
+    # scaling. That was a design error in the first version of this experiment.)
+    #
+    # The pad is a constant string, so it cannot change a similarity ORDERING:
+    # jaro-winkler and levenshtein both see the same suffix on each side of
+    # every pair, so gammas -- and therefore the pattern counts and the trained
+    # model -- are unchanged. Only the marshalled length moves.
+    pad = F.lit("z" * value_pad) if value_pad > 0 else None
+
+    def padded(col):
+        if pad is None:
+            return col
+        # Concat only when the value is present; a padded NULL would become a
+        # non-null and silently change the unobserved level.
+        return F.when(col.isNull(), col).otherwise(F.concat(col, pad))
+
     return spark.range(rows).select(
         F.col("id").alias("__row_id__"),
-        perturbed(first, 101).alias("first"),
-        perturbed(last, 202).alias("last"),
-        perturbed(dob, 303).alias("dob"),
-        perturbed(zipc, 404).alias("zip"),
-        perturbed(city, 505).alias("city"),
+        padded(perturbed(first, 101)).alias("first"),
+        padded(perturbed(last, 202)).alias("last"),
+        padded(perturbed(dob, 303)).alias("dob"),
+        padded(perturbed(zipc, 404)).alias("zip"),
+        padded(perturbed(city, 505)).alias("city"),
         # The blocking key is NEVER perturbed: it decides which pairs are
         # compared at all, so corrupting it would silently shrink the candidate
         # set and make a smaller run look like a faster one.
@@ -346,6 +367,13 @@ def main() -> int:
         "GOLDENMATCH_SPARK_REMOTE", "sc://localhost:15002"))
     ap.add_argument("--u-max-pairs", type=int, default=1_000_000)
     ap.add_argument(
+        "--value-pad", type=int, default=0,
+        help="Append N filler chars to every COMPARISON value. Crossing COUNT "
+             "is unchanged; only the bytes marshalled per crossing move. This "
+             "is the arm that separates per-CALL from per-BYTE scoring cost -- "
+             "`--fields` CANNOT, because adding a field adds a call AND its "
+             "bytes, so both hypotheses predict the same scaling.")
+    ap.add_argument(
         "--fields", type=int, default=5,
         help="Number of COMPARISON fields (max 5). Same blocking, same "
              "candidate pairs -- only the per-pair crossing count changes. "
@@ -400,11 +428,12 @@ def main() -> int:
         "rows": args.rows, "dup": args.dup,
         "blocks_per_key": args.blocks_per_key,
         "kernel_impl": impl, "kernel_runtime": runtime,
-        "stages": {}, "passes": [], "n_fields": args.fields,
+        "stages": {}, "passes": [], "n_fields": args.fields, "value_pad": args.value_pad,
     }
 
     t0 = time.perf_counter()
-    df = build_fixture(spark, args.rows, args.dup, args.blocks_per_key)
+    df = build_fixture(spark, args.rows, args.dup, args.blocks_per_key,
+                       value_pad=args.value_pad)
     # Materialise once so the fixture build is not re-run inside every stage
     # and charged to whichever stage happened to trigger it.
     df.cache()


### PR DESCRIPTION
#2614 added `--fields` and I described it as the experiment that decides whether the fatter UDF is worth building. **It is not**, and the flaw is in the reasoning I wrote:

```
per-CALL   cost ~ pairs x fields
per-BYTE   cost ~ pairs x fields x value_length
```

Adding a field adds a call **and** its bytes, so **both hypotheses predict cost linear in field count**. The arms cannot disagree. I reasoned about crossings and forgot that a field carries data.

## The measurement ran anyway, and is consistent with that

1M rows, identical candidate pairs, 5 fields vs 2:

| pass | 5-field | 2-field | ratio (2.50 = strictly linear) |
|---|---:|---:|---:|
| 0 | 27.46s | 11.25s | **2.44** |
| 1 | 18.17s | 9.58s | 1.90 |

Useful — scoring is roughly linear in field count, so scoring fewer fields costs proportionally less — but it does not pick the next optimisation.

## `--value-pad N` does

It lengthens every comparison value by a constant suffix, so the crossing **count** is identical and only the **bytes per crossing** move:

| result | meaning | consequence |
|---|---|---|
| scoring **flat** in pad | per-CALL | a fatter UDF (one call per pair) wins |
| scoring **grows** with pad | per-BYTE | it does not — only columnar/FFI moves it, which means leaving Spark Connect |

Two properties that keep the arms honest:

- **The pad is a constant suffix**, so it appears on both sides of every pair. Jaro-Winkler and Levenshtein see the same addition either side, so gammas — and therefore pattern counts and the trained model — are unchanged. Only the marshalled length moves.
- **NULLs are not padded.** A padded NULL becomes non-null and would silently change the unobserved level, altering the very distribution being held constant.

The blocking key is untouched, so the candidate set is identical across pad settings too.