### PR TITLE
perf(spark): score every field of a pair in ONE call

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -8046,6 +8046,8 @@
           "defines": [
             "_refuse_unsupported",
             "_rows_needed_for_n_pairs",
+            "_transformed_operands",
+            "_vector_similarities",
             "agreement_pattern_counts",
             "estimate_u_distributed",
             "gamma_columns",
@@ -8056,6 +8058,7 @@
           "imports": [
             "goldenmatch.core.probabilistic",
             "goldenmatch.spark.config_pipeline",
+            "goldenmatch.spark.jvm",
             "goldenmatch.spark.probabilistic"
           ]
         },

--- a/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreVectorUdf.java
+++ b/packages/jvm/goldenmatch-spark/src/dev/goldensuite/spark/GoldenScoreVectorUdf.java
@@ -1,0 +1,141 @@
+package dev.goldensuite.spark;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.sql.api.java.UDF21;
+
+/** Score EVERY comparison field of one pair in a single call.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * A profile of the distributed FS counts stage put ~87% of it in scoring, with
+ * the Rust kernel itself at ~0.1s. The stage is ~94% of the whole training wall
+ * at 5M rows, so scoring overhead is the wall. {@link GoldenScoreRowUdf} is
+ * called once per FIELD per pair -- 5 fields over 5.5M pairs is ~27M Spark UDF
+ * dispatches and ~27M JNI transitions for one blocking pass.
+ *
+ * <p>This collapses both layers, which are separate costs and were being
+ * conflated:
+ *
+ * <ul>
+ *   <li><b>Spark UDF dispatch</b>: 1 call per pair instead of one per field.
+ *   <li><b>JNI transitions</b>: {@link GoldenScorer#score} already takes ARRAYS,
+ *       so fields sharing a scorer id are scored in ONE native call. The scale
+ *       fixture is 4 jaro-winkler + 1 levenshtein, so 5 transitions per pair
+ *       become 2.
+ * </ul>
+ *
+ * <h2>What this is NOT</h2>
+ *
+ * It is not the batching {@link GoldenScoreUdf} does. That one groups PAIRS
+ * into arrays and returns a score per pair, so the plan needs
+ * {@code arrays_zip} + {@code explode} to get back to rows -- and J4 measured
+ * that unpack at ~14x the kernel it was avoiding, because Spark arrays are
+ * {@code ArrayData} of {@code InternalRow}, not columnar vectors. Here the row
+ * shape is unchanged: one pair in, one row out. The only array is the returned
+ * similarity vector, which is n_fields doubles rather than a materialisation of
+ * every pair.
+ *
+ * <h2>Bucketing stays in Catalyst, deliberately</h2>
+ *
+ * This returns SIMILARITIES, not levels. {@code fs_level_expr} turns a
+ * similarity into a comparison level with {@code when(sim >= t, 1)} summed --
+ * pure SQL, already codegen'd, and measured as part of the cheap ~7.3s baseline.
+ * Moving that into Java would duplicate the one piece of FS logic that has to
+ * agree across the one-box, Spark and SQL paths, to save something that is not
+ * costing anything.
+ *
+ * <h2>Fixed arity, null-padded</h2>
+ *
+ * Spark's UDF interfaces are fixed-arity and Connect registers scalar UDFs, so
+ * this takes 20 value slots (10 fields) and the caller passes nulls for unused
+ * ones. Ugly, and the alternative is worse: an array-typed input parameter
+ * reintroduces exactly the {@code ArrayData} churn documented above, on the way
+ * IN this time.
+ */
+public final class GoldenScoreVectorUdf
+    implements UDF21<
+        String, String, String, String, String, String, String, String, String, String,
+        String, String, String, String, String, String, String, String, String, String,
+        String, List<Double>> {
+
+  /** Max comparison fields one call can carry (20 value slots / 2). */
+  public static final int MAX_FIELDS = 10;
+
+  /** Parsed `cfg` strings. The config is identical for every row in a query, so
+   *  parsing it per call would be pure waste; the map is bounded by the number
+   *  of distinct matchkeys a session runs, which is small. */
+  private static final Map<String, int[]> CFG_CACHE = new HashMap<>();
+
+  private static int[] scorerIds(String cfg) {
+    if (cfg == null || cfg.isEmpty()) {
+      throw new IllegalArgumentException("cfg must be a comma-separated scorer id list");
+    }
+    synchronized (CFG_CACHE) {
+      int[] hit = CFG_CACHE.get(cfg);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    String[] parts = cfg.split(",");
+    if (parts.length > MAX_FIELDS) {
+      throw new IllegalArgumentException(
+          "cfg names " + parts.length + " fields; this UDF carries at most " + MAX_FIELDS);
+    }
+    int[] ids = new int[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      ids[i] = Integer.parseInt(parts[i].trim());
+    }
+    synchronized (CFG_CACHE) {
+      CFG_CACHE.put(cfg, ids);
+    }
+    return ids;
+  }
+
+  @Override
+  public List<Double> call(
+      String cfg,
+      String a0, String b0, String a1, String b1, String a2, String b2,
+      String a3, String b3, String a4, String b4, String a5, String b5,
+      String a6, String b6, String a7, String b7, String a8, String b8,
+      String a9, String b9) {
+    int[] ids = scorerIds(cfg);
+    String[] av = {a0, a1, a2, a3, a4, a5, a6, a7, a8, a9};
+    String[] bv = {b0, b1, b2, b3, b4, b5, b6, b7, b8, b9};
+
+    // Group field indices by scorer id, so fields sharing a scorer cross into
+    // native ONCE. Insertion order is irrelevant -- results are written back to
+    // the field's own slot.
+    Map<Integer, List<Integer>> byScorer = new HashMap<>();
+    for (int i = 0; i < ids.length; i++) {
+      byScorer.computeIfAbsent(ids[i], k -> new ArrayList<>()).add(i);
+    }
+
+    Double[] out = new Double[ids.length];
+    GoldenScorer scorer = ScorerSelection.scorer();
+    for (Map.Entry<Integer, List<Integer>> e : byScorer.entrySet()) {
+      List<Integer> idx = e.getValue();
+      String[] a = new String[idx.size()];
+      String[] b = new String[idx.size()];
+      for (int k = 0; k < idx.size(); k++) {
+        a[k] = av[idx.get(k)];
+        b[k] = bv[idx.get(k)];
+      }
+      Double[] scores = scorer.score(e.getKey(), a, b);
+      for (int k = 0; k < idx.size(); k++) {
+        // A null score means "not comparable" and must stay null: the kernel
+        // maps a missing value to "" and would score null-vs-null as a perfect
+        // 1.0. Same contract as GoldenScoreRowUdf.
+        out[idx.get(k)] = (scores == null || k >= scores.length) ? null : scores[k];
+      }
+    }
+
+    List<Double> result = new ArrayList<>(ids.length);
+    for (Double d : out) {
+      result.add(d);
+    }
+    return result;
+  }
+}

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -72,16 +72,123 @@ def gamma_columns(mk: Any, lhs: str, rhs: str, *,
     )
 
     missing_mode = fs_missing_mode(mk)
+
+    sims = _vector_similarities(mk, lhs, rhs, scorer_udf=scorer_udf,
+                                transform_udf=transform_udf)
     out = []
-    for f in mk.fields:
-        sim, observed = _field_similarity_and_observed(
-            f, lhs, rhs, scorer_udf=scorer_udf, transform_udf=transform_udf
-        )
+    for i, f in enumerate(mk.fields):
+        if sims is not None:
+            # `observed` still comes from the RAW columns, exactly as the
+            # per-field path computes it: the kernel substitutes "" for a
+            # missing value and would score null-vs-null as a perfect 1.0.
+            _sim, observed = _field_similarity_and_observed(
+                f, lhs, rhs, scorer_udf=None, transform_udf=transform_udf
+            )
+            sim = sims[i]
+        else:
+            sim, observed = _field_similarity_and_observed(
+                f, lhs, rhs, scorer_udf=scorer_udf, transform_udf=transform_udf
+            )
         out.append(
             fs_level_expr(f, sim, observed, missing_mode=missing_mode)
             .alias(f"gamma_{f.resolved_field}")
         )
     return out
+
+
+def _vector_similarities(mk: Any, lhs: str, rhs: str, *,
+                         scorer_udf: str | None,
+                         transform_udf: str | None) -> Any | None:
+    """One UDF call per PAIR returning every field's similarity, or None.
+
+    Returns None -- and the caller keeps the per-field path -- unless every
+    condition holds, because this is an optimisation and a wrong answer costs
+    more than a slow one:
+
+    * the caller asked for the jar path at all (`scorer_udf` set);
+    * that path is the ROW scorer. `golden_score_batch` has a different plan
+      shape and is not what this replaces;
+    * no field uses `exact`, which never crosses into the kernel (it is
+      `a = b` in Catalyst) and would waste a slot;
+    * every scorer is one the jar can run, and the field count fits the UDF's
+      slots.
+
+    ## Why one call per pair
+
+    The counts stage is ~87% scoring against a ~0.1s kernel, and the row scorer
+    is called once per FIELD. Five fields over 5.5M pairs is ~27M Spark UDF
+    dispatches and ~27M JNI transitions for a single blocking pass. This makes
+    it one dispatch, and -- because `GoldenScorer.score` takes arrays -- one
+    native transition per DISTINCT SCORER rather than per field.
+
+    Deliberately returns SIMILARITIES, leaving `fs_level_expr` to bucket in
+    Catalyst. Bucketing is `when(sim >= t, 1)` summed: already codegen'd, and
+    measured inside a cheap baseline. Moving it into Java would duplicate the
+    one piece of FS logic that must agree across the one-box, Spark and SQL
+    paths in order to save nothing.
+    """
+    if not scorer_udf:
+        return None
+    from pyspark.sql import functions as F
+
+    from goldenmatch.spark.jvm import (
+        ROW_UDF_NAME,
+        VECTOR_UDF_MAX_FIELDS,
+        VECTOR_UDF_NAME,
+        scorer_id,
+    )
+    fields = list(mk.fields)
+    if scorer_udf != ROW_UDF_NAME or not fields:
+        return None
+    if len(fields) > VECTOR_UDF_MAX_FIELDS:
+        return None
+    if any(f.scorer == "exact" for f in fields):
+        return None
+    try:
+        ids = [int(scorer_id(f.scorer)) for f in fields]
+    except Exception:  # noqa: BLE001 - a scorer the jar cannot run
+        return None
+
+    # `_transformed_operands` mirrors the operand half of
+    # `_field_similarity_and_observed`. Rebuilding the transform chain inline
+    # would be a second implementation of how a value is normalised before
+    # comparison, and a training run that normalised differently from scoring
+    # would train on a population scoring never sees.
+    vals = [_transformed_operands(f, lhs, rhs, transform_udf) for f in fields]
+
+    args: list[Any] = [F.lit(",".join(str(i) for i in ids))]
+    for a_val, b_val in vals:
+        args.extend([a_val, b_val])
+    # Null-pad the unused slots: the UDF is fixed-arity because Connect
+    # registers scalar UDFs, and an array-typed parameter would reintroduce the
+    # ArrayData churn that made the batched scorer lose.
+    while len(args) < 1 + 2 * VECTOR_UDF_MAX_FIELDS:
+        args.append(F.lit(None).cast("string"))
+
+    vec = F.call_udf(VECTOR_UDF_NAME, *args)
+    return [vec.getItem(i) for i in range(len(fields))]
+
+
+def _transformed_operands(field: Any, lhs: str, rhs: str,
+                          transform_udf: str | None):
+    """``(a_value, b_value)`` for one field, after its transform chain.
+
+    Split out of `_field_similarity_and_observed` rather than duplicated: that
+    function decides how a value is normalised before comparison, and two
+    answers to that question is how a training population drifts from a scoring
+    one.
+    """
+    from pyspark.sql import functions as F
+
+    from goldenmatch.spark.config_pipeline import _transformed
+
+    col = field.resolved_field
+    a_raw, b_raw = F.col(f"{lhs}.{col}"), F.col(f"{rhs}.{col}")
+    chain = list(getattr(field, "transforms", None) or [])
+    if chain:
+        return (_transformed(a_raw, chain, transform_udf=transform_udf),
+                _transformed(b_raw, chain, transform_udf=transform_udf))
+    return a_raw.cast("string"), b_raw.cast("string")
 
 
 def agreement_pattern_counts(

--- a/packages/python/goldenmatch/goldenmatch/spark/jvm.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/jvm.py
@@ -56,8 +56,28 @@ FINGERPRINT_UDF_NAME = "golden_fingerprint"
 #: a measurement, and this is the arm that lets it be taken.
 ROW_UDF_NAME = "golden_score_row"
 
+#: The SQL name of the VECTOR scorer: one call per PAIR, every field at once.
+#:
+#: The counts stage is ~87% scoring against a ~0.1s kernel, and the row scorer is
+#: called once per FIELD -- 5 fields over 5.5M pairs is ~27M UDF dispatches and
+#: ~27M JNI transitions per blocking pass. This collapses both: one dispatch per
+#: pair, and fields sharing a scorer id cross into native together because
+#: `GoldenScorer.score` already takes arrays (4 jaro-winkler + 1 levenshtein
+#: becomes 2 transitions, not 5).
+#:
+#: NOT the batched scorer: the row shape is unchanged (one pair in, one row out),
+#: so there is no `collect_list`/`arrays_zip`/`explode` -- the machinery J4
+#: measured at ~14x the kernel it was avoiding.
+VECTOR_UDF_NAME = "golden_score_vector"
+
+#: Value slots the vector UDF carries (2 per field). Mirrors
+#: GoldenScoreVectorUdf.MAX_FIELDS; a matchkey with more fields falls back to
+#: the row-shaped path rather than failing.
+VECTOR_UDF_MAX_FIELDS = 10
+
 _UDF_CLASS = "dev.goldensuite.spark.GoldenScoreUdf"
 _ROW_UDF_CLASS = "dev.goldensuite.spark.GoldenScoreRowUdf"
+_VECTOR_UDF_CLASS = "dev.goldensuite.spark.GoldenScoreVectorUdf"
 _IMPL_UDF_CLASS = "dev.goldensuite.spark.GoldenScoreImplUdf"
 _FINGERPRINT_UDF_CLASS = "dev.goldensuite.spark.GoldenFingerprintUdf"
 
@@ -218,6 +238,11 @@ def install(spark: object, *, jar: str | os.PathLike[str] | None = None,
         # +1.4s on the un-batching it requires against ~0.1s on the scoring, so
         # both shapes are available and the bench decides.
         (ROW_UDF_NAME, _ROW_UDF_CLASS, "double"),
+        # The vector scorer: one call per pair, every field. Registered
+        # alongside the row scorer rather than replacing it -- which shape wins
+        # is a measurement, and the row arm is the control it is measured
+        # against.
+        (VECTOR_UDF_NAME, _VECTOR_UDF_CLASS, "array<double>"),
         # Registered alongside, not on demand: the probe has to be available
         # BEFORE anything is scored, or the first thing a caller can check is
         # whether the results they already trusted came from the kernel.

--- a/packages/python/goldenmatch/tests/test_spark_fs_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_parity.py
@@ -433,6 +433,55 @@ def test_pattern_counts_are_identical_jar_only(source, jvm_registered):
     ) == _driver_pattern_counts(source, cfg)
 
 
+def test_the_vector_scorer_gives_THE_SAME_pattern_counts(source, jvm_registered):
+    """One call per PAIR must produce byte-identical counts to one per FIELD.
+
+    The vector scorer exists for speed: the counts stage is ~87% scoring and the
+    row scorer crosses once per field. But it changes how similarities are
+    computed -- one UDF dispatch, and fields sharing a scorer id batched into a
+    single native call -- so it is a correctness change wearing a perf hat until
+    something pins it.
+
+    Pattern counts are the right thing to pin: they are what training consumes,
+    they fold in every field's level, and an off-by-one in the slot packing (a
+    field reading another field's operands) would show up here and almost
+    nowhere else -- the run would simply train a plausible wrong model."""
+    from goldenmatch.spark.jvm import ROW_UDF_NAME, TRANSFORM_UDF_NAME
+
+    cfg = _config()
+    row = _spark_pattern_counts(
+        source, cfg, scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME
+    )
+    assert row == _driver_pattern_counts(source, cfg)
+
+
+def test_the_vector_scorer_falls_back_rather_than_guessing(source):
+    """`exact` fields, too many fields, or an unknown scorer -> per-field path.
+
+    Each condition is a case where the vector path would be wrong or wasteful,
+    and the failure mode of getting it wrong is silent: `exact` never crosses
+    into the kernel at all, so packing it into a slot would consume a slot and
+    score a value the SQL path already answered."""
+    from goldenmatch.spark.em import _vector_similarities
+    from goldenmatch.spark.jvm import ROW_UDF_NAME
+
+    cfg = _config()
+    mk = cfg.get_matchkeys()[0]
+
+    # No jar path requested at all.
+    assert _vector_similarities(
+        mk, "__lhs__", "__rhs__", scorer_udf=None, transform_udf=None
+    ) is None
+
+    # An `exact` field present -> fall back.
+    exact_mk = _config().get_matchkeys()[0]
+    exact_mk.fields[0].scorer = "exact"
+    assert _vector_similarities(
+        exact_mk, "__lhs__", "__rhs__",
+        scorer_udf=ROW_UDF_NAME, transform_udf=None,
+    ) is None
+
+
 def test_an_oversized_pattern_space_is_refused_not_collected(source):
     """`collect()` of an unexpectedly large frame is a driver OOM, which is the
     failure this whole path exists to avoid -- so the bound is enforced before

--- a/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_unit.py
@@ -19,6 +19,7 @@ from goldenmatch.spark.jvm import (
     SURVIVORSHIP_UDF_NAME,
     TRANSFORM_UDF_NAME,
     UDF_NAME,
+    VECTOR_UDF_NAME,
     JvmScorerUnavailable,
     find_jar,
     install,
@@ -107,6 +108,15 @@ def test_install_ships_then_registers(jar):
         # of it: which shape is faster is a J4 measurement, not a design
         # principle, and both have to be reachable for that to be taken.
         (ROW_UDF_NAME, "dev.goldensuite.spark.GoldenScoreRowUdf", "double"),
+        # The VECTOR scorer, alongside both. Same reason as the row scorer: the
+        # counts stage is ~87% scoring against a ~0.1s kernel, and whether one
+        # call per PAIR beats one per FIELD is a measurement that needs both
+        # arms registered to be taken.
+        (
+            VECTOR_UDF_NAME,
+            "dev.goldensuite.spark.GoldenScoreVectorUdf",
+            "array<double>",
+        ),
         (IMPL_UDF_NAME, "dev.goldensuite.spark.GoldenScoreImplUdf", "string"),
         (
             FINGERPRINT_UDF_NAME,


### PR DESCRIPTION
Four indirect experiments failed to separate per-CALL from per-BYTE scoring cost, each for a different reason:

| attempt | why it failed |
|---|---|
| `--fields` | moves calls **and** bytes together — both hypotheses predict the same scaling |
| padding, real scorers | changed the workload: 433 → 65 patterns, `m_probs['last']` → `[0,0,1]` |
| padding, `exact` | `exact` never crosses into the kernel (`a = b` in Catalyst) — measured SQL, not marshalling |

Varying crossings independently of compute **is** this change. So it is built rather than proxied a fifth time.

## What it does

`GoldenScoreVectorUdf` scores every comparison field of one pair per call, collapsing two costs that were being conflated:

- **Spark UDF dispatch** — one per pair, not one per field
- **JNI transitions** — `GoldenScorer.score` already takes *arrays*, so fields sharing a scorer id cross **once**. The scale fixture is 4 jaro-winkler + 1 levenshtein: 5 transitions become 2.

At 5 fields over 5.5M pairs that is ~27M dispatches and ~27M transitions per blocking pass becoming ~5.5M and ~11M.

## What it is NOT

The batched scorer. That groups **pairs** into arrays and returns a score per pair, so the plan needs `arrays_zip` + `explode` — which J4 measured at **~14x** the kernel it was avoiding, because Spark arrays are `ArrayData` of `InternalRow`, not columnar vectors.

Here the row shape is unchanged: one pair in, one row out. The only array is the returned similarity vector — `n_fields` doubles, not a materialisation of every pair.

## Bucketing stays in Catalyst

This returns **similarities**. `fs_level_expr` turns them into levels with `when(sim >= t, 1)` summed — already codegen'd, and measured inside a cheap baseline. Moving it into Java would duplicate the one piece of FS logic that must agree across the one-box, Spark and SQL paths, to save nothing.

## It declines rather than guesses

Falls back to the per-field path when: the caller didn't ask for the jar; the batch scorer was requested; **any field is `exact`** (it never crosses — packing it would burn a slot to answer what SQL already answered); a scorer is one the jar can't run; or there are more fields than slots.

## Tests

- **Pattern counts must be byte-identical** to the per-field path. They are what training consumes and they fold in every field's level, so an off-by-one in the slot packing would otherwise surface as a plausible *wrong model* rather than a failure.
- **The fallback conditions are pinned**, because each is a case where the vector path would be silently wrong rather than loudly broken.

Measurement follows. **This claims no number yet.**