### PR TITLE
perf(spark): --value-pad is only workload-neutral under `exact`

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -61,6 +61,11 @@ on:
         required: false
         type: string
         default: "1g"
+      scorer:
+        description: "Force every comparison field onto one scorer (e.g. exact). Required for a valid value_pad experiment - padding only preserves gammas under exact."
+        required: false
+        type: string
+        default: ""
       value_pad:
         description: "Append N chars to every comparison value. Same crossing COUNT, more bytes per crossing - the arm that separates per-CALL from per-BYTE scoring cost."
         required: false
@@ -469,7 +474,9 @@ jobs:
           if [ "${{ inputs.profile_counts }}" = "true" ]; then PROFILE="--profile-counts"; fi
           FIELDS="${{ inputs.train_fields || '5' }}"
           PAD="${{ inputs.value_pad || '0' }}"
-          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS" --value-pad "$PAD" $PROFILE --out spark-fs-train-scale.json
+          SCORER=""
+          if [ -n "${{ inputs.scorer }}" ]; then SCORER="--scorer ${{ inputs.scorer }}"; fi
+          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS"             --value-pad "$PAD" $SCORER $PROFILE --out spark-fs-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         if: always()

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -269,7 +269,7 @@ def profile_counts(joined, mk, *, scorer_udf, transform_udf, cands):
     return out
 
 
-def make_config(n_fields: int = 5):
+def make_config(n_fields: int = 5, scorer: str | None = None):
     """The scale config. ``n_fields`` trims the COMPARISON fields only.
 
     ## Why this is a knob
@@ -311,6 +311,20 @@ def make_config(n_fields: int = 5):
     cfg = _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
                         MatchkeyConfig, MatchkeyField)
     mk = cfg.get_matchkeys()[0]
+    if scorer:
+        # Force every comparison field onto one scorer. This exists for the
+        # `--value-pad` experiment: padding is only workload-neutral under
+        # `exact`, where `a+pad == b+pad` iff `a == b`, so the gammas -- and
+        # therefore the pattern counts and the trained model -- are untouched
+        # while the marshalled bytes move.
+        #
+        # It is NOT neutral under jaro_winkler or levenshtein, which was a real
+        # error: a shared 40-char suffix dominates the similarity, every pair
+        # clears the 0.9 threshold, and the vector space collapsed 433 -> 65
+        # patterns with m_probs for `last` going to [0, 0, 1]. Those arms were
+        # measuring different workloads, so their timings meant nothing.
+        for f in mk.fields:
+            f.scorer = scorer
     if n_fields < len(mk.fields):
         # Trim in place. Rebuilding a shorter literal risks the arms differing
         # in something other than field count, which is the one variable this
@@ -366,6 +380,12 @@ def main() -> int:
     ap.add_argument("--remote", default=os.environ.get(
         "GOLDENMATCH_SPARK_REMOTE", "sc://localhost:15002"))
     ap.add_argument("--u-max-pairs", type=int, default=1_000_000)
+    ap.add_argument(
+        "--scorer", default="",
+        help="Force every comparison field onto one scorer. Use `exact` with "
+             "--value-pad: padding preserves equality, so gammas are unchanged "
+             "and only the marshalled bytes move. Under jaro_winkler/levenshtein "
+             "padding CHANGES similarity and the arms stop being comparable.")
     ap.add_argument(
         "--value-pad", type=int, default=0,
         help="Append N filler chars to every COMPARISON value. Crossing COUNT "
@@ -428,7 +448,7 @@ def main() -> int:
         "rows": args.rows, "dup": args.dup,
         "blocks_per_key": args.blocks_per_key,
         "kernel_impl": impl, "kernel_runtime": runtime,
-        "stages": {}, "passes": [], "n_fields": args.fields, "value_pad": args.value_pad,
+        "stages": {}, "passes": [], "n_fields": args.fields, "value_pad": args.value_pad, "scorer_override": args.scorer or None,
     }
 
     t0 = time.perf_counter()
@@ -443,7 +463,7 @@ def main() -> int:
     print(f"[scale] fixture: {actual:,} rows in "
           f"{out['stages']['fixture_seconds']}s", flush=True)
 
-    cfg = make_config(args.fields)
+    cfg = make_config(args.fields, args.scorer or None)
     mk = cfg.get_matchkeys()[0]
 
     # ── u: sampled self-join. Cost tracks the SAMPLE, not the table. ──


### PR DESCRIPTION
The pad experiment ran and **the arms were not comparable**. Padding every value by 40 chars collapsed the comparison-vector space:

| | pad=0 | pad=40 |
|---|---:|---:|
| pass 0 patterns | 433 | **65** |
| pass 1 patterns | 186 | **36** |
| `m_probs['last']` | `[0.0005, 0.2157, 0.7838]` | `[0.0, 0.0, 1.0]` |

## My reasoning in #2617 was wrong

I wrote that a constant suffix *"appears on both sides of every pair, so Jaro-Winkler and Levenshtein see the same addition either side and gammas are unchanged."*

String similarity is **not invariant under a shared suffix** — a shared suffix *raises* it. That is what those metrics are for. 40 identical trailing characters dominate the score, every pair clears the 0.9 threshold, and everything becomes "agree".

So the timings meant nothing: pass 0 came out **20% faster** with more bytes, pass 1 11% slower. Inconsistent, because the two arms were different workloads.

## `exact` is where the invariance actually holds

`a+pad == b+pad` **iff** `a == b`. Gammas, pattern counts and the trained model are untouched while the marshalled bytes move. `--scorer exact` forces every field onto it.

```
--scorer exact --value-pad 0   vs   --scorer exact --value-pad 40

scoring flat   -> per-CALL -> a fatter UDF (one call per pair) wins
scoring grows  -> per-BYTE -> it does not; only columnar/FFI moves it
```

**Caveat, recorded not hidden:** `exact` is cheaper per call than `jaro_winkler`, so absolute numbers will not match production. The *ratio* between pad arms is still the answer for the marshalling component, which is the question being asked.

## Third design for this experiment

1. `--fields` — could not discriminate: adding a field adds a call **and** its bytes, so both hypotheses predict the same scaling.
2. padding with the real scorers — changed the workload.
3. this.

Both failures were caught because the harness records `distinct_patterns` and the pair count. Without those the second arm would have produced a plausible-looking ratio and I would have believed it.