### PR TITLE
fix(autoconfig): record the FS link cutoff the run actually used

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2070,6 +2070,7 @@
             "goldenmatch.core.fused_routing",
             "goldenmatch.core.indicators",
             "goldenmatch.core.pipeline",
+            "goldenmatch.core.probabilistic",
             "goldenmatch.core.profile_emitter",
             "goldenmatch.core.runtime_profile",
             "goldenmatch.core.scorer",

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -587,6 +587,9 @@ class AutoConfigController:
         self.policy = policy
         self.budget = budget
         self._memory = memory
+        # {matchkey_name: {"link_threshold": float, "source": str}} from the most
+        # recent sample pipeline run (#2637). Empty for non-probabilistic runs.
+        self._last_fs_link_thresholds: dict[str, dict] = {}
 
     # ---- Public entry point ------------------------------------------------
     def run(
@@ -1341,6 +1344,9 @@ class AutoConfigController:
             best_entry.config, best_entry.profile,
         )
 
+        # #2637: write the RESOLVED FS link cutoff onto the committed config.
+        self._stamp_resolved_link_thresholds(committed_config)
+
         # ── Controller v3 planner (phase 2): pick execution plan based on the
         # committed profile + runtime introspection. Phase 2 lands with an
         # empty rule list (no behavior change); phases 3-6 register rules.
@@ -1760,9 +1766,77 @@ class AutoConfigController:
         # the sample profile. A polars / ray sample is untouched (byte-identical).
         config = self._maybe_bucket_route_arrow(sample, config)
         if reference is None:
-            run_dedupe_df(sample, config=config, _prep_store=_prep_store)
+            _res = run_dedupe_df(sample, config=config, _prep_store=_prep_store)
         else:
