### PR TITLE
diag(fs): measure which FS levers are reachable and which have triggers

### DIFF
--- a/scripts/fs_levers/README.md
+++ b/scripts/fs_levers/README.md
@@ -1,0 +1,79 @@
+# FS lever reachability
+
+Two harnesses that answer one question about the Fellegi-Sunter path: not
+"does autoconfig set every lever" (it should not), but **can the system reach
+each lever, and does it know when to pull it?**
+
+Every lever sits in one of four states:
+
+| | has a trigger signal | no signal |
+|---|---|---|
+| **reachable** | healthy | blind lever (can pull, cannot aim) |
+| **not reachable** | **detects and cannot act** | absent |
+
+The bottom-left cell is the defect worth hunting: a working detector wired to
+nothing.
+
+## The harnesses
+
+`lever_sweep.py` runs two sweeps over the same baseline config per dataset.
+Sweep A moves the levers `build_probabilistic_matchkeys` hardcodes and never
+revisits (`levels`, `partial_threshold`). Sweep B moves everything the closed
+`ConfigEdit` vocabulary can actually reach. Comparing the two ceilings shows
+whether the healer could ever get where lever-tuning gets.
+
+`trigger_probe.py` asks whether the signals the engine already emits at
+runtime predict WHICH lever to pull. A signal is a usable trigger only if its
+firing tracks whether a cell is better or worse than the shipped default; one
+that fires everywhere carries no information.
+
+```bash
+uv sync --package goldenmatch --extra polars   # the scripts import polars directly
+python scripts/fs_levers/lever_sweep.py  --datasets ncvr_synthetic --out sweep.json
+python scripts/fs_levers/trigger_probe.py --datasets ncvr_synthetic --out triggers.json
+```
+
+Datasets come from `scripts/suggest_quality/datasets.py` and skip cleanly when
+absent. Only `ncvr_synthetic` and `historical_50k` carry information here; the
+anchors saturate at F1 1.0 and measure nothing.
+
+## What they found (2 datasets, 6 cells -- enough to locate gaps, not to tune)
+
+**`link_threshold` is the clearest "detects and cannot act".** `auto_configure_
+probabilistic_df` never sets it, so `mk.cutoff` is `None`,
+`_perturbable_matchkeys` is empty, and `ThresholdShift` returns `None`.
+Verified INERT on all four available datasets, so it is structural rather than
+data-dependent. Meanwhile the engine emits a precise diagnosis at runtime
+("linked N% ... using a FALLBACK link cutoff of 0.5000 ... Set 'link_threshold'").
+The detector works, the actuator is disconnected, and the same emptiness leaves
+`perturbation_stability` permanently unmeasured on the FS path.
+
+**EM non-convergence is a second one.** "EM did not converge after 20
+iterations" fired on exactly one cell of six -- the -0.34 F1 collapse -- and
+nothing can raise `em_iterations` in response.
+
+**Monotonicity is NOT a usable trigger**, which is the result that stops a
+tempting change. It fires on 5 of 6 cells including both baselines, and
+`n_monotonic_bad` runs the wrong way: ncvr's BEST cell has the most bad fields
+(6), historical's worst has 3. Assuming the obvious direction would actively
+mislead.
+
+**`levels` is high-variance and dataset-dependent**: F1 0.48 to 0.98, with
+`levels=5` the best value on ncvr (+0.0166) and catastrophic on historical
+(-0.3406, and 6x slower). `levels=3` is the max-min choice, so the hardcoded
+default is defensible. Adding a `LevelsEdit` without a trigger would hand the
+healer a lever it cannot aim, with a -0.34 move inside its reach.
+
+## Reading the numbers honestly
+
+The sweep sets `levels` UNIFORMLY on every field, while autoconfig picks
+per-field (`exact` fields get `levels=2, partial=0.9`). That is why a dataset's
+baseline differs from its own `levels=3, partial=0.8` cell. The sweep measures
+a strictly weaker configuration space than what ships; a real per-field edit
+could beat both, and is unmeasured.
+
+`trigger_probe.py` raises rather than returning zeros when it captures no
+messages. Its first version wrapped the run in `warnings.catch_warnings`, but
+the engine emits these through `logging`, so every `*_fired` came back `False`
+while the warnings printed to the console. A capture that records nothing looks
+exactly like a clean run.

