### PR TITLE
fix(backends): bucket / duckdb / ray now emit a ScoringProfile

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -389,6 +389,7 @@
           "defines": [
             "_bkt_debug_on",
             "_default_n_buckets",
+            "_emit_profile",
             "_ensure_alias_tables_installed",
             "_ensure_legal_forms_installed",
             "_ensure_name_tables_installed",
@@ -423,6 +424,7 @@
             "goldenmatch.core.frame",
             "goldenmatch.core.matchkey",
             "goldenmatch.core.probabilistic",
+            "goldenmatch.core.profile_emitter",
             "goldenmatch.core.scorer",
             "goldenmatch.plugins.registry",
             "goldenmatch.refdata",
@@ -4642,6 +4644,7 @@
             "find_fuzzy_matches_columnar",
             "pairs_df_to_list",
             "pairs_list_to_df",
+            "profile_threshold",
             "rerank_top_pairs",
             "reset_ne_broken",
             "score_blocks_columnar",

--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -268,6 +268,22 @@ def score_blocks_ray(
                 f"backend='chunked' or wait for Component 4 "
                 f"(streaming pair store)"
             )
+    # Report to the auto-config emitter (#2647). This backend calls
+    # `_score_one_block` directly and bypassed `core/scorer.py`'s emitting
+    # wrapper, so a run routed here left the emitter on the all-zero
+    # `ScoringProfile()` default -- which `health()` reads as "nothing
+    # happened" -> RED, refusing the run at `n_rows >= REFUSE_AT_N`.
+    #
+    # `candidates_counted=False`: the candidate total is not computed on this
+    # path, so it is ABSENT rather than zero (#2644 added the flag to say so).
+    # A no-op when no capture is open.
+    from goldenmatch.core.scorer import (
+        _emit_scoring_profile,
+        profile_threshold,
+    )
+
+    _emit_scoring_profile(all_pairs, profile_threshold(mk, all_pairs),
+                          candidates_compared=0, candidates_counted=False)
     return all_pairs
 
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1344,6 +1344,38 @@ def score_probabilistic_external_blocks(
     return out
 
 
+def _emit_profile(pairs: Any, mk: Any) -> None:
+    """Report this backend's scoring to the auto-config emitter (#2647).
+
+    `core/scorer.py` emits from its own entry points; this backend calls
+    `_score_one_block` directly and bypassed that wrapper entirely, so any run
+    routed here left the emitter holding the all-zero `ScoringProfile()`
+    default. `health()` reads that as "nothing happened" -> RED, and at
+    `n_rows >= REFUSE_AT_N` the controller REFUSES the run. Bucket is the
+    DEFAULT scorer (#526) and is chosen at exactly those sizes, so person@100k
+    was refused on a config whose blocking graded GREEN and whose clustering
+    produced 91,527 clusters with transitivity 1.0.
+
+    `candidates_counted=False` deliberately: this path never accumulates bucket
+    sizes (`_pair_count` serves only the oversized-tile budget), so the count is
+    genuinely ABSENT rather than zero, and #2644 added the flag so that is
+    sayable. The pair-derived signals are all real, and the "nothing happened"
+    clause needs BOTH counters zero -- so this clears the refusal without
+    inventing a number.
+
+    A no-op when no capture is open, so production pays nothing.
+    """
+    from goldenmatch.core.scorer import (
+        _emit_scoring_profile,
+        profile_threshold,
+    )
+
+    _emit_scoring_profile(
+        pairs, profile_threshold(mk, pairs),
+        candidates_compared=0, candidates_counted=False,
+    )
+
+
 def score_buckets(
     prepared_df: pl.DataFrame,
     blocking_config: BlockingConfig,
@@ -2725,8 +2757,23 @@ def score_buckets(
         import pyarrow as _pa
 
         if pass_tables:
-            return _pa.concat_tables(pass_tables)
+            _tbl = _pa.concat_tables(pass_tables)
+            # Arrow mode still has to report. Zipping three columns is O(pairs)
+            # and only runs when a capture is open -- `_emit_scoring_profile`
+            # returns immediately otherwise, so the zip is behind that guard.
+            from goldenmatch.core.profile_emitter import has_active_emitter
+
+            if has_active_emitter():
+                _emit_profile(
+                    list(zip(_tbl.column("id_a").to_pylist(),
+                             _tbl.column("id_b").to_pylist(),
+                             _tbl.column("score").to_pylist(), strict=True)),
+                    mk,
+                )
+            return _tbl
+        _emit_profile([], mk)
         return pairs_to_pair_stream([])
+    _emit_profile(all_pairs, mk)
     return all_pairs
 
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_duckdb.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_duckdb.py
@@ -241,6 +241,22 @@ def score_blocks_duckdb(
             "DuckDB scoring: %d blocks, %d pairs (store=%s)",
             len(blocks), len(result), resolved_db_path,
         )
+        # Report to the auto-config emitter (#2647). This backend calls
+        # `_score_one_block` directly and bypassed `core/scorer.py`'s emitting
+        # wrapper, so a run routed here left the emitter on the all-zero
+        # `ScoringProfile()` default -- which `health()` reads as "nothing
+        # happened" -> RED, refusing the run at `n_rows >= REFUSE_AT_N`.
+        #
+        # `candidates_counted=False`: the candidate total is not computed on this
+        # path, so it is ABSENT rather than zero (#2644 added the flag to say so).
+        # A no-op when no capture is open.
+        from goldenmatch.core.scorer import (
+            _emit_scoring_profile,
+            profile_threshold,
+        )
+
+        _emit_scoring_profile(result, profile_threshold(mk, result),
+                              candidates_compared=0, candidates_counted=False)
         return result
     finally:
         con.close()

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -81,6 +81,27 @@ def _candidate_count_gate() -> int:
     return v if v >= 0 else 10_000
 
 
+def profile_threshold(mk: Any, pairs: list[tuple[int, int, float]]) -> float:
+    """The cut this run actually applied, safe for ANY matchkey type (#2647).
+
+    `mk.fuzzy_threshold` RAISES for probabilistic matchkeys -- *"fuzzy_threshold
+    accessed but threshold is None. Only weighted matchkeys are guaranteed to
+    have a threshold"* -- so the emitter's threshold contract silently assumed
+    weighted. That held only because probabilistic routes to the bucket backend,
+    which emitted nothing at all; making that backend report exposed it.
+
+    The fallback is the LOWEST RETURNED SCORE, which is the operative admission
+    boundary rather than a guess: `find_fuzzy_matches` returns only pairs at or
+    above the cut, so the minimum of what came back is where the cut effectively
+    sat for this run. `mass_above_threshold` is then 1.0, which is true -- every
+    returned pair did clear it.
+    """
+    try:
+        return mk.fuzzy_threshold
+    except ValueError:
+        return min((s for _a, _b, s in pairs), default=0.0)
+
+
 def _emit_scoring_profile(
     pairs: list[tuple[int, int, float]],
     threshold: float,

--- a/packages/python/goldenmatch/tests/test_backends_emit_scoring_profile_2647.py
+++ b/packages/python/goldenmatch/tests/test_backends_emit_scoring_profile_2647.py
@@ -1,0 +1,140 @@
+"""Every scoring backend must emit a ScoringProfile, or zero-config refuses (#2647).
+
+`core/scorer.py` emits a `ScoringProfile` from its two scoring entry points.
+`score_buckets`, `score_blocks_duckdb` and `score_blocks_ray` call
+`_score_one_block` directly and bypass that wrapper, so a run routed to any of
+them leaves the emitter holding the all-zero `ScoringProfile()` default.
+
+`ScoringProfile.health()` reads that as *"No candidates compared and no pairs
+scored -> RED (nothing happened)"*, the rollup goes RED, and at
+`n_rows >= REFUSE_AT_N` `AutoConfigController` REFUSES the run.
+
+Measured on person@100,000 (run 32040304803), which routes to the bucket
+backend -- the DEFAULT scorer since #526, selected at exactly the sizes where
+`REFUSE_AT_N` applies:
+
+    blocking  GREEN   84,293 blocks, 121,372,923 comparisons, reduction 0.9757
+    scoring   RED     every field zero
+    cluster   GREEN   91,527 clusters from 100,000 rows, max size 3,
+                      transitivity 1.0
+
+Clustering cannot happen without scoring. 91,527 clusters from 100,000 rows is
+~8,473 merges, so pairs were scored, cleared a threshold, and were clustered --
+every stage downstream of scoring has real data while scoring itself reports
+nothing. The user is told the config is degenerate; the evidence says it worked.
+
+## What these tests assert, and what they deliberately do not
+
+They assert a NON-DEFAULT profile reaches the emitter, and that its verdict is
+not the "nothing happened" RED. They do NOT assert `candidates_compared`,
+because the bucket path has no cheap total -- bucket sizes are never
+accumulated, and `_pair_count` is used only for the oversized-tile budget.
+Reporting `candidates_counted=False` there is the honest answer and is exactly
+the state #2644 added the flag to express: the pair-derived signals
+(`n_pairs_scored`, `mass_above_threshold`, `dip_statistic`, the histogram) are
+real, and the count is absent rather than zero.
+
+That is sufficient to clear the refusal, because the "nothing happened" clause
+requires BOTH counters to be zero.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.backends.score_buckets import score_buckets
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.complexity_profile import HealthVerdict, ScoringProfile
+from goldenmatch.core.matchkey import _xform_sig
+from goldenmatch.core.profile_emitter import profile_capture
+
+
+def _prepared() -> pl.DataFrame:
+    field = MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)
+    col = _xform_sig(field)
+    names = ["alice", "alica", "alise", "robert", "robbert", "xavier"]
+    return pl.DataFrame({
+        "__row_id__": list(range(len(names))),
+        "name": names,
+        col: names,
+        "blk": ["X"] * len(names),
+    })
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="t", type="weighted", threshold=0.7,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])])
+
+
+def test_bucket_backend_emits_a_scoring_profile():
+    """The live bug. `score_buckets` is the DEFAULT scorer and emits nothing."""
+    with profile_capture() as emitter:
+        pairs = score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+
+    assert pairs, "fixture must produce pairs, or this proves nothing"
+    assert emitter.scoring is not None, "no ScoringProfile reached the emitter"
+    assert emitter.scoring != ScoringProfile(), "the all-zero default is not a report"
+    assert emitter.scoring.n_pairs_scored == len(pairs)
+
+
+def test_bucket_backend_profile_does_not_read_as_nothing_happened():
+    """The consequence, not just the mechanism: the emitted profile must not
+    grade RED via the "nothing happened" clause, because that is what refuses
+    the user's run at `n_rows >= REFUSE_AT_N`."""
+    with profile_capture() as emitter:
+        score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+
+    sp = emitter.scoring
+    assert not (sp.candidates_compared == 0 and sp.n_pairs_scored == 0), (
+        "this is the exact predicate that refuses the run"
+    )
+    assert sp.mass_above_threshold > 0.0
+    assert sp.health() != HealthVerdict.RED
+
+
+def test_bucket_backend_is_honest_about_the_candidate_count():
+    """`candidates_counted` must be False here rather than claiming a measured
+    zero. The bucket path never accumulates bucket sizes, so the count is
+    genuinely absent -- and #2644 exists so that absence is sayable."""
+    with profile_capture() as emitter:
+        score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+
+    assert emitter.scoring.candidates_counted is False
+
+
+def test_emitting_does_not_change_the_pairs():
+    """The emitter is a no-op without an active capture, so scoring output must
+    be identical either way. A telemetry fix that moved a pair would be a far
+    worse bug than the one it fixes."""
+    without = score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+    with profile_capture():
+        within = score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+
+    key = lambda ps: sorted((min(a, b), max(a, b), round(s, 6)) for a, b, s in ps)  # noqa: E731
+    assert key(without) == key(within)
+
+
+def test_duckdb_backend_emits_a_scoring_profile():
+    """Same gap, different backend. Skipped rather than xfailed when duckdb is
+    absent: a missing optional dependency is not evidence about the code."""
+    duckdb = pytest.importorskip("duckdb")  # noqa: F841
+    from goldenmatch.backends.score_duckdb import score_blocks_duckdb
+    from goldenmatch.core.blocker import build_blocks
+
+    blocks = build_blocks(_prepared(), _blocking())
+    with profile_capture() as emitter:
+        pairs = score_blocks_duckdb(blocks, _mk(), matched_pairs=set())
+
+    assert pairs, "fixture must produce pairs, or this proves nothing"
+    assert emitter.scoring is not None, "no ScoringProfile reached the emitter"
+    assert emitter.scoring.n_pairs_scored == len(pairs)


### PR DESCRIPTION
Closes #2647. Root cause of person@100k's zero-config refusal.

## The bug

`core/scorer.py` emits a `ScoringProfile` from its two entry points. `score_buckets`, `score_blocks_duckdb` and `score_blocks_ray` call `_score_one_block` directly and bypassed that wrapper, so any run routed to them left the emitter on the all-zero default. `health()` reads that as *"nothing happened"* → RED, and at `n_rows >= REFUSE_AT_N` the controller **refuses the run**.

Measured on person@100,000 (run 32040304803), which routes to bucket — the **default** scorer since #526, chosen at exactly the sizes where `REFUSE_AT_N` applies:

| | |
|---|---|
| blocking | **GREEN** — 84,293 blocks, 121,372,923 comparisons, reduction 0.9757 |
| scoring | **RED** — every field zero |
| cluster | **GREEN** — 91,527 clusters / 100,000 rows, max size 3, transitivity 1.0 |

Clustering cannot happen without scoring: 91,527 clusters from 100,000 rows is ~8,473 merges. Every stage downstream had real data while scoring reported nothing, and the user was told their config was degenerate.

## Two decisions worth reviewing

**`candidates_counted=False`, not a fabricated count.** The bucket path never accumulates bucket sizes (`_pair_count` serves only the oversized-tile budget), so the total is *absent*, not zero — the state #2644 added the flag to express. The pair-derived signals are real, and that is sufficient because the "nothing happened" clause needs **both** counters at zero. Threading a real count through a 1,400-line function on the default scoring path is a separate change with its own risk.

**`profile_threshold()` had to exist.** Emitting from these backends immediately broke **29 tests** on `mk.fuzzy_threshold`, which *raises* for probabilistic matchkeys — *"Only weighted matchkeys are guaranteed to have a threshold."* The emitter's contract silently assumed weighted, and that held only because probabilistic routes to bucket, which emitted nothing. The fallback is not a guess: it is the **lowest returned score**, the operative admission boundary, since `find_fuzzy_matches` returns only pairs at or above the cut. `mass_above_threshold` then reads 1.0, which is true.

## Detail

- **Arrow mode reports too.** `score_buckets` returns a `pa.Table` there, so the columns are zipped into the emitter's shape — behind `has_active_emitter()`, so production never pays the O(pairs) walk.
- **Ray's small-block path needed nothing** — it delegates to `score_blocks_parallel`, which already emits. Only its terminal return was silent.

## Tests

Verified RED first, failing with *"no ScoringProfile reached the emitter"* on a fixture that produced pairs. Five tests: emission, the verdict not reading as "nothing happened", honesty about `candidates_counted`, duckdb (skipped not xfailed when absent), and one asserting **pair output is identical with and without an active capture** — a telemetry fix that moved a pair would be worse than the bug it fixes.

Remaining local failures (`test_fs_out_of_core`, the bucket debug-mode DEBUG-line assertion) reproduce identically on clean main — env skew, verified by stashing rather than assumed.