### PR TITLE
fix(autoconfig): a constant column halved the bar on the ones that matter (#2668)

### DIFF
--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -12,12 +12,9 @@ name: goldengraph-pipeline
 
 on:
   workflow_dispatch:
-  # Nightly backstop. This lane installs goldenmatch from SOURCE but is
-  # path-filtered on its OWN paths, so a goldenmatch change never triggers it --
-  # a break can sit latent until something unrelated happens to fire the lane
-  # (that gap ran 15 days once). The schedule bounds detection to a day, and a
-  # scheduled run is on `main`, so `main-health` sees the red and files the
-  # tracking issue. Symbol-level breaks are caught earlier, on the PR, by
+  # Nightly backstop. The schedule bounds detection to a day, and a scheduled run
+  # is on `main`, so `main-health` sees the red and files the tracking issue.
+  # Symbol-level breaks are caught earlier, on the PR, by
   # scripts/check_downstream_symbols.py.
   schedule:
     - cron: "13 4 * * *"
@@ -29,6 +26,23 @@ on:
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/**"
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_goldengraph_smoke.py"
       - ".github/workflows/goldengraph-pipeline.yml"
+      # goldenmatch's ER core. This lane installs goldenmatch from SOURCE and its
+      # Phase 1.5 tests assert on what zero-config actually CLUSTERS, so a
+      # goldenmatch change can break it -- and until #2668 the filter listed only
+      # this lane's own paths, so such a change never fired it. That is exactly how
+      # #2648 landed: it edited core/scorer.py, went green on its PR because this
+      # lane did not run, and reddened `main` that night with an over-merge nobody
+      # had a PR signal for. The nightly detected it; detection is not prevention,
+      # and the break still sat in `main` until someone acted on the red.
+      #
+      # Deliberately the WHOLE package source, not an enumerated list of "the ER
+      # files". An enumerated list is the same bug one level up: it goes stale the
+      # moment the blast radius moves, and the thing being guarded here is a
+      # cross-package behavioural coupling nobody can enumerate in advance. The
+      # cost argument does not survive contact either -- the job is ~70 seconds
+      # (run #593: 04:24:09 -> 04:25:18), so this is a cheap, chatty check, and an
+      # absent check is strictly worse than a chatty one.
+      - "packages/python/goldenmatch/goldenmatch/**"
 
 permissions:
   contents: read

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1889,6 +1889,7 @@
             "_diversify_pair_budget_enabled",
             "_diversify_probabilistic_blocking",
             "_diversify_unused_orthogonal_blocking",
+            "_drop_constant_scored_fields",
             "_drop_uninformative_blocking_fields",
             "_embedder_available",
             "_emit_data_profile",

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/fixtures/wikidata_companies_HARD.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/fixtures/wikidata_companies_HARD.json
@@ -1,0 +1,18 @@
+{
+  "meta": {
+    "source": "wikidata",
+    "pulled": "test",
+    "sparql_sha": "test",
+    "domain": "companies",
+    "why": "TINY's hardest alias is 'Acme' vs 'Acme Holdings' -- a NEAR MISS that lands within a few hundredths of the 0.8 cut, so whether it merges flips on small environment differences (#2668: it fragments locally and resolves in CI, from the same commit). A fixture whose ER gap sits on a threshold boundary measures the environment, not the resolver. Here every entity carries one alias that string similarity CANNOT close -- an acronym or a rename -- so the oracle-vs-real gap is structural and stays stable as string matching improves. Each entity also carries a suffix variant that SHOULD resolve, so 'some variants merged' and 'some entity stayed fragmented' are both true by construction rather than by luck. Canonicals are lexically far apart so no cross-entity merge is plausible."
+  },
+  "entities": [
+    {"qid": "Q1", "canonical": "Helios Industrial Group", "aliases": ["Helios Industrial Group Inc.", "HIG"]},
+    {"qid": "Q2", "canonical": "Meridian Foodworks", "aliases": ["Meridian Foodworks Limited", "MFW"]},
+    {"qid": "Q3", "canonical": "Norvex Systems", "aliases": ["Norvex Systems Ltd"]},
+    {"qid": "Q4", "canonical": "Ostara Media", "aliases": ["Ostara Media LLC"]}
+  ],
+  "facts": [
+    {"anchor_qid": "Q1", "relation": "has_subsidiary", "member_qids": ["Q2", "Q3", "Q4"]}
+  ]
+}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_realworld_aggregation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_realworld_aggregation.py
@@ -103,13 +103,25 @@ def test_real_resolution_clusters_variants_and_is_not_oracle():
     the surface universe -- it merges >=1 entity's distinct surfaces into one shared key
     (variants resolved), it is NOT the oracle km (a conservative real resolver keeps more
     keys than the entity count), and on this clean fixture it makes no wrong cross-entity
-    merge."""
+    merge.
+#
+# FIXTURE (#2668): HARD, not TINY. The two assertions below need real ER to leave
+# something unresolved, and on TINY the only thing it could ever leave unresolved
+# was "Acme" vs "Acme Holdings" -- ensemble 0.8615 against a 0.8 cut, so it merges
+# or not depending on whether blocking happened to make the pair a candidate. That
+# flipped between environments on one commit (fragmented locally, resolved in CI),
+# which made these tests measure the environment rather than the resolver. HARD
+# gives every entity one alias string similarity CANNOT close (an acronym: 0.58
+# against the same cut, 0.21 clear) plus a suffix variant that plainly should
+# resolve (0.94-0.96, 0.14+ clear). Every decision now sits far from the boundary,
+# so the oracle-vs-real gap is structural and does not erode as matching improves.
+    """
     _wheel_or_skip()
     from collections import defaultdict
 
     from erkgbench.qa_e2e.realworld import _realworld_entity_surfaces, _resolution_km
 
-    rows = _realworld_entity_surfaces(_FIXTURE_DIR / "wikidata_companies_TINY.json")
+    rows = _realworld_entity_surfaces(_FIXTURE_DIR / "wikidata_companies_HARD.json")
     real = _resolution_km(rows, resolve_mode="real")
     oracle = _resolution_km(rows, resolve_mode="oracle")
 
@@ -164,16 +176,28 @@ def test_real_mode_imperfect_er_dips_gg_below_oracle():
     """1.5a (the ER contribution is real): on a seed where the anchor renders two variant
     surfaces the zero-config resolver leaves in separate clusters, the anchor FRAGMENTS in
     the real arm -> GG recall drops below the oracle arm (which pre-merges variants). This
-    dip IS the honest ER signal the oracle-vs-real delta measures."""
+    dip IS the honest ER signal the oracle-vs-real delta measures.
+#
+# FIXTURE (#2668): HARD, not TINY. The two assertions below need real ER to leave
+# something unresolved, and on TINY the only thing it could ever leave unresolved
+# was "Acme" vs "Acme Holdings" -- ensemble 0.8615 against a 0.8 cut, so it merges
+# or not depending on whether blocking happened to make the pair a candidate. That
+# flipped between environments on one commit (fragmented locally, resolved in CI),
+# which made these tests measure the environment rather than the resolver. HARD
+# gives every entity one alias string similarity CANNOT close (an acronym: 0.58
+# against the same cut, 0.21 clear) plus a suffix variant that plainly should
+# resolve (0.94-0.96, 0.14+ clear). Every decision now sits far from the boundary,
+# so the oracle-vs-real gap is structural and does not erode as matching improves.
+    """
     _wheel_or_skip()
     from erkgbench.qa_e2e.aggregation import goldengraph_aggregate, set_f1
     from erkgbench.qa_e2e.realworld import _build_realworld_store_for_mode
 
-    tiny = _FIXTURE_DIR / "wikidata_companies_TINY.json"
+    hard = _FIXTURE_DIR / "wikidata_companies_HARD.json"
 
     def gg_f1(mode):
         sg, cov, _docs, qs, _a, _s = _build_realworld_store_for_mode(
-            tiny, ambiguity=1.0, seed=0, resolve_mode=mode)
+            hard, ambiguity=1.0, seed=0, resolve_mode=mode)
         q = next(q for q in qs if q.kind == "list")
         got = goldengraph_aggregate(sg, cov, q.anchor_id, q.relation)
         return set_f1(got, set(q.gold_members))["f1"]

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -165,6 +165,15 @@ class ColumnProfile:
     # estimator, because a fixed-size sample's distinct-FRACTION climbs toward
     # 1.0 as the frame grows.
     avg_len: float = 0.0  # average string length
+    n_distinct: int | None = None
+    # EXACT count of distinct non-blank values in the profiling sample. Distinct
+    # from `cardinality_ratio`, which is that count divided by the row total and
+    # so cannot answer "is this column CONSTANT?" -- a single-valued column reads
+    # 1/n, which shrinks with the frame and is indistinguishable from a merely
+    # low-cardinality one. `_drop_constant_scored_fields` needs the exact count.
+    # ``None`` means the profile was built without value access (hand-built
+    # profiles in tests, the #2639/#2644 idiom): consumers MUST treat it as
+    # "cannot answer" and leave behaviour unchanged rather than assuming 1.
     date_parse_rate: float | None = None
     # For col_type=="date": fraction of the profiled non-null sample that parses
     # as a well-formed date (the same parser `date_diff` uses). A per-column
@@ -575,6 +584,16 @@ def profile_columns(
         profiles: list[ColumnProfile] = column_profiles_from_json(
             native_json, names_to_sample_values
         )
+        # `n_distinct` is stamped here rather than carried through the Rust
+        # classify contract: it is a property of the sample the caller already
+        # holds, not a classification result, so widening the JSON schema for it
+        # would couple the kernel to a field it has no opinion about. Stamping
+        # both branches from the same `values` keeps native and fallback
+        # byte-identical on this field, which the parity rules require.
+        for _p in profiles:
+            _vals = names_to_sample_values.get(_p.name)
+            if _vals is not None:
+                _p.n_distinct = len({v for v in _vals if v.strip()})
     else:
         # Pure-Python classification path (unchanged).
         profiles = []
@@ -621,6 +640,7 @@ def profile_columns(
                 null_rate=null_rate,
                 cardinality_ratio=cardinality_ratio,
                 avg_len=avg_len,
+                n_distinct=len(set(values)),
             ))
 
     # LLM correction pass for ambiguous columns (runs AFTER native classify,
@@ -1356,6 +1376,65 @@ def _drop_uninformative_blocking_fields(
             "with no discriminative power; threshold rescaled to %.4f",
             ", ".join(dropped), mk.name, "them" if len(dropped) > 1 else "it",
             100.0 * (total - kept) / total if total else 0.0, mk.threshold,
+        )
+
+
+def _drop_constant_scored_fields(
+    matchkeys: list[MatchkeyConfig], profiles: list[ColumnProfile],
+) -> None:
+    """Drop scored fields that are CONSTANT in the data (#2668).
+
+    Sibling of `_drop_uninformative_blocking_fields`, for the other way a scored
+    field can carry no information. There the field varies in the data but
+    blocking guarantees agreement WITHIN a block; here it does not vary at all,
+    so no pair can ever disagree on it. Either way it is a constant offset with
+    zero discriminative power.
+
+    **It does not rescale the threshold, and that difference is the whole point.**
+    A constant field at equal weight does not merely shift scores; it HALVES the
+    effective bar on the field that actually discriminates. Measured on the
+    goldengraph TINY fixture, whose `type` column is `'concept'` on every row:
+
+        score = (name + 1.0) / 2      threshold 0.8  =>  the real bar on `name` is 0.6
+        ensemble("Beta Corp", "Delta LLC") = 0.7037  =>  0.8519, a false merge
+
+    Rescaling preserves the same absolute bar, so it would preserve that merge
+    exactly -- it is a no-op on every decision. The sibling rule rescales because
+    a blocking-agreeing field is genuinely informative elsewhere and its
+    calibrated contribution should survive; a data-constant column is informative
+    NOWHERE, so the honest config is the one auto-config would have built had the
+    useless column not been in the frame. It picks 0.8 on `name` alone there, and
+    that config makes no cross-entity merge on this fixture.
+
+    A field whose profile carries no `n_distinct` is LEFT ALONE: "cannot answer"
+    must not become "assumed constant". Same for a rule that would empty a
+    matchkey, since a matchkey with no fields cannot score anything.
+    """
+    const = {
+        p.name for p in profiles
+        if p.n_distinct is not None and p.n_distinct <= 1
+    }
+    if not const:
+        return
+    for mk in matchkeys:
+        if getattr(mk, "type", None) != "weighted":
+            continue
+        fields = list(getattr(mk, "fields", None) or [])
+        keep = [f for f in fields if f.field not in const]
+        if not keep or len(keep) == len(fields):
+            continue
+        dropped = [f.field for f in fields if f.field in const]
+        mk.fields = keep
+        logger.info(
+            "auto-config: dropped %s from matchkey %r -- %s constant in the data, "
+            "so every pair agreed on %s by construction and %s only relaxed the "
+            "effective bar on the fields that do discriminate. Threshold left at "
+            "%s, which is now the bar on those fields.",
+            ", ".join(dropped), mk.name,
+            "they are" if len(dropped) > 1 else "it is",
+            "them" if len(dropped) > 1 else "it",
+            "they" if len(dropped) > 1 else "it",
+            mk.threshold,
         )
 
 
@@ -5472,9 +5551,9 @@ def _rebuild_from_decisions(
     and re-call `_rebuild_from_decisions` without re-running profile_columns /
     build_matchkeys / build_blocking.
 
-    ``_profiles`` is reserved (underscore-prefix unused parameter) for future
-    iterative-tuning hooks that may re-examine column stats without rethreading
-    them through the call chain.
+    ``_profiles`` keeps its underscore for call-compatibility, but is no longer
+    unused: `_drop_constant_scored_fields` reads `n_distinct` off it to find
+    scored columns that cannot discriminate anything (#2668).
     """
     # Rebuild final blocking from decisions, preserving runtime-only attrs
     # (learned_sample_size, learned_min_recall, skip_oversized, etc.) from
@@ -5490,6 +5569,7 @@ def _rebuild_from_decisions(
         })
 
     _drop_uninformative_blocking_fields(decisions.matchkeys, final_blocking)
+    _drop_constant_scored_fields(decisions.matchkeys, _profiles)
 
     return GoldenMatchConfig(
         matchkeys=decisions.matchkeys,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -166,14 +166,25 @@ class ColumnProfile:
     # 1.0 as the frame grows.
     avg_len: float = 0.0  # average string length
     n_distinct: int | None = None
-    # EXACT count of distinct non-blank values in the profiling sample. Distinct
-    # from `cardinality_ratio`, which is that count divided by the row total and
-    # so cannot answer "is this column CONSTANT?" -- a single-valued column reads
+    # Count of distinct non-blank values IN THE PROFILING SAMPLE. Distinct from
+    # `cardinality_ratio`, which is that count divided by the row total and so
+    # cannot answer "is this column CONSTANT?" -- a single-valued column reads
     # 1/n, which shrinks with the frame and is indistinguishable from a merely
-    # low-cardinality one. `_drop_constant_scored_fields` needs the exact count.
-    # ``None`` means the profile was built without value access (hand-built
-    # profiles in tests, the #2639/#2644 idiom): consumers MUST treat it as
-    # "cannot answer" and leave behaviour unchanged rather than assuming 1.
+    # low-cardinality one.
+    #
+    # This is a CANDIDATE signal only, never a verdict: the sample is 1,000 rows,
+    # so a column that is 99.99% one value reads 1 here. Read `full_n_distinct`
+    # to decide anything. ``None`` means the profile was built without value
+    # access (hand-built profiles in tests, the #2639/#2644 idiom).
+    full_n_distinct: int | None = None
+    # EXACT distinct count over the FULL frame, computed only for columns the
+    # sample flags as apparently-constant (`n_distinct <= 1`). Same shape as
+    # `full_cardinality_ratio` and for the same reason: a sampled statistic
+    # compared against an absolute cut makes the verdict flip with SCALE rather
+    # than with the data, which the scale-invariant-correctness commitment
+    # forbids. A value at frequency 1e-4 is missed by a 1,000-row sample ~90% of
+    # the time, so without this a 2,000-row frame keeps a field that a 5M-row
+    # frame drops. None everywhere else, including hand-built profiles.
     date_parse_rate: float | None = None
     # For col_type=="date": fraction of the profiled non-null sample that parses
     # as a well-formed date (the same parser `date_diff` uses). A per-column
@@ -675,6 +686,30 @@ def profile_columns(
     for p in profiles:
         if p.cardinality_ratio >= 1.0 and p.name in _frame_cols and frame.height > 0:
             p.full_cardinality_ratio = frame.column(p.name).n_unique() / frame.height
+
+    # EXACT full-frame distinct count for APPARENTLY-CONSTANT columns (#2668).
+    # The mirror image of the pass above, and forbidden by the same commitment:
+    # `n_distinct` is a 1,000-row sample statistic, so a column that is 99.99%
+    # one value reads 1 and `_drop_constant_scored_fields` would drop its field
+    # from the matchkey. A value at frequency 1e-4 is missed by that sample ~90%
+    # of the time, so the verdict would flip with scale -- a small frame samples
+    # the column fully and keeps the field, a large one reads it constant and
+    # drops it.
+    #
+    # The damage runs the same direction as the bug this rule exists to fix. A
+    # field that agrees on nearly every pair and disagrees only on the rare ones
+    # is carrying its whole signal in exactly those rare pairs; dropping it
+    # removes the penalty where it discriminates and the rare cross-entity pair
+    # merges.
+    #
+    # Restricting the exact count to sample-flagged columns is sound rather than
+    # a cost heuristic: a column with >1 distinct value in the sample has >1 in
+    # the full frame, so it cannot be constant and is skipped. In practice this
+    # is a handful of columns, one `n_unique()` pass each.
+    for p in profiles:
+        if (p.n_distinct is not None and p.n_distinct <= 1
+                and p.name in _frame_cols and frame.height > 0):
+            p.full_n_distinct = int(frame.column(p.name).n_unique())
 
     # Per-column date reliability signal (both classify paths converge here, so
     # the native path is covered too). For every `date` column, record the
@@ -1406,13 +1441,21 @@ def _drop_constant_scored_fields(
     useless column not been in the frame. It picks 0.8 on `name` alone there, and
     that config makes no cross-entity merge on this fixture.
 
-    A field whose profile carries no `n_distinct` is LEFT ALONE: "cannot answer"
-    must not become "assumed constant". Same for a rule that would empty a
-    matchkey, since a matchkey with no fields cannot score anything.
+    Reads `full_n_distinct`, the EXACT full-frame count, never the sampled
+    `n_distinct`. The sample is 1,000 rows, so a column that is 99.99% one value
+    reads 1 there; acting on that would drop a field on a large frame and keep it
+    on a small one -- the scale-flipping verdict `full_cardinality_ratio` exists
+    to prevent, and it would fail in the same direction as the bug this rule
+    fixes, since a field that disagrees only on rare pairs carries its whole
+    signal in exactly those pairs.
+
+    A field whose profile carries no `full_n_distinct` is LEFT ALONE: "cannot
+    answer" must not become "assumed constant". Same for a rule that would empty
+    a matchkey, since a matchkey with no fields cannot score anything.
     """
     const = {
         p.name for p in profiles
-        if p.n_distinct is not None and p.n_distinct <= 1
+        if p.full_n_distinct is not None and p.full_n_distinct <= 1
     }
     if not const:
         return

--- a/packages/python/goldenmatch/tests/test_constant_scored_field_2668.py
+++ b/packages/python/goldenmatch/tests/test_constant_scored_field_2668.py
@@ -27,10 +27,11 @@ from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.core.autoconfig import ColumnProfile, _drop_constant_scored_fields
 
 
-def _prof(name: str, n_distinct: int | None) -> ColumnProfile:
+def _prof(name: str, full_n_distinct: int | None, n_distinct: int | None = 1) -> ColumnProfile:
+    """`full_n_distinct` is the verdict; `n_distinct` is only the sample flag."""
     return ColumnProfile(
         name=name, dtype="String", col_type="string", confidence=1.0,
-        n_distinct=n_distinct,
+        n_distinct=n_distinct, full_n_distinct=full_n_distinct,
     )
 
 
@@ -73,13 +74,42 @@ def test_varying_column_is_kept():
     assert [f.field for f in mks[0].fields] == ["name", "city"]
 
 
-def test_unknown_n_distinct_is_left_alone():
+def test_unknown_full_count_is_left_alone():
     """"Cannot answer" must not become "assumed constant". Hand-built profiles
     and any future producer that does not populate the field keep their prior
     behaviour rather than acquiring a verdict on evidence nobody collected."""
     mks = [_mk([("name", 1.0), ("type", 1.0)])]
     _drop_constant_scored_fields(mks, [_prof("name", None), _prof("type", None)])
     assert [f.field for f in mks[0].fields] == ["name", "type"]
+
+
+# ── the sample proposes, the full frame disposes ──────────────────────────
+
+def test_near_constant_column_is_NOT_dropped():
+    """The scale trap. `n_distinct` is a 1,000-row sample statistic, so a column
+    that is 99.99% one value reads 1 there -- a value at frequency 1e-4 is missed
+    ~90% of the time. Acting on the sample would drop the field on a 5M-row frame
+    and keep it on a 2,000-row one: a verdict that flips with SCALE rather than
+    with the data, which is what `full_cardinality_ratio` already exists to stop.
+
+    It also fails in the same direction as the bug this rule fixes. A field that
+    agrees on nearly every pair and disagrees only on the rare ones carries its
+    whole signal in exactly those rare pairs, so dropping it removes the penalty
+    precisely where it discriminates and the rare cross-entity pair merges."""
+    mks = [_mk([("name", 1.0), ("tenant", 1.0)])]
+    # sample saw one value; the full frame has two.
+    _drop_constant_scored_fields(
+        mks, [_prof("name", 10), _prof("tenant", 2, n_distinct=1)])
+    assert [f.field for f in mks[0].fields] == ["name", "tenant"]
+
+
+def test_sample_flag_alone_never_decides():
+    """Belt and braces: a sampled n_distinct of 1 with NO full-frame count is
+    "cannot answer", not "constant"."""
+    mks = [_mk([("name", 1.0), ("tenant", 1.0)])]
+    _drop_constant_scored_fields(
+        mks, [_prof("name", 10), _prof("tenant", None, n_distinct=1)])
+    assert [f.field for f in mks[0].fields] == ["name", "tenant"]
 
 
 def test_never_empties_a_matchkey():

--- a/packages/python/goldenmatch/tests/test_constant_scored_field_2668.py
+++ b/packages/python/goldenmatch/tests/test_constant_scored_field_2668.py
@@ -1,0 +1,132 @@
+"""#2668: a column that never varies carries no signal, so scoring it only
+relaxes the bar on the columns that do.
+
+Sibling of #2526. There a field varies in the data but blocking guarantees
+agreement WITHIN a block; here it does not vary at all, so no pair can disagree
+on it. Either way the field is a constant offset with zero discriminative power.
+
+The measured case is the goldengraph TINY fixture, whose `type` column is
+`'concept'` on all ten rows. Scored at equal weight beside `name` it makes
+
+    score = (name + 1.0) / 2      threshold 0.8  ->  the real bar on `name` is 0.6
+
+and `ensemble("Beta Corp", "Delta LLC") = 0.7037` clears 0.6 comfortably, so two
+different companies merged. Dropping the column and KEEPING the threshold puts
+the bar back on `name` at 0.8, which is what auto-config picks when the useless
+column is not in the frame at all.
+
+**The no-rescale choice is the whole point of this rule and has a test below.**
+#2526 rescales, because a blocking-agreeing field is genuinely informative
+elsewhere and its calibrated contribution should survive. Rescaling here would
+preserve the same absolute bar, which is precisely the bar that produced the
+false merge -- it would be a no-op on every decision the rule exists to change.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.autoconfig import ColumnProfile, _drop_constant_scored_fields
+
+
+def _prof(name: str, n_distinct: int | None) -> ColumnProfile:
+    return ColumnProfile(
+        name=name, dtype="String", col_type="string", confidence=1.0,
+        n_distinct=n_distinct,
+    )
+
+
+def _mk(fields, threshold=0.8, mk_type="weighted"):
+    return MatchkeyConfig(
+        name="fuzzy_match", type=mk_type, threshold=threshold,
+        fields=[MatchkeyField(field=f, scorer="ensemble", weight=w) for f, w in fields],
+    )
+
+
+# ── the rule fires on a constant column ───────────────────────────────────
+
+def test_constant_column_is_dropped():
+    mks = [_mk([("name", 1.0), ("type", 1.0)])]
+    _drop_constant_scored_fields(mks, [_prof("name", 10), _prof("type", 1)])
+    assert [f.field for f in mks[0].fields] == ["name"]
+
+
+def test_threshold_is_NOT_rescaled():
+    """The load-bearing difference from #2526. Rescaling 0.8 over the surviving
+    half would give 0.6 -- the exact bar that let "Beta Corp"/"Delta LLC" (0.7037)
+    merge. Keeping 0.8 is what makes this rule change any decision at all."""
+    mks = [_mk([("name", 1.0), ("type", 1.0)], threshold=0.8)]
+    _drop_constant_scored_fields(mks, [_prof("name", 10), _prof("type", 1)])
+    assert mks[0].threshold == 0.8
+
+
+def test_zero_distinct_counts_as_constant():
+    """An all-null/all-blank column distinguishes nothing either."""
+    mks = [_mk([("name", 1.0), ("empty", 1.0)])]
+    _drop_constant_scored_fields(mks, [_prof("name", 10), _prof("empty", 0)])
+    assert [f.field for f in mks[0].fields] == ["name"]
+
+
+# ── and leaves everything else exactly alone ──────────────────────────────
+
+def test_varying_column_is_kept():
+    mks = [_mk([("name", 1.0), ("city", 1.0)])]
+    _drop_constant_scored_fields(mks, [_prof("name", 10), _prof("city", 4)])
+    assert [f.field for f in mks[0].fields] == ["name", "city"]
+
+
+def test_unknown_n_distinct_is_left_alone():
+    """"Cannot answer" must not become "assumed constant". Hand-built profiles
+    and any future producer that does not populate the field keep their prior
+    behaviour rather than acquiring a verdict on evidence nobody collected."""
+    mks = [_mk([("name", 1.0), ("type", 1.0)])]
+    _drop_constant_scored_fields(mks, [_prof("name", None), _prof("type", None)])
+    assert [f.field for f in mks[0].fields] == ["name", "type"]
+
+
+def test_never_empties_a_matchkey():
+    """A matchkey with no fields cannot score anything, so an all-constant
+    matchkey is left intact and the RED verdict is left to say so."""
+    mks = [_mk([("a", 1.0), ("b", 1.0)])]
+    _drop_constant_scored_fields(mks, [_prof("a", 1), _prof("b", 1)])
+    assert [f.field for f in mks[0].fields] == ["a", "b"]
+
+
+def test_non_weighted_matchkey_untouched():
+    # threshold=None: a probabilistic matchkey cuts on `link_threshold`, and
+    # setting `threshold` on one warns (#2483). Irrelevant to this rule.
+    mks = [_mk([("name", 1.0), ("type", 1.0)], threshold=None, mk_type="probabilistic")]
+    _drop_constant_scored_fields(mks, [_prof("name", 10), _prof("type", 1)])
+    assert [f.field for f in mks[0].fields] == ["name", "type"]
+
+
+def test_no_constants_is_a_no_op():
+    mks = [_mk([("name", 1.0), ("city", 1.0)])]
+    before = [(f.field, f.weight) for f in mks[0].fields]
+    _drop_constant_scored_fields(mks, [_prof("name", 10), _prof("city", 5)])
+    assert [(f.field, f.weight) for f in mks[0].fields] == before
+
+
+# ── end to end, on the shape that caused the regression ───────────────────
+
+def test_end_to_end_constant_column_does_not_cause_a_cross_entity_merge():
+    """The goldengraph regression in miniature: two companies whose names score
+    0.70 against each other, beside a column that is the same word everywhere.
+    With the constant column scored, the pair clears the halved bar and merges."""
+    import goldenmatch as gm
+    import pyarrow as pa
+
+    names = ["Beta Corp", "Beta Corporation", "BETA",
+             "Delta LLC", "Delta", "Gamma Ltd", "Gamma Limited"]
+    df = pa.table({"name": names, "type": ["concept"] * len(names)})
+
+    cfg = gm.auto_configure_df(df, allow_red_config=True)
+    scored = {f.field for mk in (cfg.matchkeys or []) for f in (mk.fields or [])}
+    assert "type" not in scored, "the constant column must not be scored"
+
+    res = gm.dedupe_df(df)
+    beta = {0, 1, 2}
+    delta = {3, 4}
+    for info in res.clusters.values():
+        members = {int(m) for m in info["members"]}
+        assert not (members & beta and members & delta), (
+            f"Beta and Delta merged into one cluster: {sorted(members)}"
+        )


### PR DESCRIPTION
`goldengraph-pipeline` has been red on `main` since #2648, including run #593 this morning — **after** #2672 closed #2668 last night. Those PRs fixed the related zero-config *empty-result* arc (#2663/#2673); they did not fix this. #2668 is reopened.

## What it actually is

Bisected to `6599780c` (#2648) over 72 revisions, holding the `goldengraph-native` wheel fixed so the result isolates the goldenmatch Python change.

**#2648 did not cause it, it exposed it.** The committed configs either side of that commit are identical except blocking passes (2 → 5), and the fixture's `type` column is `'concept'` on all ten rows. Scored at equal weight beside `name`:

```
score = (name + 1.0) / 2     threshold 0.8  ->  the real bar on `name` is 0.6
ensemble("Beta Corp", "Delta LLC") = 0.7037  ->  0.8519    <- false merge
```

Looser blocking made Beta × Delta a **candidate**; the constant column let it **pass**. Two different companies merged into one cluster. Worth stating plainly because it inverts the obvious reading: the resolver was not failing to cluster, it was clustering too much.

### Two hypotheses measured and discarded

Recorded so nobody re-runs them:

- **An ambient `OPENAI_API_KEY`** — refuted: keyed Abt-Buy scores 0.1838, not the 0.5037 baseline.
- **`profile_threshold` making `mass_above_threshold` 1.0 and tripping the precision-collapse guard** — refuted by instrumenting `pick_committed`: `candidates_counted=True`, `admitted_fraction` 0.39–0.42 against a 0.9 floor, so **the guard never fires**.

## The fix

A sibling of #2526's rule, for the other way a scored field can carry no information. There the field varies but blocking guarantees agreement *within a block*; here it does not vary at all.

**It deliberately does not rescale the threshold.** Rescaling preserves the same absolute bar — precisely the bar that produced the merge — so it would be a no-op on every decision the rule exists to change. #2526 rescales because a blocking-agreeing field is informative elsewhere; a data-constant column is informative nowhere, so the honest config is the one auto-config builds when the useless column isn't in the frame: 0.8 on `name` alone. `test_threshold_is_NOT_rescaled` pins it.

**Sample proposes, full frame decides** (review catch, thank you). `n_distinct` is a 1,000-row sample statistic, so a column that is 99.99% one value reads 1 and its field would be dropped — a verdict flipping with *scale*, which the `#876` note 35 lines above forbids, and failing in the same direction as the bug being fixed, since a field that disagrees only on rare pairs carries its whole signal in exactly those pairs. `full_n_distinct` now carries the verdict, computed beside `full_cardinality_ratio` and gated on `n_distinct <= 1`. Demonstrated on one `'us'` row in 200,000, which the sample did miss:

```
tenant   sample n_distinct=1     full_n_distinct=2
fields kept: ['name', 'tenant']
```

## Two gates that could not fire

Both are the shape this PR keeps running into.

- **`goldengraph-pipeline`'s push filter** listed only goldengraph's own paths, so a goldenmatch change never fired it — which is how #2648 went green on its PR and reddened `main` that night. Now includes `packages/python/goldenmatch/goldenmatch/**`: the whole package source rather than an enumerated list, because an enumerated list is the same bug one level up, and the job is ~70 seconds.
- **`bench-suggest-quality` still does not run on this PR.** Its filter covers `core/suggest/**`, `probabilistic.py` and `pipeline.py`, but not `core/autoconfig.py` — arguably the most ER-semantics-heavy file in the package. I ran it by hand (result below); **flagging it as a follow-up rather than widening a second filter in this PR.**

## Fixture re-base

The fix resolves the TINY fixture completely in CI, so the two tests measuring the oracle-vs-real ER gap had no gap left (`assert real_f1 < oracle_f1` → `1.0 < 1.0`). Both assert real ER is *imperfect*. Rather than relax them — weakening ER-quality assertions to accommodate an ER change — they now run on `wikidata_companies_HARD`.

TINY's gap was never robust: its hardest alias is `"Acme"` vs `"Acme Holdings"`, ensemble **0.8615** against a 0.8 cut, so whether it merges turns on whether blocking made the pair a candidate. HARD gives every entity one alias string similarity **cannot** close:

| | score | clear of the cut |
|---|---|---|
| `Helios Industrial Group` / `HIG` — must not merge | 0.5845 | 0.2155 |
| `Meridian Foodworks` / `MFW` — must not merge | 0.5926 | 0.2074 |
| `Helios…` / `Helios… Inc.` — must merge | 0.9643 | 0.1643 |
| worst cross-entity pair | 0.5926 | — |

**Verified the re-base does not weaken the gate:** with the autoconfig fix reverted, the HARD-based suite fails the *same four tests* the nightly failed (4 failed, 8 passed); with it, 12 passed.

## Testing

| check | result |
|---|---|
| CI on `2815442c` | **all six workflows green**, `goldengraph-pipeline` included |
| goldengraph gate | **4 failed → 12 passed**, in a CI-shaped py3.12 polars-free env and a py3.11 polars one |
| goldenmatch suite | green in CI on this commit (the `ci` job runs it sharded) |
| `suggest_quality gate` (run by hand) | **PASS** — 9 ok, **0 fail**, 4 new, 0 missing |
| `anchor_person_match` | 1.0000, **+0.0000** — the dataset #2526 recorded collapsing to 0.7303 on a similar change |
| new tests | 11, incl. `test_threshold_is_NOT_rescaled`, `test_near_constant_column_is_NOT_dropped` |
| `ruff` / `regen_docs --check` / `check_workflow_yaml` | clean |

Quality-gate deltas are against the *committed* scorecard baseline rather than current main, so the `ncvr_synthetic` +0.0125 and `historical_50k` +0.0233 improvements are not necessarily attributable to this change. The load-bearing number is **0 fail**.

## Not explained

CI resolves the old TINY fixture more completely than any local environment I could build — py3.11+polars, py3.12 polars-free, native on and off, eight hash seeds. **The re-base removes the sensitivity, not the cause.**

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` — not run, `pre-commit` is not installed here; `ruff check` run directly and clean
- [x] `regen_docs.py --check` — clean (the codemap regen is commit 2/4)
- [x] Package `CHANGELOG.md` — flagging for review: this changes zero-config ER behaviour and may warrant an entry
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated — rationale lives on the rule, the guard and the filter, next to the code each governs