### PR TITLE
fix(spark): the no-workers refusal names a symptom and deletes the evidence

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -394,7 +394,33 @@ jobs:
             [ "${N:-0}" -ge 1 ] && exit 0
             sleep 10
           done
-          echo "::error::no worker registered with the master -- every timing below would be a queue wait, not a measurement"
+          # The refusal is right, but "0 workers" is a SYMPTOM and the evidence
+          # lives in containers that the `if: always()` teardown is about to
+          # delete. The first time this fired it cost a whole run to learn
+          # nothing except that it fired.
+          #
+          # So dump what actually happened before giving up: whether each
+          # container is even running, and its logs. A worker that crashed on
+          # startup and a worker that cannot reach the master look identical
+          # from the master's `/json/` endpoint and completely different here.
+          echo "::group::master container"
+          gcloud compute ssh "$CLUSTER-master" --quiet --command \
+            "docker ps -a --filter name=spark-master --format '{{.Names}} {{.Status}}'; \
+             echo '--- logs ---'; docker logs --tail 60 spark-master 2>&1 || true" || true
+          echo "::endgroup::"
+
+          for n in $NODE_NAMES; do
+            case "$n" in *-master) continue;; esac
+            echo "::group::worker $n"
+            gcloud compute ssh "$n" --quiet --command \
+              "docker ps -a --filter name=spark-worker --format '{{.Names}} {{.Status}}'; \
+               echo '--- mount ---'; df -h /mnt/disks/scratch 2>&1 || true; \
+               ls -ld /mnt/disks/scratch 2>&1 || true; \
+               echo '--- logs ---'; docker logs --tail 60 spark-worker 2>&1 || true" || true
+            echo "::endgroup::"
+          done
+
+          echo "::error::no worker registered with the master -- every timing below would be a queue wait, not a measurement. Container status and logs are in the groups above."
           exit 1
 
       - name: Run both harnesses ON the master VM


### PR DESCRIPTION
This lane has **never completed a run** — all six executions to date failed. The fifth got furthest: past provisioning, past the NVMe mount, cluster started, then five minutes of `registered workers: 0` and a refusal.

The refusal is **correct** and should stay — a master with zero workers accepts a job and queues it forever, so every timing after that would be a queue wait, not a measurement.

What it doesn't do is say *why*. A worker that crashed on startup and a worker that can't reach the master are indistinguishable from the master's `/json/` endpoint, and the container logs that would separate them live on VMs the `if: always()` teardown deletes seconds later. That run cost five VMs and produced one bit: *it fired*.

Now dumps before exiting non-zero:
- master container status + logs
- per worker: container status, the scratch mount (`df`, `ls -ld`), last 60 lines of `docker logs`

The mount is included because it's the newest moving part — if `SPARK_LOCAL_DIRS` points somewhere the container user can't write, the worker dies at startup, and that's a one-line answer buried in a log nobody kept.

Same class of gap as the four instruments in the zero-config incident: a check that reports a symptom without the evidence costs a whole cycle per iteration.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P