### PR TITLE
fix(splink): use its DOCUMENTED lineage break; persist was why 50M OOM'd

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -101,6 +101,11 @@ on:
         required: false
         type: boolean
         default: true
+      splink_checkpoint_dir:
+        description: "GCS prefix for Splink's lineage break (its documented `parquet` default). Splink OOMs at scale without a distributed FS -- persist caches but does NOT truncate the DAG. Must be in the SAME REGION as the cluster or Splink pays cross-region I/O GoldenMatch does not."
+        required: false
+        type: string
+        default: "gs://goldenmatch-spark-bench-us-east1"
       spot:
         description: "Use SPOT VMs. OFF by default: PREEMPTIBLE_CPUS quota in golden-490919/us-central1 is 0, so SPOT provisioning FAILS. Enable only after raising it."
         required: false
@@ -645,6 +650,7 @@ jobs:
               --master spark://$MASTER_IP:7077 \
               --driver-host $MASTER_IP \
               --spark-ui http://$MASTER_IP:4040 \
+              --checkpoint-dir '${{ inputs.splink_checkpoint_dir || 'gs://goldenmatch-spark-bench-us-east1' }}/run-${{ github.run_id }}' \
               ${{ inputs.eval_quality && '--eval-quality' || '' }} \
               --out /w/splink-train-scale.json
           "
@@ -761,6 +767,16 @@ jobs:
           set -euo pipefail
           gcloud compute instances delete $NODE_NAMES --quiet --zone="$ZONE" || true
           echo "deleted: $NODE_NAMES"
+
+          # Splink's lineage-break parquet for THIS run. The bucket carries a
+          # 1-day lifecycle rule as a backstop, but a 50M run writes real volume
+          # and there is no reason to pay a day of storage for scratch nobody
+          # will read. Scoped to the run's own prefix so a concurrent dispatch
+          # is untouched, and `|| true` because losing the bench to a storage
+          # cleanup would be absurd.
+          CKPT='${{ inputs.splink_checkpoint_dir || 'gs://goldenmatch-spark-bench-us-east1' }}/run-${{ github.run_id }}'
+          gcloud storage rm -r "$CKPT" --quiet 2>/dev/null || true
+          echo "cleared: $CKPT"
 
       - name: Leaked-instance warning
         if: always() && inputs.keep_cluster

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -152,7 +152,8 @@ def _metrics_module():
     return mod
 
 
