### PR TITLE
fix(autoconfig): grade blocking skew by work concentration, not p99/mean

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+
+- **Zero-config no longer refuses healthy fine-grained blocking.** The blocking
+  RED rule graded skew with `block_sizes_p99 > 10 * (n_rows / n_blocks)`, whose
+  denominator is the mean block size -- pinned near 1 whenever blocking is
+  fine-grained, so the bar collapsed toward "any block over ~12 rows". Measured
+  at 100,000 rows, a shape with 84,293 blocks, 0.976 reduction and no singletons
+  graded RED, and at `n_rows >= 100_000` a RED blocking profile refuses the run.
+  Its largest block owned **1.9%** of the candidate pairs. The rule now measures
+  work concentration -- the largest block's share of `total_comparisons` against
+  `max(0.10, 4 / n_blocks)` -- which also catches a case the percentile missed
+  entirely: one block of 10,000 rows among 5,000 blocks owns 98.5% of the work
+  but sits *above* p99 rather than at it. New `BlockingProfile.
+  largest_block_pair_share`; ported to the TypeScript surface in lockstep.
+
 ## [3.13.0] - 2026-08-15
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -250,6 +250,20 @@ class MatchkeyProfile:
         return _max_severity(*verdicts) if verdicts else HealthVerdict.GREEN
 
 
+# Blocking-skew RED thresholds (see BlockingProfile.health).
+#
+# 0.10: a block owning more than a tenth of all candidate pairs is a straggler
+# no realistic worker pool can absorb -- 8 to 16 workers is the common case, so
+# a 1/10 share already sets the floor on wall time by itself. It is also ~5x
+# above the 0.019 measured on the healthiest fine-grained shape in the
+# head-to-head panel, so the rule has room before it starts false-positiving.
+#
+# 4.0: the same block must ALSO hold more than 4x its fair share (1/n_blocks)
+# before this counts as skew rather than coarseness. Inert above 40 blocks.
+_LARGEST_BLOCK_PAIR_SHARE_RED: float = 0.10
+_LARGEST_BLOCK_FAIR_SHARE_MULTIPLE: float = 4.0
+
+
 @dataclass(frozen=True)
 class BlockingProfile:
     _version: int = 1
@@ -345,11 +359,51 @@ class BlockingProfile:
             singleton_block_count=self.singleton_block_count * n_rows_full // n_rows_sample,
         )
 
+    @property
+    def largest_block_pair_share(self) -> float:
+        """Fraction of all candidate pairs contributed by the biggest block.
+
+        Within-block pairs are quadratic in block size, so this is the measure
+        of straggler risk: a block at 0.5 owns half the scoring work of the
+        whole run and no amount of parallelism can hide it.
+
+        Both terms are measured on the same profile, so the ratio is
+        scale-free. Note that ``extrapolate_to`` scales ``total_comparisons``
+        but NOT ``block_sizes_max`` -- an extrapolated profile would understate
+        this. That is not a live hazard: the extrapolated profile feeds the
+        PLANNER (``profile_for_planner`` in autoconfig_controller), while
+        ``health`` is called on the committed sample-scale profile.
+        """
+        if self.total_comparisons <= 0 or self.block_sizes_max < 2:
+            return 0.0
+        biggest = self.block_sizes_max * (self.block_sizes_max - 1) // 2
+        return biggest / self.total_comparisons
+
     def health(self, n_rows: int) -> HealthVerdict:
+        # `n_rows` is retained for signature stability with ClusterProfile.health
+        # and the existing call sites; the skew rule below no longer needs it.
         if self.n_blocks == 0:
             return HealthVerdict.RED
