### PR TITLE
bench(spark): size the GCE lane for a 50M head-to-head and record every metric

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -388,15 +388,79 @@ jobs:
             echo ''
             echo 'Every shuffle byte here crosses a real network, which the single-host lane cannot test.'
             echo ''
-            if [ -f spark-fs-train-scale.json ] && [ -f splink-train-scale.json ]; then
-              echo '| engine | train wall | shuffle write | shuffle read |'
-              echo '|---|---:|---:|---:|'
-              jq -r '"| goldenmatch | \(.stages.u_seconds + .stages.counts_seconds + .stages.train_seconds)s | \(.shuffle.shuffle_write_bytes // "n/a") | \(.shuffle.shuffle_read_bytes // "n/a") |"' spark-fs-train-scale.json
-              jq -r '"| splink | \(.train_total_seconds)s | \(.shuffle.shuffle_write_bytes // "n/a") | \(.shuffle.shuffle_read_bytes // "n/a") |"' splink-train-scale.json
+            # PER-ARM, not all-or-nothing. The previous version printed the
+            # table only when BOTH artifacts existed, so the most likely
+            # outcome of a large run -- GoldenMatch completes, Splink dies on
+            # disk or memory -- rendered NO numbers at all, and the completed
+            # arm's measurements were lost to a formatting branch. Splink is
+            # `continue-on-error` precisely so its failure does not cost the
+            # cluster spend; the summary has to honour that.
+            echo '### Wall and shuffle'
+            echo ''
+            echo '| engine | train wall | shuffle write | shuffle read | stages | tasks |'
+            echo '|---|---:|---:|---:|---:|---:|'
+            if [ -f spark-fs-train-scale.json ]; then
+              jq -r '"| goldenmatch | \(.stages.u_seconds + .stages.counts_seconds + .stages.train_seconds)s | \(.shuffle.shuffle_write_bytes // "n/a") | \(.shuffle.shuffle_read_bytes // "n/a") | \(.shuffle.n_stages // "n/a") | \(.shuffle.num_tasks // "n/a") |"' spark-fs-train-scale.json
             else
-              echo 'NO COMPARISON -- one or both arms produced no artifact:'
-              [ -f spark-fs-train-scale.json ] && echo '- goldenmatch: ok' || echo '- goldenmatch: MISSING'
-              [ -f splink-train-scale.json ] && echo '- splink: ok' || echo '- splink: MISSING'
+              echo '| goldenmatch | **MISSING** | | | | |'
+            fi
+            if [ -f splink-train-scale.json ]; then
+              jq -r '"| splink | \(.train_total_seconds)s | \(.shuffle.shuffle_write_bytes // "n/a") | \(.shuffle.shuffle_read_bytes // "n/a") | \(.shuffle.n_stages // "n/a") | \(.shuffle.num_tasks // "n/a") |"' splink-train-scale.json
+            elif [ "${{ inputs.splink_compare }}" = "true" ]; then
+              echo '| splink | **MISSING** | | | | |'
+            fi
+            echo ''
+
+            # Accuracy: the half a speed table cannot answer. `quality_score_groups`
+            # is printed because it is the number that says whether the bounded
+            # collect held -- an unbounded group count is a finding, not noise.
+            echo '### Accuracy'
+            echo ''
+            echo '| engine | avg precision | best F1 | @threshold | base rate | pairs | score groups |'
+            echo '|---|---:|---:|---:|---:|---:|---:|'
+            for pair in "goldenmatch:spark-fs-train-scale.json" "splink:splink-train-scale.json"; do
+              nm="${pair%%:*}"; fp="${pair#*:}"
+              if [ -f "$fp" ]; then
+                jq -r --arg nm "$nm" '"| \($nm) | \(.quality.average_precision // "n/a") | \(.quality.best_f1 // "n/a") | \(.quality.best_f1_threshold // "n/a") | \(.quality.base_rate // "n/a") | \(.quality.n_pairs // "n/a") | \(.quality_score_groups // "n/a") |"' "$fp"
+              fi
+            done
+            echo ''
+
+            # Where the time actually went. A slower engine is CPU, GC, spill or
+            # skew, and the shuffle totals alone cannot tell those apart.
+            echo '### CPU, GC, spill'
+            echo ''
+            echo '| engine | executor run | executor CPU | JVM GC | mem spill | disk spill | peak exec mem |'
+            echo '|---|---:|---:|---:|---:|---:|---:|'
+            for pair in "goldenmatch:spark-fs-train-scale.json" "splink:splink-train-scale.json"; do
+              nm="${pair%%:*}"; fp="${pair#*:}"
+              if [ -f "$fp" ]; then
+                jq -r --arg nm "$nm" '"| \($nm) | \(.shuffle.executor_run_time_ms // "n/a")ms | \(.shuffle.executor_cpu_time_ns // "n/a")ns | \(.shuffle.jvm_gc_time_ms // "n/a")ms | \(.shuffle.memory_spill_bytes // "n/a") | \(.shuffle.disk_spill_bytes // "n/a") | \(.shuffle.peak_execution_memory_max // "n/a") |"' "$fp"
+              fi
+            done
+            echo ''
+            echo 'An `n/a` above means Spark did not report the field, NOT that the value was zero.'
+            echo ''
+
+            # Executor health. At scale the likely failure is ONE node, and a
+            # cluster-wide total hides it -- so a death is surfaced, loudly.
+            echo '### Executor health'
+            echo ''
+            echo '| engine | executors | died | failed tasks | max disk used | max JVM heap |'
+            echo '|---|---:|---|---:|---:|---:|'
+            for pair in "goldenmatch:spark-fs-train-scale.json" "splink:splink-train-scale.json"; do
+              nm="${pair%%:*}"; fp="${pair#*:}"
+              if [ -f "$fp" ]; then
+                jq -r --arg nm "$nm" '.shuffle.executor_metrics as $e | "| \($nm) | \($e.n_executors // "n/a") | \(if $e.any_executor_died then "**YES** \($e.dead_executor_ids|tostring)" else "no" end) | \($e.failed_tasks_total // "n/a") | \($e.disk_used_max // "n/a") | \($e.peak_jvm_heap_max // "n/a") |"' "$fp" 2>/dev/null || echo "| $nm | (executor metrics unavailable) | | | | |"
+              fi
+            done
+            echo ''
+
+            if [ ! -f splink-train-scale.json ] && [ "${{ inputs.splink_compare }}" = "true" ]; then
+              echo '> **Splink produced no artifact.** That is a RESULT, not a lost run --'
+              echo '> it is the side expected to fail first at scale (~20x the bytes, ~940'
+              echo '> stages, re-scanning pairs per EM iteration). GoldenMatch numbers above'
+              echo '> stand. Re-dispatch larger (`workers`, `disk_gb`) to get the comparison.'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -96,6 +96,11 @@ on:
         required: false
         type: boolean
         default: true
