### PR TITLE
HELD: zero-config blocking rule fixes (regresses recall; needs a replacement plan)

### DIFF
--- a/.github/workflows/bench-blocking-ablation.yml
+++ b/.github/workflows/bench-blocking-ablation.yml
@@ -81,7 +81,7 @@ jobs:
             --out "out/ablation_${{ inputs.rows }}.json"
 
       - name: Upload results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
           name: blocking-ablation-${{ inputs.run_tag }}
           path: out/

--- a/.github/workflows/bench-blocking-ablation.yml
+++ b/.github/workflows/bench-blocking-ablation.yml
@@ -1,0 +1,88 @@
+# Which blocking passes earn their comparisons?
+#
+# auto-config's probabilistic plan for person@100K costs 121,391,850
+# comparisons, and four of its eight passes run 11-22x over the engine's own
+# pairs-per-row budget while carrying 99.7% of that work. Whether those passes
+# are worth it is a measurement, not a deduction -- dropping them is what
+# `rule_low_reduction_ratio` already did by accident on this shape, for pairwise
+# recall 0.4684.
+#
+# Runs WITH the native kernel on purpose: pure Python does not finish 121M
+# comparisons in 500 s, CI does the same work in ~27 s. A local arm would be
+# measuring the absence of the kernel.
+name: bench-blocking-ablation
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Fixture rows"
+        default: "100000"
+      dupe_rate:
+        description: "Duplicate rate"
+        default: "0.20"
+      shape:
+        description: "Fixture shape"
+        default: "person"
+      runner:
+        description: "Runner label"
+        default: "large-new-64GB"
+      run_tag:
+        description: "Artifact suffix"
+        default: "ablation"
+
+permissions:
+  contents: read
+
+env:
+  ARROW_DEFAULT_MEMORY_POOL: system
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"   # no cross-run config cache: every arm rebuilds
+
+jobs:
+  ablate:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (bucket + Arrow + FS kernels)
+        run: uv run python scripts/build_native.py
+
+      - name: Generate fixture
+        run: |
+          set -euo pipefail
+          mkdir -p fixtures out
+          uv run python scripts/bench_er_headtohead/generate_fixture.py \
+            --rows "${{ inputs.rows }}" \
+            --dupe-rate "${{ inputs.dupe_rate }}" \
+            --shape "${{ inputs.shape }}" \
+            --out "fixtures/ablate_${{ inputs.rows }}.parquet" \
+            --ground-truth "fixtures/ablate_${{ inputs.rows }}.truth.parquet"
+
+      - name: Ablate blocking passes
+        run: |
+          set -euo pipefail
+          uv run python scripts/bench_er_headtohead/ablate_blocking_passes.py \
+            --input "fixtures/ablate_${{ inputs.rows }}.parquet" \
+            --ground-truth "fixtures/ablate_${{ inputs.rows }}.truth.parquet" \
+            --out "out/ablation_${{ inputs.rows }}.json"
+
+      - name: Upload results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: blocking-ablation-${{ inputs.run_tag }}
+          path: out/
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,18 +447,26 @@ jobs:
             --ignore=packages/python/goldenmatch/tests/test_qis_harness.py \
             --ignore=packages/python/goldenmatch/tests/test_controller_adaptive_e2e.py \
             --ignore=packages/python/goldenmatch/tests/test_memory_e2e.py \
-            --ignore=packages/python/goldenmatch/tests/test_suggest_full_dist.py \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_applies_seeded_correction' \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_persists_stale_pairs_to_review_queue' \
-            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section'
-        # ^ test_suggest_full_dist is --ignored above and runs SERIALLY further
-        # down instead. It was OOM-killed under `-n auto`: PYTHONFAULTHANDLER=1
-        # produced NO dump, and faulthandler catches every fatal signal EXCEPT
-        # the uncatchable SIGKILL, so the kernel took it -- the same
-        # silent-'node down'-no-traceback signature the heavy-lane note below
-        # already documents. Root cause is understood; details and the
-        # ruled-out alternatives are in
-        # docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md.
+            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section' \
+            --deselect 'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
+        # ^ The last deselect: that test is OOM-killed under -n auto and runs
+        # SERIALLY further down instead (see the step below).
+        #
+        # DESELECT, NOT --ignore, and the distinction is load-bearing: --ignore
+        # drops the file from COLLECTION, which changes the durations pytest-split
+        # groups by and reshuffles every shard. Tried it -- shard 3 went 4,533 ->
+        # 5,088 tests and 410 of them died on a polars lazy-import recursion
+        # (polars-python py_modules.rs:19) that the previous grouping never hit.
+        # --deselect happens AFTER collection, so the groups stay byte-identical
+        # and only this one test is removed here.
+        #
+        # The OOM is established, not assumed: PYTHONFAULTHANDLER=1 produced NO
+        # dump, and faulthandler catches every fatal signal EXCEPT the uncatchable
+        # SIGKILL -- the same silent-'node down'-no-traceback signature the
+        # heavy-lane note below already documents. Details and ruled-out
+        # alternatives: docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
 
         # ^ Shard-isolation-fragile (same class as the already-ignored
         # test_memory_e2e.py): a test co-located in the shard clobbers a core
@@ -494,7 +502,8 @@ jobs:
         env:
           COVERAGE_FILE: coverage_shard${{ matrix.shard }}_serial.dat
         run: |
-          uv run pytest packages/python/goldenmatch/tests/test_suggest_full_dist.py \
+          uv run pytest \
+            'packages/python/goldenmatch/tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above' \
             --timeout=300 --timeout-method=thread \
             --cov=goldenmatch --cov-report=
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,34 @@ jobs:
             --ignore=packages/python/goldenmatch/tests/test_memory_e2e.py \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_applies_seeded_correction' \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_persists_stale_pairs_to_review_queue' \
-            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section'
+            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section'             --deselect 'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
+        # ^ The last deselect is a HARD WORKER CRASH, not an assertion:
+        # `worker 'gw0' crashed while running ...test_full_dist_on_lowers_to_high
+        # _side_valley_when_threshold_far_above`, with no OOM / SIGKILL / panic
+        # anywhere in the log. Same shard-isolation class as the trio above and
+        # re-exposed the same documented way: PR #2664 adds four test files, which
+        # reshuffles pytest-split groups and changes which tests share an xdist
+        # worker. Evidence it is co-tenancy and not the PR's logic:
+        #   * all three python shards were GREEN on #2664's parent PR #2657;
+        #   * it reproduces deterministically on #2664 (2 runs, 2 crashes) --
+        #     same files -> same split -> same co-tenancy;
+        #   * the PR's changes provably do NOT alter this test's inputs: the
+        #     committed config for the ncvr corpus is byte-identical on main and
+        #     on the branch (multi_pass, 2 passes, birth_year + zip_code,
+        #     max_block 5000), and the full-frame blocking measurement the branch
+        #     adds costs 5 ms / 4 MB on that 7,500-row frame;
+        #   * it passes locally standalone WITH the native kernel (34.5 s) and
+        #     alongside all four new files under `-n 2` (21 passed).
+        #
+        # WHAT THIS COSTS: the test is the only ACTIVE end-to-end assertion that
+        # the right-anchored dip fix survives the full marshaling path
+        # (diagnostic run -> Arrow batches -> native suggest_config -> Suggestion).
+        # It cannot move to python_goldenmatch_heavy instead: that lane syncs
+        # `--no-install-package goldenmatch-native`, so the test would SKIP there
+        # and the deselect would merely become invisible. Root cause is NOT
+        # understood and is tracked in
+        # docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md.
+        #
         # ^ Shard-isolation-fragile (same class as the already-ignored
         # test_memory_e2e.py): a test co-located in the shard clobbers a core
         # transform/scorer registration, so the memory-correction candidate pair

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,36 +447,19 @@ jobs:
             --ignore=packages/python/goldenmatch/tests/test_qis_harness.py \
             --ignore=packages/python/goldenmatch/tests/test_controller_adaptive_e2e.py \
             --ignore=packages/python/goldenmatch/tests/test_memory_e2e.py \
+            --ignore=packages/python/goldenmatch/tests/test_suggest_full_dist.py \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_applies_seeded_correction' \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_persists_stale_pairs_to_review_queue' \
-            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section'             --deselect 'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
-        # ^ The last deselect is a HARD WORKER CRASH, not an assertion:
-        # `worker 'gw0' crashed while running ...test_full_dist_on_lowers_to_high
-        # _side_valley_when_threshold_far_above`, with no OOM / SIGKILL / panic
-        # anywhere in the log. Same shard-isolation class as the trio above and
-        # re-exposed the same documented way: PR #2664 adds four test files, which
-        # reshuffles pytest-split groups and changes which tests share an xdist
-        # worker. Evidence it is co-tenancy and not the PR's logic:
-        #   * all three python shards were GREEN on #2664's parent PR #2657;
-        #   * it reproduces deterministically on #2664 (2 runs, 2 crashes) --
-        #     same files -> same split -> same co-tenancy;
-        #   * the PR's changes provably do NOT alter this test's inputs: the
-        #     committed config for the ncvr corpus is byte-identical on main and
-        #     on the branch (multi_pass, 2 passes, birth_year + zip_code,
-        #     max_block 5000), and the full-frame blocking measurement the branch
-        #     adds costs 5 ms / 4 MB on that 7,500-row frame;
-        #   * it passes locally standalone WITH the native kernel (34.5 s) and
-        #     alongside all four new files under `-n 2` (21 passed).
-        #
-        # WHAT THIS COSTS: the test is the only ACTIVE end-to-end assertion that
-        # the right-anchored dip fix survives the full marshaling path
-        # (diagnostic run -> Arrow batches -> native suggest_config -> Suggestion).
-        # It cannot move to python_goldenmatch_heavy instead: that lane syncs
-        # `--no-install-package goldenmatch-native`, so the test would SKIP there
-        # and the deselect would merely become invisible. Root cause is NOT
-        # understood and is tracked in
+            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section'
+        # ^ test_suggest_full_dist is --ignored above and runs SERIALLY further
+        # down instead. It was OOM-killed under `-n auto`: PYTHONFAULTHANDLER=1
+        # produced NO dump, and faulthandler catches every fatal signal EXCEPT
+        # the uncatchable SIGKILL, so the kernel took it -- the same
+        # silent-'node down'-no-traceback signature the heavy-lane note below
+        # already documents. Root cause is understood; details and the
+        # ruled-out alternatives are in
         # docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md.
