### PR TITLE
fix(bench): detach the harnesses from the SSH session that starts them

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -604,10 +604,29 @@ jobs:
           sha256sum -c goldenmatch-spark.jar.sha256 \
             || { echo "::error::jar checksum mismatch"; exit 1; }
 
+          # The SHADED GCS connector, for SPLINK's lineage break to gs://.
+          # GoldenMatch never touches it: it has no iterative DAG to truncate.
+          #
+          # Shipped as a file rather than `spark.jars.packages` because Ivy
+          # cannot express a classifier, and the PLAIN artifact the coordinate
+          # resolves to is 155 KB of classes whose transitive deps did not
+          # resolve compatibly against this image -- run 32274795307 died on
+          # `NoClassDefFoundError: .../interceptors/LoggingInterceptor`. The
+          # `-shaded` jar is the self-contained 38 MB build.
+          GCS_VER=3.1.17
+          GCS_BASE="https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/${GCS_VER}"
+          curl -sSfL --retry 3 --retry-delay 5 -o gcs-connector-shaded.jar \
+            "${GCS_BASE}/gcs-connector-${GCS_VER}-shaded.jar"
+          # Checksummed for the same reason the scorer jar is: a truncated
+          # download resurfaces as a baffling JVM error minutes and five VMs
+          # later, not as a download failure.
+          echo "$(curl -sSfL --retry 3 "${GCS_BASE}/gcs-connector-${GCS_VER}-shaded.jar.sha1")  gcs-connector-shaded.jar" \
+            | sha1sum -c - || { echo "::error::gcs-connector jar checksum mismatch"; exit 1; }
+
           gcloud compute scp --quiet \
             scripts/spark_fs_train_scale.py scripts/spark_splink_train_scale.py \
             scripts/_fs_quality_metrics.py scripts/_spark_shuffle_metrics.py \
-            goldenmatch-spark.jar \
+            goldenmatch-spark.jar gcs-connector-shaded.jar \
             "$MASTER:~/"
 
           gcloud compute ssh "$MASTER" --quiet --command "

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -101,6 +101,12 @@ on:
         required: false
         type: boolean
         default: true
+      splink_checkpoint_fs:
+        description: "Shared filesystem for Splink's lineage break. `hdfs` stands up a real HDFS across the cluster nodes (Spark speaks hdfs:// through the Hadoop client pyspark already bundles, so no connector is involved). `gcs` uses the bucket in splink_checkpoint_dir via the gcs-connector. `none` forces `persist`, which keeps lineage and OOMs at scale -- debugging only."
+        required: false
+        type: choice
+        default: "hdfs"
+        options: ["hdfs", "gcs", "none"]
       splink_checkpoint_dir:
         description: "GCS prefix for Splink's lineage break (its documented `parquet` default). Splink OOMs at scale without a distributed FS -- persist caches but does NOT truncate the DAG. Must be in the SAME REGION as the cluster or Splink pays cross-region I/O GoldenMatch does not."
         required: false
@@ -593,6 +599,125 @@ jobs:
           echo "::error::no worker registered with the master -- every timing below would be a queue wait, not a measurement. Container status and logs are in the groups above."
           exit 1
 
+      - name: Stand up HDFS across the cluster
+        # Splink's lineage break writes a parquet FROM THE EXECUTORS and reads
+        # it back, so it needs storage every executor can reach. Confirmed in
+        # Splink's own source rather than assumed:
+        #
+        #     checkpoint_dir = self._get_checkpoint_dir_path(spark_df)
+        #     spark_df.write.mode("overwrite").parquet(write_path)
+        #     spark_df = self.spark.read.parquet(write_path)
+        #
+        # This lane had NO distributed filesystem at all. That is the real
+        # defect: Splink's documented 100M+ deployments run on Databricks / EMR
+        # / Dataproc where a shared FS is native, and bolting a GCS connector
+        # onto bare standalone Spark was the unusual part, not Splink. Three
+        # runs died on connector configuration before the filesystem was ever
+        # reached.
+        #
+        # HDFS removes the connector from the question entirely: pyspark already
+        # bundles hadoop-client-api/runtime, so `hdfs://` needs NO extra jar on
+        # driver or executors, and it is the filesystem Spark is built around.
+        #
+        # `dfs.replication=1` ON PURPOSE. This is scratch for a lineage break
+        # that lives minutes, and replication would tax Splink with write
+        # amplification GoldenMatch does not pay. Giving the engine under test
+        # its cheapest correct configuration is the fair choice; the risk is a
+        # lost datanode failing the run, not a wrong number.
+        if: inputs.splink_compare && (inputs.splink_checkpoint_fs || 'hdfs') == 'hdfs'
+        run: |
+          set -euo pipefail
+          HADOOP_IMAGE=apache/hadoop:3.4.1
+
+          # Config written on the RUNNER and copied, rather than heredoc'd
+          # through ssh: XML inside a remote shell string is a quoting trap and
+          # a silently mangled config would surface as a filesystem that half
+          # works.
+          mkdir -p hdfs-conf
+          cat > hdfs-conf/core-site.xml <<XML
+          <?xml version="1.0"?>
+          <configuration>
+            <property><name>fs.defaultFS</name><value>hdfs://${MASTER_IP}:9000</value></property>
+            <property><name>hadoop.tmp.dir</name><value>/hadoop/tmp</value></property>
+          </configuration>
+          XML
+          cat > hdfs-conf/hdfs-site.xml <<XML
+          <?xml version="1.0"?>
+          <configuration>
+            <property><name>dfs.replication</name><value>1</value></property>
+            <property><name>dfs.namenode.name.dir</name><value>/hadoop/dfs/name</value></property>
+            <property><name>dfs.datanode.data.dir</name><value>/hadoop/dfs/data</value></property>
+            <property><name>dfs.permissions.enabled</name><value>false</value></property>
+            <property><name>dfs.namenode.rpc-bind-host</name><value>0.0.0.0</value></property>
+            <property><name>dfs.namenode.servicerpc-bind-host</name><value>0.0.0.0</value></property>
+            <property><name>dfs.namenode.http-bind-host</name><value>0.0.0.0</value></property>
+            <property><name>dfs.datanode.use.datanode.hostname</name><value>false</value></property>
+            <property><name>dfs.client.use.datanode.hostname</name><value>false</value></property>
+          </configuration>
+          XML
+          # The heredocs above are indented for YAML, so strip the leading
+          # spaces the block scalar leaves behind. `<?xml` MUST start at column
+          # 0 or the parser rejects the declaration.
+          sed -i 's/^ *//' hdfs-conf/core-site.xml hdfs-conf/hdfs-site.xml
+
+          MASTER="$CLUSTER-master"
+          for n in $NODE_NAMES; do
+            gcloud compute scp --quiet --recurse hdfs-conf "$n:~/" &
+          done
+          wait
+
+          MOUNTS="-v \$HOME/hdfs-conf/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml -v \$HOME/hdfs-conf/hdfs-site.xml:/opt/hadoop/etc/hadoop/hdfs-site.xml"
+
+          # Namenode: format, then run. The dirs are chmod 777 because the
+          # image runs as its own `hadoop` user and the host path is created by
+          # root.
+          gcloud compute ssh "$MASTER" --quiet --command "
+            set -euo pipefail
+            sudo mkdir -p /mnt/disks/scratch/hdfs-nn && sudo chmod 777 /mnt/disks/scratch/hdfs-nn
+            docker run --rm --network host $MOUNTS \
+              -v /mnt/disks/scratch/hdfs-nn:/hadoop/dfs/name \
+              $HADOOP_IMAGE hdfs namenode -format -force -nonInteractive
+            docker run -d --name hdfs-nn --network host --restart unless-stopped $MOUNTS \
+              -v /mnt/disks/scratch/hdfs-nn:/hadoop/dfs/name \
+              $HADOOP_IMAGE hdfs namenode
+          "
+
+          # A datanode on EVERY node, master included: its disk is as good as
+          # any other and the master is otherwise idle during the Splink arm.
+          for n in $NODE_NAMES; do
+            gcloud compute ssh "$n" --quiet --command "
+              set -euo pipefail
+              sudo mkdir -p /mnt/disks/scratch/hdfs-dn && sudo chmod 777 /mnt/disks/scratch/hdfs-dn
+              docker run -d --name hdfs-dn --network host --restart unless-stopped $MOUNTS \
+                -v /mnt/disks/scratch/hdfs-dn:/hadoop/dfs/data \
+                $HADOOP_IMAGE hdfs datanode
+            " &
+          done
+          wait
+
+          # VERIFIED, not assumed. A namenode with zero live datanodes accepts
+          # a mkdir and then fails every write with UnreplicatedBlocks, minutes
+          # later, inside Splink -- which would read as a Splink failure.
+          echo "waiting for datanodes to register"
+          EXPECT=$(echo $NODE_NAMES | wc -w)
+          for i in $(seq 1 40); do
+            LIVE=$(gcloud compute ssh "$MASTER" --quiet --command \
+              "docker exec hdfs-nn hdfs dfsadmin -report 2>/dev/null | grep -c '^Name:' || true" 2>/dev/null | tr -dc '0-9') || true
+            echo "  attempt $i: ${LIVE:-0}/$EXPECT live datanodes"
+            [ "${LIVE:-0}" -ge "$EXPECT" ] && break
+            sleep 10
+          done
+          [ "${LIVE:-0}" -ge 1 ] || {
+            echo "::error::no HDFS datanode registered; Splink's lineage break would fail mid-run"
+            gcloud compute ssh "$MASTER" --quiet --command "docker logs --tail 40 hdfs-nn 2>&1; docker logs --tail 40 hdfs-dn 2>&1" || true
+            exit 1
+          }
+          echo "HDFS up with ${LIVE} live datanode(s)"
+
+          gcloud compute ssh "$MASTER" --quiet --command \
+            "docker exec hdfs-nn hdfs dfs -mkdir -p /splink-ckpt && docker exec hdfs-nn hdfs dfs -chmod 777 /splink-ckpt"
+          echo "HDFS_CKPT=hdfs://${MASTER_IP}:9000/splink-ckpt/run-${{ github.run_id }}" >> $GITHUB_ENV
+
       - name: Run both harnesses ON the master VM
         # On the master, not the runner: Splink's classic driver must be
         # reachable BY the workers, and a runner behind NAT is not. This also
