### PR TITLE
fix(benchmarks): stop an ambient LLM key changing the numbers, and let the RED check fire (#2457)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1121,6 +1121,7 @@ jobs:
         run: |
           uv run --with polars --with pyarrow \
             pytest scripts/test_run_benchmarks_download.py \
+                   scripts/test_run_benchmarks_llm_isolation.py \
                    scripts/dqbench_adapters/test_leipzig_eval.py -q
 
   # Every repo path a CLAUDE.md names must exist. These files are loaded as

--- a/docs/benchmarks/latest-results.md
+++ b/docs/benchmarks/latest-results.md
@@ -6,7 +6,7 @@
 gate fails any PR whose doc drifts from its JSON, so these numbers are the
 current truth, not a stale copy pasted from a case study.
 
-**Run date:** 2026-08-11 &nbsp;·&nbsp; **path:** native (GOLDENMATCH_NATIVE=1) &nbsp;·&nbsp; **planning_effort:** normal &nbsp;·&nbsp; **LLM features:** off
+**Run date:** 2026-08-11 &nbsp;·&nbsp; **path:** native (GOLDENMATCH_NATIVE=1) &nbsp;·&nbsp; **planning_effort:** normal &nbsp;·&nbsp; **LLM features:** not recorded (run predates the ambient-key guard)
 
 | Dataset | Domain | F1 | Precision | Recall | Time |
 |---|---|---|---|---|---|

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -18,7 +18,9 @@ Datasets:
 
 Environment:
   GOLDENMATCH_AUTOCONFIG_MEMORY=0  recommended (cross-run cache off for clean numbers)
-  OPENAI_API_KEY                   required for --with-llm
+  OPENAI_API_KEY                   required for --with-llm; IGNORED otherwise (see
+                                   `_neutralize_ambient_llm_keys` -- an ambient key
+                                   silently changed the published numbers once)
 """
 from __future__ import annotations
 
@@ -211,7 +213,19 @@ def _measure_product(datasets_dir: Path, key: str) -> dict[str, Any] | None:
     from goldenmatch import dedupe_df
 
     spec = _PRODUCT_SPECS[key]
-    _dedupe = functools.partial(dedupe_df, planning_effort=_PLANNING_EFFORT)
+    # The shared helper returns only the score, so the controller verdict would be
+    # lost -- and this function used to hardcode `health: "n/a"`, which made the
+    # RED-config check in `_check_quality_floors` unable to fire on the two
+    # datasets in the worst shape. Both committed RED configs in the 2026-08-18
+    # nightly and neither tripped it (#2457). Capture it off the result instead of
+    # widening the helper's contract for one caller.
+    captured: dict[str, Any] = {}
+
+    def _dedupe(frame):
+        res = dedupe_df(frame, planning_effort=_PLANNING_EFFORT)
+        captured["result"] = res
+        return res
+
     start = time.time()
     res = run_two_source_dedupe_zeroconfig(
         datasets_dir, _dedupe,
@@ -223,16 +237,18 @@ def _measure_product(datasets_dir: Path, key: str) -> dict[str, Any] | None:
     if res is None:
         _info(f"  {spec['label']}: dataset files missing — skipping")
         return None
+    health, stop_reason = _controller_health(captured.get("result"))
     _info(
         f"  {spec['label']}: f1={res.f1:.4f} precision={res.precision:.4f} "
-        f"recall={res.recall:.4f} elapsed={elapsed:.2f}s"
+        f"recall={res.recall:.4f} elapsed={elapsed:.2f}s health={health} "
+        f"stop_reason={stop_reason}"
     )
     return {
         "name": spec["label"], "f1": round(res.f1, 4),
         "precision": round(res.precision, 4), "recall": round(res.recall, 4),
         "tp": res.true_positives, "fp": res.false_positives, "fn": res.false_negatives,
         "elapsed_seconds": round(elapsed, 2),
-        "health": "n/a", "stop_reason": "n/a", "domain": "product",
+        "health": health, "stop_reason": stop_reason, "domain": "product",
         "planning_effort": _PLANNING_EFFORT,
     }
 
@@ -300,18 +316,7 @@ def _measure_with_polars(
     recall = tp / (tp + fn) if (tp + fn) else 0.0
     f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
 
-    health = "unknown"
-    stop_reason = "unknown"
-    if hasattr(result, "postflight_report") and result.postflight_report:
-        prof = getattr(result.postflight_report, "controller_profile", None)
-        if prof is not None and hasattr(prof, "health"):
-            try:
-                health = prof.health().value
-            except Exception:
-                pass
-        hist = getattr(result.postflight_report, "controller_history", None)
-        if hist is not None and getattr(hist, "stop_reason", None) is not None:
-            stop_reason = hist.stop_reason.value
+    health, stop_reason = _controller_health(result)
 
     backend = "unknown"
     plan = getattr(getattr(result, "postflight_report", None), "controller_history", None)
@@ -535,8 +540,17 @@ def _run_dqbench(with_llm: bool = False) -> dict[str, Any] | None:
 _F1_FLOORS: dict[str, float | None] = {
     # measured 0.9912
     "Febrl3": 0.95,
-    # measured 0.5037 -- product matching is genuinely hard; this pins the floor
-    # just under the observed value so a real regression trips it.
+    # DISPUTED, deliberately left at its original value pending a decision.
+    # This was set "just under the observed 0.5037", but that 0.5037 was measured
+    # with an ambient OPENAI_API_KEY routing 959 of 2173 records through LLM
+    # extraction, while the run labelled itself "LLM features: off" (#2457).
+    # Keyless -- what CI can actually reproduce, on either the native or the
+    # fallback path, and on the very commit that published the baseline -- Abt-Buy
+    # scores f1=0.1723 (P=0.1068, R=0.4463). So this floor currently tests whether
+    # a key is in the environment, not whether matching regressed.
+    # NOT lowered here to make the lane green: Abt-Buy also commits a RED config,
+    # which fails the lane on its own, so the honest fix is a quality fix rather
+    # than a smaller number. Re-derive this from a keyless run when that lands.
     "Abt-Buy": 0.45,
     # KNOWN BAD (#2470). Measured 0.0697 / recall 0.0419. The floor is set at the
     # observed value ONLY to stop it getting worse; it is not an endorsement, and
@@ -547,6 +561,77 @@ _F1_FLOORS: dict[str, float | None] = {
     "DBLP-ACM": None,
     "NCVR": None,
 }
+
+
+def _llm_label(meta: dict[str, Any]) -> str:
+    """How to describe a run's LLM exposure, honestly, from its metadata."""
+    if meta.get("with_llm"):
+        return "on"
+    if meta.get("llm_keys_suppressed") is None:
+        # Pre-guard payload: we cannot tell whether a key was in the environment.
+        return "not recorded (run predates the ambient-key guard)"
+    return "off"
+
+
+def _controller_health(result: Any) -> tuple[str, str]:
+    """Pull (health, stop_reason) off a pipeline result, or ("unknown", ...).
+
+    Returning "unknown" rather than "n/a" matters: `_check_quality_floors` fails
+    a RED run outright, so a dataset that cannot report its health must not be
+    able to look like one that has none to report.
+    """
+    health = stop_reason = "unknown"
+    report = getattr(result, "postflight_report", None)
+    if not report:
+        return health, stop_reason
+    prof = getattr(report, "controller_profile", None)
+    if prof is not None and hasattr(prof, "health"):
+        try:
+            health = prof.health().value
+        except Exception:  # noqa: BLE001 - a health probe must never fail a run
+            pass
+    hist = getattr(report, "controller_history", None)
+    if hist is not None and getattr(hist, "stop_reason", None) is not None:
+        stop_reason = hist.stop_reason.value
+    return health, stop_reason
+
+
+#: Env vars `goldenmatch.core.llm_extract` auto-detects with no opt-in.
+_LLM_KEY_VARS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+
+
+def _neutralize_ambient_llm_keys(with_llm: bool) -> bool:
+    """Remove ambient LLM keys unless the run explicitly asked for them.
+
+    `llm_extract.llm_extract_features` reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
+    straight out of `os.environ` with no opt-in flag, so *merely having a key
+    exported* rewrites what this lane measures. On Abt-Buy that path handles 959
+    of 2173 records (44%), and the difference is not marginal:
+
+        no key   f1=0.1723  precision=0.1068   <- what CI has always measured
+        (a key present routes 44% of records through paid extraction instead)
+
+    The committed `docs/benchmarks/latest-results.json` was produced on a machine
+    with a key exported, so it published an LLM-assisted 0.5037 while its own
+    generated header said "LLM features: off" -- that label reads `--with-llm`,
+    which only ever controlled the DQbench lane. #2470 then set Abt-Buy's F1 floor
+    to 0.45 "just under the observed value", which made the floor a test of whether
+    a key happened to be in the environment. The nightly, which has no key, cannot
+    pass it (#2457).
+
+    A benchmark's whole job is a number that means the same thing on a laptop and
+    in CI, so the key is dropped rather than merely reported. Returns True when
+    something was actually removed, so the run can record that it happened.
+    """
+    if with_llm:
+        return False
+    present = [k for k in _LLM_KEY_VARS if os.environ.get(k)]
+    for k in present:
+        del os.environ[k]
+    if present:
+        _info(f"  ignoring ambient {', '.join(present)} (pass --with-llm to use it): "
+              "an LLM-assisted number is not comparable with CI's.")
+    return bool(present)
 
 
 def _check_quality_floors(results: list[dict[str, Any]]) -> list[str]:
@@ -623,7 +708,13 @@ def _render_report(payload: dict[str, Any]) -> str:
         "",
         f"**Run date:** {date} &nbsp;·&nbsp; **path:** {native_label} &nbsp;·&nbsp; "
         f"**planning_effort:** {meta.get('planning_effort', '—')} &nbsp;·&nbsp; "
-        f"**LLM features:** {'on' if meta.get('with_llm') else 'off'}",
+        # "off" here has to mean the run could not have used an LLM, not merely
+        # that it did not ask for one. The old label read `with_llm` alone, so a
+        # run with an ambient OPENAI_API_KEY published LLM-assisted numbers under
+        # an "off" header (#2457). `llm_keys_suppressed` proves the key was
+        # removed; its ABSENCE in an older payload means the run predates the
+        # guard and cannot make that claim.
+        f"**LLM features:** {_llm_label(meta)}",
         "",
     ]
     if not results:
