### PR TITLE
diag(scoring): a ScoringProfile names the code path that produced it

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -362,7 +362,8 @@
             "goldenmatch.core.golden",
             "goldenmatch.core.pairs",
             "goldenmatch.core.pipeline",
-            "goldenmatch.core.probabilistic"
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.scorer"
           ]
         },
         {
@@ -4642,6 +4643,7 @@
             "find_exact_matches",
             "find_fuzzy_matches",
             "find_fuzzy_matches_columnar",
+            "note_scoring_route",
             "pairs_df_to_list",
             "pairs_list_to_df",
             "profile_threshold",

--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -1498,6 +1498,14 @@ def run_fs_dedupe_streaming(
     ``_prepare_probabilistic_review_scoring`` alongside a review-cut ``scoring_mk``
     to match the in-memory clustering outcome exactly. ``None`` clusters every
     returned pair (the kernel scored at ``mk``'s own threshold)."""
+    # Stamp WHICH orchestration ran (#2647 follow-up). This layer chooses
+    # the branch and then delegates scoring, so without it an empty scoring
+    # profile says only "nobody emitted" -- not which of these four ran, nor
+    # which internal branch. Route-only; it never overwrites a measured field.
+    from goldenmatch.core.scorer import note_scoring_route
+
+    note_scoring_route("fs.streaming")
+
     import os as _os
     import tempfile
 
@@ -1584,6 +1592,14 @@ def run_fs_dedupe_sequential(
     polars core primitive fed only the multi-member subset). The fast single-box
     path for frames that FIT in RAM; ``run_fs_dedupe_streaming`` is the
     DuckDB-spilled variant past RAM."""
+    # Stamp WHICH orchestration ran (#2647 follow-up). This layer chooses
+    # the branch and then delegates scoring, so without it an empty scoring
+    # profile says only "nobody emitted" -- not which of these four ran, nor
+    # which internal branch. Route-only; it never overwrites a measured field.
+    from goldenmatch.core.scorer import note_scoring_route
+
+    note_scoring_route("fs.sequential")
+
     from goldenmatch.core.frame import is_polars_lazyframe
     from goldenmatch.core.frame import to_frame as _tf
 
@@ -1690,6 +1706,14 @@ def run_fs_dedupe_spill(
     inside ``_score_single_pass``), a native array-UF ``FsExternalWcc`` kernel, and
     frame-residency streaming during prep (this path keeps the frame resident — the edge
     term is what it bounds)."""
+    # Stamp WHICH orchestration ran (#2647 follow-up). This layer chooses
+    # the branch and then delegates scoring, so without it an empty scoring
+    # profile says only "nobody emitted" -- not which of these four ran, nor
+    # which internal branch. Route-only; it never overwrites a measured field.
+    from goldenmatch.core.scorer import note_scoring_route
+
+    note_scoring_route("fs.spill")
+
     import shutil as _shutil
     import tempfile as _tempfile
 
@@ -1902,6 +1926,14 @@ def run_fs_dedupe_bucketed(
     blocking + one probabilistic matchkey by
     the ``_fs_streaming_dedupe_eligible`` gate (per-pass hash-bucketing is unsound
     for SN/adaptive/ann; the single matchkey means no cross-bucket exclude set)."""
+    # Stamp WHICH orchestration ran (#2647 follow-up). This layer chooses
+    # the branch and then delegates scoring, so without it an empty scoring
+    # profile says only "nobody emitted" -- not which of these four ran, nor
+    # which internal branch. Route-only; it never overwrites a measured field.
+    from goldenmatch.core.scorer import note_scoring_route
+
+    note_scoring_route("fs.bucketed")
+
     import shutil as _shutil
     import tempfile as _tempfile
 

--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -283,7 +283,8 @@ def score_blocks_ray(
     )
 
     _emit_scoring_profile(all_pairs, profile_threshold(mk, all_pairs),
-                          candidates_compared=0, candidates_counted=False)
+                          candidates_compared=0, candidates_counted=False,
+                              route="ray")
     return all_pairs
 
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1344,7 +1344,7 @@ def score_probabilistic_external_blocks(
     return out
 
 
-def _emit_profile(pairs: Any, mk: Any) -> None:
+def _emit_profile(pairs: Any, mk: Any, route: str = "buckets") -> None:
     """Report this backend's scoring to the auto-config emitter (#2647).
 
     `core/scorer.py` emits from its own entry points; this backend calls
@@ -1372,7 +1372,7 @@ def _emit_profile(pairs: Any, mk: Any) -> None:
 
     _emit_scoring_profile(
         pairs, profile_threshold(mk, pairs),
-        candidates_compared=0, candidates_counted=False,
+        candidates_compared=0, candidates_counted=False, route=route,
     )
 
 
@@ -2768,10 +2768,10 @@ def score_buckets(
                     list(zip(_tbl.column("id_a").to_pylist(),
                              _tbl.column("id_b").to_pylist(),
                              _tbl.column("score").to_pylist(), strict=True)),
-                    mk,
+                    mk, route="buckets.arrow",
                 )
             return _tbl
-        _emit_profile([], mk)
+        _emit_profile([], mk, route="buckets.arrow.empty")
         return pairs_to_pair_stream([])
     _emit_profile(all_pairs, mk)
     return all_pairs

--- a/packages/python/goldenmatch/goldenmatch/backends/score_duckdb.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_duckdb.py
@@ -256,7 +256,8 @@ def score_blocks_duckdb(
         )
 
         _emit_scoring_profile(result, profile_threshold(mk, result),
-                              candidates_compared=0, candidates_counted=False)
+                              candidates_compared=0, candidates_counted=False,
+                              route="duckdb")
         return result
     finally:
         con.close()

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -443,6 +443,16 @@ class ScoringProfile:
     # Defaults False: a default-constructed profile is the all-zero fallback the
     # emitter yields when scoring never ran, which has no measurement behind it.
     candidates_counted: bool = False
+    # WHICH code path produced this profile (#2647 follow-up). Empty means
+    # nobody claimed it -- the all-zero default nothing ever wrote to.
+    #
+    # There are at least five scoring entry points (core/scorer.py's two,
+    # score_buckets, score_duckdb, ray_backend) plus the FS orchestrators in
+    # backends/fs_out_of_core.py, and "which one scored this run?" has been
+    # answered by INFERENCE three times, wrongly twice. A profile that names its
+    # own producer ends that: an empty route on a run whose clustering clearly
+    # worked localises the gap immediately instead of costing a CI round.
+    route: str = ""
     score_histogram: list[int] = field(default_factory=lambda: [0] * 20)
     dip_statistic: float = 0.0
     mass_above_threshold: float = 0.0

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -81,6 +81,41 @@ def _candidate_count_gate() -> int:
     return v if v >= 0 else 10_000
 
 
+def note_scoring_route(route: str) -> None:
+    """Record WHICH orchestration ran, even when it emits no profile itself.
+
+    The FS orchestrators in `backends/fs_out_of_core.py` delegate scoring, so
+    they have no pairs to report -- but they are the layer that chose the
+    branch, and that choice is exactly what has been unknown. This stamps the
+    route without touching any measured field:
+
+      * no profile captured yet -> store a route-only profile (all zeros, route
+        set). An empty scoring profile that NAMES its producer is strictly more
+        informative than an empty one that does not.
+      * a profile already captured -> keep every measured value and prefix the
+        outer route, giving `fs.sequential>buckets.arrow`. The inner emitter
+        knows what it scored; the outer one knows how it was reached.
+
+    A no-op when no capture is open, like every other emit on this path.
+    """
+    from goldenmatch.core.complexity_profile import ScoringProfile
+    from goldenmatch.core.profile_emitter import current_emitter, has_active_emitter
+
+    if not has_active_emitter():
+        return
+    em = current_emitter()
+    existing = getattr(em, "scoring", None)
+    if existing is None:
+        em.set_scoring(ScoringProfile(route=route))
+        return
+    import dataclasses
+
+    inner = existing.route
+    em.set_scoring(dataclasses.replace(
+        existing, route=f"{route}>{inner}" if inner else route
+    ))
+
+
 def profile_threshold(mk: Any, pairs: list[tuple[int, int, float]]) -> float:
     """The cut this run actually applied, safe for ANY matchkey type (#2647).
 
@@ -108,6 +143,7 @@ def _emit_scoring_profile(
     *,
     candidates_compared: int = 0,
     candidates_counted: bool = False,
+    route: str = "",
     per_field_variance: dict[str, float] | None = None,
 ) -> None:
     """Emit ScoringProfile to current emitter. No-op when emitter is null.
@@ -138,6 +174,7 @@ def _emit_scoring_profile(
         n_pairs_scored=len(scores),
         candidates_compared=candidates_compared,
         candidates_counted=candidates_counted,
+        route=route,
         score_histogram=histogram_20(scores),
         dip_statistic=hartigan_dip(scores),
         mass_above_threshold=mass_above(scores, threshold),
@@ -2257,7 +2294,8 @@ def score_blocks_parallel(
                     matched_pairs.add((min(a, b), max(a, b)))
         _emit_scoring_profile(all_pairs, mk.fuzzy_threshold,
                               candidates_compared=total_candidates,
-                              candidates_counted=True)
+                              candidates_counted=True,
+                              route="scorer.small")
         return all_pairs
 
     # Snapshot exclude_pairs so threads see a frozen copy
@@ -2360,7 +2398,8 @@ def score_blocks_parallel(
     )
     _emit_scoring_profile(all_pairs, mk.fuzzy_threshold,
                           candidates_compared=total_candidates,
-                          candidates_counted=_candidates_counted)
+                          candidates_counted=_candidates_counted,
+                          route="scorer.parallel")
     return all_pairs
 
 

--- a/packages/python/goldenmatch/tests/test_scoring_route_field.py
+++ b/packages/python/goldenmatch/tests/test_scoring_route_field.py
@@ -1,0 +1,99 @@
+"""A ScoringProfile must name the code path that produced it.
+
+There are at least six scoring entry points -- `core/scorer.py`'s two,
+`score_buckets` (list and arrow), `score_duckdb`, `ray_backend`, and the four
+orchestrators in `backends/fs_out_of_core.py`. "Which one scored this run?" has
+been answered by INFERENCE three times in the person@100k investigation and was
+wrong twice:
+
+  * #2647 assumed the bucket backend, fixed it (#2648), and person did not move;
+  * the FS orchestrators turned out to be a fifth path with no emission at all.
+
+Each wrong guess cost a full CI round. `route` makes the profile self-describing,
+so an empty scoring profile on a run whose clustering plainly worked localises
+the gap from the artifact instead of from a hypothesis.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.backends.score_buckets import score_buckets
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.complexity_profile import ScoringProfile
+from goldenmatch.core.matchkey import _xform_sig
+from goldenmatch.core.profile_emitter import profile_capture
+from goldenmatch.core.scorer import note_scoring_route
+
+
+def _prepared() -> pl.DataFrame:
+    field = MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)
+    col = _xform_sig(field)
+    names = ["alice", "alica", "alise", "robert", "robbert", "xavier"]
+    return pl.DataFrame({
+        "__row_id__": list(range(len(names))),
+        "name": names,
+        col: names,
+        "blk": ["X"] * len(names),
+    })
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="t", type="weighted", threshold=0.7,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])])
+
+
+def test_default_profile_names_no_producer():
+    """Empty is the honest default: the all-zero profile nobody wrote to."""
+    assert ScoringProfile().route == ""
+
+
+def test_bucket_backend_names_itself():
+    with profile_capture() as emitter:
+        score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+
+    assert emitter.scoring.route.startswith("buckets")
+
+
+def test_orchestrator_marker_stores_a_route_when_nothing_scored_yet():
+    """The FS case: the orchestrator chose a branch and delegated, and no
+    profile exists yet. A route-only profile beats an anonymous empty one."""
+    with profile_capture() as emitter:
+        note_scoring_route("fs.sequential")
+
+    assert emitter.scoring is not None
+    assert emitter.scoring.route == "fs.sequential"
+    assert emitter.scoring.n_pairs_scored == 0
+
+
+def test_orchestrator_marker_preserves_a_measured_profile():
+    """The nesting case, and the one that must not regress: when scoring HAS
+    reported, the outer marker records how it was reached WITHOUT overwriting a
+    single measured field. A marker that clobbered real numbers would recreate
+    the bug it exists to diagnose."""
+    with profile_capture() as emitter:
+        score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+        measured = emitter.scoring
+        assert measured.n_pairs_scored > 0
+        note_scoring_route("fs.sequential")
+
+    after = emitter.scoring
+    assert after.route == f"fs.sequential>{measured.route}"
+    assert after.n_pairs_scored == measured.n_pairs_scored
+    assert after.mass_above_threshold == measured.mass_above_threshold
+    assert after.candidates_counted == measured.candidates_counted
+
+
+def test_marker_is_a_noop_without_a_capture():
+    """Production opens no capture, so this must cost nothing and raise
+    nothing when called outside one."""
+    note_scoring_route("fs.sequential")  # must not raise

--- a/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
+++ b/scripts/bench_er_headtohead/diagnose_zeroconfig_refusal.py
@@ -248,6 +248,10 @@ def collect(shape: str, rows: int, seed: int, workdir: Path) -> dict:
     above = getattr(sc, "n_pairs_scored", 0)
     mass = getattr(sc, "mass_above_threshold", 0.0)
     out["scoring"] = {
+        # WHICH path produced this. An empty route on a run whose clustering
+        # plainly worked means nothing emitted, and names nothing -- which is
+        # exactly the state that cost three CI rounds of guessing.
+        "route": getattr(sc, "route", "") or "(none -- nothing emitted)",
         "candidates_compared": compared,
         "candidates_counted": counted,
         "n_pairs_scored": above,


### PR DESCRIPTION
Follow-up to #2648, which did **not** fix person@100k.

## Why

#2648 made bucket/duckdb/ray emit. Re-running the diagnostic on `6599780ce` (run 32044097483) showed person@100k unchanged — still RED, still an all-zero scoring profile. My prediction that it would flip to GREEN was wrong.

The assumption that person routes through the bucket backend was never verified. person is a **probabilistic** shape and goes through the four orchestrators in `backends/fs_out_of_core.py` — a fifth scoring path with **zero** `_emit_scoring_profile` calls.

That is the third time *"which code path scored this run?"* has been answered by inference in this investigation, and the second time the inference was wrong. Each wrong guess cost a CI round.

## What this adds

`ScoringProfile.route` — the artifact names its own producer:

| route | meaning |
|---|---|
| `""` | nobody emitted, and nobody is named |
| `buckets` / `buckets.arrow` / `buckets.arrow.empty` | the bucket backend, by mode |
| `scorer.small` / `scorer.parallel` | `core/scorer.py`'s two paths |
| `duckdb` / `ray` | the other two backends |
| `fs.sequential>buckets.arrow` | an FS orchestrator, over whatever actually scored |

`note_scoring_route()` covers the layer that **chooses** a branch and then delegates — the four FS orchestrators call it. It never overwrites a measured field:

- nothing captured yet → a route-only profile (all zeros, route set). An empty profile that names its producer beats an anonymous one.
- something captured → keep every measured value and prefix the outer route. The inner emitter knows what it scored; the outer knows how it was reached.

Both pinned by tests. A marker that clobbered real numbers would recreate the bug it exists to diagnose, and it must be a no-op with no capture open so production pays nothing.

## Not a fix

This does not make person GREEN. It makes the next run say **which path to fix**, from the artifact rather than from a hypothesis.