-        avg = n_rows / max(self.n_blocks, 1)
-        if self.block_sizes_p99 > 10 * avg:
+        # Skew is WORK CONCENTRATION, not a size percentile. The previous rule
+        # -- `block_sizes_p99 > 10 * (n_rows / n_blocks)` -- divided a tail
+        # percentile by the MEAN block size, which is pinned near 1 whenever
+        # blocking is fine-grained, so the bar collapsed toward "any block over
+        # ~12 rows". Measured at 100k rows it graded the person shape RED
+        # (avg 1.19, p99 72) while that shape's largest block owned 1.9% of the
+        # candidate pairs, reduction was 0.976 and there were no singletons --
+        # and a RED blocking profile at n_rows >= REFUSE_AT_N REFUSES the run.
+        # It also MISSED the case it exists for: one block of 10,000 rows among
+        # 5,000 blocks owns 98.5% of the work yet sits above p99 rather than at
+        # it, so the percentile never sees it. See #2628 and
+        # tests/test_blocking_skew_pair_share.py for both fixtures.
+        #
+        # The fair-share term keeps the rule off coarse-but-UNIFORM layouts,
+        # where a 1/n_blocks share is simply what having few blocks looks like.
+        # It costs no coverage: at small n_blocks a dominating block has to hold
+        # most of the rows, which craters reduction_ratio below.
+        skew_bar = max(_LARGEST_BLOCK_PAIR_SHARE_RED,
+                       _LARGEST_BLOCK_FAIR_SHARE_MULTIPLE / self.n_blocks)
+        if self.largest_block_pair_share > skew_bar:
             return HealthVerdict.RED
         if self.reduction_ratio < 0.5:
             return HealthVerdict.RED

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -195,8 +195,8 @@ def _green_subprofiles():
         ),
         blocking=BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+            block_sizes_p99=11, block_sizes_max=11,
         ),
         scoring=ScoringProfile(
             n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
@@ -908,8 +908,8 @@ def _yellow_subprofiles():
         ),
         blocking=BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+            block_sizes_p99=11, block_sizes_max=11,
         ),
         scoring=ScoringProfile(
             n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,

--- a/packages/python/goldenmatch/tests/test_autoconfig_history.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_history.py
@@ -25,8 +25,8 @@ def _profile(*, scoring: ScoringProfile | None = None,
                          column_types={"a": "text", "b": "id-like", "c": "text", "d": "date"}),
         blocking=blocking or BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+            block_sizes_p99=11, block_sizes_max=11,
             singleton_block_count=0, oversized_block_count=0,
         ),
         scoring=scoring or ScoringProfile(
@@ -111,8 +111,8 @@ def test_pick_committed_prefers_green_over_yellow():
                          column_types={"a": "text", "b": "id-like", "c": "text", "d": "date"}),
         blocking=BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+            block_sizes_p99=11, block_sizes_max=11,
         ),
         scoring=ScoringProfile(
             n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -33,8 +33,8 @@ def _green_profile() -> ComplexityProfile:
         ),
         blocking=BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+            block_sizes_p99=11, block_sizes_max=11,
         ),
         scoring=ScoringProfile(
             n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,

--- a/packages/python/goldenmatch/tests/test_blocking_skew_pair_share.py
+++ b/packages/python/goldenmatch/tests/test_blocking_skew_pair_share.py
@@ -1,0 +1,198 @@
+"""``BlockingProfile.health`` grades skew by WORK CONCENTRATION, not by a size percentile.
+
+## Why this file exists
+
+The old skew rule was ``block_sizes_p99 > 10 * (n_rows / n_blocks)``. Its
+denominator is the MEAN block size, which is pinned near 1 whenever blocking is
+fine-grained (``n_blocks -> n_rows``), so the bar it sets collapses toward 10
+rows no matter how healthy the layout is. Measured on the head-to-head shapes at
+100,000 rows (``scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py``,
+run 31976392050):
+
+    person   n_blocks=84,293  avg=1.19  p99=72   p99/avg=60.69  -> RED (fired)
+             reduction=0.9757  singletons=0
+             total_comparisons=121,372,923  largest block pairs=2,353,365
+             >> largest block owns 1.9% of all candidate pairs
+
+    biblio   n_blocks=22,151  avg=4.51  p99=39   p99/avg= 8.64  -> GREEN
+             reduction=0.9996  singletons=0
+             total_comparisons=1,770,258  largest block pairs=2,415
+             >> largest block owns 0.14% of all candidate pairs
+
+person graded RED -- and at ``n_rows >= REFUSE_AT_N`` a RED blocking profile
+makes zero-config REFUSE the run -- while its largest block contributed under
+2% of the work. That is not skew. The rule was reading "many small blocks" as
+"dangerous tail".
+
+## What skew actually costs
+
+Skew hurts because one block becomes a straggler: within-block pairs are
+quadratic in block size, so a single oversized block can own most of the work
+and cannot be parallelised away. The honest measure is therefore the LARGEST
+block's share of ``total_comparisons``, which these tests pin.
+
+A rejected alternative: the share of work in the top 1% of blocks. It can only
+be estimated as a lower bound from the profile (``p99`` is the size floor for
+that band, and person's max of 2,170 against a p99 of 72 shows how loose the
+bound gets), and a heavy band of mid-sized blocks parallelises fine anyway --
+it is a cost question, which ``reduction_ratio`` already owns.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.complexity_profile import BlockingProfile, HealthVerdict
+
+
+def test_person_100k_fine_grained_blocking_is_green():
+    """The measured person@100k profile. RED today, and it should not be.
+
+    Every number here is copied from the diagnostic run, so this fails on the
+    unfixed rule for exactly the reason the shape was refused in production.
+    """
+    bp = BlockingProfile(
+        keys_used=[["last_name", "zip"]],
+        n_blocks=84_293,
+        total_comparisons=121_372_923,
+        reduction_ratio=0.975725,
+        block_sizes_p50=2,
+        block_sizes_p95=10,
+        block_sizes_p99=72,
+        block_sizes_max=2_170,
+        singleton_block_count=0,
+        oversized_block_count=0,
+    )
+    # 2,170 rows -> 2,353,365 pairs, 1.9% of 121,372,923.
+    assert bp.largest_block_pair_share < 0.02
+    assert bp.health(n_rows=100_000) == HealthVerdict.GREEN
+
+
+def test_biblio_100k_stays_green():
+    """The control: GREEN under the old rule and under the new one.
+
+    Without this, a rule that graded everything GREEN would pass the suite.
+    """
+    bp = BlockingProfile(
+        keys_used=[["title_prefix"]],
+        n_blocks=22_151,
+        total_comparisons=1_770_258,
+        reduction_ratio=0.999646,
+        block_sizes_p50=6,
+        block_sizes_p95=31,
+        block_sizes_p99=39,
+        block_sizes_max=70,
+        singleton_block_count=0,
+        oversized_block_count=0,
+    )
+    assert bp.health(n_rows=100_000) == HealthVerdict.GREEN
+
+
+def test_single_dominating_block_is_red():
+    """One block of 10,000 rows inside 100,000 -- 98.5% of all pairs.
+
+    The old rule MISSES this: p99 is 18 (the giant is one block out of 5,000,
+    so it sits above the 99th percentile, not at it) against a 10*avg bar of
+    200, and reduction_ratio is 0.99 because 50M pairs is still a tiny slice of
+    5e9. A percentile cannot see a single straggler; a pair share can.
+    """
+    bp = BlockingProfile(
+        keys_used=[["state"]],
+        n_blocks=5_000,
+        # 49,995,000 pairs from the giant + ~764,847 from 4,999 blocks of 18.
+        total_comparisons=50_759_847,
+        reduction_ratio=0.989848,
+        block_sizes_p50=18,
+        block_sizes_p95=18,
+        block_sizes_p99=18,
+        block_sizes_max=10_000,
+        singleton_block_count=0,
+        oversized_block_count=1,
+    )
+    assert bp.largest_block_pair_share > 0.9
+    assert bp.health(n_rows=100_000) == HealthVerdict.RED
+
+
+def test_uniform_coarse_blocking_is_not_skew():
+    """8 equal blocks: each owns 12.5% of the work, and none is a straggler.
+
+    Guards the fair-share clause. A flat 10% bar would grade this RED purely
+    because there are few blocks, which is a coarseness complaint -- and
+    coarseness is ``reduction_ratio``'s job, not skew's.
+    """
+    bp = BlockingProfile(
+        keys_used=[["region"]],
+        n_blocks=8,
+        total_comparisons=39_600,  # 8 blocks of 100 rows -> 8 * 4,950
+        reduction_ratio=0.876,
+        block_sizes_p50=100,
+        block_sizes_p95=100,
+        block_sizes_p99=100,
+        block_sizes_max=100,
+        singleton_block_count=0,
+        oversized_block_count=0,
+    )
+    assert bp.largest_block_pair_share == 0.125
+    assert bp.health(n_rows=800) == HealthVerdict.GREEN
+
+
+def test_few_blocks_with_one_straggler_is_caught_by_reduction_not_skew():
+    """The fair-share clause is not a blanket exemption for small ``n_blocks``.
+
+    It cannot be, because a dominating block is UNCONSTRUCTIBLE at small
+    ``n_blocks`` without also cratering reduction: to own most of the pairs
+    among 8 blocks it has to hold most of the rows, and then the layout is
+    barely reducing anything. 8 blocks where one holds 700 of 800 rows keeps
+    77% of all pairs, so ``reduction_ratio`` 0.233 grades it RED before the
+    skew rule is consulted. This test pins that the exemption costs no
+    coverage, which is the only reason it is safe to have.
+    """
+    bp = BlockingProfile(
+        keys_used=[["region"]],
+        n_blocks=8,
+        # 244,650 pairs from the 700-row block + 7 blocks of ~14 (91 each).
+        total_comparisons=245_287,
+        reduction_ratio=0.233,
+        block_sizes_p50=14,
+        block_sizes_p95=14,
+        block_sizes_p99=14,
+        block_sizes_max=700,
+        singleton_block_count=0,
+        oversized_block_count=1,
+    )
+    assert bp.health(n_rows=800) == HealthVerdict.RED
+
+
+def test_zero_total_comparisons_does_not_divide_by_zero():
+    """A profile with blocks but no pairs must not raise. Every block is a
+    singleton here, which is the YELLOW rule's territory, not the skew rule's."""
+    bp = BlockingProfile(
+        keys_used=[["id"]],
+        n_blocks=1_000,
+        total_comparisons=0,
+        reduction_ratio=1.0,
+        block_sizes_p50=1,
+        block_sizes_p95=1,
+        block_sizes_p99=1,
+        block_sizes_max=1,
+        singleton_block_count=1_000,
+        oversized_block_count=0,
+    )
+    assert bp.largest_block_pair_share == 0.0
+    assert bp.health(n_rows=1_000) == HealthVerdict.YELLOW
+
+
+def test_reduction_ratio_rule_still_fires():
+    """The other two RED rules are untouched by this change."""
+    bp = BlockingProfile(
+        keys_used=[["a"]],
+        n_blocks=2,
+        total_comparisons=4_900,
+        reduction_ratio=0.01,
+        block_sizes_p50=49,
+        block_sizes_p95=49,
+        block_sizes_p99=49,
+        block_sizes_max=49,
+    )
+    assert bp.health(n_rows=100) == HealthVerdict.RED
+
+
+def test_no_blocks_still_red():
+    assert BlockingProfile().health(n_rows=100) == HealthVerdict.RED

--- a/packages/python/goldenmatch/tests/test_chao1_cardinality.py
+++ b/packages/python/goldenmatch/tests/test_chao1_cardinality.py
@@ -182,8 +182,8 @@ class TestComplexityProfileHealthThreads:
             }),
             blocking=BlockingProfile(
                 keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-                reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-                block_sizes_p99=20, block_sizes_max=25,
+                reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+                block_sizes_p99=11, block_sizes_max=11,
             ),
             scoring=ScoringProfile(
                 n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,

--- a/packages/python/goldenmatch/tests/test_complexity_profile.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile.py
@@ -23,10 +23,15 @@ def _green_data():
 
 
 def _green_blocking():
+    # Sizes are coherent with total_comparisons: 10 near-equal blocks of ~11
+    # rows give ~50 pairs each, so the biggest owns ~11% of the 500 and no
+    # block is a straggler. The old fixture claimed a 25-row block (300 pairs)
+    # inside a 500-pair total, which the skew rule now reads -- and correctly
+    # grades RED, because 60% of the work in one of ten blocks IS skew.
     return BlockingProfile(
         keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-        reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
-        block_sizes_p99=20, block_sizes_max=25,
+        reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=11,
+        block_sizes_p99=11, block_sizes_max=11,
         singleton_block_count=0, oversized_block_count=0,
     )
 
@@ -109,13 +114,18 @@ def test_matchkey_yellow_when_field_nearly_unique():
 
 
 def test_blocking_red_when_one_block_dominates():
+    # 100 rows in 10 blocks, one holding 60 of them: 1,770 of the 1,842
+    # candidate pairs, so 96% of the scoring work sits in a single block.
+    # reduction_ratio is 0.63, comfortably above its own RED bar, so this
+    # isolates the skew rule. The previous fixture put a 200-row block inside
+    # a 100-row dataset -- it fired the old percentile rule, but on numbers no
+    # profiler could ever emit.
     bp = BlockingProfile(
-        keys_used=[["a"]], n_blocks=10, total_comparisons=500,
-        reduction_ratio=0.95, block_sizes_p50=5, block_sizes_p95=15,
-        block_sizes_p99=200, block_sizes_max=200,
-        singleton_block_count=0, oversized_block_count=0,
+        keys_used=[["a"]], n_blocks=10, total_comparisons=1_842,
+        reduction_ratio=0.628, block_sizes_p50=4, block_sizes_p95=60,
+        block_sizes_p99=60, block_sizes_max=60,
+        singleton_block_count=0, oversized_block_count=1,
     )
-    # n_rows / n_blocks = 100/10 = 10; p99=200 > 10 * 10 = 100 → RED
     assert bp.health(n_rows=100) == HealthVerdict.RED
 
 

--- a/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
+++ b/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
@@ -164,9 +164,13 @@ def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
             "a": "text", "b": "text", "c": "text",
         }),
         blocking=BlockingProfile(
+            # 10 blocks of ~5 rows -> ~10 pairs each, so the biggest owns
+            # ~10% of the 100 total. The previous sizes were impossible: a
+            # 25-row block is 300 pairs on its own, three times the stated
+            # total, and the skew rule reads both fields now.
             keys_used=[["a"]], n_blocks=10, total_comparisons=100,
-            reduction_ratio=0.9, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.9, block_sizes_p50=5, block_sizes_p95=5,
+            block_sizes_p99=5, block_sizes_max=5,
             singleton_block_count=0, oversized_block_count=0,
         ),
         scoring=ScoringProfile(

--- a/packages/python/goldenmatch/tests/test_identify_failing_subprofile.py
+++ b/packages/python/goldenmatch/tests/test_identify_failing_subprofile.py
@@ -24,9 +24,13 @@ def _green_profile() -> ComplexityProfile:
             "a": "text", "b": "text", "c": "text",
         }),
         blocking=BlockingProfile(
+            # 10 blocks of ~5 rows -> ~10 pairs each, so the biggest owns
+            # ~10% of the 100 total. The previous sizes were impossible: a
+            # 25-row block is 300 pairs on its own, three times the stated
+            # total, and the skew rule reads both fields now.
             keys_used=[["a"]], n_blocks=10, total_comparisons=100,
-            reduction_ratio=0.9, block_sizes_p50=10, block_sizes_p95=15,
-            block_sizes_p99=20, block_sizes_max=25,
+            reduction_ratio=0.9, block_sizes_p50=5, block_sizes_p95=5,
+            block_sizes_p99=5, block_sizes_max=5,
             singleton_block_count=0, oversized_block_count=0,
         ),
         scoring=ScoringProfile(

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+- **`blockingHealth` grades skew by work concentration, not by a size
+  percentile.** Parity port of the Python fix: `blockSizesP99 > 10 * (nRows /
+  nBlocks)` divides a tail percentile by the mean block size, which is pinned
+  near 1 under fine-grained blocking, so it graded a measured 84,293-block
+  profile RED while its largest block owned 1.9% of the candidate pairs -- and
+  missed a single block owning 98.5%, because that block sits above p99 rather
+  than at it. Now compares `largestBlockPairShare` (exported) against
+  `max(0.10, 4 / nBlocks)`.
+
 ## [1.29.0] - 2026-08-15
 
 ### Added

--- a/packages/typescript/goldenmatch/src/core/complexityProfile.ts
+++ b/packages/typescript/goldenmatch/src/core/complexityProfile.ts
@@ -179,10 +179,38 @@ export function makeBlockingProfile(p: Partial<BlockingProfile> = {}): BlockingP
   };
 }
 
-export function blockingHealth(b: BlockingProfile, nRows: number): HealthVerdict {
+/** Blocking-skew RED thresholds. Parity with the Python
+ *  `complexity_profile._LARGEST_BLOCK_*` constants -- both surfaces must grade
+ *  the same profile identically. */
+const LARGEST_BLOCK_PAIR_SHARE_RED = 0.1;
+const LARGEST_BLOCK_FAIR_SHARE_MULTIPLE = 4.0;
+
+/** Fraction of all candidate pairs contributed by the biggest block.
+ *
+ * Within-block pairs are quadratic in block size, so this measures straggler
+ * risk: a block at 0.5 owns half the scoring work of the entire run. */
+export function largestBlockPairShare(b: BlockingProfile): number {
+  if (b.totalComparisons <= 0 || b.blockSizesMax < 2) return 0.0;
+  const biggest = Math.floor((b.blockSizesMax * (b.blockSizesMax - 1)) / 2);
+  return biggest / b.totalComparisons;
+}
+
+// `nRows` is retained for signature stability with clusterHealth and the
+// existing call sites; the skew rule no longer needs it.
+export function blockingHealth(b: BlockingProfile, _nRows: number): HealthVerdict {
   if (b.nBlocks === 0) return HealthVerdict.RED;
-  const avg = nRows / Math.max(b.nBlocks, 1);
-  if (b.blockSizesP99 > 10 * avg) return HealthVerdict.RED;
+  // Skew is WORK CONCENTRATION, not a size percentile. The previous rule --
+  // `blockSizesP99 > 10 * (nRows / nBlocks)` -- divided a tail percentile by
+  // the MEAN block size, which is pinned near 1 whenever blocking is
+  // fine-grained, so the bar collapsed toward "any block over ~12 rows".
+  // Measured at 100k rows it graded a shape RED whose largest block owned 1.9%
+  // of the candidate pairs, and MISSED a single block owning 98.5% (which sits
+  // above p99, not at it). See the Python twin and issue #2628.
+  const bar = Math.max(
+    LARGEST_BLOCK_PAIR_SHARE_RED,
+    LARGEST_BLOCK_FAIR_SHARE_MULTIPLE / b.nBlocks,
+  );
+  if (largestBlockPairShare(b) > bar) return HealthVerdict.RED;
   if (b.reductionRatio < 0.5) return HealthVerdict.RED;
   if (b.singletonBlockCount / b.nBlocks > 0.5) return HealthVerdict.YELLOW;
   return HealthVerdict.GREEN;

--- a/packages/typescript/goldenmatch/tests/unit/complexityProfile.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/complexityProfile.test.ts
@@ -55,13 +55,71 @@ describe("complexityProfile — health rollups (Python parity)", () => {
     expect(blockingHealth(makeBlockingProfile(), 100)).toBe(HealthVerdict.RED);
   });
 
-  it("blockingHealth: skewed p99 → RED", () => {
+  // Skew fixtures mirror the Python ones in
+  // tests/test_blocking_skew_pair_share.py -- same numbers, same verdicts, so
+  // the two surfaces cannot drift apart on a rule that refuses user runs.
+  it("blockingHealth: one block owning 96% of the pairs → RED", () => {
     expect(
       blockingHealth(
-        makeBlockingProfile({ nBlocks: 10, blockSizesP99: 1000, reductionRatio: 0.9 }),
+        makeBlockingProfile({
+          nBlocks: 10,
+          totalComparisons: 1842,
+          reductionRatio: 0.628,
+          blockSizesP99: 60,
+          blockSizesMax: 60,
+        }),
         100,
       ),
     ).toBe(HealthVerdict.RED);
+  });
+
+  it("blockingHealth: one giant block a percentile cannot see → RED", () => {
+    // 10,000 rows in one of 5,000 blocks: 98.5% of the work, but p99 is 18
+    // because the giant sits ABOVE the 99th percentile rather than at it.
+    expect(
+      blockingHealth(
+        makeBlockingProfile({
+          nBlocks: 5000,
+          totalComparisons: 50_759_847,
+          reductionRatio: 0.989848,
+          blockSizesP99: 18,
+          blockSizesMax: 10_000,
+        }),
+        100_000,
+      ),
+    ).toBe(HealthVerdict.RED);
+  });
+
+  it("blockingHealth: fine-grained blocking with a 1.9% largest block → GREEN", () => {
+    // The measured person@100k shape. Graded RED by the old percentile rule.
+    expect(
+      blockingHealth(
+        makeBlockingProfile({
+          nBlocks: 84_293,
+          totalComparisons: 121_372_923,
+          reductionRatio: 0.975725,
+          blockSizesP50: 2,
+          blockSizesP99: 72,
+          blockSizesMax: 2170,
+        }),
+        100_000,
+      ),
+    ).toBe(HealthVerdict.GREEN);
+  });
+
+  it("blockingHealth: 8 uniform blocks at a 12.5% share each → GREEN", () => {
+    expect(
+      blockingHealth(
+        makeBlockingProfile({
+          nBlocks: 8,
+          totalComparisons: 39_600,
+          reductionRatio: 0.876,
+          blockSizesP99: 100,
+          blockSizesMax: 100,
+        }),
+        800,
+      ),
+    ).toBe(HealthVerdict.GREEN);
   });
 
   it("blockingHealth: low reduction → RED", () => {

--- a/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
+++ b/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
@@ -29,7 +29,8 @@ prints each sub-profile's health verdict beside THE FIELD VALUES THAT DECIDE IT,
 and names the rule that fired. The rules (complexity_profile.py):
 
     blocking RED  <- n_blocks == 0
-                  <- block_sizes_p99 > 10 * (n_rows / n_blocks)   [skew]
+                  <- largest block's share of total_comparisons
+                     > max(0.10, 4 / n_blocks)                    [skew, #2628]
                   <- reduction_ratio < 0.5
     cluster  RED  <- cluster_size_max > 0.1 * n_rows
                   <- transitivity_rate < 0.85
@@ -76,26 +77,29 @@ def _blocking_report(bp, n_rows: int) -> dict:
     p99 = getattr(bp, "block_sizes_p99", 0)
     rr = getattr(bp, "reduction_ratio", 0.0)
     singles = getattr(bp, "singleton_block_count", 0)
+    # Pair-share of the biggest block: what the skew RED rule reads as of
+    # #2628. The old rule was `p99 > 10 * avg`, which compares a tail
+    # percentile to a MEAN pinned near 1 whenever blocking is fine-grained
+    # (n_blocks -> n_rows) -- it fired on person@100k, whose largest block owned
+    # 1.9% of the work with reduction 0.9757 and no singletons, and it missed a
+    # single block owning 98.5% (which sits ABOVE p99, not at it). Skew is
+    # dangerous when one block owns most of the WORK, and work is quadratic in
+    # block size, so that is what the rule now measures. `p99_over_avg` stays
+    # in the output as the retired signal, for comparison across runs.
+    total_pairs = getattr(bp, "total_comparisons", 0) or 0
+    biggest = getattr(bp, "block_sizes_max", 0) or 0
+    biggest_pairs = biggest * (biggest - 1) // 2 if biggest >= 2 else 0
+    share = biggest_pairs / total_pairs if total_pairs else 0.0
+    skew_bar = max(0.10, 4.0 / n_blocks) if n_blocks else 0.10
     fired = []
     if n_blocks == 0:
         fired.append("n_blocks == 0")
-    if p99 > 10 * avg:
-        fired.append(f"block_sizes_p99 {p99} > 10*avg {10 * avg:.1f}  [SKEW]")
+    if share > skew_bar:
+        fired.append(
+            f"largest_block_pair_share {share:.4f} > bar {skew_bar:.4f}  [SKEW]"
+        )
     if rr < 0.5:
         fired.append(f"reduction_ratio {rr:.4f} < 0.5")
-    # Pair-share of the biggest block: the measure the RED rule arguably should
-    # be using. `p99 > 10 * avg` compares a tail percentile to a MEAN that is
-    # pinned near 1 whenever blocking is fine-grained (n_blocks -> n_rows), so
-    # it fires on configs with excellent reduction and no singletons. What
-    # actually makes skew dangerous is that a few blocks own most of the WORK,
-    # and work is quadratic in block size -- so the honest question is what
-    # fraction of total candidate pairs the largest block contributes.
-    #
-    # Recorded, not acted on: changing a RED rule needs this number first, and
-    # the first version of this diagnostic did not capture it.
-    total_pairs = getattr(bp, "total_comparisons", 0) or 0
-    biggest = getattr(bp, "block_sizes_max", 0) or 0
-    biggest_pairs = biggest * (biggest - 1) // 2
     return {
         "n_blocks": n_blocks, "avg_block_size": round(avg, 2),
         "block_sizes_p50": getattr(bp, "block_sizes_p50", 0),
@@ -107,9 +111,8 @@ def _blocking_report(bp, n_rows: int) -> dict:
         "singleton_fraction": round(singles / max(n_blocks, 1), 4),
         "total_comparisons": int(total_pairs),
         "largest_block_pairs": int(biggest_pairs),
-        "largest_block_pair_share": (
-            round(biggest_pairs / total_pairs, 6) if total_pairs else None
-        ),
+        "largest_block_pair_share": round(share, 6) if total_pairs else None,
+        "skew_bar": round(skew_bar, 6),
         "p99_over_avg": round(p99 / avg, 2) if avg else None,
         "p99_over_p50": (
             round(p99 / getattr(bp, "block_sizes_p50", 0), 2)


### PR DESCRIPTION
## The rule was reading "many small blocks" as "dangerous tail"

`BlockingProfile.health` graded skew with `block_sizes_p99 > 10 * (n_rows / n_blocks)`. The denominator is the **mean block size**, which is pinned near 1 whenever blocking is fine-grained (`n_blocks -> n_rows`), so the bar collapses toward "any block over ~12 rows" no matter how healthy the layout is.

Measured at 100,000 rows (`diagnose_zeroconfig_refusal.py`, run 31976392050):

| shape | n_blocks | avg | p99 | p99/avg | reduction | **largest block's share of all pairs** | verdict |
|---|---:|---:|---:|---:|---:|---:|---|
| person | 84,293 | 1.19 | 72 | **60.7** | 0.9757 | **1.9%** (2,353,365 / 121,372,923) | **RED** |
| biblio | 22,151 | 4.51 | 39 | 8.6 | 0.9996 | 0.14% (2,415 / 1,770,258) | GREEN |

person graded RED with **under 2% of the work in its biggest block**, zero singletons and 0.976 reduction. At `n_rows >= REFUSE_AT_N` a RED blocking profile **refuses the run**, so this was zero-config turning away a config that looks good by every other signal it collects.

## It also missed the case it exists for

One block of 10,000 rows among 5,000 blocks owns **98.5%** of the candidate pairs. Its p99 is 18 (the giant sits *above* the 99th percentile, not at it) against a `10 * avg` bar of 200, and `reduction_ratio` is 0.99 because 50M pairs is still a sliver of 5e9. Old rule: **GREEN**. A percentile cannot see a single straggler.

Both fixtures are pinned in `tests/test_blocking_skew_pair_share.py` and both fail on the old rule -- one false positive, one false negative.

## What replaces it

Within-block pairs are quadratic in block size, so skew hurts when one block becomes a straggler no worker pool can absorb. The rule now measures that directly:

```
largest_block_pair_share > max(0.10, 4 / n_blocks)
```

- **0.10** -- a block owning a tenth of all candidate pairs sets the floor on wall time by itself at any realistic worker count, and it is ~5x above the 0.019 measured on the healthiest fine-grained shape in the panel.
- **4 / n_blocks** -- the block must also hold more than 4x its fair share before this counts as skew rather than coarseness. Inert above 40 blocks, and it costs no coverage: at small `n_blocks` a dominating block has to hold most of the rows, which trips `reduction_ratio` first (pinned by a test).

## Also in here

- **TypeScript ported in the same change** (`blockingHealth`, `largestBlockPairShare` exported) so the two surfaces cannot grade the same profile differently.
- **Six copies of a shared green fixture claimed a 25-row block inside a 500-pair total** -- 300 pairs from one of ten blocks. Impossible, and inert only because the old rule never read `total_comparisons`. Made coherent rather than exempted; same for a fixture that put a 200-row block in a 100-row dataset.

## Deliberately not in here

The identically-shaped **refit** rule (`rule_blocking_too_coarse`, `autoconfig_rules.py:275`) is untouched. It steers what the controller searches rather than refusing a run, and changing search behaviour needs its own evidence.

## Known gap

person also grades `scoring` RED (`n_pairs_scored=0`). That is **not** a cascade from blocking -- it comes from `scorer.py` scoring zero pairs on the sample, not from the pathological-input short-circuit path. So this fix alone will not clear person's refusal; it moves the first RED to `scoring`, which is the next thread. Re-running the diagnostic on this branch to confirm.

Local: 154 passed across the four affected modules; the 4 remaining failures in the wider sweep reproduce with the rule reverted (local env skew). TS lane deferred to CI (no node_modules in this worktree).