### PR TITLE
fix(spark): Splink was benchmarked with 8 shuffle partitions, GM with 200

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -81,6 +81,11 @@ on:
         required: false
         type: boolean
         default: false
+      match_splink_levels:
+        description: "Give GM the same four informative comparison levels Splink uses (exact / 0.9 / 0.7 / else) instead of the harness default three. Required for any accuracy comparison, or the result is a ladder difference reported as an engine difference."
+        required: false
+        type: boolean
+        default: false
       eval_quality:
         description: "Score both engines' trained models against the fixture's known entity structure and report average precision. The bar is match-or-better accuracy for GM, not a faster arrival at a worse model. Adds a scoring pass to each arm - keep train_rows modest."
         required: false
@@ -486,11 +491,13 @@ jobs:
           if [ "${{ inputs.profile_counts }}" = "true" ]; then PROFILE="--profile-counts"; fi
           EVAL=""
           if [ "${{ inputs.eval_quality }}" = "true" ]; then EVAL="--eval-quality"; fi
+          LADDER=""
+          if [ "${{ inputs.match_splink_levels }}" = "true" ]; then LADDER="--match-splink-levels"; fi
           FIELDS="${{ inputs.train_fields || '5' }}"
           PAD="${{ inputs.value_pad || '0' }}"
           SCORER=""
           if [ -n "${{ inputs.scorer }}" ]; then SCORER="--scorer ${{ inputs.scorer }}"; fi
-          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS"             --value-pad "$PAD" $SCORER $PROFILE $EVAL --out spark-fs-train-scale.json
+          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS"             --value-pad "$PAD" $SCORER $PROFILE $EVAL $LADDER --out spark-fs-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         if: always()

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -81,6 +81,11 @@ on:
         required: false
         type: boolean
         default: false
+      eval_quality:
+        description: "Score both engines' trained models against the fixture's known entity structure and report average precision. The bar is match-or-better accuracy for GM, not a faster arrival at a worse model. Adds a scoring pass to each arm - keep train_rows modest."
+        required: false
+        type: boolean
+        default: false
       train_fields:
         description: "Comparison fields for the FS scale run (max 5). Run 5 vs 2 with profile_counts to separate per-CALL from per-BYTE scoring cost."
         required: false
@@ -479,11 +484,13 @@ jobs:
           ROWS="${{ inputs.train_rows || '1000000' }}"
           PROFILE=""
           if [ "${{ inputs.profile_counts }}" = "true" ]; then PROFILE="--profile-counts"; fi
+          EVAL=""
+          if [ "${{ inputs.eval_quality }}" = "true" ]; then EVAL="--eval-quality"; fi
           FIELDS="${{ inputs.train_fields || '5' }}"
           PAD="${{ inputs.value_pad || '0' }}"
           SCORER=""
           if [ -n "${{ inputs.scorer }}" ]; then SCORER="--scorer ${{ inputs.scorer }}"; fi
-          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS"             --value-pad "$PAD" $SCORER $PROFILE --out spark-fs-train-scale.json
+          python scripts/spark_fs_train_scale.py --rows "$ROWS" --fields "$FIELDS"             --value-pad "$PAD" $SCORER $PROFILE $EVAL --out spark-fs-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         if: always()
@@ -562,7 +569,9 @@ jobs:
             exit 1
           fi
           echo "driver host (spark-master's network gateway): $GW"
-          python scripts/spark_splink_train_scale.py             --rows "${{ inputs.train_rows || '1000000' }}"             --master spark://localhost:7077             --driver-host "$GW"             --out splink-train-scale.json
+          EVAL=""
+          if [ "${{ inputs.eval_quality }}" = "true" ]; then EVAL="--eval-quality"; fi
+          python scripts/spark_splink_train_scale.py             --rows "${{ inputs.train_rows || '1000000' }}"             --master spark://localhost:7077             --driver-host "$GW"             $EVAL --out splink-train-scale.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         if: always() && inputs.splink_compare