+      eval_quality:
+        description: "Also measure ACCURACY (average precision / best F1) on both arms. Adds a predict + grouped-collect pass to each; without it the run reports speed and bytes but no quality, which is not a head-to-head."
+        required: false
+        type: boolean
+        default: true
       spot:
         description: "Use SPOT VMs. OFF by default: PREEMPTIBLE_CPUS quota in golden-490919/us-central1 is 0, so SPOT provisioning FAILS. Enable only after raising it."
         required: false
@@ -320,6 +325,7 @@ jobs:
               --rows ${{ inputs.rows || '1000000' }} \
               --remote sc://$MASTER_IP:15002 \
               --spark-ui http://$MASTER_IP:4040 \
+              ${{ inputs.eval_quality && '--eval-quality' || '' }} \
               --out /w/spark-fs-train-scale.json
           "
 
@@ -351,6 +357,7 @@ jobs:
               --master spark://$MASTER_IP:7077 \
               --driver-host $MASTER_IP \
               --spark-ui http://$MASTER_IP:4040 \
+              ${{ inputs.eval_quality && '--eval-quality' || '' }} \
               --out /w/splink-train-scale.json
           "
 

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -35,13 +35,20 @@
 #
 # ## Cost
 #
-# ~$0.60 per run: 3 x n2-standard-16 ON-DEMAND (~$2.33/hr) for ~15 min,
-# dominated by ~5 minutes of provisioning rather than the ~16s of compute. The
-# teardown step runs `if: always()`, so a failed bench still releases the
-# instances -- the same discipline bench-ray-cluster.yml uses.
+# Scales with the run. The 1M default is ~$0.60: 5 x n2-standard-16 ON-DEMAND
+# for ~15 min, dominated by ~5 minutes of provisioning rather than the ~16s of
+# compute. A 50M head-to-head is hours, not minutes, and the wall is unknown
+# until one has been run -- so read the `timeout-minutes` below as the cost
+# ceiling, not the expected spend.
 #
-# Preemptible on purpose: a bench that loses its VMs mid-run should be re-run,
-# not paid for at on-demand rates.
+# The teardown step runs `if: always()`, so a failed bench still releases the
+# instances -- the same discipline bench-ray-cluster.yml uses. `keep_cluster`
+# defeats that ON PURPOSE and leaves the VMs billing; it is for debugging and
+# the operator deletes them by hand.
+#
+# ON-DEMAND, not preemptible: PREEMPTIBLE_CPUS quota in this project is 0 (see
+# the provisioning step). A multi-hour 50M run is also the worst case for
+# preemption -- losing the cluster at hour two wastes the whole spend.
 #
 # ## Both engines run ON the master VM, deliberately
 #
@@ -73,7 +80,12 @@ on:
         description: "Worker VMs (the master VM runs master + Connect + both drivers)"
         required: false
         type: string
-        default: "2"
+        default: "4"
+      disk_gb:
+        description: "Boot disk per node, in GB. This is SHUFFLE SPILL space, not OS space -- Splink projects to ~840GB of cumulative shuffle at 50M. Do not lower it for a large run."
+        required: false
+        type: string
+        default: "500"
       zone:
         description: "GCE zone"
         required: false
@@ -107,7 +119,7 @@ env:
 jobs:
   cluster:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
@@ -159,7 +171,8 @@ jobs:
         # `bench=gm-spark` label -- so a leaked VM can be traced and swept.
         run: |
           set -euo pipefail
-          N=${{ inputs.workers || '2' }}
+          N=${{ inputs.workers || '4' }}
+          DISK_GB=${{ inputs.disk_gb || '500' }}
           MT="${{ inputs.machine_type || 'n2-standard-16' }}"
           NAMES="$CLUSTER-master"
           for i in $(seq 1 "$N"); do NAMES="$NAMES $CLUSTER-w$i"; done
@@ -182,15 +195,31 @@ jobs:
 
           # Container-Optimized OS: docker is already present, so no apt round
           # trip per node and no image drift between the master and the workers.
+          #
+          # Disk is sized for SHUFFLE SPILL, not for the OS. Spark spills to the
+          # worker's local dirs, which here is the boot disk, and 100GB does not
+          # survive a 50M head-to-head. Projected from the measured 1M run
+          # (#2652), scaling linearly because the fixture's block size is pinned
+          # at 12 rows (dup=3 x blocks_per_key=4) so pairs grow with rows:
+          #
+          #     engine        shuffle write @1M   projected @50M
+          #     GoldenMatch          832 MB            ~41 GB
+          #     Splink            16,784 MB           ~840 GB
+          #
+          # Cumulative is not concurrent peak (Spark reclaims between stages),
+          # but 840 GB across 940 stages against 100 GB is the single most
+          # likely way a paid multi-hour run dies. 500 GB is a few dollars of
+          # PD-balanced against the cost of re-running the cluster.
           gcloud compute instances create $NAMES \
             --machine-type="$MT" \
             --image-family=cos-stable --image-project=cos-cloud \
-            --boot-disk-size=100GB \
+            --boot-disk-size="${DISK_GB}GB" \
+            --boot-disk-type=pd-balanced \
             $PROV \
             --labels=bench=gm-spark,run-id=${{ github.run_id }} \
             --scopes=cloud-platform \
             --quiet
-          echo "provisioned: $NAMES"
+          echo "provisioned: $NAMES (disk ${DISK_GB}GB pd-balanced)"
 
       # SSH goes over the instance's EXTERNAL IP rather than IAP.
       # `--tunnel-through-iap` would be tidier, but it needs
