### PR TITLE
perf(scoring): count candidate pairs when it is FREE, not by block count

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4640,6 +4640,7 @@
             "_score_one_block_columnar",
             "_soundex_score_matrix",
             "_soundex_score_single",
+            "cheap_n_rows",
             "find_exact_matches",
             "find_fuzzy_matches",
             "find_fuzzy_matches_columnar",

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -56,6 +56,42 @@ def reset_ne_broken() -> None:
         _NE_BROKEN.clear()
 
 
+def cheap_n_rows(block: Any) -> int | None:
+    """Row count IF reading it costs nothing; ``None`` when it would collect.
+
+    The candidate-count loop is gated on BLOCK COUNT because `Block.n_rows()`
+    goes through `materialize()`. But materialising is only expensive for one
+    of the shapes a block can take:
+
+      * `RowIdBlock` carries an int array -- `len(_ids)`, free;
+      * `Block.df` already a seam `Frame` or an eager native frame -- `.height`,
+        free (`materialize()` returns it unchanged);
+      * `Block.df` a polars LazyFrame -- `.collect()`, NOT free.
+
+    Only the last deserves the gate. Returning None for it, and a real number
+    otherwise, lets the caller count without ever paying to count.
+    """
+    ids = getattr(block, "_ids", None)
+    if ids is not None:
+        try:
+            return len(ids)
+        except TypeError:  # pragma: no cover - an array without __len__
+            return None
+
+    d = getattr(block, "df", None)
+    if d is None:
+        return None
+
+    from goldenmatch.core.frame import Frame, is_polars_lazyframe
+
+    if is_polars_lazyframe(d):
+        return None  # would collect -- decline
+    if isinstance(d, Frame):
+        return d.height
+    h = getattr(d, "height", None)
+    return int(h) if isinstance(h, int) else None
+
+
 def _candidate_count_gate() -> int:
     """Max blocks for which the candidate-count loop runs. Default 10,000.
 
@@ -2336,7 +2372,15 @@ def score_blocks_parallel(
     # to serve a diagnostic would be the wrong trade.
     _CANDIDATE_COUNT_SKIP_THRESHOLD = _candidate_count_gate()
     _n_blocks_for_count_gate = len(blocks)
-    if _n_blocks_for_count_gate <= _CANDIDATE_COUNT_SKIP_THRESHOLD:
+    # Count when it is FREE, whatever the block count. `cheap_n_rows` declines
+    # only for blocks that would have to collect, so this pays nothing and
+    # rescues the common case: above the gate the profile used to report
+    # `candidates_compared=0` even when every count was an attribute read.
+    _free = [cheap_n_rows(b) for b in blocks]
+    if blocks and all(n is not None for n in _free):
+        total_candidates = sum(n * (n - 1) // 2 for n in _free)  # type: ignore[operator]
+        _candidates_counted = True
+    elif _n_blocks_for_count_gate <= _CANDIDATE_COUNT_SKIP_THRESHOLD:
         total_candidates = 0
         _candidates_counted = True
         for block in blocks:

--- a/packages/python/goldenmatch/tests/test_cheap_candidate_count.py
+++ b/packages/python/goldenmatch/tests/test_cheap_candidate_count.py
@@ -1,0 +1,137 @@
+"""Count candidate pairs when it is FREE, instead of skipping on block count.
+
+`score_blocks_parallel` skips its candidate-count loop above
+`GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS` blocks (default 10,000), because
+`Block.n_rows()` calls `materialize()` and doing that serially for tens of
+thousands of blocks is real time. That gate is right for LAZY blocks. It is
+pure loss for the rest:
+
+  * `RowIdBlock.n_rows()` is `len(self._ids)` -- an array length;
+  * `Block.materialize()` RETURNS IMMEDIATELY when `df` is already a `Frame`,
+    and only `.collect()`s a polars LazyFrame.
+
+So above the gate the profile reported `candidates_compared=0` /
+`candidates_counted=False` even when the number was one attribute read away.
+That is what made #2639's two consumers unusable at scale and forced the
+diagnostic in #2646 to buy the count back with a deliberate serial pass.
+
+The rule here is "count when free, never pay to count": if every block can be
+measured without materialising, the total is real and `candidates_counted` is
+True regardless of how many blocks there are. If ANY block would have to
+collect, behaviour falls back to exactly the existing gate -- so the lazy path
+this protects is untouched.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.blocker import BlockResult as Block
+from goldenmatch.core.matchkey import _xform_sig
+from goldenmatch.core.profile_emitter import profile_capture
+from goldenmatch.core.scorer import cheap_n_rows, score_blocks_parallel
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="t", type="weighted", threshold=0.7,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+
+
+def _block(key: str, names: list[str], start_id: int) -> Block:
+    col = _xform_sig(MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0))
+    return Block(block_key=key, df=pl.DataFrame({
+        "__row_id__": list(range(start_id, start_id + len(names))),
+        "name": names,
+        col: names,
+    }))
+
+
+def test_cheap_n_rows_reads_an_eager_block_for_free():
+    assert cheap_n_rows(_block("a", ["alice", "alica"], 0)) == 2
+
+
+def test_cheap_n_rows_declines_a_lazy_block():
+    """A LazyFrame would have to `.collect()`. Declining is the whole point:
+    this must never be the thing that makes scoring slower."""
+    lazy = Block(block_key="a", df=pl.DataFrame({"__row_id__": [0, 1]}).lazy())
+    assert cheap_n_rows(lazy) is None
+
+
+def test_cheap_n_rows_reads_a_row_id_block_for_free():
+    """`RowIdBlock` carries an int array and no frame at all."""
+    from goldenmatch.core.blocker import RowIdBlock
+
+    blk = RowIdBlock(block_key="a", ids=[1, 2, 3], blocking_fields=("name",))
+    assert cheap_n_rows(blk) == 3
+
+
+def test_count_survives_the_gate_when_every_block_is_free(monkeypatch):
+    """The live gap. With the gate set to 1, two blocks are 'too many' and the
+    old code reported nothing -- yet both counts are attribute reads."""
+    monkeypatch.setenv("GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS", "1")
+    blocks = [
+        _block("a", ["alice", "alica", "alise"], 0),
+        _block("b", ["robert", "robbert", "roberto"], 100),
+        _block("c", ["carol", "caroll", "carola"], 200),
+    ]
+    with profile_capture() as emitter:
+        score_blocks_parallel(blocks, _mk(), set(), max_workers=2)
+
+    sp = emitter.scoring
+    assert sp.candidates_counted is True, "both blocks were free to measure"
+    assert sp.route == "scorer.parallel"
+    # 3 rows per block -> 3 within-block pairs each.
+    assert sp.candidates_compared == 9
+
+
+def test_gate_still_applies_when_a_block_would_collect(monkeypatch):
+    """The protection this must not remove: one lazy block among many, past the
+    gate, and the count is skipped exactly as before rather than paying for a
+    collect nobody asked for."""
+    monkeypatch.setenv("GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS", "1")
+    col = _xform_sig(MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0))
+    lazy = Block(block_key="lazy", df=pl.DataFrame({
+        "__row_id__": [200, 201], "name": ["zed", "zedd"], col: ["zed", "zedd"],
+    }).lazy())
+    # THREE blocks, not two: `score_blocks_parallel` short-circuits to a
+    # sequential path at `len(blocks) <= 2` which counts unconditionally, so a
+    # two-block fixture never reaches the gate this test is about. The route
+    # field caught that -- the first version came back `scorer.small`.
+    blocks = [_block("a", ["alice", "alica"], 0),
+              _block("b", ["bob", "bobb"], 50), lazy]
+
+    with profile_capture() as emitter:
+        score_blocks_parallel(blocks, _mk(), set(), max_workers=2)
+
+    assert emitter.scoring.route == "scorer.parallel"
+    assert emitter.scoring.candidates_counted is False
+    assert emitter.scoring.candidates_compared == 0
+
+
+def test_counting_does_not_change_the_pairs(monkeypatch):
+    """Counting is measurement. It must not move a pair."""
+    blocks = lambda: [_block("a", ["alice", "alica", "alise"], 0)]  # noqa: E731
+    monkeypatch.setenv("GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS", "0")
+    off = score_blocks_parallel(blocks(), _mk(), set(), max_workers=2)
+    monkeypatch.setenv("GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS", "1000000")
+    on = score_blocks_parallel(blocks(), _mk(), set(), max_workers=2)
+
+    key = lambda ps: sorted((min(a, b), max(a, b), round(s, 6)) for a, b, s in ps)  # noqa: E731
+    assert key(off) == key(on)
+
+
+@pytest.mark.parametrize("n_blocks", [3, 5, 8])
+def test_counted_total_matches_the_closed_form(monkeypatch, n_blocks):
+    """`candidates_compared` must be the real within-block pair total, not an
+    approximation: 3 rows per block is 3 pairs, so n blocks is 3n."""
+    monkeypatch.setenv("GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS", "1")
+    blocks = [
+        _block(f"k{i}", ["alice", "alica", "alise"], i * 100)
+        for i in range(n_blocks)
+    ]
+    with profile_capture() as emitter:
+        score_blocks_parallel(blocks, _mk(), set(), max_workers=2)
+
+    assert emitter.scoring.candidates_compared == 3 * n_blocks


