### PR TITLE
docs(readme): rewrite the root README without em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 
 Your customer data lives in a CRM, a billing system, and three spreadsheets nobody owns. Some records are duplicates. Some are the same company spelled four different ways. Nobody can answer *how many customers do we actually have*, and every dashboard built on top inherits the doubt.
 
-**Splink-beating entity resolution — Arrow-native, Rust-fast, zero-tuning — feeding a durable identity layer, so messy records from every source become stable golden entities with whole-record, Customer-360 provenance.**
+**Splink-beating entity resolution, Arrow-native and Rust-fast with zero tuning, feeding a durable identity layer so messy records from every source become stable golden entities with whole-record, Customer-360 provenance.**
 
-Zero-config matching that **beats expert-tuned Splink head-to-head on messy customer records**, in an **Arrow-native, Rust-authoritative** engine verified from a laptop CSV to a **100M-row dedupe in 9.2 minutes**. The identities it produces live in a **transaction-native control plane** — stable `entity_id`s, per-field provenance, merge/split, and a tamper-evident audit log — one call away as a Customer 360. It even **owns its primitives**: byte-identical, faster-than-`rapidfuzz` / `jellyfish` / FAISS Rust kernels, not rented dependencies.
+Zero-config matching that **beats expert-tuned Splink head-to-head on messy customer records**, in an **Arrow-native, Rust-authoritative** engine verified from a laptop CSV to a **100M-row dedupe in 9.2 minutes**. The identities it produces live in a **transaction-native control plane** carrying stable `entity_id`s, per-field provenance, merge/split, and a tamper-evident audit log, all one call away as a Customer 360. It even **owns its primitives**: byte-identical, faster-than-`rapidfuzz` / `jellyfish` / FAISS Rust kernels, not rented dependencies.
 
 **Python · TypeScript · SQL, at 4-decimal parity · native in Postgres + DuckDB · edge WASM · 70+ MCP tools · beats hand-tuned Splink · 100M rows in 9.2 min**
 
 <br>
 
 <!-- Headline package: goldenmatch -->