--- a/scripts/_fs_quality_metrics.py
+++ b/scripts/_fs_quality_metrics.py
@@ -1,0 +1,88 @@
+"""Ranking-quality metrics for the GM-vs-Splink comparison.
+
+## Why this is a shared module rather than a function in each harness
+
+The two engines are compared on the quality of the model each one TRAINS, so
+the metric must not also differ between them. Two hand-written average-precision
+implementations that disagree by a percent would be indistinguishable from a
+model that is a percent better, and the whole point of the exercise is to tell
+those apart. One implementation, imported by both arms.
+
+## Why average precision and not F1 at a threshold
+
+The engines calibrate differently, and a threshold comparison would measure the
+calibration rather than the model. Average precision integrates over every
+threshold, so it answers the question that actually matters -- does this model
+RANK true pairs above false ones -- without either side being credited or
+penalised for where it happens to put a cut. Best-F1 is reported alongside it
+because it is the number practitioners recognise, with the threshold that
+achieved it so it cannot be read as a threshold-free result.
+
+## The base rate is reported too, and it is not decoration
+
+Average precision is bounded below by the positive rate, so 0.90 means something
+very different at a 1% base rate than at a 60% one. A comparison that omits it
+invites reading a number that a constant classifier could reach.
+"""
+from __future__ import annotations
+
+
+def ranking_metrics(scored: list[tuple[float, bool]]) -> dict:
+    """Average precision, best F1, and the base rate, from (score, is_true).
+
+    Ties are handled by grouping equal scores into a single threshold step.
+    Treating tied scores as if the true ones came first inflates average
+    precision, and comparison vectors collide HEAVILY here -- millions of pairs
+    share a few hundred distinct weights -- so tie handling is not a detail on
+    this data, it is most of the ranking.
+    """
+    if not scored:
+        return {"average_precision": None, "best_f1": None,
+                "best_f1_threshold": None, "n_pairs": 0, "n_true": 0,
+                "base_rate": None}
+
+    n = len(scored)
+    n_true = sum(1 for _s, t in scored if t)
+    if n_true == 0:
+        return {"average_precision": None, "best_f1": None,
+                "best_f1_threshold": None, "n_pairs": n, "n_true": 0,
+                "base_rate": 0.0}
+
+    # Descending by score; ties adjacent so they can be consumed as one step.
+    scored = sorted(scored, key=lambda st: -st[0])
+
+    tp = fp = 0
+    prev_recall = 0.0
+    ap = 0.0
+    best_f1 = 0.0
+    best_thr = None
+
+    i = 0
+    while i < n:
+        thr = scored[i][0]
+        j = i
+        while j < n and scored[j][0] == thr:
+            if scored[j][1]:
+                tp += 1
+            else:
+                fp += 1
+            j += 1
+        # Precision/recall AFTER admitting the whole tie group -- the only
+        # defensible point, since a threshold cannot separate equal scores.
+        precision = tp / (tp + fp)
+        recall = tp / n_true
+        ap += precision * (recall - prev_recall)
+        prev_recall = recall
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        if f1 > best_f1:
+            best_f1, best_thr = f1, thr
+        i = j
+
+    return {
+        "average_precision": round(ap, 6),
+        "best_f1": round(best_f1, 6),
+        "best_f1_threshold": (round(best_thr, 6) if best_thr is not None else None),
+        "n_pairs": n,
+        "n_true": n_true,
+        "base_rate": round(n_true / n, 6),
+    }

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -270,7 +270,8 @@ def profile_counts(joined, mk, *, scorer_udf, transform_udf, cands):
     return out
 
 
