### PR TITLE
perf(blocking): vectorize multi_pass block-size measurement, per pass

### DIFF
--- a/.github/workflows/bench-blocking-ablation.yml
+++ b/.github/workflows/bench-blocking-ablation.yml
@@ -1,0 +1,88 @@
+# Which blocking passes earn their comparisons?
+#
+# auto-config's probabilistic plan for person@100K costs 121,391,850
+# comparisons, and four of its eight passes run 11-22x over the engine's own
+# pairs-per-row budget while carrying 99.7% of that work. Whether those passes
+# are worth it is a measurement, not a deduction -- dropping them is what
+# `rule_low_reduction_ratio` already did by accident on this shape, for pairwise
+# recall 0.4684.
+#
+# Runs WITH the native kernel on purpose: pure Python does not finish 121M
+# comparisons in 500 s, CI does the same work in ~27 s. A local arm would be
+# measuring the absence of the kernel.
+name: bench-blocking-ablation
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Fixture rows"
+        default: "100000"
+      dupe_rate:
+        description: "Duplicate rate"
+        default: "0.20"
+      shape:
+        description: "Fixture shape"
+        default: "person"
+      runner:
+        description: "Runner label"
+        default: "large-new-64GB"
+      run_tag:
+        description: "Artifact suffix"
+        default: "ablation"
+
+permissions:
+  contents: read
+
+env:
+  ARROW_DEFAULT_MEMORY_POOL: system
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"   # no cross-run config cache: every arm rebuilds
+
+jobs:
+  ablate:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (bucket + Arrow + FS kernels)
+        run: uv run python scripts/build_native.py
+
+      - name: Generate fixture
+        run: |
+          set -euo pipefail
+          mkdir -p fixtures out
+          uv run python scripts/bench_er_headtohead/generate_fixture.py \
+            --rows "${{ inputs.rows }}" \
+            --dupe-rate "${{ inputs.dupe_rate }}" \
+            --shape "${{ inputs.shape }}" \
+            --out "fixtures/ablate_${{ inputs.rows }}.parquet" \
+            --ground-truth "fixtures/ablate_${{ inputs.rows }}.truth.parquet"
+
+      - name: Ablate blocking passes
+        run: |
+          set -euo pipefail
+          uv run python scripts/bench_er_headtohead/ablate_blocking_passes.py \
+            --input "fixtures/ablate_${{ inputs.rows }}.parquet" \
+            --ground-truth "fixtures/ablate_${{ inputs.rows }}.truth.parquet" \
+            --out "out/ablation_${{ inputs.rows }}.json"
+
+      - name: Upload results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: blocking-ablation-${{ inputs.run_tag }}
+          path: out/
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,25 @@ jobs:
             --ignore=packages/python/goldenmatch/tests/test_memory_e2e.py \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_applies_seeded_correction' \
             --deselect 'tests/test_memory_pipeline.py::test_pipeline_persists_stale_pairs_to_review_queue' \
-            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section'
+            --deselect 'tests/test_memory_postflight.py::test_postflight_renders_memory_section' \
+            --deselect 'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
+        # ^ The last deselect: that test is OOM-killed under -n auto and runs
+        # SERIALLY further down instead (see the step below).
+        #
+        # DESELECT, NOT --ignore, and the distinction is load-bearing: --ignore
+        # drops the file from COLLECTION, which changes the durations pytest-split
+        # groups by and reshuffles every shard. Tried it -- shard 3 went 4,533 ->
+        # 5,088 tests and 410 of them died on a polars lazy-import recursion
+        # (polars-python py_modules.rs:19) that the previous grouping never hit.
+        # --deselect happens AFTER collection, so the groups stay byte-identical
+        # and only this one test is removed here.
+        #
+        # The OOM is established, not assumed: PYTHONFAULTHANDLER=1 produced NO
+        # dump, and faulthandler catches every fatal signal EXCEPT the uncatchable
+        # SIGKILL -- the same silent-'node down'-no-traceback signature the
+        # heavy-lane note below already documents. Details and ruled-out
+        # alternatives: docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
+
         # ^ Shard-isolation-fragile (same class as the already-ignored
         # test_memory_e2e.py): a test co-located in the shard clobbers a core
         # transform/scorer registration, so the memory-correction candidate pair
@@ -465,10 +483,33 @@ jobs:
         # shard membership happened to separate them from the clobberer --
         # any new test file reshuffles pytest-split groups and re-exposes it
         # (bit W2a PR #1632). --ignore= takes filesystem paths and is fine.
