### PR TITLE
fix(spark): make the Splink comparison lane actually measure something -- GM is 13.6x faster, not 5x slower

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -233,14 +233,6 @@ jobs:
           SPARK_EXECUTOR_CORES: ${{ inputs.worker_cores || '1' }}
           SPARK_EXECUTOR_MEMORY: ${{ inputs.worker_memory || '1g' }}
         run: |
-          # BEFORE `up`, and world-writable on purpose. The workers bind-mount
-          # this path (see the compose file) and the Spark image runs as a
-          # non-root user, so a directory Docker auto-creates at mount time is
-          # root-owned and the executors cannot write their checkpoints into it.
-          # Creating it here as the runner user with an open mode is the one
-          # ordering that works for both sides.
-          mkdir -p /tmp/spark-checkpoint
-          chmod 777 /tmp/spark-checkpoint
           docker compose -f docker/spark-cluster/docker-compose.yml up -d
           echo "cluster sized: 2 workers x ${SPARK_WORKER_CORES} core(s) / ${SPARK_WORKER_MEMORY}" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -233,6 +233,14 @@ jobs:
           SPARK_EXECUTOR_CORES: ${{ inputs.worker_cores || '1' }}
           SPARK_EXECUTOR_MEMORY: ${{ inputs.worker_memory || '1g' }}
         run: |
+          # BEFORE `up`, and world-writable on purpose. The workers bind-mount
+          # this path (see the compose file) and the Spark image runs as a
+          # non-root user, so a directory Docker auto-creates at mount time is
+          # root-owned and the executors cannot write their checkpoints into it.
+          # Creating it here as the runner user with an open mode is the one
+          # ordering that works for both sides.
+          mkdir -p /tmp/spark-checkpoint
+          chmod 777 /tmp/spark-checkpoint
           docker compose -f docker/spark-cluster/docker-compose.yml up -d
           echo "cluster sized: 2 workers x ${SPARK_WORKER_CORES} core(s) / ${SPARK_WORKER_MEMORY}" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -492,8 +492,42 @@ jobs:
           path: spark-fs-train-scale.json
           if-no-files-found: ignore
 
-      # Splink on the SAME cluster. Deliberately AFTER the GM run so both see an
-      # identical warm cluster, and gated so the correctness lane is unaffected.
+
+      # Python worker" fails on its own rather than because an empty virtualenv
+      # was shipped to make it fail. The local lane can only simulate this.
+      - name: Inventory -- what runs with no Python on REAL executors
+        continue-on-error: true
+        env:
+          GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
+          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
+          GOLDENMATCH_SPARK_PYENV: "none"
+        run: |
+          python scripts/spark_jar_only_inventory.py \
+            --out spark-cluster-inventory.json
+
+      # Splink on the SAME cluster -- LAST, and with the Connect server stopped.
+      #
+      # Standalone Spark hands an application every free core unless
+      # `spark.cores.max` says otherwise, and the Connect server IS an
+      # application: it registers when the cluster starts and holds all 16 cores
+      # for the life of the lane. A second app then queues for resources that
+      # never free. Run 31978493018 shows it in four lines:
+      #
+      #     Master: Registering worker 172.18.0.4 with 8 cores, 16.0 GiB RAM
+      #     Master: Registering worker 172.18.0.3 with 8 cores, 16.0 GiB RAM
+      #     Master: Registering app Spark Connect server
+      #     Master: Registering app splink-train-scale      <- no cores left
+      #
+      # The symptom is "no executor registered within 120s", which reads like a
+      # connectivity fault and is not one. That misread cost a run: the driver
+      # host WAS also wrong (default bridge 172.17.0.1 against a cluster on
+      # 172.18.x), fixing it changed nothing, and core starvation was the cause
+      # both times.
+      #
+      # Capping the Connect app instead would split the cluster and leave both
+      # engines' numbers unrepresentative. Stopping it gives each engine the
+      # WHOLE cluster in turn, which is the comparison worth having. This runs
+      # last so nothing downstream needs Connect back.
       - name: Splink FS training on the same cluster
         if: inputs.splink_compare && inputs.train_rows != '0' && inputs.train_rows != ''
         # NOT continue-on-error. This step exists to produce ONE number, and it
@@ -505,6 +539,8 @@ jobs:
         run: |
           set -euo pipefail
           pip install "splink==4.0.16" >/dev/null