-def make_config(n_fields: int = 5, scorer: str | None = None):
+def make_config(n_fields: int = 5, scorer: str | None = None,
+                match_splink_levels: bool = False):
     """The scale config. ``n_fields`` trims the COMPARISON fields only.
 
     ## Why this is a knob
@@ -326,6 +327,35 @@ def make_config(n_fields: int = 5, scorer: str | None = None):
         # measuring different workloads, so their timings meant nothing.
         for f in mk.fields:
             f.scorer = scorer
+    if match_splink_levels:
+        # Mirror Splink's comparison ladder EXACTLY, because the accuracy
+        # comparison was otherwise measuring a config difference and calling it
+        # an engine difference.
+        #
+        # Splink's `JaroWinklerAtThresholds(f, [0.9, 0.7])` yields five states:
+        # null, EXACT, jw >= 0.9, jw >= 0.7, else. This harness's default is
+        # three -- agree / partial >= 0.7 / disagree -- which lumps "identical",
+        # "jw 0.95" and "jw 0.75" together and is strictly less discriminating.
+        # Measured at 200k rows on an identical pair population (1,854,038
+        # pairs, 200,004 true): GM 0.7557 average precision against Splink's
+        # 0.7911. A coarser ladder is also a cheaper one, so the speed advantage
+        # was partly bought with it.
+        #
+        # `level_thresholds` are DESCENDING cutoffs and the level is the count
+        # cleared, so [1.0, 0.9, 0.7] gives exact -> 3, >= 0.9 -> 2, >= 0.7 -> 1,
+        # else 0, plus -1 unobserved: the same four informative levels Splink
+        # has.
+        #
+        # `dob` is the odd one out. Splink compares it with
+        # `DamerauLevenshteinAtThresholds([1, 2])` -- an EDIT DISTANCE -- while
+        # this field is scored by a similarity ratio. The dates are a fixed ten
+        # characters ("19xx-01-01"), so one edit is 0.9 and two is 0.8; the
+        # thresholds below are that conversion, and they are only equivalent
+        # because the width is fixed.
+        for f in mk.fields:
+            f.levels = 4
+            f.level_thresholds = ([1.0, 0.9, 0.8] if f.field == "dob"
+                                  else [1.0, 0.9, 0.7])
     if n_fields < len(mk.fields):
         # Trim in place. Rebuilding a shorter literal risks the arms differing
         # in something other than field count, which is the one variable this
@@ -436,6 +466,12 @@ def main() -> int:
              "block and the run sat in the join for 24 minutes until the step "
              "timeout killed it, with no output naming the cause. This turns "
              "that into a fast, specific refusal.")
+    ap.add_argument("--match-splink-levels", action="store_true",
+                    help="Give every comparison field the same four informative "
+                         "levels Splink uses (exact / 0.9 / 0.7 / else) instead "
+                         "of this harness's default three. Without it an "
+                         "accuracy comparison measures a ladder difference and "
+                         "reports it as an engine difference.")
     ap.add_argument("--eval-quality", action="store_true",
                     help="After training, score the SAME candidate pairs with "
                          "the trained model and report ranking quality against "
@@ -490,7 +526,8 @@ def main() -> int:
     print(f"[scale] fixture: {actual:,} rows in "
           f"{out['stages']['fixture_seconds']}s", flush=True)
 
-    cfg = make_config(args.fields, args.scorer or None)
+    cfg = make_config(args.fields, args.scorer or None,
+                      match_splink_levels=args.match_splink_levels)
     mk = cfg.get_matchkeys()[0]
 
     # ── u: sampled self-join. Cost tracks the SAMPLE, not the table. ──

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -610,33 +610,70 @@ def main() -> int:
 
         n_entities = max(args.rows // max(args.dup, 1), 1)
         t = time.perf_counter()
-        scored: list[tuple[float, bool]] = []
+
+        # DEDUPLICATE ACROSS BLOCKING PASSES before scoring. A pair that blocks
+        # on both keys is one pair, and scoring it twice puts it in the ranking
+        # twice. The first version of this concatenated the passes and reported
+        # 282,247 true pairs where the fixture contains 200,004 (66,666
+        # entities x 3), a 41% overlap counted as extra data -- which raised the
+        # base rate from 0.108 to 0.143 and flattered GM's average precision,
+        # since AP is bounded below by the base rate. Splink's `predict()`
+        # dedupes across its blocking rules, so the arms were being scored on
+        # different populations.
+        cands = None
         for key_config in blocking_passes(cfg):
-            cands = pass_candidates(df, key_config, id_col="__row_id__")
-            joined = join_candidates_to_sources(cands, df, id_col="__row_id__")
-            gammas = gamma_columns(mk, CAND_LHS, CAND_RHS,
-                                   scorer_udf=ROW_UDF_NAME,
-                                   transform_udf=TRANSFORM_UDF_NAME)
-            # Match weight = the per-field log2(m/u) for the level the pair
-            # landed on, summed. `match_weights[field][level]` IS that table,
-            # so this is a lookup rather than a second derivation of the weight.
-            weight = F.lit(0.0)
-            for col, f in zip(gammas, mk.fields):
-                per_level = model.match_weights[f.resolved_field]
-                expr = F.lit(0.0)
-                for level, val in enumerate(per_level):
-                    expr = F.when(col == F.lit(level),
-                                  F.lit(float(val))).otherwise(expr)
-                weight = weight + expr
-            truth = (F.col(f"{CAND_LHS}.__row_id__") % F.lit(n_entities)
-                     == F.col(f"{CAND_RHS}.__row_id__") % F.lit(n_entities))
-            scored.extend(
-                (float(r["w"]), bool(r["is_true"]))
-                for r in joined.select(weight.alias("w"),
-                                       truth.alias("is_true")).collect()
-            )
+            one = pass_candidates(df, key_config, id_col="__row_id__")
+            cands = one if cands is None else cands.unionByName(one)
+        cands = cands.dropDuplicates(["a", "b"])
+
+        joined = join_candidates_to_sources(cands, df, id_col="__row_id__")
+        gammas = gamma_columns(mk, CAND_LHS, CAND_RHS,
+                               scorer_udf=ROW_UDF_NAME,
+                               transform_udf=TRANSFORM_UDF_NAME)
+        # Match weight = the per-field log2(m/u) for the level the pair landed
+        # on, summed. `match_weights[field][level]` IS that table, so this is a
+        # lookup rather than a second derivation of the weight.
+        weight = F.lit(0.0)
+        for col, f in zip(gammas, mk.fields):
+            per_level = model.match_weights[f.resolved_field]
+            expr = F.lit(0.0)
+            for level, val in enumerate(per_level):
+                expr = F.when(col == F.lit(level),
+                              F.lit(float(val))).otherwise(expr)
+            weight = weight + expr
+        truth = (F.col(f"{CAND_LHS}.__row_id__") % F.lit(n_entities)
+                 == F.col(f"{CAND_RHS}.__row_id__") % F.lit(n_entities))
+        scored = [
+            (float(r["w"]), bool(r["is_true"]))
+            for r in joined.select(weight.alias("w"),
+                                   truth.alias("is_true")).collect()
+        ]
         out["stages"]["score_seconds"] = round(time.perf_counter() - t, 2)
-        out["quality"] = _metrics_module().ranking_metrics(scored)
+        q = _metrics_module().ranking_metrics(scored)
+        # `dup` rows per entity give dup*(dup-1)/2 true pairs each, and every
+        # entity's rows share a blocking key by construction, so the candidate
+        # set must contain ALL of them and no duplicates. Checked rather than
+        # assumed: the un-deduplicated first version reported 282,247 true pairs
+        # against an expected 200,004 and the inflated base rate raised average
+        # precision, which is exactly the kind of error that reads as a result.
+        # Exact, including the remainder. `rows` is rarely a multiple of
+        # n_entities, so a few entities carry one extra row and contribute
+        # C(q+1, 2) rather than C(q, 2). The naive n_entities*C(dup,2) gives
+        # 199,998 at 200k/dup=3 where the truth is 200,004 -- and a guard that
+        # is wrong by six fires on every correct run, gets read as noise, and
+        # then gets deleted.
+        _n_ent = max(args.rows // max(args.dup, 1), 1)
+        _q, _r = divmod(args.rows, _n_ent)
+        expected_true = (_r * ((_q + 1) * _q // 2)
+                         + (_n_ent - _r) * (_q * (_q - 1) // 2))
+        q["expected_true_pairs"] = expected_true
+        q["true_pairs_match_expected"] = (q["n_true"] == expected_true)
+        if not q["true_pairs_match_expected"]:
+            print(f"[scale] WARNING quality population is wrong: found "
+                  f"{q['n_true']:,} true pairs, fixture contains "
+                  f"{expected_true:,}. The metric below is NOT comparable to "
+                  f"the other engine's.", flush=True)
+        out["quality"] = q
         print(f"[scale] quality {out['quality']}", flush=True)
 
     out["total_seconds"] = round(sum(out["stages"].values()), 2)

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -45,6 +45,7 @@ import argparse
 import json
 import os
 import time
+from pathlib import Path
 
 
 def build_fixture(spark, rows: int, dup: int, blocks_per_key: int, value_pad: int = 0):
@@ -371,6 +372,25 @@ def _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
     )
 
 
+def _metrics_module():
+    """The SHARED ranking metric, imported by file path.
+
+    Both arms of the comparison score with this one implementation. Two
+    hand-written average precisions that disagreed by a percent would look
+    exactly like a model that is a percent better, which is the distinction the
+    comparison exists to make.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "_fs_quality_metrics.py"
+    spec = importlib.util.spec_from_file_location("_fs_quality_metrics", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--rows", type=int, default=1_000_000)
@@ -416,6 +436,13 @@ def main() -> int:
              "block and the run sat in the join for 24 minutes until the step "
              "timeout killed it, with no output naming the cause. This turns "
              "that into a fast, specific refusal.")
