### PR TITLE
diag(zeroconfig): record which of the two scoring-RED causes fired

### DIFF
--- a/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
+++ b/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
@@ -193,12 +193,43 @@ def collect(shape: str, rows: int, seed: int, workdir: Path) -> dict:
     out["iterations"] = len(getattr(history, "entries", []) or [])
     out["blocking"] = _blocking_report(profile.blocking, n)
     out["cluster"] = _cluster_report(profile.cluster, n)
+    # `candidates_compared` is the field that tells the two scoring-RED causes
+    # apart, and the first version of this report omitted it -- so a person@100k
+    # run showed `n_pairs_scored=0` with no way to say which had happened:
+    #
+    #   candidates_compared == 0  -> the emitter never received a ScoringProfile,
+    #       so `emitter.scoring or ScoringProfile()` fell back to the all-zero
+    #       default. Scoring never ran. That RED is DOWNSTREAM of whatever
+    #       stopped the sample pipeline.
+    #   candidates_compared > 0   -> pairs were compared and NONE cleared the
+    #       threshold. That RED is a real, independent signal about the
+    #       threshold or the scorers, and fixing blocking will not clear it.
+    #
+    # Note `n_pairs_scored` counts pairs ABOVE the threshold, not pairs scored
+    # (scorer.py builds it from `find_fuzzy_matches` output, which is already
+    # filtered; autoconfig_policy.py renders the same field as
+    # `n_pairs_above_threshold`). The name reads like the denominator and is
+    # actually the numerator, which is what made the ambiguity above easy to
+    # miss. Reported here under both names rather than silently renamed.
+    sc = profile.scoring
+    compared = getattr(sc, "candidates_compared", 0)
+    above = getattr(sc, "n_pairs_scored", 0)
     out["scoring"] = {
-        "n_pairs_scored": getattr(profile.scoring, "n_pairs_scored", 0),
-        "dip_statistic": round(getattr(profile.scoring, "dip_statistic", 0.0), 6),
-        "mass_above_threshold": round(getattr(profile.scoring, "mass_above_threshold", 0.0), 6),
+        "candidates_compared": compared,
+        "n_pairs_scored": above,
+        "n_pairs_above_threshold": above,  # the same field, under its true name
+        "above_threshold_rate": round(above / compared, 8) if compared else None,
+        "scoring_ran": compared > 0,
+        "dip_statistic": round(getattr(sc, "dip_statistic", 0.0), 6),
+        "mass_above_threshold": round(getattr(sc, "mass_above_threshold", 0.0), 6),
+        "mass_in_borderline": round(getattr(sc, "mass_in_borderline", 0.0), 6),
         "random_pair_above_threshold_rate":
-            getattr(profile.scoring, "random_pair_above_threshold_rate", None),
+            getattr(sc, "random_pair_above_threshold_rate", None),
+        "red_cause": (
+            None if (compared > 0 and getattr(sc, "mass_above_threshold", 0.0) > 0.0)
+            else "scoring-never-ran (candidates_compared == 0)" if compared == 0
+            else "nothing-cleared-threshold (candidates compared, mass == 0)"
+        ),
     }
     return out
 


### PR DESCRIPTION
## What and why

Follow-up to #2615. Re-running its diagnostic returned `person@100k: scoring=RED, n_pairs_scored=0`, and the report had no field distinguishing two causes that lead to **opposite** conclusions:

| `candidates_compared` | meaning | consequence |
|---|---|---|
| `== 0` | the emitter never received a `ScoringProfile`, so `emitter.scoring or ScoringProfile()` fell back to the all-zero default. Scoring never ran. | the RED is **downstream** of whatever stopped the sample pipeline |
| `> 0` | pairs were compared and none cleared the threshold | the RED is an **independent** signal; changing the blocking rule will not clear it |

Since #2615 exists to decide whether the blocking RED rule is worth changing, and person@100k is RED on *both* blocking and scoring, this determines whether that lever is inert. The report now carries `candidates_compared`, `above_threshold_rate`, `scoring_ran` and an explicit `red_cause`.

## The naming trap that hid it

`n_pairs_scored` **is not the number of pairs scored.** `scorer.py:89` builds it from `find_fuzzy_matches` output, which is already filtered to pairs *above* the threshold, and `autoconfig_policy.py:298` renders the same field as `n_pairs_above_threshold`. The name reads like the denominator and is actually the numerator.

Reported here under **both** names rather than silently renamed, because other surfaces (TUI, web telemetry, CLI renderer) read the existing field and a rename is a separate change.

## Scope note

This is the diagnostic only. No rule, threshold, or runtime behavior changes. Consistent with #2615's own posture: read the number first, change the rule second.

Same omission class #2615 called out in its own first version, which is worth noting: a diagnostic that does not capture the quantity the decision needs sends you back for another run.

## Changes

- `scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py`: scoring block records `candidates_compared`, `n_pairs_above_threshold`, `above_threshold_rate`, `scoring_ran`, `mass_in_borderline` and a derived `red_cause`.

## Testing

- Ran end-to-end on `person@100000`; the JSON now carries the new fields.
- Diagnostic-only script, not imported by the library and not in any CI lane.
- Reproduction needs `uv sync --package goldenmatch --extra polars`: the script imports polars directly, but polars is an optional extra of `goldenmatch`, so a default install fails with `ModuleNotFoundError` before reaching the controller.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a, diagnostic script)
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_