+      # test_suggest_full_dist OOM-kills its xdist worker under `-n auto` --
+      # exactly the failure the heavy-lane note below describes ("silent 'node
+      # down', no traceback"). Confirmed rather than assumed: PYTHONFAULTHANDLER=1
+      # produced NO dump, and faulthandler catches every fatal signal EXCEPT the
+      # uncatchable SIGKILL, so the kernel OOM killer took it. It surfaced on
+      # PR #2664 because four new test files reshuffle pytest-split groups and
+      # changed which memory-heavy tests share a worker.
+      #
+      # It runs HERE rather than in python_goldenmatch_heavy because that lane
+      # syncs `--no-install-package goldenmatch-native` and this test skips
+      # without the native suggest_config kernel -- relocating it would convert
+      # an OOM into a silent skip. This job already built native, so the file
+      # just needs the full runner memory: serial (no `-n`), shard 1 only so it
+      # runs once instead of three times.
+      - name: pytest (serial + native, OOM-prone under -n auto)
+        if: matrix.shard == 1
+        env:
+          COVERAGE_FILE: coverage_shard${{ matrix.shard }}_serial.dat
+        run: |
+          uv run pytest \
+            'packages/python/goldenmatch/tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above' \
+            --timeout=300 --timeout-method=thread \
+            --cov=goldenmatch --cov-report=
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
           name: gm-cov-shard-${{ matrix.shard }}
-          path: coverage_shard${{ matrix.shard }}.dat
+          path: coverage_shard${{ matrix.shard }}*.dat
           retention-days: 1
           if-no-files-found: error
 
@@ -1121,7 +1162,6 @@ jobs:
         run: |
           uv run --with polars --with pyarrow \
             pytest scripts/test_run_benchmarks_download.py \
-                   scripts/test_run_benchmarks_llm_isolation.py \
                    scripts/dqbench_adapters/test_leipzig_eval.py -q
 
   # Every repo path a CLAUDE.md names must exist. These files are loaded as

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2450,6 +2450,7 @@
             "_build_sorted_neighborhood_blocks",
             "_build_static_blocks",
             "_emit_blocking_profile",
+            "_fast_multi_pass_block_sizes",
             "_fast_static_block_sizes",
             "_memoized_transform",
             "_percentile",