@@ -738,6 +829,10 @@ def main() -> int:
     # Force it off unless the caller has deliberately overridden it.
     os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
 
+    # Same class of leak, and the one that actually bit us (#2457). See the
+    # function's docstring for the incident.
+    llm_keys_suppressed = _neutralize_ambient_llm_keys(args.with_llm)
+
     global _PLANNING_EFFORT
     _PLANNING_EFFORT = args.planning_effort
     _info(f"planning_effort={_PLANNING_EFFORT} memory={os.environ.get('GOLDENMATCH_AUTOCONFIG_MEMORY')}")
@@ -789,6 +884,10 @@ def main() -> int:
         "metadata": {
             "date": datetime.date.today().isoformat(),
             "with_llm": args.with_llm,
+            # Distinct from `with_llm`, which is the *request*. This is whether a
+            # key was on the machine and had to be suppressed to keep the run
+            # comparable -- the thing that silently moved Abt-Buy by 33 F1 points.
+            "llm_keys_suppressed": llm_keys_suppressed,
             "planning_effort": _PLANNING_EFFORT,
             "native": os.environ.get("GOLDENMATCH_NATIVE"),
             "datasets_dir": str(args.datasets_dir),

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -18,9 +18,9 @@ Datasets:
 
 Environment:
   GOLDENMATCH_AUTOCONFIG_MEMORY=0  recommended (cross-run cache off for clean numbers)
-  OPENAI_API_KEY                   required for --with-llm; IGNORED otherwise (see
-                                   `_neutralize_ambient_llm_keys` -- an ambient key
-                                   silently changed the published numbers once)
+  OPENAI_API_KEY                   required for --with-llm; IGNORED otherwise, so
+                                   an ambient key cannot quietly change the numbers
+                                   (see `_neutralize_ambient_llm_keys`)
 """
 from __future__ import annotations
 
@@ -540,17 +540,28 @@ def _run_dqbench(with_llm: bool = False) -> dict[str, Any] | None:
 _F1_FLOORS: dict[str, float | None] = {
     # measured 0.9912
     "Febrl3": 0.95,
-    # DISPUTED, deliberately left at its original value pending a decision.
-    # This was set "just under the observed 0.5037", but that 0.5037 was measured
-    # with an ambient OPENAI_API_KEY routing 959 of 2173 records through LLM
-    # extraction, while the run labelled itself "LLM features: off" (#2457).
-    # Keyless -- what CI can actually reproduce, on either the native or the
-    # fallback path, and on the very commit that published the baseline -- Abt-Buy
-    # scores f1=0.1723 (P=0.1068, R=0.4463). So this floor currently tests whether
-    # a key is in the environment, not whether matching regressed.
+    # DISPUTED. Set "just under the observed 0.5037" -- but that 0.5037 is
+    # UNREPRODUCED, and until someone reproduces it this floor is not known to
+    # describe anything. Measured 2026-08-18, all on the same 1118 ground-truth
+    # pairs, every cell f1=0.17-0.18 against the baseline's 0.5037 / P=0.8219:
+    #
+    #   committed baseline (2026-08-11, native=1)  0.5037  P 0.8219   494 pairs
+    #   CI nightly, native=0, no key               0.1723  P 0.1068
+    #   local HEAD, native=0, no key               0.1723  P 0.1068  4673 pairs
+    #   local HEAD, native=1, no key               0.1723  P 0.1068
+    #   local 8145b498 (the baseline's OWN commit) 0.1723  P 0.1068
+    #   local HEAD, native=0, WITH an LLM key      0.1838  P 0.1132
+    #
+    # So it is not a code regression (the publishing commit scores 0.1723), not
+    # the kernel-vs-fallback split, and not the ambient LLM key -- each was
+    # measured and ruled out. The baseline emitted 494 pairs where every
+    # reproduction emits ~4673, so whatever produced it was configured very
+    # differently. Cause still unknown; do not re-derive this floor from a number
+    # nobody can reproduce.
+    #
     # NOT lowered here to make the lane green: Abt-Buy also commits a RED config,
     # which fails the lane on its own, so the honest fix is a quality fix rather
-    # than a smaller number. Re-derive this from a keyless run when that lands.
+    # than a smaller number.
     "Abt-Buy": 0.45,
     # KNOWN BAD (#2470). Measured 0.0697 / recall 0.0419. The floor is set at the
     # observed value ONLY to stop it getting worse; it is not an endorsement, and
@@ -605,23 +616,20 @@ def _neutralize_ambient_llm_keys(with_llm: bool) -> bool:
 
     `llm_extract.llm_extract_features` reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
     straight out of `os.environ` with no opt-in flag, so *merely having a key
-    exported* rewrites what this lane measures. On Abt-Buy that path handles 959
-    of 2173 records (44%), and the difference is not marginal:
+    exported* changes what this lane measures. On Abt-Buy that path handles 959 of
+    2173 records (44%), and it is worth a real, if modest, shift:
 
-        no key   f1=0.1723  precision=0.1068   <- what CI has always measured
-        (a key present routes 44% of records through paid extraction instead)
-
-    The committed `docs/benchmarks/latest-results.json` was produced on a machine
-    with a key exported, so it published an LLM-assisted 0.5037 while its own
-    generated header said "LLM features: off" -- that label reads `--with-llm`,
-    which only ever controlled the DQbench lane. #2470 then set Abt-Buy's F1 floor
-    to 0.45 "just under the observed value", which made the floor a test of whether
-    a key happened to be in the environment. The nightly, which has no key, cannot
-    pass it (#2457).
+        no key   f1=0.1723  P=0.1068  R=0.4463   <- what CI measures
+        key      f1=0.1838  P=0.1132  R=0.4875   (+0.0115 F1, ~50x the wall clock)
 
     A benchmark's whole job is a number that means the same thing on a laptop and
     in CI, so the key is dropped rather than merely reported. Returns True when
     something was actually removed, so the run can record that it happened.
+
+    Scope note, because the measurement above corrected an earlier guess of mine:
+    this does NOT explain the committed 0.5037 Abt-Buy baseline. That number is
+    unreproduced -- see the `Abt-Buy` entry in `_F1_FLOORS`. The guard is
+    justified on determinism alone, not as a fix for that.
     """
     if with_llm:
         return False

--- a/scripts/test_run_benchmarks_llm_isolation.py
+++ b/scripts/test_run_benchmarks_llm_isolation.py
@@ -21,15 +21,10 @@ not prove it would be a check that does not fire.
 """
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+import os
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-
-import run_benchmarks as rb  # noqa: E402
-
+import run_benchmarks as rb
 
 # ── the keys are actually removed ─────────────────────────────────────────
 
@@ -37,7 +32,6 @@ import run_benchmarks as rb  # noqa: E402
 def test_ambient_key_is_removed_by_default(monkeypatch, var):
     monkeypatch.setenv(var, "sk-not-a-real-key")
     assert rb._neutralize_ambient_llm_keys(with_llm=False) is True
-    import os
     assert os.environ.get(var) is None
 
 
@@ -45,7 +39,6 @@ def test_with_llm_keeps_the_key(monkeypatch):
     """--with-llm is a deliberate request; it must still reach the provider."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-not-a-real-key")
     assert rb._neutralize_ambient_llm_keys(with_llm=True) is False