-            run_match_df(sample, reference, config=config)
+            _res = run_match_df(sample, reference, config=config)
+        # #2637: keep the RESOLVED FS link cutoff and its provenance from this
+        # sample run. `_stamp_resolved_link_thresholds` writes it onto the
+        # committed config so the cutoff stops being implicit. Reading it here
+        # is the only place it is available: `resolve_thresholds` runs inside
+        # the pipeline, after auto-config has already produced the config, so
+        # nothing upstream can know the number.
+        try:
+            self._last_fs_link_thresholds = dict(
+                (_res or {}).get("fs_link_thresholds") or {}
+            )
+        except Exception:  # noqa: BLE001 - telemetry must never fail a run
+            self._last_fs_link_thresholds = {}
+
+    def _stamp_resolved_link_thresholds(self, config: GoldenMatchConfig) -> None:
+        """Write the resolved FS link cutoff onto the committed config (#2637).
+
+        A probabilistic matchkey cuts on ``link_threshold``. Auto-config never
+        set it, so the number was resolved three layers down at scoring time by
+        ``resolve_thresholds`` (explicit > EM-calibrated > fixed default) and the
+        config it handed back was SILENT about the single most consequential
+        Fellegi-Sunter decision. Two costs, both measured in #2636:
+
+        - ``mk.cutoff`` was ``None``, so ``_perturbable_matchkeys`` was empty and
+          ``ThresholdShift`` returned ``None``. The healer's only FS-specific
+          lever was inert on every auto-config FS config (verified on 4 of 4
+          datasets), and ``threshold_perturbations`` yielded nothing, leaving
+          ``perturbation_stability`` permanently unmeasured on this path.
+        - the user in #2483 swept a field that does not cut and measured nothing,
+          with no way to see that no decision had ever been made.
+
+        This does NOT change the cutoff. It records the value the run already
+        used, so behaviour is byte-identical and the lever becomes reachable.
+        Only ``fallback`` / ``calibrated`` sources are stamped: ``configured``
+        means the user set it and must not be overwritten.
+
+        Silent no-op when the sample run recorded nothing (non-probabilistic
+        configs, or a path that never reached FS scoring) -- a missing
+        measurement must not invent a cutoff, which would be exactly the
+        fabricated-default problem this exists to remove.
+        """
+        recorded = getattr(self, "_last_fs_link_thresholds", None)
+        if not recorded:
+            return
+        from goldenmatch.core.probabilistic import (
+            LINK_THRESHOLD_CALIBRATED,
+            LINK_THRESHOLD_FALLBACK,
+        )
+        stampable = (LINK_THRESHOLD_FALLBACK, LINK_THRESHOLD_CALIBRATED)
+        for mk in config.get_matchkeys():
+            if getattr(mk, "type", None) != "probabilistic":
+                continue
+            if mk.link_threshold is not None:
+                continue  # user's own value; never overwrite
+            entry = recorded.get(mk.name)
+            if not isinstance(entry, dict) or entry.get("source") not in stampable:
+                continue
+            value = entry.get("link_threshold")
+            if value is None:
+                continue
+            try:
+                mk.link_threshold = float(value)
+            except (TypeError, ValueError):
+                continue
+            logger.info(
+                "auto-config: recorded resolved link_threshold=%.4f on matchkey "
+                "%r (source=%s) so the cutoff is explicit and tunable (#2637)",
+                float(value), mk.name, entry.get("source"),
+            )
 
     @staticmethod
     def _maybe_bucket_route_arrow(

--- a/packages/python/goldenmatch/tests/test_link_threshold_stamp_2637.py
+++ b/packages/python/goldenmatch/tests/test_link_threshold_stamp_2637.py
@@ -1,0 +1,249 @@
+"""#2637: the committed config records the FS link cutoff it actually used.
+
+A probabilistic matchkey cuts on ``link_threshold``. Auto-config never set it,
+so the number was resolved three layers down at scoring time and the config
+handed back was silent about the most consequential Fellegi-Sunter decision.
+
+Two costs, both measured in #2636:
+
+- ``mk.cutoff`` was ``None``, so ``_perturbable_matchkeys`` was empty and
+  ``ThresholdShift`` returned ``None``. The healer's ONLY FS-specific lever was
+  inert on every auto-config FS config, and ``threshold_perturbations`` yielded
+  nothing, leaving ``perturbation_stability`` permanently unmeasured there.
+- the #2483 reporter swept a field that does not cut and measured nothing, with
+  no way to see that no decision had ever been made.
+
+The stamp records the value the run ALREADY used, so results must not move.
+That equivalence is the load-bearing assertion here; the reachability
+assertions are worth nothing if the cutoff silently changed.
+"""
+from __future__ import annotations
+
+import warnings
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_controller import (
+    AutoConfigController,
+    ControllerBudget,
+    resolve_planning_effort,
+)
+from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+from goldenmatch.core.config_edits import ThresholdShift, _perturbable_matchkeys
+from goldenmatch.core.probabilistic import (
+    LINK_THRESHOLD_CALIBRATED,
+    LINK_THRESHOLD_CONFIGURED,
+    LINK_THRESHOLD_FALLBACK,
+)
+from goldenmatch.core.zero_label_confidence import threshold_perturbations
+
+
+def _controller() -> AutoConfigController:
+    return AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget.for_dataset(1000, resolve_planning_effort("fast")),
+    )
+
+
+def _cfg(mtype: str = "probabilistic", **mk_kw) -> GoldenMatchConfig:
+    field = MatchkeyField(
+        field="name",
+        scorer="jaro_winkler",
+        **({"weight": 1.0} if mtype == "weighted" else {}),
+    )
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="p", type=mtype, fields=[field], **mk_kw)],
+        blocking=BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["name"], transforms=["lowercase"])]
+        ),
+    )
+
+
+# ── the stamp writes what the run resolved ─────────────────────────────────
+
+@pytest.mark.parametrize("source", [LINK_THRESHOLD_FALLBACK, LINK_THRESHOLD_CALIBRATED])
+def test_stamps_resolved_cutoff(source):
+    """Both non-user sources are recorded: neither was chosen by the config."""
+    ctrl = _controller()
+    ctrl._last_fs_link_thresholds = {"p": {"link_threshold": 0.62, "source": source}}
+    cfg = _cfg()
+    assert cfg.get_matchkeys()[0].link_threshold is None
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    assert cfg.get_matchkeys()[0].link_threshold == pytest.approx(0.62)
+
+
+def test_never_overwrites_a_user_value():
+    """`configured` means the user chose it. Overwriting would be a silent
+    behaviour change on an explicit instruction."""
+    ctrl = _controller()
+    ctrl._last_fs_link_thresholds = {
+        "p": {"link_threshold": 0.62, "source": LINK_THRESHOLD_CONFIGURED}
+    }
+    cfg = _cfg(link_threshold=0.80)
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    assert cfg.get_matchkeys()[0].link_threshold == pytest.approx(0.80)
+
+
+def test_no_measurement_invents_nothing():
+    """A missing measurement must NOT produce a cutoff.
+
+    Fabricating one here would be the same defect this exists to remove: a
+    number in the config that nothing about the data chose.
+    """
+    ctrl = _controller()
+    ctrl._last_fs_link_thresholds = {}
+    cfg = _cfg()
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    assert cfg.get_matchkeys()[0].link_threshold is None
+
+
+def test_weighted_matchkey_is_untouched():
+    """`link_threshold` is not the operative cutoff on a weighted matchkey."""
+    ctrl = _controller()
+    ctrl._last_fs_link_thresholds = {
+        "p": {"link_threshold": 0.62, "source": LINK_THRESHOLD_FALLBACK}
+    }
+    cfg = _cfg("weighted", threshold=0.85)
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    mk = cfg.get_matchkeys()[0]
+    assert mk.link_threshold is None
+    assert mk.threshold == pytest.approx(0.85)
+
+
+def test_unknown_matchkey_name_is_ignored():
+    ctrl = _controller()
+    ctrl._last_fs_link_thresholds = {
+        "other": {"link_threshold": 0.62, "source": LINK_THRESHOLD_FALLBACK}
+    }
+    cfg = _cfg()
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    assert cfg.get_matchkeys()[0].link_threshold is None
+
+
+@pytest.mark.parametrize("entry", [
+    {"link_threshold": None, "source": LINK_THRESHOLD_FALLBACK},
+    {"source": LINK_THRESHOLD_FALLBACK},
+    {"link_threshold": "not-a-number", "source": LINK_THRESHOLD_FALLBACK},
+    "not-a-dict",
+])
+def test_malformed_telemetry_is_a_no_op(entry):
+    """Telemetry must never fail a run or write junk into a config."""
+    ctrl = _controller()
+    ctrl._last_fs_link_thresholds = {"p": entry}
+    cfg = _cfg()
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    assert cfg.get_matchkeys()[0].link_threshold is None
+
+
+# ── what the stamp unlocks (the point of #2637) ────────────────────────────
+
+def test_the_healers_only_fs_lever_goes_live():
+    """Before: ThresholdShift returned None on every auto-config FS config."""
+    ctrl = _controller()
+    cfg = _cfg()
+    assert _perturbable_matchkeys(cfg) == []
+    assert ThresholdShift(0.05).apply(cfg) is None
+
+    ctrl._last_fs_link_thresholds = {
+        "p": {"link_threshold": 0.50, "source": LINK_THRESHOLD_FALLBACK}
+    }
+    ctrl._stamp_resolved_link_thresholds(cfg)
+
+    assert len(_perturbable_matchkeys(cfg)) == 1
+    shifted = ThresholdShift(0.05).apply(cfg)
+    assert shifted is not None
+    assert shifted.get_matchkeys()[0].link_threshold == pytest.approx(0.55)
+
+
+def test_perturbation_stability_stops_being_dark():
+    """`threshold_perturbations` yielded 0 variants on the FS path, so the
+    zero-label stability signal was never measured (correctly `None`, but
+    never computed). It has inputs now."""
+    ctrl = _controller()
+    cfg = _cfg()
+    assert threshold_perturbations(cfg) == []
+    ctrl._last_fs_link_thresholds = {
+        "p": {"link_threshold": 0.50, "source": LINK_THRESHOLD_FALLBACK}
+    }
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    variants = threshold_perturbations(cfg)
+    assert len(variants) == 2
+    # The inert field is still never written (#2483).
+    assert all(v.get_matchkeys()[0].threshold is None for v in variants)
+
+
+def test_stamped_config_reports_a_cutoff():
+    """#2483's user-facing complaint: the config said nothing about the cut."""
+    ctrl = _controller()
+    cfg = _cfg()
+    assert cfg.get_matchkeys()[0].cutoff is None
+    ctrl._last_fs_link_thresholds = {
+        "p": {"link_threshold": 0.50, "source": LINK_THRESHOLD_FALLBACK}
+    }
+    ctrl._stamp_resolved_link_thresholds(cfg)
+    mk = cfg.get_matchkeys()[0]
+    assert mk.cutoff_field == "link_threshold"
+    assert mk.cutoff == pytest.approx(0.50)
+
+
+# ── equivalence: recording the number must not change the answer ───────────
+
+def _person_df(n: int = 240) -> pl.DataFrame:
+    first = ["ada", "grace", "alan", "edsger", "barbara", "donald"]
+    last = ["lovelace", "hopper", "turing", "dijkstra", "liskov", "knuth"]
+    rows = []
+    for i in range(n):
+        f, l = first[i % len(first)], last[(i // 2) % len(last)]
+        rows.append({
+            "rid": f"r{i}",
+            "name": f"{f} {l}" if i % 3 else f"{f[0]}. {l}",
+            "city": ["leeds", "york", "hull"][i % 3],
+        })
+    return pl.DataFrame(rows)
+
+
+def test_stamping_the_resolved_value_does_not_change_results():
+    """The load-bearing assertion.
+
+    A run whose config carries the cutoff it resolved must produce exactly the
+    output of the run that resolved it implicitly. Verified here on a synthetic
+    frame; also checked out-of-test on ncvr_synthetic (F1 0.966000 both ways),
+    historical_50k @8k (0.858600) and the synthetic anchor (1.000000).
+    """
+    import goldenmatch
+
+    df = _person_df()
+    cfg = _cfg(link_threshold=None)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        base = goldenmatch.dedupe_df(df, config=cfg)
+        resolved = (base.stats or {}).get("fs_link_thresholds") or {}
+
+        # Nothing to compare if this path never reached FS scoring.
+        if not resolved:
+            pytest.skip("no FS cutoff resolved on this path")
+
+        stamped_cfg = cfg.model_copy(deep=True)
+        ctrl = _controller()
+        ctrl._last_fs_link_thresholds = resolved
+        ctrl._stamp_resolved_link_thresholds(stamped_cfg)
+        assert stamped_cfg.get_matchkeys()[0].link_threshold is not None
+
+        after = goldenmatch.dedupe_df(df, config=stamped_cfg)
+
+    def _pairs(res):
+        return sorted(
+            (min(a, b), max(a, b), round(s, 10)) for a, b, s in res.scored_pairs
+        )
+
+    assert _pairs(after) == _pairs(base)
+    assert sorted(map(sorted, base.clusters.values())) == sorted(
+        map(sorted, after.clusters.values())
+    )

--- a/scripts/fs_levers/README.md
+++ b/scripts/fs_levers/README.md
@@ -45,8 +45,19 @@ probabilistic_df` never sets it, so `mk.cutoff` is `None`,
 Verified INERT on all four available datasets, so it is structural rather than
 data-dependent. Meanwhile the engine emits a precise diagnosis at runtime
 ("linked N% ... using a FALLBACK link cutoff of 0.5000 ... Set 'link_threshold'").
-The detector works, the actuator is disconnected, and the same emptiness leaves
+The detector works, the actuator was disconnected, and the same emptiness leaves
 `perturbation_stability` permanently unmeasured on the FS path.
+
+> **Partly fixed, and this harness will not show it.** #2645 makes the
+> controller stamp the resolved cutoff onto the committed config, so
+> `ThresholdShift` is live on the zero-config `auto_configure_df` /
+> `dedupe_df` path. It does NOT reach `auto_configure_probabilistic_df`,
+> which is non-iterative by design: it never runs the controller, so it
+> never trains, so there is no resolved cutoff to record. Since the sweeps
+> below build their baseline from `auto_configure_probabilistic_df`, they
+> still report `ThresholdShift: INERT` — that is the entry point's inherent
+> limit, not the fix failing. Check the zero-config path if you want to see
+> the lever live.
 
 **EM non-convergence is a second one.** "EM did not converge after 20
 iterations" fired on exactly one cell of six -- the -0.34 F1 collapse -- and


### PR DESCRIPTION
Closes the `link_threshold` half of #2637 (measured in #2636).

## What and why

A probabilistic matchkey cuts on `link_threshold`. Auto-config never set it, so the number was resolved three layers down at scoring time by `resolve_thresholds` (explicit > EM-calibrated > fixed default) and the committed config stayed **silent about the most consequential Fellegi-Sunter decision**. Two measured costs:

- `mk.cutoff` was `None` → `_perturbable_matchkeys` empty → `ThresholdShift` returned `None`. The healer's **only** FS-specific lever was inert on every auto-config FS config (verified 4 of 4 datasets), and `threshold_perturbations` yielded nothing, leaving `perturbation_stability` permanently unmeasured on that path.
- the #2483 reporter swept a field that does not cut and measured nothing, with no way to see that no decision had ever been made.

## The mechanism turned out to be simpler than the issue assumed

The `fs_link_thresholds` channel #2483 added **already** carries the resolved value and its provenance out to the pipeline's return dict, and `link_threshold_source()` already classifies it as `configured` / `calibrated` / `fallback`. The controller was calling `run_dedupe_df` and discarding the result. So this is read-what-already-exists plus a guarded stamp, not new plumbing.

The controller is also the *only* place that can know the value: it already trains in `_run_pipeline_sample`, whereas auto-config returns before any EM runs.

## Behaviour does not change

It records the number the run already used. Verified **byte-identical scored pairs and clusters**, plus equal F1/P/R, on three datasets with real matches:

| dataset | unstamped | stamped | identical |
|---|---:|---:|:--:|
| ncvr_synthetic | 0.966000 | 0.966000 | ✅ |
| historical_50k @8k | 0.858600 | 0.858600 | ✅ |
| synthetic | 1.000000 | 1.000000 | ✅ |

After the stamp: `link_threshold=0.5`, `cutoff=0.5`, `perturbable=1`, `ThresholdShift` **APPLIES**, `threshold_perturbations` yields **2** variants where it previously yielded **0**.

Only `fallback` / `calibrated` are stamped. `configured` is the user's own value and is never overwritten. A missing measurement is a silent no-op rather than a fabricated default — inventing a cutoff would be the same defect this removes.

## Scope limit (please read; it affects how the harness reads afterward)

`auto_configure_probabilistic_df` is **non-iterative by design** and never runs the controller, so it never trains and cannot know a resolved cutoff. **The stamp does not reach it**, and that entry point still reports `ThresholdShift: INERT`.

This is inherent rather than an oversight — you cannot record a resolved value without resolving it — but it matters practically: that is the entry point `scripts/fs_levers/` measures, so re-running the harness after this lands will still show `INERT` and could look like the fix failed. Noted in the harness README in this PR for exactly that reason.

Net: this covers the zero-config `auto_configure_df` / `dedupe_df` path.

## Changes

- `core/autoconfig_controller.py`: `_run_pipeline_sample` keeps `fs_link_thresholds`; new `_stamp_resolved_link_thresholds` applied at commit; `_last_fs_link_thresholds` initialised in `__init__`.
- `tests/test_link_threshold_stamp_2637.py`: 14 tests.
- `scripts/fs_levers/README.md`: records the scope limit.

## Testing

- New tests: **14 passed**.
- Regression sweep over every autoconfig / probabilistic / zero-label / config-edits suite (51 files): **915 passed, 12 skipped, 0 failures**.
- `ruff check` clean on both changed files.
- Equivalence checked out-of-test on the three datasets above (pairs + clusters, not just F1).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a — verified no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (harness README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_