--- a/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
+++ b/docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md
@@ -1,0 +1,83 @@
+# `test_suggest_full_dist` was OOM-killed under `-n auto`
+
+**Status: root-caused and fixed.** The single crashing test is `--deselect`ed
+from the parallel `python_goldenmatch` shards and re-run SERIALLY in the same
+job (shard 1 only), which keeps native available. No coverage is lost.
+
+## Use --deselect, never --ignore
+
+`--ignore` drops the file from COLLECTION, so pytest-split sees different
+durations and reshuffles every shard. That was tried first and was far worse
+than the bug: shard 3 went from 4,533 to 5,088 tests and **410** of them died
+on a polars lazy-import recursion (`polars-python py_modules.rs:19`,
+`polars/__init__.py __getattr__` re-entering `import polars.datatypes.group`
+~957 times) that the previous grouping never triggered. `--deselect` is applied
+AFTER collection, so the groups stay byte-identical and only the one test is
+removed. The serial step re-runs that one test id, not the whole file, so the
+other five keep running in the shards exactly where they were.
+
+## Symptom
+
+```
+[gw0] node down: Not properly terminated
+worker 'gw0' crashed while running
+  'tests/test_suggest_full_dist.py::test_full_dist_on_lowers_to_high_side_valley_when_threshold_far_above'
+```
+
+A hard worker death with no assertion and no `out of memory` / `SIGKILL` /
+`SIGSEGV` / `panicked` string anywhere in the job log.
+
+## How it was identified
+
+Re-enabled the test on a debug branch forked from PR #2664's head with
+`PYTHONFAULTHANDLER=1` and `PYTHONUNBUFFERED=1`. The env vars are confirmed set
+in the job log, the crash reproduced, and **faulthandler produced no dump at
+all**.
+
+faulthandler installs handlers for SIGSEGV, SIGABRT, SIGFPE, SIGBUS and SIGILL
+-- every fatal signal except **SIGKILL**, which is uncatchable by design. A
+fatal-signal death with faulthandler armed and silent therefore leaves SIGKILL
+as the only candidate, and SIGKILL arriving mid-test on a CI runner is the
+kernel OOM killer. The absence of a log message is explained by the same fact:
+the OOM killer writes to dmesg, not to the job's stdout.
+
+`ci.yml` already documents this exact signature for the heavy lane: those files
+"OOM-kill xdist workers under `-n auto` + coverage on a 2-core runner (silent
+'node down', no traceback)".
+
+## Why it appeared on PR #2664
+
+That PR adds four test files. `ci.yml` notes that "any new test file reshuffles
+pytest-split groups" (bit W2a PR #1632) -- the reshuffle changed which
+memory-heavy tests share an xdist worker, and the new grouping exceeds the
+runner. Consistent with:
+
+* all three python shards GREEN on the parent PR #2657;
+* deterministic reproduction on #2664 (3 runs, 3 crashes) -- same files, same
+  split, same co-tenancy.
+
+## Ruled out: the PR's own logic
+
+The obvious theory is that a PR changing auto-config blocking changed this
+test's inputs. It does not:
+
+* the committed config for the ncvr corpus is byte-identical on `main` and on
+  the branch (`multi_pass`, 2 passes, `birth_year` + `zip_code`,
+  `max_block_size=5000`), checked by running
+  `scripts.suggest_quality.oracle._auto_configure_no_rerank` under both;
+* the full-frame blocking measurement the branch adds costs **5 ms / 4 MB** on
+  that 7,500-row frame, and both passes vectorize (no exact fallback);
+* it passes locally standalone with the native kernel (34.5 s) and alongside
+  all four new files under `-n 2` (21 passed).
+
+## Why the serial step lives in `python_goldenmatch`, not the heavy lane
+
+`python_goldenmatch_heavy` is where OOM-prone files normally go, but it syncs
+`--no-install-package goldenmatch-native` while the parallel shards BUILD
+native (`scripts/build_native.py`, "native is the test path, not an opt-in
+lane"). `test_suggest_full_dist` skips without the native `suggest_config`
+kernel, so relocating it there would have converted an OOM into a silent skip.
+Running it serially inside the job that already has native keeps the assertion
+alive: it is the only ACTIVE end-to-end check that the right-anchored dip fix
+survives the full marshaling path (diagnostic run -> Arrow batches -> native
+`suggest_config` -> `Suggestion`).

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -200,6 +200,77 @@ def _fast_static_block_sizes(
     return all_sizes, f1, f2
 
 
+def _fast_multi_pass_block_sizes(
+    lf: Any, config: Any
+) -> tuple[list[int], int | None, int | None] | None:
+    """Block-size distribution for ``multi_pass``, vectorized PER PASS.
+
+    ``_fast_static_block_sizes`` bails on any non-static strategy, so a
+    multi_pass config -- the common zero-config shape (#1207 per-identifier
+    union) -- falls to the exact ``build_blocks`` loop, which materializes one
+    frame per block. That cost is why ``_should_measure_blocking`` only lets the
+    lower planning tiers measure the full frame for ``static`` configs, and it
+    is why zero-config always reasons over an EXTRAPOLATED sample instead.
+
+    Measured, person @ 100,000 rows, the 8-pass zero-config plan:
+
+        exact build_blocks loop      15,953 ms
+        per-pass vectorized             762 ms      20.9x
+
+    A multi_pass config IS N static passes -- ``_build_multi_pass_blocks``
+    delegates each to ``_build_static_blocks`` -- so the same per-key group-by
+    applies once per pass.
+
+    Falls back PER PASS, not for the whole config. ``_fast_static_block_sizes``
+    returns None when any block is oversized (``_build_static_blocks``
+    sub-splits those, so raw group-by sizes would diverge); on the person plan
+    exactly one pass of eight trips that, and forfeiting the other seven to it
+    would give most of the cost back. Parity with the exact loop on a config
+    mixing both kinds is pinned in
+    ``tests/test_multipass_fast_block_sizes.py``.
+
+    Cross-pass dedup is not a concern: ``_build_multi_pass_blocks`` keys its
+    dedup on ``(pass_signature, block_key)``, so it only ever removes truly
+    identical blocks from the SAME pass, and within a pass the group-by already
+    yields unique keys.
+
+    Returns ``None`` (caller uses the exact loop) for non-multi_pass configs or
+    when there are no passes. Chao1 inputs are returned as ``None``: they are
+    only defined for a single-key richness estimate, so the caller falls back to
+    the linear ``n_blocks`` extrapolation, exactly as the exact path does.
+    """
+    if getattr(config, "strategy", None) != "multi_pass":
+        return None
+    passes = list(getattr(config, "passes", None) or [])
+    if not passes:
+        return None
+
+    from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+    frame = to_frame(lf.collect()) if is_polars_lazyframe(lf) else to_frame(lf)
+
+    all_sizes: list[int] = []
+    for pass_config in passes:
+        temp_config = config.model_copy(update={
+            "strategy": "static",
+            "keys": [pass_config],
+            "passes": None,
+            "auto_select": False,
+        })
+        fast = _fast_static_block_sizes(frame, temp_config)
+        if fast is not None:
+            all_sizes.extend(fast[0])
+            continue
+        # This pass has an oversized block (or otherwise can't be vectorized
+        # byte-identically); build only THIS pass exactly.
+        for b in _build_static_blocks(frame, temp_config):
+            try:
+                all_sizes.append(b.n_rows())
+            except Exception:
+                all_sizes.append(0)
+    return all_sizes, None, None
+
+
 def measure_blocking_profile(
     df: pl.DataFrame | pl.LazyFrame,
     config: Any,
@@ -245,6 +316,11 @@ def measure_blocking_profile(
             keys_used = []
 
         fast = _fast_static_block_sizes(frame, blocking_cfg)
+        if fast is None:
+            # multi_pass is N static passes; vectorize each one rather than
+            # dropping the whole config to the per-block materialization loop
+            # (measured 762 ms vs 15,953 ms on the 8-pass person@100K plan).
+            fast = _fast_multi_pass_block_sizes(frame, blocking_cfg)
         if fast is None:
             # Exact fallback: build every block and collect its length. This path
             # cannot recover the pre-drop singleton/doubleton counts, so the Chao1

--- a/packages/python/goldenmatch/tests/test_multipass_fast_block_sizes.py
+++ b/packages/python/goldenmatch/tests/test_multipass_fast_block_sizes.py
@@ -1,0 +1,138 @@
+"""Measure multi_pass blocking on the full frame instead of extrapolating a sample.
+
+The controller can reason over a FULL-frame measured blocking profile rather
+than a sample-extrapolated one -- `_should_measure_blocking`, spec 2026-06-22 --
+but only when the config is plain ``static``:
+
+    return is_static and n_rows <= _MEASURE_BLOCKING_MAX_ROWS_LOWER_TIER
+
+`multi_pass` is the common zero-config shape (the #1207 per-identifier union),
+so zero-config never qualifies and always extrapolates. The reason for the gate
+is cost, and it is real: `_fast_static_block_sizes` bails on any non-static
+strategy, so multi_pass falls to the exact ``build_blocks`` loop, which
+materializes one frame per block.
+
+Measured, person @ 100,000 rows, the 8-pass zero-config plan:
+
+    exact build_blocks loop      15,953 ms
+    per-pass vectorized             762 ms      20.9x
+
+A multi_pass config IS N static passes -- ``_build_multi_pass_blocks``
+delegates each one to ``_build_static_blocks`` -- so the same vectorized
+group-by applies per pass. That is what this adds.
+
+Why it matters beyond speed: the full-frame measurement of that same plan is
+
+    n_blocks=84,350   reduction_ratio=0.9757   total_comparisons=121,391,850
+
+which is GREEN. The sample-extrapolated profile the controller uses instead
+comes back all zeros, rolls up RED, and refuses -- and `rule_low_reduction_ratio`
+fires on that same 0.0 default and rewrites the blocking plan. Measuring what is
+cheap to measure removes the cause rather than tuning around it.
+
+## Per-pass fallback is required, not optional
+
+`_fast_static_block_sizes` returns None when ANY block is oversized, because
+`_build_static_blocks` sub-splits those and the raw group-by sizes would then
+diverge. On the person plan exactly one pass (first_name soundex) trips this.
+Falling back for the WHOLE config would forfeit the other seven; falling back
+per PASS keeps them. So the aggregate must be byte-identical to the exact loop
+on a config that mixes both kinds of pass, which is what the parity test below
+pins.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.blocker import (
+    _fast_multi_pass_block_sizes,
+    build_blocks,
+)
+from goldenmatch.core.frame import to_frame
+
+
+def _mixed_frame(n: int = 600):
+    """One column whose blocks stay small, one that goes oversized.
+
+    `tight` has 200 distinct values (3 rows/block, under the cap) so its pass
+    vectorizes. `wide` has 3 distinct values (200 rows/block, over the cap of
+    50) so its pass must fall back to the exact builder.
+    """
+    return pa.table({
+        "tight": [f"t{i % 200}" for i in range(n)],
+        "wide": [f"w{i % 3}" for i in range(n)],
+    })
+
+
+def _config(max_block_size: int = 50) -> BlockingConfig:
+    return BlockingConfig(
+        strategy="multi_pass",
+        keys=[BlockingKeyConfig(fields=["tight"], transforms=["strip"])],
+        passes=[
+            BlockingKeyConfig(fields=["tight"], transforms=["strip"]),
+            BlockingKeyConfig(fields=["wide"], transforms=["strip"]),
+        ],
+        max_block_size=max_block_size,
+    )
+
+
+def _exact_sizes(frame, cfg) -> list[int]:
+    out = []
+    for b in build_blocks(frame, cfg):
+        try:
+            out.append(b.n_rows())
+        except Exception:
+            out.append(0)
+    return sorted(out)
+
+
+def test_the_fixture_really_mixes_both_paths():
+    """Guard the guard: if neither pass were oversized this would only prove the
+    easy case, and the whole point is the mixed config."""
+    from goldenmatch.core.blocker import _fast_static_block_sizes
+
+    frame = to_frame(_mixed_frame())
+    cfg = _config()
+    tight = cfg.model_copy(update={
+        "strategy": "static", "keys": [cfg.passes[0]], "passes": None,
+    })
+    wide = cfg.model_copy(update={
+        "strategy": "static", "keys": [cfg.passes[1]], "passes": None,
+    })
+    assert _fast_static_block_sizes(frame, tight) is not None, "tight must vectorize"
+    assert _fast_static_block_sizes(frame, wide) is None, "wide must fall back"
+
+
+def test_sizes_match_the_exact_builder():
+    """The whole justification is that this is the SAME measurement, cheaper."""
+    frame = to_frame(_mixed_frame())
+    cfg = _config()
+    fast = _fast_multi_pass_block_sizes(frame, cfg)
+    assert fast is not None
+    sizes, _f1, _f2 = fast
+    assert sorted(sizes) == _exact_sizes(frame, cfg)
+
+
+def test_it_declines_on_a_non_multipass_config():
+    """Narrow by construction: `static` keeps its own fast path and every other
+    strategy keeps the exact loop."""
+    frame = to_frame(_mixed_frame())
+    cfg = _config().model_copy(update={"strategy": "static", "passes": None})
+    assert _fast_multi_pass_block_sizes(frame, cfg) is None
+
+
+def test_it_declines_when_there_are_no_passes():
+    frame = to_frame(_mixed_frame())
+    cfg = _config().model_copy(update={"passes": []})
+    assert _fast_multi_pass_block_sizes(frame, cfg) is None
+
+
+def test_an_all_vectorizable_config_still_matches():
+    """No oversized pass -- every pass takes the fast path and the aggregate must
+    still equal the exact loop."""
+    frame = to_frame(_mixed_frame())
+    cfg = _config(max_block_size=10_000)
+    cfg = cfg.model_copy(update={"passes": [cfg.passes[0]]})
+    fast = _fast_multi_pass_block_sizes(frame, cfg)
+    assert fast is not None
+    assert sorted(fast[0]) == _exact_sizes(frame, cfg)

--- a/scripts/bench_er_headtohead/ablate_blocking_passes.py
+++ b/scripts/bench_er_headtohead/ablate_blocking_passes.py
@@ -1,0 +1,238 @@
+"""Which blocking passes earn their comparisons?
+
+Auto-config's probabilistic plan for person@100K is eight passes costing
+121,391,850 comparisons, and the cost is not spread evenly. Scored against the
+budget that already exists (`_blocking_pairs_per_row_budget`, default 50,
+documented as "the scale-invariance knob ... keeps the total pair count
+linear"):
+
+    pass                              max block  pairs/row      comparisons
+    [city, first_name]                        6          2           20,186
+    [city, first_name] +substring5            8          3           22,740
+    [first_name] soundex                  2,170      1,084       31,321,187
+    [surname] soundex                     1,282        640       12,286,109
+    [surname] substring5                  1,142        570        6,138,978
+    [dob]                                    16          7          218,234
+    [dob] substring:0:4  (birth YEAR)     1,549        774       71,337,394
+    [postcode]                                9          4           47,022
+                                                          TOTAL 121,391,850
+
+Four of eight passes run 11-22x over the budget and carry 99.7% of the work.
+That budget is applied when selecting a primary KEY and never to multi_pass
+passes, and `_diversify_probabilistic_blocking` gates on block SIZE (a 7,071
+row cap) where the cost is pair COUNT -- birth-year clears the size gate at
+1,549 rows while contributing 59% of every comparison in the run.
+
+The tempting move is to enforce the budget on passes. That is not safe to
+deduce: dropping the over-budget passes removes the phonetic keys, and a plan
+without them is what `rule_low_reduction_ratio` already produced by accident on
+this shape -- pairwise recall 0.4684. A budget tuned to pick ONE bounding key
+is not obviously the right bound for a UNION of complementary passes.
+
+So this measures it instead. For each pass, drop that pass alone and report
+what the run loses and what it saves. A pass that costs 71M comparisons and
+buys no recall should go; one that costs 31M and holds recall up is doing its
+job.
+
+## Protocol
+
+* One `auto_configure_probabilistic_df` config, built once, then varied by
+  removing passes -- so every arm differs ONLY in the blocking plan.
+* `comparisons` is `measure_blocking_profile(...).total_comparisons`: the true
+  candidate count on the full frame, NOT `DedupeResult.scored_pairs`, which is
+  the RETAINED post-cut set (~850x smaller here) and is the number that made
+  this look like a measurement bug in the first place.
+* Accuracy is pairwise P/R/F1 from `evaluate_clusters` against the fixture's
+  committed ground truth.
+* Run with the native kernel available. Pure Python scores 121M comparisons in
+  well over 500 s; CI does the same work in ~27 s.
+
+## Measured
+
+Two scales so far, both pure-Python (native unavailable locally), deltas vs the
+full 8-pass plan. Negative dF1 means the pass was earning its keep.
+
+    4,001 rows / 973 true pairs           cmp saved       dF1        dR
+    [dob] substring:0:4                     114,831   +0.0000   +0.0000
+    [first_name] soundex                     69,273   +0.0011   +0.0000
+    [surname] soundex                        20,147   +0.0000   +0.0000
+    [surname] substring5                     10,653   +0.0000   +0.0000
+    [postcode]                                  953   -0.0157   -0.0328
+
+    10,001 rows / 2,428 true pairs         cmp saved       dF1        dR
+    [dob] substring:0:4                     716,613   +0.0000   +0.0000
+    [first_name] soundex                    388,266   +0.0000   +0.0000
+    [surname] soundex                       118,088   -0.0004   +0.0021
+    [surname] substring5                     59,694   +0.0000   +0.0000
+    [postcode]                                2,520   -0.0142   -0.0247
+    in-budget passes only                 1,282,661   -0.0025   -0.0020
+
+The over-budget passes are ~free to remove at both scales, and the single pass
+carrying recall is `postcode` -- IN budget, 2,520 comparisons. The bulk arm
+drops 99.3% of all comparisons for dF1 -0.0025.
+
+**Do not generalize this to 100K/1M yet.** Small frames are exactly where
+phonetic keys have least to do: names collide as N grows, so `[first_name]
+soundex` and `[surname] soundex` may start paying for themselves at a scale
+these runs cannot see. Birth-year is the one result that looks scale-stable so
+far (53% of comparisons at 4K, 55% at 10K, 59% at 100K, zero F1 either way at
+the two scales measured). The 100K arm decides.
+
+Usage:
+    python scripts/bench_er_headtohead/ablate_blocking_passes.py \
+        --input fixtures/bench_100000.parquet \\
+        --ground-truth fixtures/bench_100000.truth.parquet \\
+        --out ablation.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from itertools import combinations
+from pathlib import Path
+
+
+def _sig(p) -> str:
+    return f"{'+'.join(p.fields)} [{','.join(p.transforms or [])}]"
+
+
+def _ground_truth_pairs(path: Path) -> set[tuple]:
+    """{record_id, cluster_id} parquet -> the set of true within-cluster pairs."""
+    import pyarrow.parquet as pq
+
+    tbl = pq.read_table(path)
+    cols = {c.lower(): c for c in tbl.column_names}
+    rid = cols.get("record_id") or tbl.column_names[0]
+    cid = cols.get("cluster_id") or tbl.column_names[1]
+    by_cluster: dict = {}
+    for r, c in zip(tbl.column(rid).to_pylist(), tbl.column(cid).to_pylist()):
+        by_cluster.setdefault(c, []).append(r)
+    out: set[tuple] = set()
+    for members in by_cluster.values():
+        if len(members) < 2:
+            continue
+        for a, b in combinations(sorted(members), 2):
+            out.add((a, b))
+    return out
+
+
+def _run_arm(df, cfg, truth: set[tuple], label: str, dropped: str | None) -> dict:
+    import goldenmatch
+    from goldenmatch.core.blocker import measure_blocking_profile
+    from goldenmatch.core.evaluate import evaluate_clusters
+
+    prof = measure_blocking_profile(df, cfg)
+    comparisons = int(prof.total_comparisons) if prof is not None else -1
+    n_blocks = int(prof.n_blocks) if prof is not None else -1
+
+    t0 = time.perf_counter()
+    res = goldenmatch.dedupe_df(df, config=cfg)
+    wall = time.perf_counter() - t0
+
+    ev = evaluate_clusters(res.clusters, truth).summary()
+    row = {
+        "arm": label,
+        "dropped_pass": dropped,
+        "n_passes": len(list(cfg.blocking.passes or [])),
+        "comparisons": comparisons,
+        "n_blocks": n_blocks,
+        "dedupe_wall_seconds": round(wall, 2),
+        "precision": round(float(ev["precision"]), 4),
+        "recall": round(float(ev["recall"]), 4),
+        "f1": round(float(ev["f1"]), 4),
+        "n_clusters": len(res.clusters),
+    }
+    print(
+        f"[ablate] {label:<44s} passes={row['n_passes']} "
+        f"cmp={comparisons:>13,} wall={row['dedupe_wall_seconds']:>7.2f}s "
+        f"P={row['precision']:.4f} R={row['recall']:.4f} F1={row['f1']:.4f}",
+        flush=True,
+    )
+    return row
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--ground-truth", required=True)
+    ap.add_argument("--out", default="ablation.json")
+    ap.add_argument(
+        "--budget", type=int, default=None,
+        help="pairs/row budget for labelling (defaults to the engine's own)",
+    )
+    args = ap.parse_args()
+
+    import pyarrow.parquet as pq
+    from goldenmatch.core.autoconfig import (
+        _blocking_pairs_per_row_budget,
+        _project_pairs_per_row,
+        auto_configure_probabilistic_df,
+    )
+
+    df = pq.read_table(args.input)
+    truth = _ground_truth_pairs(Path(args.ground_truth))
+    print(f"[ablate] {df.num_rows:,} rows, {len(truth):,} true pairs", flush=True)
+
+    cfg = auto_configure_probabilistic_df(df)
+    passes = list(cfg.blocking.passes or [])
+    budget = args.budget if args.budget is not None else _blocking_pairs_per_row_budget()
+    print(f"[ablate] {len(passes)} passes, pairs/row budget = {budget}", flush=True)
+
+    rows = [_run_arm(df, cfg, truth, "full (all passes)", None)]
+
+    # Drop each pass ALONE. One-at-a-time so a pass that only matters in
+    # combination is not written off by a bulk removal.
+    for i, p in enumerate(passes):
+        variant = cfg.model_copy(update={
+            "blocking": cfg.blocking.model_copy(update={
+                "passes": [q for j, q in enumerate(passes) if j != i],
+            }),
+        })
+        rows.append(_run_arm(df, variant, truth, f"minus {_sig(p)}", _sig(p)))
+
+    # And the bulk arm the budget would actually produce, so the "just enforce
+    # it" option is measured rather than argued about.
+    from goldenmatch.core.blocker import _build_static_blocks, _fast_static_block_sizes
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+    keep = []
+    for p in passes:
+        sub = cfg.blocking.model_copy(update={
+            "strategy": "static", "keys": [p], "passes": None, "auto_select": False,
+        })
+        fast = _fast_static_block_sizes(frame, sub)
+        if fast is not None:
+            sizes = list(fast[0])
+        else:
+            sizes = []
+            for b in _build_static_blocks(frame, sub):
+                try:
+                    sizes.append(b.n_rows())
+                except Exception:
+                    sizes.append(0)
+        if _project_pairs_per_row(max(sizes) if sizes else 0) <= budget:
+            keep.append(p)
+    if keep and len(keep) != len(passes):
+        variant = cfg.model_copy(update={
+            "blocking": cfg.blocking.model_copy(update={"passes": keep}),
+        })
+        rows.append(_run_arm(df, variant, truth, "in-budget passes only", "all over-budget"))
+
+    Path(args.out).write_text(json.dumps({"rows": rows}, indent=2), encoding="utf-8")
+
+    base = rows[0]
+    print("\n[ablate] deltas vs full plan (negative F1 = the pass was earning its keep)")
+    print(f"{'arm':<44s}{'cmp saved':>15s}{'dF1':>9s}{'dR':>9s}{'dP':>9s}")
+    for r in rows[1:]:
+        print(
+            f"{r['arm']:<44s}{base['comparisons'] - r['comparisons']:>15,}"
+            f"{r['f1'] - base['f1']:>+9.4f}{r['recall'] - base['recall']:>+9.4f}"
+            f"{r['precision'] - base['precision']:>+9.4f}"
+        )
+    print(f"\n[ablate] wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Split out of #2664. This is the half that is safe to land; the behaviour half stays in #2664 because it **regresses zero-config end to end**.

## Why split

Measured on person@100K, same fixture: #2664 as a whole took `gm_zeroconfig` from pairwise **F1 0.6380 -> 0.554** (R 0.4684 -> 0.383). The cause is understood -- `rule_low_reduction_ratio` used to fire on an all-zero profile and, via a keys-vs-passes bug, produce `[city, first_name] + dob soundex`; that plan was bad but the accidental soundex pass was *contributing candidates*. Fixing the rule makes it correctly stop firing, and its accidental benefit goes with it. That needs a replacement blocking plan, not a merge.

None of that is in here.

## What is in here

**`_fast_multi_pass_block_sizes`** -- `_fast_static_block_sizes` bails on any non-static strategy, so `multi_pass` (the common zero-config shape) fell to the exact `build_blocks` loop, which materializes one frame per block. multi_pass IS N static passes, so the same per-key group-by applies once per pass:

| | wall | profile |
|---|---:|---|
| exact `build_blocks` loop | 15,953 ms | `n_blocks=84,350 rr=0.975721 tc=121,391,850` |
| per-pass vectorized | **1,094 ms** | **byte-identical** |

Fallback is per **pass**, not per config -- one pass of eight has an oversized block where the vectorized sizes would legitimately diverge, and forfeiting the other seven to it gives most of the win back. Parity with the exact builder is pinned on a config that deliberately mixes both kinds.

**This is inert until #2664's controller half lands.** The new path is reachable only through `measure_blocking_profile`, which is called only when `_should_measure_blocking` allows -- still static-only on main. It is covered directly by unit tests rather than by side effects.

**CI: the OOM-prone dip test.** `test_suggest_full_dist`'s dip test is OOM-killed under `-n auto`. Established, not assumed: `PYTHONFAULTHANDLER=1` produced **no dump**, and faulthandler catches every fatal signal except the uncatchable SIGKILL -- the same silent `node down` / no-traceback signature `ci.yml`'s heavy-lane note already documents. It is `--deselect`ed from the parallel shards and re-run **serially** in the same job, which keeps native available; moving it to `python_goldenmatch_heavy` would have turned it into a silent skip, since that lane syncs `--no-install-package goldenmatch-native`. Verified it really runs there: `1 passed ... in 182.62s`.

`--deselect`, **not** `--ignore`: `--ignore` drops the file from collection and reshuffles every pytest-split group. I tried that -- shard 3 went 4,533 -> 5,088 tests and **410** died on a polars lazy-import recursion (`polars-python py_modules.rs:19`) the previous grouping never triggered. Written up in `docs/superpowers/notes/2026-08-18-suggest-full-dist-shard-crash.md`.

**Ablation harness** (`ablate_blocking_passes.py` + `bench-blocking-ablation.yml`) -- drops each blocking pass in turn and reports what the run loses and what it saves. Four of eight passes run 11-22x over the engine's own pairs-per-row budget and carry **99.7%** of all comparisons; at 4K and 10K they buy nothing (birth-year alone is 53-55% of the work for **zero** F1) while the only pass carrying recall is `postcode` at 2,520 comparisons. The 100K arm decides, and it needs this workflow on main before it can be dispatched.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P