-    import os
     assert os.environ["OPENAI_API_KEY"] == "sk-not-a-real-key"
 
 
@@ -58,7 +51,6 @@ def test_no_key_present_reports_nothing_suppressed(monkeypatch):
 def test_both_keys_removed_together(monkeypatch):
     """Anthropic is the fallback provider, so stripping only OpenAI leaves the
     extraction path live on a different vendor -- same defect, quieter."""
-    import os
     monkeypatch.setenv("OPENAI_API_KEY", "sk-a")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-b")
     assert rb._neutralize_ambient_llm_keys(with_llm=False) is True

--- a/scripts/test_run_benchmarks_llm_isolation.py
+++ b/scripts/test_run_benchmarks_llm_isolation.py
@@ -1,0 +1,126 @@
+"""#2457: an ambient LLM key must not change what the benchmark lane measures.
+
+`goldenmatch.core.llm_extract` reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
+straight out of `os.environ` with no opt-in flag, so merely having a key
+exported rewrote what this lane reported. On Abt-Buy that path handles 959 of
+2173 records, and the gap is not marginal:
+
+    no key   f1=0.1723  precision=0.1068   <- what CI has always measured
+    a key    routes 44% of records through paid extraction instead
+
+The committed `docs/benchmarks/latest-results.json` was produced on a machine
+with a key exported. It published 0.5037 under a generated header reading
+"LLM features: off" -- that label read `--with-llm`, which only ever controlled
+the DQbench lane. #2470 then pinned Abt-Buy's floor at 0.45 "just under the
+observed value", so the floor became a test of whether a key was in the
+environment, and the keyless nightly could never pass it.
+
+Two properties are pinned here, and the second is the one with teeth: a guard
+that strips the key but still lets the report claim "off" for a run that could
+not prove it would be a check that does not fire.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import run_benchmarks as rb  # noqa: E402
+
+
+# ── the keys are actually removed ─────────────────────────────────────────
+
+@pytest.mark.parametrize("var", ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"])
+def test_ambient_key_is_removed_by_default(monkeypatch, var):
+    monkeypatch.setenv(var, "sk-not-a-real-key")
+    assert rb._neutralize_ambient_llm_keys(with_llm=False) is True
+    import os
+    assert os.environ.get(var) is None
+
+
+def test_with_llm_keeps_the_key(monkeypatch):
+    """--with-llm is a deliberate request; it must still reach the provider."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-not-a-real-key")
+    assert rb._neutralize_ambient_llm_keys(with_llm=True) is False
+    import os
+    assert os.environ["OPENAI_API_KEY"] == "sk-not-a-real-key"
+
+
+def test_no_key_present_reports_nothing_suppressed(monkeypatch):
+    for var in rb._LLM_KEY_VARS:
+        monkeypatch.delenv(var, raising=False)
+    assert rb._neutralize_ambient_llm_keys(with_llm=False) is False
+
+
+def test_both_keys_removed_together(monkeypatch):
+    """Anthropic is the fallback provider, so stripping only OpenAI leaves the
+    extraction path live on a different vendor -- same defect, quieter."""
+    import os
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-a")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-b")
+    assert rb._neutralize_ambient_llm_keys(with_llm=False) is True
+    assert not [k for k in rb._LLM_KEY_VARS if os.environ.get(k)]
+
+
+# ── the report cannot claim "off" it has not earned ───────────────────────
+
+def test_label_off_only_when_suppression_ran():
+    assert rb._llm_label({"with_llm": False, "llm_keys_suppressed": False}) == "off"
+    assert rb._llm_label({"with_llm": False, "llm_keys_suppressed": True}) == "off"
+
+
+def test_label_on_when_requested():
+    assert rb._llm_label({"with_llm": True, "llm_keys_suppressed": False}) == "on"
+
+
+def test_pre_guard_payload_does_not_claim_off():
+    """The regression itself: the old committed JSON has no `llm_keys_suppressed`,
+    so nothing can prove a key was absent. It must not render as a flat "off"."""
+    label = rb._llm_label({"with_llm": False})
+    assert label != "off"
+    assert "not recorded" in label
+
+
+# ── product datasets report real controller health ────────────────────────
+
+class _Prof:
+    def health(self):
+        return type("H", (), {"value": "RED"})()
+
+
+class _Hist:
+    stop_reason = type("S", (), {"value": "BUDGET_ITERATIONS"})()
+
+
+class _Report:
+    controller_profile = _Prof()
+    controller_history = _Hist()
+
+
+class _Result:
+    postflight_report = _Report()
+
+
+def test_controller_health_reads_a_red_verdict():
+    assert rb._controller_health(_Result()) == ("RED", "BUDGET_ITERATIONS")
+
+
+def test_controller_health_unknown_not_na_when_absent():
+    """"unknown" rather than "n/a" is load-bearing: `_check_quality_floors` fails
+    a RED run outright, so "cannot report" must not look like "nothing to report".
+    The product datasets hardcoded "n/a", which is why two RED configs in the
+    2026-08-18 nightly passed the RED check in silence."""
+    assert rb._controller_health(object()) == ("unknown", "unknown")
+    assert rb._controller_health(None) == ("unknown", "unknown")
+
+
+def test_red_health_is_a_breach_even_above_the_floor():
+    """The check the "n/a" hardcode disabled."""
+    breaches = rb._check_quality_floors([
+        {"name": "Abt-Buy", "f1": 0.99, "health": "RED",
+         "stop_reason": "BUDGET_ITERATIONS"},
+    ])
+    assert any("RED" in b for b in breaches)

