### PR TITLE
fix(autoconfig): candidates_compared==0 meant "not counted", and two rules read it as zero

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ### Fixed
 
+- **`candidates_compared` was structurally 0 at scale, and two auto-config
+  decisions read it as a signal (#2639).** `scorer.py` skips the candidate-count
+  loop above 10,000 blocks -- counting calls `Block.n_rows()`, which
+  materialises -- leaving a 0 that means *not counted*, indistinguishable from a
+  measured zero. At 100k rows person had 84,293 blocks and biblio 22,151, so both
+  were past the gate: **biblio reported `candidates_compared=0` having scored
+  1,493,182 pairs at 99.9998% above threshold.** The two consumers failed in
+  opposite directions -- `rule_blocking_singleton_trap` treated every
+  fine-grained shape as the trap and offered to *coarsen* its blocking, while the
+  controller's LLM escalation early-returned on the same zero and was silently
+  dead at scale. New `ScoringProfile.candidates_counted` separates the cases and
+  each consumer now states which one it means. `health()` is deliberately
+  unchanged: its clause needs both counters zero, where `mass_above_threshold` is
+  necessarily 0.0 and the next clause returns RED anyway. TypeScript gets the
+  field for shape parity only -- it has no skip gate, so no bug, and mirroring
+  the guard would change behaviour for a state it never produces.
+
 - **Zero-config no longer refuses healthy fine-grained blocking.** The blocking
   RED rule graded skew with `block_sizes_p99 > 10 * (n_rows / n_blocks)`, whose
   denominator is the mean block size -- pinned near 1 whenever blocking is

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -2077,7 +2077,14 @@ class AutoConfigController:
         """
         from goldenmatch.core.autoconfig_rules import _llm_api_key_available
         sp = profile.scoring
-        if sp.candidates_compared == 0:
+        # Only bail on a MEASURED zero (#2639). `candidates_compared` is 0
+        # whenever scoring skipped its count loop -- which it does above 10,000
+        # blocks -- so this early return was firing on every fine-grained shape
+        # and the escalation was silently dead at exactly the scale it exists
+        # for. When the count is unknown the `mass_in_borderline` check below
+        # decides, and that one is computed over pairs that were actually
+        # scored, so it cannot be satisfied by a run where nothing happened.
+        if sp.candidates_counted and sp.candidates_compared == 0:
             return config
         if sp.mass_in_borderline < 0.10:
             return config

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -221,6 +221,17 @@ def rule_blocking_singleton_trap(
         return None
     bp = profile.blocking
     sp = profile.scoring
+    # This rule's whole premise is "the scorer saw zero candidate pairs", and
+    # its action COARSENS blocking. Firing it on a healthy shape is the
+    # expensive direction, so it abstains unless the count is real (#2639).
+    #
+    # `candidates_compared` is 0 whenever scoring skipped its count loop, which
+    # it does above 10,000 blocks -- so before this guard, EVERY fine-grained
+    # shape looked like the trap. biblio@100k scored 1,493,182 pairs with 99.99%
+    # of the mass above threshold and was still eligible to have its blocking
+    # coarsened to `first_token`.
+    if not sp.candidates_counted:
+        return None
     # If candidates were actually compared, this is not the singleton trap.
     if sp.candidates_compared > 0:
         return None

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -426,6 +426,23 @@ class ScoringProfile:
     _version: int = 1
     n_pairs_scored: int = 0
     candidates_compared: int = 0
+    # Was `candidates_compared` actually MEASURED? (#2639)
+    #
+    # `scorer.py` skips the candidate-count loop above 10,000 blocks -- counting
+    # calls `Block.n_rows()`, which materialises, and doing that serially for
+    # tens of thousands of blocks is real time. The skip is deliberate and
+    # logged, but it leaves a 0 that means "not counted" and is indistinguishable
+    # from a measured zero. Measured at 100k rows: person had 84,293 blocks and
+    # biblio 22,151, so BOTH were past the gate, and biblio reported
+    # candidates_compared=0 having scored 1,493,182 pairs.
+    #
+    # Consumers must branch on this rather than on `candidates_compared == 0`,
+    # because the two readings lead to opposite actions -- see
+    # tests/test_candidates_counted_2639.py.
+    #
+    # Defaults False: a default-constructed profile is the all-zero fallback the
+    # emitter yields when scoring never ran, which has no measurement behind it.
+    candidates_counted: bool = False
     score_histogram: list[int] = field(default_factory=lambda: [0] * 20)
     dip_statistic: float = 0.0
     mass_above_threshold: float = 0.0

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -60,6 +60,7 @@ def _emit_scoring_profile(
     threshold: float,
     *,
     candidates_compared: int = 0,
+    candidates_counted: bool = False,
     per_field_variance: dict[str, float] | None = None,
 ) -> None:
     """Emit ScoringProfile to current emitter. No-op when emitter is null.
@@ -89,6 +90,7 @@ def _emit_scoring_profile(
     profile = ScoringProfile(
         n_pairs_scored=len(scores),
         candidates_compared=candidates_compared,
+        candidates_counted=candidates_counted,
         score_histogram=histogram_20(scores),
         dip_statistic=hartigan_dip(scores),
         mass_above_threshold=mass_above(scores, threshold),
@@ -2206,7 +2208,9 @@ def score_blocks_parallel(
             if track_matched:
                 for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
-        _emit_scoring_profile(all_pairs, mk.fuzzy_threshold, candidates_compared=total_candidates)
+        _emit_scoring_profile(all_pairs, mk.fuzzy_threshold,
+                              candidates_compared=total_candidates,
+                              candidates_counted=True)
         return all_pairs
 
     # Snapshot exclude_pairs so threads see a frozen copy
@@ -2238,6 +2242,7 @@ def score_blocks_parallel(
     _n_blocks_for_count_gate = len(blocks)
     if _n_blocks_for_count_gate <= _CANDIDATE_COUNT_SKIP_THRESHOLD:
         total_candidates = 0
+        _candidates_counted = True
         for block in blocks:
             try:
                 n = block.n_rows()
@@ -2252,6 +2257,10 @@ def score_blocks_parallel(
             _n_blocks_for_count_gate, _CANDIDATE_COUNT_SKIP_THRESHOLD,
         )
         total_candidates = 0
+        # NOT counted, and said so rather than left as an ambiguous 0 (#2639).
+        # Consumers that read `candidates_compared == 0` as "no candidates"
+        # were firing on every shape past this gate.
+        _candidates_counted = False
 
     all_pairs = []
     total_blocks = len(blocks)
@@ -2291,7 +2300,9 @@ def score_blocks_parallel(
         "Parallel scoring: %d blocks, %d workers, %d pairs found",
         total_blocks, max_workers, len(all_pairs),
     )
-    _emit_scoring_profile(all_pairs, mk.fuzzy_threshold, candidates_compared=total_candidates)
+    _emit_scoring_profile(all_pairs, mk.fuzzy_threshold,
+                          candidates_compared=total_candidates,
+                          candidates_counted=_candidates_counted)
     return all_pairs
 
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -493,7 +493,9 @@ def test_rule_singleton_trap_fires_on_mostly_singleton_blocks_with_no_pairs():
             oversized_block_count=0,
         ),
         scoring=ScoringProfile(
-            n_pairs_scored=0, candidates_compared=0,  # no candidates compared
+            # A MEASURED zero -- the real trap. See #2639: an uncounted 0 now
+            # makes the rule abstain rather than coarsen healthy blocking.
+            n_pairs_scored=0, candidates_compared=0, candidates_counted=True,
             mass_above_threshold=0.0,
             dip_statistic=0.0,
         ),
@@ -568,7 +570,12 @@ def test_rule_singleton_trap_fires_when_no_candidates_even_with_dense_blocks():
             block_sizes_p50=10, block_sizes_p99=15, block_sizes_max=15,
             singleton_block_count=2,  # only 20% singletons but candidates_compared=0
         ),
+        # candidates_counted=True: these fixtures mean a MEASURED zero, which
+        # is the actual singleton trap. Since #2639 an uncounted 0 makes the
+        # rule abstain, because `scorer.py` skips the count above 10,000 blocks
+        # and every fine-grained shape looked like the trap.
         scoring=ScoringProfile(n_pairs_scored=0, candidates_compared=0,
+                                candidates_counted=True,
                                 mass_above_threshold=0.0, dip_statistic=0.0),
         cluster=ClusterProfile(transitivity_rate=1.0),
     )
@@ -603,7 +610,12 @@ def test_rule_singleton_trap_returns_none_when_no_text_field_in_matchkey():
             block_sizes_p50=2, block_sizes_p99=3, block_sizes_max=3,
             singleton_block_count=18,
         ),
+        # candidates_counted=True: these fixtures mean a MEASURED zero, which
+        # is the actual singleton trap. Since #2639 an uncounted 0 makes the
+        # rule abstain, because `scorer.py` skips the count above 10,000 blocks
+        # and every fine-grained shape looked like the trap.
         scoring=ScoringProfile(n_pairs_scored=0, candidates_compared=0,
+                                candidates_counted=True,
                                 mass_above_threshold=0.0, dip_statistic=0.0),
         cluster=ClusterProfile(transitivity_rate=1.0),
     )