-[![PyPI — goldenmatch](https://img.shields.io/pypi/v/goldenmatch?color=d4a017&label=pypi%3Agoldenmatch&logo=pypi&logoColor=white)](https://pypi.org/project/goldenmatch/)
-[![npm — goldenmatch](https://img.shields.io/npm/v/goldenmatch?color=cb3837&label=npm%3Agoldenmatch&logo=npm&logoColor=white)](https://www.npmjs.com/package/goldenmatch)
+[![PyPI: goldenmatch](https://img.shields.io/pypi/v/goldenmatch?color=d4a017&label=pypi%3Agoldenmatch&logo=pypi&logoColor=white)](https://pypi.org/project/goldenmatch/)
+[![npm: goldenmatch](https://img.shields.io/npm/v/goldenmatch?color=cb3837&label=npm%3Agoldenmatch&logo=npm&logoColor=white)](https://www.npmjs.com/package/goldenmatch)
 [![Python](https://img.shields.io/badge/python-3.11%2B-3776ab?logo=python&logoColor=white)](https://python.org)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-5fa04e?logo=nodedotjs&logoColor=white)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
@@ -42,12 +42,12 @@ Zero-config matching that **beats expert-tuned Splink head-to-head on messy cust
 
 </div>
 
-[![GoldenMatch web workbench — pair drilldown with NL prose](packages/python/goldenmatch/docs/screenshots/web/web-inspector.png)](https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI)
+[![GoldenMatch web workbench: pair drilldown with NL prose](packages/python/goldenmatch/docs/screenshots/web/web-inspector.png)](https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI)
 
 <p align="center"><sub><em>Pair drilldown in the web workbench: cluster members, field-level diff, and a one-line NL explanation per pair. <code>pip install goldenmatch[web]</code> then <code>goldenmatch serve-ui &lt;project&gt;</code>. <a href="https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI">More screenshots →</a></em></sub></p>
 
-<!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **v3.13.0** — **Fellegi-Sunter training runs distributed on Spark.** The E-step reads only the
+<!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->
+> **v3.13.0: Fellegi-Sunter training runs distributed on Spark.** The E-step reads only the
 comparison vector, so identical vectors collapse to one counted row and the whole
 step becomes a Spark `GROUP BY` over agreement patterns -- the cluster counts, the
 driver only fits. Training cost tracks DISTINCT vectors (bounded by
@@ -56,13 +56,13 @@ distributed counting stage 5.25x, while distinct patterns grew 3.0% (433 -> 446)
 and driver-side EM stayed at 0.01s. Runs on jar-only executors via
 `goldenmatch-spark`, off the same Rust kernel every other surface uses.
 >
-> **v3.12.0** — **Semantic-model discovery reaches warehouse scale.** Model derivation now runs
+> **v3.12.0: Semantic-model discovery reaches warehouse scale.** Model derivation now runs
 off `information_schema` instead of a sampled frame, plus catalog reconciliation
 and a real-LLM namer validation harness -- so a warehouse's existing model can be
 discovered, reconciled against what is really there, and named without hand
 curation.
 >
-> **v3.11.0** — **Customer 360 serving surface, and a fused FS kernel that covers the
+> **v3.11.0: Customer 360 serving surface, and a fused FS kernel that covers the
 reference-data name scorers.** `customer_360` composes the golden record,
 per-field provenance, linked source records, the event timeline and the
 relationship neighborhood into one read, with semantic-layer drill-through; the
@@ -74,16 +74,16 @@ in-RAM sequential Arrow-native batch scorer with end-WCC.
 
 ## What you get: the golden entity
 
-Most entity-resolution tools hand you clusters and stop. GoldenMatch keeps going: it resolves messy records into a **durable golden entity** — one per real-world customer — that survives re-runs, carries provenance on *every field*, and answers "who is this, and where did each value come from?" in a single call.
+Most entity-resolution tools hand you clusters and stop. GoldenMatch keeps going: it resolves messy records into a **durable golden entity**, one per real-world customer, that survives re-runs, carries provenance on *every field*, and answers "who is this, and where did each value come from?" in a single call.
 
-- **A stable identity, not a throwaway cluster id.** Every entity gets a stable `entity_id` (UUIDv7) that persists across runs as new data arrives — records are absorbed, entities merge or split, but the id an entity earns is the id downstream systems can rely on. Run-local cluster numbers reshuffle on every run; these don't.
-- **Whole-record provenance.** Every field of the golden record traces back to the source record that won it — which source, when it was last seen, and which survivorship strategy picked it — with the values it *didn't* pick kept visible, not silently dropped. Provenance is on the whole unified record, not just the match decision.
+- **A stable identity, not a throwaway cluster id.** Every entity gets a stable `entity_id` (UUIDv7) that persists across runs as new data arrives. Records are absorbed, entities merge or split, but the id an entity earns is the id downstream systems can rely on. Run-local cluster numbers reshuffle on every run; these don't.
+- **Whole-record provenance.** Every field of the golden record traces back to the source record that won it: which source, when it was last seen, and which survivorship strategy picked it. The values it *didn't* pick stay visible rather than being silently dropped. Provenance is on the whole unified record, not just the match decision.
 - **Governed by construction.** Conflicting values collapse to one best value by an explicit survivorship policy (most-complete · source-priority · most-recent · majority-vote); every identity change lands in an **append-only event timeline**; and the log is sealed with a **hash-chained, tamper-evident audit** that a reviewer (or the other language port) can independently verify.
 
-`customer_360(entity_id)` composes it into one read — golden record, per-field provenance, every linked source record, the event timeline, and the entity's relationship neighborhood:
+`customer_360(entity_id)` composes it into one read: golden record, per-field provenance, every linked source record, the event timeline, and the entity's relationship neighborhood:
 
 ```jsonc
-// customer_360("018f...c2a1")  — trimmed
+// customer_360("018f...c2a1")  (trimmed)
 {
   "entity_id": "018f2b7e-...-c2a1", "confidence": 0.97, "record_count": 3,
   "sources": ["salesforce", "billing", "support"],
@@ -100,7 +100,7 @@ Most entity-resolution tools hand you clusters and stop. GoldenMatch keeps going
 }
 ```
 
-> **What ships today vs. what's emerging.** The **identity spine is production-grade and in `main`**: stable `entity_id`s, per-field provenance, survivorship, merge/split, the append-only log + audit chain, cross-channel stitching, the relationship overlay, and **incremental resolution** against a persisted index (a new record resolves without a full re-run). The **`customer_360()` serving view** above and the **source-registry** layer that keeps it fresh from live systems are the newer, actively-landing pieces (the source connectors — Snowflake, BigQuery, Salesforce, HubSpot — ship today; the registry that wires them into the spine is emerging) — see [the Customer 360 design + ADR](context-network/architecture/customer-360-data-connection.md). We label the seam rather than blur it.
+> **What ships today vs. what's emerging.** The **identity spine is production-grade and in `main`**: stable `entity_id`s, per-field provenance, survivorship, merge/split, the append-only log + audit chain, cross-channel stitching, the relationship overlay, and **incremental resolution** against a persisted index (a new record resolves without a full re-run). The **`customer_360()` serving view** above and the **source-registry** layer that keeps it fresh from live systems are the newer, actively-landing pieces. The source connectors (Snowflake, BigQuery, Salesforce, HubSpot) ship today; the registry that wires them into the spine is emerging. See [the Customer 360 design + ADR](context-network/architecture/customer-360-data-connection.md). We label the seam rather than blur it.
 
 The golden entity lives in the **control plane**; the matching that builds it runs in the **compute engine**. That split is the next section.
 
@@ -108,16 +108,16 @@ The golden entity lives in the **control plane**; the matching that builds it ru
 
 ## One product, two engines
 
-The golden entity above is produced by two engines that optimize for genuinely different things — and keeping them distinct is the architecture, not an implementation detail ([ADR 0047](context-network/decisions/0047-one-product-two-engines-architecture.md)).
+The golden entity above is produced by two engines that optimize for genuinely different things, and keeping them distinct is the architecture, not an implementation detail ([ADR 0047](context-network/decisions/0047-one-product-two-engines-architecture.md)).
 
 ```mermaid
 flowchart LR
     src([source records])
     e360([golden entities · Customer 360])
-    subgraph compute ["Identity Compute Engine — Arrow-native, Rust-authoritative"]
+    subgraph compute ["Identity Compute Engine: Arrow-native, Rust-authoritative"]
         match[block · score · cluster]
     end
-    subgraph control ["Identity Control Plane — transaction-native state machine"]
+    subgraph control ["Identity Control Plane: transaction-native state machine"]
         spine[stable ids · survivorship · merge/split · provenance · audit]
     end
     src --> compute -->|resolution batch + evidence| control --> e360
@@ -127,28 +127,28 @@ flowchart LR
 | | Identity Compute Engine | Identity Control Plane |
 |---|---|---|
 | **Shape** | Arrow at bulk boundaries, Rust-authoritative kernels | Transaction-native state machine (SQLite default · Postgres) |
-| **Job** | Block, score, cluster — throughput, vectorized, deterministic per run | Stable ids, survivorship, merge/split, provenance, append-only audit |
+| **Job** | Block, score, cluster: throughput, vectorized, deterministic per run | Stable ids, survivorship, merge/split, provenance, append-only audit |
 | **State** | Stateless per call; measurement-driven kernelization | Durable, transactional, replayable, auditable |
 | **Backends** | DataFusion · Ray · Sail · Spark are *replaceable* execution backends, none synonymous with GoldenMatch | Storage backends conform to one externally-observable semantics |
 
-**Many surfaces, one answer.** The same capabilities reach Python, edge-safe TypeScript (with an opt-in WASM backend running the *same* Rust kernels), SQL inside PostgreSQL and DuckDB, and MCP / REST / A2A — governed by **specification + conformance**, not copy-paste. There is one authoritative owner per capability; pure-Python / standalone-TS paths are classified, conformance-tested fallbacks. Where a boundary can't cross byte-for-byte, we [measure and label it](#cross-language-parity) rather than claim parity.
+**Many surfaces, one answer.** The same capabilities reach Python, edge-safe TypeScript (with an opt-in WASM backend running the *same* Rust kernels), SQL inside PostgreSQL and DuckDB, and MCP / REST / A2A, all governed by **specification + conformance**, not copy-paste. There is one authoritative owner per capability; pure-Python / standalone-TS paths are classified, conformance-tested fallbacks. Where a boundary can't cross byte-for-byte, we [measure and label it](#cross-language-parity) rather than claim parity.
 
 **Why a platform engineer should care:**
 
-- **The compute layer isn't framework lock-in.** It's Arrow-native and backend-replaceable — push the heavy matching to a query engine that plans, spills, and distributes (verified to 100M rows), without the identity state coming along for the ride.
-- **The identity layer is a real state machine**, not a columnar rebuild-every-time batch — durable ids, transactional merge/split, provenance and audit as first-class operations you can integrate against.
-- **Behavior is consistent where it's shared** — SQL, Python, and TypeScript track the same answers to a conformance spec, so the surface you build on isn't quietly inventing its own semantics.
+- **The compute layer isn't framework lock-in.** It's Arrow-native and backend-replaceable, so you can push the heavy matching to a query engine that plans, spills, and distributes (verified to 100M rows) without the identity state coming along for the ride.
+- **The identity layer is a real state machine**, not a columnar rebuild-every-time batch. Durable ids, transactional merge/split, provenance and audit are first-class operations you can integrate against.
+- **Behavior is consistent where it's shared.** SQL, Python, and TypeScript track the same answers to a conformance spec, so the surface you build on isn't quietly inventing its own semantics.
 
 ---
 
 ## Resolution that beats the expert
 
-The identity layer is only as good as the matching underneath it — and the matching starts at zero config. `dedupe_df(df)` runs with no rules and no training data: it profiles the data, picks a defensible configuration, and returns golden records immediately. The config it chose comes back on `result.config` — inspectable, diffable, versionable. Never a black box.
+The identity layer is only as good as the matching underneath it, and the matching starts at zero config. `dedupe_df(df)` runs with no rules and no training data: it profiles the data, picks a defensible configuration, and returns golden records immediately. The config it chose comes back on `result.config`: inspectable, diffable, versionable. Never a black box.
 
-- **Beats the expert, out of the box.** On messy customer records, the opt-in Fellegi-Sunter engine beats hand-tuned Splink head-to-head — `historical_50k` pairwise F1 **0.827 vs 0.757**, cluster B³ **0.862 vs 0.788**, one shared evaluator, [reproducible bake-off](docs/benchmarks/2026-06-09-splink-bakeoff.md). Fuzzy, exact, probabilistic (Fellegi-Sunter), and LLM scorers, with EM-trained weights and calibrated scores.
-- **A healing loop, not a one-shot.** Zero-config gets you most of the way; then every run checks a free unsupervised signal and, when there's headroom, attaches **ranked, self-verified config tweaks** to `result.suggestions`. Each is kept only if it doesn't worsen a health proxy — so a suggestion never makes results worse. `dedupe_df(df, heal=True)` applies and re-runs in one call. You close the gap to expert-tuned without being the expert.
-- **Privacy-preserving record linkage.** Match across organizations without sharing raw data — Bloom-filter PPRL, **92.4% F1 on FEBRL4**, with HMAC-salted encodings.
-- **Self-verifying.** Every step runs preflight + postflight checks and returns an inspectable report instead of failing silently — the "advanced, never black-box" contract that makes an automated identity layer safe to build on.
+- **Beats the expert, out of the box.** On messy customer records, the opt-in Fellegi-Sunter engine beats hand-tuned Splink head-to-head, with `historical_50k` pairwise F1 **0.827 vs 0.757**, cluster B³ **0.862 vs 0.788**, one shared evaluator, [reproducible bake-off](docs/benchmarks/2026-06-09-splink-bakeoff.md). Fuzzy, exact, probabilistic (Fellegi-Sunter), and LLM scorers, with EM-trained weights and calibrated scores.
+- **A healing loop, not a one-shot.** Zero-config gets you most of the way; then every run checks a free unsupervised signal and, when there's headroom, attaches **ranked, self-verified config tweaks** to `result.suggestions`. Each is kept only if it doesn't worsen a health proxy, so a suggestion never makes results worse. `dedupe_df(df, heal=True)` applies and re-runs in one call. You close the gap to expert-tuned without being the expert.
+- **Privacy-preserving record linkage.** Match across organizations without sharing raw data: Bloom-filter PPRL, **92.4% F1 on FEBRL4**, with HMAC-salted encodings.
+- **Self-verifying.** Every step runs preflight + postflight checks and returns an inspectable report instead of failing silently. That is the "advanced, never black-box" contract that makes an automated identity layer safe to build on.
 
 > Runs on **unstructured input**, too: extract records from PDFs and images, then resolve them like any other source (`pip install goldenmatch[documents]`).
 
@@ -156,7 +156,7 @@ The identity layer is only as good as the matching underneath it — and the mat
 
 ## Runs where your stack is
 
-The engine and the identity layer reach your stack through the surface you already use — the *same* capabilities, governed by conformance ([one product, two engines](#one-product-two-engines)), not a thin re-implementation per surface.
+The engine and the identity layer reach your stack through the surface you already use, with the *same* capabilities governed by conformance ([one product, two engines](#one-product-two-engines)) rather than re-implemented thinly per surface.
 
 - **SQL-native, at parity.** The same functions run inside **PostgreSQL** (pgrx extension) and **DuckDB**: dedupe · match · score · auto-config + telemetry · identity-graph reads · profiling · `evaluate` · Fellegi-Sunter scoring · GoldenFlow transforms. Resolve without moving data out of the warehouse.
 - **Python and edge-safe TypeScript.** The full suite ships on **npm** alongside PyPI. The TS cores are dependency-free and `node:*`-free (browsers, Cloudflare Workers, Vercel Edge, Deno); an opt-in WebAssembly backend (`await enableWasm()`) swaps in the *same* pyo3-free Rust kernels the Python wheels and SQL UDFs use, with pure-TS as the byte-identical default.
@@ -172,19 +172,19 @@ Surface parity is *not* the same as handing any pipeline phase from one language
 | Boundary | Verdict |
 | --- | --- |
 | **Identity graph DB** | ✅ byte-safe + cryptographically cross-verifiable (a seal written by one toolkit validates under the other) |
-| **`score → cluster`** and the end-to-end split-run | ✅ byte-safe — reproduces the single-language run |
+| **`score → cluster`** and the end-to-end split-run | ✅ byte-safe, reproduces the single-language run |
 | Cluster JSON · config YAML · Learning Memory · `record_fingerprint` | ✅ portable |
-| **String scoring** | 🟡 4-decimal tolerance — a pair on a threshold can flip (byte-identical only with the shared WASM scorer) |
-| **Standardize / dates** · embeddings · auto-config controller | 🟠 divergent — not byte-portable |
+| **String scoring** | 🟡 4-decimal tolerance; a pair on a threshold can flip (byte-identical only with the shared WASM scorer) |
+| **Standardize / dates** · embeddings · auto-config controller | 🟠 divergent, not byte-portable |
 | Distributed / Ray · document (VLM) ingest | ⛔ Python-only by architecture |
 
 **Rule of thumb:** hand off at the **cluster** or **identity** boundary and it's seamless; don't split across `standardize`/dates, embeddings, or the controller and expect bit-exact reproduction. Full detail + the runnable harness that keeps these verdicts honest: [Cross-language parity & phase-handoff limits](https://docs.bensevern.dev/docs/concepts/cross-language-parity).
 
 ---
 
-## The suite — the pipeline into the spine
+## The suite: the pipeline into the spine
 
-GoldenMatch is the headline, but resolution is only as good as what feeds it. Five sibling tools clean, standardize, and map records *before* they reach the identity layer — each stands alone, but they compose into one pipeline, orchestrated declaratively by GoldenPipe:
+GoldenMatch is the headline, but resolution is only as good as what feeds it. Five sibling tools clean, standardize, and map records *before* they reach the identity layer. Each stands alone, but they compose into one pipeline, orchestrated declaratively by GoldenPipe:
 
 ```mermaid
 flowchart LR
@@ -200,36 +200,36 @@ flowchart LR
 
 | Package | Lang | Role in the pipeline | Install |
 |---|---|---|---|
-| **[InferMap](packages/python/infermap/README.md)** | Python · TS | Schema mapping — auto-aligns columns across heterogeneous sources | `pip install infermap` · `npm i infermap` |
-| **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS | Data-quality scanning — encoding, format validation, anomaly detection | `pip install goldencheck` · `npm i goldencheck` |
-| **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers — phone, date, address, categorical | `pip install goldenflow` · `npm i goldenflow` |
+| **[InferMap](packages/python/infermap/README.md)** | Python · TS | Schema mapping: auto-aligns columns across heterogeneous sources | `pip install infermap` · `npm i infermap` |
+| **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS | Data-quality scanning: encoding, format validation, anomaly detection | `pip install goldencheck` · `npm i goldencheck` |
+| **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers: phone, date, address, categorical | `pip install goldenflow` · `npm i goldenflow` |
 | **[GoldenMatch](packages/python/goldenmatch/README.md)** | Python · TS | Zero-config entity resolution → the identity spine. **Headline package.** | `pip install goldenmatch` · `npm i goldenmatch` |
-| **[GoldenAnalysis](packages/python/goldenanalysis/README.md)** | Python · TS | Analysis & reporting — any stage's artifacts → a unified `AnalysisReport` + cross-run regression detection | `pip install goldenanalysis` · `npm i goldenanalysis` |
-| **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python · TS | Orchestrator — declarative YAML wiring the steps | `pip install goldenpipe` · `npm i goldenpipe` |
+| **[GoldenAnalysis](packages/python/goldenanalysis/README.md)** | Python · TS | Analysis & reporting: any stage's artifacts → a unified `AnalysisReport` + cross-run regression detection | `pip install goldenanalysis` · `npm i goldenanalysis` |
+| **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python · TS | Orchestrator: declarative YAML wiring the steps | `pip install goldenpipe` · `npm i goldenpipe` |
 | **[golden-suite](packages/python/golden-suite/README.md)** | Python | One-line meta-install: the whole suite + native acceleration | `pip install golden-suite` |
 
 > The deepest docs live in **[packages/python/goldenmatch/README.md](packages/python/goldenmatch/README.md)** (~1,300 lines: full feature list, CLI, architecture, benchmarks).
 
 ### Owned libraries (standalone)
 
-The suite owns its string-matching primitives instead of renting them — byte-identical drop-in replacements, published on their own so they're usable outside the suite too.
+The suite owns its string-matching primitives instead of renting them: byte-identical drop-in replacements, published on their own so they're usable outside the suite too.
 
 | Library | Replaces | What it is | Install |
 |---|---|---|---|
 | **[goldenfuzz](packages/rust/extensions/goldenfuzz-py/README.md)** | `rapidfuzz` | Fuzzy-string scorers + the full `fuzz.*` composite family + one-vs-many `extract`/`cdist`. Byte-identical (oracle-fuzzed), faster on short strings. | `pip install goldenfuzz` · `cargo add goldenfuzz-core` |
-| **[goldenphonetic](packages/rust/extensions/goldenphonetic-py/README.md)** | `jellyfish` | Phonetic encoders — soundex / metaphone / nysiis / match-rating. Byte-identical (6,000-input + 2,500-pair fuzz corpus), pure-Rust zero-dep. | `pip install goldenphonetic` · `cargo add goldenphonetic-core` |
-| **[goldenmatch-hnsw](packages/rust/extensions/hnsw-py/README.md)** | FAISS `IndexHNSWFlat` | Pure-Rust HNSW approximate-nearest-neighbor index (zero C deps) — powers embedding-based blocking across Python, Rust, and TS/WASM. | `pip install goldenmatch-hnsw` |
+| **[goldenphonetic](packages/rust/extensions/goldenphonetic-py/README.md)** | `jellyfish` | Phonetic encoders: soundex / metaphone / nysiis / match-rating. Byte-identical (6,000-input + 2,500-pair fuzz corpus), pure-Rust zero-dep. | `pip install goldenphonetic` · `cargo add goldenphonetic-core` |
+| **[goldenmatch-hnsw](packages/rust/extensions/hnsw-py/README.md)** | FAISS `IndexHNSWFlat` | Pure-Rust HNSW approximate-nearest-neighbor index (zero C deps). Powers embedding-based blocking across Python, Rust, and TS/WASM. | `pip install goldenmatch-hnsw` |
 
 ### Knowledge graphs
 
-Entity resolution is the stage most GraphRAG pipelines do worst — duplicate surface forms of one entity scatter across documents. Two packages put GoldenMatch's resolution there:
+Entity resolution is the stage most GraphRAG pipelines do worst: duplicate surface forms of one entity scatter across documents. Two packages put GoldenMatch's resolution there:
 
 | Package | What it does | Status |
 |---|---|---|
 | **[goldenmatch-kg](packages/python/goldenmatch-kg/README.md)** | Drop-in GoldenMatch resolution as the ER stage of existing KG frameworks (neo4j-graphrag, LlamaIndex, Graphiti). | in-repo · not published (by design) |
-| **[goldengraph](packages/python/goldengraph/README.md)** | Build-your-own-KG from text — `text → LLM extraction → GoldenMatch resolution → durable bi-temporal store`. Rust engine; ER is the differentiator. | in-repo · first PyPI release pending |
+| **[goldengraph](packages/python/goldengraph/README.md)** | Build-your-own-KG from text: `text → LLM extraction → GoldenMatch resolution → durable bi-temporal store`. Rust engine; ER is the differentiator. | in-repo · first PyPI release pending |
 
-**Measured, not asserted** ([ER-KG-Bench](packages/python/goldenmatch/benchmarks/er-kg-bench)): resolution scores **F1 0.602** on the labelled set, ahead of Neo4j-KGBuilder (0.456), neo4j-graphrag (0.403), and MS-GraphRAG / LightRAG / Cognee / mem0 (0.066). A resolved graph also does two things passage-window RAG structurally can't — **exact aggregation** (size-invariant where RAG recall collapses `0.99 → 0.64` across cluster-size buckets) and **temporal as-of** (`1.000` vs `0.002` on past-date queries).
+**Measured, not asserted** ([ER-KG-Bench](packages/python/goldenmatch/benchmarks/er-kg-bench)): resolution scores **F1 0.602** on the labelled set, ahead of Neo4j-KGBuilder (0.456), neo4j-graphrag (0.403), and MS-GraphRAG / LightRAG / Cognee / mem0 (0.066). A resolved graph also does two things passage-window RAG structurally can't: **exact aggregation** (size-invariant where RAG recall collapses `0.99 → 0.64` across cluster-size buckets) and **temporal as-of** (`1.000` vs `0.002` on past-date queries).
 
 ---
 
@@ -237,25 +237,25 @@ Entity resolution is the stage most GraphRAG pipelines do worst — duplicate su
 
 Every headline number maps back to a single committed runner (`scripts/run_benchmarks.py`); see [`docs/reproducing-benchmarks.md`](docs/reproducing-benchmarks.md) for per-number commands, dataset URLs, and expected output with tolerance.
 
-- **Accuracy on customer-shaped data** — NC Voter **0.9719** F1 (real-data sample), Febrl3 **0.9912** F1; the opt-in Fellegi-Sunter path beats hand-tuned Splink head-to-head on every dataset Splink scores ([bake-off](docs/benchmarks/2026-06-09-splink-bakeoff.md)). (Bibliographic DBLP-ACM lands **96.4%** F1 for the record-linkage crowd, but customer identity is the focus.)
-- **Privacy-preserving** — PPRL **92.4%** F1 on FEBRL4, matching across parties with no shared raw data.
-- **Scale envelope** ([`docs/scale-envelope.md`](docs/scale-envelope.md)) — per-backend ranges (in-memory/bucket to a few M · DuckDB out-of-core to ~50M · Ray distributed ≥ 50M), block-size failure modes, and a decision tree for picking a backend.
+- **Accuracy on customer-shaped data.** NC Voter **0.9719** F1 (real-data sample), Febrl3 **0.9912** F1; the opt-in Fellegi-Sunter path beats hand-tuned Splink head-to-head on every dataset Splink scores ([bake-off](docs/benchmarks/2026-06-09-splink-bakeoff.md)). (Bibliographic DBLP-ACM lands **96.4%** F1 for the record-linkage crowd, but customer identity is the focus.)
+- **Privacy-preserving.** PPRL **92.4%** F1 on FEBRL4, matching across parties with no shared raw data.
+- **Scale envelope** ([`docs/scale-envelope.md`](docs/scale-envelope.md)): per-backend ranges (in-memory/bucket to a few M · DuckDB out-of-core to ~50M · Ray distributed ≥ 50M), block-size failure modes, and a decision tree for picking a backend.
 
-**Verified at the top end:** a full **100M-row** dedupe on a 5-node Ray cluster in **9.2 min** (554 s), **20,000,000 golden records recovered exactly**, driver peak **0.36 GB RSS**. The default distributed path is **recall-complete** — duplicates merge correctly *no matter how the input is partitioned* (blocking-key shuffle scoring + distributed randomized-contraction WCC), and it stays driver-collect-free end to end. Recipe: [`configs/distributed-100m.yaml`](packages/python/goldenmatch/configs/distributed-100m.yaml).
+**Verified at the top end:** a full **100M-row** dedupe on a 5-node Ray cluster in **9.2 min** (554 s), **20,000,000 golden records recovered exactly**, driver peak **0.36 GB RSS**. The default distributed path is **recall-complete**: duplicates merge correctly *no matter how the input is partitioned* (blocking-key shuffle scoring + distributed randomized-contraction WCC), and it stays driver-collect-free end to end. Recipe: [`configs/distributed-100m.yaml`](packages/python/goldenmatch/configs/distributed-100m.yaml).
 
 **Fellegi-Sunter training, distributed on Spark:** the E-step collapses to one Spark `GROUP BY` over agreement patterns, so training cost tracks the number of DISTINCT comparison vectors (bounded by `prod(levels + 1)`), not the pair count. Measured on a real 2-worker Spark cluster (jar-only executors, no Python installed), 1M -> 5M rows: candidate pairs grew **5.00x** and the distributed counting stage **5.25x**, while distinct patterns grew **3.0%** (433 -> 446) and driver-side EM stayed at **0.01s**. That is the property the tier rests on -- the cluster absorbs the data, the driver's work stays flat.
 
 Three reproducible real-world pipelines run this on public data at scale:
 
-- **[shell-company-network](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)** — investigative ER across ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC. **−62.5% analyst-hours to triage** vs single-source baselines.
-- **[vuln-attribution](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)** — **6,126,895 OSS-vulnerability records → 847,475 canonical vulns** across 40 sources in ~5 minutes on one 64GB runner.
-- **[sanctions-reconciliation](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)** — cross-list coverage on 85 public sanctions lists across 50+ jurisdictions.
+- **[shell-company-network](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)**: investigative ER across ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC. **−62.5% analyst-hours to triage** vs single-source baselines.
+- **[vuln-attribution](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)**: **6,126,895 OSS-vulnerability records → 847,475 canonical vulns** across 40 sources in ~5 minutes on one 64GB runner.
+- **[sanctions-reconciliation](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)**: cross-list coverage on 85 public sanctions lists across 50+ jurisdictions.
 
 ---
 
 ## Install & quick start
 
-**Dedupe a CSV in 30 seconds** — zero config, writes `<timestamp>_golden.csv`:
+**Dedupe a CSV in 30 seconds**, zero config, writes `<timestamp>_golden.csv`:
 
 ```bash
 pip install goldenmatch && goldenmatch dedupe customers.csv
@@ -277,7 +277,7 @@ import { dedupe } from "goldenmatch";           // edge-safe: browsers, Vercel E
 const result = dedupe(rows, { fuzzy: { name: 0.85 }, blocking: ["zip"], threshold: 0.85 });
 ```
 
-**The whole suite, configured for speed** — [`golden-suite`](packages/python/golden-suite/README.md) pulls in every package plus the native (Rust) kernels, pinned and defaulted to the perf-optimized config. Native wheels are **hard** dependencies on purpose: a platform without a wheel fails loudly rather than silently running the slow pure-Python path.
+**The whole suite, configured for speed.** [`golden-suite`](packages/python/golden-suite/README.md) pulls in every package plus the native (Rust) kernels, pinned and defaulted to the perf-optimized config. Native wheels are **hard** dependencies on purpose: a platform without a wheel fails loudly rather than silently running the slow pure-Python path.
 
 ```bash
 pip install golden-suite
@@ -288,7 +288,7 @@ pip install golden-suite[mcp]     # + aggregator MCP server (every tool, one end
 pip install golden-suite[all]     # everything
 ```
 
-**Just GoldenMatch** — fat optional extras, pay only for what you use (native acceleration is default on common platforms):
+**Just GoldenMatch.** Fat optional extras, so you pay only for what you use (native acceleration is default on common platforms):
 
 ```bash
 pip install goldenmatch                    # core (CSV in, CSV out) + native
@@ -300,21 +300,21 @@ pip install goldenmatch[postgres]          # + Postgres sync  (also: [snowflake]
 pip install goldenmatch[mcp]               # + MCP server     (also: [agent] A2A, [web] browser workbench)
 ```
 
-**Web workbench** — `pip install 'goldenmatch[web]'` then `goldenmatch serve-ui my-project` (opens `http://localhost:5050`): edit rules with live validation, preview against a sampled slice, label pairs (mirrored into Learning Memory), compare runs.
+**Web workbench.** `pip install 'goldenmatch[web]'` then `goldenmatch serve-ui my-project` (opens `http://localhost:5050`): edit rules with live validation, preview against a sampled slice, label pairs (mirrored into Learning Memory), compare runs.
 
-**More:** [`examples/`](examples/README.md) — [Python](examples/python/README.md) (quickstart, full pipeline, customer 360, PPRL, MCP client) · [TypeScript](examples/typescript/README.md) (quickstart, Vercel Edge, MCP client) · [Airflow](examples/airflow/README.md).
+**More:** [`examples/`](examples/README.md), covering [Python](examples/python/README.md) (quickstart, full pipeline, customer 360, PPRL, MCP client) · [TypeScript](examples/typescript/README.md) (quickstart, Vercel Edge, MCP client) · [Airflow](examples/airflow/README.md).
 
 ---
 
 ## Deploy
 
-**Remote MCP (nothing to install)** — hosted on [Smithery](https://smithery.ai/servers/benzsevern/goldenmatch); connect any MCP client:
+**Remote MCP (nothing to install).** Hosted on [Smithery](https://smithery.ai/servers/benzsevern/goldenmatch); connect any MCP client:
 
 ```json
 { "mcpServers": { "goldenmatch": { "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/" } } }
 ```
 
-**Containers** — every package ships as a multi-arch image (linux/amd64 + arm64) on GHCR, pull anonymously:
+**Containers.** Every package ships as a multi-arch image (linux/amd64 + arm64) on GHCR, pull anonymously:
 
 ```bash
 docker run -p 8300:8300 ghcr.io/benseverndev-oss/goldensuite-mcp:latest   # one container, every tool
@@ -322,7 +322,7 @@ docker run -p 8200:8200 ghcr.io/benseverndev-oss/goldenmatch-mcp:latest   # per-
 docker run -e POSTGRES_PASSWORD=secret ghcr.io/benseverndev-oss/goldenmatch-extensions:latest   # Postgres + extension
 ```
 
-**Airflow** — 13 drop-in DAGs at [`examples/airflow/`](examples/airflow/README.md) (TaskFlow API, Airflow 2.7+ / 3.x; idempotent, marker-protected), grouped by lifecycle stage:
+**Airflow.** 13 drop-in DAGs at [`examples/airflow/`](examples/airflow/README.md) (TaskFlow API, Airflow 2.7+ / 3.x; idempotent, marker-protected), grouped by lifecycle stage:
 
 | Group | DAGs |
 |---|---|
@@ -351,8 +351,8 @@ goldenmatch/
 └── justfile · pyproject.toml (uv workspace) · pnpm-workspace.yaml (Turborepo) · .github/workflows/ci.yml
 ```
 
-- **Cargo — no root workspace.** `packages/rust/extensions/` is itself a Cargo workspace (the `postgres` crate is excluded for pgrx); Cargo commands run from inside it.
-- **TypeScript — one pnpm workspace.** `packages/typescript/*` form a single pnpm + Turborepo workspace.
+- **Cargo: no root workspace.** `packages/rust/extensions/` is itself a Cargo workspace (the `postgres` crate is excluded for pgrx); Cargo commands run from inside it.
+- **TypeScript: one pnpm workspace.** `packages/typescript/*` form a single pnpm + Turborepo workspace.
 
 ```bash
 just install   # uv sync + per-package npm install + cargo fetch
@@ -375,4 +375,4 @@ pnpm turbo run build test typecheck           # full pipeline (cached after firs
 
 ---
 
-<sub>This repo was formed on **2026-05-01** by folding 8 sibling repos into `goldenmatch` via `git filter-repo` (full history preserved). Built by **[Ben Severn](https://bensevern.dev)**. MIT — see [LICENSE](LICENSE).</sub>
+<sub>This repo was formed on **2026-05-01** by folding 8 sibling repos into `goldenmatch` via `git filter-repo` (full history preserved). Built by **[Ben Severn](https://bensevern.dev)**. MIT, see [LICENSE](LICENSE).</sub>

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -56,8 +56,8 @@ npm install goldenmatch
 > is an edge-safe subset (no Ray/GPU distributed engine, no web UI); everything else is at
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
-<!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **v3.13.0** — **Fellegi-Sunter training runs distributed on Spark.** The E-step reads only the
+<!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->
+> **v3.13.0: Fellegi-Sunter training runs distributed on Spark.** The E-step reads only the
 comparison vector, so identical vectors collapse to one counted row and the whole
 step becomes a Spark `GROUP BY` over agreement patterns -- the cluster counts, the
 driver only fits. Training cost tracks DISTINCT vectors (bounded by
@@ -66,13 +66,13 @@ distributed counting stage 5.25x, while distinct patterns grew 3.0% (433 -> 446)
 and driver-side EM stayed at 0.01s. Runs on jar-only executors via
 `goldenmatch-spark`, off the same Rust kernel every other surface uses.
 >
-> **v3.12.0** — **Semantic-model discovery reaches warehouse scale.** Model derivation now runs
+> **v3.12.0: Semantic-model discovery reaches warehouse scale.** Model derivation now runs
 off `information_schema` instead of a sampled frame, plus catalog reconciliation
 and a real-LLM namer validation harness -- so a warehouse's existing model can be
 discovered, reconciled against what is really there, and named without hand
 curation.
 >
-> **v3.11.0** — **Customer 360 serving surface, and a fused FS kernel that covers the
+> **v3.11.0: Customer 360 serving surface, and a fused FS kernel that covers the
 reference-data name scorers.** `customer_360` composes the golden record,
 per-field provenance, linked source records, the event timeline and the
 relationship neighborhood into one read, with semantic-layer drill-through; the

--- a/scripts/sync_readme_callouts.py
+++ b/scripts/sync_readme_callouts.py
@@ -66,7 +66,7 @@ def render_block(callouts: list[tuple[str, str]], target_path: Path) -> str:
         comment_suffix = "from CHANGELOG.md"
     rendered_callouts = callouts[:MAX_CALLOUTS]
     lines = [
-        f"{FENCE_START}  (auto-synced {comment_suffix} by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->"
+        f"{FENCE_START}  (auto-synced {comment_suffix} by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->"
     ]
     for i, (version, body) in enumerate(rendered_callouts):
         lines.append(_format_callout(version, body, is_first=(i == 0)))
@@ -76,7 +76,13 @@ def render_block(callouts: list[tuple[str, str]], target_path: Path) -> str:
     return "\n".join(lines)
 
 
-_BOLD_TITLE_RE = re.compile(r"^\*\*(?P<title>[^*]+)\*\*\s*(?P<sep>—|--|-)\s*(?P<rest>.*)$", re.DOTALL)
+_BOLD_TITLE_RE = re.compile(
+    # The separator is OPTIONAL: a CHANGELOG entry that opens `**Title.** rest`
+    # with no dash at all should still fold, otherwise it renders as two
+    # adjacent bold spans (`**v1.2.3:** **Title.**`).
+    r"^\*\*(?P<title>[^*]+)\*\*\s*(?P<sep>—|--|-)?\s*(?P<rest>.*)$",
+    re.DOTALL,
+)
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
 
 
@@ -90,8 +96,13 @@ def _format_callout(version: str, body: str, *, is_first: bool) -> str:
 
     Input body is the raw text from the CHANGELOG marker. If it leads
     with ``**Title** — rest``, fold the version into the bold span so
-    the homepage reads ``**vX.Y.Z — Title** — rest``. Otherwise just
-    bold the version.
+    the homepage reads ``**vX.Y.Z: Title** rest``. Otherwise just bold
+    the version.
+
+    The rendered separator is a colon, not an em dash. Input is still
+    parsed leniently (``_BOLD_TITLE_RE`` accepts em dash / ``--`` / ``-``)
+    because the CHANGELOG is written by hand and we do not want a
+    punctuation choice there to change how a callout is structured.
     """
     body = body.strip()
     new_badge = ""  # latest callout is already first; no emoji marker
@@ -100,8 +111,8 @@ def _format_callout(version: str, body: str, *, is_first: bool) -> str:
     if match:
         title = match.group("title").strip()
         rest = match.group("rest").strip()
-        return f"> **{new_badge}{label} — {title}** — {rest}"
-    return f"> **{new_badge}{label}** — {body}"
+        return f"> **{new_badge}{label}: {title}** {rest}"
+    return f"> **{new_badge}{label}:** {body}"
 
 
 def rewrite_target(path: Path, new_block: str) -> tuple[str, str]:


### PR DESCRIPTION
## What and why

Follow-up to #2621, which removed one em dash. This removes the remaining 63 from the root README by **rewriting the sentences**, not by substituting punctuation:

- a dash carrying a parenthetical became a comma pair or a colon
- a dash joining two independent clauses became a full stop and a real sentence
- a dash introducing a list or an appositive became a colon
- bold lead-ins (`**Containers** — every package ships...`) became `**Containers.** Every package ships...`

Three of the em dashes were machine-written, so the generator changed too. `scripts/sync_readme_callouts.py` now renders the callout separator as a colon. Two notes on that:

- Its **input** regex still accepts an em dash / `--` / `-`. The CHANGELOG is hand-written, and a punctuation choice there should not change how a callout is structured.
- That regex now also makes the separator **optional**. Every current CHANGELOG entry opens `**Title.** rest` with no dash at all, so it never matched the fold branch and rendered as two adjacent bold spans (`**v3.13.0:** **Title.**`). It now reads `**v3.13.0: Title.** rest`.

Regenerating writes both callout blocks, so `packages/python/goldenmatch/README.md` picks up the same three lines. The other 126 em dashes in that file are untouched and out of scope.

## Changes

- `README.md`: 63 em dashes removed via sentence rewrites; no claims, numbers, links, or section order changed.
- `scripts/sync_readme_callouts.py`: colon separator on output, optional separator on input, comment explaining both.
- `packages/python/goldenmatch/README.md`: the 3 regenerated callout lines only.

## Testing

- `python scripts/sync_readme_callouts.py --check` passes (this is the CI gate at `ci.yml:4173`).
- `python scripts/check_docs_consistency.py` passes (`ci.yml:4191`).
- `grep -c '—' README.md` returns 0.
- No anchor links pointed at the one renamed heading (`## The suite — ...` to `## The suite: ...`); checked repo-wide before renaming.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (docs + generator; both gates run above)
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, no library behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_