--- a/scripts/test_run_benchmarks_llm_isolation.py
+++ b/scripts/test_run_benchmarks_llm_isolation.py
@@ -2,18 +2,20 @@
 
 `goldenmatch.core.llm_extract` reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
 straight out of `os.environ` with no opt-in flag, so merely having a key
-exported rewrote what this lane reported. On Abt-Buy that path handles 959 of
-2173 records, and the gap is not marginal:
+exported changes what this lane reports. On Abt-Buy that path handles 959 of
+2173 records, and it moves the score:
 
-    no key   f1=0.1723  precision=0.1068   <- what CI has always measured
-    a key    routes 44% of records through paid extraction instead
+    no key   f1=0.1723  P=0.1068  R=0.4463   <- what CI measures
+    key      f1=0.1838  P=0.1132  R=0.4875
 
-The committed `docs/benchmarks/latest-results.json` was produced on a machine
-with a key exported. It published 0.5037 under a generated header reading
-"LLM features: off" -- that label read `--with-llm`, which only ever controlled
-the DQbench lane. #2470 then pinned Abt-Buy's floor at 0.45 "just under the
-observed value", so the floor became a test of whether a key was in the
-environment, and the keyless nightly could never pass it.
+A benchmark whose answer depends on an unrelated env var cannot be compared
+across machines, which is the whole reason the lane exists. So the key is
+dropped rather than merely reported.
+
+Note the guard is justified by determinism alone. It does NOT explain the
+committed 0.5037 Abt-Buy baseline: that was the first hypothesis, and the keyed
+measurement above refuted it. See the `Abt-Buy` entry in `_F1_FLOORS` for the
+full matrix and what remains unexplained.
 
 Two properties are pinned here, and the second is the one with teeth: a guard
 that strips the key but still lets the report claim "off" for a run that could