+          # Free the cores. See the note above the step.
+          docker compose -f docker/spark-cluster/docker-compose.yml stop spark-connect
           # The driver runs HERE; the executors are containers. They must route
           # back to the driver, so `spark.driver.host` has to be an address they
           # can reach, not localhost. Getting this wrong does not error -- the
@@ -539,18 +575,6 @@ jobs:
           # cannot turn a good run red -- it just stops a MISSING measurement
           # from being quieter than a bad one.
           if-no-files-found: error
-
-      # Python worker" fails on its own rather than because an empty virtualenv
-      # was shipped to make it fail. The local lane can only simulate this.
-      - name: Inventory -- what runs with no Python on REAL executors
-        continue-on-error: true
-        env:
-          GOLDENMATCH_SPARK_REMOTE: "sc://localhost:15002"
-          GOLDENMATCH_SPARK_JAR: packages/jvm/goldenmatch-spark/build/goldenmatch-spark.jar
-          GOLDENMATCH_SPARK_PYENV: "none"
-        run: |
-          python scripts/spark_jar_only_inventory.py \
-            --out spark-cluster-inventory.json
 
       - name: Summary
         if: always()

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -496,22 +496,36 @@ jobs:
       # identical warm cluster, and gated so the correctness lane is unaffected.
       - name: Splink FS training on the same cluster
         if: inputs.splink_compare && inputs.train_rows != '0' && inputs.train_rows != ''
-        continue-on-error: true
+        # NOT continue-on-error. This step exists to produce ONE number, and it
+        # is only reached when `splink_compare` is explicitly requested. Run
+        # 31978060027 was green with no Splink result at all: the step exited 1
+        # on "no executor registered within 120s" and the swallowed exit made a
+        # measurement failure look like a completed comparison.
         timeout-minutes: 45
         run: |
           set -euo pipefail
           pip install "splink==4.0.16" >/dev/null
           # The driver runs HERE; the executors are containers. They must route
-          # back to the driver, so `spark.driver.host` has to be the docker
-          # bridge gateway, not localhost. Getting this wrong does not error --
-          # the job hangs on "Initial job has not accepted any resources" -- so
-          # it is resolved explicitly and printed.
-          FMT='{{ (index .IPAM.Config 0).Gateway }}'
-          GW=$(docker network inspect spark-cluster_spark --format "$FMT" 2>/dev/null || true)
+          # back to the driver, so `spark.driver.host` has to be an address they
+          # can reach, not localhost. Getting this wrong does not error -- the
+          # job hangs on "Initial job has not accepted any resources" -- so it is
+          # resolved explicitly and printed.
+          #
+          # Read the gateway off the MASTER CONTAINER's own network rather than
+          # naming the compose network. The name is `<project>_spark`, the
+          # project is inferred from the compose file's directory, and guessing
+          # it wrong fails SILENTLY: `docker network inspect <missing> 2>/dev/null
+          # || true` yielded "" and the fallback handed back the DEFAULT bridge
+          # gateway 172.17.0.1, while the cluster was on 172.18.x. The workers
+          # could not route to it and no executor ever registered. Asking the
+          # container which network it is actually on cannot drift.
+          GW=$(docker inspect spark-master \
+                 --format '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}')
           if [ -z "$GW" ]; then
-            GW=$(docker network inspect bridge --format "$FMT")
+            echo "::error::could not resolve a gateway from the spark-master container's networks. Without a routable driver host the workers cannot call back and the job would hang until the 120s executor timeout."
+            exit 1
           fi
-          echo "driver host (docker bridge gateway): $GW"
+          echo "driver host (spark-master's network gateway): $GW"
           python scripts/spark_splink_train_scale.py             --rows "${{ inputs.train_rows || '1000000' }}"             --master spark://localhost:7077             --driver-host "$GW"             --out splink-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
@@ -519,7 +533,12 @@ jobs:
         with:
           name: splink-train-scale
           path: splink-train-scale.json
-          if-no-files-found: warn
+          # `error` rather than `warn`: this upload runs `if: always()`, so on a
+          # failed comparison the only other signal is a warning annotation
+          # nobody reads. The step above already failed in that case, so this
+          # cannot turn a good run red -- it just stops a MISSING measurement
+          # from being quieter than a bad one.
+          if-no-files-found: error
 
       # Python worker" fails on its own rather than because an empty virtualenv
       # was shipped to make it fail. The local lane can only simulate this.
