### PR TITLE
ci(benchmarks): run nightly instead of weekly

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,16 +3,31 @@ name: benchmarks
 # Real-benchmark runs (DBLP-ACM, Febrl3, NCVR, DQbench).
 # Datasets are gitignored — they're large and (DQbench) license-restricted.
 # This workflow runs:
-#   - On schedule (Mondays 06:00 UTC) so trend data accrues over time.
+#   - On schedule (nightly, 06:47 UTC) so trend data accrues over time.
 #   - On workflow_dispatch so a release PR can trigger a fresh measurement.
 # The synthetic-fixture smoke (committed fixtures) lives in ci.yml's
 # synthetic_benchmarks job and runs on every PR.
 
 on:
   schedule:
-    # Mondays 06:00 UTC — early enough that results are ready when the
-    # week starts; weekly cadence avoids burning CI minutes on noise.
-    - cron: "0 6 * * 1"
+    # Nightly, 06:47 UTC. This was weekly, and the weekly cadence was the
+    # problem rather than the saving: `main-health` clears a red row only on
+    # the next AUTOMATIC run (a workflow_dispatch is deliberately excluded,
+    # since a narrower dispatch can pass and mask a real red). So a lane
+    # failure held the main-health issue open for up to seven days AFTER its
+    # fix had landed, twice in a row -- #2461 fixed run #95 and #2659 fixed
+    # run #98, and both times the signal could not clear.
+    #
+    # The cost argument for weekly does not survive contact: the job is a
+    # ~7-minute single runner, so nightly is ~45 min/month of CI. A stale red
+    # that trains people to ignore main-health is far more expensive. Same
+    # move #2557 already made for the North Star scoreboard, for the same
+    # reason.
+    #
+    # 06:47 rather than 06:00: `spark-cluster.yml` already holds 06:00, and
+    # this repo otherwise favours off-the-hour minutes (13/17/23/33/37/43/53)
+    # to dodge the top-of-hour scheduler congestion that delays GitHub crons.
+    - cron: "47 6 * * *"
   workflow_dispatch:
     inputs:
       datasets:


### PR DESCRIPTION
## What and why

`main-health` clears a red row only on the next **automatic** run — a `workflow_dispatch` is deliberately excluded, since a narrower dispatch can pass and mask a real red. With a weekly cron, that means a lane failure holds the main-health issue open for **up to seven days after its fix has landed**.

That has now happened twice in a row on this exact lane:

| | failing run | fix | signal could clear |
|---|---|---|---|
| 1 | #95 (2026-08-10) | #2461, same day | next Monday |
| 2 | #98 (2026-08-17 03:05) | #2659 (2026-08-17 22:47) | next Monday |

The second time it also made a stale issue look like a live red — which is the failure mode that trains people to stop reading main-health at all.

**The cost argument for weekly does not survive contact.** The job is a ~7-minute single runner, so nightly is roughly **45 min/month** of CI against a signal that currently lags reality by up to a week. #2557 already made the same move on the North Star scoreboard, for the same reason.

## Why 06:47 and not 06:00

`spark-cluster.yml` already holds `0 6 * * *`, and this repo otherwise favours off-the-hour minutes (13/17/23/33/37/43/53) with explicit comments about dodging the top-of-hour scheduler congestion that delays GitHub crons. Landing a third job on 06:00 would work against a convention the repo already documents. Verified `47 6` is unused.

## Changes

- `.github/workflows/benchmarks.yml`: `0 6 * * 1` → `47 6 * * *`, with the rationale inline so the next person does not "optimise" it back to weekly.

## Testing

- `python scripts/check_workflow_yaml.py` passes (127 files, no duplicate keys).
- Parsed schedule confirmed as `[{'cron': '47 6 * * *'}]` rather than read off the diff.
- Checked no stale `06:00` / `Mondays` text was left behind in the header or comments.

## Note

This does not itself clear #2457. That still needs one automatic run to go green — which is now tomorrow rather than next Monday, and is the point of the change.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a, workflow schedule)
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a, CI cadence only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (rationale inline in the workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfNn3WiFCSJ8UXNsMwqM9)_