### PR DESCRIPTION
## What and why

The 2026-08-18 nightly `benchmarks` run failed on `Abt-Buy: f1=0.1723 is below the floor 0.4500`. This fixes three real defects the investigation turned up. It does **not** fix #2457, and the section below says why.

**It is not a code regression, and I could not reproduce the baseline at all.** Every hypothesis was measured and ruled out, all on the same 1118 ground-truth pairs:

| run | F1 | Precision | pairs emitted |
|---|---|---|---|
| committed baseline (2026-08-11, `native=1`) | **0.5037** | 0.8219 | 494 |
| CI nightly #99, `native=0`, no key | 0.1723 | 0.1068 | |
| local HEAD, `native=0`, no key | 0.1723 | 0.1068 | 4673 |
| local HEAD, `native=1`, no key | 0.1723 | 0.1068 | |
| local `8145b498` (the commit that *published* the baseline) | 0.1723 | 0.1068 | |
| local HEAD, `native=0`, **with** an LLM key | 0.1838 | 0.1132 | |

So: not a code regression (the publishing commit itself scores 0.1723), not the kernel-vs-fallback split, and **not the ambient LLM key** — that was my first hypothesis and the last row refutes it. The baseline emitted 494 pairs where every reproduction emits ~4673, so whatever produced it was configured very differently. **Cause unknown.**