-        #
+
         # ^ Shard-isolation-fragile (same class as the already-ignored
         # test_memory_e2e.py): a test co-located in the shard clobbers a core
         # transform/scorer registration, so the memory-correction candidate pair
@@ -492,10 +475,32 @@ jobs:
         # shard membership happened to separate them from the clobberer --
         # any new test file reshuffles pytest-split groups and re-exposes it
         # (bit W2a PR #1632). --ignore= takes filesystem paths and is fine.
+      # test_suggest_full_dist OOM-kills its xdist worker under `-n auto` --
+      # exactly the failure the heavy-lane note below describes ("silent 'node
+      # down', no traceback"). Confirmed rather than assumed: PYTHONFAULTHANDLER=1
+      # produced NO dump, and faulthandler catches every fatal signal EXCEPT the
+      # uncatchable SIGKILL, so the kernel OOM killer took it. It surfaced on
+      # PR #2664 because four new test files reshuffle pytest-split groups and
+      # changed which memory-heavy tests share a worker.
+      #
+      # It runs HERE rather than in python_goldenmatch_heavy because that lane
+      # syncs `--no-install-package goldenmatch-native` and this test skips
+      # without the native suggest_config kernel -- relocating it would convert
+      # an OOM into a silent skip. This job already built native, so the file
+      # just needs the full runner memory: serial (no `-n`), shard 1 only so it
+      # runs once instead of three times.
+      - name: pytest (serial + native, OOM-prone under -n auto)
+        if: matrix.shard == 1
+        env:
+          COVERAGE_FILE: coverage_shard${{ matrix.shard }}_serial.dat
+        run: |
+          uv run pytest packages/python/goldenmatch/tests/test_suggest_full_dist.py \
+            --timeout=300 --timeout-method=thread \
+            --cov=goldenmatch --cov-report=
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
           name: gm-cov-shard-${{ matrix.shard }}
-          path: coverage_shard${{ matrix.shard }}.dat
+          path: coverage_shard${{ matrix.shard }}*.dat
           retention-days: 1
           if-no-files-found: error
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2450,6 +2450,7 @@
             "_build_sorted_neighborhood_blocks",
             "_build_static_blocks",
             "_emit_blocking_profile",
+            "_fast_multi_pass_block_sizes",
             "_fast_static_block_sizes",
             "_memoized_transform",
             "_percentile",

--- a/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
+++ b/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
@@ -1,71 +1,71 @@
-# `test_suggest_full_dist` crashes its xdist worker after a shard reshuffle
+# `test_suggest_full_dist` was OOM-killed under `-n auto`
 
-**Status:** unresolved. Deselected in `python_goldenmatch` (parallel shards) so
-PR #2664 can land; the test still runs nowhere in CI.
+**Status: root-caused and fixed.** The file is `--ignore`d from the parallel
+`python_goldenmatch` shards and runs SERIALLY in the same job (shard 1 only),
+which keeps native available. No coverage is lost.
 
 ## Symptom
 
 ```
+[gw0] node down: Not properly terminated
 worker 'gw0' crashed while running
   'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
-FAILED ... - worker 'gw0' crashed while running ...
-===== 1 failed, 4449 passed, 83 skipped ... =====
 ```
 
-A hard worker death, not an assertion. No `out of memory`, `SIGKILL`,
-`SIGSEGV`, or Rust `panicked` string appears anywhere in the job log.
+A hard worker death with no assertion and no `out of memory` / `SIGKILL` /
+`SIGSEGV` / `panicked` string anywhere in the job log.
 
-## What is established
+## How it was identified
 
-* **Green before the reshuffle.** All three `python_goldenmatch` shards passed
-  on PR #2657, which merged.
-* **Deterministic after it.** Two runs on PR #2664 (heads `5225a158` and
-  `38086235`), two crashes, same test.
-* **Not caused by #2664's logic.** That PR changes auto-config blocking, so the
-  obvious theory is that it changed this test's inputs. It does not:
-  * the committed config for the ncvr corpus is byte-identical on `main` and on
-    the branch (`multi_pass`, 2 passes, `birth_year` + `zip_code`,
-    `max_block_size=5000`) -- checked by running
-    `scripts.suggest_quality.oracle._auto_configure_no_rerank` under both;
-  * the full-frame blocking measurement the branch adds costs **5 ms / 4 MB**
-    on that 7,500-row frame, and both passes vectorize (no exact fallback).
-* **Not reproducible off CI.** Passes standalone with the native kernel
-  (34.5 s), and passes alongside all four of #2664's new test files under
-  `-n 2` (21 passed). Local is Windows; CI is Linux.
+Re-enabled the test on a debug branch forked from PR #2664's head with
+`PYTHONFAULTHANDLER=1` and `PYTHONUNBUFFERED=1`. The env vars are confirmed set
+in the job log, the crash reproduced, and **faulthandler produced no dump at
+all**.
 
-The remaining difference is co-tenancy: #2664 adds four test files, and
-`ci.yml` already documents that "any new test file reshuffles pytest-split
-groups and re-exposes it (bit W2a PR #1632)" for the
-`test_memory_pipeline` / `test_memory_postflight` trio. This is the same class,
-except it manifests as a crash rather than a wrong value.
+faulthandler installs handlers for SIGSEGV, SIGABRT, SIGFPE, SIGBUS and SIGILL
+-- every fatal signal except **SIGKILL**, which is uncatchable by design. A
+fatal-signal death with faulthandler armed and silent therefore leaves SIGKILL
+as the only candidate, and SIGKILL arriving mid-test on a CI runner is the
+kernel OOM killer. The absence of a log message is explained by the same fact:
+the OOM killer writes to dmesg, not to the job's stdout.
 
-## Why it was deselected rather than moved
+`ci.yml` already documents this exact signature for the heavy lane: those files
+"OOM-kill xdist workers under `-n auto` + coverage on a 2-core runner (silent
+'node down', no traceback)".
 
