### PR TITLE
ci(suggest-quality): fetch DBLP-ACM so the gate can actually score it

### DIFF
--- a/.github/workflows/bench-suggest-quality.yml
+++ b/.github/workflows/bench-suggest-quality.yml
@@ -110,6 +110,21 @@ jobs:
           print("OK: suggest_config present in native ext")
           PY
 
+      # The real datasets live under a gitignored path, so CI has never had
+      # them and `dblp_acm` has always reported `skipped: dblp_acm (absent)`.
+      # That is why it cannot be blessed: blessing a dataset CI cannot load
+      # turns a legitimate skip into a permanent MISSING failure (#2566 tried,
+      # the gate caught it, it was reverted). The gate is right; the data was
+      # the missing piece. See #2635.
+      #
+      # Deliberately NOT fatal: the fetcher exits 0 whether or not the download
+      # worked, so a Leipzig outage degrades to exactly today's behaviour rather
+      # than reddening a quality gate on someone else's downtime. Once a dataset
+      # is blessed, its absence becomes a MISSING failure in the gate itself,
+      # which is the right place for that to be enforced.
+      - name: Fetch skip-when-absent datasets (best-effort)
+        run: uv run python -m scripts.suggest_quality.fetch_datasets
+
       - name: Run suggest_quality ${{ inputs.mode || 'gate' }}
         env:
           GOLDENMATCH_SUGGEST_FULL_DIST: ${{ (startsWith(inputs.mode, 'gym') || inputs.mode == 'bakeoff') && '1' || '0' }}