### PR DESCRIPTION
Closes the follow-up deferred in #2644 and #2646: production gets a real `candidates_compared`, not just diagnostics.

## The gate was right for one block shape and wrong for the rest

`score_blocks_parallel` skips its candidate-count loop above `GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS` (default 10,000) because `Block.n_rows()` goes through `materialize()`. That cost is real — for **lazy** blocks:

| shape | cost of the count |
|---|---|
| `RowIdBlock` | `len(_ids)` — an array length |
| `Block.df` already a `Frame` / eager native frame | `.height` — `materialize()` returns it unchanged |
| `Block.df` a polars LazyFrame | `.collect()` — **the only expensive case** |

So above the gate the profile reported `candidates_compared=0` with `candidates_counted=False` even when every count was one attribute read away. That is what left #2639's two consumers inert at scale, and what forced #2646's diagnostic to buy the number back with a deliberate serial pass over 84,293 blocks.

## The rule: count when free, never pay to count

`cheap_n_rows()` returns a real count for the free shapes and `None` for the one that would collect.

- **every block free** → the total is real and `candidates_counted=True`, whatever the block count;
- **any block would collect** → falls back to exactly the existing gate.

Production gets a genuine count at fine-grained blocking; the lazy path the gate exists to protect is untouched; nothing ever pays to count.

## Three of the nine tests are about not fooling myself

- **counting must not move a pair** — it is measurement, not behaviour;
- **the gate must STILL apply** when a lazy block is present. A change that quietly removed that protection would sail through a naive "is it counted now?" check;
- **the fixtures assert `route == "scorer.parallel"`.** The first version used two blocks and came back `scorer.small` — `score_blocks_parallel` short-circuits at `len(blocks) <= 2` to a path that always counted, so the test never reached the gate it was written for. The route field from #2649 caught it before it could pass for the wrong reason.

1,928 pass across the affected surface. The 4 remaining local failures reproduce identically on clean main — env skew, verified by stashing.