### PR TITLE
fix(spark): COS drops intra-VPC traffic; open the host firewall

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -317,6 +317,40 @@ jobs:
           echo "MASTER_IP=$MASTER_IP" >> $GITHUB_ENV
           CORES=$(( $(echo "${{ inputs.machine_type || 'n2-standard-16' }}" | grep -oE '[0-9]+$') ))
 
+          # Open the COS HOST firewall to intra-VPC traffic.
+          #
+          # Container-Optimized OS ships a default-DENY iptables INPUT policy.
+          # The GCP VPC firewall being permissive is not enough -- the packet is
+          # dropped after it arrives. Diagnosed from a run where every process
+          # was healthy and the connection still failed:
+          #
+          #     master:  Successfully started service 'sparkMaster' on port 7077
+          #     worker:  Connecting to /10.142.0.23:7077 timed out (120000 ms)
+          #
+          # TIMED OUT, not connection-refused, is the tell: a closed port refuses
+          # immediately, a DROP rule produces exactly this silence. And
+          # `default-allow-internal` carries NO target tags and allows
+          # tcp:0-65535 from 10.128.0.0/9, so GCP was never the blocker.
+          #
+          # The single-host lane never hit this because master, workers and
+          # Connect were containers on ONE host talking over localhost. It is
+          # the one thing that could only appear once the topology became real,
+          # which is the whole reason this lane exists.
+          #
+          # Whole subnet rather than a port list, deliberately: Spark's
+          # executor/driver/BlockManager ports are EPHEMERAL, so an allowlist of
+          # 7077/8080/15002/4040 would clear registration and then fail during
+          # the shuffle -- a far more expensive place to discover it. The VPC
+          # firewall remains the real boundary; this only stops COS
+          # second-guessing traffic GCP has already allowed.
+          for n in $NODE_NAMES; do
+            gcloud compute ssh "$n" --quiet --command \
+              "sudo iptables -w -C INPUT -s 10.128.0.0/9 -j ACCEPT 2>/dev/null || \
+               sudo iptables -w -I INPUT 1 -s 10.128.0.0/9 -j ACCEPT" &
+          done
+          wait
+          echo "COS host firewall opened to 10.128.0.0/9 on every node"
+
           gcloud compute ssh "$MASTER" --quiet --command "
             docker run -d --name spark-master --network host \
               -e SPARK_NO_DAEMONIZE=true $SPARK_IMAGE \


### PR DESCRIPTION
Workers never registered. The diagnostics from #2681 answered it on the **first run that reached them**, which is what they were for:

```
master:  Successfully started service 'sparkMaster' on port 7077  [Up 8m]
worker:  Connecting to /10.142.0.23:7077 timed out (120000 ms)    [Up 6m]
```

Both processes healthy, connection dies anyway.

**`TIMED OUT` rather than connection-refused is the tell.** A closed port refuses immediately; only a DROP rule produces that silence. And I verified `default-allow-internal` carries **no target tags** and allows `tcp:0-65535` from `10.128.0.0/9` — so the VPC firewall was never the blocker. Container-Optimized OS ships its own default-deny iptables `INPUT` policy, and the packet is dropped after it arrives.

The single-host lane could never have caught this: master, workers and Connect were containers on **one host** talking over localhost. It's precisely the class of bug that only appears once the topology is real — which is the reason this lane exists.

## Why the whole subnet, not a port list

Spark's executor / driver / BlockManager ports are **ephemeral**. An allowlist of 7077 + 8080 + 15002 + 4040 would clear registration and then fail during the shuffle — a much more expensive place to find out. The VPC firewall stays the real boundary; this only stops COS second-guessing traffic GCP already allowed.

Idempotent (`-C` before `-I`) so a re-run doesn't stack duplicate rules.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P