-def build_session(master: str, driver_host: str | None, wait_s: int):
+def build_session(master: str, driver_host: str | None, wait_s: int,
+                  checkpoint_dir: str | None = None):
     """A session tuned NO differently from the one GM gets.
 
     This used to set `spark.sql.shuffle.partitions=8`, with the rationale that
@@ -189,7 +190,32 @@ def build_session(master: str, driver_host: str | None, wait_s: int):
     )
     if driver_host:
         b = b.config("spark.driver.host", driver_host)
+    if checkpoint_dir and checkpoint_dir.startswith("gs://"):
+        # The GCS Hadoop connector, so `gs://` resolves at all. The Spark image
+        # does not bundle it, and without it a gs:// checkpoint dir fails with
+        # "No FileSystem for scheme: gs".
+        #
+        # Auth comes from the VM's metadata server: the nodes are created with
+        # `--scopes=cloud-platform` and run as the default compute service
+        # account, which holds roles/editor. No key material is passed here.
+        b = (
+            b.config("spark.jars.packages",
+                     "com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.21")
+            .config("spark.hadoop.fs.gs.impl",
+                    "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")
+            .config("spark.hadoop.fs.AbstractFileSystem.gs.impl",
+                    "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS")
+            .config("spark.hadoop.google.cloud.auth.service.account.enable", "true")
+        )
     spark = b.getOrCreate()
+
+    # `parquet` -- Splink's ACTUAL default -- reads its write path from
+    # `sc.setCheckpointDir`, so the dir has to be set even though nothing calls
+    # `.checkpoint()`. See `_get_checkpoint_dir_path` in
+    # splink/internals/spark/database_api.py.
+    if checkpoint_dir:
+        spark.sparkContext.setCheckpointDir(checkpoint_dir)
+        print(f"[splink] checkpoint dir {checkpoint_dir}", flush=True)
 
     # Splink's Spark backend breaks lineage with `Dataset.checkpoint()`, which
     # needs a checkpoint dir, and a checkpoint dir on THIS topology has nowhere
@@ -264,6 +290,12 @@ def main() -> int:
     ap.add_argument("--spark-ui", default="http://localhost:4040",
                     help="Spark UI of THIS classic driver (it runs on the host "
                          "and binds 4040). Read for stage-level shuffle bytes.")
+    ap.add_argument("--checkpoint-dir", default=os.environ.get("SPLINK_CHECKPOINT_DIR", ""),
+                    help="Distributed-filesystem path for Splink's lineage "
+                         "break (e.g. gs://bucket/prefix). REQUIRED for the "
+                         "documented `parquet` default; without one this falls "
+                         "back to `persist`, which does NOT truncate lineage "
+                         "and OOMs at scale.")
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -274,22 +306,42 @@ def main() -> int:
             "GM runs over Spark Connect (addArtifact is Connect-only); Splink "
             "cannot (it uses sparkContext). Same cluster, different front door."
         ),
-        # Recorded, not buried. Splink's default lineage break is `checkpoint`,
-        # which needs a distributed filesystem this lane has no way to provide.
-        # `persist` skips that write, so if it moves the wall it moves it in
-        # SPLINK's favour -- the deviation cannot manufacture a GM win.
-        "break_lineage_method": "persist",
-        "break_lineage_deviation": (
-            "Splink's Spark default is `checkpoint`; it requires a checkpoint "
-            "dir on a non-local filesystem (Spark refuses local paths outside "
-            "local mode) and this cluster has only container-local disk. "
-            "`persist` materialises to executor memory/disk instead."
+        # `parquet` is Splink's ACTUAL default -- verified in
+        # splink/internals/spark/database_api.py:
+        #     elif not self.break_lineage_method:
+        #         self.break_lineage_method = "parquet"
+        #
+        # An earlier version of this harness ran `persist` and recorded that
+        # Splink's default was `checkpoint`. Both were wrong, and the second
+        # error hid the first: `persist()` CACHES but keeps the lineage for
+        # fault recovery, while `checkpoint`/`parquet` materialise and CUT it.
+        # Splink's performance guide is explicit that without breaking lineage
+        # "big jobs fail to complete", and at 50M that is exactly what happened
+        # -- executors died with exit 52 (JVM OOM) after 33 EM iterations built
+        # an unbounded DAG.
+        #
+        # The old note argued the deviation "biases the wall in Splink's
+        # favour". True of wall-clock, false of MEMORY, which is the axis it
+        # died on. A configuration that cannot finish is not a favour.
+        "break_lineage_method": ("parquet" if args.checkpoint_dir else "persist"),
+        "break_lineage_note": (
+            "parquet == Splink's own default, backed by a distributed "
+            "filesystem, which is what its docs assume. Splink pays real "
+            "GCS write+read per lineage break; GoldenMatch pays none because "
+            "its counting stage has no iterative DAG to truncate. That "
+            "asymmetry is a property of the engines, not of this harness."
+            if args.checkpoint_dir else
+            "NO --checkpoint-dir given, so this fell back to `persist`, which "
+            "does NOT truncate lineage. Expect OOM at scale. This is a "
+            "misconfiguration, not a Splink limit."
         ),
+        "checkpoint_dir": args.checkpoint_dir or None,
     }
     t_all = time.perf_counter()
 
     spark, n_exec = build_session(args.master, args.driver_host or None,
-                                  args.executor_wait)
+                                  args.executor_wait,
+                                  args.checkpoint_dir or None)
     out["executors"] = n_exec
 
     fx = _fixture_module()
@@ -368,7 +420,8 @@ def main() -> int:
     # checkpoint dir.
     linker = Linker(
         df, settings,
-        db_api=SparkAPI(spark_session=spark, break_lineage_method="persist"),
+        db_api=SparkAPI(spark_session=spark,
+                        break_lineage_method=out["break_lineage_method"]),
     )
 
     # u, from random pairs -- the same quantity the GM harness times as `u`.


### PR DESCRIPTION
Splink died at 50M with executors exiting **52** (JVM OOM) and cascading `FetchFailed`. Before retrying on bigger hardware I checked whether the harness had set Splink up correctly. **It hadn't**, and the misconfiguration is the likely cause.

## Two errors, the second hiding the first

The harness ran `break_lineage_method="persist"` and recorded that *"Splink's Spark default is `checkpoint`"*. Both wrong. From `splink/internals/spark/database_api.py`:

```python
elif not self.break_lineage_method:
    self.break_lineage_method = "parquet"        # <- the actual default
```

and the branches do materially different things:

```python
persist:     spark_df.persist()                 # caches, KEEPS lineage
checkpoint:  spark_df.checkpoint()              # truncates
parquet:     write.parquet(...) + read back     # truncates
```

`persist()` caches but Spark retains the full DAG for fault recovery. Splink's performance guide is explicit that without breaking lineage **"big jobs fail to complete"** — and 33 EM iterations over 463,923,179 pairs is exactly that shape.

The old note argued the deviation *"biases the wall in Splink's favour"*. True of wall-clock, **false of memory**, which is the axis it died on. That claim let a setup bug read as an engine limit.

## Doing it properly

`parquet` needs a distributed filesystem, which the original author correctly said this lane lacked. No longer true — the bench SA has `storage.objectAdmin`, and the VMs run as the default compute SA (`roles/editor`) with `--scopes=cloud-platform`, so GCS works with no key material.

- new bucket `gs://goldenmatch-spark-bench-us-east1`, **same region as the cluster** — every existing bucket is `us-central1` and cross-region I/O per lineage break would penalise Splink for *our* bucket placement
- 1-day lifecycle backstop; teardown also removes the run's own prefix
- **GCS Hadoop connector** via `spark.jars.packages` — the Spark image doesn't bundle it and `gs://` fails with *"No FileSystem for scheme: gs"*
- `parquet` reads its path from `sc.setCheckpointDir` even though nothing calls `.checkpoint()`

Without `--checkpoint-dir` it still falls back to `persist`, and the artifact now says **"This is a misconfiguration, not a Splink limit"** so nobody can quote an OOM as an engine result.

## The asymmetry, recorded not hidden

Splink now pays real GCS write+read per lineage break; GoldenMatch pays none because its counting stage has no iterative DAG to truncate. That's a property of the engines, and it's in the artifact.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P