### PR TITLE
feat(spark): measure shuffle BYTES, the topology-independent multi-node proxy

### DIFF
--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -618,6 +618,19 @@ jobs:
                 echo '|---|---:|---:|'
                 jq -r '"| goldenmatch | \(.actual_rows) | \(.total_seconds)s |"' spark-fs-train-scale.json
                 jq -r '"| splink | \(.actual_rows) | \(.total_seconds)s |"' splink-train-scale.json
+                echo ''
+                echo '### Shuffle bytes (topology-independent)'
+                echo ''
+                echo 'Network cost on ANY cluster is a function of what crosses the exchange, so this transfers to a real multi-node topology while a wall measured on one host does not.'
+                echo ''
+                echo '| engine | shuffle write | shuffle read | stages |'
+                echo '|---|---:|---:|---:|'
+                jq -r '"| goldenmatch | \(.shuffle.shuffle_write_bytes // "n/a") | \(.shuffle.shuffle_read_bytes // "n/a") | \(.shuffle.n_stages // "n/a") |"' spark-fs-train-scale.json
+                jq -r '"| splink | \(.shuffle.shuffle_write_bytes // "n/a") | \(.shuffle.shuffle_read_bytes // "n/a") | \(.shuffle.n_stages // "n/a") |"' splink-train-scale.json
+                for f in spark-fs-train-scale.json splink-train-scale.json; do
+                  ERR=$(jq -r '.shuffle.error // .shuffle.note // empty' "$f")
+                  if [ -n "$ERR" ]; then echo ''; echo "> \`$f\`: $ERR"; fi
+                done
                 CONFOUND=$(jq -r '.session_confound // empty' splink-train-scale.json)
                 if [ -n "$CONFOUND" ]; then
                   echo ''

--- a/docker/spark-cluster/docker-compose.yml
+++ b/docker/spark-cluster/docker-compose.yml
@@ -127,6 +127,11 @@ services:
     depends_on: [spark-master]
     ports:
       - "15002:15002"
+      # The Connect server IS the driver, so its Spark UI carries the stage
+      # metrics for every GM query. Mapped to 4041 because Splink's classic
+      # driver runs on the HOST and binds 4040 itself -- a clash there would be
+      # silent and the two engines' numbers would swap.
+      - "4041:4040"
     # `addArtifact` is Connect-only, so the whole tier requires this server --
     # it is not an alternative front end, it is the only door.
     #