--- a/scripts/fs_levers/lever_sweep.py
+++ b/scripts/fs_levers/lever_sweep.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Do the untuned FS levers matter, and can the healer reach them?
+
+Two sweeps over the same baseline config, per dataset:
+
+  A. AUTOCONFIG levers -- `levels` and `partial_threshold` are set to fixed
+     constants by `build_probabilistic_matchkeys` (levels=3, partial=0.6/0.8)
+     and never revisited by anything. Sweep them and see whether F1 moves.
+
+  B. HEALER/OPTIMIZER levers -- the closed ConfigEdit vocabulary. Only
+     `threshold_shift` reaches anything FS-specific; the rest are shared with
+     the weighted path. Sweep what it CAN reach.
+
+The comparison that matters is ceiling(A) vs ceiling(B). If A's ceiling is
+meaningfully above B's, the healer cannot get there from here no matter how
+long it searches, because the lever is not in its vocabulary.
+
+Everything is measured against the same evaluator on the same ground truth,
+so the numbers are comparable across both sweeps.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import polars as pl  # noqa: E402
+
+
+def _f1(result, gt_pairs) -> dict:
+    from goldenmatch.core.evaluate import evaluate_clusters
+    ev = evaluate_clusters(result.clusters, gt_pairs).summary()
+    return {"f1": ev["f1"], "precision": ev["precision"], "recall": ev["recall"]}
+
+
+def _run(df, cfg, gt_pairs) -> dict:
+    import goldenmatch
+    t = time.perf_counter()
+    res = goldenmatch.dedupe_df(df, config=cfg)
+    out = _f1(res, gt_pairs)
+    out["seconds"] = round(time.perf_counter() - t, 2)
+    return out
+
+
+def _with_levels(cfg, levels: int | None, partial: float | None):
+    """Copy cfg, overriding levels / partial_threshold on every FS field."""
+    new = cfg.model_copy(deep=True)
+    for mk in new.get_matchkeys():
+        if getattr(mk, "type", None) != "probabilistic":
+            continue
+        for f in (mk.fields or []):
+            if levels is not None:
+                f.levels = levels
+            if partial is not None:
+                f.partial_threshold = partial
+    return new
+
+
+def sweep_autoconfig(df, cfg, gt, levels_grid, partial_grid) -> list[dict]:
+    """Sweep the two levers autoconfig hardcodes and never tunes."""
+    rows = []
+    for lv in levels_grid:
+        for pt in partial_grid:
+            try:
+                r = _run(df, _with_levels(cfg, lv, pt), gt)
+            except Exception as e:  # noqa: BLE001 - one cell must not lose the grid
+                r = {"error": f"{type(e).__name__}: {str(e)[:120]}"}
+            r.update({"lever": "autoconfig", "levels": lv, "partial_threshold": pt})
+            rows.append(r)
+            print(f"    levels={lv} partial={pt}: "
+                  f"{r.get('f1', r.get('error'))}", flush=True)
+    return rows
+
+
+def sweep_healer(df, cfg, gt, offsets, scorers) -> list[dict]:
+    """Sweep what the closed ConfigEdit vocabulary can actually reach.
+
+    Mirrors config_optimizer's own edit families: ThresholdShift over the
+    offset grid, ScorerSwap over the scorer grid. These are the FS-reachable
+    members; weight_shift is weighted-only, and blocking edits are held fixed
+    so the comparison isolates the matchkey.
+    """
+    from goldenmatch.core.config_edits import ScorerSwap, ThresholdShift
+    rows = []
+    for o in offsets:
+        edit = ThresholdShift(o)
+        new = edit.apply(cfg)
+        if new is None:
+            print(f"    {edit.label}: NOT APPLICABLE", flush=True)
+            rows.append({"lever": "healer", "edit": edit.label,
+                         "applicable": False})
+            continue
+        try:
+            r = _run(df, new, gt)
+        except Exception as e:  # noqa: BLE001
+            r = {"error": f"{type(e).__name__}: {str(e)[:120]}"}
+        r.update({"lever": "healer", "edit": edit.label, "applicable": True})
+        rows.append(r)
+        print(f"    {edit.label}: {r.get('f1', r.get('error'))}", flush=True)
+
+    for mk in cfg.get_matchkeys():
+        if getattr(mk, "type", None) != "probabilistic":
+            continue
+        for f in (mk.fields or []):
+            for sc in scorers:
+                if f.scorer == sc:
+                    continue
+                edit = ScorerSwap(mk.name, f.field, sc)
+                new = edit.apply(cfg)
+                if new is None:
+                    continue
+                try:
+                    r = _run(df, new, gt)
+                except Exception as e:  # noqa: BLE001
+                    r = {"error": f"{type(e).__name__}: {str(e)[:120]}"}
+                r.update({"lever": "healer", "edit": edit.label,
+                          "applicable": True})
+                rows.append(r)
+                print(f"    {edit.label}: {r.get('f1', r.get('error'))}",
+                      flush=True)
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--datasets", nargs="+",
+                    default=["synthetic", "anchor_person_match"])
+    ap.add_argument("--row-cap", type=int, default=None)
+    ap.add_argument("--levels", nargs="+", type=int, default=[2, 3, 5])
+    ap.add_argument("--partials", nargs="+", type=float,
+                    default=[0.6, 0.8, 0.9])
+    ap.add_argument("--offsets", nargs="+", type=float,
+                    default=[-0.10, -0.05, 0.05, 0.10])
+    ap.add_argument("--scorers", nargs="+",
+                    default=["jaro_winkler", "token_sort", "levenshtein"])
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from scripts.suggest_quality.datasets import REGISTRY
+
+    by_name = {d.name: d for d in REGISTRY}
+    report = []
+    for name in args.datasets:
+        ds = by_name.get(name)
+        if ds is None:
+            print(f"[skip] unknown dataset {name}")
+            continue
+        loaded = ds.loader()
+        if loaded is None:
+            print(f"[skip] {name}: data not present locally")
+            continue
+        df, gt = loaded
+        if args.row_cap and df.height > args.row_cap:
+            df = df.head(args.row_cap)
+            gt = {(a, b) for a, b in gt if a < args.row_cap and b < args.row_cap}
+        print(f"\n=== {name}: rows={df.height} gt_pairs={len(gt)}", flush=True)
+
+        cfg = auto_configure_probabilistic_df(df)
+        base = _run(df, cfg, gt)
+        # What autoconfig actually chose, so the baseline is inspectable.
+        chosen = [
+            {"field": f.field, "scorer": f.scorer, "levels": f.levels,
+             "partial_threshold": f.partial_threshold}
+            for mk in cfg.get_matchkeys() if getattr(mk, "type", None) == "probabilistic"
+            for f in (mk.fields or [])
+        ]
+        print(f"  baseline f1={base['f1']:.4f}  fields={len(chosen)}", flush=True)
+        print("  AUTOCONFIG sweep (levels x partial_threshold):", flush=True)
+        a = sweep_autoconfig(df, cfg, gt, args.levels, args.partials)
+        print("  HEALER sweep (closed ConfigEdit vocabulary):", flush=True)
+        h = sweep_healer(df, cfg, gt, args.offsets, args.scorers)
+
+        report.append({
+            "dataset": name, "rows": df.height, "gt_pairs": len(gt),
+            "baseline": base, "autoconfig_chose": chosen,
+            "autoconfig_sweep": a, "healer_sweep": h,
+        })
+        args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fs_levers/lever_sweep.py
+++ b/scripts/fs_levers/lever_sweep.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-import polars as pl  # noqa: E402
 
 
 def _f1(result, gt_pairs) -> dict:
@@ -141,6 +140,7 @@ def main() -> int:
     args = ap.parse_args()
 
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
     from scripts.suggest_quality.datasets import REGISTRY
 
     by_name = {d.name: d for d in REGISTRY}

--- a/scripts/fs_levers/trigger_probe.py
+++ b/scripts/fs_levers/trigger_probe.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Do the FS runtime warnings PREDICT which lever to pull?
+
+Capability without a trigger is not usable. This asks whether the two signals
+the engine already emits are discriminative:
+
+  monotonicity  "FS match weights are non-monotonic for field(s): X"
+                fires when a partial agreement level outweighs exact agreement,
+                i.e. the level structure does not fit the data. Candidate
+                trigger for a `levels` change.
+
+  fallback cut  "linked N% of records using a FALLBACK link cutoff of 0.5000"
+                fires when no link_threshold was set AND EM produced no
+                calibrated cutoff. Candidate trigger for setting link_threshold.
+
+For each (dataset, levels) cell it records which warnings fired, how many
+fields they named, and the resulting F1. A signal is a usable trigger only if
+its firing tracks whether that cell is BETTER or WORSE than the shipped
+default -- a warning that fires everywhere carries no information.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import logging
+import warnings
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+_MONO = re.compile(r"non-monotonic for field\(s\): ([^—]+?) —")
+_FALLBACK = re.compile(r"linked ([\d.]+)% .*FALLBACK link cutoff of ([\d.]+)")
+_NOCONV = re.compile(r"EM did not converge after (\d+) iterations \(delta=([\d.]+)\)")
+
+
+class _Capture(logging.Handler):
+    """These messages go through `logging`, NOT `warnings.warn`.
+
+    The first version of this probe wrapped the run in
+    `warnings.catch_warnings(record=True)` and recorded nothing -- every
+    `*_fired` came back False while the warnings printed to the console.
+    A capture that silently records nothing looks exactly like a clean run,
+    which is the same false-negative shape this session already hit twice.
+    """
+
+    def __init__(self):
+        super().__init__(level=0)
+        self.messages: list[str] = []
+
+    def emit(self, record):
+        try:
+            self.messages.append(record.getMessage())
+        except Exception:
+            pass
+
+
+def _with_levels(cfg, levels):
+    new = cfg.model_copy(deep=True)
+    for mk in new.get_matchkeys():
+        if getattr(mk, "type", None) != "probabilistic":
+            continue
+        for f in (mk.fields or []):
+            f.levels = levels
+    return new
+
+
+def _run_capturing(df, cfg, gt):
+    import goldenmatch
+    from goldenmatch.core.evaluate import evaluate_clusters
+    cap = _Capture()
+    root = logging.getLogger()
+    prev_level = root.level
+    root.addHandler(cap)
+    root.setLevel(logging.DEBUG)
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            t = time.perf_counter()
+            res = goldenmatch.dedupe_df(df, config=cfg)
+            secs = round(time.perf_counter() - t, 2)
+    finally:
+        root.removeHandler(cap)
+        root.setLevel(prev_level)
+    # Both channels: the engine uses logging for these, but capture
+    # warnings.warn too so a future move between channels cannot go dark.
+    msgs = [str(w.message) for w in caught] + cap.messages
+    if not msgs:
+        raise RuntimeError("capture recorded NOTHING -- instrument is broken")
+    mono_fields, fallback, noconv = [], None, None
+    for m in msgs:
+        hit = _MONO.search(m)
+        if hit:
+            mono_fields += [s.strip() for s in hit.group(1).split(",") if s.strip()]
+        hit = _FALLBACK.search(m)
+        if hit:
+            fallback = {"match_rate_pct": float(hit.group(1)),
+                        "cutoff": float(hit.group(2))}
+        hit = _NOCONV.search(m)
+        if hit:
+            noconv = {"iterations": int(hit.group(1)),
+                      "delta": float(hit.group(2))}
+    ev = evaluate_clusters(res.clusters, gt).summary()
+    return {
+        "f1": ev["f1"], "precision": ev["precision"], "recall": ev["recall"],
+        "seconds": secs,
+        "monotonicity_fired": bool(mono_fields),
+        "monotonic_bad_fields": sorted(set(mono_fields)),
+        "n_monotonic_bad": len(set(mono_fields)),
+        "fallback_cutoff_fired": fallback is not None,
+        "fallback": fallback,
+        "em_nonconvergence_fired": noconv is not None,
+        "em_nonconvergence": noconv,
+        "n_messages_captured": len(msgs),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--datasets", nargs="+", required=True)
+    ap.add_argument("--levels", nargs="+", type=int, default=[2, 3, 5])
+    ap.add_argument("--row-cap", type=int, default=None)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from scripts.suggest_quality.datasets import REGISTRY
+    by_name = {d.name: d for d in REGISTRY}
+
+    report = []
+    for name in args.datasets:
+        ds = by_name.get(name)
+        loaded = ds.loader() if ds else None
+        if loaded is None:
+            print(f"[skip] {name}")
+            continue
+        df, gt = loaded
+        if args.row_cap and df.height > args.row_cap:
+            df = df.head(args.row_cap)
+            gt = {(a, b) for a, b in gt if a < args.row_cap and b < args.row_cap}
+        cfg = auto_configure_probabilistic_df(df)
+        print(f"\n=== {name} rows={df.height}", flush=True)
+
+        base = _run_capturing(df, cfg, gt)
+        print(f"  baseline(as-shipped) f1={base['f1']:.4f} "
+              f"mono={base['monotonicity_fired']}{base['monotonic_bad_fields']} "
+              f"fallback={base['fallback_cutoff_fired']}", flush=True)
+
+        cells = []
+        for lv in args.levels:
+            r = _run_capturing(df, _with_levels(cfg, lv), gt)
+            r["levels"] = lv
+            r["delta_vs_baseline"] = round(r["f1"] - base["f1"], 4)
+            cells.append(r)
+            print(f"  levels={lv}: f1={r['f1']:.4f} "
+                  f"(delta {r['delta_vs_baseline']:+.4f})  "
+                  f"mono_fired={r['monotonicity_fired']} "
+                  f"n_bad={r['n_monotonic_bad']} "
+                  f"fallback={r['fallback_cutoff_fired']}"
+                  f"{r['fallback']['match_rate_pct'] if r['fallback'] else ''} "
+                  f"EM_noconv={r['em_nonconvergence_fired']}", flush=True)
+
+        report.append({"dataset": name, "rows": df.height,
+                       "baseline": base, "cells": cells})
+        args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fs_levers/trigger_probe.py
+++ b/scripts/fs_levers/trigger_probe.py
@@ -22,10 +22,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import sys
 import time
-import logging
 import warnings
 from pathlib import Path
 
@@ -126,6 +126,7 @@ def main() -> int:
     args = ap.parse_args()
 
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
     from scripts.suggest_quality.datasets import REGISTRY
     by_name = {d.name: d for d in REGISTRY}
 


### PR DESCRIPTION
## What and why

Two harnesses for one question about the Fellegi-Sunter path: not *"does autoconfig set every lever"* (it should not), but **can the system reach each lever, and does it know when to pull it?**

Every lever sits in one of four states. The bottom-left cell is the defect worth hunting: a working detector wired to nothing.

| | has a trigger signal | no signal |
|---|---|---|
| **reachable** | healthy | blind lever (can pull, cannot aim) |
| **not reachable** | **detects and cannot act** | absent |

## The audit

| Lever | Reachable | Knows when | State |
|---|---|---|---|
| blocking strategy / keys | ✅ 2 edit types | ✅ `BlockingProfile.health` + skew rule | healthy |
| `scorer` | ✅ `ScorerSwap` | ✅ noise-aware selection, negative evidence | healthy |
| matchkey type | ✅ `MatchkeyTypeSwap` | ✅ `rule_select_probabilistic_matchkey` | healthy |
| **`link_threshold`** | ❌ inert | ✅ explicit runtime warning | **detects, cannot act** |
| **`em_iterations`** | ❌ | ✅ non-convergence warning | **detects, cannot act** |
| `levels` / `partial_threshold` | ❌ | ❌ (candidate trigger tested, does not work) | absent |
| `review_threshold`, `level_thresholds`, `guard` | ❌ | ❌ | absent |

The three healthy ones are the load-bearing set, and are why zero-config works as well as it does.

## Findings

**`link_threshold` is the clearest gap.** `auto_configure_probabilistic_df` never sets it → `mk.cutoff` is `None` → `_perturbable_matchkeys` is empty → `ThresholdShift.apply()` returns `None`. Verified INERT on all four available datasets, so structural rather than data-dependent:

```
synthetic            link_threshold=None  perturbable=0  ThresholdShift=INERT
anchor_person_match  link_threshold=None  perturbable=0  ThresholdShift=INERT
ncvr_synthetic       link_threshold=None  perturbable=0  ThresholdShift=INERT
historical_50k       link_threshold=None  perturbable=0  ThresholdShift=INERT
```

Meanwhile the engine emits a precise diagnosis at runtime naming the exact fix (*"linked N% ... using a FALLBACK link cutoff of 0.5000 ... Set 'link_threshold'"*). The detector works; the actuator is disconnected. The same emptiness leaves `perturbation_stability` permanently unmeasured on the FS path (it correctly returns `None`, so no false confidence, but the signal never fires).

**EM non-convergence is a second one**, fired on exactly one cell of six (the −0.34 collapse) with nothing able to raise `em_iterations`.

**Monotonicity is NOT a usable trigger** — the result that stops a tempting change:

| dataset | levels | F1 | Δ | mono fires | n_bad | EM diverged |
|---|---:|---:|---:|:--:|---:|:--:|
| ncvr | 2 | 0.8496 | −0.1164 | ✅ | 1 | |
| ncvr | 3 | 0.9670 | +0.0010 | ✅ | 3 | |
| ncvr | 5 | **0.9826** | **+0.0166** | ✅ | **6** | |
| hist | 2 | 0.6533 | −0.1676 | ❌ | 0 | |
| hist | 3 | 0.8069 | −0.0140 | ✅ | 1 | |
| hist | 5 | **0.4803** | **−0.3406** | ✅ | 3 | ✅ |

It fires on 5 of 6 cells including both baselines, and `n_monotonic_bad` runs the **wrong way**: ncvr's best cell has the most bad fields. Assuming the obvious direction would actively mislead.

**`levels` is high-variance and dataset-dependent** (0.48–0.98; `levels=5` is best on ncvr and catastrophic on historical, also 6x slower). `levels=3` is the max-min choice, so the hardcoded default is defensible. Adding a `LevelsEdit` without a trigger would hand the healer a lever it cannot aim, with a −0.34 move inside its reach.

## Scope

**Measurement only.** No rule, threshold, default or runtime behavior changes.

## Changes

- `scripts/fs_levers/lever_sweep.py`, `trigger_probe.py`, `README.md`.

## Testing

- Both harnesses run end-to-end from their committed paths.
- New scripts, not imported by the library and not in any CI lane.
- Needs `uv sync --package goldenmatch --extra polars` (the scripts import polars directly; it is an optional extra of `goldenmatch`).

## Honest limits

- **Two informative datasets, six cells.** `dblp_acm`, `febrl3`, `ncvr_real` are absent locally; the anchors saturate at F1 1.0. Enough to locate gaps, not to tune a threshold.
- The sweep sets `levels` **uniformly** on every field while autoconfig picks per-field, so a dataset's baseline differs from its own `levels=3, partial=0.8` cell. It measures a strictly weaker configuration space than what ships; a per-field edit could beat both and is unmeasured.
- `trigger_probe.py` now raises when it captures nothing. Its first version used `warnings.catch_warnings` while the engine emits through `logging`, so every `*_fired` came back `False` while the warnings printed to console.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a, diagnostic scripts)
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (`scripts/fs_levers/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_