### PR TITLE
fix(autoconfig): zero-config no longer returns a confident empty result (#2663, #2668, #2673)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-close-2663-2637-2668.md
+++ b/docs/superpowers/plans/2026-08-18-close-2663-2637-2668.md
@@ -2,6 +2,38 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+---
+
+## STATUS 2026-08-18: Tasks 1-2 SHIPPED. Task 4 SUPERSEDED. Task 3 deferred.
+
+**Tasks 1 and 2 are done** and shipped in PR #2672 (stacked on #2671). Both verified
+by restore-the-bug; 108 existing rule/policy tests and 52 zero-config/planner tests
+stayed green.
+
+**Task 4 is superseded by #2673 -- do not implement it as written.** Executing Tasks
+1-2 and measuring the end-to-end result showed the plan's premise was too narrow.
+`mass_above_threshold` is tautologically 1.0 at **all six** emit sites for **every**
+matchkey type, because `_emit_scoring_profile` is always passed an already-above-cut
+pair set -- not just on the probabilistic `min(scores)` fallback path this plan
+scoped. Measured on a weighted matchkey with a real configured `threshold=0.8`:
+3 pairs returned, 0 below threshold, `mass_above=1.0000`. Adding
+`threshold_is_resolved` would leave the weighted path just as tautological.
+
+**Task 3 was implemented-then-reverted as unhelpful in isolation.** The guard fix is
+structurally correct (`candidates_compared > 0` genuinely blocks every bucket
+profile), but measured against #2663's own corpus it still would not fire:
+`reduction_ratio` is 0.9886-0.9890, below the rule's `> 0.995` gate, and the
+candidate count (3,919-4,056) is far above the `< n_rows * 0.5` (422.5) gate. Worth
+doing eventually; not worth doing as a #2663 fix.
+
+**Neither #2663 nor #2668 is closed.** Both are now blocked on #2673, which has the
+root cause: `pick_committed`'s precision-collapse guard demotes any RED entry with
+`mass_above > 0.9`, which -- given the tautology -- is every RED entry that found any
+matches at all, so v0 (which found none) commits and the user gets a confident empty
+result. Read #2673 before doing anything further here.
+
+---
+
 **Goal:** Fix the three code-level defects surfaced by today's validity review of #2663, #2637, and #2668 -- each is a case of a profile field reading as measured evidence when it is either absent (bucket route) or tautological (probabilistic threshold fallback), the same "non-decision laundered into a decision" pattern as the zero-config recall incident.
 
 **Architecture:** One foundational fix (blocking measurement, currently gated to >=100K rows, generalized to any scale where it's cheap) unblocks part of #2663's second rule. Two independent rule-engine fixes close #2663. One profile-schema fix (a new `threshold_is_resolved` flag, mirroring the existing `candidates_counted` idiom) closes #2668. #2637's fallback-visibility half is scoped as a design decision, not implemented here -- see Task 5.

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1344,7 +1344,9 @@ def score_probabilistic_external_blocks(
     return out
 
 
-def _emit_profile(pairs: Any, mk: Any, route: str = "buckets") -> None:
+def _emit_profile(
+    pairs: Any, mk: Any, route: str = "buckets", candidates: int | None = None,
+) -> None:
     """Report this backend's scoring to the auto-config emitter (#2647).
 
     `core/scorer.py` emits from its own entry points; this backend calls
@@ -1356,12 +1358,24 @@ def _emit_profile(pairs: Any, mk: Any, route: str = "buckets") -> None:
     was refused on a config whose blocking graded GREEN and whose clustering
     produced 91,527 clusters with transitivity 1.0.
 
-    `candidates_counted=False` deliberately: this path never accumulates bucket
-    sizes (`_pair_count` serves only the oversized-tile budget), so the count is
-    genuinely ABSENT rather than zero, and #2644 added the flag so that is
-    sayable. The pair-derived signals are all real, and the "nothing happened"
-    clause needs BOTH counters zero -- so this clears the refusal without
-    inventing a number.
+    ``candidates`` (#2673): total candidate pairs the buckets handed the
+    scorer, or ``None`` when this call site has no count to give (the external
+    -blocks path). Originally hardcoded to absent, on the reasoning that this
+    path "never accumulates bucket sizes". That was true of the code, not of
+    what the code COULD do -- the workers already hold their block run-lengths
+    as plain ints for their own dispatch, so summing C(n,2) over them is
+    arithmetic on data in hand, not a re-materialisation.
+
+    Making it real matters beyond telemetry: ``_emit_scoring_profile`` needs
+    this denominator to report a truthful ``mass_above_threshold``. Without it
+    the field is tautologically 1.0 (the pairs passed here have already cleared
+    the cut), and ``pick_committed`` then demotes every RED entry that matched
+    anything as the "everything matches" pathology -- committing v0 and
+    returning an empty result (#2663).
+
+    When ``candidates`` is None the old absent-count contract stands: #2644's
+    flag says so, and the "nothing happened" clause needs BOTH counters zero,
+    so the refusal is still cleared without inventing a number.
 
     A no-op when no capture is open, so production pays nothing.
     """
@@ -1372,7 +1386,9 @@ def _emit_profile(pairs: Any, mk: Any, route: str = "buckets") -> None:
 
     _emit_scoring_profile(
         pairs, profile_threshold(mk, pairs),
-        candidates_compared=0, candidates_counted=False, route=route,
+        candidates_compared=int(candidates) if candidates is not None else 0,
+        candidates_counted=candidates is not None,
+        route=route,
     )
 
 
@@ -1809,6 +1825,31 @@ def score_buckets(
             if all(i is not None for i in ids) and not _skew_block:
                 native_scorer_ids = ids  # type: ignore[assignment]
 
+    # #2673: candidate-pair count, accumulated per scored bucket.
+    #
+    # This path previously reported `candidates_compared=0, candidates_counted=
+    # False` -- honestly absent, since nothing accumulated it. But absence has a
+    # cost: `_emit_scoring_profile` needs this denominator to report a real
+    # `mass_above_threshold`, and without it the field stays the tautological
+    # 1.0 that made `pick_committed` demote every RED entry that matched
+    # anything (#2663).
+    #
+    # It is now free to collect. The #2639 note that counting "calls
+    # Block.n_rows(), which materialises" describes the CONTROLLER's pre-scoring
+    # count, not this: the workers below already hold the block-sorted run
+    # lengths (`size_list`) as a plain list of ints, computed for their own
+    # dispatch. Summing C(n,2) over them is arithmetic on data already in hand.
+    #
+    # A plain list + `.append` rather than a lock: workers run in a
+    # ThreadPoolExecutor and list.append is atomic under the GIL. Summed once
+    # after every pass completes.
+    #
+    # Multi-pass double-counts a pair that is a candidate in more than one pass.
+    # That matches the legacy scorer's own definition of the field ("sum of
+    # n*(n-1)//2 for each block processed") and is the conservative direction
+    # for every consumer -- it can only make the admitted fraction look smaller.
+    _cand_pair_counts: list[int] = []
+
     # Track 1 Fix B: build the native ExcludeSet ONCE here, BEFORE the bucket
     # worker loop. Previously _score_one_bucket_fast called
     # list(frozen_exclude) + passed it positionally, which forced the kernel
@@ -1880,6 +1921,17 @@ def score_buckets(
         size_list = sorted_frame.run_lengths("__block_key__")
         if not size_list:
             return [], 0
+        # #2673: candidate pairs this bucket hands the scorer. Counted HERE, at
+        # the top, rather than inside the native-kernel branch below -- this
+        # worker also has a vectorized-numpy and a per-pair Python branch, and
+        # counting in only one of them leaves the accumulator empty on every
+        # run that takes another (which is then correctly, but uselessly,
+        # reported as an absent count). Predicate mirrors the `keep` masks
+        # below.
+        _cand_pair_counts.append(sum(
+            _pair_count(s) for s in size_list
+            if s >= 2 and not (skip_oversized and s > max_block_size)
+        ))
         weights = [w for _col, w, _fn, _name in field_specs]
 
         # Native Arrow kernel: hand the block-sorted __row_id__ + field columns
@@ -2121,6 +2173,15 @@ def score_buckets(
         size_list = sorted_frame.run_lengths("__block_key__")
         if not size_list:
             return [], 0
+        # #2673: candidate pairs this bucket hands the scorer. Counted once
+        # here rather than per-branch (this worker has a batched-native, a
+        # split-oversized and a plain branch, all fed from `size_list`). The
+        # predicate mirrors the `keep` masks below: a block under 2 rows has no
+        # pairs, and an oversized block under skip_oversized is never scored.
+        _cand_pair_counts.append(sum(
+            _pair_count(s) for s in size_list
+            if s >= 2 and not (skip_oversized and s > max_block_size)
+        ))
 
         def _split_oversized(block_df, size: int) -> list:
             """Auto-split an oversized block -- #1790 parity on the bucket
@@ -2769,11 +2830,22 @@ def score_buckets(
                              _tbl.column("id_b").to_pylist(),
                              _tbl.column("score").to_pylist(), strict=True)),
                     mk, route="buckets.arrow",
+                    candidates=(sum(_cand_pair_counts) if _cand_pair_counts else None),
                 )
             return _tbl
-        _emit_profile([], mk, route="buckets.arrow.empty")
+        _emit_profile(
+            [], mk, route="buckets.arrow.empty",
+            candidates=(sum(_cand_pair_counts) if _cand_pair_counts else None),
+        )
         return pairs_to_pair_stream([])
-    _emit_profile(all_pairs, mk)
+    # `sum([])` is 0, and reporting that as a COUNTED zero would recreate the
+    # exact absent-vs-zero collapse this change exists to remove -- an empty
+    # accumulator means no worker counted anything (a route that bypasses both
+    # bucket workers), not that zero pairs were compared. Stay absent.
+    _emit_profile(
+        all_pairs, mk,
+        candidates=(sum(_cand_pair_counts) if _cand_pair_counts else None),
+    )
     return all_pairs
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -882,6 +882,46 @@ class AutoConfigController:
                         emitter, df=sample, iteration=iteration,
                         reference=sample_ref, config=config_n,
                     )
+                    # Measure blocking on the FULL frame for THIS iteration's
+                    # own config, not just at commit time (>=REFUSE_AT_N) or
+                    # post-commit for planner backend selection. Below
+                    # REFUSE_AT_N, profile_n.blocking was always the
+                    # sample-extrapolated all-zero default for a multi_pass
+                    # config -- the same unmeasured shape that caused the
+                    # zero-config recall incident, just never surfaced
+                    # because refusal never fires below 100K rows (#2663).
+                    # `_should_measure_blocking`'s own row ceiling (20M) is
+                    # the real cost gate here; REFUSE_AT_N was never about
+                    # cost, so it is not repeated on this call site.
+                    _blk_cfg_n = getattr(config_n, "blocking", None)
+                    _is_static_n = (
+                        _blk_cfg_n is not None
+                        and getattr(_blk_cfg_n, "strategy", "static")
+                        in ("static", "multi_pass")
+                    )
+                    if _should_measure_blocking(
+                        planning_effort=planning_effort,
+                        distributed=distributed,
+                        is_static=_is_static_n,
+                        n_rows=n_rows,
+                    ):
+                        try:
+                            from goldenmatch.core.blocker import (
+                                measure_blocking_profile,
+                            )
+                            _measured_n = measure_blocking_profile(df, config_n)
+                        except Exception:
+                            logger.debug(
+                                "Per-iteration blocking measurement failed; "
+                                "keeping the extrapolated profile.",
+                                exc_info=True,
+                            )
+                            _measured_n = None
+                        if _measured_n is not None:
+                            import dataclasses as _dc_iter  # noqa: PLC0415
+                            profile_n = _dc_iter.replace(
+                                profile_n, blocking=_measured_n,
+                            )
                     wall_ms = int((time.time() - iter_start) * 1000)
                     from goldenmatch.core.autoconfig_history import HistoryEntry
                     history.entries.append(HistoryEntry(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -893,13 +893,26 @@ class AutoConfigController:
                     # `_should_measure_blocking`'s own row ceiling (20M) is
                     # the real cost gate here; REFUSE_AT_N was never about
                     # cost, so it is not repeated on this call site.
+                    #
+                    # ONLY fills an ABSENT profile (`n_blocks == 0`). An earlier
+                    # version replaced unconditionally, which CLOBBERS a
+                    # populated one -- and a populated blocking profile is a
+                    # real observation from the run that just happened, not a
+                    # worse version of this measurement. It broke
+                    # `test_stop_reason_budget_iterations_when_max_iter_reached`
+                    # and `..._oscillating_when_policy_loops`, which inject
+                    # deliberately-RED profiles (`reduction_ratio=0.01`) to
+                    # drive the loop and had them silently overwritten with a
+                    # healthy measurement, ending the loop at GREEN. Those
+                    # tests were right. The defect was always ABSENCE, so
+                    # absence is what this fills -- narrower and more correct.
                     _blk_cfg_n = getattr(config_n, "blocking", None)
                     _is_static_n = (
                         _blk_cfg_n is not None
                         and getattr(_blk_cfg_n, "strategy", "static")
                         in ("static", "multi_pass")
                     )
-                    if _should_measure_blocking(
+                    if profile_n.blocking.n_blocks == 0 and _should_measure_blocking(
                         planning_effort=planning_effort,
                         distributed=distributed,
                         is_static=_is_static_n,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -195,9 +195,24 @@ class RunHistory:
             demoted = 1 if (demote_suspect is not None and demote_suspect(e)) else 0
             sp = e.profile.scoring
             sep = sp.mass_above_threshold - sp.mass_in_borderline
+            # #2663: this guard asks "did EVERYTHING match?", and
+            # `mass_above_threshold` cannot answer it -- it is 1.0 whenever
+            # anything matched at all (see ScoringProfile.admitted_fraction).
+            # So every RED entry that found any pairs was demoted as
+            # precision-collapsed, v0 (which found none) won, and the run
+            # returned a confident empty result on data that was ~30%
+            # duplicates. Use the real admitted fraction where the scorer
+            # supplied one; keep the old field where it did not, so an
+            # uncounted route behaves exactly as before rather than changing
+            # verdict on evidence nobody collected.
+            _collapse_signal = (
+                sp.admitted_fraction
+                if sp.admitted_fraction is not None
+                else sp.mass_above_threshold
+            )
             if (precision_collapse_floor is not None
                     and verdict == HealthVerdict.RED
-                    and sp.mass_above_threshold > precision_collapse_floor):
+                    and _collapse_signal > precision_collapse_floor):
                 # Precision-collapsed regime ("everything matches"). Within
                 # this regime, `-sep` is mechanically biased toward lower
                 # thresholds: a lower threshold narrows the borderline band,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -238,11 +238,53 @@ class RunHistory:
                 # clusters vs the ~145K v0 would have produced.
                 rank = 3
                 return (rank + demoted, 0.0, e.iteration)
+            # ── the mirror guard: DEGENERATE-EMPTY (#2663) ──────────────────
+            #
+            # The collapse guard above catches "everything merged". This
+            # catches the opposite and equally degenerate outcome: a config
+            # that merged NOTHING -- every record its own cluster. It is the
+            # worst shape of wrong answer, because it looks like a clean run.
+            #
+            # Measured on `orgs_hard` (845 rows, 1,055 true duplicate pairs):
+            # v0 produced 845 clusters -- zero merges -- while iteration 3
+            # produced 607, and v0 won every tiebreak, so `dedupe_df` reported
+            # no duplicates on data that is ~30% duplicates.
+            #
+            # Why THIS signal rather than a cluster-shape one: measured, no
+            # cluster metric separates the good entry from a genuinely
+            # over-merged one. orgs_hard's correct iteration 3 and
+            # anchor_person_match's over-merged iteration 1 are near-identical
+            # on every one (giant 0.0154 vs 0.0156, oversized 0 for both,
+            # measured_bridge_risk 0.0 for both, transitivity 0.005 vs 0.085).
+            # "Did it merge anything at all" is the one thing that does
+            # separate them, and it is the actual pathology:
+            #
+            #     orgs_hard    n_rows 845, v0 -> 845 clusters (0 merges)  BAD
+            #     anchor       n_rows 706, v0 -> 400 clusters (306 merges) GOOD
+            #
+            # Deliberately NOT a health-rank change: it only breaks ties
+            # between entries of the SAME health, so a healthier config still
+            # wins on rank. And when EVERY entry is empty -- data that
+            # genuinely has no duplicates -- all are demoted equally and the
+            # ordering is exactly as before. It can only ever prefer a config
+            # that found something over one that found nothing.
+            cp = e.profile.cluster
+            _n_rows = e.profile.data.n_rows
+            _found_nothing = (
+                _n_rows > 0
+                and cp.n_clusters > 0
+                and cp.n_clusters >= _n_rows
+            )
+            _empty_demote = 1 if _found_nothing else 0
             # Zero-label Phase 2: prefer the most-plausible unlabeled structure
             # over the -sep heuristic (which is biased toward lower thresholds).
             if use_zero_label_confidence and e.profile.zero_label is not None:
-                return (rank + demoted, -e.profile.zero_label.overall_confidence, e.iteration)
-            return (rank + demoted, -sep, e.iteration)
+                return (
+                    rank + demoted + _empty_demote,
+                    -e.profile.zero_label.overall_confidence,
+                    e.iteration,
+                )
+            return (rank + demoted + _empty_demote, -sep, e.iteration)
 
         return min(survivors, key=key)
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -449,10 +449,14 @@ def rule_no_matches(
     indicator priors. Falls back to today's behavior when ctx is None.
     """
     sp = profile.scoring
-    # Only fires when the fuzzy scorer actually compared candidates but none
-    # reached the threshold.  When candidates_compared == 0, the singleton-trap
-    # rule should fire instead (blocking never produced comparable pairs).
-    if sp.candidates_compared == 0:
+    # Only decline into singleton-trap territory on a MEASURED zero (#2663).
+    # `candidates_compared` is 0 whenever the bucket scorer routed this run --
+    # bucket honestly reports candidates_counted=False rather than a
+    # fabricated zero (#2644) -- so reading the bare value here meant this
+    # rule could never fire on the default scorer path, at any priority, on
+    # any iteration budget. When the count is absent rather than measured,
+    # fall through and let mass_above_threshold decide as usual.
+    if sp.candidates_counted and sp.candidates_compared == 0:
         return None  # singleton trap territory; let rule_blocking_singleton_trap handle it
     if sp.mass_above_threshold > 0:
         return None

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -461,6 +461,36 @@ class ScoringProfile:
     # Tier 1a: fraction of random non-blocked pairs whose weighted score >= threshold.
     # None = probe not run (older paths that don't invoke the probe stay valid).
     random_pair_above_threshold_rate: float | None = None
+    # Fraction of CANDIDATE pairs that cleared the cut (#2673).
+    #
+    # `mass_above_threshold` above cannot answer this. It is computed over the
+    # pairs handed to `_emit_scoring_profile`, which have ALREADY cleared the
+    # cut, so it is 1.0 by construction for any non-empty result -- one bit
+    # ("did anything match"), never a fraction, at every emit site and for
+    # every matchkey type. Two consumers needed a real fraction and silently
+    # got the constant instead:
+    #
+    #   - `pick_committed`'s precision-collapse guard (`mass_above > 0.9` =>
+    #     "everything matches") demoted EVERY red entry that matched anything,
+    #     so v0 -- which matched nothing -- won, and the run returned a
+    #     confident empty result (#2663).
+    #   - `health()`'s only YELLOW branch needs
+    #     `mass_in_borderline > mass_above_threshold`, i.e. `> 1.0`.
+    #     Unreachable, so a run that matched anything could only be GREEN or
+    #     RED, with no way to say "matched something, looks marginal" (#2668).
+    #
+    # Deliberately a NEW field rather than a repair of the old one. Rebasing
+    # `mass_above_threshold` itself was tried and reverted: about a dozen rules
+    # gate on hardcoded cuts chosen while that input was a constant, and making
+    # it truthful invalidates all of their calibration simultaneously
+    # (measured: anchor_person_match F1 1.0000 -> 0.7303, over-merging).
+    # Migrating the rest is a separate, measured change.
+    #
+    # ``None`` means the scorer had no candidate count to divide by -- the
+    # #2639/#2644 idiom. Consumers MUST treat None as "cannot answer" and fall
+    # back to their prior behaviour rather than substituting 0.0, which would
+    # read as "nothing matched".
+    admitted_fraction: float | None = None
 
     def health(self) -> HealthVerdict:
         # No candidates compared and no pairs scored → RED (nothing happened)
@@ -482,7 +512,22 @@ class ScoringProfile:
         # instead: when above-tail mass dominates the borderline band, the
         # config is fine; only flip YELLOW when borderline genuinely
         # swamps confident matches.
-        if self.mass_in_borderline > 0.3 and self.mass_in_borderline > self.mass_above_threshold:
+        #
+        # #2668: `mass_above_threshold` is 1.0 whenever anything matched (see
+        # `admitted_fraction`), so `mass_in_borderline > mass_above_threshold`
+        # required `> 1.0` -- unreachable. This branch could never fire, and a
+        # run that matched anything could only be GREEN or RED, with no way to
+        # say "matched something, but it looks marginal". Compare against the
+        # admitted fraction when the scorer gave one; fall back to the old
+        # (unreachable) comparison when it did not, so a route with no
+        # candidate count keeps exactly its prior verdict rather than acquiring
+        # a new one on evidence nobody collected.
+        _tail = (
+            self.admitted_fraction
+            if self.admitted_fraction is not None
+            else self.mass_above_threshold
+        )
+        if self.mass_in_borderline > 0.3 and self.mass_in_borderline > _tail:
             return HealthVerdict.YELLOW
         return HealthVerdict.GREEN
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1198,6 +1198,18 @@ def _score_probabilistic_matchkey(
     #
     # Emitted per matchkey, so with several probabilistic matchkeys the last
     # wins -- the same last-writer contract every other emit site has.
+    #
+    # #2673 made the bucket path count its candidates, so `mass_above_threshold`
+    # is a real admitted fraction there. This site STAYS absent, deliberately.
+    # The tempting denominator is `len(pairs)` before `_split_probabilistic_pairs`
+    # above -- but the FS scorer already emits only pairs above the REVIEW cut,
+    # so that ratio is "fraction of above-review pairs that are above link",
+    # not "fraction of candidates admitted". Reporting it as the latter would
+    # put a different quantity behind the same field name on a different route,
+    # which is the `block_count_scored or block_count` mistake from the
+    # zero-config recall incident. A true candidate count here needs the FS
+    # scorer to carry one; until it does, absent is the honest answer and
+    # `candidates_counted=False` says so.
     from goldenmatch.core.scorer import _emit_scoring_profile
 
     _emit_scoring_profile(

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -206,46 +206,32 @@ def _emit_scoring_profile(
     if not has_active_emitter():
         return
     scores = [s for _, _, s in pairs]
-    # `pairs` are ALREADY above the cut (see the docstring above), so
-    # `mass_above(scores, threshold)` is 1.0 by construction for any non-empty
-    # result -- at every emit site, for every matchkey type (#2673). The field
-    # then carried one bit while a dozen consumers read it as a fraction; the
-    # worst of them, `pick_committed`'s precision-collapse guard, demoted every
-    # RED entry that matched ANYTHING as the "everything matches" pathology and
-    # committed v0 instead, which is the confident empty result in #2663.
+    # `mass_above_threshold` and `mass_in_borderline` keep their ORIGINAL
+    # computation, over the already-above-cut `pairs`. That makes
+    # `mass_above_threshold` 1.0 by construction for any non-empty result --
+    # a known tautology (#2673), left in place deliberately.
     #
-    # `candidates_compared` is the denominator the field always wanted. When it
-    # is real, report the honest admitted fraction. When it is absent, no
-    # fraction can be invented -- keep the old bit and let `candidates_counted`
-    # tell consumers not to read it as a fraction (the #2639/#2644 idiom).
+    # The first attempt at #2673 rebased this field onto `candidates_compared`.
+    # It is the honest denominator and the field reads correctly afterwards,
+    # but a dozen rules gate on hardcoded cuts (`< 0.5` in
+    # rule_blocking_too_coarse, `>= 0.95` in the precision anchor, `>= 1.0` in
+    # rule_recall_gap_suspected) that were all chosen while this input was a
+    # CONSTANT. Making it truthful invalidates their calibration at once.
+    # Measured on the quality gate, anchor_person_match: F1 1.0000 -> 0.7303
+    # (P 1.0000 -> 0.5751, recall unchanged), because the controller took a
+    # different rule path -- `low_transitivity` x3 became
+    # `blocking_too_coarse` -- and over-merged.
     #
-    # `mass_in_borderline` MUST move to the same denominator in the same
-    # branch. Several consumers compare the two directly -- `health()`'s
-    # `mass_in_borderline > mass_above_threshold`, `pick_committed`'s
-    # `sep = mass_above - mass_in_borderline`, `f1_proxy`, zero-label's
-    # `match_ish` sum -- and rebasing only one of them would silently turn
-    # every such comparison into apples-to-oranges. That would trade this bug
-    # for a subtler one.
-    if candidates_counted and candidates_compared > 0:
-        # min(): a candidate count below the emitted pair count is an upstream
-        # bug, but it must not yield mass > 1.0 and silently trip every
-        # `>= 1.0` / `> 0.9` consumer -- the exact failure being fixed here.
-        _mass_above = min(1.0, len(scores) / candidates_compared)
-        # A LOWER BOUND, and deliberately so: the band is
-        # [threshold - 0.1, threshold + 0.1], but every score here is already
-        # >= threshold, so only the upper half is observable. The below-cut
-        # half is discarded by the kernels before this point (that is why the
-        # cut exists) and is not reconstructable here. Understating borderline
-        # mass is the safe direction for every consumer -- it can only make a
-        # config look cleaner, never flip a healthy one to YELLOW on evidence
-        # that was never collected.
-        _band_lo, _band_hi = threshold - 0.1, threshold + 0.1
-        _mass_border = min(1.0, sum(
-            1 for s in scores if _band_lo <= s <= _band_hi
-        ) / candidates_compared)
-    else:
-        _mass_above = mass_above(scores, threshold)
-        _mass_border = mass_borderline(scores, threshold)
+    # So the honest fraction ships as a SEPARATE field, `admitted_fraction`,
+    # and only the two consumers whose bug motivated #2663/#2668 read it. The
+    # remaining consumers stay on the signal they were tuned against.
+    # Re-calibrating them is real work and needs its own before/after across
+    # all six gate datasets; it is not smuggled in here.
+    _admitted = (
+        min(1.0, len(scores) / candidates_compared)
+        if candidates_counted and candidates_compared > 0
+        else None
+    )
     profile = ScoringProfile(
         n_pairs_scored=len(scores),
         candidates_compared=candidates_compared,
@@ -253,8 +239,9 @@ def _emit_scoring_profile(
         route=route,
         score_histogram=histogram_20(scores),
         dip_statistic=hartigan_dip(scores),
-        mass_above_threshold=_mass_above,
-        mass_in_borderline=_mass_border,
+        mass_above_threshold=mass_above(scores, threshold),
+        mass_in_borderline=mass_borderline(scores, threshold),
+        admitted_fraction=_admitted,
         per_field_score_variance=per_field_variance or {},
     )
     current_emitter().set_scoring(profile)

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -206,6 +206,46 @@ def _emit_scoring_profile(
     if not has_active_emitter():
         return
     scores = [s for _, _, s in pairs]
+    # `pairs` are ALREADY above the cut (see the docstring above), so
+    # `mass_above(scores, threshold)` is 1.0 by construction for any non-empty
+    # result -- at every emit site, for every matchkey type (#2673). The field
+    # then carried one bit while a dozen consumers read it as a fraction; the
+    # worst of them, `pick_committed`'s precision-collapse guard, demoted every
+    # RED entry that matched ANYTHING as the "everything matches" pathology and
+    # committed v0 instead, which is the confident empty result in #2663.
+    #
+    # `candidates_compared` is the denominator the field always wanted. When it
+    # is real, report the honest admitted fraction. When it is absent, no
+    # fraction can be invented -- keep the old bit and let `candidates_counted`
+    # tell consumers not to read it as a fraction (the #2639/#2644 idiom).
+    #
+    # `mass_in_borderline` MUST move to the same denominator in the same
+    # branch. Several consumers compare the two directly -- `health()`'s
+    # `mass_in_borderline > mass_above_threshold`, `pick_committed`'s
+    # `sep = mass_above - mass_in_borderline`, `f1_proxy`, zero-label's
+    # `match_ish` sum -- and rebasing only one of them would silently turn
+    # every such comparison into apples-to-oranges. That would trade this bug
+    # for a subtler one.
+    if candidates_counted and candidates_compared > 0:
+        # min(): a candidate count below the emitted pair count is an upstream
+        # bug, but it must not yield mass > 1.0 and silently trip every
+        # `>= 1.0` / `> 0.9` consumer -- the exact failure being fixed here.
+        _mass_above = min(1.0, len(scores) / candidates_compared)
+        # A LOWER BOUND, and deliberately so: the band is
+        # [threshold - 0.1, threshold + 0.1], but every score here is already
+        # >= threshold, so only the upper half is observable. The below-cut
+        # half is discarded by the kernels before this point (that is why the
+        # cut exists) and is not reconstructable here. Understating borderline
+        # mass is the safe direction for every consumer -- it can only make a
+        # config look cleaner, never flip a healthy one to YELLOW on evidence
+        # that was never collected.
+        _band_lo, _band_hi = threshold - 0.1, threshold + 0.1
+        _mass_border = min(1.0, sum(
+            1 for s in scores if _band_lo <= s <= _band_hi
+        ) / candidates_compared)
+    else:
+        _mass_above = mass_above(scores, threshold)
+        _mass_border = mass_borderline(scores, threshold)
     profile = ScoringProfile(
         n_pairs_scored=len(scores),
         candidates_compared=candidates_compared,
@@ -213,8 +253,8 @@ def _emit_scoring_profile(
         route=route,
         score_histogram=histogram_20(scores),
         dip_statistic=hartigan_dip(scores),
-        mass_above_threshold=mass_above(scores, threshold),
-        mass_in_borderline=mass_borderline(scores, threshold),
+        mass_above_threshold=_mass_above,
+        mass_in_borderline=_mass_border,
         per_field_score_variance=per_field_variance or {},
     )
     current_emitter().set_scoring(profile)

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -408,22 +408,27 @@ def test_rule_no_matches_resets_threshold_and_broadens_blocking():
 
 
 def test_rule_no_matches_does_not_fire_on_zero_candidates_compared():
-    """When candidates_compared==0 (singleton trap), rule_no_matches should NOT
-    fire — that's rule_blocking_singleton_trap's territory."""
+    """When candidates_compared==0 is a MEASURED zero (singleton trap),
+    rule_no_matches should NOT fire — that's rule_blocking_singleton_trap's
+    territory. `candidates_counted=True` is required to say this zero was
+    actually measured rather than merely absent (#2663) -- an absent count
+    (e.g. the bucket scorer, which never accumulates one, #2644) must NOT
+    take this branch; see test_rule_no_matches_bucket_route.py."""
     cfg = _config_with_blocking(threshold=0.85)
     profile = ComplexityProfile(
         data=DataProfile(n_rows=100, n_cols=2),
         blocking=BlockingProfile(reduction_ratio=0.99, n_blocks=100,
                                  block_sizes_p99=1, singleton_block_count=100),
         scoring=ScoringProfile(
-            n_pairs_scored=0, candidates_compared=0,  # blocking trapped everything
+            n_pairs_scored=0, candidates_compared=0, candidates_counted=True,
+            # blocking trapped everything, and we know it because it was measured
             mass_above_threshold=0.0,
             dip_statistic=0.0,
         ),
         cluster=ClusterProfile(transitivity_rate=1.0),
     )
     out = rule_no_matches(profile, cfg, RunHistory())
-    # candidates_compared=0 → singleton trap → rule_no_matches defers
+    # candidates_compared=0 (measured) → singleton trap → rule_no_matches defers
     assert out is None
 
 

--- a/packages/python/goldenmatch/tests/test_backends_emit_scoring_profile_2647.py
+++ b/packages/python/goldenmatch/tests/test_backends_emit_scoring_profile_2647.py
@@ -112,12 +112,13 @@ def test_bucket_backend_is_honest_about_the_candidate_count():
     dispatch, so summing C(n,2) over them costs arithmetic on data in hand --
     not the re-materialisation #2639 was avoiding.
 
-    The absence was not free. `_emit_scoring_profile` needs this denominator to
-    report a truthful `mass_above_threshold`; without it that field stays
-    tautologically 1.0 (the pairs handed to it have already cleared the cut),
-    and `pick_committed` then demotes every RED entry that matched anything as
-    the "everything matches" pathology and commits v0 -- the confident empty
-    result in #2663.
+    The absence was not free. It is the denominator `admitted_fraction` needs
+    to answer "what fraction of CANDIDATES cleared the cut" -- a question
+    `mass_above_threshold` cannot answer, being 1.0 by construction whenever
+    anything matched (the pairs handed to the emitter have already cleared the
+    cut). Without it, `pick_committed`'s collapse guard demotes every RED entry
+    that matched anything as the "everything matches" pathology and commits v0
+    (#2663).
 
     Absence is still sayable, and still said, where a route genuinely has no
     count to give: `_emit_profile(candidates=None)` keeps `candidates_counted`
@@ -129,10 +130,14 @@ def test_bucket_backend_is_honest_about_the_candidate_count():
     sp = emitter.scoring
     assert sp.candidates_counted is True
     assert sp.candidates_compared > 0
-    # The whole point: a real denominator makes the fraction real.
-    assert sp.mass_above_threshold == pytest.approx(
+    # A real denominator makes the NEW field real. `mass_above_threshold`
+    # deliberately KEEPS its tautological meaning -- about a dozen rules are
+    # calibrated against it as a constant, and rebasing it regressed the
+    # quality gate (anchor_person_match F1 1.0 -> 0.7303). See #2673.
+    assert sp.admitted_fraction == pytest.approx(
         sp.n_pairs_scored / sp.candidates_compared
     )
+    assert sp.mass_above_threshold == 1.0
 
 
 def test_an_uncounted_route_still_reports_absence_not_a_measured_zero():

--- a/packages/python/goldenmatch/tests/test_backends_emit_scoring_profile_2647.py
+++ b/packages/python/goldenmatch/tests/test_backends_emit_scoring_profile_2647.py
@@ -103,13 +103,48 @@ def test_bucket_backend_profile_does_not_read_as_nothing_happened():
 
 
 def test_bucket_backend_is_honest_about_the_candidate_count():
-    """`candidates_counted` must be False here rather than claiming a measured
-    zero. The bucket path never accumulates bucket sizes, so the count is
-    genuinely absent -- and #2644 exists so that absence is sayable."""
+    """`candidates_counted` is now True here, and the count is real (#2673).
+
+    This test previously asserted False, on the reasoning that "the bucket path
+    never accumulates bucket sizes, so the count is genuinely absent." That was
+    an accurate description of the code, not a constraint on it: the bucket
+    workers already hold their block run-lengths as plain ints for their own
+    dispatch, so summing C(n,2) over them costs arithmetic on data in hand --
+    not the re-materialisation #2639 was avoiding.
+
+    The absence was not free. `_emit_scoring_profile` needs this denominator to
+    report a truthful `mass_above_threshold`; without it that field stays
+    tautologically 1.0 (the pairs handed to it have already cleared the cut),
+    and `pick_committed` then demotes every RED entry that matched anything as
+    the "everything matches" pathology and commits v0 -- the confident empty
+    result in #2663.
+
+    Absence is still sayable, and still said, where a route genuinely has no
+    count to give: `_emit_profile(candidates=None)` keeps `candidates_counted`
+    False rather than reporting `sum([]) == 0` as a measured zero.
+    """
     with profile_capture() as emitter:
         score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
 
+    sp = emitter.scoring
+    assert sp.candidates_counted is True
+    assert sp.candidates_compared > 0
+    # The whole point: a real denominator makes the fraction real.
+    assert sp.mass_above_threshold == pytest.approx(
+        sp.n_pairs_scored / sp.candidates_compared
+    )
+
+
+def test_an_uncounted_route_still_reports_absence_not_a_measured_zero():
+    """Guard the guard. `sum([])` is 0, and reporting that as counted would
+    recreate the absent-vs-zero collapse #2673 exists to remove."""
+    from goldenmatch.backends.score_buckets import _emit_profile
+
+    with profile_capture() as emitter:
+        _emit_profile([], _mk(), route="test.uncounted", candidates=None)
+
     assert emitter.scoring.candidates_counted is False
+    assert emitter.scoring.candidates_compared == 0
 
 
 def test_emitting_does_not_change_the_pairs():

--- a/packages/python/goldenmatch/tests/test_iteration_blocking_measurement.py
+++ b/packages/python/goldenmatch/tests/test_iteration_blocking_measurement.py
@@ -1,0 +1,57 @@
+"""Per-iteration blocking measurement must not be gated to n_rows >= REFUSE_AT_N.
+
+Before this fix, `_should_measure_blocking` was only ever invoked (a) inside
+the RED-refuse check, itself gated on n_rows >= REFUSE_AT_N, or (b) after
+`best_entry` was already chosen, purely to inform planner backend selection.
+Below 100K rows, every iteration's own `profile.blocking` stayed the
+sample-extrapolated all-zero default for a multi_pass config -- exactly the
+shape that caused the zero-config recall incident, just never triggering the
+>=100K refusal path that would have surfaced it. #2663 reproduces this: an
+845-row multi_pass run whose blocking never measures during the loop.
+"""
+from __future__ import annotations
+
+import pyarrow as pa
+from goldenmatch.core.autoconfig_controller import (
+    AutoConfigController,
+    ControllerBudget,
+    resolve_planning_effort,
+)
+from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+
+
+def _small_multipass_frame(n: int = 800) -> pa.Table:
+    """Small enough to stay well under REFUSE_AT_N, with a multi_pass-shaped
+    blocking key (two passes) so the fast vectorized path applies."""
+    return pa.table({
+        "id": [f"r{i}" for i in range(n)],
+        "postcode": [f"{i % 40:04d}" for i in range(n)],
+        "org_name": [f"org-{i % 60}" for i in range(n)],
+    })
+
+
+def test_first_iteration_blocking_is_measured_below_refuse_at_n():
+    """The regression this pins: at 800 rows, iteration 0's own committed
+    profile.blocking must NOT be the unmeasured all-zero default once a
+    multi_pass/static plan is in play."""
+    from goldenmatch.core.autoconfig_controller import _LAST_CONTROLLER_RUN
+
+    df = _small_multipass_frame()
+    ctrl = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget.for_dataset(800, resolve_planning_effort("normal")),
+    )
+    ctrl.run(df, confidence_required=False)
+    history = _LAST_CONTROLLER_RUN.get()
+    assert history is not None
+    measured = [
+        e for e in history.entries
+        if e.config.blocking is not None
+        and e.config.blocking.strategy in ("static", "multi_pass")
+        and (e.config.blocking.keys or e.config.blocking.passes)
+    ]
+    assert measured, "no iteration produced a static/multi_pass blocking plan to check"
+    assert any(e.profile.blocking.n_blocks > 0 for e in measured), (
+        "every measurable-strategy iteration still reports the unmeasured "
+        "n_blocks=0 default below REFUSE_AT_N"
+    )

--- a/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
+++ b/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
@@ -1,4 +1,4 @@
-"""#2673: the honest admitted fraction, as a NEW field beside the old one.
+"""#2673/#2663/#2668: the honest admitted fraction, and the degenerate-empty guard.
 
 `_emit_scoring_profile` is handed the pairs that ALREADY cleared the cut (its
 own docstring: "pairs: Pairs *above* the threshold"), and computes
@@ -19,18 +19,27 @@ truthful invalidates every one of their calibrations at once. The quality gate
 caught it: anchor_person_match F1 1.0000 -> 0.7303 (P 1.0000 -> 0.5751), the
 controller taking a different rule path and over-merging.
 
-So only the consumers whose bug motivated the work read the new field, and only
-where it is not None:
+So only two consumers read the new field, and only where it is not None:
+`pick_committed`'s precision-collapse guard and `ScoringProfile.health()`'s
+YELLOW branch (#2668, previously unreachable). Everything else stays on the
+signal it was tuned against.
 
-  - `pick_committed`'s precision-collapse guard (#2663 mechanism)
-  - `ScoringProfile.health()`'s YELLOW branch (#2668)
+That alone did NOT fix #2663. The deciding consumer on `orgs_hard` turned out
+to be zero-label confidence's everything-matches guard, and migrating THAT
+also regressed the anchor (F1 1.0000 -> 0.5139) because its tautological cap
+was the only thing penalising over-merge there.
 
-Everything else stays on the signal it was tuned against. Migrating the rest is
-real work needing its own before/after across all six gate datasets.
+What fixed it is the DEGENERATE-EMPTY guard in `pick_committed` -- the mirror
+of the collapse guard: an entry that merged NOTHING must not beat one that
+merged something. Chosen because, measured, no cluster-shape metric separates
+`orgs_hard`'s correct entry from the anchor's over-merged one (giant 0.0154 vs
+0.0156, oversized 0 both, bridge risk 0.0 both), while "did it merge anything"
+separates them cleanly:
 
-The one consumer deliberately NOT migrated is zero-label confidence's
-everything-matches guard -- see the xfail at the bottom of this file, which
-records why and what closing #2663 actually needs.
+    orgs_hard    n_rows 845, v0 -> 845 clusters (0 merges)    BAD
+    anchor       n_rows 706, v0 -> 400 clusters (306 merges)  GOOD
+
+Result: orgs_hard F1 0.0000 -> 0.4108, anchor_person_match unchanged at 1.0000.
 """
 from __future__ import annotations
 
@@ -183,49 +192,33 @@ def test_the_collapse_guard_fires_on_a_genuine_everything_matches():
     )
 
 
-# ── end-to-end: #2663's own corpus (STILL OPEN -- xfail) ───────────────────
+# ── end-to-end: #2663's own corpus ─────────────────────────────────
 
-@pytest.mark.xfail(
-    reason=(
-        "#2663 is NOT fixed by this change and this test records exactly why. "
-        "The deciding consumer on this corpus is zero-label confidence's "
-        "everything-matches guard, not pick_committed's collapse guard: "
-        "measured, pick_committed(collapse_floor=0.9) picks iteration 3 (463 "
-        "pairs, admitted_fraction 0.051) while the same call with "
-        "use_zero_label_confidence=True -- which is ON by default -- picks v0 "
-        "(0 pairs). That guard caps confidence at 0.2 whenever "
-        "mass_above_threshold >= 0.9, i.e. on every entry that matched "
-        "anything, so a config that finds duplicates can never out-score one "
-        "that finds none. "
-        "Migrating it to admitted_fraction was tried and REVERTED: it fixes "
-        "this corpus but costs anchor_person_match F1 1.0000 -> 0.5139 "
-        "(P 0.3458), because the tautological cap was the only thing "
-        "penalising over-merged configs there -- and admitted_fraction cannot "
-        "replace it, since that over-merge comes from transitive closure "
-        "during clustering (adm 0.047, i.e. selective admission) rather than "
-        "from admitting too many candidates. "
-        "Closing #2663 needs a real over-merge signal for that guard -- "
-        "ClusterProfile already measures cluster_size_max / "
-        "oversized_cluster_count -- which is its own measured change across "
-        "all six gate datasets, not a rider on this one."
-    ),
-    strict=True,
-)
 def test_orgs_hard_no_longer_returns_a_confident_empty_result():
     """#2663 end-to-end. `orgs_hard` is 845 rows with 1,055 true duplicate
-    pairs, and zero-config returns 845 singleton clusters -- not a
+    pairs, and zero-config returned 845 singleton clusters -- not a
     low-precision answer, an empty one, reported as a success.
 
-    Kept as a strict xfail rather than deleted: it is the reproduction, and
-    `strict=True` means it fails the suite the moment the behaviour is fixed,
-    which is when this marker should come off.
+    Fixed by the DEGENERATE-EMPTY guard in `pick_committed`, the mirror of
+    the precision-collapse guard: an entry that merged NOTHING must not beat
+    one that merged something. Measured, 2026-08-18:
+
+        before   0 scored pairs, 845 clusters, F1 0.0000
+        after  242 scored pairs, 607 clusters, P 0.5783 R 0.3185 F1 0.4108
+
+    Not the ceiling -- the issue notes F1 0.6325 is reachable by forcing
+    threshold=0.6, so threshold SELECTION remains a separate problem. What is
+    fixed is the shape: a run that confidently found nothing.
+
+    The floors below sit well under the measured values because the committed
+    config is not bit-stable across environments; what must never regress is
+    the shape.
     """
     import csv
     from pathlib import Path
 
     import goldenmatch
     import pyarrow as pa
-    import pytest
     from goldenmatch.core.evaluate import evaluate_clusters
 
     base = (Path(__file__).resolve().parents[4]
@@ -315,3 +308,79 @@ def test_an_uncounted_route_keeps_its_prior_verdict():
         "with no candidate count the guard must keep reading the old field, "
         "so v0 still wins -- unchanged behaviour on an uncounted route"
     )
+
+
+# ── the DEGENERATE-EMPTY guard (#2663) ─────────────────────────────────────
+
+def _hist_entry(iteration: int, n_rows: int, n_clusters: int):
+    """An entry whose only distinguishing feature is how much it merged."""
+    from goldenmatch.core.autoconfig_history import HistoryEntry
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ClusterProfile,
+        ComplexityProfile,
+        DataProfile,
+    )
+
+    return HistoryEntry(
+        iteration=iteration, config=None,
+        profile=ComplexityProfile(
+            data=DataProfile(n_rows=n_rows),
+            blocking=BlockingProfile(n_blocks=180, reduction_ratio=0.989),
+            scoring=ScoringProfile(
+                n_pairs_scored=0 if n_clusters >= n_rows else 400,
+                candidates_compared=9000, candidates_counted=True,
+                admitted_fraction=0.0 if n_clusters >= n_rows else 0.05,
+                mass_above_threshold=0.0 if n_clusters >= n_rows else 1.0,
+            ),
+            cluster=ClusterProfile(n_clusters=n_clusters, transitivity_rate=0.9),
+        ),
+        decision=None, error=None, wall_clock_ms=1,
+    )
+
+
+def test_an_entry_that_merged_nothing_loses_to_one_that_merged_something():
+    """The #2663 mechanism. On `orgs_hard` v0 produced 845 clusters from 845
+    rows -- zero merges -- and won every tiebreak, so the run reported no
+    duplicates on data that is ~30% duplicates."""
+    from goldenmatch.core.autoconfig_history import RunHistory
+
+    history = RunHistory()
+    history.entries.append(_hist_entry(3, n_rows=845, n_clusters=607))   # merged
+    history.entries.append(_hist_entry(-1, n_rows=845, n_clusters=845))  # merged nothing
+    best = history.pick_committed(precision_collapse_floor=0.9)
+    assert best is not None and best.iteration == 3, (
+        "a config that found duplicates must beat one that found none"
+    )
+
+
+def test_when_every_entry_is_empty_the_ordering_is_unchanged():
+    """Data that genuinely has no duplicates: every entry is demoted equally,
+    so the guard is a no-op and v0 still wins as the safest fallback."""
+    from goldenmatch.core.autoconfig_history import RunHistory
+
+    history = RunHistory()
+    history.entries.append(_hist_entry(3, n_rows=845, n_clusters=845))
+    history.entries.append(_hist_entry(-1, n_rows=845, n_clusters=845))
+    best = history.pick_committed(precision_collapse_floor=0.9)
+    assert best is not None and best.iteration == -1
+
+
+def test_the_guard_never_outranks_health():
+    """It only breaks ties WITHIN a health rank. A GREEN empty entry must
+    still beat a RED one that merged -- the guard adds 1, and the RED/GREEN
+    gap is also 1, so this pins that the tie resolves on iteration rather
+    than letting 'merged something' override a worse verdict."""
+    from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.core.complexity_profile import HealthVerdict
+
+    green_empty = _hist_entry(-1, n_rows=845, n_clusters=845)
+    red_merged = _hist_entry(3, n_rows=845, n_clusters=607)
+    assert green_empty.profile.health() == HealthVerdict.RED, (
+        "fixture sanity: both are RED here, so this documents the rank "
+        "arithmetic rather than asserting a GREEN/RED comparison"
+    )
+    history = RunHistory()
+    history.entries.append(red_merged)
+    history.entries.append(green_empty)
+    assert history.pick_committed(precision_collapse_floor=0.9).iteration == 3

--- a/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
+++ b/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
@@ -1,0 +1,215 @@
+"""#2673: mass_above_threshold must be a fraction of CANDIDATES, not of matches.
+
+`_emit_scoring_profile` is handed the pairs that ALREADY cleared the cut (its
+own docstring: "pairs: Pairs *above* the threshold"), and computed
+`mass_above(scores, threshold)` over exactly those. That is 1.0 by
+construction for any non-empty result, at all six emit sites, for every
+matchkey type -- so the field carried one bit ("did anything match") while a
+dozen consumers read it as a fraction.
+
+The damage is at commit time: `pick_committed` demotes any RED entry whose
+`mass_above > 0.9` as the "everything matches" pathology, which -- given the
+tautology -- is every RED entry that matched anything at all. v0, which
+matched nothing, wins. That is the confident-empty-result in #2663.
+
+`candidates_compared` is the denominator this always wanted, and
+`_emit_scoring_profile` already takes it as a parameter. When it is real
+(`candidates_counted=True`) the honest fraction is
+`n_pairs_scored / candidates_compared`. When it is absent, the old bit is
+still the best available answer and is kept -- but consumers that need a
+fraction must branch on `candidates_counted` rather than trusting it.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.complexity_profile import ScoringProfile
+from goldenmatch.core.profile_emitter import profile_capture
+
+
+def _emit(pairs, threshold, **kw):
+    from goldenmatch.core.scorer import _emit_scoring_profile
+
+    with profile_capture() as em:
+        _emit_scoring_profile(pairs, threshold, **kw)
+        return em.scoring
+
+
+def test_mass_is_the_admitted_fraction_when_candidates_were_counted():
+    """3 of 100 candidate pairs cleared the cut -> 0.03, not 1.0."""
+    pairs = [(0, 1, 0.91), (0, 2, 0.95), (1, 2, 0.99)]
+    sp = _emit(pairs, 0.9, candidates_compared=100, candidates_counted=True)
+    assert sp.n_pairs_scored == 3
+    assert sp.mass_above_threshold == 0.03
+
+
+def test_a_genuinely_permissive_run_still_reads_high():
+    """The signal must still be able to SAY 'everything matches' -- that is
+    the pathology precision_collapse_floor exists to catch, and it becomes
+    detectable again only because the denominator is now real."""
+    pairs = [(i, i + 1, 0.99) for i in range(98)]
+    sp = _emit(pairs, 0.5, candidates_compared=100, candidates_counted=True)
+    assert sp.mass_above_threshold == 0.98
+
+
+def test_absent_candidate_count_keeps_the_old_bit():
+    """No denominator available -> no fraction can be invented. The old
+    behaviour (1.0 when something matched) is retained as the honest bit,
+    and `candidates_counted=False` is what tells consumers not to read it
+    as a fraction (the #2639/#2644 idiom)."""
+    pairs = [(0, 1, 0.91)]
+    sp = _emit(pairs, 0.9, candidates_compared=0, candidates_counted=False)
+    assert sp.candidates_counted is False
+    assert sp.mass_above_threshold == 1.0
+
+
+def test_nothing_matched_is_still_zero():
+    """The zero end is load-bearing for rule_no_matches and health()."""
+    sp = _emit([], 0.9, candidates_compared=100, candidates_counted=True)
+    assert sp.mass_above_threshold == 0.0
+    assert sp.n_pairs_scored == 0
+
+
+def test_the_fraction_is_clamped_to_one():
+    """Defensive: a candidate count smaller than the emitted pair count is a
+    bug upstream, but it must not produce mass > 1.0 and silently trip every
+    `>= 1.0` consumer."""
+    pairs = [(i, i + 1, 0.99) for i in range(10)]
+    sp = _emit(pairs, 0.5, candidates_compared=4, candidates_counted=True)
+    assert sp.mass_above_threshold == 1.0
+
+
+# ── the consumer this was breaking ─────────────────────────────────────────
+
+def test_precision_collapse_guard_no_longer_demotes_a_selective_run():
+    """`pick_committed` demoted every RED entry that matched anything, because
+    mass_above was always 1.0 > the 0.9 floor. A selective run (3 of 100
+    candidates) must now survive and beat a v0 that matched nothing."""
+    from goldenmatch.core.autoconfig_history import HistoryEntry, RunHistory
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ComplexityProfile,
+        DataProfile,
+    )
+
+    def _entry(iteration: int, n_pairs: int, cand: int) -> HistoryEntry:
+        return HistoryEntry(
+            iteration=iteration,
+            config=None,  # pick_committed only reads .profile / .error
+            profile=ComplexityProfile(
+                data=DataProfile(n_rows=845),
+                blocking=BlockingProfile(n_blocks=180, reduction_ratio=0.989),
+                scoring=ScoringProfile(
+                    n_pairs_scored=n_pairs,
+                    candidates_compared=cand,
+                    candidates_counted=True,
+                    mass_above_threshold=(min(1.0, n_pairs / cand) if cand else 0.0),
+                ),
+            ),
+            decision=None, error=None, wall_clock_ms=1,
+        )
+
+    history = RunHistory()
+    # v0 matched nothing; iteration 2 matched 3 of 100 candidates.
+    history.entries.append(_entry(2, 3, 100))
+    history.entries.append(_entry(-1, 0, 100))
+    best = history.pick_committed(precision_collapse_floor=0.9)
+    assert best is not None
+    assert best.iteration == 2, (
+        "the entry that actually matched something must win over a v0 that "
+        "matched nothing; it is only 'precision collapse' if the fraction is "
+        "genuinely near 1.0"
+    )
+
+
+# ── #2668: health() could never say YELLOW ─────────────────────────────────
+
+def test_health_can_reach_yellow_again():
+    """#2668 observed that `health()`'s only YELLOW branch --
+    `mass_in_borderline > 0.3 and mass_in_borderline > mass_above_threshold`
+    -- needed `mass_in_borderline > 1.0` once mass_above was pinned at 1.0.
+    Impossible. So on any run that matched anything, health could only be
+    GREEN or RED: there was no way to say "matched something, but it looks
+    marginal", which is exactly the pressure that kept the controller from
+    converging somewhere loose.
+    """
+    from goldenmatch.core.complexity_profile import HealthVerdict
+
+    borderline_heavy = ScoringProfile(
+        n_pairs_scored=40, candidates_compared=1000, candidates_counted=True,
+        mass_above_threshold=0.04, mass_in_borderline=0.35, dip_statistic=0.02,
+    )
+    assert borderline_heavy.health() == HealthVerdict.YELLOW
+
+    clean = ScoringProfile(
+        n_pairs_scored=40, candidates_compared=1000, candidates_counted=True,
+        mass_above_threshold=0.04, mass_in_borderline=0.01, dip_statistic=0.02,
+    )
+    assert clean.health() == HealthVerdict.GREEN
+
+
+def test_the_collapse_guard_fires_on_a_genuine_everything_matches():
+    """The other direction: the guard must still catch what it was written
+    for. 990 of 1000 candidates admitted IS precision collapse, and now reads
+    as 0.99 rather than being indistinguishable from a 3-in-1000 run."""
+    permissive = ScoringProfile(
+        n_pairs_scored=990, candidates_compared=1000, candidates_counted=True,
+        mass_above_threshold=0.99, mass_in_borderline=0.0, dip_statistic=0.02,
+    )
+    assert permissive.mass_above_threshold > 0.9, (
+        "precision_collapse_floor=0.9 must still trip on a genuinely "
+        "permissive config -- the fix restores the signal, it does not "
+        "disable the guard"
+    )
+
+
+# ── end-to-end: #2663's own corpus ─────────────────────────────────────────
+
+def test_orgs_hard_no_longer_returns_a_confident_empty_result():
+    """#2663 end-to-end. `orgs_hard` is 845 rows with 1,055 true duplicate
+    pairs, and zero-config returned 845 singleton clusters -- not a
+    low-precision answer, an empty one, reported as a success.
+
+    Measured on this fix (2026-08-18): 242 scored pairs, 607 clusters,
+    P 0.5783 / R 0.3185 / F1 0.4108. The issue notes F1 0.6325 is reachable
+    on this corpus by forcing threshold=0.6, so this is not the ceiling --
+    threshold SELECTION is a separate problem. The floors below are set well
+    under the measured values because the controller's committed config is
+    not bit-stable across environments; what must never regress is the shape
+    -- a run that finds nothing at all.
+    """
+    import csv
+    from pathlib import Path
+
+    import pyarrow as pa
+    import pytest
+
+    import goldenmatch
+    from goldenmatch.core.evaluate import evaluate_clusters
+
+    base = (Path(__file__).resolve().parents[4]
+            / "scripts/suggest_quality/corpora/orgs_hard")
+    if not (base / "records.csv").exists():
+        pytest.skip("orgs_hard corpus not present")
+
+    with open(base / "records.csv", newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    cols = [c for c in rows[0] if c != "hardness"]
+    df = pa.table({c: [r[c] for r in rows] for c in cols})
+
+    with open(base / "truth.csv", newline="", encoding="utf-8") as f:
+        truth = {
+            (min(int(r["row_a"]), int(r["row_b"])),
+             max(int(r["row_a"]), int(r["row_b"])))
+            for r in csv.DictReader(f)
+        }
+
+    res = goldenmatch.dedupe_df(df)
+    assert len(res.scored_pairs) > 0, (
+        "zero-config found NOTHING on a corpus that is ~30% duplicates -- "
+        "the #2663 regression, and the worst shape of wrong answer because "
+        "it looks like a clean run"
+    )
+    assert len(res.clusters) < df.num_rows, "every record its own cluster"
+
+    ev = evaluate_clusters(res.clusters, truth).summary()
+    assert ev["recall"] >= 0.15, f"recall collapsed: {ev}"
+    assert ev["precision"] >= 0.35, f"precision collapsed: {ev}"

--- a/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
+++ b/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
@@ -1,26 +1,40 @@
-"""#2673: mass_above_threshold must be a fraction of CANDIDATES, not of matches.
+"""#2673: the honest admitted fraction, as a NEW field beside the old one.
 
 `_emit_scoring_profile` is handed the pairs that ALREADY cleared the cut (its
-own docstring: "pairs: Pairs *above* the threshold"), and computed
+own docstring: "pairs: Pairs *above* the threshold"), and computes
 `mass_above(scores, threshold)` over exactly those. That is 1.0 by
 construction for any non-empty result, at all six emit sites, for every
-matchkey type -- so the field carried one bit ("did anything match") while a
-dozen consumers read it as a fraction.
+matchkey type -- so `mass_above_threshold` carries one bit ("did anything
+match") while about a dozen consumers read it as a fraction.
 
-The damage is at commit time: `pick_committed` demotes any RED entry whose
-`mass_above > 0.9` as the "everything matches" pathology, which -- given the
-tautology -- is every RED entry that matched anything at all. v0, which
-matched nothing, wins. That is the confident-empty-result in #2663.
+`ScoringProfile.admitted_fraction` is the real thing: n_pairs_scored over
+candidates_compared, or None when the scorer had no count to divide by.
 
-`candidates_compared` is the denominator this always wanted, and
-`_emit_scoring_profile` already takes it as a parameter. When it is real
-(`candidates_counted=True`) the honest fraction is
-`n_pairs_scored / candidates_compared`. When it is absent, the old bit is
-still the best available answer and is kept -- but consumers that need a
-fraction must branch on `candidates_counted` rather than trusting it.
+It is a NEW field rather than a repair of the old one, and that was decided by
+measurement, not taste. Rebasing `mass_above_threshold` itself was implemented
+and reverted: the rules gate on hardcoded cuts (`< 0.5` in
+rule_blocking_too_coarse, `>= 0.95` in the precision anchor, `>= 1.0` in
+rule_recall_gap_suspected) chosen while that input was a CONSTANT, so making it
+truthful invalidates every one of their calibrations at once. The quality gate
+caught it: anchor_person_match F1 1.0000 -> 0.7303 (P 1.0000 -> 0.5751), the
+controller taking a different rule path and over-merging.
+
+So only the consumers whose bug motivated the work read the new field, and only
+where it is not None:
+
+  - `pick_committed`'s precision-collapse guard (#2663 mechanism)
+  - `ScoringProfile.health()`'s YELLOW branch (#2668)
+
+Everything else stays on the signal it was tuned against. Migrating the rest is
+real work needing its own before/after across all six gate datasets.
+
+The one consumer deliberately NOT migrated is zero-label confidence's
+everything-matches guard -- see the xfail at the bottom of this file, which
+records why and what closing #2663 actually needs.
 """
 from __future__ import annotations
 
+import pytest
 from goldenmatch.core.complexity_profile import ScoringProfile
 from goldenmatch.core.profile_emitter import profile_capture
 
@@ -38,7 +52,8 @@ def test_mass_is_the_admitted_fraction_when_candidates_were_counted():
     pairs = [(0, 1, 0.91), (0, 2, 0.95), (1, 2, 0.99)]
     sp = _emit(pairs, 0.9, candidates_compared=100, candidates_counted=True)
     assert sp.n_pairs_scored == 3
-    assert sp.mass_above_threshold == 0.03
+    assert sp.admitted_fraction == 0.03
+    assert sp.mass_above_threshold == 1.0, "the old field keeps its old (tautological) meaning"
 
 
 def test_a_genuinely_permissive_run_still_reads_high():
@@ -47,34 +62,37 @@ def test_a_genuinely_permissive_run_still_reads_high():
     detectable again only because the denominator is now real."""
     pairs = [(i, i + 1, 0.99) for i in range(98)]
     sp = _emit(pairs, 0.5, candidates_compared=100, candidates_counted=True)
-    assert sp.mass_above_threshold == 0.98
+    assert sp.admitted_fraction == 0.98
 
 
-def test_absent_candidate_count_keeps_the_old_bit():
-    """No denominator available -> no fraction can be invented. The old
-    behaviour (1.0 when something matched) is retained as the honest bit,
-    and `candidates_counted=False` is what tells consumers not to read it
-    as a fraction (the #2639/#2644 idiom)."""
+def test_absent_candidate_count_reports_none_not_zero():
+    """No denominator available -> no fraction can be invented, and ``None``
+    is the only honest answer. ``0.0`` would read as "nothing matched", which
+    is the absent-vs-zero collapse this whole change exists to remove
+    (#2639/#2644)."""
     pairs = [(0, 1, 0.91)]
     sp = _emit(pairs, 0.9, candidates_compared=0, candidates_counted=False)
     assert sp.candidates_counted is False
+    assert sp.admitted_fraction is None
     assert sp.mass_above_threshold == 1.0
 
 
-def test_nothing_matched_is_still_zero():
-    """The zero end is load-bearing for rule_no_matches and health()."""
+def test_nothing_matched_is_zero_not_none():
+    """A MEASURED zero is a real answer and must be distinguishable from the
+    absent case above. Load-bearing for rule_no_matches and health()."""
     sp = _emit([], 0.9, candidates_compared=100, candidates_counted=True)
+    assert sp.admitted_fraction == 0.0
     assert sp.mass_above_threshold == 0.0
     assert sp.n_pairs_scored == 0
 
 
 def test_the_fraction_is_clamped_to_one():
     """Defensive: a candidate count smaller than the emitted pair count is a
-    bug upstream, but it must not produce mass > 1.0 and silently trip every
-    `>= 1.0` consumer."""
+    bug upstream, but it must not exceed 1.0 and silently trip every
+    `>= 1.0` / `> 0.9` consumer -- the exact failure being fixed."""
     pairs = [(i, i + 1, 0.99) for i in range(10)]
     sp = _emit(pairs, 0.5, candidates_compared=4, candidates_counted=True)
-    assert sp.mass_above_threshold == 1.0
+    assert sp.admitted_fraction == 1.0
 
 
 # ── the consumer this was breaking ─────────────────────────────────────────
@@ -101,7 +119,8 @@ def test_precision_collapse_guard_no_longer_demotes_a_selective_run():
                     n_pairs_scored=n_pairs,
                     candidates_compared=cand,
                     candidates_counted=True,
-                    mass_above_threshold=(min(1.0, n_pairs / cand) if cand else 0.0),
+                    admitted_fraction=(min(1.0, n_pairs / cand) if cand else 0.0),
+                    mass_above_threshold=1.0 if n_pairs else 0.0,  # the old tautology, unchanged
                 ),
             ),
             decision=None, error=None, wall_clock_ms=1,
@@ -135,13 +154,15 @@ def test_health_can_reach_yellow_again():
 
     borderline_heavy = ScoringProfile(
         n_pairs_scored=40, candidates_compared=1000, candidates_counted=True,
-        mass_above_threshold=0.04, mass_in_borderline=0.35, dip_statistic=0.02,
+        admitted_fraction=0.04, mass_above_threshold=1.0,
+        mass_in_borderline=0.35, dip_statistic=0.02,
     )
     assert borderline_heavy.health() == HealthVerdict.YELLOW
 
     clean = ScoringProfile(
         n_pairs_scored=40, candidates_compared=1000, candidates_counted=True,
-        mass_above_threshold=0.04, mass_in_borderline=0.01, dip_statistic=0.02,
+        admitted_fraction=0.04, mass_above_threshold=1.0,
+        mass_in_borderline=0.01, dip_statistic=0.02,
     )
     assert clean.health() == HealthVerdict.GREEN
 
@@ -152,29 +173,52 @@ def test_the_collapse_guard_fires_on_a_genuine_everything_matches():
     as 0.99 rather than being indistinguishable from a 3-in-1000 run."""
     permissive = ScoringProfile(
         n_pairs_scored=990, candidates_compared=1000, candidates_counted=True,
-        mass_above_threshold=0.99, mass_in_borderline=0.0, dip_statistic=0.02,
+        admitted_fraction=0.99, mass_above_threshold=1.0,
+        mass_in_borderline=0.0, dip_statistic=0.02,
     )
-    assert permissive.mass_above_threshold > 0.9, (
+    assert permissive.admitted_fraction > 0.9, (
         "precision_collapse_floor=0.9 must still trip on a genuinely "
         "permissive config -- the fix restores the signal, it does not "
         "disable the guard"
     )
 
 
-# ── end-to-end: #2663's own corpus ─────────────────────────────────────────
+# ── end-to-end: #2663's own corpus (STILL OPEN -- xfail) ───────────────────
 
+@pytest.mark.xfail(
+    reason=(
+        "#2663 is NOT fixed by this change and this test records exactly why. "
+        "The deciding consumer on this corpus is zero-label confidence's "
+        "everything-matches guard, not pick_committed's collapse guard: "
+        "measured, pick_committed(collapse_floor=0.9) picks iteration 3 (463 "
+        "pairs, admitted_fraction 0.051) while the same call with "
+        "use_zero_label_confidence=True -- which is ON by default -- picks v0 "
+        "(0 pairs). That guard caps confidence at 0.2 whenever "
+        "mass_above_threshold >= 0.9, i.e. on every entry that matched "
+        "anything, so a config that finds duplicates can never out-score one "
+        "that finds none. "
+        "Migrating it to admitted_fraction was tried and REVERTED: it fixes "
+        "this corpus but costs anchor_person_match F1 1.0000 -> 0.5139 "
+        "(P 0.3458), because the tautological cap was the only thing "
+        "penalising over-merged configs there -- and admitted_fraction cannot "
+        "replace it, since that over-merge comes from transitive closure "
+        "during clustering (adm 0.047, i.e. selective admission) rather than "
+        "from admitting too many candidates. "
+        "Closing #2663 needs a real over-merge signal for that guard -- "
+        "ClusterProfile already measures cluster_size_max / "
+        "oversized_cluster_count -- which is its own measured change across "
+        "all six gate datasets, not a rider on this one."
+    ),
+    strict=True,
+)
 def test_orgs_hard_no_longer_returns_a_confident_empty_result():
     """#2663 end-to-end. `orgs_hard` is 845 rows with 1,055 true duplicate
-    pairs, and zero-config returned 845 singleton clusters -- not a
+    pairs, and zero-config returns 845 singleton clusters -- not a
     low-precision answer, an empty one, reported as a success.
 
-    Measured on this fix (2026-08-18): 242 scored pairs, 607 clusters,
-    P 0.5783 / R 0.3185 / F1 0.4108. The issue notes F1 0.6325 is reachable
-    on this corpus by forcing threshold=0.6, so this is not the ceiling --
-    threshold SELECTION is a separate problem. The floors below are set well
-    under the measured values because the controller's committed config is
-    not bit-stable across environments; what must never regress is the shape
-    -- a run that finds nothing at all.
+    Kept as a strict xfail rather than deleted: it is the reproduction, and
+    `strict=True` means it fails the suite the moment the behaviour is fixed,
+    which is when this marker should come off.
     """
     import csv
     from pathlib import Path
@@ -212,3 +256,62 @@ def test_orgs_hard_no_longer_returns_a_confident_empty_result():
     ev = evaluate_clusters(res.clusters, truth).summary()
     assert ev["recall"] >= 0.15, f"recall collapsed: {ev}"
     assert ev["precision"] >= 0.35, f"precision collapsed: {ev}"
+
+
+def test_an_uncounted_route_keeps_its_prior_verdict():
+    """The blast-radius guard, and the reason `admitted_fraction` is a NEW
+    field instead of a repair of `mass_above_threshold`.
+
+    Rebasing the old field was tried and reverted: about a dozen rules gate on
+    hardcoded cuts (`< 0.5` in rule_blocking_too_coarse, `>= 0.95` in the
+    precision anchor, `>= 1.0` in rule_recall_gap_suspected) that were all
+    chosen while that input was a CONSTANT 1.0. Making it truthful invalidates
+    their calibration at once -- measured on the quality gate,
+    anchor_person_match went F1 1.0000 -> 0.7303 (P 1.0000 -> 0.5751) because
+    the controller took a different rule path and over-merged.
+
+    So a route that supplies no candidate count must behave EXACTLY as before:
+    `admitted_fraction` is None, and both migrated consumers fall back to the
+    old field rather than substituting a value.
+    """
+    from goldenmatch.core.autoconfig_history import HistoryEntry, RunHistory
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ComplexityProfile,
+        DataProfile,
+        HealthVerdict,
+    )
+
+    uncounted = ScoringProfile(
+        n_pairs_scored=40, candidates_compared=0, candidates_counted=False,
+        admitted_fraction=None, mass_above_threshold=1.0,
+        mass_in_borderline=0.35, dip_statistic=0.02,
+    )
+    # Old comparison (0.35 > 1.0) is False -> GREEN, exactly as before #2668.
+    assert uncounted.health() == HealthVerdict.GREEN
+
+    # And the collapse guard still demotes it on the old field, as before.
+    def _entry(iteration: int, sp: ScoringProfile) -> HistoryEntry:
+        return HistoryEntry(
+            iteration=iteration, config=None,
+            profile=ComplexityProfile(
+                data=DataProfile(n_rows=845),
+                blocking=BlockingProfile(n_blocks=1, reduction_ratio=0.01),
+                scoring=sp,
+            ),
+            decision=None, error=None, wall_clock_ms=1,
+        )
+
+    red_uncounted = ScoringProfile(
+        n_pairs_scored=40, candidates_compared=0, candidates_counted=False,
+        admitted_fraction=None, mass_above_threshold=1.0,
+        mass_in_borderline=0.0, dip_statistic=0.0,
+    )
+    history = RunHistory()
+    history.entries.append(_entry(2, red_uncounted))
+    history.entries.append(_entry(-1, red_uncounted))
+    best = history.pick_committed(precision_collapse_floor=0.9)
+    assert best is not None and best.iteration == -1, (
+        "with no candidate count the guard must keep reading the old field, "
+        "so v0 still wins -- unchanged behaviour on an uncounted route"
+    )

--- a/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
+++ b/packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py
@@ -179,10 +179,9 @@ def test_orgs_hard_no_longer_returns_a_confident_empty_result():
     import csv
     from pathlib import Path
 
+    import goldenmatch
     import pyarrow as pa
     import pytest
-
-    import goldenmatch
     from goldenmatch.core.evaluate import evaluate_clusters
 
     base = (Path(__file__).resolve().parents[4]

--- a/packages/python/goldenmatch/tests/test_rule_no_matches_bucket_route.py
+++ b/packages/python/goldenmatch/tests/test_rule_no_matches_bucket_route.py
@@ -1,0 +1,71 @@
+"""#2663: rule_no_matches must fire on a bucket-routed profile.
+
+`candidates_compared == 0` means two different things depending on
+`candidates_counted` (#2639/#2644): a MEASURED zero (blocking truly produced
+no candidates -- rule_blocking_singleton_trap's territory) or an ABSENT
+count (bucket never accumulates one). `rule_no_matches` read only the raw
+value, so it could never fire on the bucket path -- not "rarely," never.
+Bucket is the default scorer at nearly every scale (#526).
+"""
+from __future__ import annotations
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_no_matches
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ScoringProfile,
+)
+
+
+def _weighted_cfg(threshold: float = 0.8) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=threshold,
+            fields=[MatchkeyField(field="org_name", scorer="jaro_winkler", weight=1.0)],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["postcode"], transforms=["strip"])],
+        ),
+    )
+
+
+def _profile(*, candidates_compared: int, candidates_counted: bool, n_blocks: int) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=845),
+        blocking=BlockingProfile(n_blocks=n_blocks, reduction_ratio=0.9 if n_blocks else 0.0),
+        scoring=ScoringProfile(
+            mass_above_threshold=0.0,
+            n_pairs_scored=0,
+            candidates_compared=candidates_compared,
+            candidates_counted=candidates_counted,
+        ),
+    )
+
+
+def test_declines_on_a_measured_zero_candidate_count():
+    """Unchanged behavior: a REAL zero defers to the singleton-trap rule."""
+    profile = _profile(candidates_compared=0, candidates_counted=True, n_blocks=12)
+    result = rule_no_matches(profile, _weighted_cfg(), RunHistory())
+    assert result is None
+
+
+def test_fires_on_an_absent_candidate_count_bucket_route():
+    """The regression this pins: bucket's honest candidates_counted=False
+    must not be read as 'no candidates exist' -- it means 'not counted'.
+    mass_above_threshold == 0 with n_blocks > 0 (blocking clearly ran) is
+    real signal even without a candidate count."""
+    profile = _profile(candidates_compared=0, candidates_counted=False, n_blocks=12)
+    result = rule_no_matches(profile, _weighted_cfg(), RunHistory())
+    assert result is not None, "rule_no_matches must fire on an absent-but-plausible bucket profile"
+    new_cfg, decision = result
+    assert new_cfg.get_matchkeys()[0].threshold < 0.8


### PR DESCRIPTION
Closes #2663. Closes #2673. **Refs** #2668 (see "What this does NOT fix" below).

Rebased onto `main` now that #2671 has landed.

## The root cause

`_emit_scoring_profile` is handed pairs that have **already cleared the cut** — its own docstring says so — and computes `mass_above(scores, threshold)` over exactly those. That is **1.0 by construction** for any non-empty result, at all six emit sites, for every matchkey type. The field carries one bit while ~a dozen consumers read it as a fraction.

Verified before changing anything, on two unrelated datasets:

| run | pairs returned | below threshold | mass_above |
|---|---|---|---|
| `orgs_hard`, **weighted** mk, real `threshold=0.8` | 3 | **0** | 1.0000 |
| healthy high-recall synthetic | 8,343 | **0** | 1.0000 |

The first is a weighted matchkey with a genuine configured cutoff, so this is *not* the probabilistic `min(scores)` fallback #2668 blamed.

## Three designs; the quality gate rejected the first two

**1. Rebase `mass_above_threshold` itself.** Correct about the field, wrong about blast radius. The rules gate on hardcoded cuts (`< 0.5` in `rule_blocking_too_coarse`, `>= 0.95` in the precision anchor, `>= 1.0` in `rule_recall_gap_suspected`) all chosen while that input was a **constant**. Gate result: `anchor_person_match` **F1 1.0000 → 0.7303** (P → 0.5751), controller taking a different rule path and over-merging. Reverted.

**2. Also migrate zero-label's everything-matches guard.** That guard turned out to be the *actual* deciding consumer on `orgs_hard` — `pick_committed(collapse_floor)` picks iteration 3 (463 pairs) while the same call with `use_zero_label_confidence=True` (on by default) picks v0 (0 pairs). But migrating it cost the anchor **F1 1.0000 → 0.5139**: its tautological cap was the only thing penalising over-merge there. Reverted.

**3. What shipped.** The honest fraction lands as a **new** field, `ScoringProfile.admitted_fraction`, read by only two consumers and only where it is not `None`. Everything else stays on the signal it was calibrated against.

Then, separately, the mirror of the precision-collapse guard: **DEGENERATE-EMPTY** — an entry that merged *nothing* must not beat one that merged something.

## Why that signal and not a cluster-shape one

Measured, rather than assumed. No cluster metric separates `orgs_hard`'s **correct** entry from the anchor's **over-merged** one:

```
signal                   orgs_hard it3 (good)   anchor it1 (over-merged)
cluster_size_max/n_rows  0.0154                 0.0156
oversized_cluster_count  0                      0
measured_bridge_risk     0.0                    0.0
transitivity_rate        0.005                  0.085
```

"Did it merge anything at all" separates them cleanly, and is the pathology itself rather than a proxy:

```
orgs_hard   n_rows 845, v0 -> 845 clusters (0 merges)    BAD
anchor      n_rows 706, v0 -> 400 clusters (306 merges)  GOOD
```

Deliberately narrow: it only breaks ties **within** a health rank, and when every entry is empty (data with genuinely no duplicates) all demote equally and ordering is byte-identical. Both properties have tests.

## Measured

```
orgs_hard (#2663)     F1 0.0000 -> 0.4108   (0 -> 242 pairs, 845 -> 607 clusters)
anchor_person_match   F1 1.0000 -> 1.0000   (unchanged)
```

0.4108 is not the ceiling — the issue notes 0.6325 is reachable by forcing `threshold=0.6`, so threshold *selection* remains a separate problem. What is fixed is the shape: a confident empty result on data that is ~30% duplicates.

#2668's specific complaint is also fixed: `health()` can reach YELLOW again (its branch previously required `mass_in_borderline > 1.0`).

## Also in this PR

- **Blocking measured per-iteration at any scale**, not only `>= REFUSE_AT_N`. On `orgs_hard`: `n_blocks 0 → 180/281`, `reduction_ratio 0.0000 → 0.9890`. Fills an **absent** profile only — an earlier version replaced unconditionally and clobbered deliberately-RED injected profiles, which CI caught.
- **`rule_no_matches` could never fire on the bucket route** — it read a bare `candidates_compared == 0` where bucket always reports 0 with `candidates_counted=False`.
- **Bucket now counts its candidates.** The prior "genuinely ABSENT" note described what the code did, not what it could do.
- `duckdb` / `ray` / FS-pipeline emits stay honestly absent, with in-code reasoning for why a convenient denominator there would mean something different.

## Test plan

- [x] 13 tests in `test_mass_above_is_a_real_fraction.py`, incl. end-to-end on `orgs_hard`
- [x] restore-the-bug verified for the blocking-measurement and `rule_no_matches` fixes
- [x] ~180 local tests green across autoconfig / rules / zero-label / bucket / parity / planner
- [x] ruff clean
- [ ] full `ci.yml` — **`quality_gate` is the gate that matters here**; it rejected two prior designs

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P

---

## What this does NOT fix: #2668's lane

I originally wrote `Closes #2668` here and then checked it, which is the only reason this section exists.

`goldengraph-pipeline` — the lane #2668 actually reports — is `workflow_dispatch` + nightly only, path-filtered on its **own** paths, so a goldenmatch change never triggers it (`goldengraph_native` reads `skipping` on this PR). Nothing in this PR's CI touches it.

So I dispatched it against this branch: [run 32183284751](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32183284751). **It fails identically to `main`** — same four tests in `test_realworld_aggregation.py`, same assertions, same values:

```
assert any(len(ks) > 1 for ks in keys_by_entity.values())   -> False
assert gg and min(gg) >= 0.99                               -> [0.8] and 0.8 >= 0.99
```

Zero effect. So what this PR fixes is #2668's **stated mechanism** — `health()` could never return YELLOW because its branch required `mass_in_borderline > 1.0` — and that mechanism is real and now fixed, but it is **not** what drives that lane's over-merge. #2668 stays open with a comment recording the verification.

Worth noting for whoever picks it up: the lane was green on 2026-08-17 and red on 2026-08-18. Besides #2648 (the issue's own bisect target), that window also contains #2655 *"the data-driven cut admitted TWICE the match rate EM estimated"*, #2650, #2646, #2645 and #2644 — several of which move thresholds or scoring profiles. The bisect deserves a re-run against the current tree rather than being inherited.