--- a/scripts/_spark_shuffle_metrics.py
+++ b/scripts/_spark_shuffle_metrics.py
@@ -1,0 +1,113 @@
+"""Shuffle BYTES per stage, from Spark's REST API.
+
+## Why bytes and not seconds
+
+The open question on the Spark tier is whether GoldenMatch's advantage survives
+a real multi-node cluster. The rig cannot answer it: both workers are containers
+on ONE host, so a shuffle never crosses a network, and a wall measured there
+says nothing about one that does.
+
+Bytes do transfer. Network cost on ANY topology is a function of what crosses
+the exchange, so measuring that answers the question without needing the
+network -- and without the overlay-network hack, whose own DERP relay fallback
+would make a latency measurement meaningless in a way the output would not show.
+
+The prediction this tests: GoldenMatch's counting stage is a `GROUP BY` over
+agreement patterns whose output is bounded by `prod(levels + 1)`, and Spark
+combines map-side, so what crosses should be ~`partitions x distinct patterns`
+regardless of pair count -- kilobytes. Splink re-scans pairs per EM iteration,
+so its shuffle should scale with pairs and repeat ~26 times. If that holds, the
+advantage widens with cluster size rather than narrowing, and the claim needs no
+multi-node wall to stand.
+
+## Why the parsing is a separate function
+
+`summarize()` takes the decoded `/stages` payload and is unit-testable; only
+`fetch()` touches the network. A metric that silently reports zero because a
+field was renamed is the failure mode here, so `summarize` distinguishes "no
+shuffle" from "no stages" and says which.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def summarize(stages: list[dict[str, Any]], top_n: int = 5) -> dict[str, Any]:
+    """Totals plus the heaviest stages, from a Spark `/stages` payload.
+
+    `stages` is the decoded list. Keys are Spark's own
+    (`shuffleWriteBytes` / `shuffleReadBytes`); a payload missing BOTH on every
+    stage yields `fields_present: False` rather than a confident zero, because a
+    renamed field and a genuinely shuffle-free job are not the same finding.
+    """
+    if not stages:
+        return {"n_stages": 0, "fields_present": False,
+                "shuffle_write_bytes": None, "shuffle_read_bytes": None,
+                "top_stages": [],
+                "note": "no stages returned -- wrong app id, or the UI was gone"}
+
+    seen_field = False
+    rows = []
+    for st in stages:
+        w = st.get("shuffleWriteBytes")
+        r = st.get("shuffleReadBytes")
+        if w is not None or r is not None:
+            seen_field = True
+        rows.append({
+            "stage_id": st.get("stageId"),
+            "name": (st.get("name") or "")[:80],
+            "write_bytes": int(w or 0),
+            "read_bytes": int(r or 0),
+            "num_tasks": st.get("numTasks"),
+        })
+
+    if not seen_field:
+        return {"n_stages": len(stages), "fields_present": False,
+                "shuffle_write_bytes": None, "shuffle_read_bytes": None,
+                "top_stages": [],
+                "note": ("no stage carried shuffleWriteBytes/shuffleReadBytes -- "
+                         "the field names moved; do NOT read this as zero shuffle")}
+
+    rows.sort(key=lambda r: r["write_bytes"] + r["read_bytes"], reverse=True)
+    return {
+        "n_stages": len(stages),
+        "fields_present": True,
+        "shuffle_write_bytes": sum(r["write_bytes"] for r in rows),
+        "shuffle_read_bytes": sum(r["read_bytes"] for r in rows),
+        "top_stages": rows[:top_n],
+    }
+
+
+def fetch(base_url: str, timeout: float = 10.0) -> dict[str, Any]:
+    """Shuffle totals for the newest application at `base_url` (a Spark UI).
+
+    Never raises: this is instrumentation attached to a benchmark, and a
+    metrics endpoint that is down must not take the measurement with it. The
+    error is RECORDED so an absent number reads as "the probe failed", never as
+    "there was no shuffle".
+    """
+    def _get(path: str) -> Any:
+        with urllib.request.urlopen(f"{base_url}{path}", timeout=timeout) as fh:
+            return json.loads(fh.read().decode("utf-8"))
+
+    try:
+        apps = _get("/api/v1/applications")
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        return {"error": f"{type(e).__name__}: {str(e)[:160]}", "base_url": base_url}
+    if not apps:
+        return {"error": "no applications at this UI", "base_url": base_url}
+
+    app_id = apps[0].get("id")
+    try:
+        stages = _get(f"/api/v1/applications/{app_id}/stages")
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        return {"error": f"{type(e).__name__}: {str(e)[:160]}",
+                "base_url": base_url, "app_id": app_id}
+
+    out = summarize(stages)
+    out["app_id"] = app_id
+    out["base_url"] = base_url
+    return out

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -431,6 +431,23 @@ def _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
     )
 
 
+def _shuffle_module():
+    """The SHARED shuffle-metrics reader, imported by file path.
+
+    Same reasoning as the ranking metric: one implementation, so a difference
+    between the two engines' numbers is a difference between the ENGINES.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "_spark_shuffle_metrics.py"
+    spec = importlib.util.spec_from_file_location("_spark_shuffle_metrics", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _metrics_module():
     """The SHARED ranking metric, imported by file path.
 
@@ -508,6 +525,10 @@ def main() -> int:
                          "number means nothing without it: the bar is "
                          "match-or-better accuracy, not a faster arrival at a "
                          "worse model.")
+    ap.add_argument("--spark-ui", default="http://localhost:4041",
+                    help="Spark UI of the CONNECT driver (compose maps its 4040 "
+                         "to 4041, because Splink's classic driver binds 4040 on "
+                         "the host). Read for stage-level shuffle bytes.")
     ap.add_argument("--out", default="")
     args = ap.parse_args()
 
@@ -741,6 +762,18 @@ def main() -> int:
                   f"the other engine's.", flush=True)
         out["quality"] = q
         print(f"[scale] quality {out['quality']}", flush=True)
+
+    # Shuffle BYTES, the topology-independent half of the multi-node question.
+    # A wall measured on two containers sharing one host says nothing about a
+    # real cluster, because the exchange never crosses a network here. What
+    # crosses it does transfer: network cost on any topology is a function of
+    # bytes. The prediction under test is that GM's counting stage moves
+    # ~partitions x distinct patterns regardless of pair count, because the
+    # GROUP BY output is bounded by prod(levels + 1) and Spark combines
+    # map-side. Never fatal -- a metrics endpoint that is down must not take the
+    # measurement with it, so a failure is RECORDED rather than raised.
+    out["shuffle"] = _shuffle_module().fetch(args.spark_ui)
+    print(f"[scale] shuffle {out['shuffle']}", flush=True)
 
     out["total_seconds"] = round(sum(out["stages"].values()), 2)
 

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -116,6 +116,23 @@ def _fixture_module():
     return mod
 
 
+def _shuffle_module():
+    """The SHARED shuffle-metrics reader, imported by file path.
+
+    Same reasoning as the ranking metric: one implementation, so a difference
+    between the two engines' numbers is a difference between the ENGINES.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "_spark_shuffle_metrics.py"
+    spec = importlib.util.spec_from_file_location("_spark_shuffle_metrics", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _metrics_module():
     """The SHARED ranking metric, imported by file path.
 
@@ -244,6 +261,9 @@ def main() -> int:
                          "GM-vs-Splink accuracy verdict -- this fixture's "
                          "config was chosen to stress prod(levels+1) for a "
                          "scale test. See the bakeoff for accuracy.")
+    ap.add_argument("--spark-ui", default="http://localhost:4040",
+                    help="Spark UI of THIS classic driver (it runs on the host "
+                         "and binds 4040). Read for stage-level shuffle bytes.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -428,6 +448,12 @@ def main() -> int:
             [(float(r["w"]), bool(r["is_true"])) for r in rows_]
         )
         print(f"[splink] quality {out['quality']}", flush=True)
+
+    # Same instrument, same reasoning as the GM arm -- see there. Splink
+    # re-scans pairs once per EM iteration, so its exchange should scale with
+    # PAIRS and repeat ~26 times, against GM's bounded pattern output.
+    out["shuffle"] = _shuffle_module().fetch(args.spark_ui)
+    print(f"[splink] shuffle {out['shuffle']}", flush=True)
 
     out["stages"]["total_seconds"] = round(time.perf_counter() - t_all, 2)
     # `train_total` is the number to put beside GM's u + counts + train. The


### PR DESCRIPTION
Answers the multi-node question without needing a multi-node cluster.

## Why bytes, not seconds

The rig has both workers as containers on **one host**, so the exchange never crosses a network. A wall measured there says nothing about one that does — that limitation is recorded in the compose file, and it is why #2613 had to retract a *"~0% of the counts stage is the GROUP BY exchange"* reading.

Bytes transfer where seconds do not. Network cost on **any** topology is a function of what crosses the exchange, so measuring that answers the question without the network — and without the runners-on-an-overlay-network hack, whose DERP relay fallback would corrupt a latency measurement in a way the output would not show.

## The prediction it tests

GM's counting stage is a `GROUP BY` whose output is bounded by `prod(levels + 1)`, and Spark combines map-side, so what crosses should be ~`partitions × distinct patterns` — **kilobytes, whatever the pair count**. Splink re-scans pairs once per EM iteration, ~26 times.

If that holds, the advantage **widens** with cluster size, and the claim needs no multi-node wall to stand. If it doesn't, that's the more interesting result.

## Two failure modes handled explicitly

This produces a number someone will quote, so:

- **`summarize()` distinguishes "no shuffle" from "the field names moved."** A payload carrying neither `shuffleWriteBytes` nor `shuffleReadBytes` on any stage returns `None` with a note saying so — never a confident zero. Unit-checked against an empty payload, a renamed-field payload, and a real one.
- **`fetch()` never raises.** Instrumentation attached to a benchmark must not take the measurement down with it, so a dead endpoint is recorded as an error and reads as *"the probe failed"*, never *"there was no shuffle"*.

Both arms import the one implementation, so a difference between their numbers is a difference between the **engines**, not between two readers — same reasoning as the shared ranking metric.

## One detail worth checking in review

Compose maps the Connect driver's UI to host **4041**, not 4040. Splink's *classic* driver runs on the host and binds 4040 itself; that clash would be silent, and the two engines' numbers would simply swap.