--- a/packages/python/goldenmatch/tests/test_candidates_counted_2639.py
+++ b/packages/python/goldenmatch/tests/test_candidates_counted_2639.py
@@ -1,0 +1,146 @@
+"""`candidates_compared == 0` must not be read as "zero candidates" (#2639).
+
+`scorer.py` skips the candidate-count loop above 10,000 blocks, because
+`Block.n_rows()` materialises and doing that serially for tens of thousands of
+blocks costs real time. The skip is deliberate and logged. What it leaves behind
+is a `candidates_compared` of 0 that means NOT COUNTED, indistinguishable from a
+measured zero -- and two consumers read that field as a decision signal.
+
+Measured on run 31995984041, both shapes at 100,000 rows:
+
+    person@100k   84,293 blocks   n_pairs_scored 0          candidates_compared 0
+    biblio@100k   22,151 blocks   n_pairs_scored 1,493,182  candidates_compared 0
+
+biblio scored 1.49M pairs with 99.9998% of the mass above threshold and still
+reports `candidates_compared == 0`. Any dataset with fine-grained blocking is
+past the gate, so at production scale this field is structurally zero.
+
+The two consumers break in OPPOSITE directions, which is why one fix cannot be
+"treat 0 as zero" or "treat 0 as unknown" globally:
+
+  * `rule_blocking_singleton_trap` guards with `if candidates_compared > 0:
+    return None`. Above the gate that guard never fires, so a dataset that
+    scored 1.49M pairs stays eligible for singleton-trap remediation -- whose
+    action COARSENS blocking to `first_token`.
+  * `_maybe_decorate_with_llm_scorer` early-returns on `candidates_compared ==
+    0`, so the escalation is silently dead at exactly the scale it exists for.
+
+`ScoringProfile.health()` also reads the field, at
+`candidates_compared == 0 and n_pairs_scored == 0`. That one is left alone
+deliberately: it can only fire when both are zero, and `mass_above_threshold` is
+necessarily 0.0 in that case, so the very next clause returns RED anyway. The
+verdict does not change, and rewriting a rule whose behaviour is unaffected
+would be churn on a path that decides whether a user's run is refused.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_blocking_singleton_trap
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ScoringProfile,
+)
+
+
+def _config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            passes=[BlockingKeyConfig(fields=["name"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk", type="weighted", threshold=0.85,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            ),
+        ],
+    )
+
+
+def _profile(scoring: ScoringProfile) -> ComplexityProfile:
+    """A profile whose blocking is fine-grained and healthy -- 84,293 blocks,
+    the person@100k shape that provoked this."""
+    return ComplexityProfile(
+        data=DataProfile(n_rows=100_000, n_cols=3,
+                         column_types={"name": "name", "zip": "text", "dob": "date"}),
+        blocking=BlockingProfile(
+            keys_used=[["name"]], n_blocks=84_293,
+            total_comparisons=121_372_923, reduction_ratio=0.975725,
+            block_sizes_p50=2, block_sizes_p95=10, block_sizes_p99=72,
+            block_sizes_max=2_170, singleton_block_count=0,
+        ),
+        scoring=scoring,
+    )
+
+
+def test_singleton_trap_abstains_when_the_count_was_not_taken():
+    """The biblio case: 1.49M pairs scored, count skipped, and the rule must
+    NOT offer to coarsen blocking.
+
+    This is the live misfire. Today the `candidates_compared > 0` guard cannot
+    fire, so the rule proceeds on a shape that scored a million and a half
+    pairs.
+    """
+    scoring = ScoringProfile(
+        n_pairs_scored=1_493_182,
+        candidates_compared=0,      # not counted -- 22,151 blocks, past the gate
+        candidates_counted=False,
+        dip_statistic=0.013133,
+        mass_above_threshold=0.999998,
+        mass_in_borderline=0.175348,
+    )
+    out = rule_blocking_singleton_trap(_profile(scoring), _config(), RunHistory())
+    assert out is None
+
+
+def test_singleton_trap_still_fires_on_a_measured_zero():
+    """The guard against over-correcting: when the count WAS taken and really is
+    zero, the rule must still fire. A fix that simply disabled the rule would
+    pass the test above and be useless."""
+    scoring = ScoringProfile(
+        n_pairs_scored=0,
+        candidates_compared=0,
+        candidates_counted=True,    # measured, genuinely zero
+        mass_above_threshold=0.0,
+    )
+    out = rule_blocking_singleton_trap(_profile(scoring), _config(), RunHistory())
+    assert out is not None, "a measured zero with blocks present IS the trap"
+
+
+def test_singleton_trap_does_not_fire_when_candidates_were_measured():
+    """Unchanged behaviour: a measured non-zero count is not the trap."""
+    scoring = ScoringProfile(
+        n_pairs_scored=500, candidates_compared=10_000,
+        candidates_counted=True, mass_above_threshold=0.4,
+    )
+    out = rule_blocking_singleton_trap(_profile(scoring), _config(), RunHistory())
+    assert out is None
+
+
+def test_default_profile_is_not_counted():
+    """A default-constructed ScoringProfile has no measurement behind it, so it
+    must not claim one. The all-zero fallback is what the emitter produces when
+    scoring never ran at all."""
+    assert ScoringProfile().candidates_counted is False
+
+
+def test_health_verdict_is_unchanged_by_the_flag():
+    """`health()` is deliberately untouched. Pinned so a later change to it is a
+    decision rather than a side effect: with both counters zero the verdict is
+    RED either way, because mass_above_threshold is 0.0 and the next clause
+    catches it."""
+    from goldenmatch.core.complexity_profile import HealthVerdict
+
+    for counted in (True, False):
+        sp = ScoringProfile(n_pairs_scored=0, candidates_compared=0,
+                            candidates_counted=counted, mass_above_threshold=0.0)
+        assert sp.health() == HealthVerdict.RED

--- a/packages/typescript/goldenmatch/src/core/autoconfigController.ts
+++ b/packages/typescript/goldenmatch/src/core/autoconfigController.ts
@@ -469,6 +469,8 @@ export class AutoConfigController {
 
     return makeScoringProfile({
       candidatesCompared: total,
+      // This surface counts unconditionally, so the count is always real.
+      candidatesCounted: true,
       nPairsScored: total,
       scoreHistogram: histogram,
       dipStatistic: dipStat,

--- a/packages/typescript/goldenmatch/src/core/complexityProfile.ts
+++ b/packages/typescript/goldenmatch/src/core/complexityProfile.ts
@@ -219,6 +219,16 @@ export function blockingHealth(b: BlockingProfile, _nRows: number): HealthVerdic
 export interface ScoringProfile {
   readonly nPairsScored: number;
   readonly candidatesCompared: number;
+  /** Was `candidatesCompared` actually MEASURED? (#2639)
+   *
+   * Shape parity with Python, where `scorer.py` skips the candidate-count loop
+   * above 10,000 blocks and leaves a 0 that means "not counted" -- which two
+   * consumers there read as "no candidates". THIS surface has no such skip:
+   * `computeScoringProfile` always sets a real `candidatesCompared`, so the
+   * rules here are deliberately NOT given the abstain guard the Python ones
+   * needed. Mirroring a fix for a bug this surface does not have would change
+   * behaviour for a state it never produces. */
+  readonly candidatesCounted: boolean;
   readonly scoreHistogram: readonly number[];
   readonly dipStatistic: number;
   readonly massAboveThreshold: number;
@@ -231,6 +241,7 @@ export function makeScoringProfile(p: Partial<ScoringProfile> = {}): ScoringProf
   return {
     nPairsScored: p.nPairsScored ?? 0,
     candidatesCompared: p.candidatesCompared ?? 0,
+    candidatesCounted: p.candidatesCounted ?? false,
     scoreHistogram: p.scoreHistogram ?? new Array(20).fill(0),
     dipStatistic: p.dipStatistic ?? 0.0,
     massAboveThreshold: p.massAboveThreshold ?? 0.0,

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -12,6 +12,35 @@ question this script exists for:
 So the central claim of the distributed tier -- that FS training works at a size
 one box cannot hold -- has never been tested. This script is that test.
 
+## What --eval-quality is FOR, and what it is not
+
+It is a REGRESSION GUARD on the distributed path: does Spark-trained FS rank
+pairs about as well as it did last time. It is NOT a GoldenMatch-vs-Splink
+accuracy verdict, and a run of it must not be quoted as one.
+
+That question is already answered, better, elsewhere.
+`docs/benchmarks/2026-06-09-splink-bakeoff.md` puts GM's ZERO-TUNING auto-config
+against an expert hand-rolled Splink spec on real datasets under one shared
+evaluator, and GM matches or beats it everywhere Splink scores:
+
+    historical_50k    GM 0.778  Splink 0.757   +0.021
+    febrl3            GM 0.991  Splink 0.965   +0.026
+    synthetic_person  GM 0.998  Splink 0.996   +0.001
+
+This harness measured the opposite (Splink +0.021 average precision) and the
+difference is the CONFIG, not the engines. The comparison config here exists to
+exercise the `prod(levels + 1)` bound for a SCALE test -- its own comment says
+"FIVE fields at three levels each ... so the driver-side EM has a bound worth
+testing" -- and was never chosen for accuracy. Running it against Splink's
+comparison-library defaults measures that choice.
+
+The tell was that the two comparisons inverted on BOTH axes: the bakeoff has
+Splink 3-19x FASTER single-box and less accurate; this lane has Splink ~22x
+slower and more accurate. When both flip, the harness is the variable.
+
+So: use this to catch a regression in the distributed trainer. Use the bakeoff
+for accuracy claims.
+
 ## The fixture is generated IN SPARK, deliberately
 
 Every column comes from ``spark.range(n)`` and SQL expressions, so no row ever

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -35,6 +35,35 @@ ships. A reader wanting to isolate "is our kernel slower" needs a different
 experiment; a reader asking "should I use GM or Splink on my cluster" wants
 exactly this one.
 
+## What --eval-quality is FOR, and what it is not
+
+It is a REGRESSION GUARD on the distributed path: does Spark-trained FS rank
+pairs about as well as it did last time. It is NOT a GoldenMatch-vs-Splink
+accuracy verdict, and a run of it must not be quoted as one.
+
+That question is already answered, better, elsewhere.
+`docs/benchmarks/2026-06-09-splink-bakeoff.md` puts GM's ZERO-TUNING auto-config
+against an expert hand-rolled Splink spec on real datasets under one shared
+evaluator, and GM matches or beats it everywhere Splink scores:
+
+    historical_50k    GM 0.778  Splink 0.757   +0.021
+    febrl3            GM 0.991  Splink 0.965   +0.026
+    synthetic_person  GM 0.998  Splink 0.996   +0.001
+
+This harness measured the opposite (Splink +0.021 average precision) and the
+difference is the CONFIG, not the engines. The comparison config here exists to
+exercise the `prod(levels + 1)` bound for a SCALE test -- its own comment says
+"FIVE fields at three levels each ... so the driver-side EM has a bound worth
+testing" -- and was never chosen for accuracy. Running it against Splink's
+comparison-library defaults measures that choice.
+
+The tell was that the two comparisons inverted on BOTH axes: the bakeoff has
+Splink 3-19x FASTER single-box and less accurate; this lane has Splink ~22x
+slower and more accurate. When both flip, the harness is the variable.
+
+So: use this to catch a regression in the distributed trainer. Use the bakeoff
+for accuracy claims.
+
 ## Read the cluster sizing before reading the number
 
 The default rig is two workers at one core each on a 4-CPU runner -- two
@@ -209,11 +238,12 @@ def main() -> int:
                          "iteration count -- and therefore the wall -- varies "
                          "by more than half between identical runs.")
     ap.add_argument("--eval-quality", action="store_true",
-                    help="After training, score the candidate pairs and report "
-                         "ranking quality against the fixture's known entity "
-                         "structure. The speed number means nothing without it: "
-                         "the goal is match-or-better accuracy, not a faster "
-                         "arrival at a worse model.")
+                    help="REGRESSION GUARD on the distributed trainer: score "
+                         "the candidate pairs and report ranking quality "
+                         "against the fixture's known entity structure. NOT a "
+                         "GM-vs-Splink accuracy verdict -- this fixture's "
+                         "config was chosen to stress prod(levels+1) for a "
+                         "scale test. See the bakeoff for accuracy.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 


### PR DESCRIPTION
Closes #2639.

## The evidence

Run 31995984041, both shapes at 100,000 rows:

| | person@100k | biblio@100k |
|---|---:|---:|
| blocks | 84,293 | 22,151 |
| `n_pairs_scored` | 0 | **1,493,182** |
| `mass_above_threshold` | 0.0 | **0.999998** |
| `candidates_compared` | 0 | **0** |

biblio scored 1.49M pairs at 99.9998% above threshold and reported zero candidates compared. `scorer.py` skips the count above 10,000 blocks -- `Block.n_rows()` materialises, and doing that serially for tens of thousands of blocks is real time -- so the skip is correct, but it leaves a 0 that means *not counted*. Every shape with fine-grained blocking is past that gate.

## Two consumers, breaking in opposite directions

This is why neither "treat 0 as zero" nor "treat 0 as unknown" works globally:

- **`rule_blocking_singleton_trap`** guards with `if candidates_compared > 0: return None`, commented *"If candidates were actually compared, this is not the singleton trap."* Above the gate that guard could never fire, so a shape that scored 1.49M pairs stayed eligible for remediation whose action **coarsens** blocking to `first_token`.
- **`_maybe_decorate_with_llm_scorer`** early-returns on `candidates_compared == 0`, so the escalation was **silently dead** at exactly the scale it exists for.

## The fix

`ScoringProfile.candidates_counted` records whether the count is real. Set at the two counting sites, cleared at the skip, in the same branch as the value so the two cannot drift. Each consumer then says which case it means:

- the rule **abstains** when the count is unknown — coarsening healthy blocking is the expensive direction;
- the escalation bails only on a **measured** zero, otherwise letting `mass_in_borderline` decide. That signal is computed over pairs that were actually scored, so it cannot be satisfied by a run where nothing happened.

## Deliberately not changed

**`health()`.** Its clause needs *both* counters zero, and `mass_above_threshold` is necessarily 0.0 in that case, so the very next clause returns RED anyway. The verdict cannot change, and this is the path that decides whether a user's run is refused. Pinned by a test so a later change is a decision rather than a side effect.

**The TypeScript rules.** That surface gets the field for shape parity, but `computeScoringProfile` counts unconditionally — it has no skip gate, so no bug. Giving its rules the abstain guard would change behaviour for a state it never produces.

**The count itself.** Making it cheap (taking the height where the block is already materialised inside the scoring worker) is a real improvement and a separate change; this one makes the existing ambiguity honest first.

## Tests

`tests/test_candidates_counted_2639.py` — 5 tests, verified RED before the fix. Includes the over-correction guard: a measured zero must **still** fire the trap, so a fix that merely disabled the rule would fail. Three existing fixtures now say `candidates_counted=True`, which is the measured zero they always meant.

217 pass across the eight affected modules.