-`python_goldenmatch_heavy` is where OOM-prone files go, but it syncs
-`--no-install-package goldenmatch-native` while the parallel shards **build**
+## Why it appeared on PR #2664
+
+That PR adds four test files. `ci.yml` notes that "any new test file reshuffles
+pytest-split groups" (bit W2a PR #1632) -- the reshuffle changed which
+memory-heavy tests share an xdist worker, and the new grouping exceeds the
+runner. Consistent with:
+
+* all three python shards GREEN on the parent PR #2657;
+* deterministic reproduction on #2664 (3 runs, 3 crashes) -- same files, same
+  split, same co-tenancy.
+
+## Ruled out: the PR's own logic
+
+The obvious theory is that a PR changing auto-config blocking changed this
+test's inputs. It does not:
+
+* the committed config for the ncvr corpus is byte-identical on `main` and on
+  the branch (`multi_pass`, 2 passes, `birth_year` + `zip_code`,
+  `max_block_size=5000`), checked by running
+  `scripts.suggest_quality.oracle._auto_configure_no_rerank` under both;
+* the full-frame blocking measurement the branch adds costs **5 ms / 4 MB** on
+  that 7,500-row frame, and both passes vectorize (no exact fallback);
+* it passes locally standalone with the native kernel (34.5 s) and alongside
+  all four new files under `-n 2` (21 passed).
+
+## Why the serial step lives in `python_goldenmatch`, not the heavy lane
+
+`python_goldenmatch_heavy` is where OOM-prone files normally go, but it syncs
+`--no-install-package goldenmatch-native` while the parallel shards BUILD
 native (`scripts/build_native.py`, "native is the test path, not an opt-in
 lane"). `test_suggest_full_dist` skips without the native `suggest_config`
-kernel, so relocating it would convert a crash into a silent skip -- the check
-that does not fire.
-
-## What the deselect costs
-
-The test is the only ACTIVE end-to-end assertion that the right-anchored dip
-fix survives the full marshaling path (diagnostic run -> Arrow batches ->
-native `suggest_config` -> `Suggestion`). Its sibling
-`..._does_not_collapse...` is explicitly a regression guard whose loop body is
-vacuous on this corpus, so it does not cover the same ground. The Rust unit
-tests cover the dip logic but not the boundary.
-
-## Next steps for whoever picks this up
-
-1. Reproduce on Linux with the shard's actual membership:
-   `pytest packages/python/goldenmatch --splits 3 --group 3 -n auto` with
-   native built, and bisect the co-tenant by `--deselect`ing halves.
-2. If a co-tenant is implicated, look for global-state mutation (env vars,
-   transform/scorer registration) that changes the config handed to
-   `suggest_config` -- a different kernel input is the only route from
-   co-tenancy to a segfault.
-3. `faulthandler` is worth enabling in that job (`PYTHONFAULTHANDLER=1`); the
-   absence of any signal string in the log is itself suspicious and may just be
-   xdist swallowing the child's stderr.
+kernel, so relocating it there would have converted an OOM into a silent skip.
+Running it serially inside the job that already has native keeps the assertion
+alive: it is the only ACTIVE end-to-end check that the right-anchored dip fix
+survives the full marshaling path (diagnostic run -> Arrow batches -> native
+`suggest_config` -> `Suggestion`).

--- a/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
+++ b/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
@@ -1,0 +1,71 @@
+# `test_suggest_full_dist` crashes its xdist worker after a shard reshuffle
+
+**Status:** unresolved. Deselected in `python_goldenmatch` (parallel shards) so
+PR #2664 can land; the test still runs nowhere in CI.
+
+## Symptom
+
+```
+worker 'gw0' crashed while running
+  'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
+FAILED ... - worker 'gw0' crashed while running ...
+===== 1 failed, 4449 passed, 83 skipped ... =====
+```
+
+A hard worker death, not an assertion. No `out of memory`, `SIGKILL`,
+`SIGSEGV`, or Rust `panicked` string appears anywhere in the job log.
+
+## What is established
+
+* **Green before the reshuffle.** All three `python_goldenmatch` shards passed
+  on PR #2657, which merged.
+* **Deterministic after it.** Two runs on PR #2664 (heads `5225a158` and
+  `38086235`), two crashes, same test.
+* **Not caused by #2664's logic.** That PR changes auto-config blocking, so the
+  obvious theory is that it changed this test's inputs. It does not:
+  * the committed config for the ncvr corpus is byte-identical on `main` and on
+    the branch (`multi_pass`, 2 passes, `birth_year` + `zip_code`,
+    `max_block_size=5000`) -- checked by running
+    `scripts.suggest_quality.oracle._auto_configure_no_rerank` under both;
+  * the full-frame blocking measurement the branch adds costs **5 ms / 4 MB**
+    on that 7,500-row frame, and both passes vectorize (no exact fallback).
+* **Not reproducible off CI.** Passes standalone with the native kernel
+  (34.5 s), and passes alongside all four of #2664's new test files under
+  `-n 2` (21 passed). Local is Windows; CI is Linux.
+
+The remaining difference is co-tenancy: #2664 adds four test files, and
+`ci.yml` already documents that "any new test file reshuffles pytest-split
+groups and re-exposes it (bit W2a PR #1632)" for the
+`test_memory_pipeline` / `test_memory_postflight` trio. This is the same class,
+except it manifests as a crash rather than a wrong value.
+
+## Why it was deselected rather than moved
+
+`python_goldenmatch_heavy` is where OOM-prone files go, but it syncs
+`--no-install-package goldenmatch-native` while the parallel shards **build**
+native (`scripts/build_native.py`, "native is the test path, not an opt-in
+lane"). `test_suggest_full_dist` skips without the native `suggest_config`
+kernel, so relocating it would convert a crash into a silent skip -- the check
+that does not fire.
+
+## What the deselect costs
+
+The test is the only ACTIVE end-to-end assertion that the right-anchored dip
+fix survives the full marshaling path (diagnostic run -> Arrow batches ->
+native `suggest_config` -> `Suggestion`). Its sibling
+`..._does_not_collapse...` is explicitly a regression guard whose loop body is
+vacuous on this corpus, so it does not cover the same ground. The Rust unit
+tests cover the dip logic but not the boundary.
+
+## Next steps for whoever picks this up
+
+1. Reproduce on Linux with the shard's actual membership:
+   `pytest packages/python/goldenmatch --splits 3 --group 3 -n auto` with
+   native built, and bisect the co-tenant by `--deselect`ing halves.
+2. If a co-tenant is implicated, look for global-state mutation (env vars,
+   transform/scorer registration) that changes the config handed to
+   `suggest_config` -- a different kernel input is the only route from
+   co-tenancy to a segfault.
+3. `faulthandler` is worth enabling in that job (`PYTHONFAULTHANDLER=1`); the
+   absence of any signal string in the log is itself suspicious and may just be
+   xdist swallowing the child's stderr.

--- a/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
+++ b/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
@@ -1,8 +1,20 @@
 # `test_suggest_full_dist` was OOM-killed under `-n auto`
 
-**Status: root-caused and fixed.** The file is `--ignore`d from the parallel
-`python_goldenmatch` shards and runs SERIALLY in the same job (shard 1 only),
-which keeps native available. No coverage is lost.
+**Status: root-caused and fixed.** The single crashing test is `--deselect`ed
+from the parallel `python_goldenmatch` shards and re-run SERIALLY in the same
+job (shard 1 only), which keeps native available. No coverage is lost.
+
+## Use --deselect, never --ignore
+
+`--ignore` drops the file from COLLECTION, so pytest-split sees different
+durations and reshuffles every shard. That was tried first and was far worse
+than the bug: shard 3 went from 4,533 to 5,088 tests and **410** of them died
+on a polars lazy-import recursion (`polars-python py_modules.rs:19`,
+`polars/__init__.py __getattr__` re-entering `import polars.datatypes.group`
+~957 times) that the previous grouping never triggered. `--deselect` is applied
+AFTER collection, so the groups stay byte-identical and only the one test is
+removed. The serial step re-runs that one test id, not the whole file, so the
+other five keep running in the shards exactly where they were.
 
 ## Symptom
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -5293,6 +5293,34 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
     # Opt-in (GOLDENMATCH_BLOCKING_PRUNE_PASSES=1): drop redundant/all-noise
     # multi-pass passes by likely-match yield.
     blocking = _maybe_prune_blocking_passes(blocking, df)
+    # Diversify onto orthogonal stable keys, exactly as
+    # `auto_configure_probabilistic_df` does. This path -- the one the zero-config
+    # CONTROLLER builds its initial config from -- stopped one line short of it
+    # and paid for it. person @ 100K, same fixture, same run (32084546976):
+    #
+    #     lane                     scored pairs  pairwise P       R      F1
+    #     gm_probabilistic_shipped      142,933      0.9992  0.9949  0.9970
+    #     gm_zeroconfig                  11,319      1.0000  0.4684  0.6380
+    #
+    # Precision 1.0000 at recall 0.4684 is candidate generation, not scoring:
+    # the pairs are never PROPOSED, and no threshold recovers a pair that was
+    # never scored. Resolved blocking was 2 passes ([city, first_name] |
+    # dob soundex) against 8, so a duplicate co-blocked only when city AND
+    # first_name agreed -- the failure this lever's docstring describes for
+    # historical_50k (blocking_recall 0.585).
+    #
+    # `n_rows_full` is load-bearing, not decoration: the controller passes a ~6K
+    # sample, and without the projection the #1857 guard measures sample-sized
+    # blocks, keeps a birth-YEAR anchor that is ~15K rows at 1M, and trades this
+    # recall bug for the OOM that guard exists to prevent.
+    if has_fuzzy:
+        blocking = _diversify_probabilistic_blocking(
+            blocking, profiles, df,
+            n_rows_full=total_rows,
+            # v0's own gate (build_blocking's NULL_RATE_CEILING), not the lever's
+            # looser 0.6: see the note in `_diversify_probabilistic_blocking`.
+            max_null_rate=0.20,
+        )
 
     # ── Data-driven strategy selection ──
 
@@ -5915,6 +5943,9 @@ def _diversify_probabilistic_blocking(
     blocking: BlockingConfig | None,
     profiles: list[ColumnProfile],
     df: Any = None,
+    *,
+    n_rows_full: int | None = None,
+    max_null_rate: float = 0.6,
 ) -> BlockingConfig | None:
     """Add orthogonal stable-key blocking passes for the probabilistic path.
 
@@ -5939,6 +5970,27 @@ def _diversify_probabilistic_blocking(
     scales where it helps (a birth-year block is ~1.5K rows at 100K) and is
     dropped only where it would be pathological. Without ``df`` (older callers)
     the guard is a no-op, preserving prior behavior.
+
+    ``n_rows_full`` scale-corrects that guard for callers handing us a SAMPLE.
+    The zero-config controller does: it builds its initial config from a ~5-6K
+    sample (measured: 6,324 rows for a 100K frame). Uncorrected, every anchor
+    looks tiny on a sample and is kept -- including birth-YEAR, ~1.5K rows at
+    100K but ~15K at 1M, which is the exact OOM #1857 added this guard for.
+    Block size grows ~linearly with N (``project_max_block_size``). Full-frame
+    callers pass None and are byte-identical.
+
+    ``max_null_rate`` defaults to the 0.6 this lever has always used -- additive
+    passes tolerate more nulls than a primary key, because the static blocker
+    filters null/sentinel block keys so a null row is simply absent from THIS
+    pass while still covered by the name passes, and error-heavy PII
+    (historical_50k dob/postcode ~24% null) is where these anchors matter most.
+    The v0 caller passes ``build_blocking``'s stricter 0.20 instead. That is
+    deliberately conservative: v0's Tier-2 contract
+    (``test_legacy_v0_skips_high_null_blocking_candidate``) is that a >20%-null
+    column is not a blocking field, and whether additive passes should be exempt
+    is a real question but an UNMEASURED one. Relaxing it here would be an
+    argument, not evidence, so v0 keeps its gate and the question is left for a
+    panel run that can actually answer it.
     """
     if blocking is None or not _fs_autoconfig_v2_enabled():
         return blocking
@@ -5960,23 +6012,44 @@ def _diversify_probabilistic_blocking(
         pass
 
     def _projected_max_block(field: str, transforms: list[str]) -> int:
-        """Exact max block size this single-field pass would produce (0 if
-        unknown / uncomputable — treated as safe so the pass is kept)."""
+        """Max block size this single-field pass would produce at FULL scale
+        (0 if unknown / uncomputable -- treated as safe so the pass is kept).
+
+        Runs on the Frame seam rather than raw polars expressions. It used to
+        build ``pl.col(field)`` and call ``df.select(expr)``, which raises on a
+        ``pyarrow.Table`` and landed in the ``except`` below -- returning 0,
+        which this guard reads as SAFE. Post-Polars-eviction most callers hand
+        this a pa.Table, so the #1857 scale guard was silently disabled on the
+        arrow lane that is now the default. Found while wiring this lever into
+        the controller path: the guard could not drop a birth-YEAR anchor even
+        when the projection asked it to.
+
+        It also derives the key through ``derive_block_key``, so the measured
+        key matches what the blocker will actually compute (the old code only
+        handled a leading ``substring:`` and ignored every other transform).
+        """
         if df is None:
             return 0
         try:
-            col = pl.col(field).cast(pl.Utf8)
-            if transforms and transforms[0].startswith("substring:"):
-                _, start, length = transforms[0].split(":")
-                col = col.str.slice(int(start), int(length))
-            sizes = (
-                df.select(col.alias("__k__"))
+            from goldenmatch.core.frame import to_frame as _to_frame  # noqa: PLC0415
+
+            frame = _to_frame(df)
+            counts = (
+                frame.derive_block_key([field], list(transforms or []))
                 .drop_nulls()
-                .group_by("__k__")
-                .len()
-                .get_column("len")
+                .value_counts_desc()
             )
-            return int(sizes.max()) if sizes.len() else 0
+            measured = int(counts[0][1]) if counts else 0
+            if measured and n_rows_full:
+                from goldenmatch.core.blocking_candidates import (  # noqa: PLC0415
+                    project_max_block_size,
+                )
+                sample_n = int(frame.height)
+                if int(n_rows_full) > sample_n:
+                    return int(project_max_block_size(
+                        measured, sample_n, int(n_rows_full),
+                    ))
+            return measured
         except Exception:
             return 0
 
@@ -6005,7 +6078,7 @@ def _diversify_probabilistic_blocking(
         # null-valued row is simply absent from THIS pass (no giant null block)
         # while still covered by the name passes. Error-heavy PII (historical_50k
         # dob/postcode ~24% null) is exactly where these keys matter most.
-        if p.null_rate > 0.6:
+        if p.null_rate > max_null_rate:
             continue
         if p.col_type == "date":
             _add([p.name], ["substring:0:4"])  # birth YEAR — tolerant of day/month errors

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -70,9 +70,24 @@ def _should_measure_blocking(
       no-materialization invariant).
     - thinking/einstein always measure — their wall budget absorbs the slow
       ``build_blocks`` fallback for non-static / oversized-split configs.
-    - fast/normal measure only when F1's cheap vectorized fast path applies
-      (``strategy="static"``) AND the frame is under the budget-backstop ceiling,
-      so a huge frame that would hit the slow fallback can't blow the tight wall.
+    - fast/normal measure only when a cheap vectorized path applies AND the
+      frame is under the budget-backstop ceiling, so a huge frame that would hit
+      the slow fallback can't blow the tight wall.
+
+    ``is_static`` now means "a vectorized path applies", which covers
+    ``multi_pass`` as well as ``static``. multi_pass is N static passes
+    (``_build_multi_pass_blocks`` delegates each to ``_build_static_blocks``),
+    and ``_fast_multi_pass_block_sizes`` vectorizes them per pass -- measured
+    1,094 ms vs 15,953 ms on the 8-pass person@100K plan, byte-identical
+    profile.
+
+    This is the load-bearing case, not an incremental one: multi_pass is the
+    common zero-config shape (#1207 per-identifier union), so before this the
+    zero-config path ALWAYS extrapolated from a ~6K sample. On person@100K that
+    extrapolation returns an all-zero blocking profile, which rolls up RED and
+    refuses, and feeds `reduction_ratio=0.0` to `rule_low_reduction_ratio` --
+    which then rewrites the blocking plan on evidence nobody collected. The
+    measured profile for the same config is `reduction_ratio=0.9757`, GREEN.
     """
     if distributed:
         return False
@@ -1087,6 +1102,74 @@ class AutoConfigController:
         # guard below -- a caller passes confidence_required=False to keep
         # warn-and-run on NON-RED degenerate blocking.
         _committed_red = best_entry.profile.health() == HealthVerdict.RED
+        if (
+            _committed_red
+            and n_rows >= REFUSE_AT_N
+            and not allow_red_config
+            and _identify_failing_subprofile(best_entry.profile) == "blocking"
+        ):
+            # Do not refuse on EXTRAPOLATED blocking evidence when measuring is
+            # cheap. The profile driving this decision comes from a ~6K sample
+            # (6,324 rows for a 100K frame); the full-frame measurement of the
+            # same config costs ~1.1s and is exact.
+            #
+            # It is not a marginal difference. person@100K, the 8-pass
+            # zero-config plan: the sample profile arrives as all zeros
+            # (reduction_ratio 0.0, n_blocks 0) and rolls up RED, while the
+            # measured profile is reduction_ratio 0.9757 / n_blocks 84,350 --
+            # GREEN. Refusing there is refusing on the DEFAULT VALUE of a field
+            # nobody populated.
+            #
+            # The same all-zero default also reaches `rule_low_reduction_ratio`
+            # (0.0 < 0.5), which is why zero-config's blocking plan was being
+            # rewritten on evidence that was never collected.
+            #
+            # Only runs when blocking is the failing sub-profile (nothing else
+            # is re-evidenced here) and when a vectorized path applies, so the
+            # refusal path can't take on the slow per-block loop.
+            _blk_cfg = getattr(best_entry.config, "blocking", None)
+            if _should_measure_blocking(
+                planning_effort=planning_effort,
+                distributed=distributed,
+                is_static=(
+                    _blk_cfg is not None
+                    and getattr(_blk_cfg, "strategy", "static")
+                    in ("static", "multi_pass")
+                ),
+                n_rows=n_rows,
+            ):
+                try:
+                    from goldenmatch.core.blocker import (  # noqa: PLC0415
+                        measure_blocking_profile,
+                    )
+                    _measured = measure_blocking_profile(df, best_entry.config)
+                except Exception:
+                    logger.debug(
+                        "Pre-refusal blocking measurement failed; keeping the "
+                        "extrapolated verdict.", exc_info=True,
+                    )
+                    _measured = None
+                if _measured is not None:
+                    import dataclasses as _dc  # noqa: PLC0415
+
+                    _remeasured = _dc.replace(
+                        best_entry.profile, blocking=_measured,
+                    )
+                    if _remeasured.health() != HealthVerdict.RED:
+                        logger.info(
+                            "auto-config: sample-extrapolated blocking read RED "
+                            "(reduction_ratio=%.4f, n_blocks=%d) but the measured "
+                            "full-frame profile is %s (reduction_ratio=%.4f, "
+                            "n_blocks=%d) -- committing instead of refusing.",
+                            best_entry.profile.blocking.reduction_ratio,
+                            best_entry.profile.blocking.n_blocks,
+                            _remeasured.health().name,
+                            _measured.reduction_ratio, _measured.n_blocks,
+                        )
+                        best_entry = _dc.replace(
+                            best_entry, profile=_remeasured,
+                        )
+                        _committed_red = False
         if _committed_red and n_rows >= REFUSE_AT_N and not allow_red_config:
             # Report the ACTUAL failing sub-profile (priority-ordered). Only
             # when blocking is genuinely the failing cause AND the committed
@@ -1382,9 +1465,14 @@ class AutoConfigController:
         # Distributed always extrapolates (a full-frame pass would defeat its
         # no-materialization invariant). Any measurement failure falls back too.
         _blocking_cfg = getattr(committed_config, "blocking", None)
+        # "static" here means "a vectorized block-size path applies", which now
+        # includes multi_pass via `_fast_multi_pass_block_sizes` (N static
+        # passes, vectorized per pass). multi_pass is the common zero-config
+        # shape, so restricting this to plain static meant zero-config never
+        # measured and always extrapolated from the sample.
         _is_static = (
             _blocking_cfg is not None
-            and getattr(_blocking_cfg, "strategy", "static") == "static"
+            and getattr(_blocking_cfg, "strategy", "static") in ("static", "multi_pass")
         )
         if _should_measure_blocking(
             planning_effort=planning_effort,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -357,6 +357,14 @@ def rule_low_reduction_ratio(
     if _near_dup_locked(current):
         return None
     bp = profile.blocking
+    if bp.n_blocks == 0:
+        # Nothing measured yet. `reduction_ratio` defaults to 0.0, so without
+        # this the rule reads an UNMEASURED profile as "reduction ratio is
+        # zero", fires on iteration 0 before any pipeline run exists, and
+        # rewrites blocking on evidence that was never collected. Measured on
+        # person@100K the real ratio is 0.999077 -- the rule should never fire
+        # on this dataset at all, and every run of it was acting on the default.
+        return None
     if bp.reduction_ratio >= 0.5:
         return None
     if current.blocking is None or not current.blocking.keys:
@@ -369,11 +377,33 @@ def rule_low_reduction_ratio(
         return None
     used = _existing_blocking_fields(current)
     soundex_candidate = next((c for c in text_cols if c not in used), text_cols[0])
-    existing_keys = list(current.blocking.keys)
+    # The plan to augment is `passes` when the config carries one, and `keys`
+    # only for the keys-driven strategies. Reading `keys` unconditionally made
+    # this rule DELETE the plan it meant to add to: auto-config emits eight
+    # passes for person@100K while `keys` holds just the primary
+    # `[city, first_name]`, so the update below rebuilt `passes` as
+    # "[city, first_name] + soundex" and silently dropped the other seven.
+    #
+    # Measured cost, person @ 100K, same fixture (run 32084546976):
+    #
+    #     lane                     scored pairs  pairwise P       R      F1
+    #     gm_probabilistic_shipped      142,933      0.9992  0.9949  0.9970
+    #     gm_zeroconfig                  11,319      1.0000  0.4684  0.6380
+    #
+    # Precision 1.0000 at recall 0.4684 is the tell: a dropped pass removes
+    # candidates and never adds them, so the loss is recall-only and no
+    # threshold can recover a pair that was never proposed. The rule fires
+    # BECAUSE the reduction ratio is low (too many comparisons) and then removes
+    # 75% of the blocking plan -- which does cut comparisons, true ones included.
+    #
+    # Same keys-vs-passes hazard `_carries_own_blocking_plan` (#2488) was added
+    # for: "`not blocking.keys` ... is only correct for the keys-driven
+    # strategies".
+    existing = list(current.blocking.passes or []) or list(current.blocking.keys or [])
     new_pass = BlockingKeyConfig(fields=[soundex_candidate], transforms=["soundex"])
     new_blocking = current.blocking.model_copy(update={
         "strategy": "multi_pass",
-        "passes": existing_keys + [new_pass],
+        "passes": existing + [new_pass],
     })
     new_cfg = current.model_copy(update={"blocking": new_blocking})
     decision = PolicyDecision(

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -200,6 +200,77 @@ def _fast_static_block_sizes(
     return all_sizes, f1, f2
 
 
+def _fast_multi_pass_block_sizes(
+    lf: Any, config: Any
+) -> tuple[list[int], int | None, int | None] | None:
+    """Block-size distribution for ``multi_pass``, vectorized PER PASS.
+
+    ``_fast_static_block_sizes`` bails on any non-static strategy, so a
+    multi_pass config -- the common zero-config shape (#1207 per-identifier
+    union) -- falls to the exact ``build_blocks`` loop, which materializes one
+    frame per block. That cost is why ``_should_measure_blocking`` only lets the
+    lower planning tiers measure the full frame for ``static`` configs, and it
+    is why zero-config always reasons over an EXTRAPOLATED sample instead.
+
+    Measured, person @ 100,000 rows, the 8-pass zero-config plan:
+
+        exact build_blocks loop      15,953 ms
+        per-pass vectorized             762 ms      20.9x
+
+    A multi_pass config IS N static passes -- ``_build_multi_pass_blocks``
+    delegates each to ``_build_static_blocks`` -- so the same per-key group-by
+    applies once per pass.
+
+    Falls back PER PASS, not for the whole config. ``_fast_static_block_sizes``
+    returns None when any block is oversized (``_build_static_blocks``
+    sub-splits those, so raw group-by sizes would diverge); on the person plan
+    exactly one pass of eight trips that, and forfeiting the other seven to it
+    would give most of the cost back. Parity with the exact loop on a config
+    mixing both kinds is pinned in
+    ``tests/test_multipass_fast_block_sizes.py``.
+
+    Cross-pass dedup is not a concern: ``_build_multi_pass_blocks`` keys its
+    dedup on ``(pass_signature, block_key)``, so it only ever removes truly
+    identical blocks from the SAME pass, and within a pass the group-by already
+    yields unique keys.
+
+    Returns ``None`` (caller uses the exact loop) for non-multi_pass configs or
+    when there are no passes. Chao1 inputs are returned as ``None``: they are
+    only defined for a single-key richness estimate, so the caller falls back to
+    the linear ``n_blocks`` extrapolation, exactly as the exact path does.
+    """
+    if getattr(config, "strategy", None) != "multi_pass":
+        return None
+    passes = list(getattr(config, "passes", None) or [])
+    if not passes:
+        return None
+
+    from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+    frame = to_frame(lf.collect()) if is_polars_lazyframe(lf) else to_frame(lf)
+
+    all_sizes: list[int] = []
+    for pass_config in passes:
+        temp_config = config.model_copy(update={
+            "strategy": "static",
+            "keys": [pass_config],
+            "passes": None,
+            "auto_select": False,
+        })
+        fast = _fast_static_block_sizes(frame, temp_config)
+        if fast is not None:
+            all_sizes.extend(fast[0])
+            continue
+        # This pass has an oversized block (or otherwise can't be vectorized
+        # byte-identically); build only THIS pass exactly.
+        for b in _build_static_blocks(frame, temp_config):
+            try:
+                all_sizes.append(b.n_rows())
+            except Exception:
+                all_sizes.append(0)
+    return all_sizes, None, None
+
+
 def measure_blocking_profile(
     df: pl.DataFrame | pl.LazyFrame,
     config: Any,
@@ -245,6 +316,11 @@ def measure_blocking_profile(
             keys_used = []
 
         fast = _fast_static_block_sizes(frame, blocking_cfg)
+        if fast is None:
+            # multi_pass is N static passes; vectorize each one rather than
+            # dropping the whole config to the per-block materialization loop
+            # (measured 762 ms vs 15,953 ms on the 8-pass person@100K plan).
+            fast = _fast_multi_pass_block_sizes(frame, blocking_cfg)
         if fast is None:
             # Exact fallback: build every block and collect its length. This path
             # cannot recover the pre-drop singleton/doubleton counts, so the Chao1

--- a/packages/python/goldenmatch/tests/test_multipass_fast_block_sizes.py
+++ b/packages/python/goldenmatch/tests/test_multipass_fast_block_sizes.py
@@ -1,0 +1,139 @@
+"""Measure multi_pass blocking on the full frame instead of extrapolating a sample.
+
+The controller can reason over a FULL-frame measured blocking profile rather
+than a sample-extrapolated one -- `_should_measure_blocking`, spec 2026-06-22 --
+but only when the config is plain ``static``:
+
+    return is_static and n_rows <= _MEASURE_BLOCKING_MAX_ROWS_LOWER_TIER
+
+`multi_pass` is the common zero-config shape (the #1207 per-identifier union),
+so zero-config never qualifies and always extrapolates. The reason for the gate
+is cost, and it is real: `_fast_static_block_sizes` bails on any non-static
+strategy, so multi_pass falls to the exact ``build_blocks`` loop, which
+materializes one frame per block.
+
+Measured, person @ 100,000 rows, the 8-pass zero-config plan:
+
+    exact build_blocks loop      15,953 ms
+    per-pass vectorized             762 ms      20.9x
+
+A multi_pass config IS N static passes -- ``_build_multi_pass_blocks``
+delegates each one to ``_build_static_blocks`` -- so the same vectorized
+group-by applies per pass. That is what this adds.
+
+Why it matters beyond speed: the full-frame measurement of that same plan is
+
+    n_blocks=84,350   reduction_ratio=0.9757   total_comparisons=121,391,850
+
+which is GREEN. The sample-extrapolated profile the controller uses instead
+comes back all zeros, rolls up RED, and refuses -- and `rule_low_reduction_ratio`
+fires on that same 0.0 default and rewrites the blocking plan. Measuring what is
+cheap to measure removes the cause rather than tuning around it.
+
+## Per-pass fallback is required, not optional
+
+`_fast_static_block_sizes` returns None when ANY block is oversized, because
+`_build_static_blocks` sub-splits those and the raw group-by sizes would then
+diverge. On the person plan exactly one pass (first_name soundex) trips this.
+Falling back for the WHOLE config would forfeit the other seven; falling back
+per PASS keeps them. So the aggregate must be byte-identical to the exact loop
+on a config that mixes both kinds of pass, which is what the parity test below
+pins.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.blocker import (
+    _fast_multi_pass_block_sizes,
+    build_blocks,
+)
+from goldenmatch.core.frame import to_frame
+
+
+def _mixed_frame(n: int = 600):
+    """One column whose blocks stay small, one that goes oversized.
+
+    `tight` has 200 distinct values (3 rows/block, under the cap) so its pass
+    vectorizes. `wide` has 3 distinct values (200 rows/block, over the cap of
+    50) so its pass must fall back to the exact builder.
+    """
+    return pa.table({
+        "tight": [f"t{i % 200}" for i in range(n)],
+        "wide": [f"w{i % 3}" for i in range(n)],
+    })
+
+
+def _config(max_block_size: int = 50) -> BlockingConfig:
+    return BlockingConfig(
+        strategy="multi_pass",
+        keys=[BlockingKeyConfig(fields=["tight"], transforms=["strip"])],
+        passes=[
+            BlockingKeyConfig(fields=["tight"], transforms=["strip"]),
+            BlockingKeyConfig(fields=["wide"], transforms=["strip"]),
+        ],
+        max_block_size=max_block_size,
+    )
+
+
+def _exact_sizes(frame, cfg) -> list[int]:
+    out = []
+    for b in build_blocks(frame, cfg):
+        try:
+            out.append(b.n_rows())
+        except Exception:
+            out.append(0)
+    return sorted(out)
+
+
+def test_the_fixture_really_mixes_both_paths():
+    """Guard the guard: if neither pass were oversized this would only prove the
+    easy case, and the whole point is the mixed config."""
+    from goldenmatch.core.blocker import _fast_static_block_sizes
+
+    frame = to_frame(_mixed_frame())
+    cfg = _config()
+    tight = cfg.model_copy(update={
+        "strategy": "static", "keys": [cfg.passes[0]], "passes": None,
+    })
+    wide = cfg.model_copy(update={
+        "strategy": "static", "keys": [cfg.passes[1]], "passes": None,
+    })
+    assert _fast_static_block_sizes(frame, tight) is not None, "tight must vectorize"
+    assert _fast_static_block_sizes(frame, wide) is None, "wide must fall back"
+
+
+def test_sizes_match_the_exact_builder():
+    """The whole justification is that this is the SAME measurement, cheaper."""
+    frame = to_frame(_mixed_frame())
+    cfg = _config()
+    fast = _fast_multi_pass_block_sizes(frame, cfg)
+    assert fast is not None
+    sizes, _f1, _f2 = fast
+    assert sorted(sizes) == _exact_sizes(frame, cfg)
+
+
+def test_it_declines_on_a_non_multipass_config():
+    """Narrow by construction: `static` keeps its own fast path and every other
+    strategy keeps the exact loop."""
+    frame = to_frame(_mixed_frame())
+    cfg = _config().model_copy(update={"strategy": "static", "passes": None})
+    assert _fast_multi_pass_block_sizes(frame, cfg) is None
+
+
+def test_it_declines_when_there_are_no_passes():
+    frame = to_frame(_mixed_frame())
+    cfg = _config().model_copy(update={"passes": []})
+    assert _fast_multi_pass_block_sizes(frame, cfg) is None
+
+
+def test_an_all_vectorizable_config_still_matches():
+    """No oversized pass -- every pass takes the fast path and the aggregate must
+    still equal the exact loop."""
+    frame = to_frame(_mixed_frame())
+    cfg = _config(max_block_size=10_000)
+    cfg = cfg.model_copy(update={"passes": [cfg.passes[0]]})
+    fast = _fast_multi_pass_block_sizes(frame, cfg)
+    assert fast is not None
+    assert sorted(fast[0]) == _exact_sizes(frame, cfg)

--- a/packages/python/goldenmatch/tests/test_multipass_fast_block_sizes.py
+++ b/packages/python/goldenmatch/tests/test_multipass_fast_block_sizes.py
@@ -43,7 +43,6 @@ pins.
 from __future__ import annotations
 
 import pyarrow as pa
-
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
 from goldenmatch.core.blocker import (
     _fast_multi_pass_block_sizes,

--- a/packages/python/goldenmatch/tests/test_planner_integration.py
+++ b/packages/python/goldenmatch/tests/test_planner_integration.py
@@ -56,6 +56,47 @@ def _read_plan():
     return profile, history, plan
 
 
+
+def _force_pair_count(monkeypatch, total: int) -> None:
+    """Make the planner see ``total`` candidate pairs, whichever way the
+    controller obtained its blocking profile.
+
+    These tests used to patch ``BlockingProfile.extrapolate_to`` alone, because
+    the controller always extrapolated the sample profile for the planner. It
+    no longer does: `_should_measure_blocking` now also covers ``multi_pass``
+    (the common zero-config shape), so a frame this small takes the MEASURED
+    branch, `extrapolate_to` is never called, and the injection silently did
+    nothing -- the planner saw the real pair count and picked
+    `plan_selected_simple`.
+
+    Patching both seams keeps the tests about what they are actually for -- that
+    rule_chunked fires at >= 50M pairs and rule_duckdb at >= 5B -- rather than
+    about which code path supplied the number.
+    """
+    import dataclasses
+
+    from goldenmatch.core import blocker as _blocker
+    from goldenmatch.core.complexity_profile import BlockingProfile
+
+    real_extrapolate = BlockingProfile.extrapolate_to
+
+    def big_extrapolate(self, n_rows_sample, n_rows_full):
+        out = real_extrapolate(self, n_rows_sample, n_rows_full)
+        return dataclasses.replace(out, total_comparisons=total)
+
+    monkeypatch.setattr(BlockingProfile, "extrapolate_to", big_extrapolate)
+
+    real_measure = _blocker.measure_blocking_profile
+
+    def big_measure(df, config):
+        out = real_measure(df, config)
+        if out is None:
+            return None
+        return dataclasses.replace(out, total_comparisons=total)
+
+    monkeypatch.setattr(_blocker, "measure_blocking_profile", big_measure)
+
+
 # ── Simple plan (end-to-end, no monkey-patch) ──────────────────────────────
 
 
@@ -98,7 +139,6 @@ def test_integration_chunked_plan_fires_at_high_pair_count(monkeypatch):
     (chunked backend has no extra dep on CI but keeping a uniform pattern
     across non-default-backend tests reduces drift risk)."""
     from goldenmatch.core import runtime_profile as runtime_mod
-    from goldenmatch.core.complexity_profile import BlockingProfile
 
     _stub_apply_to(monkeypatch)
 
@@ -107,14 +147,7 @@ def test_integration_chunked_plan_fires_at_high_pair_count(monkeypatch):
 
     monkeypatch.setattr(runtime_mod, "capture_runtime_profile", fat_runtime)
 
-    real_extrapolate = BlockingProfile.extrapolate_to
-
-    def big_pairs(self, n_rows_sample, n_rows_full):
-        out = real_extrapolate(self, n_rows_sample, n_rows_full)
-        import dataclasses
-        return dataclasses.replace(out, total_comparisons=200_000_000)
-
-    monkeypatch.setattr(BlockingProfile, "extrapolate_to", big_pairs)
+    _force_pair_count(monkeypatch, 200_000_000)
 
     gm.dedupe_df(_small_df())
     _profile, _history, plan = _read_plan()
@@ -128,18 +161,10 @@ def test_integration_duckdb_plan_fires_on_dense_pairs(monkeypatch):
     """Rule 5 fires when pair_count >= 5B, regardless of RAM. apply_to is
     stubbed so the pipeline doesn't try to load the duckdb optional dep
     (which CI doesn't install)."""
-    from goldenmatch.core.complexity_profile import BlockingProfile
 
     _stub_apply_to(monkeypatch)
 
-    real_extrapolate = BlockingProfile.extrapolate_to
-
-    def huge_pairs(self, n_rows_sample, n_rows_full):
-        out = real_extrapolate(self, n_rows_sample, n_rows_full)
-        import dataclasses
-        return dataclasses.replace(out, total_comparisons=6_000_000_000)
-
-    monkeypatch.setattr(BlockingProfile, "extrapolate_to", huge_pairs)
+    _force_pair_count(monkeypatch, 6_000_000_000)
 
     gm.dedupe_df(_small_df())
     _profile, _history, plan = _read_plan()

--- a/packages/python/goldenmatch/tests/test_rule_low_reduction_preserves_passes.py
+++ b/packages/python/goldenmatch/tests/test_rule_low_reduction_preserves_passes.py
@@ -1,0 +1,172 @@
+"""`rule_low_reduction_ratio` rebuilds `passes` from `keys` and drops the rest.
+
+The rule means to ADD one soundex pass. It builds the replacement list from
+``current.blocking.keys``:
+
+    existing_keys = list(current.blocking.keys)
+    new_blocking = current.blocking.model_copy(update={
+        "strategy": "multi_pass",
+        "passes": existing_keys + [new_pass],
+    })
+
+For a keys-driven config those are the same thing. For a ``multi_pass`` config
+the plan lives in ``passes`` and ``keys`` holds only the primary key, so every
+other pass is silently discarded.
+
+Measured, person @ 100,000 rows (run 32084546976). Auto-config emits eight
+passes; the controller commits two:
+
+    _legacy_auto_configure_v0 (traced)      8 passes
+        [city, first_name] | [city, first_name]+substring5 | first_name soundex
+        | surname soundex | surname substring5 | dob | dob substring4 | postcode
+
+    controller committed config              2 passes
+        [city, first_name] | dob soundex
+
+`[city, first_name]` is exactly `blocking.keys`, and `dob soundex` is this
+rule's addition. The six survivors of neither list are gone.
+
+What it costs, same fixture, same run:
+
+    lane                     scored pairs  pairwise P       R      F1
+    gm_probabilistic_shipped      142,933      0.9992  0.9949  0.9970
+    gm_zeroconfig                  11,319      1.0000  0.4684  0.6380
+
+Precision 1.0000 with recall 0.4684 is the signature: a discarded pass removes
+candidates, never adds them, so the damage is recall-only and no threshold can
+recover it. The rule fires because the reduction ratio is LOW (too many
+candidate pairs) and then removes 75% of the blocking plan, which does reduce
+comparisons -- it just reduces the true ones too.
+
+The repo already knows this hazard. `_carries_own_blocking_plan` (#2488) exists
+because ``not blocking.keys`` "is only correct for the keys-driven strategies".
+This rule was never updated.
+
+The existing coverage
+(`test_autoconfig_policy.py::test_rule_low_reduction_fires_and_adds_multi_pass`)
+asserts `len(passes) >= 2` on a config that has keys and NO passes, so the two
+lists coincide and the bug is invisible there. It stays green after the fix.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_low_reduction_ratio
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ClusterProfile,
+    ComplexityProfile,
+    DataProfile,
+    ScoringProfile,
+)
+
+_PASSES = [
+    BlockingKeyConfig(fields=["city", "first_name"], transforms=["lowercase", "strip"]),
+    BlockingKeyConfig(fields=["city", "first_name"], transforms=["lowercase", "substring:0:5"]),
+    BlockingKeyConfig(fields=["first_name"], transforms=["lowercase", "soundex"]),
+    BlockingKeyConfig(fields=["surname"], transforms=["lowercase", "soundex"]),
+    BlockingKeyConfig(fields=["surname"], transforms=["lowercase", "substring:0:5"]),
+    BlockingKeyConfig(fields=["dob"], transforms=["lowercase", "strip"]),
+    BlockingKeyConfig(fields=["dob"], transforms=["substring:0:4"]),
+    BlockingKeyConfig(fields=["postcode"], transforms=["strip"]),
+]
+
+
+def _multipass_config() -> GoldenMatchConfig:
+    """The shape auto-config actually emits: the plan in `passes`, the primary
+    key alone in `keys`."""
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="probabilistic_auto", type="probabilistic",
+            fields=[MatchkeyField(field="first_name", scorer="jaro_winkler"),
+                    MatchkeyField(field="surname", scorer="jaro_winkler")],
+        )],
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["city", "first_name"],
+                                    transforms=["lowercase", "strip"])],
+            passes=list(_PASSES),
+        ),
+    )
+
+
+def _low_reduction_profile() -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=100_000, n_cols=6,
+                         column_types={"first_name": "name", "surname": "name",
+                                       "city": "geo", "dob": "text"}),
+        blocking=BlockingProfile(keys_used=[["city", "first_name"]], n_blocks=14_081,
+                                 total_comparisons=4000, reduction_ratio=0.1,
+                                 block_sizes_p99=15),
+        scoring=ScoringProfile(n_pairs_scored=4000, mass_above_threshold=0.4,
+                               dip_statistic=0.05),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+
+
+def _sigs(blocking):
+    return [(tuple(p.fields), tuple(p.transforms or []))
+            for p in (blocking.passes or [])]
+
+
+def test_the_rule_still_fires_on_this_shape():
+    """Guard the guard: if it stopped firing, the assertions below would pass
+    for the wrong reason."""
+    assert rule_low_reduction_ratio(
+        _low_reduction_profile(), _multipass_config(), RunHistory(),
+    ) is not None
+
+
+def test_existing_passes_survive():
+    """The rule is additive by intent. It must not delete the plan it is
+    augmenting."""
+    cfg = _multipass_config()
+    before = _sigs(cfg.blocking)
+    new_cfg, _decision = rule_low_reduction_ratio(
+        _low_reduction_profile(), cfg, RunHistory(),
+    )
+    after = _sigs(new_cfg.blocking)
+
+    missing = [s for s in before if s not in after]
+    assert not missing, (
+        f"dropped {len(missing)} of {len(before)} blocking passes: {missing}"
+    )
+
+
+def test_it_still_adds_the_soundex_pass():
+    new_cfg, _ = rule_low_reduction_ratio(
+        _low_reduction_profile(), _multipass_config(), RunHistory(),
+    )
+    assert [p for p in new_cfg.blocking.passes if "soundex" in (p.transforms or [])]
+    assert new_cfg.blocking.strategy == "multi_pass"
+
+
+def test_it_adds_exactly_one_pass():
+    """Pinned so 'nothing was dropped' cannot be satisfied by duplicating the
+    plan (keys + passes concatenated would also keep everything)."""
+    cfg = _multipass_config()
+    new_cfg, _ = rule_low_reduction_ratio(
+        _low_reduction_profile(), cfg, RunHistory(),
+    )
+    assert len(new_cfg.blocking.passes or []) == len(_PASSES) + 1
+
+
+def test_a_keys_only_config_is_unchanged():
+    """The keys-driven shape the rule was written against must behave exactly as
+    before: `passes` becomes keys + the soundex pass."""
+    cfg = _multipass_config()
+    cfg.blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+    )
+    new_cfg, _ = rule_low_reduction_ratio(
+        _low_reduction_profile(), cfg, RunHistory(),
+    )
+    assert _sigs(new_cfg.blocking)[0] == (("city",), ("lowercase",))
+    assert len(new_cfg.blocking.passes) == 2

--- a/packages/python/goldenmatch/tests/test_zeroconfig_blocking_diversity.py
+++ b/packages/python/goldenmatch/tests/test_zeroconfig_blocking_diversity.py
@@ -1,0 +1,147 @@
+"""Zero-config never gets the blocking-diversification lever, and pays 53% recall.
+
+Measured, person @ 100,000 rows, same fixture, same run (32084546976):
+
+    lane                     scored pairs  pairwise P       R      F1
+    gm_probabilistic_shipped      142,933      0.9992  0.9949  0.9970
+    gm_zeroconfig                  11,319      1.0000  0.4684  0.6380
+    splink                         23,825      0.9999  0.9904  0.9952
+
+Precision 1.0000 with recall 0.4684 is candidate generation, not scoring: the
+pairs are never proposed, and no threshold can recover a pair that was never
+scored. The resolved blocking explains it exactly --
+
+    auto_configure_probabilistic_df   8 passes
+        [city, first_name] | [city, first_name]+substring5 | first_name soundex
+        | surname soundex  | surname substring5 | dob | dob substring4 | postcode
+
+    auto_configure_df (zero-config)   2 passes
+        [city, first_name] | dob soundex
+
+-- so a duplicate is a candidate only if it agrees on city AND first_name, or on
+soundex(dob). The probabilistic path gives it eight independent chances,
+including the surname and postcode anchors that catch pairs whose name or city
+was corrupted.
+
+The cause is one missing call. Both paths run `build_blocking` ->
+`_maybe_prune_blocking_passes` -> `apply_quality_aware_blocking`, but only
+`auto_configure_probabilistic_df` then runs
+`_diversify_probabilistic_blocking`, whose own docstring describes this failure:
+
+    "Auto-config blocking tends to key entirely on the name column(s); on
+     error-heavy PII data that caps the candidate ceiling (audit:
+     historical_50k blocking_recall 0.585 -- 42% of true pairs never co-block
+     because their names are corrupted even though dob/postcode agree)."
+
+`_legacy_auto_configure_v0`, which the controller calls for its initial config,
+stops one line earlier.
+
+## Why this needs a scale projection that the existing caller does not
+
+`auto_configure_probabilistic_df` passes the FULL frame, so the lever's #1857
+scale guard measures true block sizes. The controller passes a ~5-6K SAMPLE
+(measured: 6,324 rows for a 100K frame). `_projected_max_block` measures the df
+it is handed with no correction, so on a sample every anchor looks tiny and is
+kept -- including birth-YEAR, which is ~1.5K rows at 100K but ~15K rows at 1M
+and is exactly the OOM #1857 added the guard for.
+
+So the guard must project sample -> full population before comparing against the
+row cap, using `project_max_block_size` (block size grows ~linearly with N).
+Without that, moving the lever would trade a recall bug for a memory bomb.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.core.autoconfig import (
+    _diversify_probabilistic_blocking,
+    build_blocking,
+    profile_columns,
+)
+from goldenmatch.core.blocking_candidates import project_max_block_size
+
+
+def _frame(n: int = 3000):
+    """A person-shaped frame with a low-cardinality date anchor.
+
+    `birth_date`'s YEAR has 40 distinct values, so its largest block holds a
+    fixed FRACTION of rows -- small on a sample, pathological at 1M. That is the
+    property the projection has to see.
+    """
+    return pa.table({
+        "record_id": [f"r{i}" for i in range(n)],
+        "first_name": [f"name{i % 900}" for i in range(n)],
+        "surname": [f"sur{i % 700}" for i in range(n)],
+        "birth_date": [f"{1950 + (i % 40)}-01-01" for i in range(n)],
+        "postcode": [f"{10000 + (i % 800)}" for i in range(n)],
+        "city": [f"city{i % 60}" for i in range(n)],
+    })
+
+
+def _passes(blocking):
+    return [(tuple(p.fields), tuple(p.transforms or []))
+            for p in (list(blocking.passes or []) or list(blocking.keys or []))]
+
+
+def test_the_lever_still_diversifies_when_given_the_full_frame():
+    """Guard the guard: if the lever stopped adding anchors on a full frame,
+    every other assertion here would pass for the wrong reason."""
+    df = _frame()
+    profiles = profile_columns(df)
+    base = build_blocking(profiles, df)
+    out = _diversify_probabilistic_blocking(base, profiles, df)
+    assert len(_passes(out)) > len(_passes(base))
+
+
+def test_a_sample_sized_call_projects_to_the_full_population():
+    """The controller hands this a ~6K sample of a 1M frame.
+
+    Birth-YEAR here has 40 distinct values: ~75 rows per block on a 3K sample,
+    but ~25,000 at 1M -- far past the FS scorer's per-block row cap. Measuring
+    the sample alone keeps the pass and reintroduces #1857.
+    """
+    df = _frame()
+    profiles = profile_columns(df)
+    base = build_blocking(profiles, df)
+
+    unprojected = _diversify_probabilistic_blocking(base, profiles, df)
+    projected = _diversify_probabilistic_blocking(
+        base, profiles, df, n_rows_full=1_000_000,
+    )
+
+    year_sig = (("birth_date",), ("substring:0:4",))
+    assert year_sig in _passes(unprojected), (
+        "the year anchor is safe at sample scale, so the unprojected call keeps it"
+    )
+    assert year_sig not in _passes(projected), (
+        "at 1M rows that same anchor is a ~25K-row block; it must be dropped"
+    )
+
+
+def test_projection_is_linear_in_rows():
+    """Pinned because the guard's correctness rests on it: a fixed-cardinality
+    key's largest block holds a roughly fixed FRACTION of rows."""
+    assert project_max_block_size(75, 3_000, 1_000_000) > 20_000
+    assert project_max_block_size(75, 3_000, 3_000) == 75
+
+
+def test_full_frame_callers_are_unchanged():
+    """`auto_configure_probabilistic_df` passes the full frame and no
+    `n_rows_full`. That path is already correct and must stay byte-identical."""
+    df = _frame()
+    profiles = profile_columns(df)
+    base = build_blocking(profiles, df)
+    assert _passes(_diversify_probabilistic_blocking(base, profiles, df)) == _passes(
+        _diversify_probabilistic_blocking(base, profiles, df, n_rows_full=None)
+    )
+
+
+def test_n_rows_full_below_sample_height_is_a_noop():
+    """Defensive: a caller passing a smaller full-N than the frame it handed us
+    must not cause the projection to SHRINK a block and wave through a pass the
+    unprojected guard would have dropped."""
+    df = _frame()
+    profiles = profile_columns(df)
+    base = build_blocking(profiles, df)
+    assert _passes(
+        _diversify_probabilistic_blocking(base, profiles, df, n_rows_full=10)
+    ) == _passes(_diversify_probabilistic_blocking(base, profiles, df))

--- a/scripts/bench_er_headtohead/ablate_blocking_passes.py
+++ b/scripts/bench_er_headtohead/ablate_blocking_passes.py
@@ -47,8 +47,39 @@ job.
 * Run with the native kernel available. Pure Python scores 121M comparisons in
   well over 500 s; CI does the same work in ~27 s.
 
+## Measured
+
+Two scales so far, both pure-Python (native unavailable locally), deltas vs the
+full 8-pass plan. Negative dF1 means the pass was earning its keep.
+
+    4,001 rows / 973 true pairs           cmp saved       dF1        dR
+    [dob] substring:0:4                     114,831   +0.0000   +0.0000
+    [first_name] soundex                     69,273   +0.0011   +0.0000
+    [surname] soundex                        20,147   +0.0000   +0.0000
+    [surname] substring5                     10,653   +0.0000   +0.0000
+    [postcode]                                  953   -0.0157   -0.0328
+
+    10,001 rows / 2,428 true pairs         cmp saved       dF1        dR
+    [dob] substring:0:4                     716,613   +0.0000   +0.0000
+    [first_name] soundex                    388,266   +0.0000   +0.0000
+    [surname] soundex                       118,088   -0.0004   +0.0021
+    [surname] substring5                     59,694   +0.0000   +0.0000
+    [postcode]                                2,520   -0.0142   -0.0247
+    in-budget passes only                 1,282,661   -0.0025   -0.0020
+
+The over-budget passes are ~free to remove at both scales, and the single pass
+carrying recall is `postcode` -- IN budget, 2,520 comparisons. The bulk arm
+drops 99.3% of all comparisons for dF1 -0.0025.
+
+**Do not generalize this to 100K/1M yet.** Small frames are exactly where
+phonetic keys have least to do: names collide as N grows, so `[first_name]
+soundex` and `[surname] soundex` may start paying for themselves at a scale
+these runs cannot see. Birth-year is the one result that looks scale-stable so
+far (53% of comparisons at 4K, 55% at 10K, 59% at 100K, zero F1 either way at
+the two scales measured). The 100K arm decides.
+
 Usage:
-    python scripts/bench_er_headtohead/ablate_blocking_passes.py \\
+    python scripts/bench_er_headtohead/ablate_blocking_passes.py \
         --input fixtures/bench_100000.parquet \\
         --ground-truth fixtures/bench_100000.truth.parquet \\
         --out ablation.json

--- a/scripts/bench_er_headtohead/ablate_blocking_passes.py
+++ b/scripts/bench_er_headtohead/ablate_blocking_passes.py
@@ -1,0 +1,207 @@
+"""Which blocking passes earn their comparisons?
+
+Auto-config's probabilistic plan for person@100K is eight passes costing
+121,391,850 comparisons, and the cost is not spread evenly. Scored against the
+budget that already exists (`_blocking_pairs_per_row_budget`, default 50,
+documented as "the scale-invariance knob ... keeps the total pair count
+linear"):
+
+    pass                              max block  pairs/row      comparisons
+    [city, first_name]                        6          2           20,186
+    [city, first_name] +substring5            8          3           22,740
+    [first_name] soundex                  2,170      1,084       31,321,187
+    [surname] soundex                     1,282        640       12,286,109
+    [surname] substring5                  1,142        570        6,138,978
+    [dob]                                    16          7          218,234
+    [dob] substring:0:4  (birth YEAR)     1,549        774       71,337,394
+    [postcode]                                9          4           47,022
+                                                          TOTAL 121,391,850
+
+Four of eight passes run 11-22x over the budget and carry 99.7% of the work.
+That budget is applied when selecting a primary KEY and never to multi_pass
+passes, and `_diversify_probabilistic_blocking` gates on block SIZE (a 7,071
+row cap) where the cost is pair COUNT -- birth-year clears the size gate at
+1,549 rows while contributing 59% of every comparison in the run.
+
+The tempting move is to enforce the budget on passes. That is not safe to
+deduce: dropping the over-budget passes removes the phonetic keys, and a plan
+without them is what `rule_low_reduction_ratio` already produced by accident on
+this shape -- pairwise recall 0.4684. A budget tuned to pick ONE bounding key
+is not obviously the right bound for a UNION of complementary passes.
+
+So this measures it instead. For each pass, drop that pass alone and report
+what the run loses and what it saves. A pass that costs 71M comparisons and
+buys no recall should go; one that costs 31M and holds recall up is doing its
+job.
+
+## Protocol
+
+* One `auto_configure_probabilistic_df` config, built once, then varied by
+  removing passes -- so every arm differs ONLY in the blocking plan.
+* `comparisons` is `measure_blocking_profile(...).total_comparisons`: the true
+  candidate count on the full frame, NOT `DedupeResult.scored_pairs`, which is
+  the RETAINED post-cut set (~850x smaller here) and is the number that made
+  this look like a measurement bug in the first place.
+* Accuracy is pairwise P/R/F1 from `evaluate_clusters` against the fixture's
+  committed ground truth.
+* Run with the native kernel available. Pure Python scores 121M comparisons in
+  well over 500 s; CI does the same work in ~27 s.
+
+Usage:
+    python scripts/bench_er_headtohead/ablate_blocking_passes.py \\
+        --input fixtures/bench_100000.parquet \\
+        --ground-truth fixtures/bench_100000.truth.parquet \\
+        --out ablation.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from itertools import combinations
+from pathlib import Path
+
+
+def _sig(p) -> str:
+    return f"{'+'.join(p.fields)} [{','.join(p.transforms or [])}]"
+
+
+def _ground_truth_pairs(path: Path) -> set[tuple]:
+    """{record_id, cluster_id} parquet -> the set of true within-cluster pairs."""
+    import pyarrow.parquet as pq
+
+    tbl = pq.read_table(path)
+    cols = {c.lower(): c for c in tbl.column_names}
+    rid = cols.get("record_id") or tbl.column_names[0]
+    cid = cols.get("cluster_id") or tbl.column_names[1]
+    by_cluster: dict = {}
+    for r, c in zip(tbl.column(rid).to_pylist(), tbl.column(cid).to_pylist()):
+        by_cluster.setdefault(c, []).append(r)
+    out: set[tuple] = set()
+    for members in by_cluster.values():
+        if len(members) < 2:
+            continue
+        for a, b in combinations(sorted(members), 2):
+            out.add((a, b))
+    return out
+
+
+def _run_arm(df, cfg, truth: set[tuple], label: str, dropped: str | None) -> dict:
+    import goldenmatch
+    from goldenmatch.core.blocker import measure_blocking_profile
+    from goldenmatch.core.evaluate import evaluate_clusters
+
+    prof = measure_blocking_profile(df, cfg)
+    comparisons = int(prof.total_comparisons) if prof is not None else -1
+    n_blocks = int(prof.n_blocks) if prof is not None else -1
+
+    t0 = time.perf_counter()
+    res = goldenmatch.dedupe_df(df, config=cfg)
+    wall = time.perf_counter() - t0
+
+    ev = evaluate_clusters(res.clusters, truth).summary()
+    row = {
+        "arm": label,
+        "dropped_pass": dropped,
+        "n_passes": len(list(cfg.blocking.passes or [])),
+        "comparisons": comparisons,
+        "n_blocks": n_blocks,
+        "dedupe_wall_seconds": round(wall, 2),
+        "precision": round(float(ev["precision"]), 4),
+        "recall": round(float(ev["recall"]), 4),
+        "f1": round(float(ev["f1"]), 4),
+        "n_clusters": len(res.clusters),
+    }
+    print(
+        f"[ablate] {label:<44s} passes={row['n_passes']} "
+        f"cmp={comparisons:>13,} wall={row['dedupe_wall_seconds']:>7.2f}s "
+        f"P={row['precision']:.4f} R={row['recall']:.4f} F1={row['f1']:.4f}",
+        flush=True,
+    )
+    return row
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--ground-truth", required=True)
+    ap.add_argument("--out", default="ablation.json")
+    ap.add_argument(
+        "--budget", type=int, default=None,
+        help="pairs/row budget for labelling (defaults to the engine's own)",
+    )
+    args = ap.parse_args()
+
+    import pyarrow.parquet as pq
+    from goldenmatch.core.autoconfig import (
+        _blocking_pairs_per_row_budget,
+        _project_pairs_per_row,
+        auto_configure_probabilistic_df,
+    )
+
+    df = pq.read_table(args.input)
+    truth = _ground_truth_pairs(Path(args.ground_truth))
+    print(f"[ablate] {df.num_rows:,} rows, {len(truth):,} true pairs", flush=True)
+
+    cfg = auto_configure_probabilistic_df(df)
+    passes = list(cfg.blocking.passes or [])
+    budget = args.budget if args.budget is not None else _blocking_pairs_per_row_budget()
+    print(f"[ablate] {len(passes)} passes, pairs/row budget = {budget}", flush=True)
+
+    rows = [_run_arm(df, cfg, truth, "full (all passes)", None)]
+
+    # Drop each pass ALONE. One-at-a-time so a pass that only matters in
+    # combination is not written off by a bulk removal.
+    for i, p in enumerate(passes):
+        variant = cfg.model_copy(update={
+            "blocking": cfg.blocking.model_copy(update={
+                "passes": [q for j, q in enumerate(passes) if j != i],
+            }),
+        })
+        rows.append(_run_arm(df, variant, truth, f"minus {_sig(p)}", _sig(p)))
+
+    # And the bulk arm the budget would actually produce, so the "just enforce
+    # it" option is measured rather than argued about.
+    from goldenmatch.core.blocker import _build_static_blocks, _fast_static_block_sizes
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    keep = []
+    for p in passes:
+        sub = cfg.blocking.model_copy(update={
+            "strategy": "static", "keys": [p], "passes": None, "auto_select": False,
+        })
+        fast = _fast_static_block_sizes(frame, sub)
+        if fast is not None:
+            sizes = list(fast[0])
+        else:
+            sizes = []
+            for b in _build_static_blocks(frame, sub):
+                try:
+                    sizes.append(b.n_rows())
+                except Exception:
+                    sizes.append(0)
+        if _project_pairs_per_row(max(sizes) if sizes else 0) <= budget:
+            keep.append(p)
+    if keep and len(keep) != len(passes):
+        variant = cfg.model_copy(update={
+            "blocking": cfg.blocking.model_copy(update={"passes": keep}),
+        })
+        rows.append(_run_arm(df, variant, truth, "in-budget passes only", "all over-budget"))
+
+    Path(args.out).write_text(json.dumps({"rows": rows}, indent=2), encoding="utf-8")
+
+    base = rows[0]
+    print("\n[ablate] deltas vs full plan (negative F1 = the pass was earning its keep)")
+    print(f"{'arm':<44s}{'cmp saved':>15s}{'dF1':>9s}{'dR':>9s}{'dP':>9s}")
+    for r in rows[1:]:
+        print(
+            f"{r['arm']:<44s}{base['comparisons'] - r['comparisons']:>15,}"
+            f"{r['f1'] - base['f1']:>+9.4f}{r['recall'] - base['recall']:>+9.4f}"
+            f"{r['precision'] - base['precision']:>+9.4f}"
+        )
+    print(f"\n[ablate] wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -132,23 +132,44 @@ def _config_telemetry(cfg) -> dict:
     except Exception as e:  # noqa: BLE001
         out["matchkeys_error"] = f"{type(e).__name__}: {e}"
     try:
-        # `BlockingConfig.keys`, NOT `.passes`. The first version of this read
-        # `.passes` and got `[]` for every lane at both scales -- a plausible
-        # empty list rather than an error, which is the worst way for telemetry
-        # to be wrong. `.passes` is kept as a fallback only because some callers
-        # construct with that alias.
+        # `.passes` FIRST, `.keys` only as the fallback -- and the order is the
+        # whole point. For a `multi_pass` config the plan lives in `.passes`
+        # while `.keys` holds just the primary key, so reading `.keys` first
+        # reported ONE pass for an eight-pass plan. That is not a cosmetic
+        # under-report: it is why `blocking_passes: [["city","first_name"]]`
+        # appeared identical for `gm_zeroconfig` and `gm_probabilistic_shipped`
+        # in run 32084546976, and why the two lanes looked like they differed
+        # only in threshold when they actually differed 2-passes-vs-8.
+        #
+        # The original comment justified `.keys` because a first version read
+        # `.passes` and got `[]` for every lane. Empty-vs-absent is the real
+        # distinction there: `or` on an EMPTY list falls through to keys, while
+        # `is None` does not. Same keys-vs-passes confusion that
+        # `_carries_own_blocking_plan` (#2488) exists for and that
+        # `rule_low_reduction_ratio` had.
+        #
+        # Transforms are recorded too: `[city, first_name]` appears twice in the
+        # probabilistic plan differing ONLY by transform (strip vs
+        # substring:0:5), so fields alone cannot tell two passes apart.
         blocking = getattr(cfg, "blocking", None)
-        keys = getattr(blocking, "keys", None)
-        if keys is None:
-            keys = getattr(blocking, "passes", None)
-        if keys is None:
+        keys = list(getattr(blocking, "passes", None) or []) or list(
+            getattr(blocking, "keys", None) or []
+        )
+        if blocking is None:
+            out["blocking_error"] = "resolved config exposed no blocking at all"
+        elif not keys:
             out["blocking_error"] = (
-                "resolved config exposed neither blocking.keys nor .passes"
+                "resolved config exposed neither blocking.passes nor .keys"
             )
         else:
             out["blocking_passes"] = [
-                list(getattr(k, "fields", []) or []) for k in keys
+                {
+                    "fields": list(getattr(k, "fields", []) or []),
+                    "transforms": list(getattr(k, "transforms", []) or []),
+                }
+                for k in keys
             ]
+            out["blocking_n_passes"] = len(keys)
             out["blocking_strategy"] = getattr(blocking, "strategy", None)
             out["blocking_max_block_size"] = getattr(blocking, "max_block_size", None)
     except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
**HELD.** This is the behaviour half of the original PR. It **regresses zero-config end to end** and must not merge in this shape. The safe half was split out into #2667.

## The regression, measured

person@100K, same fixture, `gm_zeroconfig`:

| | before (main) | with this PR |
|---|---:|---:|
| pairwise R | 0.4684 | **0.383** |
| pairwise F1 | 0.6380 | **0.554** |
| scored pairs | 11,319 | **9,250** |
| block_count | 14,081 | **3,287** |

Fewer candidates, not more -- the opposite of the intent. For reference on the same run: `gm_probabilistic_shipped` F1 0.997, splink 0.995.

## Why

`rule_low_reduction_ratio` fires at iteration 0 on an **unmeasured** profile (`reduction_ratio` defaults to `0.0`, and `0.0 < 0.5`), then rebuilds `passes` from `keys` -- discarding six of eight passes. Both are genuine bugs and both are fixed here, with tests.

But the discarded-plan bug had an accidental *benefit*: the rule's own addition, `dob soundex`, was contributing candidates. Once the blocking profile is measured properly (`reduction_ratio 0.9757`, GREEN) the rule correctly stops firing -- and the soundex pass stops being added too. **The fixes remove a bad rule's side effect without replacing it.**

So the open question is not "are these bugs real" (they are, and they are fixed) but **what blocking plan zero-config should actually commit**. That needs the 100K ablation, which needs #2667 on main to dispatch.

## What is still in here

* both `rule_low_reduction_ratio` defects (unmeasured-profile firing; `keys` vs `passes`)
* `_diversify_probabilistic_blocking`: arrow-seam scale-guard repair (it built raw polars expressions that RAISE on a `pyarrow.Table` and landed in `except: return 0`, where 0 reads as "safe" -- so the #1857 guard has been silently disabled on the default arrow lane) plus `n_rows_full` projection for sample callers
* controller: `_should_measure_blocking` extended to `multi_pass`, and measure-before-refusing
* `test_planner_integration` updated -- those tests injected pair counts through `extrapolate_to`, a seam the controller stops using once it measures

## Corrections recorded in-branch

Two of my own claims here were wrong and are corrected in `c9b7dd6c` rather than quietly superseded: there is **no** pair-count mismatch (I read `scored_pairs`, the retained post-cut set, as the candidate count -- `measure_blocking_profile`'s 121,391,850 was right), and the controller was **not** hanging (121M comparisons in pure Python with `GOLDENMATCH_NATIVE=0`; CI does the same work in ~27 s).

Depends on #2667. Rebase onto main once that lands, so this carries only the behaviour delta.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P
