### PR TITLE
docs(readme): open with the problem, before the proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Golden Suite
 
+Your customer data lives in a CRM, a billing system, and three spreadsheets nobody owns. Some records are duplicates. Some are the same company spelled four different ways. Nobody can answer *how many customers do we actually have* — and every dashboard built on top inherits the doubt.
+
 **Splink-beating entity resolution — Arrow-native, Rust-fast, zero-tuning — feeding a durable identity layer, so messy records from every source become stable golden entities with whole-record, Customer-360 provenance.**
 
 Zero-config matching that **beats expert-tuned Splink head-to-head on messy customer records**, in an **Arrow-native, Rust-authoritative** engine verified from a laptop CSV to a **100M-row dedupe in 9.2 minutes**. The identities it produces live in a **transaction-native control plane** — stable `entity_id`s, per-field provenance, merge/split, and a tamper-evident audit log — one call away as a Customer 360. It even **owns its primitives**: byte-identical, faster-than-`rapidfuzz` / `jellyfish` / FAISS Rust kernels, not rented dependencies.


### PR DESCRIPTION
## What and why

The README opened straight into proof density (Splink-beating, 100M/9.2min, owned primitives). That is the right content and it stays exactly where it is — but a reader who has not yet decided they have this problem has nothing to attach the numbers to. This adds one scenario paragraph above the positioning line so the proof lands on a reader who already recognises the situation.

Two things I deliberately did not do:

- **I did not replace the existing opening.** It front-loads evidence and already carries the sharpest line in the file ("Most entity-resolution tools hand you clusters and stop. GoldenMatch keeps going."). Swapping narrative in for proof would have been a downgrade.
- **I did not extend the paragraph into the KG / semantic-ontology / Customer-360 chain.** That chain is real, but it is the maximal configuration; presenting it as the standard one is a promise the median reader will not experience. If we want it, it belongs in a separate "where it goes from there" section, not the opener.

Note this does not help *discovery* — by the time someone reads the README they have already found the repo. It helps conversion.

## Changes

- `README.md`: one scenario paragraph added between the title and the existing positioning line. Nothing removed or reordered.

## Testing

- `python scripts/check_docs_consistency.py` — passes (README is under its gates).
- No code paths touched; docs-only, so CI path filters run the `changes` job only.

## Checklist

- [x] Tests added/updated and passing locally for the changed package — n/a, docs-only
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed — n/a, no behavior change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_