### PR TITLE
fix(bench): report the blocking plan that actually ran, not just the primary key

### DIFF
--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -132,23 +132,44 @@ def _config_telemetry(cfg) -> dict:
     except Exception as e:  # noqa: BLE001
         out["matchkeys_error"] = f"{type(e).__name__}: {e}"
     try:
-        # `BlockingConfig.keys`, NOT `.passes`. The first version of this read
-        # `.passes` and got `[]` for every lane at both scales -- a plausible
-        # empty list rather than an error, which is the worst way for telemetry
-        # to be wrong. `.passes` is kept as a fallback only because some callers
-        # construct with that alias.
+        # `.passes` FIRST, `.keys` only as the fallback -- and the order is the
+        # whole point. For a `multi_pass` config the plan lives in `.passes`
+        # while `.keys` holds just the primary key, so reading `.keys` first
+        # reported ONE pass for an eight-pass plan. That is not a cosmetic
+        # under-report: it is why `blocking_passes: [["city","first_name"]]`
+        # appeared identical for `gm_zeroconfig` and `gm_probabilistic_shipped`
+        # in run 32084546976, and why the two lanes looked like they differed
+        # only in threshold when they actually differed 2-passes-vs-8.
+        #
+        # The original comment justified `.keys` because a first version read
+        # `.passes` and got `[]` for every lane. Empty-vs-absent is the real
+        # distinction there: `or` on an EMPTY list falls through to keys, while
+        # `is None` does not. Same keys-vs-passes confusion that
+        # `_carries_own_blocking_plan` (#2488) exists for and that
+        # `rule_low_reduction_ratio` had.
+        #
+        # Transforms are recorded too: `[city, first_name]` appears twice in the
+        # probabilistic plan differing ONLY by transform (strip vs
+        # substring:0:5), so fields alone cannot tell two passes apart.
         blocking = getattr(cfg, "blocking", None)
-        keys = getattr(blocking, "keys", None)
-        if keys is None:
-            keys = getattr(blocking, "passes", None)
-        if keys is None:
+        keys = list(getattr(blocking, "passes", None) or []) or list(
+            getattr(blocking, "keys", None) or []
+        )
+        if blocking is None:
+            out["blocking_error"] = "resolved config exposed no blocking at all"
+        elif not keys:
             out["blocking_error"] = (
-                "resolved config exposed neither blocking.keys nor .passes"
+                "resolved config exposed neither blocking.passes nor .keys"
             )
         else:
             out["blocking_passes"] = [
-                list(getattr(k, "fields", []) or []) for k in keys
+                {
+                    "fields": list(getattr(k, "fields", []) or []),
+                    "transforms": list(getattr(k, "transforms", []) or []),
+                }
+                for k in keys
             ]
+            out["blocking_n_passes"] = len(keys)
             out["blocking_strategy"] = getattr(blocking, "strategy", None)
             out["blocking_max_block_size"] = getattr(blocking, "max_block_size", None)
     except Exception as e:  # noqa: BLE001

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -174,6 +174,28 @@ def _config_telemetry(cfg) -> dict:
             out["blocking_max_block_size"] = getattr(blocking, "max_block_size", None)
     except Exception as e:  # noqa: BLE001
         out["blocking_error"] = f"{type(e).__name__}: {e}"
+    # Everything ELSE the resolved config carries, minus the two blocks already
+    # reported above. Two lanes on the same fixture were found committing an
+    # IDENTICAL 8-pass blocking plan and identical matchkeys while producing
+    # 3,287 vs 83,436 blocks and pairwise F1 0.5536 vs 0.9970 -- so the
+    # difference lives in a config field neither of those blocks covers, and
+    # naming candidates one at a time has already cost several CI rounds.
+    # Dump the rest wholesale (scalars/short reprs only, so the artifact stays
+    # readable) rather than guessing which field matters.
+    try:
+        dump = cfg.model_dump() if hasattr(cfg, "model_dump") else dict(vars(cfg))
+        rest = {}
+        for k, v in sorted(dump.items()):
+            if k in ("matchkeys", "blocking"):
+                continue
+            if v is None or isinstance(v, (bool, int, float, str)):
+                rest[k] = v
+            else:
+                r = repr(v)
+                rest[k] = r if len(r) <= 300 else r[:300] + "...<truncated>"
+        out["config_other"] = rest
+    except Exception as e:  # noqa: BLE001
+        out["config_other_error"] = f"{type(e).__name__}: {e}"
     return out
 
 


### PR DESCRIPTION
`_config_telemetry` read `blocking.keys` first and fell back to `.passes`. For a `multi_pass` config the plan lives in `.passes` while `.keys` holds only the primary key, so an **eight-pass plan was reported as one pass**.

Not cosmetic: in run 32084546976 it made `gm_zeroconfig` and `gm_probabilistic_shipped` look like they had identical blocking (both printed `[[city,first_name]]`) when one ran 2 passes and the other 8. The lanes appeared to differ only in threshold, and I believed the artifact before tracing the configs by hand.

The original comment justified `.keys` because a first version read `.passes` and got `[]` for every lane. Empty-vs-absent is the real distinction: `or` on an empty list falls through to `.keys`, `is None` does not.

Also records **transforms** (`[city, first_name]` appears twice in the probabilistic plan differing only by `strip` vs `substring:0:5` -- fields alone cannot tell two passes apart) and `blocking_n_passes`.

Unblocks the open zero-config question: with the rule fixes applied the controller commits a plan producing 3,287 blocks / 9,250 pairs at person@100K and nothing reports which plan that is. Pure Python cannot finish that frame (121M comparisons), so the answer must come from CI -- and the bench could not tell us.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P