@@ -296,6 +325,17 @@ jobs:
 
       - name: Splink on the same cluster
         if: inputs.splink_compare
+        # `continue-on-error`: Splink is the side expected to fail first at
+        # scale -- it shuffles ~20x the bytes (#2652) and re-scans pairs per EM
+        # iteration across ~940 stages. If it dies on disk or memory at 50M,
+        # that outcome is ITSELF the measurement, and losing GoldenMatch's
+        # completed numbers to a red step would waste the whole cluster spend.
+        #
+        # The failure is NOT swallowed: the summary step below prints
+        # `splink: MISSING` and the run is re-dispatched larger. Making it
+        # explicit there rather than auto-retrying in-workflow is deliberate --
+        # an automatic retry reprovisions a bigger paid cluster unattended.
+        continue-on-error: true
         # Connect is stopped first: standalone Spark hands an application every
         # free core unless `spark.cores.max` says otherwise, and the Connect
         # server IS an application holding them all. Splink would queue forever.
@@ -337,7 +377,7 @@ jobs:
           {
             echo '## Spark FS on a REAL multi-node cluster'
             echo ''
-            echo "${{ inputs.workers || '2' }} worker VM(s) + 1 master, \`${{ inputs.machine_type || 'n2-standard-16' }}\`, SPOT, zone \`${{ inputs.zone || 'us-central1-a' }}\`."
+            echo "${{ inputs.workers || '4' }} worker VM(s) + 1 master, \`${{ inputs.machine_type || 'n2-standard-16' }}\`, ${{ inputs.disk_gb || '500' }}GB/node, ${{ inputs.rows || '1000000' }} rows, zone \`${{ inputs.zone || 'us-central1-a' }}\`."
             echo ''
             echo 'Every shuffle byte here crosses a real network, which the single-host lane cannot test.'
             echo ''

--- a/packages/python/goldenmatch/tests/test_fs_quality_metrics_grouped.py
+++ b/packages/python/goldenmatch/tests/test_fs_quality_metrics_grouped.py
@@ -1,0 +1,151 @@
+"""`ranking_metrics_grouped` must equal `ranking_metrics` on the same data.
+
+That equivalence is the whole justification for the grouped form. It exists
+because the ungrouped one cannot run at 50M: its caller collects one
+`(score, is_true)` tuple PER CANDIDATE PAIR to the driver, which is 5.5M at the
+1M scale the harness was written for and **275M** at 50M -- tens of GB of Python
+objects on a driver in a container. A head-to-head with no accuracy number is
+not a head-to-head, so the metric has to survive the scale.
+
+Grouping is exact rather than approximate because `ranking_metrics` already
+consumes its input in tie-groups: it advances to the next distinct score, admits
+every pair at that score, and only then computes precision/recall. The per-pair
+identity inside a tie group is never used -- only the counts. So if these two
+ever disagree, the grouped form is wrong, and a benchmark comparing two engines
+on a metric that quietly changed meaning is worse than no benchmark.
+
+These tests are the proof, so they compare against the REAL function on shared
+inputs rather than against hand-computed constants. A hand-computed expectation
+would only prove I can do the arithmetic the same wrong way twice.
+"""
+from __future__ import annotations
+
+import importlib.util
+import random
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+_MOD = Path(__file__).resolve().parents[4] / "scripts" / "_fs_quality_metrics.py"
+
+
+def _load():
+    if not _MOD.exists():
+        pytest.skip(f"{_MOD} not present")
+    spec = importlib.util.spec_from_file_location("_fs_quality_metrics", _MOD)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _group(scored: list[tuple[float, bool]]) -> list[tuple[float, int, int]]:
+    """The exact aggregation the Spark `groupBy(score)` produces."""
+    total: Counter = Counter()
+    trues: Counter = Counter()
+    for s, t in scored:
+        total[s] += 1
+        if t:
+            trues[s] += 1
+    return [(s, trues[s], total[s]) for s in total]
+
+
+def _assert_same(m, scored):
+    a = m.ranking_metrics(scored)
+    b = m.ranking_metrics_grouped(_group(scored))
+    assert a == b, f"grouped != ungrouped\nungrouped={a}\ngrouped  ={b}"
+    return a
+
+
+# ── equivalence on the shapes that actually occur ──────────────────────────
+
+def test_agrees_on_a_clean_separation():
+    m = _load()
+    scored = [(0.9, True)] * 10 + [(0.1, False)] * 90
+    out = _assert_same(m, scored)
+    assert out["average_precision"] == 1.0
+
+
+def test_agrees_when_ties_span_both_classes():
+    """The case grouping could plausibly get wrong: one score carrying both
+    true and false pairs. `ranking_metrics` admits the whole tie group before
+    measuring, and the grouped form must do the same."""
+    m = _load()
+    scored = [(0.5, True)] * 3 + [(0.5, False)] * 7 + [(0.9, True)] * 2
+    _assert_same(m, scored)
+
+
+def test_agrees_on_interleaved_scores():
+    m = _load()
+    scored = [(0.9, True), (0.8, False), (0.7, True), (0.6, False),
+              (0.5, True), (0.4, False)]
+    _assert_same(m, scored)
+
+
+@pytest.mark.parametrize("seed", [1, 7, 42, 1337])
+def test_agrees_on_random_data_with_heavy_ties(seed):
+    """Randomised, with a deliberately SMALL score alphabet so tie groups are
+    large -- which is the real shape here, since a pair's weight is a sum of
+    per-field match weights over bounded gamma levels."""
+    m = _load()
+    rng = random.Random(seed)
+    alphabet = [round(x * 0.05, 2) for x in range(21)]
+    scored = [
+        (rng.choice(alphabet), rng.random() < 0.3)
+        for _ in range(2000)
+    ]
+    _assert_same(m, scored)
+
+
+@pytest.mark.parametrize("seed", [3, 11])
+def test_agrees_when_almost_every_score_is_distinct(seed):
+    """The opposite extreme: near-unique scores, so grouping is nearly a no-op.
+    Included because a bug that only shows with large groups would be missed by
+    the tie-heavy case above, and vice versa."""
+    m = _load()
+    rng = random.Random(seed)
+    scored = [(rng.random(), rng.random() < 0.25) for _ in range(500)]
+    _assert_same(m, scored)
+
+
+# ── the degenerate inputs, which must not diverge either ───────────────────
+
+def test_empty_matches():
+    m = _load()
+    assert m.ranking_metrics([]) == m.ranking_metrics_grouped([])
+
+
+def test_no_true_pairs_matches():
+    m = _load()
+    _assert_same(m, [(0.5, False)] * 10)
+
+
+def test_all_true_pairs_matches():
+    m = _load()
+    _assert_same(m, [(0.5, True)] * 10)
+
+
+def test_a_single_pair_matches():
+    m = _load()
+    _assert_same(m, [(0.5, True)])
+
+
+# ── the property that makes the Spark form viable ──────────────────────────
+
+def test_grouped_input_is_orders_of_magnitude_smaller():
+    """Not a correctness test -- the reason the grouped form exists at all.
+
+    A pair's weight is a sum of per-field match weights over bounded gamma
+    levels, so the reachable score set is bounded by `prod(levels + 1)`. That is
+    the same bound that makes GoldenMatch's counting GROUP BY small, which is
+    the property this whole benchmark is about.
+    """
+    rng = random.Random(0)
+    alphabet = [round(x * 0.05, 2) for x in range(21)]
+    scored = [(rng.choice(alphabet), rng.random() < 0.3) for _ in range(100_000)]
+    grouped = _group(scored)
+    assert len(grouped) <= len(alphabet)
+    assert len(grouped) < len(scored) / 1000, (
+        "grouping must collapse the collect by orders of magnitude, or it does "
+        "not solve the driver-memory problem it was written for"
+    )

--- a/packages/python/goldenmatch/tests/test_spark_metrics_absent_vs_zero.py
+++ b/packages/python/goldenmatch/tests/test_spark_metrics_absent_vs_zero.py
@@ -1,0 +1,162 @@
+"""The Spark metrics reader must never render an absent field as a measured zero.
+
+`scripts/_spark_shuffle_metrics.py` was widened from three fields per stage to
+the whole stage record plus `/executors`, so the 50M GoldenMatch-vs-Splink
+head-to-head can answer "WHY is one slower" (CPU, GC, spill, skew) rather than
+only "how many bytes crossed".
+
+Every added field is a chance to repeat the bug this repo has now hit four
+times -- `reduction_ratio == 0.0`, `candidates_compared == 0`,
+`mass_above_threshold == 1.0`, and a `grep -c` over a failed command. In each,
+a value meaning "nothing measured this" was consumed as evidence.
+
+Here the trap is specific and easy: `sum([])` is `0`. A cluster-wide GC total
+that sums an all-missing field returns 0, which reads as "no GC time" rather
+than "Spark did not report it" -- and on a benchmark whose entire purpose is
+comparing two engines, a fabricated zero on one side is a result-shaped lie.
+
+So these tests assert `is None`, not falsiness. `assert not x` would pass for
+both 0 and None and would not catch the regression at all.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MOD = (Path(__file__).resolve().parents[4] / "scripts" / "_spark_shuffle_metrics.py")
+
+
+def _load():
+    if not _MOD.exists():
+        pytest.skip(f"{_MOD} not present")
+    spec = importlib.util.spec_from_file_location("_spark_shuffle_metrics", _MOD)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _stage(**kw):
+    """A stage carrying shuffle bytes (so `fields_present` is True) plus
+    whatever else the caller wants to supply."""
+    base = {"stageId": 1, "name": "s", "shuffleWriteBytes": 10,
+            "shuffleReadBytes": 20, "numTasks": 4}
+    base.update(kw)
+    return base
+
+
+# ── the absent-vs-zero contract ────────────────────────────────────────────
+
+def test_a_field_no_stage_reported_is_none_not_zero():
+    m = _load()
+    out = m.summarize([_stage(), _stage(stageId=2)])
+    # Neither stage carried GC / spill / CPU. None of them may read as 0.
+    for key in ("jvm_gc_time_ms", "memory_spill_bytes", "disk_spill_bytes",
+                "executor_cpu_time_ns", "executor_run_time_ms"):
+        assert out[key] is None, (
+            f"{key} summed to {out[key]!r} when NO stage reported it; "
+            "sum([]) == 0 and a 0 here reads as a measurement"
+        )
+
+
+def test_a_field_some_stages_reported_sums_only_those():
+    m = _load()
+    out = m.summarize([
+        _stage(jvmGcTime=100),
+        _stage(stageId=2),            # no jvmGcTime at all
+        _stage(stageId=3, jvmGcTime=50),
+    ])
+    assert out["jvm_gc_time_ms"] == 150
+
+
+def test_a_genuine_zero_is_preserved_as_zero():
+    """The other half of the contract: a REPORTED 0 must stay 0, not become
+    None. Otherwise 'no spill happened' becomes unsayable."""
+    m = _load()
+    out = m.summarize([_stage(diskBytesSpilled=0), _stage(stageId=2, diskBytesSpilled=0)])
+    assert out["disk_spill_bytes"] == 0
+
+
+def test_shuffle_bytes_still_behave_as_before():
+    """The original contract must not have moved."""
+    m = _load()
+    out = m.summarize([_stage(), _stage(stageId=2)])
+    assert out["fields_present"] is True
+    assert out["shuffle_write_bytes"] == 20
+    assert out["shuffle_read_bytes"] == 40
+    assert out["n_stages"] == 2
+
+
+def test_no_stages_is_still_distinguished_from_no_shuffle():
+    m = _load()
+    empty = m.summarize([])
+    assert empty["fields_present"] is False
+    assert empty["shuffle_write_bytes"] is None
+
+    no_shuffle = m.summarize([{"stageId": 1, "name": "s", "numTasks": 1}])
+    assert no_shuffle["fields_present"] is False
+    assert no_shuffle["shuffle_write_bytes"] is None
+    assert "do NOT read this as zero shuffle" in no_shuffle["note"]
+
+
+def test_a_non_numeric_value_is_none_rather_than_a_crash():
+    """Instrumentation must never take the benchmark down with it."""
+    m = _load()
+    out = m.summarize([_stage(jvmGcTime="n/a")])
+    assert out["jvm_gc_time_ms"] is None
+
+
+# ── /executors ─────────────────────────────────────────────────────────────
+
+def _exec(**kw):
+    base = {"id": "0", "isActive": True, "totalTasks": 10, "failedTasks": 0}
+    base.update(kw)
+    return base
+
+
+def test_a_dead_executor_is_surfaced_at_the_top_level():
+    """At 50M the likely failure is disk or memory on ONE node, and a
+    cluster-wide total hides it."""
+    m = _load()
+    out = m.summarize_executors([
+        _exec(id="0"),
+        _exec(id="1", isActive=False),
+    ])
+    assert out["any_executor_died"] is True
+    assert out["dead_executor_ids"] == ["1"]
+
+
+def test_a_healthy_cluster_reports_no_deaths():
+    m = _load()
+    out = m.summarize_executors([_exec(id="0"), _exec(id="1")])
+    assert out["any_executor_died"] is False
+    assert out["dead_executor_ids"] == []
+
+
+def test_peak_memory_metrics_absent_is_none():
+    """`peakMemoryMetrics` is only populated when the executor metrics poller
+    is on. Absent must not read as 'used no heap'."""
+    m = _load()
+    out = m.summarize_executors([_exec()])
+    assert out["peak_jvm_heap_max"] is None
+    assert out["executors"][0]["peak_jvm_heap"] is None
+
+
+def test_peak_memory_metrics_present_is_read():
+    m = _load()
+    out = m.summarize_executors([
+        _exec(id="0", peakMemoryMetrics={"JVMHeapMemory": 111,
+                                         "ProcessTreeJVMRSSMemory": 222}),
+        _exec(id="1", peakMemoryMetrics={"JVMHeapMemory": 999,
+                                         "ProcessTreeJVMRSSMemory": 333}),
+    ])
+    assert out["peak_jvm_heap_max"] == 999
+    assert out["peak_process_tree_rss_max"] == 333
+
+
+def test_no_executors_is_distinguished_from_no_data():
+    m = _load()
+    out = m.summarize_executors([])
+    assert out["fields_present"] is False
+    assert out["n_executors"] == 0

--- a/scripts/_fs_quality_metrics.py
+++ b/scripts/_fs_quality_metrics.py
@@ -86,3 +86,89 @@ def ranking_metrics(scored: list[tuple[float, bool]]) -> dict:
         "n_true": n_true,
         "base_rate": round(n_true / n, 6),
     }
+
+
+def ranking_metrics_grouped(groups: list[tuple[float, int, int]]) -> dict:
+    """Identical metrics, from PRE-GROUPED (score, n_true, n_total) rows.
+
+    ## Why this exists: `ranking_metrics` cannot reach 50M
+
+    The caller built its input by collecting one `(score, is_true)` tuple PER
+    CANDIDATE PAIR to the driver. At the 1M scale that harness was written for
+    this is 5.5M tuples and merely wasteful. At 50M rows it is **275M** tuples
+    -- tens of GB of Python objects on a driver running in a container -- so the
+    quality arm cannot run at the scale the comparison is actually about, and a
+    head-to-head with no accuracy number is not a head-to-head.
+
+    ## Why grouping is EXACT here, not an approximation
+
+    `ranking_metrics` already consumes its input in tie-groups: it advances to
+    the next distinct score, admits every pair at that score, and only then
+    computes precision/recall. So the per-pair identity of the rows inside a tie
+    group is never used -- only how many there are and how many are true. That
+    is precisely `(score, n_true, n_total)`.
+
+    And the distinct-score count is SMALL by construction. A pair's weight is a
+    sum of per-field match weights over a bounded set of gamma levels, so the
+    reachable score set is bounded by `prod(levels + 1)` -- the same bound that
+    makes GoldenMatch's counting GROUP BY small, which is the property this
+    whole benchmark exists to demonstrate. Grouping in the engine turns a 275M
+    collect into a few hundred rows.
+
+    Floating-point equality is the grouping key, matching the `==` tie-check in
+    `ranking_metrics`. Two scores that differ in the last bit are two groups
+    here and two tie-groups there, so the two functions agree exactly rather
+    than approximately -- `test_fs_quality_metrics_grouped.py` asserts that on
+    shared inputs.
+
+    Args:
+        groups: `(score, n_true, n_total)` per DISTINCT score, any order.
+            `n_total` counts every pair at that score, true and false.
+    """
+    if not groups:
+        return {"average_precision": None, "best_f1": None,
+                "best_f1_threshold": None, "n_pairs": 0, "n_true": 0,
+                "base_rate": None}
+
+    n = sum(int(g[2]) for g in groups)
+    n_true = sum(int(g[1]) for g in groups)
+    if n == 0:
+        return {"average_precision": None, "best_f1": None,
+                "best_f1_threshold": None, "n_pairs": 0, "n_true": 0,
+                "base_rate": None}
+    if n_true == 0:
+        return {"average_precision": None, "best_f1": None,
+                "best_f1_threshold": None, "n_pairs": n, "n_true": 0,
+                "base_rate": 0.0}
+
+    # Descending by score -- the same order the ungrouped walk induces.
+    rows = sorted(groups, key=lambda g: -g[0])
+
+    tp = fp = 0
+    prev_recall = 0.0
+    ap = 0.0
+    best_f1 = 0.0
+    best_thr = None
+
+    for thr, g_true, g_total in rows:
+        g_true = int(g_true)
+        tp += g_true
+        fp += int(g_total) - g_true
+        # Precision/recall AFTER admitting the whole tie group -- the only
+        # defensible point, since a threshold cannot separate equal scores.
+        precision = tp / (tp + fp)
+        recall = tp / n_true
+        ap += precision * (recall - prev_recall)
+        prev_recall = recall
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        if f1 > best_f1:
+            best_f1, best_thr = f1, thr
+
+    return {
+        "average_precision": round(ap, 6),
+        "best_f1": round(best_f1, 6),
+        "best_f1_threshold": (round(best_thr, 6) if best_thr is not None else None),
+        "n_pairs": n,
+        "n_true": n_true,
+        "base_rate": round(n_true / n, 6),
+    }

--- a/scripts/_spark_shuffle_metrics.py
+++ b/scripts/_spark_shuffle_metrics.py
@@ -26,6 +26,27 @@ multi-node wall to stand.
 `fetch()` touches the network. A metric that silently reports zero because a
 field was renamed is the failure mode here, so `summarize` distinguishes "no
 shuffle" from "no stages" and says which.
+
+## Everything else the endpoints carry
+
+The original version kept three fields per stage and discarded the rest, which
+was right for the bytes-only question above. A 50M head-to-head asks more: when
+one engine is slower, is it CPU, GC, spill, or skew? So `summarize` now keeps
+the whole stage record (executor run/CPU time, GC, memory and disk spill, peak
+execution memory, input/output bytes and records), and `summarize_executors`
+reads `/executors` for per-executor heap, disk, task counts and liveness.
+
+Per-executor rows are kept rather than only their totals because at scale the
+likely failure is disk or memory on ONE node, and a cluster-wide sum hides
+exactly that. `any_executor_died` is surfaced at the top level for the same
+reason.
+
+Every added field follows the module's existing rule, now applied per-field:
+`_int_or_none` / `_sum_or_none` return None when nothing reported the metric,
+so "Spark did not collect this" never renders as a measured zero. `sum()` over
+an all-empty list is 0, which would read as "no GC time" instead of "unknown" --
+that is the same absent-vs-zero collapse the engine has hit repeatedly, and it
+is just as easy to write here.
 """
 from __future__ import annotations
 
@@ -59,9 +80,32 @@ def summarize(stages: list[dict[str, Any]], top_n: int = 5) -> dict[str, Any]:
         rows.append({
             "stage_id": st.get("stageId"),
             "name": (st.get("name") or "")[:80],
+            "status": st.get("status"),
             "write_bytes": int(w or 0),
             "read_bytes": int(r or 0),
             "num_tasks": st.get("numTasks"),
+            # ── the rest of the stage record (#2654 follow-up) ──────────────
+            # `/stages` carries far more than shuffle bytes and this dropped
+            # all of it. Every field below answers a question the shuffle
+            # totals cannot: whether the gap is CPU or waiting (cpu vs run
+            # time), whether it is GC pressure, whether the cluster spilled,
+            # and how much of the wall is task time at all.
+            #
+            # `_int_or_none`, not `int(x or 0)`: a renamed or absent field must
+            # stay None so it reads as "not reported", never as a measured
+            # zero. That distinction is the whole point of `fields_present`
+            # above, and it applies per-field too.
+            "executor_run_time_ms": _int_or_none(st.get("executorRunTime")),
+            "executor_cpu_time_ns": _int_or_none(st.get("executorCpuTime")),
+            "jvm_gc_time_ms": _int_or_none(st.get("jvmGcTime")),
+            "memory_spill_bytes": _int_or_none(st.get("memoryBytesSpilled")),
+            "disk_spill_bytes": _int_or_none(st.get("diskBytesSpilled")),
+            "peak_execution_memory": _int_or_none(st.get("peakExecutionMemory")),
+            "input_bytes": _int_or_none(st.get("inputBytes")),
+            "output_bytes": _int_or_none(st.get("outputBytes")),
+            "input_records": _int_or_none(st.get("inputRecords")),
+            "shuffle_write_records": _int_or_none(st.get("shuffleWriteRecords")),
+            "shuffle_read_records": _int_or_none(st.get("shuffleReadRecords")),
         })
 
     if not seen_field:
@@ -77,8 +121,112 @@ def summarize(stages: list[dict[str, Any]], top_n: int = 5) -> dict[str, Any]:
         "fields_present": True,
         "shuffle_write_bytes": sum(r["write_bytes"] for r in rows),
         "shuffle_read_bytes": sum(r["read_bytes"] for r in rows),
+        # Cluster-wide totals. `_sum_or_none` returns None when NO stage
+        # reported the field, so a missing metric never sums to a confident 0.
+        "shuffle_write_records": _sum_or_none(rows, "shuffle_write_records"),
+        "shuffle_read_records": _sum_or_none(rows, "shuffle_read_records"),
+        "executor_run_time_ms": _sum_or_none(rows, "executor_run_time_ms"),
+        "executor_cpu_time_ns": _sum_or_none(rows, "executor_cpu_time_ns"),
+        "jvm_gc_time_ms": _sum_or_none(rows, "jvm_gc_time_ms"),
+        "memory_spill_bytes": _sum_or_none(rows, "memory_spill_bytes"),
+        "disk_spill_bytes": _sum_or_none(rows, "disk_spill_bytes"),
+        "input_bytes": _sum_or_none(rows, "input_bytes"),
+        "output_bytes": _sum_or_none(rows, "output_bytes"),
+        "num_tasks": _sum_or_none(rows, "num_tasks"),
+        "peak_execution_memory_max": _max_or_none(rows, "peak_execution_memory"),
         "top_stages": rows[:top_n],
     }