@@ -535,6 +554,8 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          SPLINK_COMPARE: ${{ inputs.splink_compare }}
         run: |
           {
             echo '## Spark cluster lane'
@@ -545,6 +566,28 @@ jobs:
               echo '```json'
               cat spark-cluster-inventory.json
               echo '```'
+            fi
+            # The whole point of `splink_compare` is two walls side by side, so
+            # say plainly when one of them is missing. A summary that silently
+            # shows GM alone reads like a comparison that was made and won.
+            if [ "${SPLINK_COMPARE}" = "true" ]; then
+              echo ''
+              echo '### GM vs Splink, same cluster'
+              if [ -f spark-fs-train-scale.json ] && [ -f splink-train-scale.json ]; then
+                echo '| engine | rows | total wall |'
+                echo '|---|---:|---:|'
+                jq -r '"| goldenmatch | \(.actual_rows) | \(.total_seconds)s |"' spark-fs-train-scale.json
+                jq -r '"| splink | \(.actual_rows) | \(.total_seconds)s |"' splink-train-scale.json
+                CONFOUND=$(jq -r '.session_confound // empty' splink-train-scale.json)
+                if [ -n "$CONFOUND" ]; then
+                  echo ''
+                  echo "> session confound recorded: \`${CONFOUND}\`"
+                fi
+              else
+                echo 'NO COMPARISON. One or both engines did not produce a result:'
+                [ -f spark-fs-train-scale.json ] && echo '- goldenmatch: ok' || echo '- goldenmatch: MISSING'
+                [ -f splink-train-scale.json ] && echo '- splink: ok' || echo '- splink: MISSING'
+              fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -101,6 +101,18 @@ services:
       /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker
       spark://spark-master:7077
       --cores ${SPARK_WORKER_CORES:-1} --memory ${SPARK_WORKER_MEMORY:-1g}
+    volumes:
+      # Shared checkpoint storage for the Splink comparison lane ONLY. Splink's
+      # Spark backend truncates lineage with `Dataset.checkpoint()`, which the
+      # EXECUTORS write and the driver reads -- and the driver runs on the host
+      # while the executors are containers, so without an identical path on both
+      # sides the job dies with "Checkpoint directory has not been set" or, once
+      # set, cannot find what it wrote. Same path on both sides is the point of
+      # the identical source and target here.
+      #
+      # Nothing else in this lane uses it: GM never checkpoints, so the GM
+      # numbers are unaffected by its presence.
+      - /tmp/spark-checkpoint:/tmp/spark-checkpoint
     # Defaults stay 1 core / 1g: the ORIGINAL point of this cluster is topology,
     # not throughput -- an 8-row fixture proving the jar-only property on real
     # executors, on a 4 CPU / 16 GB GitHub runner that also holds the master,

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -101,18 +101,6 @@ services:
       /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker
       spark://spark-master:7077
       --cores ${SPARK_WORKER_CORES:-1} --memory ${SPARK_WORKER_MEMORY:-1g}
-    volumes:
-      # Shared checkpoint storage for the Splink comparison lane ONLY. Splink's
-      # Spark backend truncates lineage with `Dataset.checkpoint()`, which the
-      # EXECUTORS write and the driver reads -- and the driver runs on the host
-      # while the executors are containers, so without an identical path on both
-      # sides the job dies with "Checkpoint directory has not been set" or, once
-      # set, cannot find what it wrote. Same path on both sides is the point of
-      # the identical source and target here.
-      #
-      # Nothing else in this lane uses it: GM never checkpoints, so the GM
-      # numbers are unaffected by its presence.
-      - /tmp/spark-checkpoint:/tmp/spark-checkpoint
     # Defaults stay 1 core / 1g: the ORIGINAL point of this cluster is topology,
     # not throughput -- an 8-row fixture proving the jar-only property on real
     # executors, on a 4 CPU / 16 GB GitHub runner that also holds the master,

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -85,8 +85,10 @@ def _fixture_module():
     return mod
 
 
-def build_session(master: str, driver_host: str | None, wait_s: int):
+def build_session(master: str, driver_host: str | None, wait_s: int,
+                  checkpoint_dir: str):
     from pyspark.sql import SparkSession
+    from splink.backends.spark import similarity_jar_location
 
     b = (
         SparkSession.builder.master(master)
@@ -95,10 +97,29 @@ def build_session(master: str, driver_host: str | None, wait_s: int):
         # partitions on a small cluster is pure scheduling overhead.
         .config("spark.sql.shuffle.partitions", "8")
         .config("spark.driver.bindAddress", "0.0.0.0")
+        # Splink ships its own similarity UDFs (jaro_winkler, damerau
+        # levenshtein) as a JVM jar, and WITHOUT IT THE COMPARISON IS INVALID
+        # rather than merely degraded: Splink warns "Unable to load custom Spark
+        # SQL functions such as jaro_winkler ... You will not be able to use
+        # these functions in your linkage" and carries on, so the run completes
+        # having compared something other than what GM compares. `spark.jars`
+        # also ships it to the executors, which is where the UDFs evaluate.
+        .config("spark.jars", similarity_jar_location())
     )
     if driver_host:
         b = b.config("spark.driver.host", driver_host)
     spark = b.getOrCreate()
+
+    # Splink's Spark backend truncates lineage with `Dataset.checkpoint()`,
+    # which raises "Checkpoint directory has not been set in the SparkContext"
+    # unless one is set. The path has to resolve to the SAME storage from the
+    # driver (this host) and the executors (containers), so the compose file
+    # bind-mounts a host directory at an identical path inside the workers.
+    # Left as Splink's default `checkpoint` break-lineage method deliberately:
+    # switching to `persist` would dodge the mount but would also stop measuring
+    # the configuration Splink actually recommends on Spark.
+    Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
+    spark.sparkContext.setCheckpointDir(f"file://{checkpoint_dir}")
 
     # Refuse to measure a cluster that never gave us executors. Without this the
     # run "works" -- it just runs everything on the driver and reports a wall
@@ -138,6 +159,11 @@ def main() -> int:
     ap.add_argument("--max-pairs", type=int, default=1_000_000,
                     help="Splink's u-estimation sample. Matches the GM harness's "
                          "--u-max-pairs so the u stage is comparable.")
+    ap.add_argument("--checkpoint-dir", default=os.environ.get(
+        "SPLINK_CHECKPOINT_DIR", "/tmp/spark-checkpoint"),
+        help="Shared between this driver and the container executors. Must be "
+             "the SAME path inside the workers -- see the bind mount in "
+             "docker/spark-cluster/docker-compose.yml.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -152,8 +178,9 @@ def main() -> int:
     t_all = time.perf_counter()
 
     spark, n_exec = build_session(args.master, args.driver_host or None,
-                                  args.executor_wait)
+                                  args.executor_wait, args.checkpoint_dir)
     out["executors"] = n_exec
+    out["checkpoint_dir"] = args.checkpoint_dir
 
     fx = _fixture_module()
     t = time.perf_counter()
@@ -175,6 +202,13 @@ def main() -> int:
     # cut; both give three informative levels per field.
     settings = SettingsCreator(
         link_type="dedupe_only",
+        # The fixture's id column. Without this Splink looks for a literal
+        # `unique_id`, does not find it, and prints "SETTINGS VALIDATION:
+        # Errors were identified in your settings dictionary ... Missing
+        # column(s) from input dataframe(s): `unique_id`" -- then continues.
+        # A validation error it recovers from is exactly the kind of defect
+        # that produces a number nobody can trust.
+        unique_id_column_name="record_id",
         blocking_rules_to_generate_predictions=[block_on("blk"), block_on("last")],
         comparisons=[
             cl.JaroWinklerAtThresholds("first", [0.9, 0.7]),

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -85,8 +85,7 @@ def _fixture_module():
     return mod
 
 
-def build_session(master: str, driver_host: str | None, wait_s: int,
-                  checkpoint_dir: str):
+def build_session(master: str, driver_host: str | None, wait_s: int):
     from pyspark.sql import SparkSession
     from splink.backends.spark import similarity_jar_location
 
@@ -110,16 +109,26 @@ def build_session(master: str, driver_host: str | None, wait_s: int,
         b = b.config("spark.driver.host", driver_host)
     spark = b.getOrCreate()
 
-    # Splink's Spark backend truncates lineage with `Dataset.checkpoint()`,
-    # which raises "Checkpoint directory has not been set in the SparkContext"
-    # unless one is set. The path has to resolve to the SAME storage from the
-    # driver (this host) and the executors (containers), so the compose file
-    # bind-mounts a host directory at an identical path inside the workers.
-    # Left as Splink's default `checkpoint` break-lineage method deliberately:
-    # switching to `persist` would dodge the mount but would also stop measuring
-    # the configuration Splink actually recommends on Spark.
-    Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
-    spark.sparkContext.setCheckpointDir(f"file://{checkpoint_dir}")
+    # Splink's Spark backend breaks lineage with `Dataset.checkpoint()`, which
+    # needs a checkpoint dir, and a checkpoint dir on THIS topology has nowhere
+    # to live. Spark says so itself:
+    #
+    #   WARN SparkContext: Spark is not running in local mode, therefore the
+    #   checkpoint directory must not be on the local filesystem.
+    #
+    # A bind-mounted host path gets the driver and executors to the same inode
+    # but not to the same identity: the driver (runner user) creates the
+    # per-application subdirectory at 755 and the executors (non-root user in
+    # the container) then fail with "Mkdirs failed to create
+    # file:/tmp/spark-checkpoint/<uuid>/.../_temporary/...". chmod on the base
+    # directory does not reach the subdirectories Spark makes later. Fixing it
+    # properly means HDFS/S3, which this lane does not have.
+    #
+    # So `persist` instead, and RECORDED as a deviation rather than quietly
+    # taken -- see `break_lineage_method` in the output. It does not
+    # disadvantage Splink: persist materialises to executor memory/disk and
+    # skips the distributed-filesystem write that checkpointing would pay, so
+    # if it biases the wall at all it biases it in Splink's favour.
 
     # Refuse to measure a cluster that never gave us executors. Without this the
     # run "works" -- it just runs everything on the driver and reports a wall
@@ -159,11 +168,6 @@ def main() -> int:
     ap.add_argument("--max-pairs", type=int, default=1_000_000,
                     help="Splink's u-estimation sample. Matches the GM harness's "
                          "--u-max-pairs so the u stage is comparable.")
-    ap.add_argument("--checkpoint-dir", default=os.environ.get(
-        "SPLINK_CHECKPOINT_DIR", "/tmp/spark-checkpoint"),
-        help="Shared between this driver and the container executors. Must be "
-             "the SAME path inside the workers -- see the bind mount in "
-             "docker/spark-cluster/docker-compose.yml.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -174,13 +178,23 @@ def main() -> int:
             "GM runs over Spark Connect (addArtifact is Connect-only); Splink "
             "cannot (it uses sparkContext). Same cluster, different front door."
         ),
+        # Recorded, not buried. Splink's default lineage break is `checkpoint`,
+        # which needs a distributed filesystem this lane has no way to provide.
+        # `persist` skips that write, so if it moves the wall it moves it in
+        # SPLINK's favour -- the deviation cannot manufacture a GM win.
+        "break_lineage_method": "persist",
+        "break_lineage_deviation": (
+            "Splink's Spark default is `checkpoint`; it requires a checkpoint "
+            "dir on a non-local filesystem (Spark refuses local paths outside "
+            "local mode) and this cluster has only container-local disk. "
+            "`persist` materialises to executor memory/disk instead."
+        ),
     }
     t_all = time.perf_counter()
 
     spark, n_exec = build_session(args.master, args.driver_host or None,
-                                  args.executor_wait, args.checkpoint_dir)
+                                  args.executor_wait)
     out["executors"] = n_exec
-    out["checkpoint_dir"] = args.checkpoint_dir
 
     fx = _fixture_module()
     t = time.perf_counter()
@@ -218,7 +232,14 @@ def main() -> int:
             cl.JaroWinklerAtThresholds("city", [0.9, 0.7]),
         ],
     )
