### PR TITLE
fix(bench): read the DBLP-ACM result frame on either lane (#2457)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,8 +1108,14 @@ jobs:
       # RUN the scripts/ unit tests and not merely lint them -- a test that CI
       # only ever lints is the "a check exists and does not fire" class.
       # Network-free: `_ensure_datasets` is stubbed, so nothing here fetches.
+      # dqbench_adapters: the DBLP-ACM adapter read `.height` on whatever
+      # `match_df` returned, which is polars-only, so the arrow lane took the
+      # weekly `benchmarks` run red for a week (#2457). That lane is not in
+      # ci-required and runs on a schedule, so nothing caught it at PR time.
       - name: Pytest (scripts/ unit tests)
-        run: uv run pytest scripts/test_run_benchmarks_download.py -q
+        run: |
+          uv run pytest scripts/test_run_benchmarks_download.py \
+                        scripts/dqbench_adapters/test_leipzig_eval.py -q
 
   # Every repo path a CLAUDE.md names must exist. These files are loaded as
   # authoritative agent context, so a dead pointer does not merely fail to help --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1112,10 +1112,16 @@ jobs:
       # `match_df` returned, which is polars-only, so the arrow lane took the
       # weekly `benchmarks` run red for a week (#2457). That lane is not in
       # ci-required and runs on a schedule, so nothing caught it at PR time.
+      # `--with polars pyarrow`: this job syncs with --no-install-workspace, so
+      # neither is present, and the leipzig test is ABOUT polars/arrow interop --
+      # it cannot be written to skip when they are missing without becoming the
+      # check that does not fire. Added ephemerally, same idiom as er_matcher's
+      # `uv run --with scikit-learn`.
       - name: Pytest (scripts/ unit tests)
         run: |
-          uv run pytest scripts/test_run_benchmarks_download.py \
-                        scripts/dqbench_adapters/test_leipzig_eval.py -q
+          uv run --with polars --with pyarrow \
+            pytest scripts/test_run_benchmarks_download.py \
+                   scripts/dqbench_adapters/test_leipzig_eval.py -q
 
   # Every repo path a CLAUDE.md names must exist. These files are loaded as
   # authoritative agent context, so a dead pointer does not merely fail to help --

--- a/scripts/dqbench_adapters/leipzig_eval.py
+++ b/scripts/dqbench_adapters/leipzig_eval.py
@@ -20,6 +20,29 @@ from pathlib import Path
 import polars as pl
 
 
+def _as_polars(frame):
+    """Normalise a result frame to polars, whichever lane produced it.
+
+    `match_df` returns a `pyarrow.Table` on the arrow lane and a
+    `pl.DataFrame` on the classic one. This module reads `.height` and
+    `.iter_rows(named=True)`, which are polars-only, so an arrow result
+    raised `AttributeError: 'pyarrow.lib.Table' object has no attribute
+    'height'` and took the whole scheduled `benchmarks` lane red (#2457).
+
+    Converted here rather than by importing `goldenmatch.core.frame`: this
+    module deliberately takes `match_df` / `dedupe_df` by injection so it
+    stays free of goldenmatch import cost, and reaching into the package for
+    a two-line coercion would undo that.
+    """
+    if frame is None:
+        return None
+    if hasattr(frame, "height"):  # already polars
+        return frame
+    if hasattr(frame, "num_rows"):  # pyarrow.Table
+        return pl.from_arrow(frame)
+    return frame
+
+
 @dataclass
 class LeipzigResult:
     found_pairs: int
@@ -123,7 +146,7 @@ def run_dblp_acm_zeroconfig(
     n_dblp = len(dblp_ids)
 
     found: set[tuple[str, str]] = set()
-    matched = getattr(result, "matched", None)
+    matched = _as_polars(getattr(result, "matched", None))
     if matched is not None and matched.height > 0:
         # match_df stamps target_row_id (from the first arg) and
         # ref_row_id (from the second arg). They're positional indices

--- a/scripts/dqbench_adapters/test_leipzig_eval.py
+++ b/scripts/dqbench_adapters/test_leipzig_eval.py
@@ -1,0 +1,97 @@
+"""#2457: the DBLP-ACM adapter must read whichever frame type the lane returns.
+
+`match_df` returns a `pyarrow.Table` on the arrow lane and a `pl.DataFrame` on
+the classic one. This adapter reads `.height` and `.iter_rows(named=True)`,
+which are polars-only, so an arrow result raised
+
+    AttributeError: 'pyarrow.lib.Table' object has no attribute 'height'
+
+and took the whole scheduled `benchmarks` lane red. Nothing gated it: the lane
+is weekly, is not in `ci-required`, and no test exercised the adapter with an
+arrow frame.
+
+The load-bearing assertion is that both lanes produce the SAME score. A test
+that only checked "arrow input does not raise" would pass on an adapter that
+silently found zero pairs, which is the failure this benchmark exists to
+detect.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from leipzig_eval import _as_polars, run_dblp_acm_zeroconfig  # noqa: E402
+
+
+class _Result:
+    """Minimal stand-in for what `match_df` returns."""
+
+    def __init__(self, matched):
+        self.matched = matched
+
+
+_PAIRS = {"__target_row_id__": [0, 1], "__ref_row_id__": [2, 3]}
+
+
+def _corpus(tmp_path: Path) -> Path:
+    """The three CSVs the adapter needs, with a mapping it can score against."""
+    d = tmp_path / "DBLP-ACM"
+    d.mkdir(parents=True)
+    pl.DataFrame({"id": ["conf/vldb/a", "conf/vldb/b"],
+                  "title": ["alpha", "beta"]}).write_csv(d / "DBLP2.csv")
+    pl.DataFrame({"id": ["100", "200"],
+                  "title": ["alpha", "beta"]}).write_csv(d / "ACM.csv")
+    pl.DataFrame({"idDBLP": ["conf/vldb/a", "conf/vldb/b"],
+                  "idACM": ["100", "200"]}).write_csv(
+        d / "DBLP-ACM_perfectMapping.csv")
+    return tmp_path
+
+
+# ── the coercion itself ───────────────────────────────────────────────────
+
+def test_arrow_table_becomes_polars():
+    out = _as_polars(pa.table(_PAIRS))
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 2
+
+
+def test_polars_passes_through_unchanged():
+    df = pl.DataFrame(_PAIRS)
+    assert _as_polars(df) is df
+
+
+def test_none_stays_none():
+    assert _as_polars(None) is None
+
+
+# ── the adapter reads both lanes identically ──────────────────────────────
+
+@pytest.mark.parametrize("wrap", [pl.DataFrame, pa.table], ids=["polars", "arrow"])
+def test_adapter_scores_both_frame_types(tmp_path, wrap):
+    """Arrow was an AttributeError before; both must now score the same."""
+    root = _corpus(tmp_path)
+    res = run_dblp_acm_zeroconfig(root, lambda a, b: _Result(wrap(_PAIRS)))
+    assert res is not None
+    assert res.ground_truth_pairs == 2
+    assert res.found_pairs == 2
+    assert res.f1 == pytest.approx(1.0)
+
+
+def test_both_lanes_agree_exactly(tmp_path):
+    """The regression this pins: a silently-empty arrow read would still
+    return a LeipzigResult, just with f1=0. Compare the two directly."""
+    root = _corpus(tmp_path)
+    a = run_dblp_acm_zeroconfig(root, lambda x, y: _Result(pl.DataFrame(_PAIRS)))
+    b = run_dblp_acm_zeroconfig(root, lambda x, y: _Result(pa.table(_PAIRS)))
+    assert a == b
+
+
+def test_absent_corpus_returns_none(tmp_path):
+    """The lane's legitimate skip path must keep working."""
+    assert run_dblp_acm_zeroconfig(tmp_path, lambda x, y: _Result(None)) is None


### PR DESCRIPTION
Fixes the live red on `main` tracked by #2457.

## What and why

The weekly `benchmarks` run ([#98](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32001068678), 2026-08-17) dies in the DBLP-ACM adapter:

```
leipzig_eval.py:127  if matched is not None and matched.height > 0:
AttributeError: 'pyarrow.lib.Table' object has no attribute 'height'
```

`match_df` returns a `pyarrow.Table` on the arrow lane and a `pl.DataFrame` on the classic one; `.height` and `.iter_rows(named=True)` are polars-only.

This is the **third distinct instance** of the same class on this one lane, after #2250 and #2461: a polars-native subsystem sitting behind an Arrow-shaped entry point.

Note this supersedes the previous triage on #2457, which concluded no code change was needed because the red run predated its own fix. That was true of the *earlier* failure; run #98 post-dates #2461 and is a different bug.

## Scope

- Coerced **locally** rather than by importing `goldenmatch.core.frame`. This module deliberately takes `match_df` / `dedupe_df` by **injection** so it stays free of goldenmatch import cost, and reaching into the package for a two-line coercion would undo that. Documented in the helper.
- `run_two_source_dedupe_zeroconfig` reads `ded.clusters`, a plain dict, so it is frame-agnostic and unaffected. Checked rather than assumed.
- `ncvr.py:161` uses `.height` on a polars frame it builds itself. Not a bug.

## The test is wired into CI, not just added

`scripts_lint` is gated exactly on `scripts/**` and its own existing comment says that is the right place to run the scripts tests *"and not merely lint them, a test that CI only ever lints is the 'a check exists and does not fire' class."* It was running one file. The weekly `benchmarks` lane is **not** in `ci-required`, so without this the fix would have no PR-time gate and the next instance of this class would again be found by a scheduled red a week later.

**The load-bearing assertion is that both lanes score identically**, not that arrow stops raising. An adapter that silently read zero pairs would still return a `LeipzigResult`, just with `f1=0`, which is exactly the failure this benchmark exists to detect.

## Changes

- `scripts/dqbench_adapters/leipzig_eval.py`: `_as_polars()` coercion at the one result-frame read.
- `scripts/dqbench_adapters/test_leipzig_eval.py`: 7 tests.
- `.github/workflows/ci.yml`: `scripts_lint` runs the new file.

## Testing

- 7 new tests pass; both adapter test files together: **22 passed**.
- **Verified failing-before**: reverting the one-line coercion reproduces the exact CI error, `AttributeError: 'pyarrow.lib.Table' object has no attribute 'height'`, on 2 of the 7.
- `python scripts/check_workflow_yaml.py` passes (127 files, no duplicate keys).
- `ruff check scripts/` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, benchmark harness only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (rationale is in the code + this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_