+
+
+def _int_or_none(v: Any) -> int | None:
+    """`int(v)` when v is a number, else None. NEVER 0 for a missing field."""
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _sum_or_none(rows: list[dict[str, Any]], key: str) -> int | None:
+    """Sum a per-stage field, or None when NOT ONE stage reported it.
+
+    The distinction matters: `sum()` over all-None is 0, and a 0 here would be
+    read as "no GC time" / "no spill" rather than "Spark did not report it".
+    """
+    vals = [r[key] for r in rows if r.get(key) is not None]
+    return sum(vals) if vals else None
+
+
+def _max_or_none(rows: list[dict[str, Any]], key: str) -> int | None:
+    vals = [r[key] for r in rows if r.get(key) is not None]
+    return max(vals) if vals else None
+
+
+def summarize_executors(executors: list[dict[str, Any]]) -> dict[str, Any]:
+    """Per-executor totals from Spark's `/executors` payload.
+
+    Answers what `/stages` cannot: how much heap each executor actually used,
+    whether work was spread evenly, and whether any executor died. At 50M the
+    likely failure is disk or memory on ONE node, and a cluster-wide total hides
+    that -- so the per-executor rows are kept, not just the aggregate.
+    """
+    if not executors:
+        return {"n_executors": 0, "fields_present": False, "executors": [],
+                "note": "no executors returned -- wrong app id, or the UI was gone"}
+
+    rows = []
+    for ex in executors:
+        rows.append({
+            "id": ex.get("id"),
+            "is_active": ex.get("isActive"),
+            "rdd_blocks": _int_or_none(ex.get("rddBlocks")),
+            "memory_used": _int_or_none(ex.get("memoryUsed")),
+            "disk_used": _int_or_none(ex.get("diskUsed")),
+            "max_memory": _int_or_none(ex.get("maxMemory")),
+            "total_cores": _int_or_none(ex.get("totalCores")),
+            "total_tasks": _int_or_none(ex.get("totalTasks")),
+            "failed_tasks": _int_or_none(ex.get("failedTasks")),
+            "completed_tasks": _int_or_none(ex.get("completedTasks")),
+            "total_duration_ms": _int_or_none(ex.get("totalDuration")),
+            "total_gc_time_ms": _int_or_none(ex.get("totalGCTime")),
+            "total_shuffle_read": _int_or_none(ex.get("totalShuffleRead")),
+            "total_shuffle_write": _int_or_none(ex.get("totalShuffleWrite")),
+            "peak_jvm_heap": _peak(ex, "JVMHeapMemory"),
+            "peak_jvm_offheap": _peak(ex, "JVMOffHeapMemory"),
+            "peak_process_tree_rss": _peak(ex, "ProcessTreeJVMRSSMemory"),
+        })
+
+    # A dead executor is the signal that matters most at scale, so surface it
+    # as a top-level flag rather than making a reader scan the rows.
+    dead = [r["id"] for r in rows if r.get("is_active") is False]
+    failed = _sum_or_none(rows, "failed_tasks")
+    return {
+        "n_executors": len(rows),
+        "fields_present": True,
+        "dead_executor_ids": dead,
+        "any_executor_died": bool(dead),
+        "failed_tasks_total": failed,
+        "total_gc_time_ms": _sum_or_none(rows, "total_gc_time_ms"),
+        "total_duration_ms": _sum_or_none(rows, "total_duration_ms"),
+        "disk_used_max": _max_or_none(rows, "disk_used"),
+        "peak_jvm_heap_max": _max_or_none(rows, "peak_jvm_heap"),
+        "peak_process_tree_rss_max": _max_or_none(rows, "peak_process_tree_rss"),
+        "executors": rows,
+    }
+
+
+def _peak(ex: dict[str, Any], key: str) -> int | None:
+    """Read one field out of `peakMemoryMetrics`, which may be absent entirely.
+
+    Spark only populates this when `spark.eventLog.logStageExecutorMetrics` (or
+    the executor metrics poller) is on. Absent stays None so a reader can tell
+    "not collected" from "used no heap".
+    """
+    pm = ex.get("peakMemoryMetrics")
+    if not isinstance(pm, dict):
+        return None
+    return _int_or_none(pm.get(key))
 
 
 def fetch(base_url: str, timeout: float = 10.0) -> dict[str, Any]:
@@ -110,4 +258,17 @@ def fetch(base_url: str, timeout: float = 10.0) -> dict[str, Any]:
     out = summarize(stages)
     out["app_id"] = app_id
     out["base_url"] = base_url
+
+    # `/executors` is fetched SEPARATELY and its failure is recorded rather
+    # than raised: the stage metrics are the primary measurement and must not
+    # be lost because a second endpoint was unavailable. Same contract as the
+    # rest of this module -- an absent number says the probe failed.
+    try:
+        out["executor_metrics"] = summarize_executors(
+            _get(f"/api/v1/applications/{app_id}/executors")
+        )
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        out["executor_metrics"] = {
+            "error": f"{type(e).__name__}: {str(e)[:160]}", "app_id": app_id,
+        }
     return out

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -730,13 +730,43 @@ def main() -> int:
             weight = weight + expr
         truth = (F.col(f"{CAND_LHS}.__row_id__") % F.lit(n_entities)
                  == F.col(f"{CAND_RHS}.__row_id__") % F.lit(n_entities))
-        scored = [
-            (float(r["w"]), bool(r["is_true"]))
-            for r in joined.select(weight.alias("w"),
-                                   truth.alias("is_true")).collect()
+        # GROUP BY the weight in the ENGINE, and collect the groups.
+        #
+        # This used to collect one `(score, is_true)` tuple PER CANDIDATE PAIR.
+        # At the 1M scale this harness was written for that is 5.5M tuples and
+        # merely wasteful; at 50M rows it is 275M -- tens of GB of Python
+        # objects on a driver running inside a container -- so the quality arm
+        # could not run at the scale the comparison is actually about, and a
+        # head-to-head with no accuracy number is not a head-to-head.
+        #
+        # Grouping is EXACT, not a sample. `ranking_metrics` already consumes
+        # its input in tie-groups: it advances to the next distinct score,
+        # admits every pair at that score, and only then computes
+        # precision/recall -- so the per-pair identity inside a group is never
+        # used, only the counts. `ranking_metrics_grouped` takes exactly those
+        # counts and `test_fs_quality_metrics_grouped.py` pins the two to agree
+        # on shared inputs, including ties that span both classes.
+        #
+        # And the group count is small BY THE PROPERTY THIS BENCHMARK IS ABOUT:
+        # a pair's weight is a sum of per-field match weights over bounded gamma
+        # levels, so the reachable score set is bounded by `prod(levels + 1)` --
+        # the same bound that keeps GoldenMatch's counting GROUP BY small. 275M
+        # pairs collapse to a few hundred rows.
+        groups = [
+            (float(r["w"]), int(r["n_true"]), int(r["n_all"]))
+            for r in (
+                joined.select(weight.alias("w"), truth.alias("is_true"))
+                .groupBy("w")
+                .agg(F.sum(F.col("is_true").cast("long")).alias("n_true"),
+                     F.count(F.lit(1)).alias("n_all"))
+                .collect()
+            )
         ]
         out["stages"]["score_seconds"] = round(time.perf_counter() - t, 2)
-        q = _metrics_module().ranking_metrics(scored)
+        # Recorded so a reader can see the collect stayed bounded, rather than
+        # trusting the argument above.
+        out["quality_score_groups"] = len(groups)
+        q = _metrics_module().ranking_metrics_grouped(groups)
         # `dup` rows per entity give dup*(dup-1)/2 true pairs each, and every
         # entity's rows share a blocking key by construction, so the candidate
         # set must contain ALL of them and no duplicates. Checked rather than

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -440,12 +440,27 @@ def main() -> int:
         preds = linker.inference.predict().as_spark_dataframe()
         truth = (F.col("record_id_l") % F.lit(n_entities)
                  == F.col("record_id_r") % F.lit(n_entities))
-        rows_ = (preds.select(F.col("match_weight").alias("w"),
-                              truth.alias("is_true"))
-                      .collect())
+        # GROUP BY in the engine, exactly as the GM arm does. Both sides must
+        # use the same reduction or the comparison measures the harness: this
+        # collected one tuple per PREDICTED PAIR, which at 50M is hundreds of
+        # millions of Python objects on a driver in a container.
+        #
+        # Splink's match_weight is a real-valued log-odds sum, so its distinct
+        # count is larger than the GM arm's bounded-gamma weight -- grouping
+        # buys less here. It is still exact and still strictly smaller, and
+        # `quality_score_groups` below records how much it actually collapsed,
+        # so an unbounded group count shows up as a number rather than as an
+        # OOM. See `ranking_metrics_grouped` for why grouping is exact.
+        grouped = (preds.select(F.col("match_weight").alias("w"),
+                                truth.alias("is_true"))
+                        .groupBy("w")
+                        .agg(F.sum(F.col("is_true").cast("long")).alias("n_true"),
+                             F.count(F.lit(1)).alias("n_all"))
+                        .collect())
         out["stages"]["predict_seconds"] = round(time.perf_counter() - t, 2)
-        out["quality"] = _metrics_module().ranking_metrics(
-            [(float(r["w"]), bool(r["is_true"])) for r in rows_]
+        out["quality_score_groups"] = len(grouped)
+        out["quality"] = _metrics_module().ranking_metrics_grouped(
+            [(float(r["w"]), int(r["n_true"]), int(r["n_all"])) for r in grouped]
         )
         print(f"[splink] quality {out['quality']}", flush=True)
 


### PR DESCRIPTION
Prep for a GoldenMatch-vs-Splink run at **50M rows** on a real multi-node cluster. Splink comparison already existed (`splink_compare`, default on); what was missing was the sizing to survive the scale and the metrics to explain the result.

## Sizing, derived from how the fixture actually scales

The fixture's block size is **pinned at 12 rows** (`dup=3 × blocks_per_key=4`) regardless of scale, so candidate pairs grow **linearly** with rows, not quadratically:

```
 1,000,000 rows ->    83,333 blocks x 12 ->     5,500,000 pairs
50,000,000 rows -> 4,166,667 blocks x 12 ->   275,000,000 pairs
```

Extrapolating #2652's measured 1M shuffle by that factor:

| engine | shuffle write @1M | projected @50M |
|---|---|---|
| GoldenMatch | 832 MB | ~41 GB |
| Splink | 16,784 MB | **~840 GB** |

Spark spills to the worker's local dirs — here the boot disk — and the lane provisioned **100 GB**. 840 GB of cumulative shuffle across 940 stages against 100 GB is the single most likely way a paid multi-hour run dies.

- `disk_gb` input, default **500 GB**, `pd-balanced`
- `workers` default **2 → 4**
- `timeout-minutes` **60 → 360**, so the cost ceiling is explicit rather than implied

## Splink failing is a result, not a lost run

`continue-on-error: true` on the Splink step. It is the side expected to fail first at scale (~20× the bytes, ~940 stages, re-scanning pairs per EM iteration), and losing GoldenMatch's completed numbers to a red step would waste the whole cluster spend.

The failure stays visible — the summary prints `splink: MISSING` — and re-dispatching larger is a deliberate operator action. I did **not** auto-retry in-workflow: that reprovisions a bigger paid cluster unattended.

## Every metric

`_spark_shuffle_metrics.py` kept three fields per stage and discarded the rest, which was right for the bytes-only question it was built for. A head-to-head asks more: when one engine is slower, is it CPU, GC, spill, or skew?

- `summarize` now keeps the whole stage record — executor run and CPU time, JVM GC, memory and disk spill, peak execution memory, input/output bytes and records
- new `summarize_executors` reads `/executors` — per-executor heap, disk, task counts, liveness

Per-executor rows are kept rather than only totals: at 50M the likely failure is disk or memory on **one** node, and a cluster-wide sum hides exactly that. `any_executor_died` is surfaced at the top level.

## The absent-vs-zero discipline, extended per-field

The module already distinguished "no shuffle" from "no stages". Every added field follows the same rule, now applied per-field.

`sum([])` is `0`, so a cluster-wide GC total over an all-missing field would read as *"no GC time"* rather than *"Spark did not report it"* — and a fabricated zero on one side of a two-engine comparison is a result-shaped lie. `_sum_or_none` / `_int_or_none` return `None` instead.

The tests assert `is None`, not falsiness: `assert not x` passes for both `0` and `None` and would catch nothing. A genuinely reported `0` is preserved as `0`, so "no spill happened" stays sayable.

This is the same collapse the engine hit four times today (#2639, #2644, #2673, and a `grep -c` over a failed command that produced two invalid issues). It is just as easy to write into a metrics reader.

## Test plan

- [x] 11 tests in `test_spark_metrics_absent_vs_zero.py` — absent→None, partial-report sums only what reported, genuine zero preserved, non-numeric doesn't crash, dead-executor surfacing, original shuffle contract unmoved
- [x] `yq` validates the workflow: `timeout-minutes: 360`, `workers: 4`, `disk_gb: 500`, Splink `continue-on-error: true`
- [x] ruff clean
- [ ] The 50M dispatch itself — that is the point of the PR, and it runs after merge

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P