## Changes

Each stands on its own merits; none depended on the refuted hypothesis.

- **Ambient `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` are dropped unless `--with-llm` is passed.** `goldenmatch/core/llm_extract.py:50` reads them straight from `os.environ` with no opt-in, and on Abt-Buy that path handles 959 of 2173 records — worth +0.0115 F1 at roughly 50x the wall clock. A benchmark whose answer depends on an unrelated env var cannot be compared across machines, which is the whole point of the lane. Sits beside the existing forced-off auto-config-memory guard, which exists for the same reason. Both vars, not just OpenAI: Anthropic is the fallback provider, so stripping one leaves the same defect on the other vendor.
- **`_measure_product` hardcoded `"health": "n/a"`**, so the RED-config check in `_check_quality_floors` could never fire on the two product datasets. Both committed RED configs in the nightly and neither tripped it. Health is now read off the result via a shared `_controller_health`; a result that cannot report says `"unknown"`, never `"n/a"`, so "cannot report" stays distinguishable from "nothing to report".
- **The report's LLM label** no longer infers "off" from the DQbench flag — a payload with no `llm_keys_suppressed` renders `not recorded (run predates the ambient-key guard)`, and the committed `.md` is re-rendered, so the published doc stops claiming something it cannot support.
- **The Abt-Buy floor comment** records the full matrix above and warns against re-deriving the floor from a number nobody can reproduce.