--- a/scripts/suggest_quality/fetch_datasets.py
+++ b/scripts/suggest_quality/fetch_datasets.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fetch the skip-when-absent datasets this gate can score, for CI.
+
+## Why this exists
+
+`scripts/suggest_quality/datasets.py` loads real datasets from
+`packages/python/goldenmatch/tests/benchmarks/datasets`, which is gitignored.
+On a developer's machine they are usually there; in CI they never are. So
+`dblp_acm` has always reported `skipped: dblp_acm (absent)` and **cannot be
+blessed in `scorecard.json`**: blessing a dataset CI cannot load converts a
+legitimate skip into a permanent MISSING failure on every run (attempted in
+#2566, caught by the gate, reverted).
+
+The gate is right to refuse, and softening it would be the wrong fix. The
+missing piece is the data, so this fetches it.
+
+Note the trap #2635 records: a pre-bless run on a laptop cannot warn about
+this, because locally the dataset IS present. Local reported 2 skipped where
+CI reported 3. A gate can only warn about what it can see.
+
+## What it does NOT do
+
+It does not fail the build. A Leipzig outage degrades to exactly today's
+behaviour (the dataset is absent, the gate skips it) rather than reddening a
+quality gate on someone else's downtime. Once a dataset is blessed, its
+absence becomes a MISSING failure *in the gate*, which is the right place for
+that decision to be enforced.
+
+It reuses `run_benchmarks._fetch_dblp_acm` rather than reimplementing the
+fetch, so the URL, its `GOLDENMATCH_DBLP_ACM_URL` override, the retry policy
+and the zip-flattening quirk stay in one place.
+
+Usage:
+    python -m scripts.suggest_quality.fetch_datasets
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.run_benchmarks import _fetch_dblp_acm  # noqa: E402
+from scripts.suggest_quality.datasets import _DATASETS_ROOT, REGISTRY  # noqa: E402
+
+# name -> fetcher. Only datasets with a redistributable, stable public source
+# belong here; `febrl3` comes from the `recordlinkage` package and `ncvr_real`
+# has no public URL, so both stay legitimately skip-when-absent.
+_FETCHERS = {
+    "dblp_acm": _fetch_dblp_acm,
+}
+
+
+def main() -> int:
+    _DATASETS_ROOT.mkdir(parents=True, exist_ok=True)
+    print(f"datasets root: {_DATASETS_ROOT}")
+
+    for name, fetch in _FETCHERS.items():
+        try:
+            ok = fetch(_DATASETS_ROOT)
+        except Exception as exc:  # noqa: BLE001 - best-effort by design
+            print(f"  {name}: fetch raised ({type(exc).__name__}: {exc})")
+            ok = False
+        print(f"  {name}: {'fetched' if ok else 'NOT fetched (gate will skip it)'}")
+
+    # Report what the gate will actually see, which is the thing that matters
+    # and is not the same question as "did the download return 200".
+    print("\nloadable by the gate:")
+    for d in REGISTRY:
+        try:
+            loaded = d.loader()
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {d.name:22s} ERROR {type(exc).__name__}: {str(exc)[:60]}")
+            continue
+        if loaded is None:
+            print(f"  {d.name:22s} absent")
+        else:
+            df, gt = loaded
+            print(f"  {d.name:22s} present  rows={df.height} gt_pairs={len(gt)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The prerequisite half of #2635.

## What and why

`scripts/suggest_quality/datasets.py` reads real datasets from `packages/python/goldenmatch/tests/benchmarks/datasets`, which is **gitignored**. CI has therefore never had them, and `dblp_acm` has always reported:

```
skipped: dblp_acm (absent)
```

That is precisely why it cannot be blessed. Blessing a dataset CI cannot load turns a legitimate skip into a **permanent MISSING failure** on every run. #2566 attempted it, the gate caught it, and the bless was reverted in the same PR.

**The gate was right and must not be softened.** Its docstring calls a blessed-but-absent dataset *"a regression that hides as 'it didn't run'"*, which is the check-exists-but-does-not-fire protection this repo keeps needing. The data was the missing piece, so this fetches it.

## Design

- **Reuses `run_benchmarks._fetch_dblp_acm`** rather than reimplementing the download, so the URL, its `GOLDENMATCH_DBLP_ACM_URL` override, the retry policy and the zip-flattening quirk stay in one place. Target path comes from `datasets._DATASETS_ROOT` for the same reason.
- **Deliberately not fatal.** The fetcher exits 0 whether or not the download succeeded, so a Leipzig outage degrades to exactly today's behaviour rather than reddening a quality gate on someone else's downtime. Once a dataset *is* blessed, its absence becomes a MISSING failure in the gate itself, which is the right place to enforce that.
- **Reports what the gate will actually see**, which is a different question from "did the download return 200" and is the one that decides whether a dataset can be blessed.
- Only `dblp_acm` is wired. `febrl3` comes from the `recordlinkage` package and `ncvr_real` has no public URL, so both stay legitimately skip-when-absent.

## Not blessing here, deliberately

Blessing needs a number from a CI run that **loaded** the data, and no such run exists yet. Blessing on a locally-measured value would recreate exactly the failure #2566 hit — and #2635 records the trap that makes it easy: a pre-bless run on a laptop cannot warn about this, because locally the dataset *is* present (local reported 2 skipped where CI reported 3).

Sequence: land this → confirm a real run loads it → bless as a follow-up.

## Changes

- `scripts/suggest_quality/fetch_datasets.py` (new).
- `.github/workflows/bench-suggest-quality.yml`: best-effort fetch step before the gate run.

## Testing

Verified locally, both paths:

```
# clean state
dblp_acm: fetched
dblp_acm               present  rows=4910 gt_pairs=2224

# dead URL (GOLDENMATCH_DBLP_ACM_URL=https://example.invalid/nope.zip)
dblp_acm: NOT fetched (gate will skip it)
EXIT=0            # other datasets unaffected
```

- `python scripts/check_workflow_yaml.py` passes (127 files, no duplicate keys).
- `ruff check scripts/suggest_quality/` clean.
- Confirmed the fetched CSVs are gitignored (`packages/python/goldenmatch/.gitignore:17`), so no dataset is committed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a — CI wiring; both paths exercised by hand)
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, no library change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (rationale in the script docstring + workflow comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_