@@ -730,6 +855,16 @@ jobs:
           # job -- it prints `splink: MISSING` and reads as "Splink could not do
           # 50M". Publishing a transport failure as an engine limit is the exact
           # unfairness this comparison exists to avoid.
+          # Which shared filesystem Splink breaks lineage onto. `none` leaves
+          # the flag off entirely, which makes the harness fall back to
+          # `persist` -- correct output, keeps lineage, OOMs at scale.
+          case "${{ inputs.splink_checkpoint_fs || 'hdfs' }}" in
+            hdfs) CKPT="${HDFS_CKPT:?HDFS was selected but the HDFS step did not export HDFS_CKPT}" ;;
+            gcs)  CKPT="${{ inputs.splink_checkpoint_dir || 'gs://goldenmatch-spark-bench-us-east1' }}/run-${{ github.run_id }}" ;;
+            none) CKPT="" ;;
+          esac
+          echo "splink lineage break -> ${CKPT:-persist (no shared FS)}"
+
           source scripts/gce_detached.sh
           gce_detached "$MASTER" splink <<REMOTE
           python spark_splink_train_scale.py \
@@ -737,7 +872,7 @@ jobs:
             --master spark://$MASTER_IP:7077 \
             --driver-host $MASTER_IP \
             --spark-ui http://$MASTER_IP:4040 \
-            --checkpoint-dir '${{ inputs.splink_checkpoint_dir || 'gs://goldenmatch-spark-bench-us-east1' }}/run-${{ github.run_id }}' \
+            ${CKPT:+--checkpoint-dir $CKPT} \
             ${{ inputs.eval_quality && '--eval-quality' || '' }} \
             --out /w/splink-train-scale.json
           REMOTE

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -149,20 +149,48 @@ jobs:
         timeout-minutes: 15
         run: |
           set -euo pipefail
+
+          # THE ACTUAL CAUSE, from run 32276315793:
+          #
+          #   E: Could not get lock /var/lib/apt/lists/lock.
+          #      It is held by process 2356 (apt-get)
+          #
+          # Not an upstream outage. GitHub-hosted runners run their own apt work
+          # (unattended-upgrades and friends) shortly after boot, and the
+          # vendor's setup script calls `apt-get update` internally, where it
+          # cannot be given lock options. Whether this step passes is a race
+          # against the runner's own housekeeping, which is why it passed three
+          # times this morning and then failed three times in a row.
+          #
+          # So: WAIT for the lock rather than race it.
+          wait_for_apt() {
+            for _ in $(seq 1 90); do
+              if sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend \
+                            /var/lib/dpkg/lock >/dev/null 2>&1; then
+                sleep 5
+              else
+                return 0
+              fi
+            done
+            echo "::warning::apt lock still held after 450s"
+            return 1
+          }
+
           ok=""
           for attempt in 1 2 3; do
-            # `apt-get update` is kept rather than left to the vendor script.
-            # The script does appear to run one, but the original step did not
-            # rely on that and neither will this.
+            wait_for_apt || true
+            # `DPkg::Lock::Timeout` makes OUR apt calls wait for the lock
+            # instead of erroring. It cannot be passed into the vendor script,
+            # which is what `wait_for_apt` above is for.
             if timeout 240 bash -c "curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash" \
-               && timeout 240 sudo apt-get update \
-               && timeout 240 sudo apt-get install -y infisical; then
+               && timeout 240 sudo apt-get -o DPkg::Lock::Timeout=180 update \
+               && timeout 240 sudo apt-get -o DPkg::Lock::Timeout=180 install -y infisical; then
               ok=1; break
             fi
             echo "::warning::Infisical CLI install attempt $attempt failed or timed out; retrying"
-            sleep 15
+            sleep 20
           done
-          [ -n "$ok" ] || { echo "::error::Infisical CLI install failed 3x -- upstream apt repo is unreachable, this is not a repo change"; exit 1; }
+          [ -n "$ok" ] || { echo "::error::Infisical CLI install failed 3x. Check the log for 'Could not get lock' (runner apt contention) vs a genuine network/repo error before assuming an upstream outage"; exit 1; }
           infisical --version
 
       - name: Fetch GCP creds from Infisical
@@ -841,8 +869,19 @@ jobs:
         if: always() && !inputs.keep_cluster
         run: |
           set -euo pipefail
-          gcloud compute instances delete $NODE_NAMES --quiet --zone="$ZONE" || true
-          echo "deleted: $NODE_NAMES"
+          # `${NODE_NAMES:-}`, because this step is `always()` and a job that
+          # fails BEFORE provisioning never sets it. Under `set -u` the bare
+          # expansion aborts the step on line 1, which also skipped the GCS
+          # cleanup below -- teardown failing open is the one thing it must
+          # never do. Surfaced by run 32276315793, where the Infisical step
+          # failed early for the first time and teardown died with
+          # `NODE_NAMES: unbound variable`.
+          if [ -z "${NODE_NAMES:-}" ]; then
+            echo "no instances were provisioned; nothing to delete"
+          else
+            gcloud compute instances delete $NODE_NAMES --quiet --zone="${ZONE:-}" || true
+            echo "deleted: $NODE_NAMES"
+          fi
 
           # Splink's lineage-break parquet for THIS run. The bucket carries a
           # 1-day lifecycle rule as a backstop, but a 50M run writes real volume

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -139,66 +139,6 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
-      - name: Install the Infisical CLI
-        # BOUNDED, because this step wedged twice in a row on 2026-08-19 (runs
-        # 32271581601 and 32273435168), each time sitting >10 minutes on a step
-        # that normally takes seconds, on two different runners. The vendor's
-        # `setup.deb.sh` bootstraps pip and runs its own `apt-get` before ours,
-        # so the hang is inside a third-party script this lane cannot see into.
-        #
-        # Unbounded, that hang inherits the JOB's `timeout-minutes: 360` -- a
-        # dependency outage silently converts into six hours of billed runner
-        # before anyone learns anything. `timeout` turns it into a legible
-        # failure in four minutes. The retry covers the transient case; it does
-        # NOT paper over a real outage, because three bounded attempts still
-        # fail fast and say so.
-        timeout-minutes: 15
-        run: |
-          set -euo pipefail
-
-          # THE ACTUAL CAUSE, from run 32276315793:
-          #
-          #   E: Could not get lock /var/lib/apt/lists/lock.
-          #      It is held by process 2356 (apt-get)
-          #
-          # Not an upstream outage. GitHub-hosted runners run their own apt work
-          # (unattended-upgrades and friends) shortly after boot, and the
-          # vendor's setup script calls `apt-get update` internally, where it
-          # cannot be given lock options. Whether this step passes is a race
-          # against the runner's own housekeeping, which is why it passed three
-          # times this morning and then failed three times in a row.
-          #
-          # So: WAIT for the lock rather than race it.
-          wait_for_apt() {
-            for _ in $(seq 1 90); do
-              if sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend \
-                            /var/lib/dpkg/lock >/dev/null 2>&1; then
-                sleep 5
-              else
-                return 0
-              fi
-            done
-            echo "::warning::apt lock still held after 450s"
-            return 1
-          }
-
-          ok=""
-          for attempt in 1 2 3; do
-            wait_for_apt || true
-            # `DPkg::Lock::Timeout` makes OUR apt calls wait for the lock
-            # instead of erroring. It cannot be passed into the vendor script,
-            # which is what `wait_for_apt` above is for.
-            if timeout 240 bash -c "curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash" \
-               && timeout 240 sudo apt-get -o DPkg::Lock::Timeout=180 update \
-               && timeout 240 sudo apt-get -o DPkg::Lock::Timeout=180 install -y infisical; then
-              ok=1; break
-            fi
-            echo "::warning::Infisical CLI install attempt $attempt failed or timed out; retrying"
-            sleep 20
-          done
-          [ -n "$ok" ] || { echo "::error::Infisical CLI install failed 3x. Check the log for 'Could not get lock' (runner apt contention) vs a genuine network/repo error before assuming an upstream outage"; exit 1; }
-          infisical --version
-
       - name: Fetch GCP creds from Infisical
         # Identical mechanism to bench-ray-cluster.yml -- same Machine Identity,
         # same project, same masking. Reusing it rather than adding GH secrets
@@ -212,16 +152,68 @@ jobs:
             echo "::error::INFISICAL_CLIENT_ID / INFISICAL_CLIENT_SECRET not set; see docs/distributed/ray-gce-cluster.md"
             exit 1
           fi
