### PR TITLE
chore(scoreboard): nightly adoption snapshot

### DIFF
--- a/context-network/planning/scoreboard.jsonl
+++ b/context-network/planning/scoreboard.jsonl
@@ -5,3 +5,4 @@
 {"date": "2026-08-14", "stars": 128, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 4949}
 {"date": "2026-08-15", "stars": 128, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": 136980, "npm_30d": 4949}
 {"date": "2026-08-16", "stars": 128, "forks": 14, "open_issues_nonmaintainer": 1, "pypi_30d": 139180, "npm_30d": 4374}
+{"date": "2026-08-17", "stars": 128, "forks": 14, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 4374}

--- a/context-network/planning/scoreboard.md
+++ b/context-network/planning/scoreboard.md
@@ -5,14 +5,14 @@
 [north-star-roadmap.md](./north-star-roadmap.md): *is GoldenMatch becoming the
 tool developers reach for by default?* Trend > snapshot.
 
-**Latest: 2026-08-16** (vs previous snapshot)
+**Latest: 2026-08-17** (vs previous snapshot)
 
 | Signal | Now | WoW | North Star reading |
 |---|---|---|---|
 | GitHub stars | 128 | 128 (▬0) | discovery momentum |
-| Forks | 14 | 14 (▲+1) | intent-to-use |
-| PyPI downloads (30d, suite) | 139.2k | 139.2k (▲+2200) | actual reach |
-| npm downloads (30d, suite) | 4.4k | 4.4k (▼-575) | actual reach (TS) |
+| Forks | 14 | 14 (▬0) | intent-to-use |
+| PyPI downloads (30d, suite) | — | — | actual reach |
+| npm downloads (30d, suite) | 4.4k | 4.4k (▬0) | actual reach (TS) |
 | Open issues, non-maintainer | 1 | 1 (▬0) | "someone reached for it"† |
 
 † Raw count — still needs human triage to exclude badge-marketing bots
@@ -23,6 +23,7 @@ GENUINE inbound issue from a stranger**; a bot filing a promo badge does not cou
 
 | Date | Stars | Forks | PyPI 30d | npm 30d | Ext. issues |
 |---|---|---|---|---|---|
+| 2026-08-17 | 128 | 14 | — | 4.4k | 1 |
 | 2026-08-16 | 128 | 14 | 139.2k | 4.4k | 1 |
 | 2026-08-15 | 128 | 13 | 137.0k | 4.9k | 1 |
 | 2026-08-14 | 128 | 13 | — | 4.9k | 1 |


### PR DESCRIPTION
Nightly North Star adoption snapshot: stars, forks, PyPI/npm 30-day
downloads and non-maintainer inbound issues, appended to the trend.

Generated by `scripts/scoreboard.py` via `.github/workflows/scoreboard.yml`.
The `.md` is rewritten wholesale from the `.jsonl` each run; the new
data is the single appended row.