-    linker = Linker(df, settings, db_api=SparkAPI(spark_session=spark))
+    # See the note in build_session: `checkpoint` needs a distributed
+    # filesystem this lane does not have. Declared here, and echoed into the
+    # artifact below, so no reader has to infer it from the absence of a
+    # checkpoint dir.
+    linker = Linker(
+        df, settings,
+        db_api=SparkAPI(spark_session=spark, break_lineage_method="persist"),
+    )
 
     # u, from random pairs -- the same quantity the GM harness times as `u`.
     t = time.perf_counter()


### PR DESCRIPTION
## The number, first

1M rows, one cluster (2 workers x 8 cores / 16g on `large-new-64GB`), same fixture from the same `build_fixture`, run 31979445092:

| stage | goldenmatch | splink | ratio |
|---|---:|---:|---:|
| u (random sampling) | 3.81s | 4.56s | 1.2x |
| M-step (GM counts / Splink EM) | **15.14s** | **253.96s** | **16.8x** |
| driver-side fit | 0.0s | (in EM) | |
| **train total** | **18.95s** | **258.52s** | **13.6x** |

Fixture build excluded from both -- it is the harness, not the engine.

**This reverses the premise.** Every performance decision on this tier has been sized against "we are ~5x slower than Splink". `spark_splink_train_scale.py`'s own docstring notes that number appears nowhere in this repo; it now has a measured replacement pointing the other way.