-          TOKEN=$(infisical login --silent --plain --method=universal-auth \
-            --client-id="$INFISICAL_CLIENT_ID" --client-secret="$INFISICAL_CLIENT_SECRET")
+          # Infisical's REST API directly, NOT the CLI. Installing the CLI needs
+          # apt, and apt on a GitHub-hosted runner needs a lock the runner's own
+          # housekeeping holds: runs 32271581601, 32273435168, 32276315793 and
+          # 32278438000 all died there, the last one with
+          #
+          #     apt lock still held after 450s
+          #     E: Could not get lock /var/lib/apt/lists/lock.
+          #        It is held by process 2199 (apt-get)
+          #
+          # after waiting for it and retrying three times. There is no published
+          # standalone binary to fall back to (checked: the CLI's releases carry
+          # no assets), so the way to stop losing runs to a package manager is
+          # to stop needing one. `curl` and `jq` are preinstalled.
+          #
+          # Same Machine Identity, same project, same secrets, same masking --
+          # only the transport changes. Routes verified against the live API
+          # before this was written, using NO credentials: an empty POST to the
+          # login route returns 422 and a bogus one returns 401 "Invalid
+          # credentials", which proves both the path and the field names; the
+          # secret routes return 401 rather than 404, which proves they exist.
+          API="${INFISICAL_API:-https://app.infisical.com}"
+          PROJECT_ID=a99885f0-c5af-4ae1-9dc8-255cc60aa129
+          ENV_SLUG=dev
+
+          # Built with jq rather than string interpolation so a quote or
+          # backslash in the client secret cannot break the JSON.
+          LOGIN_BODY=$(jq -nc --arg id "$INFISICAL_CLIENT_ID" \
+                              --arg sec "$INFISICAL_CLIENT_SECRET" \
+                              '{clientId:$id, clientSecret:$sec}')
+          LOGIN=$(curl -sS --max-time 60 -X POST "$API/api/v1/auth/universal-auth/login" \
+                    -H 'Content-Type: application/json' -d "$LOGIN_BODY")
+          TOKEN=$(jq -r '.accessToken // empty' <<<"$LOGIN")
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Infisical login failed: $(jq -r '.message // "no accessToken in response"' <<<"$LOGIN")"
+            exit 1
+          fi
           echo "::add-mask::$TOKEN"
 