+    ap.add_argument("--eval-quality", action="store_true",
+                    help="After training, score the SAME candidate pairs with "
+                         "the trained model and report ranking quality against "
+                         "the fixture's known entity structure. The speed "
+                         "number means nothing without it: the bar is "
+                         "match-or-better accuracy, not a faster arrival at a "
+                         "worse model.")
     ap.add_argument("--out", default="")
     args = ap.parse_args()
 
@@ -564,6 +591,54 @@ def main() -> int:
         k: [round(x, 4) for x in v] for k, v in model.match_weights.items()
     }
     out["proportion_matched"] = round(model.proportion_matched, 6)
+
+    if args.eval_quality:
+        # Score the SAME candidate pairs the training used, with the model just
+        # trained, and rank them against the fixture's known entity structure.
+        #
+        # Truth needs no label column: `build_fixture` assigns
+        # entity = id % n_entities with n_entities = rows // dup, so two rows
+        # are a true pair exactly when their ids are congruent. Carrying a label
+        # column instead would change the frame and make the quality fixture
+        # differ from the one the speed runs measure.
+        #
+        # Weights come from `gamma_columns` -- the same expressions the SCORING
+        # path builds -- so this measures the shipped model on the shipped
+        # ladder, not a re-derivation of what a level means.
+        from goldenmatch.spark.em import gamma_columns
+        from pyspark.sql import functions as F
+
+        n_entities = max(args.rows // max(args.dup, 1), 1)
+        t = time.perf_counter()
+        scored: list[tuple[float, bool]] = []
+        for key_config in blocking_passes(cfg):
+            cands = pass_candidates(df, key_config, id_col="__row_id__")
+            joined = join_candidates_to_sources(cands, df, id_col="__row_id__")
+            gammas = gamma_columns(mk, CAND_LHS, CAND_RHS,
+                                   scorer_udf=ROW_UDF_NAME,
+                                   transform_udf=TRANSFORM_UDF_NAME)
+            # Match weight = the per-field log2(m/u) for the level the pair
+            # landed on, summed. `match_weights[field][level]` IS that table,
+            # so this is a lookup rather than a second derivation of the weight.
+            weight = F.lit(0.0)
+            for col, f in zip(gammas, mk.fields):
+                per_level = model.match_weights[f.resolved_field]
+                expr = F.lit(0.0)
+                for level, val in enumerate(per_level):
+                    expr = F.when(col == F.lit(level),
+                                  F.lit(float(val))).otherwise(expr)
+                weight = weight + expr
+            truth = (F.col(f"{CAND_LHS}.__row_id__") % F.lit(n_entities)
+                     == F.col(f"{CAND_RHS}.__row_id__") % F.lit(n_entities))
+            scored.extend(
+                (float(r["w"]), bool(r["is_true"]))
+                for r in joined.select(weight.alias("w"),
+                                       truth.alias("is_true")).collect()
+            )
+        out["stages"]["score_seconds"] = round(time.perf_counter() - t, 2)
+        out["quality"] = _metrics_module().ranking_metrics(scored)
+        print(f"[scale] quality {out['quality']}", flush=True)
+
     out["total_seconds"] = round(sum(out["stages"].values()), 2)
 
     print(f"[scale] DONE rows={actual:,} total={out['total_seconds']}s "

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -352,6 +352,30 @@ def main() -> int:
     print(f"[splink] EM in {out['stages']['em_seconds']}s over {sum(iters)} "
           f"iteration(s) {iters}", flush=True)
 
+    # The trained model itself, not just how long it took to train. GM records
+    # m_probs / u_probs / match_weights and this side recorded neither, so when
+    # the two engines disagreed on accuracy there was no way to ask WHERE --
+    # which field, which level. A per-level m/u table makes the next question
+    # answerable from the artifact instead of another run.
+    try:
+        model = linker.misc.save_model_to_json()
+        out["model"] = {
+            c["output_column_name"]: [
+                {"label": lv.get("comparison_vector_value"),
+                 "sql": lv.get("sql_condition"),
+                 "m": lv.get("m_probability"),
+                 "u": lv.get("u_probability")}
+                for lv in c.get("comparison_levels", [])
+            ]
+            for c in model.get("comparisons", [])
+        }
+        out["probability_two_random_records_match"] = model.get(
+            "probability_two_random_records_match")
+    except Exception as e:  # noqa: BLE001 - diagnostic, never fatal
+        # Recorded rather than swallowed: an absent `model` key must read as
+        # "the export broke", not as "the model was empty".
+        out["model_export_error"] = f"{type(e).__name__}: {str(e)[:200]}"
+
     if args.eval_quality:
         # Ground truth is a pure function of the row id and needs no extra
         # column: `build_fixture` assigns entity = id % n_entities with

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -62,7 +62,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
+import re
 import time
 from pathlib import Path
 
@@ -262,9 +264,6 @@ def main() -> int:
     # so it is taken from its own log records; `iterations` staying 0 in the
     # artifact means the log format moved and the number should not be trusted
     # rather than silently reading as "no work".
-    import logging
-    import re
-
     class _EMIterationCounter(logging.Handler):
         _PAT = re.compile(r"^Iteration (\d+):")
 

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -183,6 +183,10 @@ def main() -> int:
     ap.add_argument("--max-pairs", type=int, default=1_000_000,
                     help="Splink's u-estimation sample. Matches the GM harness's "
                          "--u-max-pairs so the u stage is comparable.")
+    ap.add_argument("--seed", type=int, default=42,
+                    help="Seeds Splink's u random sampling. Unseeded, the EM "
+                         "iteration count -- and therefore the wall -- varies "
+                         "by more than half between identical runs.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -225,6 +229,43 @@ def main() -> int:
     from splink import comparison_library as cl
     from splink.backends.spark import SparkAPI
 
+    # Count EM iterations, because the wall is roughly linear in them and a
+    # seed only makes the count REPRODUCIBLE, not equal across configurations.
+    # Reporting seconds without iterations invites reading a convergence
+    # difference as a speed difference -- which is exactly the mistake the
+    # unseeded runs produced. Splink does not expose the count as an attribute,
+    # so it is taken from its own log records; `iterations` staying 0 in the
+    # artifact means the log format moved and the number should not be trusted
+    # rather than silently reading as "no work".
+    import logging
+    import re
+
+    class _EMIterationCounter(logging.Handler):
+        _PAT = re.compile(r"^Iteration (\d+):")
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.per_session: list[int] = []
+            self._current = 0
+
+        def emit(self, record: logging.LogRecord) -> None:
+            m = self._PAT.match(str(record.getMessage()))
+            if not m:
+                return
+            n = int(m.group(1))
+            if n <= self._current and self._current:
+                self.per_session.append(self._current)
+            self._current = n
+
+        def finish(self) -> list[int]:
+            if self._current:
+                self.per_session.append(self._current)
+                self._current = 0
+            return self.per_session
+
+    em_counter = _EMIterationCounter()
+    logging.getLogger("splink").addHandler(em_counter)
+
     # The SAME five fields the GM harness compares, at the same shape: two
     # jaro-winkler name fields, a levenshtein date, and two more jaro-winkler.
     # Splink expresses levels as thresholds and GM as `levels=3` with a partial
@@ -258,7 +299,16 @@ def main() -> int:
 
     # u, from random pairs -- the same quantity the GM harness times as `u`.
     t = time.perf_counter()
-    linker.training.estimate_u_using_random_sampling(max_pairs=args.max_pairs)
+    # SEEDED, and this is the difference between a measurement and a lottery
+    # ticket. Unseeded, each run draws a different random pair sample, gets
+    # different u estimates, starts EM somewhere else and converges in a
+    # different number of iterations -- and every iteration is a distributed
+    # Spark job, so the wall follows. Two runs of the IDENTICAL configuration
+    # (31983859191, 31983866350) logged 33 and 16 iterations and came out at
+    # 321.12s and 197.29s: a 63% spread, against GM's 1.4% across the same pair
+    # of runs. Any single unseeded Splink number is drawn from that.
+    linker.training.estimate_u_using_random_sampling(
+        max_pairs=args.max_pairs, seed=args.seed)
     out["stages"]["u_seconds"] = round(time.perf_counter() - t, 2)
     print(f"[splink] u in {out['stages']['u_seconds']}s", flush=True)
 
@@ -267,7 +317,15 @@ def main() -> int:
     for rule in (block_on("blk"), block_on("last")):
         linker.training.estimate_parameters_using_expectation_maximisation(rule)
     out["stages"]["em_seconds"] = round(time.perf_counter() - t, 2)
-    print(f"[splink] EM in {out['stages']['em_seconds']}s", flush=True)
+    iters = em_counter.finish()
+    out["em_iterations_per_session"] = iters
+    out["em_iterations_total"] = sum(iters)
+    out["em_seconds_per_iteration"] = (
+        round(out["stages"]["em_seconds"] / sum(iters), 3) if sum(iters) else None
+    )
+    out["seed"] = args.seed
+    print(f"[splink] EM in {out['stages']['em_seconds']}s over {sum(iters)} "
+          f"iteration(s) {iters}", flush=True)
 
     out["stages"]["total_seconds"] = round(time.perf_counter() - t_all, 2)
     # `train_total` is the number to put beside GM's u + counts + train. The

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -86,15 +86,30 @@ def _fixture_module():
 
 
 def build_session(master: str, driver_host: str | None, wait_s: int):
+    """A session tuned NO differently from the one GM gets.
+
+    This used to set `spark.sql.shuffle.partitions=8`, with the rationale that
+    "the default 200 on a small cluster is pure scheduling overhead". That was
+    written for the original 2-executor-core topology rig, where it was true.
+    When the lane grew a `worker_cores` input and started running on 16 cores,
+    the constant did not grow with it and quietly became a HANDICAP that GM
+    never paid: the GM harness sets no partition count at all, so it ran on
+    Spark's default 200 while Splink was pinned to 8. Eight partitions on
+    sixteen cores leaves most of the cluster idle through every shuffle, and
+    makes each partition large enough to push an executor over -- which is how
+    the 5M run died, with `MetadataFetchFailedException: Missing an output
+    location for shuffle 13 partition 3` after an executor was lost.
+
+    Nothing is tuned here now. Both engines get Spark's defaults, which is the
+    only setting that needs no justification to a reader who suspects the
+    benchmark was rigged.
+    """
     from pyspark.sql import SparkSession
     from splink.backends.spark import similarity_jar_location
 
     b = (
         SparkSession.builder.master(master)
         .appName("splink-train-scale")
-        # Splink materialises many intermediate tables; the default 200 shuffle
-        # partitions on a small cluster is pure scheduling overhead.
-        .config("spark.sql.shuffle.partitions", "8")
         .config("spark.driver.bindAddress", "0.0.0.0")
         # Splink ships its own similarity UDFs (jaro_winkler, damerau
         # levenshtein) as a JVM jar, and WITHOUT IT THE COMPARISON IS INVALID

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -85,6 +85,25 @@ def _fixture_module():
     return mod
 
 
+def _metrics_module():
+    """The SHARED ranking metric, imported by file path.
+
+    Both arms score with this one implementation. Two hand-written average
+    precisions that disagree by a percent would look exactly like a model that
+    is a percent better, which is the distinction the whole comparison exists
+    to make.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "_fs_quality_metrics.py"
+    spec = importlib.util.spec_from_file_location("_fs_quality_metrics", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def build_session(master: str, driver_host: str | None, wait_s: int):
     """A session tuned NO differently from the one GM gets.
 
@@ -187,6 +206,12 @@ def main() -> int:
                     help="Seeds Splink's u random sampling. Unseeded, the EM "
                          "iteration count -- and therefore the wall -- varies "
                          "by more than half between identical runs.")
+    ap.add_argument("--eval-quality", action="store_true",
+                    help="After training, score the candidate pairs and report "
+                         "ranking quality against the fixture's known entity "
+                         "structure. The speed number means nothing without it: "
+                         "the goal is match-or-better accuracy, not a faster "
+                         "arrival at a worse model.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -326,6 +351,30 @@ def main() -> int:
     out["seed"] = args.seed
     print(f"[splink] EM in {out['stages']['em_seconds']}s over {sum(iters)} "
           f"iteration(s) {iters}", flush=True)
+
+    if args.eval_quality:
+        # Ground truth is a pure function of the row id and needs no extra
+        # column: `build_fixture` assigns entity = id % n_entities with
+        # n_entities = rows // dup, so two rows are a true pair exactly when
+        # their ids are congruent. Deriving it here rather than carrying a
+        # label column means the fixture the engines TRAIN on is byte-identical
+        # to the one the speed runs use -- a label column would change the
+        # frame and quietly make the two experiments different.
+        from pyspark.sql import functions as F
+
+        n_entities = max(args.rows // max(args.dup, 1), 1)
+        t = time.perf_counter()
+        preds = linker.inference.predict().as_spark_dataframe()
+        truth = (F.col("record_id_l") % F.lit(n_entities)
+                 == F.col("record_id_r") % F.lit(n_entities))
+        rows_ = (preds.select(F.col("match_weight").alias("w"),
+                              truth.alias("is_true"))
+                      .collect())
+        out["stages"]["predict_seconds"] = round(time.perf_counter() - t, 2)
+        out["quality"] = _metrics_module().ranking_metrics(
+            [(float(r["w"]), bool(r["is_true"])) for r in rows_]
+        )
+        print(f"[splink] quality {out['quality']}", flush=True)
 
     out["stages"]["total_seconds"] = round(time.perf_counter() - t_all, 2)
     # `train_total` is the number to put beside GM's u + counts + train. The


### PR DESCRIPTION
## The defect

`build_session` set `spark.sql.shuffle.partitions=8`, with a comment that justified it: *"the default 200 shuffle partitions on a small cluster is pure scheduling overhead"*. True of the ORIGINAL rig -- two workers at one core each. It stopped being true when the lane gained a `worker_cores` input and started running on 16, and the constant did not move with it.

The GM harness sets no partition count at all, so **GM ran on Spark's default 200 while Splink was pinned to 8**. Eight partitions caps Splink at eight-way parallelism regardless of cluster size, so on the 16-core runs it could use half the machine. GM paid nothing for this.

It also killed the 5M run -- fewer partitions means bigger ones, and an executor was lost mid-shuffle:

```
SparkException: ShuffleMapStage 41 has failed the maximum allowable number of
times: 4. Most recent failure reason: MetadataFetchFailedException: Missing an
output location for shuffle 13 partition 3
```

## What it does to the published number

| cores | GM train | Splink train | ratio | 8 partitions limiting? |
|---:|---:|---:|---:|---|
| 4 | 23.02s | 281.33s | 12.2x | no |
| 8 | 14.62s | 264.49s | 18.1x | no |
| 16 | 18.95s | 258.52s | 13.6x | **yes** |

The 16-core **13.6x should not be quoted**. The 4- and 8-core points are clean, and they bracket it at 12.2x and 18.1x, so the order of magnitude survives while the exact multiple does not.

Separately, and independent of this fix: the GM column is non-monotonic (23.0 -> 14.6 -> 19.0) against a run-to-run noise floor already measured at ~23% on identical configuration. **No scaling claim is supportable from that series either way.** A matched series with repeats is running to replace it.

## The fix

Nothing is tuned. Both engines get Spark's defaults, which is the only configuration that needs no defending to a reader who suspects the benchmark was rigged. The docstring records why the constant was there and why it is gone, so it does not get re-added as an optimisation.