The u stage is a dead heat, so the entire gap is the M-step -- which is exactly the counted-aggregation property the tier was built on. GM's E-step reads only the comparison vector, so 5,499,993 and 4,338,617 candidate pairs collapse to **433** and **186** distinct agreement patterns and the driver fits in 0.0s. Splink re-runs a Spark job per EM iteration over the pairs themselves.

## Read these before quoting it

- **Session confound (unchanged, recorded in the artifact).** GM runs over Spark Connect because `addArtifact` is Connect-only; Splink cannot (it needs `sparkContext`) and gets a classic session against the same master. Same cluster, different front door.
- **`break_lineage_method="persist"`, a disclosed deviation.** Splink's Spark default is `checkpoint`, which needs a checkpoint dir on a non-local filesystem, and this cluster has only container-local disk. persist skips the distributed-filesystem write checkpointing would pay, so any bias runs **in Splink's favour** -- the deviation cannot manufacture a GM win.
- **Training only.** Not scoring, not clustering.
- **Noise floor is not tiny.** GM's counts stage measured 12.25s on the previous run of the identical configuration and 15.14s here, ~23% run-to-run. It does not threaten 13.6x.

## Why it took four runs to get one number

Each iteration was a real defect, and three of the four would have produced a *plausible number* rather than an error if a fourth had not crashed first.

