### PR TITLE
docs(readme): drop the em dash from the opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Golden Suite
 
-Your customer data lives in a CRM, a billing system, and three spreadsheets nobody owns. Some records are duplicates. Some are the same company spelled four different ways. Nobody can answer *how many customers do we actually have* — and every dashboard built on top inherits the doubt.
+Your customer data lives in a CRM, a billing system, and three spreadsheets nobody owns. Some records are duplicates. Some are the same company spelled four different ways. Nobody can answer *how many customers do we actually have*, and every dashboard built on top inherits the doubt.
 
 **Splink-beating entity resolution — Arrow-native, Rust-fast, zero-tuning — feeding a durable identity layer, so messy records from every source become stable golden entities with whole-record, Customer-360 provenance.**
 


### PR DESCRIPTION
## What and why

Follow-up to #2620. The scenario paragraph it added used an em dash; a comma carries the same clause break without it.

Scope note: the rest of the README still contains 70 em dashes and this PR does not touch them. This removes only the one introduced in #2620, so it is not a style sweep and nothing else in the file changes.

## Changes

- `README.md`: one em dash replaced with a comma in the opening paragraph.

## Testing

- `python scripts/check_docs_consistency.py` passes.
- Docs-only, no code paths touched.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a, docs-only)
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_