-          PROJ=$(infisical secrets get GCP_RAY_BENCH_PROJECT_ID \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$TOKEN")
+          # v3-raw first, v4 as fallback: both are live today and the pair
+          # survives either being retired. Only the VALUE goes to stdout, so a
+          # diagnostic can never be captured as a secret.
+          get_secret() {
+            local name="$1" out val
+            out=$(curl -sS --max-time 60 -H "Authorization: Bearer $TOKEN" \
+                  "$API/api/v3/secrets/raw/$name?workspaceId=$PROJECT_ID&environment=$ENV_SLUG&secretPath=%2F") || true
+            val=$(jq -r '.secret.secretValue // empty' <<<"$out")
+            if [ -z "$val" ]; then
+              out=$(curl -sS --max-time 60 -H "Authorization: Bearer $TOKEN" \
+                    "$API/api/v4/secrets/$name?projectId=$PROJECT_ID&environment=$ENV_SLUG&secretPath=%2F") || true
+              val=$(jq -r '.secret.secretValue // empty' <<<"$out")
+            fi
+            if [ -z "$val" ]; then
+              echo "::error::could not read $name from Infisical: $(jq -r '.message // "empty value from both v3 and v4"' <<<"$out")" >&2
+              return 1
+            fi
+            printf '%s' "$val"
+          }
+
+          PROJ=$(get_secret GCP_RAY_BENCH_PROJECT_ID)
           echo "::add-mask::$PROJ"
 
-          infisical secrets get GCP_SA_KEY_B64 \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$TOKEN" \
+          get_secret GCP_SA_KEY_B64 \
             | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
           chmod 600 "$HOME/gcp-sa.json"
           python3 -c "import json; json.load(open('$HOME/gcp-sa.json'))"

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -613,14 +613,22 @@ jobs:
             docker exec pyenv sh -c \
               'apt-get update -qq && apt-get install -y -qq --no-install-recommends default-jre-headless >/dev/null'
             docker exec pyenv java -version
-            docker exec -e GOLDENMATCH_SPARK_JAR=/w/goldenmatch-spark.jar \
-              pyenv python spark_fs_train_scale.py \
-              --rows ${{ inputs.rows || '1000000' }} \
-              --remote sc://$MASTER_IP:15002 \
-              --spark-ui http://$MASTER_IP:4040 \
-              ${{ inputs.eval_quality && '--eval-quality' || '' }} \
-              --out /w/spark-fs-train-scale.json
           "
+
+          # DETACHED, not inside the ssh --command above. Run 32259409214 lost
+          # its SSH session 11 minutes into this exact call with the harness
+          # healthy and mid-pass, and took the run and five VMs with it.
+          # scripts/gce_detached.sh carries the mechanism and the log.
+          source scripts/gce_detached.sh
+          gce_detached "$MASTER" fs <<REMOTE
+          export GOLDENMATCH_SPARK_JAR=/w/goldenmatch-spark.jar
+          python spark_fs_train_scale.py \
+            --rows ${{ inputs.rows || '1000000' }} \
+            --remote sc://$MASTER_IP:15002 \
+            --spark-ui http://$MASTER_IP:4040 \
+            ${{ inputs.eval_quality && '--eval-quality' || '' }} \
+            --out /w/spark-fs-train-scale.json
+          REMOTE
 
       - name: Splink on the same cluster
         if: inputs.splink_compare
@@ -642,18 +650,24 @@ jobs:
         run: |
           set -euo pipefail
           MASTER="$CLUSTER-master"
-          gcloud compute ssh "$MASTER" --quiet --command "
-            set -euo pipefail
-            docker stop spark-connect
-            docker exec pyenv python spark_splink_train_scale.py \
-              --rows ${{ inputs.rows || '1000000' }} \
-              --master spark://$MASTER_IP:7077 \
-              --driver-host $MASTER_IP \
-              --spark-ui http://$MASTER_IP:4040 \
-              --checkpoint-dir '${{ inputs.splink_checkpoint_dir || 'gs://goldenmatch-spark-bench-us-east1' }}/run-${{ github.run_id }}' \
-              ${{ inputs.eval_quality && '--eval-quality' || '' }} \
-              --out /w/splink-train-scale.json
-          "
+          gcloud compute ssh "$MASTER" --quiet --command "docker stop spark-connect"
+
+          # DETACHED, and this arm needs it more than the FS one. The step is
+          # `continue-on-error: true`, so a dropped SSH here does NOT fail the
+          # job -- it prints `splink: MISSING` and reads as "Splink could not do
+          # 50M". Publishing a transport failure as an engine limit is the exact
+          # unfairness this comparison exists to avoid.
+          source scripts/gce_detached.sh
+          gce_detached "$MASTER" splink <<REMOTE
+          python spark_splink_train_scale.py \
+            --rows ${{ inputs.rows || '1000000' }} \
+            --master spark://$MASTER_IP:7077 \
+            --driver-host $MASTER_IP \
+            --spark-ui http://$MASTER_IP:4040 \
+            --checkpoint-dir '${{ inputs.splink_checkpoint_dir || 'gs://goldenmatch-spark-bench-us-east1' }}/run-${{ github.run_id }}' \
+            ${{ inputs.eval_quality && '--eval-quality' || '' }} \
+            --out /w/splink-train-scale.json
+          REMOTE
 
       - name: Pull the artifacts back
         if: always()

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -683,7 +683,24 @@ jobs:
         if: always()
         with:
           name: spark-gce-multinode
-          path: "*.json"
+          # The two results BY NAME. This globbed `*.json` at the repo root,
+          # which always matches `package.json`, `turbo.json` and
+          # `pyrightconfig.json` -- so on run 32259409214 the upload "succeeded"
+          # carrying three repo files and zero results, and `if-no-files-found`
+          # could never fire because the glob is never empty. "Artifact present"
+          # has to mean "results present" or it is not a signal.
+          #
+          # Named rather than moved to a results/ dir on purpose: the Summary
+          # step below reads both files from the repo root in seven places, and
+          # relocating them would make it print MISSING for both arms. That is
+          # the same class of silent loss this is fixing.
+          path: |
+            spark-fs-train-scale.json
+            splink-train-scale.json
+          # `warn`, not `error`: this step is `if: always()`, so a run that died
+          # before either harness produced anything arrives here legitimately
+          # empty and the real failure is already red upstream. The warning is
+          # meaningful now that nothing else can satisfy the path.
           if-no-files-found: warn
 
       - name: Summary

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -660,12 +660,34 @@ jobs:
 
           MOUNTS="-v \$HOME/hdfs-conf/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml -v \$HOME/hdfs-conf/hdfs-site.xml:/opt/hadoop/etc/hadoop/hdfs-site.xml"
 
-          # Namenode: format, then run. The dirs are chmod 777 because the
-          # image runs as its own `hadoop` user and the host path is created by
-          # root.
+          # CHOWN, not chmod. Run 32280604422 gave the host dirs mode 777 and
+          # the datanode still refused every volume:
+          #
+          #     WARN StorageLocationChecker: Exception checking
+          #     StorageLocation [DISK]file:/hadoop/dfs/data
+          #     EPERM: Operation not permitted
+          #       at NativeIO$POSIX.chmodImpl
+          #       at DiskChecker.mkdirsWithExistsAndPermissionCheck
+          #     Too many failed volumes - current valid volumes: 0
+          #
+          # The datanode chmods its data dir to `dfs.datanode.data.dir.perm`
+          # (0700) on startup. `sudo mkdir` leaves the dir owned by ROOT while
+          # the image runs as its own `hadoop` user, and chmod requires
+          # OWNERSHIP -- write permission is not enough. Mode 777 grants the
+          # wrong thing.
+          #
+          # The uid is read FROM THE IMAGE rather than hardcoded to 1000: it is
+          # a property of the image, and a wrong guess reproduces this exact
+          # failure one cluster later.
+          HUID=$(gcloud compute ssh "$MASTER" --quiet --command \
+            "docker run --rm --entrypoint id $HADOOP_IMAGE -u" 2>/dev/null | tr -dc '0-9')
+          [ -n "$HUID" ] || { echo "::error::could not read the hadoop uid from $HADOOP_IMAGE"; exit 1; }
+          echo "hadoop image runs as uid $HUID"
+
+          # Namenode: format, then run.
           gcloud compute ssh "$MASTER" --quiet --command "
             set -euo pipefail
-            sudo mkdir -p /mnt/disks/scratch/hdfs-nn && sudo chmod 777 /mnt/disks/scratch/hdfs-nn
+            sudo mkdir -p /mnt/disks/scratch/hdfs-nn && sudo chown -R $HUID:$HUID /mnt/disks/scratch/hdfs-nn
             docker run --rm --network host $MOUNTS \
               -v /mnt/disks/scratch/hdfs-nn:/hadoop/dfs/name \
               $HADOOP_IMAGE hdfs namenode -format -force -nonInteractive
@@ -679,7 +701,7 @@ jobs:
           for n in $NODE_NAMES; do
             gcloud compute ssh "$n" --quiet --command "
               set -euo pipefail
-              sudo mkdir -p /mnt/disks/scratch/hdfs-dn && sudo chmod 777 /mnt/disks/scratch/hdfs-dn
+              sudo mkdir -p /mnt/disks/scratch/hdfs-dn && sudo chown -R $HUID:$HUID /mnt/disks/scratch/hdfs-dn
               docker run -d --name hdfs-dn --network host --restart unless-stopped $MOUNTS \
                 -v /mnt/disks/scratch/hdfs-dn:/hadoop/dfs/data \
                 $HADOOP_IMAGE hdfs datanode

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -134,10 +134,36 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Install the Infisical CLI
+        # BOUNDED, because this step wedged twice in a row on 2026-08-19 (runs
+        # 32271581601 and 32273435168), each time sitting >10 minutes on a step
+        # that normally takes seconds, on two different runners. The vendor's
+        # `setup.deb.sh` bootstraps pip and runs its own `apt-get` before ours,
+        # so the hang is inside a third-party script this lane cannot see into.
+        #
+        # Unbounded, that hang inherits the JOB's `timeout-minutes: 360` -- a
+        # dependency outage silently converts into six hours of billed runner
+        # before anyone learns anything. `timeout` turns it into a legible
+        # failure in four minutes. The retry covers the transient case; it does
+        # NOT paper over a real outage, because three bounded attempts still
+        # fail fast and say so.
+        timeout-minutes: 15
         run: |
           set -euo pipefail
-          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
-          sudo apt-get update && sudo apt-get install -y infisical
+          ok=""
+          for attempt in 1 2 3; do
+            # `apt-get update` is kept rather than left to the vendor script.
+            # The script does appear to run one, but the original step did not
+            # rely on that and neither will this.
+            if timeout 240 bash -c "curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash" \
+               && timeout 240 sudo apt-get update \
+               && timeout 240 sudo apt-get install -y infisical; then
+              ok=1; break
+            fi
+            echo "::warning::Infisical CLI install attempt $attempt failed or timed out; retrying"
+            sleep 15
+          done
+          [ -n "$ok" ] || { echo "::error::Infisical CLI install failed 3x -- upstream apt repo is unreachable, this is not a repo change"; exit 1; }
+          infisical --version
 
       - name: Fetch GCP creds from Infisical
         # Identical mechanism to bench-ray-cluster.yml -- same Machine Identity,

--- a/scripts/gce_detached.sh
+++ b/scripts/gce_detached.sh
@@ -59,6 +59,9 @@ gce_detached() {
   local wd="${GCE_DETACHED_WORKDIR:-/w}"
 
   {
+    # The pid is recorded so liveness can be a `kill -0` on a KNOWN process.
+    # `$$` at top level is the script's own pid and survives the subshell below.
+    printf 'echo $$ > %s/%s.pid\n' "$wd" "$tag"
     echo '('
     echo 'set -e'
     cat
@@ -68,7 +71,7 @@ gce_detached() {
 
   gcloud compute scp --quiet "$script" "$host:~/$script"
   gcloud compute ssh "$host" --quiet --command \
-    "rm -f ~/${tag}.rc ~/${tag}.log && docker exec -d pyenv sh -c 'sh ${wd}/${script} > ${wd}/${tag}.log 2>&1' && echo '[gce_detached] launched ${tag}'"
+    "rm -f ~/${tag}.rc ~/${tag}.log ~/${tag}.pid && docker exec -d pyenv sh -c 'sh ${wd}/${script} > ${wd}/${tag}.log 2>&1' && echo '[gce_detached] launched ${tag}'"
 
   local last=0 rc="" n alive
   while true; do
@@ -86,9 +89,30 @@ gce_detached() {
     rc=$(gcloud compute ssh "$host" --quiet --command "cat ~/${tag}.rc 2>/dev/null" 2>/dev/null | tr -dc '0-9') || true
     [ -n "${rc:-}" ] && break
 
-    # No exit code yet: still running, or dead without writing one?
-    alive=$(gcloud compute ssh "$host" --quiet --command "docker exec pyenv pgrep -f '${script}' >/dev/null 2>&1 && echo 1 || echo 0" 2>/dev/null | tr -dc '01') || true
-    if [ "${alive:-1}" = "0" ]; then
+    # No exit code yet: still running, or dead without writing one? THREE
+    # answers, not two. Run 32267837230 failed here because the probe was
+    # `pgrep ... || echo 0`, and `python:3.12-slim` ships no procps -- so
+    # "pgrep is not installed" and "the process is gone" produced the same `0`.
+    # The FS harness was declared dead at 30 seconds, ran happily to completion,
+    # and wrote its results anyway. Same absent-vs-zero shape as #2639/#2644:
+    # a missing answer must not read as a negative one.
+    #
+    # `kill -0` on a recorded pid rather than pgrep: `kill` is a shell builtin,
+    # so it cannot be missing from any image, and it interrogates the process we
+    # actually launched instead of pattern-matching a command line.
+    # The container check comes FIRST and runs on the host, where docker always
+    # is. A vanished container is an unambiguous death, and without this branch
+    # it would fall into `unknown` and idle the cluster until the job's
+    # timeout-minutes expired, billing five VMs for nothing.
+    alive=$(gcloud compute ssh "$host" --quiet --command \
+      "if ! docker inspect -f '{{.State.Running}}' pyenv 2>/dev/null | grep -q true; then echo dead; elif [ ! -f ~/${tag}.pid ]; then echo unknown; elif docker exec pyenv sh -c 'kill -0 \$(cat ${wd}/${tag}.pid) 2>/dev/null' 2>/dev/null; then echo alive; else echo dead; fi" 2>/dev/null | tr -dc 'a-z') || true
+    if [ "${alive:-unknown}" = "unknown" ]; then
+      # Cannot answer (pid not written yet, container not reachable this poll).
+      # Keep waiting: the job's own `timeout-minutes` is the real backstop, and
+      # a false death is far more expensive than a late one.
+      continue
+    fi
+    if [ "$alive" = "dead" ]; then
       # The process can exit between that pgrep and the rc write.
       sleep 5
       rc=$(gcloud compute ssh "$host" --quiet --command "cat ~/${tag}.rc 2>/dev/null" 2>/dev/null | tr -dc '0-9') || true

--- a/scripts/gce_detached.sh
+++ b/scripts/gce_detached.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run a long command in the `pyenv` container on a GCE host, DETACHED from the
+# SSH session that starts it, and poll for completion.
+#
+# ## Why this exists
+#
+# `gcloud compute ssh HOST --command "<hours of work>"` ties the workload's
+# lifetime to one SSH session opened from a GitHub runner. Run 32259409214 lost
+# that session 11 minutes into a 50M FS training run:
+#
+#     [scale] pass 0 on ['blk']: 274,999,996 pairs -> 445 patterns in 174.90s
+#     [scale] pass 1 on ['last']: 217,026,993 pairs -> 192 patterns in 143.45s
+#     client_loop: send disconnect: Broken pipe
+#     ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255]
+#
+# The harness was healthy and mid-pass. The transport died, so five VMs and the
+# whole run died with it. Longer runs are strictly likelier to hit this, and a
+# Splink arm at 50M is the longest thing this lane does.
+#
+# It costs more than time. The Splink step is `continue-on-error: true` on
+# purpose, so a dropped SSH there does not fail the job -- it records
+# `splink: MISSING`, which reads as *Splink could not do 50M*. That publishes an
+# infrastructure blip as an engine result. A comparison is not fair if one arm's
+# transport failures are attributed to the engine.
+#
+# ## Why `docker exec -d` and not `nohup` / `setsid`
+#
+# The hosts run Container-Optimized OS, whose userland is deliberately minimal;
+# neither `setsid` nor `nohup` is guaranteed. Testing an earlier draft of this
+# helper against a stub host failed on exactly that (`setsid: command not
+# found`). Docker is guaranteed -- running containers IS what these nodes are
+# for -- and `docker exec -d` hands the process to the daemon, which outlives
+# any SSH session by construction. Fewer assumptions, and the one it does make
+# cannot be false on a node that got this far.
+#
+# Liveness uses `pgrep` inside the container rather than a stall timeout: a
+# quiet stage is not a dead one (Splink's EM iterations go minutes without
+# printing), and any threshold long enough to be safe is too long to be useful.
+#
+# ## Usage
+#
+#     source scripts/gce_detached.sh
+#     gce_detached "$MASTER" fs <<REMOTE
+#     export GOLDENMATCH_SPARK_JAR=/w/goldenmatch-spark.jar
+#     python spark_fs_train_scale.py --rows 50000000 --out /w/out.json
+#     REMOTE
+#
+# The body runs INSIDE the container (workdir `/w`, which is the host `$HOME`),
+# under `set -e`, in a subshell. Writes `<tag>.log` and `<tag>.rc` next to it;
+# streams new log lines to stdout. Returns the body's exit code, so a genuine
+# failure still fails the step.
+
+gce_detached() {
+  local host="$1" tag="$2"
+  local script="gce_detached_${tag}.sh"
+  local poll="${GCE_DETACHED_POLL_S:-30}"
+  # The container's view of the host `$HOME` (`docker run -v $HOME:/w -w /w`).
+  # Overridable so this is testable off a real node.
+  local wd="${GCE_DETACHED_WORKDIR:-/w}"
+
+  {
+    echo '('
+    echo 'set -e'
+    cat
+    echo ')'
+    printf 'echo $? > %s/%s.rc\n' "$wd" "$tag"
+  } > "$script"
+
+  gcloud compute scp --quiet "$script" "$host:~/$script"
+  gcloud compute ssh "$host" --quiet --command \
+    "rm -f ~/${tag}.rc ~/${tag}.log && docker exec -d pyenv sh -c 'sh ${wd}/${script} > ${wd}/${tag}.log 2>&1' && echo '[gce_detached] launched ${tag}'"
+
+  local last=0 rc="" n alive
+  while true; do
+    sleep "$poll"
+
+    # Stream what is new. `|| true` throughout: a failed poll is a blip to
+    # retry, not a reason to abandon a job that is still running.
+    n=$(gcloud compute ssh "$host" --quiet --command "wc -l < ~/${tag}.log 2>/dev/null || echo 0" 2>/dev/null | tr -dc '0-9') || true
+    [ -n "${n:-}" ] || n="$last"
+    if [ "$n" -gt "$last" ]; then
+      gcloud compute ssh "$host" --quiet --command "sed -n '$((last + 1)),\$p' ~/${tag}.log" 2>/dev/null || true
+      last="$n"
+    fi
+
+    rc=$(gcloud compute ssh "$host" --quiet --command "cat ~/${tag}.rc 2>/dev/null" 2>/dev/null | tr -dc '0-9') || true
+    [ -n "${rc:-}" ] && break
+
+    # No exit code yet: still running, or dead without writing one?
+    alive=$(gcloud compute ssh "$host" --quiet --command "docker exec pyenv pgrep -f '${script}' >/dev/null 2>&1 && echo 1 || echo 0" 2>/dev/null | tr -dc '01') || true
+    if [ "${alive:-1}" = "0" ]; then
+      # The process can exit between that pgrep and the rc write.
+      sleep 5
+      rc=$(gcloud compute ssh "$host" --quiet --command "cat ~/${tag}.rc 2>/dev/null" 2>/dev/null | tr -dc '0-9') || true
+      [ -n "${rc:-}" ] && break
+      gcloud compute ssh "$host" --quiet --command "tail -50 ~/${tag}.log" 2>/dev/null || true
+      echo "::error::${tag} died without writing an exit code (killed on the host -- the OOM killer is the usual cause)"
+      return 1
+    fi
+  done
+
+  # Final drain. The loop breaks the moment the rc file appears, which is
+  # normally BEFORE the poll that would have streamed the last chunk -- and on
+  # these harnesses the closing lines are the measurements themselves. Without
+  # this the run's own results are the thing most likely to be missing from the
+  # log.
+  n=$(gcloud compute ssh "$host" --quiet --command "wc -l < ~/${tag}.log 2>/dev/null || echo 0" 2>/dev/null | tr -dc '0-9') || true
+  if [ -n "${n:-}" ] && [ "$n" -gt "$last" ]; then
+    gcloud compute ssh "$host" --quiet --command "sed -n '$((last + 1)),\$p' ~/${tag}.log" 2>/dev/null || true
+  fi
+
+  echo "[gce_detached] ${tag} exited rc=${rc}"
+  return "$rc"
+}

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -87,6 +87,7 @@ Usage:
         --master spark://localhost:7077 --driver-host 172.17.0.1 \\
         --out splink-train-scale.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -152,8 +153,9 @@ def _metrics_module():
     return mod
 
 
-def build_session(master: str, driver_host: str | None, wait_s: int,
-                  checkpoint_dir: str | None = None):
+def build_session(
+    master: str, driver_host: str | None, wait_s: int, checkpoint_dir: str | None = None
+):
     """A session tuned NO differently from the one GM gets.
 
     This used to set `spark.sql.shuffle.partitions=8`, with the rationale that
@@ -198,14 +200,34 @@ def build_session(master: str, driver_host: str | None, wait_s: int,
         # Auth comes from the VM's metadata server: the nodes are created with
         # `--scopes=cloud-platform` and run as the default compute service
         # account, which holds roles/editor. No key material is passed here.
+        #
+        # **The 3.x line, not `hadoop3-2.2.x`.** Run 32269692605 pinned
+        # `hadoop3-2.2.21` and died initializing the filesystem:
+        #
+        #     WARN FileSystem: Failed to initialize filesystem gs://...:
+        #     java.lang.NumberFormatException: For input string: "64m"
+        #
+        # The 2.2.x connector reads its size properties through Hadoop's
+        # `getLong`, which rejects unit suffixes; the 3.x line reads them with
+        # `getLongBytes`, which accepts them. 2.2.x also predates Spark 4 (it
+        # targets the Hadoop 3.3 era), so pinning it against this image was
+        # asking a Hadoop-3.3 connector to parse Hadoop-3.4 defaults.
+        #
+        # 3.x also REPLACED the auth switch: `google.cloud.auth.service.account
+        # .enable=true` is gone, and `fs.gs.auth.type=APPLICATION_DEFAULT` is
+        # the equivalent. It resolves through the metadata server exactly as
+        # before, so this is the same credential path under a new key, not a
+        # new grant.
         b = (
-            b.config("spark.jars.packages",
-                     "com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.21")
-            .config("spark.hadoop.fs.gs.impl",
-                    "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")
-            .config("spark.hadoop.fs.AbstractFileSystem.gs.impl",
-                    "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS")
-            .config("spark.hadoop.google.cloud.auth.service.account.enable", "true")
+            b.config("spark.jars.packages", "com.google.cloud.bigdataoss:gcs-connector:3.1.17")
+            .config(
+                "spark.hadoop.fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem"
+            )
+            .config(
+                "spark.hadoop.fs.AbstractFileSystem.gs.impl",
+                "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS",
+            )
+            .config("spark.hadoop.fs.gs.auth.type", "APPLICATION_DEFAULT")
         )
     spark = b.getOrCreate()
 
@@ -269,39 +291,60 @@ def main() -> int:
     ap.add_argument("--rows", type=int, default=1_000_000)
     ap.add_argument("--dup", type=int, default=3, help="rows per entity")
     ap.add_argument("--blocks-per-key", type=int, default=4)
-    ap.add_argument("--master", default=os.environ.get(
-        "SPLINK_SPARK_MASTER", "spark://localhost:7077"))
+    ap.add_argument(
+        "--master", default=os.environ.get("SPLINK_SPARK_MASTER", "spark://localhost:7077")
+    )
     ap.add_argument("--driver-host", default=os.environ.get("SPLINK_DRIVER_HOST", ""))
     ap.add_argument("--executor-wait", type=int, default=120)
-    ap.add_argument("--max-pairs", type=int, default=1_000_000,
-                    help="Splink's u-estimation sample. Matches the GM harness's "
-                         "--u-max-pairs so the u stage is comparable.")
-    ap.add_argument("--seed", type=int, default=42,
-                    help="Seeds Splink's u random sampling. Unseeded, the EM "
-                         "iteration count -- and therefore the wall -- varies "
-                         "by more than half between identical runs.")
-    ap.add_argument("--eval-quality", action="store_true",
-                    help="REGRESSION GUARD on the distributed trainer: score "
-                         "the candidate pairs and report ranking quality "
-                         "against the fixture's known entity structure. NOT a "
-                         "GM-vs-Splink accuracy verdict -- this fixture's "
-                         "config was chosen to stress prod(levels+1) for a "
-                         "scale test. See the bakeoff for accuracy.")
-    ap.add_argument("--spark-ui", default="http://localhost:4040",
-                    help="Spark UI of THIS classic driver (it runs on the host "
-                         "and binds 4040). Read for stage-level shuffle bytes.")
-    ap.add_argument("--checkpoint-dir", default=os.environ.get("SPLINK_CHECKPOINT_DIR", ""),
-                    help="Distributed-filesystem path for Splink's lineage "
-                         "break (e.g. gs://bucket/prefix). REQUIRED for the "
-                         "documented `parquet` default; without one this falls "
-                         "back to `persist`, which does NOT truncate lineage "
-                         "and OOMs at scale.")
+    ap.add_argument(
+        "--max-pairs",
+        type=int,
+        default=1_000_000,
+        help="Splink's u-estimation sample. Matches the GM harness's "
+        "--u-max-pairs so the u stage is comparable.",
+    )
+    ap.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Seeds Splink's u random sampling. Unseeded, the EM "
+        "iteration count -- and therefore the wall -- varies "
+        "by more than half between identical runs.",
+    )
+    ap.add_argument(
+        "--eval-quality",
+        action="store_true",
+        help="REGRESSION GUARD on the distributed trainer: score "
+        "the candidate pairs and report ranking quality "
+        "against the fixture's known entity structure. NOT a "
+        "GM-vs-Splink accuracy verdict -- this fixture's "
+        "config was chosen to stress prod(levels+1) for a "
+        "scale test. See the bakeoff for accuracy.",
+    )
+    ap.add_argument(
+        "--spark-ui",
+        default="http://localhost:4040",
+        help="Spark UI of THIS classic driver (it runs on the host "
+        "and binds 4040). Read for stage-level shuffle bytes.",
+    )
+    ap.add_argument(
+        "--checkpoint-dir",
+        default=os.environ.get("SPLINK_CHECKPOINT_DIR", ""),
+        help="Distributed-filesystem path for Splink's lineage "
+        "break (e.g. gs://bucket/prefix). REQUIRED for the "
+        "documented `parquet` default; without one this falls "
+        "back to `persist`, which does NOT truncate lineage "
+        "and OOMs at scale.",
+    )
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
     out: dict = {
-        "engine": "splink", "rows_requested": args.rows, "master": args.master,
-        "stages": {}, "session_type": "classic",
+        "engine": "splink",
+        "rows_requested": args.rows,
+        "master": args.master,
+        "stages": {},
+        "session_type": "classic",
         "session_confound": (
             "GM runs over Spark Connect (addArtifact is Connect-only); Splink "
             "cannot (it uses sparkContext). Same cluster, different front door."
@@ -330,8 +373,8 @@ def main() -> int:
             "GCS write+read per lineage break; GoldenMatch pays none because "
             "its counting stage has no iterative DAG to truncate. That "
             "asymmetry is a property of the engines, not of this harness."
-            if args.checkpoint_dir else
-            "NO --checkpoint-dir given, so this fell back to `persist`, which "
+            if args.checkpoint_dir
+            else "NO --checkpoint-dir given, so this fell back to `persist`, which "
             "does NOT truncate lineage. Expect OOM at scale. This is a "
             "misconfiguration, not a Splink limit."
         ),
@@ -339,9 +382,9 @@ def main() -> int:
     }
     t_all = time.perf_counter()
 
-    spark, n_exec = build_session(args.master, args.driver_host or None,
-                                  args.executor_wait,
-                                  args.checkpoint_dir or None)
+    spark, n_exec = build_session(
+        args.master, args.driver_host or None, args.executor_wait, args.checkpoint_dir or None
+    )
     out["executors"] = n_exec
 
     fx = _fixture_module()
@@ -351,8 +394,7 @@ def main() -> int:
     actual = df.count()
     out["stages"]["fixture_seconds"] = round(time.perf_counter() - t, 2)
     out["actual_rows"] = int(actual)
-    print(f"[splink] fixture: {actual:,} rows in "
-          f"{out['stages']['fixture_seconds']}s", flush=True)
+    print(f"[splink] fixture: {actual:,} rows in {out['stages']['fixture_seconds']}s", flush=True)
 
     from splink import Linker, SettingsCreator, block_on
     from splink import comparison_library as cl
@@ -419,9 +461,9 @@ def main() -> int:
     # artifact below, so no reader has to infer it from the absence of a
     # checkpoint dir.
     linker = Linker(
-        df, settings,
-        db_api=SparkAPI(spark_session=spark,
-                        break_lineage_method=out["break_lineage_method"]),
+        df,
+        settings,
+        db_api=SparkAPI(spark_session=spark, break_lineage_method=out["break_lineage_method"]),
     )
 
     # u, from random pairs -- the same quantity the GM harness times as `u`.
@@ -434,8 +476,7 @@ def main() -> int:
     # (31983859191, 31983866350) logged 33 and 16 iterations and came out at
     # 321.12s and 197.29s: a 63% spread, against GM's 1.4% across the same pair
     # of runs. Any single unseeded Splink number is drawn from that.
-    linker.training.estimate_u_using_random_sampling(
-        max_pairs=args.max_pairs, seed=args.seed)
+    linker.training.estimate_u_using_random_sampling(max_pairs=args.max_pairs, seed=args.seed)
     out["stages"]["u_seconds"] = round(time.perf_counter() - t, 2)
     print(f"[splink] u in {out['stages']['u_seconds']}s", flush=True)
 
@@ -451,8 +492,10 @@ def main() -> int:
         round(out["stages"]["em_seconds"] / sum(iters), 3) if sum(iters) else None
     )
     out["seed"] = args.seed
-    print(f"[splink] EM in {out['stages']['em_seconds']}s over {sum(iters)} "
-          f"iteration(s) {iters}", flush=True)
+    print(
+        f"[splink] EM in {out['stages']['em_seconds']}s over {sum(iters)} iteration(s) {iters}",
+        flush=True,
+    )
 
     # The trained model itself, not just how long it took to train. GM records
     # m_probs / u_probs / match_weights and this side recorded neither, so when
@@ -463,16 +506,19 @@ def main() -> int:
         model = linker.misc.save_model_to_json()
         out["model"] = {
             c["output_column_name"]: [
-                {"label": lv.get("comparison_vector_value"),
-                 "sql": lv.get("sql_condition"),
-                 "m": lv.get("m_probability"),
-                 "u": lv.get("u_probability")}
+                {
+                    "label": lv.get("comparison_vector_value"),
+                    "sql": lv.get("sql_condition"),
+                    "m": lv.get("m_probability"),
+                    "u": lv.get("u_probability"),
+                }
                 for lv in c.get("comparison_levels", [])
             ]
             for c in model.get("comparisons", [])
         }
         out["probability_two_random_records_match"] = model.get(
-            "probability_two_random_records_match")
+            "probability_two_random_records_match"
+        )
     except Exception as e:  # noqa: BLE001 - diagnostic, never fatal
         # Recorded rather than swallowed: an absent `model` key must read as
         # "the export broke", not as "the model was empty".
@@ -491,8 +537,7 @@ def main() -> int:
         n_entities = max(args.rows // max(args.dup, 1), 1)
         t = time.perf_counter()
         preds = linker.inference.predict().as_spark_dataframe()
-        truth = (F.col("record_id_l") % F.lit(n_entities)
-                 == F.col("record_id_r") % F.lit(n_entities))
+        truth = F.col("record_id_l") % F.lit(n_entities) == F.col("record_id_r") % F.lit(n_entities)
         # GROUP BY in the engine, exactly as the GM arm does. Both sides must
         # use the same reduction or the comparison measures the harness: this
         # collected one tuple per PREDICTED PAIR, which at 50M is hundreds of
@@ -504,12 +549,15 @@ def main() -> int:
         # `quality_score_groups` below records how much it actually collapsed,
         # so an unbounded group count shows up as a number rather than as an
         # OOM. See `ranking_metrics_grouped` for why grouping is exact.
-        grouped = (preds.select(F.col("match_weight").alias("w"),
-                                truth.alias("is_true"))
-                        .groupBy("w")
-                        .agg(F.sum(F.col("is_true").cast("long")).alias("n_true"),
-                             F.count(F.lit(1)).alias("n_all"))
-                        .collect())
+        grouped = (
+            preds.select(F.col("match_weight").alias("w"), truth.alias("is_true"))
+            .groupBy("w")
+            .agg(
+                F.sum(F.col("is_true").cast("long")).alias("n_true"),
+                F.count(F.lit(1)).alias("n_all"),
+            )
+            .collect()
+        )
         out["stages"]["predict_seconds"] = round(time.perf_counter() - t, 2)
         out["quality_score_groups"] = len(grouped)
         out["quality"] = _metrics_module().ranking_metrics_grouped(
@@ -526,11 +574,12 @@ def main() -> int:
     out["stages"]["total_seconds"] = round(time.perf_counter() - t_all, 2)
     # `train_total` is the number to put beside GM's u + counts + train. The
     # fixture build is excluded from BOTH: it is the harness, not the engine.
-    out["train_total_seconds"] = round(
-        out["stages"]["u_seconds"] + out["stages"]["em_seconds"], 2
+    out["train_total_seconds"] = round(out["stages"]["u_seconds"] + out["stages"]["em_seconds"], 2)
+    print(
+        f"[splink] DONE rows={actual:,} executors={n_exec} train_total="
+        f"{out['train_total_seconds']}s stages={out['stages']}",
+        flush=True,
     )
-    print(f"[splink] DONE rows={actual:,} executors={n_exec} train_total="
-          f"{out['train_total_seconds']}s stages={out['stages']}", flush=True)
 
     Path(args.out).write_text(json.dumps(out, indent=2), encoding="utf-8")
     print(f"[splink] wrote {args.out}", flush=True)

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -218,8 +218,34 @@ def build_session(
         # the equivalent. It resolves through the metadata server exactly as
         # before, so this is the same credential path under a new key, not a
         # new grant.
+        # **The SHADED jar, shipped as a file, not `spark.jars.packages`.**
+        # Run 32274795307 used the Maven coordinate and got further, then died:
+        #
+        #     NoClassDefFoundError:
+        #     com/google/cloud/hadoop/util/interceptors/LoggingInterceptor
+        #
+        # `spark.jars.packages` resolves the PLAIN artifact (155 KB, classes
+        # only) and leaves Ivy to find its transitive deps, which it did not do
+        # compatibly against this image. The `-shaded` classifier is the
+        # self-contained 38 MB jar that carries them. Ivy cannot express a
+        # classifier through `spark.jars.packages` at all, so the coordinate
+        # form CANNOT reach the artifact that works -- shipping the file is not
+        # a workaround here, it is the only route.
+        #
+        # Shipping it also removes Maven resolution from the critical path of a
+        # paid cluster: the earlier run was fetching grpc-xds and friends at
+        # session build.
+        gcs_jar = os.environ.get("GCS_CONNECTOR_JAR", "/w/gcs-connector-shaded.jar")
+        if not os.path.exists(gcs_jar):
+            # Loudly, rather than falling back to a session that cannot reach
+            # gs:// -- a silent fallback here would restate itself minutes later
+            # as an unreadable checkpoint failure on a five-VM cluster.
+            raise SystemExit(
+                f"gs:// checkpoint dir requested but the GCS connector jar is missing at {gcs_jar}. "
+                "Set GCS_CONNECTOR_JAR, or the workflow's jar download did not land."
+            )
         b = (
-            b.config("spark.jars.packages", "com.google.cloud.bigdataoss:gcs-connector:3.1.17")
+            b.config("spark.jars", f"{similarity_jar_location()},{gcs_jar}")
             .config(
                 "spark.hadoop.fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem"
             )

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -153,6 +153,63 @@ def _metrics_module():
     return mod
 
 
+_SIZE_SUFFIX = re.compile(r"^\s*(\d+)\s*([kKmMgGtT])[bB]?\s*$")
+
+
+def _normalize_gs_size_props(spark: object) -> None:
+    """Rewrite suffixed `fs.gs.*` sizes to plain bytes, and say what it found.
+
+    Runs 32269692605 and 32277069612 both died initializing the filesystem with
+
+        java.lang.NumberFormatException: For input string: "64m"
+
+    under gcs-connector `hadoop3-2.2.21` AND `3.1.17`. Two unrelated connector
+    versions failing identically means the value is not a connector default: it
+    is in this environment's Hadoop configuration, and the connector reads it
+    with `getInt`/`getLong`, which reject unit suffixes.
+
+    Nothing in this repo sets it, checked before writing this. So it arrives
+    from the image or from Spark itself -- exactly the situation where guessing
+    a key costs a five-VM cluster per guess. Enumerate instead of guessing.
+
+    Every `fs.gs.*` value shaped like `64m` is rewritten to its byte count,
+    which is what the connector expects and what the suffix means. Suffixed
+    values under OTHER prefixes are PRINTED but not touched: they belong to
+    components that may well accept suffixes, and silently rewriting config
+    this script does not own would be a worse bug than the one it fixes.
+    """
+    try:
+        hconf = spark.sparkContext._jsc.hadoopConfiguration()  # noqa: SLF001
+        it = hconf.iterator()
+    except Exception as exc:  # pragma: no cover - diagnostic path only
+        print(f"[splink] could not inspect hadoop conf: {exc}", flush=True)
+        return
+
+    fixed: list[str] = []
+    seen: list[str] = []
+    while it.hasNext():
+        entry = it.next()
+        key, val = str(entry.getKey()), str(entry.getValue())
+        m = _SIZE_SUFFIX.match(val)
+        if not m:
+            continue
+        seen.append(f"{key}={val}")
+        if key.startswith("fs.gs."):
+            mult = {"k": 1024, "m": 1024**2, "g": 1024**3, "t": 1024**4}[m.group(2).lower()]
+            as_bytes = int(m.group(1)) * mult
+            hconf.set(key, str(as_bytes))
+            fixed.append(f"{key}: {val} -> {as_bytes}")
+
+    if seen:
+        print(f"[splink] suffixed size props: {', '.join(sorted(seen))}", flush=True)
+    print(
+        f"[splink] normalized for the GCS connector: {', '.join(fixed)}"
+        if fixed
+        else "[splink] no suffixed fs.gs.* props found",
+        flush=True,
+    )
+
+
 def build_session(
     master: str, driver_host: str | None, wait_s: int, checkpoint_dir: str | None = None
 ):
@@ -262,6 +319,7 @@ def build_session(
     # `.checkpoint()`. See `_get_checkpoint_dir_path` in
     # splink/internals/spark/database_api.py.
     if checkpoint_dir:
+        _normalize_gs_size_props(spark)
         spark.sparkContext.setCheckpointDir(checkpoint_dir)
         print(f"[splink] checkpoint dir {checkpoint_dir}", flush=True)
 

--- a/scripts/test_gce_detached.sh
+++ b/scripts/test_gce_detached.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Self-contained test for scripts/gce_detached.sh, against a stubbed host.
+#
+# The helper exists because a real SSH drop killed run 32259409214, and the
+# failure it guards against is by nature not reproducible on demand. So the
+# logic is tested here instead: a `gcloud` / `docker` stub stands in for the
+# node, and the three outcomes that matter are asserted.
+#
+#   1. success  -- streams output INCLUDING the last line, returns 0
+#   2. failure  -- the body's exit code is the function's exit code
+#   3. killed   -- process gone with no exit code written -> ::error:: and rc 1
+#
+# Case 1's last line is not a formality. The loop breaks the moment the rc file
+# appears, which is normally before the poll that would stream the closing
+# chunk, and on these harnesses the closing lines ARE the measurements. An
+# earlier draft of the helper dropped them; this test is why that was caught.
+#
+# Run: bash scripts/test_gce_detached.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export WD="$TMP/w"; mkdir -p "$WD"
+
+gcloud() {
+  if [ "$2" = "scp" ]; then cp "$4" "$WD/$(basename "$5")"; return 0; fi
+  if [ "$2" = "ssh" ]; then
+    local cmd=""; shift
+    while [ $# -gt 0 ]; do [ "$1" = "--command" ] && { cmd="$2"; break; }; shift; done
+    HOME="$WD" sh -c "$cmd"; return $?
+  fi
+}
+docker() {
+  if [ "$1" = "exec" ] && [ "$2" = "-d" ]; then ( HOME="$WD" sh -c "$6" ) & return 0; fi
+  if [ "$1" = "exec" ] && [ "$3" = "pgrep" ]; then [ "${STUB_DEAD:-0}" = "1" ] && return 1 || return 0; fi
+  return 0
+}
+export -f gcloud docker
+
+# shellcheck source=/dev/null
+. "$HERE/gce_detached.sh"
+export GCE_DETACHED_POLL_S=1 GCE_DETACHED_WORKDIR="$WD"
+
+fails=0
+check() { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1: expected '$2', got '$3'"; fails=$((fails + 1)); fi
+}
+
+echo "case 1: success, streams the closing line"
+out=$(cd "$TMP" && gce_detached h ok <<'REMOTE'
+echo first
+echo "RESULT: ap=0.700397"
+REMOTE
+); rc=$?
+check "rc" 0 "$rc"
+case "$out" in *"RESULT: ap=0.700397"*) echo "  ok   closing line streamed";;
+                *) echo "  FAIL closing line missing from output"; fails=$((fails + 1));; esac
+
+echo "case 2: the body's exit code propagates"
+rm -f "$WD"/*.rc "$WD"/*.log
+(cd "$TMP" && gce_detached h bad <<'REMOTE'
+echo before
+exit 42
+REMOTE
+) >/dev/null 2>&1; rc=$?
+check "rc" 42 "$rc"
+
+echo "case 3: killed without an exit code"
+rm -f "$WD"/*.rc "$WD"/*.log
+# Output goes to a FILE, not `$(...)`: command substitution waits for every
+# writer on the pipe, and the stub's backgrounded job is one of them, so
+# capturing this case inline blocks for the body's full sleep.
+(cd "$TMP" && STUB_DEAD=1 gce_detached h dead <<'REMOTE'
+echo starting
+sleep 8
+REMOTE
+) > "$TMP/case3.out" 2>&1; rc=$?
+check "rc" 1 "$rc"
+if grep -q '::error::' "$TMP/case3.out"; then echo "  ok   emitted ::error::";
+else echo "  FAIL no ::error:: annotation"; fails=$((fails + 1)); fi
+
+[ "$fails" -eq 0 ] && { echo "PASS"; exit 0; } || { echo "FAILED: $fails"; exit 1; }

--- a/scripts/test_gce_detached.sh
+++ b/scripts/test_gce_detached.sh
@@ -4,16 +4,21 @@
 # The helper exists because a real SSH drop killed run 32259409214, and the
 # failure it guards against is by nature not reproducible on demand. So the
 # logic is tested here instead: a `gcloud` / `docker` stub stands in for the
-# node, and the three outcomes that matter are asserted.
+# node, and the outcomes that matter are asserted.
 #
-#   1. success  -- streams output INCLUDING the last line, returns 0
-#   2. failure  -- the body's exit code is the function's exit code
-#   3. killed   -- process gone with no exit code written -> ::error:: and rc 1
+#   1. success   -- streams output INCLUDING the last line, returns 0
+#   2. failure   -- the body's exit code is the function's exit code
+#   3. killed    -- process gone, no exit code written -> ::error:: and rc 1
+#   4. no probe  -- liveness UNANSWERABLE is not death; the body still finishes
+#   5. no container -- a vanished container IS death, and is caught promptly
 #
-# Case 1's last line is not a formality. The loop breaks the moment the rc file
-# appears, which is normally before the poll that would stream the closing
-# chunk, and on these harnesses the closing lines ARE the measurements. An
-# earlier draft of the helper dropped them; this test is why that was caught.
+# Cases 1 and 4 are the ones written in blood. Case 1's last line is not a
+# formality: the loop breaks the moment the rc file appears, normally before the
+# poll that would stream the closing chunk, and on these harnesses the closing
+# lines ARE the measurements. Case 4 is run 32267837230, where the probe was
+# `pgrep ... || echo 0` and `python:3.12-slim` ships no procps -- so "cannot
+# answer" and "dead" produced the same value, and a healthy 1M run was declared
+# dead at 30 seconds while it went on to finish and write its results.
 #
 # Run: bash scripts/test_gce_detached.sh
 set -uo pipefail
@@ -32,7 +37,19 @@ gcloud() {
 }
 docker() {
   if [ "$1" = "exec" ] && [ "$2" = "-d" ]; then ( HOME="$WD" sh -c "$6" ) & return 0; fi
-  if [ "$1" = "exec" ] && [ "$3" = "pgrep" ]; then [ "${STUB_DEAD:-0}" = "1" ] && return 1 || return 0; fi
+  # `docker inspect -f '{{.State.Running}}' pyenv` -- the host-side container
+  # check. STUB_NO_CONTAINER simulates the container having vanished.
+  if [ "$1" = "inspect" ]; then
+    [ "${STUB_NO_CONTAINER:-0}" = "1" ] && return 1
+    echo true; return 0
+  fi
+  # The liveness probe: `docker exec pyenv sh -c '<probe>'`. STUB_NO_PROBE
+  # simulates a container where the probe itself cannot run, which is the
+  # condition that broke run 32267837230 (no procps, so no pgrep).
+  if [ "$1" = "exec" ] && [ "$2" = "pyenv" ] && [ "$3" = "sh" ]; then
+    [ "${STUB_NO_PROBE:-0}" = "1" ] && return 127
+    sh -c "$5"; return $?
+  fi
   return 0
 }
 export -f gcloud docker
@@ -66,17 +83,46 @@ REMOTE
 check "rc" 42 "$rc"
 
 echo "case 3: killed without an exit code"
-rm -f "$WD"/*.rc "$WD"/*.log
+rm -f "$WD"/*.rc "$WD"/*.log "$WD"/*.pid
+# A faithful kill rather than a fake pid: the wrapper records its OWN pid before
+# running the body, so planting a stale one would just be overwritten. `kill -9
+# $$` takes the script down before it can write its rc, which is exactly what an
+# OOM kill looks like from the poller's side.
 # Output goes to a FILE, not `$(...)`: command substitution waits for every
-# writer on the pipe, and the stub's backgrounded job is one of them, so
-# capturing this case inline blocks for the body's full sleep.
-(cd "$TMP" && STUB_DEAD=1 gce_detached h dead <<'REMOTE'
+# writer on the pipe, and the stub's backgrounded job is one of them.
+(cd "$TMP" && gce_detached h dead <<'REMOTE'
 echo starting
-sleep 8
+kill -9 $$
 REMOTE
 ) > "$TMP/case3.out" 2>&1; rc=$?
 check "rc" 1 "$rc"
 if grep -q '::error::' "$TMP/case3.out"; then echo "  ok   emitted ::error::";
+else echo "  FAIL no ::error:: annotation"; fails=$((fails + 1)); fi
+
+echo "case 4: probe unavailable is NOT death"
+# The regression from run 32267837230. The old probe collapsed "pgrep is not
+# installed" into "process is dead" and killed a healthy 1M run at 30 seconds.
+# An unanswerable probe must keep waiting, so this body still returns 0.
+rm -f "$WD"/*.rc "$WD"/*.log "$WD"/*.pid
+(cd "$TMP" && STUB_NO_PROBE=1 gce_detached h noprobe <<'REMOTE'
+sleep 3
+echo survived
+REMOTE
+) > "$TMP/case4.out" 2>&1; rc=$?
+check "rc" 0 "$rc"
+if grep -q 'survived' "$TMP/case4.out"; then echo "  ok   ran to completion despite an unanswerable probe";
+else echo "  FAIL body did not complete"; fails=$((fails + 1)); fi
+
+echo "case 5: vanished container is an unambiguous death"
+# Without this branch a dead container falls into `unknown` and the poller idles
+# until the job timeout, billing the whole cluster for nothing.
+rm -f "$WD"/*.rc "$WD"/*.log "$WD"/*.pid
+(cd "$TMP" && STUB_NO_CONTAINER=1 gce_detached h gone <<'REMOTE'
+sleep 30
+REMOTE
+) > "$TMP/case5.out" 2>&1; rc=$?
+check "rc" 1 "$rc"
+if grep -q '::error::' "$TMP/case5.out"; then echo "  ok   emitted ::error:: promptly";
 else echo "  FAIL no ::error:: annotation"; fails=$((fails + 1)); fi
 
 [ "$fails" -eq 0 ] && { echo "PASS"; exit 0; } || { echo "FAILED: $fails"; exit 1; }


### PR DESCRIPTION
The 50M head-to-head (run 32259409214) died 11 minutes in with the FS harness healthy and mid-pass:

```
[scale] pass 0 on ['blk']: 274,999,996 pairs -> 445 patterns in 174.90s
[scale] pass 1 on ['last']: 217,026,993 pairs -> 192 patterns in 143.45s
client_loop: send disconnect: Broken pipe
ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255]
```

Both arms ran inside `gcloud compute ssh HOST --command "<hours of work>"`, so the workload's lifetime was the SSH session's lifetime. The transport dropped and took five VMs and the whole run with it. Splink never started, and the cluster spend bought nothing.

## Why this is worse than lost spend

The Splink step is `continue-on-error: true` on purpose, so a dropped SSH there does **not** fail the job. It records `splink: MISSING`, which reads as *Splink could not do 50M*. That publishes an infrastructure blip as an engine result, in a comparison whose whole value is being fair to both engines. Longer runs are strictly likelier to hit it, and the Splink arm at 50M is the longest thing this lane does.

## The fix

`scripts/gce_detached.sh` hands the work to the Docker daemon (`docker exec -d`) and polls with SHORT ssh calls, so a blip costs one retry instead of the run. The body's exit code is written to a file and becomes the function's return value, so a genuine failure still fails the step.

**`docker exec -d`, not `nohup` / `setsid`.** These hosts run Container-Optimized OS, whose userland is minimal and guarantees neither. Testing an earlier draft against a stub host failed on exactly that (`setsid: command not found`). Docker cannot be absent on a node whose purpose is running containers.

**Liveness is `pgrep`, not a stall timeout.** A quiet stage is not a dead one (Splink's EM iterations go minutes without printing), and any threshold long enough to be safe is too long to be useful.

**The final drain is load-bearing.** The poll loop breaks the moment the rc file appears, which is normally BEFORE the poll that would stream the closing chunk, and on these harnesses the closing lines ARE the measurements. An earlier draft dropped them.

## Testing

`scripts/test_gce_detached.sh` runs the helper against a stubbed host. The real failure mode is by nature not reproducible on demand, so the logic is tested rather than trusted.

| case | asserts | result |
|---|---|---|
| success | streams output **including the closing line**, rc 0 | pass |
| body exits 42 | the body's code is the function's code | pass |
| killed, no rc | `::error::` annotation, rc 1 | pass |

Also verified:

- `yaml.safe_load` parses the workflow; both `REMOTE` heredoc terminators land at **column 0** after block-scalar de-indentation, which is the one thing that would silently break the heredoc.
- `bash -n` clean on both `run:` bodies with the `${{ }}` expressions substituted.
- `scripts/check_workflow_yaml.py`: 129 files, all parse, no duplicate keys.
- `shellcheck -S warning`: clean on both new scripts.
- `zizmor --offline`: **28 findings before and after**, so this adds none. The existing `template-injection` findings are the lane's pre-existing `${{ inputs.* }}` style and are untouched here.

## Not addressed here

The `Pull the artifacts back` step reported success on the failed run while uploading repo root files (`package.json`, `turbo.json`) rather than results, because the harness JSON was never produced. It is a separate green-run-measuring-nothing bug and wants its own change.