1. **Green run measuring nothing.** `continue-on-error: true` on the Splink step meant it exited 1 with an `::error::` annotation and the job still concluded success. Removed -- the step is only reached when `splink_compare` is explicitly requested and exists to produce one number.
2. **Driver host resolved to the wrong bridge.** `docker network inspect spark-cluster_spark ... 2>/dev/null || true` fell back to the *default* bridge gateway 172.17.0.1 while the cluster was on 172.18.x. Now read off the master container's own network, which cannot drift with the compose project name. Real bug, and **not** the cause of the failure I blamed it for.
3. **The Connect server held every core.** Standalone Spark gives an app all free cores unless `spark.cores.max` says otherwise, and Connect is an app -- it registered at cluster start and held all 16 for the lane's life, so Splink queued forever. The symptom ("no executor registered within 120s") reads like a connectivity fault and is not one, which is what sent me to the driver host twice. Splink now runs last, after the final consumer of Connect, with Connect stopped, so each engine gets the whole cluster in turn.
4. **Two silent invalidators, once Splink could actually start.** Its similarity jar was unregistered -- Splink *warns* "You will not be able to use these functions in your linkage" and continues, which would have timed a comparison set that is not the one GM computes. And `unique_id_column_name` was unset, so Splink printed a settings-validation error for a missing `unique_id` column and continued. Both now fixed; the run log is clean of both.
5. **Checkpoint storage.** The crash that stopped the whole thing. A bind-mounted host path gets driver and executors to the same inode but not the same identity -- the driver creates the per-app subdirectory at 755 and the container's non-root user cannot write inside it. `persist` instead; the mount and chmod are removed rather than left looking load-bearing.

Also: `if-no-files-found` on the splink artifact goes `warn` -> `error`, and the job summary now prints both walls in one table or says **NO COMPARISON** and names the missing side.

## What this means for the FFI decision

The vector-scorer result (#2625, 2.3x slower) still stands as a fact about batching inside Spark SQL, and the architectural reasoning for leaving the row-shaped UDF domain is unchanged. But its *justification* was closing a Splink gap. On this workload there is no gap to close, so that work should be re-argued on its own merits rather than inherited.