### What this does NOT do

**It does not make the nightly green — it makes it fail louder.** With the RED check finally able to fire, both product datasets now breach on RED controller health. That is a pre-existing quality problem the `"n/a"` hardcode was hiding, so **#2457 should stay open**.

**The 0.45 floor is not lowered.** Lowering it would not help anyway (the RED breach fails independently), and #2470's own comment asks for floor changes to be a reviewable decision rather than a way to make red look green. It is also not currently known to describe anything, since the number it was derived from is unreproduced.

Worth an explicit call: whether Abt-Buy should join Amazon-Google's documented "KNOWN BAD, floor pinned only to stop it getting worse" status, and whether anyone can account for that 0.5037.

## Testing

- `pytest scripts/test_run_benchmarks_llm_isolation.py scripts/test_run_benchmarks_download.py scripts/dqbench_adapters/test_leipzig_eval.py -q` — **33 passed**. 11 new tests; the load-bearing one asserts a pre-guard payload does *not* render as a flat "off", since a guard that strips the key but still lets the report claim "off" would be another check that does not fire.
- Wired into the existing `scripts_lint` pytest step, same `uv run --with polars --with pyarrow` idiom already there.
- **End to end with a key exported**, which is the behaviour under test:
  ```
  ignoring ambient OPENAI_API_KEY (pass --with-llm to use it): an LLM-assisted number is not comparable with CI's.
  Abt-Buy: f1=0.1723 precision=0.1068 recall=0.4463 health=red stop_reason=budget_time
    - Abt-Buy: controller health is RED (stop_reason=budget_time) -- the metrics are not trustworthy
  ```
  The number now matches CI exactly with a key present, and the RED check fires for the first time.
- `run_benchmarks.py --report docs/benchmarks/latest-results.md --check` — current (it failed before the `.md` was re-rendered, which is how I caught that this change moves the rendered output).
- `ruff check scripts/` clean; `scripts/check_workflow_yaml.py` — 127 files, all parse, no duplicate keys.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — not run, `pre-commit` is not installed in this environment; `ruff check` was run directly and is clean
- [x] Package `CHANGELOG.md` updated if behavior changed — n/a, this changes `scripts/` and CI wiring, not a published package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — the findings are documented on the guard function and the disputed floor, next to the code each governs