### PR TITLE
fix(bench): four misconfigurations that made Splink look worse than it is

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -870,6 +870,41 @@ jobs:
           MASTER="$CLUSTER-master"
           gcloud compute ssh "$MASTER" --quiet --command "docker stop spark-connect"
 
+          # WAIT for the master to reclaim the cores Connect was holding.
+          #
+          # Run 32283966821 did not, and Splink built its session with
+          #
+          #     [splink] 2 executor(s) registered
+          #
+          # against GoldenMatch's 4 -- then died with
+          # `OutOfMemoryError: Java heap space` and `exited with code 52` at
+          # 50M. Splink ran the comparison on HALF the cluster's memory, and
+          # without this check that reads as "Splink cannot do 50M" when what
+          # was measured is "Splink got two executors".
+          #
+          # `docker stop` returns when the CONTAINER is gone, not when the
+          # standalone master has released the application's cores; the two are
+          # seconds to a minute apart, and the gap is invisible unless you look
+          # for it. At 1M it happened to close in time, which is why this only
+          # appeared at 50M -- a race that resolves itself on small runs is the
+          # worst kind, because it looks like a size-dependent engine limit.
+          #
+          # Polled ON THE MASTER: the standalone UI is not reachable from the
+          # runner, only from inside the VPC.
+          echo "waiting for the master to release Connect's cores"
+          for i in $(seq 1 30); do
+            USED=$(gcloud compute ssh "$MASTER" --quiet --command \
+              "curl -s http://localhost:8080/json/ | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get(\"coresused\",-1))'" 2>/dev/null | tr -dc '0-9-')
+            echo "  attempt $i: coresused=${USED:-unknown}"
+            [ "${USED:-1}" = "0" ] && break
+            sleep 10
+          done
+          # Not fatal on its own: the harness reports the executor count it
+          # actually saw, and the summary carries it, so a short-changed run is
+          # legible rather than silent. Failing here would throw away a
+          # GoldenMatch arm that already succeeded.
+          [ "${USED:-1}" = "0" ] || echo "::warning::master still reports coresused=${USED:-unknown}; Splink may start under-provisioned"
+
           # DETACHED, and this arm needs it more than the FS one. The step is
           # `continue-on-error: true`, so a dropped SSH here does NOT fail the
           # job -- it prints `splink: MISSING` and reads as "Splink could not do

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -856,9 +856,19 @@ jobs:
             [ -f "$f" ] || { echo "::error::harness imports $f but it does not exist"; exit 1; }
           done
 
+          # Build the goldenmatch wheel FROM THIS CHECKOUT so the lane measures
+          # the tree under test rather than the last release. See the install
+          # line below for what this cost before.
+          python -m pip install --quiet build
+          python -m build --wheel --outdir wheelhouse packages/python/goldenmatch >/dev/null
+          WHEEL=$(ls wheelhouse/goldenmatch-*.whl | head -1)
+          [ -n "$WHEEL" ] || { echo "::error::no goldenmatch wheel was built"; exit 1; }
+          echo "built $(basename "$WHEEL")"
+
           gcloud compute scp --quiet \
             scripts/spark_fs_train_scale.py scripts/spark_splink_train_scale.py \
             $DEPS \
+            "$WHEEL" \
             goldenmatch-spark.jar gcs-connector-shaded.jar \
             "$MASTER:~/"
 
@@ -868,7 +878,20 @@ jobs:
               -v /mnt/disks/scratch:/scratch \
               -e SPARK_LOCAL_DIRS=/scratch \
               python:3.12-slim sleep infinity
-            docker exec pyenv pip install --quiet 'goldenmatch[spark]' splink==4.0.16
+            # The wheel built from THIS CHECKOUT, not PyPI.
+            #
+            # Run 32298929875 died with
+            #
+            #     TypeError: estimate_u_distributed() got an unexpected
+            #     keyword argument 'total_rows'
+            #
+            # because the harness is copied from the repo while the LIBRARY came
+            # from `pip install goldenmatch[spark]` -- the published 3.13.0,
+            # without the change being measured. This lane could therefore only
+            # ever measure ALREADY-RELEASED code, so any performance fix had to
+            # ship before it could be tested. Same family as the #688 stale-wheel
+            # footgun, except that one degraded silently and this one errored.
+            docker exec pyenv pip install --quiet \"/w/\$(ls /w | grep -m1 '^goldenmatch-.*\\.whl$')[spark]\" splink==4.0.16
 
             # A JVM, for SPLINK only. GoldenMatch does not need one here: it
             # talks to the cluster over Spark CONNECT (`sc://`), which is a gRPC

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -863,7 +863,13 @@ jobs:
           python -m build --wheel --outdir wheelhouse packages/python/goldenmatch >/dev/null
           WHEEL=$(ls wheelhouse/goldenmatch-*.whl | head -1)
           [ -n "$WHEEL" ] || { echo "::error::no goldenmatch wheel was built"; exit 1; }
-          echo "built $(basename "$WHEEL")"
+          # Resolved HERE and interpolated as a plain name. Doing the lookup
+          # inside the ssh command needed a `$( )` nested in two layers of
+          # quoting, and run 32299878830 evaluated it on the wrong side of the
+          # boundary: pip ran on the runner and its output was executed as a
+          # command (`bash: line 13: Collecting: command not found`).
+          WHEEL_BASE=$(basename "$WHEEL")
+          echo "built $WHEEL_BASE"
 
           gcloud compute scp --quiet \
             scripts/spark_fs_train_scale.py scripts/spark_splink_train_scale.py \
@@ -891,7 +897,8 @@ jobs:
             # ever measure ALREADY-RELEASED code, so any performance fix had to
             # ship before it could be tested. Same family as the #688 stale-wheel
             # footgun, except that one degraded silently and this one errored.
-            docker exec pyenv pip install --quiet \"/w/\$(ls /w | grep -m1 '^goldenmatch-.*\\.whl$')[spark]\" splink==4.0.16
+            docker exec pyenv pip install --quiet '/w/$WHEEL_BASE[spark]' splink==4.0.16
+            docker exec pyenv python -c 'import goldenmatch, inspect; from goldenmatch.spark.em import estimate_u_distributed as f; print(\"[env] goldenmatch\", goldenmatch.__version__, \"total_rows:\", \"total_rows\" in inspect.signature(f).parameters)'
 
             # A JVM, for SPLINK only. GoldenMatch does not need one here: it
             # talks to the cluster over Spark CONNECT (`sc://`), which is a gRPC

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -437,6 +437,10 @@ jobs:
             --format='get(networkInterfaces[0].networkIP)')
           echo "MASTER_IP=$MASTER_IP" >> $GITHUB_ENV
           CORES=$(( $(echo "${{ inputs.machine_type || 'n2-standard-16' }}" | grep -oE '[0-9]+$') ))
+          # ONE definition of executor memory, used by the Connect server below
+          # and exported for the Splink arm. Two literals drift, and a drifted
+          # heap size is indistinguishable from an engine that needs more memory.
+          EXEC_MEM=48g
 
           # Open the COS HOST firewall to intra-VPC traffic.
           #
@@ -551,8 +555,14 @@ jobs:
                 --conf spark.connect.grpc.binding.port=15002 \
                 --conf spark.driver.host=$MASTER_IP \
                 --conf spark.executor.cores=$CORES \
-                --conf spark.executor.memory=48g
+                --conf spark.executor.memory=$EXEC_MEM
           "
+          # Exported so the SPLINK arm is launched with the SAME sizing. It was
+          # not, and took Spark's default `spark.executor.memory=1g` against
+          # GoldenMatch's 48g -- a 48x heap disadvantage that reads as an engine
+          # limit. See the Splink step.
+          echo "EXEC_MEM=$EXEC_MEM" >> $GITHUB_ENV
+          echo "EXEC_CORES=$CORES" >> $GITHUB_ENV
 
       - name: Refuse to measure a cluster with no registered workers
         # The failure this lane must not have: a master with zero workers
@@ -944,6 +954,9 @@ jobs:
           python spark_splink_train_scale.py \
             --rows ${{ inputs.rows || '1000000' }} \
             --shuffle-partitions ${{ inputs.shuffle_partitions || '-1' }} \
+            --executor-memory $EXEC_MEM \
+            --executor-cores $EXEC_CORES \
+            --expect-executors ${{ inputs.workers || '4' }} \
             --master spark://$MASTER_IP:7077 \
             --driver-host $MASTER_IP \
             --spark-ui http://$MASTER_IP:4040 \

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -19,6 +19,38 @@
 # do not. This lane converts that ratio into measured NETWORK time, on separate
 # machines, which is the one thing the byte count cannot tell you.
 #
+# ## THAT ~20x IS WRONG, and this lane is what found out (2026-08-19)
+#
+# The proxy ran Splink misconfigured in four separate ways, each of which this
+# lane hit and fixed in turn:
+#
+#   1. `break_lineage_method="persist"`, which caches WITHOUT truncating the
+#      DAG. Splink's documented default is `parquet`.
+#   2. No distributed filesystem, so `parquet` had nowhere to write. This
+#      cluster now stands up HDFS.
+#   3. Splink starting before the master released Connect's cores, and its own
+#      wait returning on the FIRST executor to register.
+#   4. **`spark.executor.memory` left at Spark's 1g default while GoldenMatch's
+#      Connect server got 48g.** A 48x heap disadvantage.
+#
+# Measured at 1M with both arms on the same cluster, the same 48g executors,
+# the same 320 shuffle partitions (5x cores, per Splink's own guide), and the
+# same shared metric implementations (run 32290866436):
+#
+#     wall            35.82s   vs   90.89s      2.5x
+#     shuffle write   2.71 GB  vs   4.15 GB     1.5x
+#     stages          197      vs   449         2.3x
+#     spill           0 / 0    vs   0 / 0       equal
+#     GC              31.6s    vs   37.6s       1.19x
+#     avg precision   0.71524  vs   0.703386
+#     best F1         0.685667 vs   0.646975
+#
+# GoldenMatch wins every axis. The margin is SINGLE-DIGIT, not an order of
+# magnitude, and the earlier "Splink spills 4 GB where we spill zero" was an
+# artefact of the 1g heap: with equal memory BOTH spill nothing.
+#
+# Do not quote the 20x. It measured our configuration, not the engines.
+#
 # ## Why GCE standalone and not Dataproc
 #
 # Two reasons, and the second matters more.

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -101,6 +101,11 @@ on:
         required: false
         type: boolean
         default: true
+      shuffle_partitions:
+        description: "spark.sql.shuffle.partitions for BOTH arms. `-1` (default) derives 5x total executor cores, which is what Splink's performance guide recommends. `0` leaves Spark's default 200, which is what both engines ran on before and is a number NEITHER vendor recommends. Applied to both engines from one shared implementation (scripts/_spark_tuning.py) so the comparison can never measure a tuning difference."
+        required: false
+        type: string
+        default: "-1"
       splink_checkpoint_fs:
         description: "Shared filesystem for Splink's lineage break. `hdfs` stands up a real HDFS across the cluster nodes (Spark speaks hdfs:// through the Hadoop client pyspark already bundles, so no connector is involved). `gcs` uses the bucket in splink_checkpoint_dir via the gcs-connector. `none` forces `persist`, which keeps lineage and OOMs at scale -- debugging only."
         required: false
@@ -836,6 +841,7 @@ jobs:
           export GOLDENMATCH_SPARK_JAR=/w/goldenmatch-spark.jar
           python spark_fs_train_scale.py \
             --rows ${{ inputs.rows || '1000000' }} \
+            --shuffle-partitions ${{ inputs.shuffle_partitions || '-1' }} \
             --remote sc://$MASTER_IP:15002 \
             --spark-ui http://$MASTER_IP:4040 \
             ${{ inputs.eval_quality && '--eval-quality' || '' }} \
@@ -883,6 +889,7 @@ jobs:
           gce_detached "$MASTER" splink <<REMOTE
           python spark_splink_train_scale.py \
             --rows ${{ inputs.rows || '1000000' }} \
+            --shuffle-partitions ${{ inputs.shuffle_partitions || '-1' }} \
             --master spark://$MASTER_IP:7077 \
             --driver-host $MASTER_IP \
             --spark-ui http://$MASTER_IP:4040 \

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -795,9 +795,28 @@ jobs:
           echo "$(curl -sSfL --retry 3 "${GCS_BASE}/gcs-connector-${GCS_VER}-shaded.jar.sha1")  gcs-connector-shaded.jar" \
             | sha1sum -c - || { echo "::error::gcs-connector jar checksum mismatch"; exit 1; }
 
+          # The helper list is DERIVED from what the harnesses actually import,
+          # not maintained by hand. Run 32286853831 died at session build with
+          #
+          #     FileNotFoundError: '/w/_spark_tuning.py'
+          #
+          # because a new shared module was added to the repo and not to this
+          # list -- the whole run lost, GoldenMatch's arm included, to a copy
+          # step. A hand-kept list of a growing set is the same bug waiting to
+          # recur; both harnesses name their helpers as string literals, so ask
+          # the source.
+          DEPS=$(grep -ho '"_[a-z_]*\.py"' \
+                   scripts/spark_fs_train_scale.py scripts/spark_splink_train_scale.py \
+                 | tr -d '"' | sort -u | sed 's|^|scripts/|')
+          echo "harness helpers: $(echo $DEPS | tr '\n' ' ')"
+          [ -n "$DEPS" ] || { echo "::error::could not derive the harness helper list"; exit 1; }
+          for f in $DEPS; do
+            [ -f "$f" ] || { echo "::error::harness imports $f but it does not exist"; exit 1; }
+          done
+
           gcloud compute scp --quiet \
             scripts/spark_fs_train_scale.py scripts/spark_splink_train_scale.py \
-            scripts/_fs_quality_metrics.py scripts/_spark_shuffle_metrics.py \
+            $DEPS \
             goldenmatch-spark.jar gcs-connector-shaded.jar \
             "$MASTER:~/"
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,18 @@ Every headline number maps back to a single committed runner (`scripts/run_bench
 
 **Fellegi-Sunter training, distributed on Spark:** the E-step collapses to one Spark `GROUP BY` over agreement patterns, so training cost tracks the number of DISTINCT comparison vectors (bounded by `prod(levels + 1)`), not the pair count. Measured on a real 2-worker Spark cluster (jar-only executors, no Python installed), 1M -> 5M rows: candidate pairs grew **5.00x** and the distributed counting stage **5.25x**, while distinct patterns grew **3.0%** (433 -> 446) and driver-side EM stayed at **0.01s**. That is the property the tier rests on -- the cluster absorbs the data, the driver's work stays flat.
 
+**Head-to-head vs Splink on a real Spark cluster, at 50M rows.** Both engines on the *same* 5-node cluster, the same fixture, the same shared metric implementation, and Splink configured the way its own performance guide prescribes -- `break_lineage_method="parquet"` onto a real distributed filesystem, shuffle partitions at 5x cluster cores, and identical 48 GB executors. Over **463,923,179 candidate pairs**, scored identically by both:
+
+| | GoldenMatch | Splink | ratio |
+| --- | ---: | ---: | ---: |
+| wall | **862s** | 1,248s | 1.45x |
+| shuffle write | **128.5 GB** | 212.1 GB | 1.65x |
+| stages | **197** | 394 | 2.00x |
+| executor CPU | **47,121s** | 63,759s | 1.35x |
+| spill | 0 | 0 | -- |
+
+Reported with it, because a benchmark that only publishes its wins is not evidence: **Splink's `u` estimation is 2.3x faster than ours**, the margin **narrows with scale** (2.54x at 1M -> 1.45x at 50M, so do not extrapolate upward), the run is **N=1** on a synthetic fixture, and the accuracy figures in it are *not* an accuracy verdict -- for that, see the [bake-off](docs/benchmarks/2026-06-09-splink-bakeoff.md). Four earlier attempts at this comparison were invalid because *we* had misconfigured Splink; each defect and its effect is documented alongside the results. [Full method, caveats and reproduce command](docs/benchmarks/2026-08-19-spark-50m-head-to-head.md).
+
 Three reproducible real-world pipelines run this on public data at scale:
 
 - **[shell-company-network](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)**: investigative ER across ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC. **−62.5% analyst-hours to triage** vs single-source baselines.

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.13.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.13.1` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs/benchmarks/2026-08-19-spark-50m-head-to-head.md
+++ b/docs/benchmarks/2026-08-19-spark-50m-head-to-head.md
@@ -1,0 +1,138 @@
+# Distributed FS training at 50M: GoldenMatch vs Splink on one Spark cluster
+
+**Date:** 2026-08-19
+**Commit:** `db796d951` (`feat/shuffle-partitions`)
+**Cluster:** 4 x `n2-standard-16` workers + 1 master, `us-east1-c`, 750 GB local NVMe/node
+**Workflow:** `bench-spark-gce-cluster.yml`, runs `32292243875` (50M) and `32290866436` (1M)
+**Harnesses:** `scripts/spark_fs_train_scale.py` (GoldenMatch), `scripts/spark_splink_train_scale.py` (Splink 4.0.16)
+
+## What this measures
+
+Fellegi-Sunter **model training** on a real multi-node Spark cluster: estimate
+`u`, then EM parameter estimation, then a scoring/predict pass. Not clustering,
+not survivorship.
+
+Both arms run on the **same cluster**, over the **same fixture** (literally the
+same `build_fixture` function, same seed, same rows), and are scored by the
+**same metric implementation** (`scripts/_fs_quality_metrics.py`). Where the two
+engines could be given different Spark settings, they are given identical ones
+from a single shared module (`scripts/_spark_tuning.py`), so a difference in the
+numbers is a difference in the engines rather than in the tuning.
+
+This is the first run of this comparison that is valid. Every earlier one was
+not, for reasons documented below.
+
+## Why every earlier Splink number in this repo was wrong
+
+Splink failed four times at 50M before this run. Each failure was **our**
+misconfiguration, and each one, if published, would have read as a Splink
+limitation.
+
+| # | Defect | What it actually did |
+|---|---|---|
+| 1 | `break_lineage_method="persist"` | Caches without truncating the DAG. Splink's documented default is `parquet`. Fixing it took 1M from **337s to 104s**. |
+| 2 | No distributed filesystem | `parquet` writes from the executors and reads back, so it needs shared storage. This lane had none. Now stands up HDFS across the cluster nodes. |
+| 3 | Executor-count races | Splink started before the master released Spark Connect's cores, and its own wait returned on the FIRST executor to register. It ran on **2 executors against GoldenMatch's 4**, and derived 160 shuffle partitions instead of 320. |
+| 4 | `spark.executor.memory` unset | Splink took Spark's **1g** default while GoldenMatch's Connect server was launched with **48g**. A 48x heap disadvantage. |
+
+Number 4 caused the 50M OOMs (`exited with code 52`), and it also produced a
+result that was previously read as a property of the engines: Splink spilling
+4.09 GB memory / 1.88 GB disk where GoldenMatch spilled zero. **With equal
+memory both arms spill nothing**, and the GC gap that looked like 5.9x is 1.19x.
+
+Splink's documented deployments run 100M+ on Databricks / EMR / Dataproc, where
+a shared filesystem and sane executor sizing are native. Bolting a benchmark
+onto bare standalone Spark is what introduced all four defects, and they are
+ours, not Splink's.
+
+## Results: 50M rows, 463,923,179 candidate pairs
+
+Both arms: 4 executors, 48g each, 16 cores each, 320 shuffle partitions,
+`break_lineage_method="parquet"` onto HDFS. Zero spill, zero failed tasks, no
+executor deaths on either side. Identical pair counts.
+
+| | GoldenMatch | Splink | ratio |
+|---|---:|---:|---:|
+| **wall total** | **862.25s** | **1,247.80s** | 1.45x |
+| u / estimate | 98.63s | 43.29s | **0.44x** (Splink faster) |
+| counts vs EM | 364.66s | 631.44s | 1.73x |
+| score / predict | 387.38s | 552.60s | 1.43x |
+| shuffle write | 128.46 GB | 212.07 GB | 1.65x |
+| shuffle read | 128.46 GB | 223.38 GB | 1.74x |
+| stages | 197 | 394 | 2.00x |
+| tasks | 35,679 | 31,357 | 0.88x |
+| executor CPU | 47,121s | 63,759s | 1.35x |
+| JVM GC | 273s | 413s | 1.51x |
+| memory spill | 0 | 0 | — |
+| disk spill | 0 | 0 | — |
+| average precision | 0.700397 | 0.641803 | — |
+| best F1 | 0.684516 | 0.600296 | — |
+
+## Results: 1M rows (the same run configuration, for scaling)
+
+| | GoldenMatch | Splink | ratio |
+|---|---:|---:|---:|
+| wall total | 35.82s | 90.89s | 2.54x |
+| shuffle write | 2.71 GB | 4.15 GB | 1.53x |
+| stages | 197 | 449 | 2.28x |
+| GC | 31.6s | 37.6s | 1.19x |
+| spill | 0 / 0 | 0 / 0 | — |
+| average precision | 0.71524 | 0.703386 | — |
+| best F1 | 0.685667 | 0.646975 | — |
+
+## Verdict
+
+On Spark, distributed, at 50M rows, with Splink configured the way its own
+performance guide prescribes, **GoldenMatch is faster on wall, moves fewer bytes,
+runs half the stages, and burns less CPU and less GC**.
+
+That claim has not been available before. The existing bake-off
+(`2026-06-09-splink-bakeoff.md`) records Splink as **3-19x faster single-box**
+and notes it "retains distributed Fellegi-Sunter at 1B+ rows on Spark". This run
+addresses the distributed half of that framing on Splink's own ground.
+
+## Honest framing
+
+- **Do not quote the accuracy numbers from this run as a GM-vs-Splink accuracy
+  verdict.** Both harnesses say so in their own docstrings. The comparison config
+  here exists to exercise the `prod(levels + 1)` EM bound for a SCALE test and was
+  never chosen for accuracy; running it against Splink's comparison-library
+  defaults partly measures that choice. For accuracy, cite
+  `2026-06-09-splink-bakeoff.md`, which puts zero-tuning GoldenMatch against an
+  expert hand-rolled Splink spec on real datasets under one shared evaluator
+  (0.778 vs 0.757, 0.991 vs 0.965, 0.998 vs 0.996).
+- **Splink's `u` estimation is 2.3x faster than ours** (43.29s vs 98.63s). A real
+  stage-level loss, reported rather than buried, and the next thing to work on.
+- **The margin narrows with scale**: 2.54x at 1M, 1.45x at 50M. Splink scales
+  better relatively. **Do not extrapolate this ratio to 200M** — the trend runs
+  against us.
+- **Session type is an unavoidable confound.** GoldenMatch runs over Spark
+  Connect (`sc://`) because `addArtifact` is Connect-only; Splink cannot, because
+  it reaches for `sparkContext`, which Connect does not expose. So Splink drives a
+  classic session. This is how each engine actually ships, which makes it the
+  honest product comparison, but it is a difference between the arms.
+- **`spark.default.parallelism` is set for neither arm.** Splink's guide
+  recommends it alongside `spark.sql.shuffle.partitions`, but it is a static core
+  config that cannot be set at runtime on a Connect session. Setting it for Splink
+  alone would hand one arm a knob the other cannot reach, so neither gets it.
+- **N=1.** One run per engine at each size. Ratios are directional. Runner and
+  cluster variance are not characterised.
+- The fixture is **synthetic** and one shape (5 fields, 3 levels, seeded typos and
+  nulls). It is not a stand-in for customer data.
+
+## Reproduce
+
+```
+gh workflow run bench-spark-gce-cluster.yml --ref main \
+  -f rows=50000000 -f workers=4 -f disk_gb=750 \
+  -f machine_type=n2-standard-16 -f zone=us-east1-c \
+  -f splink_compare=true -f eval_quality=true \
+  -f splink_checkpoint_fs=hdfs -f shuffle_partitions=-1
+```
+
+`shuffle_partitions=-1` derives 5x total executor cores from the cluster's own
+executor list. `splink_checkpoint_fs=hdfs` stands up a namenode on the master and
+a datanode on every node; `gcs` is also supported and is what a Dataproc or EMR
+user would have.
+
+Cost is roughly one hour of 5 x `n2-standard-16` on-demand per 50M run.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,7 +6,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.13.1] - 2026-08-19
+
+
 ### Fixed
+
+- **`u` estimation cost the TABLE, not the sample, on the distributed Spark
+  path.** `random_pairs` draws ~1,415 rows regardless of source size (the
+  inverse of r(r-1)/2 for a 1M-pair budget), but getting them cost THREE full
+  passes over the source: a `count()` purely to turn the pair budget into a
+  sampling fraction, plus a self-join whose two sides both referenced the
+  UNMATERIALISED sample, so the scan and hash filter ran twice. Measured on a
+  50M-row Spark cluster the stage took 98.63s where Splink's took 43.29s, while
+  at 1M it was FASTER than Splink (8.48s vs 13.69s) -- 50x the rows made it
+  11.6x slower, which a fixed-size sample should not do. The sample is now
+  cached before the self-join, and `estimate_u_distributed` /
+  `train_em_distributed` accept an optional `total_rows` so a caller that has
+  already counted the frame does not pay for a second count. Three passes become
+  one. `total_rows` is optional and omitting it keeps the previous behaviour, so
+  this is not a breaking change.
 
 - **`candidates_compared` was structurally 0 at scale, and two auto-config
   decisions read it as a signal (#2639).** `scorer.py` skips the candidate-count

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -46,7 +46,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.13.0"
+__version__ = "3.13.1"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -589,6 +589,7 @@ def train_em_distributed(
     max_patterns: int = MAX_PATTERNS,
     max_tf_values: int = MAX_TF_VALUES,
     tf_freqs: dict[str, dict[str, float]] | None = None,
+    total_rows: int | None = None,
     tf_collision: dict[str, float] | None = None,
 ) -> Any:
     """Train one matchkey's FS model with no pair sample anywhere.
@@ -639,10 +640,14 @@ def train_em_distributed(
             "without one there are no candidate pairs to estimate m from"
         )
 
+    # `total_rows` forwarded so the SHIPPED path gets the same saving the
+    # benchmark harness does. Without it `u` pays a full count over the source
+    # purely to turn a pair budget into a sampling fraction, and a caller that
+    # has just counted the frame -- most of them have -- should not pay twice.
     u_probs = estimate_u_distributed(
         source_df, mk, id_col=id_col, scorer_udf=scorer_udf,
         transform_udf=transform_udf, max_pairs=u_max_pairs, seed=seed,
-        max_patterns=max_patterns,
+        max_patterns=max_patterns, total_rows=total_rows,
     )
 
     # A GROUP BY over VALUES, not comparison vectors -- the one thing the counts

--- a/packages/python/goldenmatch/goldenmatch/spark/em.py
+++ b/packages/python/goldenmatch/goldenmatch/spark/em.py
@@ -333,6 +333,7 @@ def random_pairs(
     seed: int = 42,
     lhs: str | None = None,
     rhs: str | None = None,
+    total_rows: int | None = None,
 ) -> Any:
     """A joined frame of RANDOM record pairs, for estimating ``u``.
 
@@ -361,7 +362,14 @@ def random_pairs(
     than exact -- about +/-3% of the rows at the default budget, so +/-5% of the
     pairs, which is noise against a level distribution.
     """
-    total = source_df.count()
+    # `total_rows` skips a FULL PASS over the source. The count exists only to
+    # turn a pair budget into a sampling fraction, and every caller in this repo
+    # already knows the row count -- paying for a second scan to rediscover it
+    # is the sample costing what the table costs. Measured at 50M (run
+    # 32292243875), this stage ran 98.63s against Splink's 43.29s while at 1M it
+    # BEAT Splink (8.48s vs 13.69s): 50x the rows made it 11.6x slower, which a
+    # fixed-size sample should not do.
+    total = source_df.count() if total_rows is None else total_rows
     if total < 2:
         raise ValueError(
             f"u needs at least 2 records to form a pair; the source has {total}"
@@ -386,6 +394,22 @@ def random_pairs(
         )
         sample = source_df.where(h < F.lit(float(want) / total * buckets))
 
+    # MATERIALISED before the self-join. Both sides of the join reference the
+    # same plan, so an unmaterialised `sample` makes Spark evaluate the source
+    # scan and the hash filter TWICE -- and with `count()` above, three full
+    # passes over the table to produce a sample of ~1,415 rows out of 50M
+    # (0.0028% of it). Caching collapses that to one.
+    #
+    # The frame is tiny by construction: `_rows_needed_for_n_pairs` is the
+    # inverse of r(r-1)/2, so a 1M-pair budget is ~1,415 rows regardless of how
+    # large the source is. Caching it costs nothing and is not a memory risk at
+    # any source size.
+    #
+    # Guarded: `cache` is absent on the hand-built frames some callers and tests
+    # pass, and an optimisation must not become a new requirement on the input.
+    if hasattr(sample, "cache"):
+        sample = sample.cache()
+
     a = sample.alias(lhs)
     b = sample.alias(rhs)
     return a.join(b, F.col(f"{lhs}.{id_col}") < F.col(f"{rhs}.{id_col}"))
@@ -401,6 +425,7 @@ def estimate_u_distributed(
     max_pairs: int = 1_000_000,
     seed: int = 42,
     max_patterns: int = MAX_PATTERNS,
+    total_rows: int | None = None,
 ) -> dict[str, list[float]]:
     """``u`` estimated on the cluster, from random pairs.
 
@@ -418,7 +443,7 @@ def estimate_u_distributed(
     from goldenmatch.core.probabilistic import estimate_u_from_counts
 
     joined = random_pairs(
-        source_df, id_col=id_col, max_pairs=max_pairs, seed=seed
+        source_df, id_col=id_col, max_pairs=max_pairs, seed=seed, total_rows=total_rows
     )
     from goldenmatch.spark.config_pipeline import CAND_LHS, CAND_RHS
 

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.13.0"
+version = "3.13.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.13.0",
+      "version": "3.13.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/tests/test_spark_fs_unit.py
+++ b/packages/python/goldenmatch/tests/test_spark_fs_unit.py
@@ -448,3 +448,40 @@ def test_a_source_too_small_to_form_a_pair_is_refused():
     frame = SimpleNamespace(count=lambda: 1)
     with pytest.raises(ValueError, match="at least 2 records"):
         random_pairs(frame, id_col="id")
+
+
+def test_random_pairs_does_not_count_when_total_is_known():
+    """`u`'s sample must not cost a full pass the caller already paid for.
+
+    Measured on the 50M GCE cluster (run 32292243875): the `u` stage took
+    98.63s against Splink's 43.29s, while at 1M it was FASTER than Splink
+    (8.48s vs 13.69s). 50x the rows made it 11.6x slower, which is not what a
+    fixed-size sample should do -- the docstring's claim that "cost tracks the
+    SAMPLE, not the table" did not hold.
+
+    One reason is this `count()`. It is a full pass over the source purely to
+    turn a pair budget into a sampling fraction, and every caller in this repo
+    already knows the row count. Passing it in removes the pass.
+    """
+    from types import SimpleNamespace
+
+    from goldenmatch.spark.em import random_pairs
+
+    calls = []
+    frame = SimpleNamespace(count=lambda: calls.append("count") or 10)
+    with pytest.raises(ValueError, match="at least 2 records"):
+        random_pairs(frame, id_col="id", total_rows=1)
+    assert calls == [], "count() was called even though total_rows was supplied"
+
+
+def test_random_pairs_still_counts_when_total_is_unknown():
+    """The parameter is an optimisation, not a new requirement on callers."""
+    from types import SimpleNamespace
+
+    from goldenmatch.spark.em import random_pairs
+
+    calls = []
+    frame = SimpleNamespace(count=lambda: calls.append("count") or 1)
+    with pytest.raises(ValueError, match="at least 2 records"):
+        random_pairs(frame, id_col="id")
+    assert calls == ["count"]

--- a/scripts/_spark_tuning.py
+++ b/scripts/_spark_tuning.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Spark settings applied IDENTICALLY to both arms of the comparison.
+
+## Why this is a shared module and not two copies
+
+Splink's performance guide recommends `spark.sql.shuffle.partitions` at roughly
+5x the cluster's CPU count. Both harnesses previously ran on Spark's default
+200, which is a number neither vendor recommends -- fair in the sense that
+neither was tuned, and wrong in the sense that it is not how Splink says to run
+at scale.
+
+The fix is to follow the guidance for BOTH engines. That only stays true if the
+setting is applied from one implementation: two copies of "the same" tuning
+drift, and a benchmark whose arms are tuned differently measures the tuning.
+Same reasoning as `_fs_quality_metrics.py` being shared -- a difference between
+the arms' numbers should be a difference between the ENGINES.
+
+## Why only `spark.sql.shuffle.partitions`
+
+The guide also names `spark.default.parallelism`. That one is a static core
+config, not settable at runtime on a Spark CONNECT session -- which is how
+GoldenMatch connects and Splink cannot. Setting it for Splink alone would hand
+one arm a knob the other cannot reach, which is exactly the asymmetry this
+module exists to prevent. It is left at Spark's default for both, and that is
+recorded rather than quietly omitted.
+
+`spark.sql.shuffle.partitions` IS a runtime SQL conf, so it applies identically
+through Connect and through a classic session.
+"""
+
+from __future__ import annotations
+
+
+def executor_cores_from_ui(spark_ui: str | None) -> int | None:
+    """Total executor cores as the CLUSTER reports them, or None.
+
+    Read from the Spark UI's executor list rather than derived from the
+    workflow's `workers x machine cores`: the derived figure is what we ASKED
+    for, and Splink's guidance is about the cores the job actually has. If an
+    executor failed to register, deriving would silently over-shard.
+
+    The driver appears in that list with `total_cores` 0, so summing is safe.
+    Returns None on any failure -- an absent measurement must leave Spark's
+    default in place rather than produce a fabricated setting.
+    """
+    if not spark_ui:
+        return None
+    try:
+        import importlib.util
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parent / "_spark_shuffle_metrics.py"
+        spec = importlib.util.spec_from_file_location("_spark_shuffle_metrics", path)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        info = mod.fetch(spark_ui)
+        rows = (info.get("executor_metrics") or {}).get("executors") or []
+        total = sum(r.get("total_cores") or 0 for r in rows)
+        return total or None
+    except Exception:
+        return None
+
+
+def resolve_shuffle_partitions(requested: int, executor_cores: int | None) -> int | None:
+    """The partition count to use, or None to leave Spark's default alone.
+
+    ``requested`` of 0 means "leave it alone"; a negative value means "derive it
+    from the cluster" as 5x total executor cores, per Splink's guide. Returns
+    None when it cannot be derived, so the caller leaves the default rather than
+    inventing a number -- an absent input must not become a fabricated setting.
+    """
+    if requested > 0:
+        return requested
+    if requested < 0 and executor_cores and executor_cores > 0:
+        return 5 * executor_cores
+    return None
+
+
+def apply_shuffle_partitions(
+    spark, requested: int, spark_ui: str | None = None, executor_cores: int | None = None
+) -> int | None:
+    """Set `spark.sql.shuffle.partitions`, and report what was actually applied.
+
+    Returns the value set, or None if left at Spark's default. The return value
+    is written into both harnesses' JSON so an artifact can never be read
+    without knowing which partition count produced it.
+    """
+    if executor_cores is None:
+        executor_cores = executor_cores_from_ui(spark_ui)
+    n = resolve_shuffle_partitions(requested, executor_cores)
+    if n is None:
+        try:
+            current = spark.conf.get("spark.sql.shuffle.partitions")
+        except Exception:  # pragma: no cover - diagnostic only
+            current = "unknown"
+        print(f"[tuning] shuffle.partitions left at Spark's default ({current})", flush=True)
+        return None
+    spark.conf.set("spark.sql.shuffle.partitions", str(n))
+    print(f"[tuning] shuffle.partitions = {n}", flush=True)
+    return n

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -68,6 +68,7 @@ Usage (from the repo root, against a running Connect endpoint):
 
     python scripts/spark_fs_train_scale.py --rows 1000000 --out scale.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -126,16 +127,15 @@ def build_fixture(spark, rows: int, dup: int, blocks_per_key: int, value_pad: in
         # character is the typo the docstring above describes and preserves the
         # field's cardinality.
         return (
-            F.when(h < F.lit(6), base)                                    # 60% clean
-             .when(h < F.lit(8), F.regexp_replace(base, ".$", ""))        # 20% truncated
-             .when(h < F.lit(9), F.concat(base, F.lit("x")))              # 10% typo
-             .otherwise(F.lit(None).cast("string"))                       # 10% missing
+            F.when(h < F.lit(6), base)  # 60% clean
+            .when(h < F.lit(8), F.regexp_replace(base, ".$", ""))  # 20% truncated
+            .when(h < F.lit(9), F.concat(base, F.lit("x")))  # 10% typo
+            .otherwise(F.lit(None).cast("string"))  # 10% missing
         )
 
     first = F.concat(F.lit("ann"), ent_s)
     last = F.concat(F.lit("lee"), (ent % F.lit(max(n_entities // 3, 1))).cast("string"))
-    dob = F.concat(F.lit("19"), F.lpad((ent % F.lit(80)).cast("string"), 2, "0"),
-                   F.lit("-01-01"))
+    dob = F.concat(F.lit("19"), F.lpad((ent % F.lit(80)).cast("string"), 2, "0"), F.lit("-01-01"))
     zipc = F.concat(F.lit("z"), F.lpad((ent % F.lit(500)).cast("string"), 3, "0"))
     city = F.concat(F.lit("city"), (ent % F.lit(40)).cast("string"))
 
@@ -170,9 +170,9 @@ def build_fixture(spark, rows: int, dup: int, blocks_per_key: int, value_pad: in
         # The blocking key is NEVER perturbed: it decides which pairs are
         # compared at all, so corrupting it would silently shrink the candidate
         # set and make a smaller run look like a faster one.
-        F.concat(F.lit("k"),
-                 (ent / F.lit(max(blocks_per_key, 1))).cast("int").cast("string"))
-         .alias("blk"),
+        F.concat(
+            F.lit("k"), (ent / F.lit(max(blocks_per_key, 1))).cast("int").cast("string")
+        ).alias("blk"),
     )
 
 
@@ -281,10 +281,7 @@ def profile_counts(joined, mk, *, scorer_udf, transform_udf, cands):
     # 4. + the wide GROUP BY over every pair: the exchange this whole question
     #    is about.
     t = time.perf_counter()
-    (joined.select(*gammas)
-        .groupBy(*[F.col(n) for n in names])
-        .agg(F.count(F.lit(1)))
-        .collect())
+    (joined.select(*gammas).groupBy(*[F.col(n) for n in names]).agg(F.count(F.lit(1))).collect())
     out["grouped_seconds"] = round(time.perf_counter() - t, 2)
 
     # Deltas. Each prefix contains the ones before it, so the attribution is the
@@ -299,8 +296,7 @@ def profile_counts(joined, mk, *, scorer_udf, transform_udf, cands):
     return out
 
 
-def make_config(n_fields: int = 5, scorer: str | None = None,
-                match_splink_levels: bool = False):
+def make_config(n_fields: int = 5, scorer: str | None = None, match_splink_levels: bool = False):
     """The scale config. ``n_fields`` trims the COMPARISON fields only.
 
     ## Why this is a knob
@@ -339,8 +335,9 @@ def make_config(n_fields: int = 5, scorer: str | None = None,
         MatchkeyField,
     )
 
-    cfg = _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
-                        MatchkeyConfig, MatchkeyField)
+    cfg = _build_config(
+        GoldenMatchConfig, BlockingConfig, BlockingKeyConfig, MatchkeyConfig, MatchkeyField
+    )
     mk = cfg.get_matchkeys()[0]
     if scorer:
         # Force every comparison field onto one scorer. This exists for the
@@ -383,8 +380,7 @@ def make_config(n_fields: int = 5, scorer: str | None = None,
         # because the width is fixed.
         for f in mk.fields:
             f.levels = 4
-            f.level_thresholds = ([1.0, 0.9, 0.8] if f.field == "dob"
-                                  else [1.0, 0.9, 0.7])
+            f.level_thresholds = [1.0, 0.9, 0.8] if f.field == "dob" else [1.0, 0.9, 0.7]
     if n_fields < len(mk.fields):
         # Trim in place. Rebuilding a shorter literal risks the arms differing
         # in something other than field count, which is the one variable this
@@ -393,8 +389,9 @@ def make_config(n_fields: int = 5, scorer: str | None = None,
     return cfg
 
 
-def _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
-                  MatchkeyConfig, MatchkeyField):
+def _build_config(
+    GoldenMatchConfig, BlockingConfig, BlockingKeyConfig, MatchkeyConfig, MatchkeyField
+):
     return GoldenMatchConfig(
         blocking=BlockingConfig(
             strategy="multi_pass",
@@ -413,18 +410,24 @@ def _build_config(GoldenMatchConfig, BlockingConfig, BlockingKeyConfig,
             # capped it at 9 -- the run reported 3 and 2 distinct patterns and
             # could not have reported more than 9 whatever the data looked like.
             MatchkeyConfig(
-                name="fs", type="probabilistic",
+                name="fs",
+                type="probabilistic",
                 fields=[
-                    MatchkeyField(field="first", scorer="jaro_winkler",
-                                  levels=3, partial_threshold=0.7),
-                    MatchkeyField(field="last", scorer="jaro_winkler",
-                                  levels=3, partial_threshold=0.7),
-                    MatchkeyField(field="dob", scorer="levenshtein",
-                                  levels=3, partial_threshold=0.7),
-                    MatchkeyField(field="zip", scorer="jaro_winkler",
-                                  levels=3, partial_threshold=0.7),
-                    MatchkeyField(field="city", scorer="jaro_winkler",
-                                  levels=3, partial_threshold=0.7),
+                    MatchkeyField(
+                        field="first", scorer="jaro_winkler", levels=3, partial_threshold=0.7
+                    ),
+                    MatchkeyField(
+                        field="last", scorer="jaro_winkler", levels=3, partial_threshold=0.7
+                    ),
+                    MatchkeyField(
+                        field="dob", scorer="levenshtein", levels=3, partial_threshold=0.7
+                    ),
+                    MatchkeyField(
+                        field="zip", scorer="jaro_winkler", levels=3, partial_threshold=0.7
+                    ),
+                    MatchkeyField(
+                        field="city", scorer="jaro_winkler", levels=3, partial_threshold=0.7
+                    ),
                 ],
             ),
         ],
@@ -441,6 +444,24 @@ def _shuffle_module():
 
     path = Path(__file__).resolve().parent / "_spark_shuffle_metrics.py"
     spec = importlib.util.spec_from_file_location("_spark_shuffle_metrics", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tuning_module():
+    """The SHARED Spark tuning, imported by file path.
+
+    Same reasoning as the shuffle reader and the ranking metric: both arms have
+    to be tuned by ONE implementation, or the benchmark measures the tuning
+    rather than the engines.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "_spark_tuning.py"
+    spec = importlib.util.spec_from_file_location("_spark_tuning", path)
     if spec is None or spec.loader is None:
         raise SystemExit(f"cannot load {path}")
     mod = importlib.util.module_from_spec(spec)
@@ -471,64 +492,96 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--rows", type=int, default=1_000_000)
     ap.add_argument("--dup", type=int, default=3, help="rows per entity")
-    ap.add_argument("--blocks-per-key", type=int, default=4,
-                    help="entities sharing one blocking value")
-    ap.add_argument("--remote", default=os.environ.get(
-        "GOLDENMATCH_SPARK_REMOTE", "sc://localhost:15002"))
+    ap.add_argument(
+        "--blocks-per-key", type=int, default=4, help="entities sharing one blocking value"
+    )
+    ap.add_argument(
+        "--remote", default=os.environ.get("GOLDENMATCH_SPARK_REMOTE", "sc://localhost:15002")
+    )
     ap.add_argument("--u-max-pairs", type=int, default=1_000_000)
     ap.add_argument(
-        "--scorer", default="",
+        "--scorer",
+        default="",
         help="Force every comparison field onto one scorer. Use `exact` with "
-             "--value-pad: padding preserves equality, so gammas are unchanged "
-             "and only the marshalled bytes move. Under jaro_winkler/levenshtein "
-             "padding CHANGES similarity and the arms stop being comparable.")
+        "--value-pad: padding preserves equality, so gammas are unchanged "
+        "and only the marshalled bytes move. Under jaro_winkler/levenshtein "
+        "padding CHANGES similarity and the arms stop being comparable.",
+    )
     ap.add_argument(
-        "--value-pad", type=int, default=0,
+        "--value-pad",
+        type=int,
+        default=0,
         help="Append N filler chars to every COMPARISON value. Crossing COUNT "
-             "is unchanged; only the bytes marshalled per crossing move. This "
-             "is the arm that separates per-CALL from per-BYTE scoring cost -- "
-             "`--fields` CANNOT, because adding a field adds a call AND its "
-             "bytes, so both hypotheses predict the same scaling.")
+        "is unchanged; only the bytes marshalled per crossing move. This "
+        "is the arm that separates per-CALL from per-BYTE scoring cost -- "
+        "`--fields` CANNOT, because adding a field adds a call AND its "
+        "bytes, so both hypotheses predict the same scaling.",
+    )
     ap.add_argument(
-        "--fields", type=int, default=5,
+        "--fields",
+        type=int,
+        default=5,
         help="Number of COMPARISON fields (max 5). Same blocking, same "
-             "candidate pairs -- only the per-pair crossing count changes. "
-             "Run 5 vs 2 and compare `scoring_udf`: linear in field count "
-             "means the cost is per-CALL (fewer, fatter calls win); flat means "
-             "per-BYTE (only columnar/FFI moves it).")
+        "candidate pairs -- only the per-pair crossing count changes. "
+        "Run 5 vs 2 and compare `scoring_udf`: linear in field count "
+        "means the cost is per-CALL (fewer, fatter calls win); flat means "
+        "per-BYTE (only columnar/FFI moves it).",
+    )
     ap.add_argument(
-        "--profile-counts", action="store_true",
+        "--profile-counts",
+        action="store_true",
         help="Attribute the counts stage across pair generation / record "
-             "join / scoring UDF / GROUP BY exchange. Times PREFIXES of the "
-             "same DAG, so it costs ~3x a normal counts stage -- a "
-             "diagnostic, not something to leave on. Without it, every "
-             "optimisation of a stage that is 94%% of the wall is a guess "
-             "about which part of it is expensive.")
+        "join / scoring UDF / GROUP BY exchange. Times PREFIXES of the "
+        "same DAG, so it costs ~3x a normal counts stage -- a "
+        "diagnostic, not something to leave on. Without it, every "
+        "optimisation of a stage that is 94%% of the wall is a guess "
+        "about which part of it is expensive.",
+    )
     ap.add_argument(
-        "--max-block-pairs", type=int, default=50_000_000,
+        "--max-block-pairs",
+        type=int,
+        default=50_000_000,
         help="refuse a pass whose LARGEST single block would emit more pairs "
-             "than this. A skewed blocking key does not fail, it hangs -- the "
-             "constant-prefix truncation bug put 20%% of the table in one "
-             "block and the run sat in the join for 24 minutes until the step "
-             "timeout killed it, with no output naming the cause. This turns "
-             "that into a fast, specific refusal.")
-    ap.add_argument("--match-splink-levels", action="store_true",
-                    help="Give every comparison field the same four informative "
-                         "levels Splink uses (exact / 0.9 / 0.7 / else) instead "
-                         "of this harness's default three. Without it an "
-                         "accuracy comparison measures a ladder difference and "
-                         "reports it as an engine difference.")
-    ap.add_argument("--eval-quality", action="store_true",
-                    help="After training, score the SAME candidate pairs with "
-                         "the trained model and report ranking quality against "
-                         "the fixture's known entity structure. The speed "
-                         "number means nothing without it: the bar is "
-                         "match-or-better accuracy, not a faster arrival at a "
-                         "worse model.")
-    ap.add_argument("--spark-ui", default="http://localhost:4041",
-                    help="Spark UI of the CONNECT driver (compose maps its 4040 "
-                         "to 4041, because Splink's classic driver binds 4040 on "
-                         "the host). Read for stage-level shuffle bytes.")
+        "than this. A skewed blocking key does not fail, it hangs -- the "
+        "constant-prefix truncation bug put 20%% of the table in one "
+        "block and the run sat in the join for 24 minutes until the step "
+        "timeout killed it, with no output naming the cause. This turns "
+        "that into a fast, specific refusal.",
+    )
+    ap.add_argument(
+        "--match-splink-levels",
+        action="store_true",
+        help="Give every comparison field the same four informative "
+        "levels Splink uses (exact / 0.9 / 0.7 / else) instead "
+        "of this harness's default three. Without it an "
+        "accuracy comparison measures a ladder difference and "
+        "reports it as an engine difference.",
+    )
+    ap.add_argument(
+        "--eval-quality",
+        action="store_true",
+        help="After training, score the SAME candidate pairs with "
+        "the trained model and report ranking quality against "
+        "the fixture's known entity structure. The speed "
+        "number means nothing without it: the bar is "
+        "match-or-better accuracy, not a faster arrival at a "
+        "worse model.",
+    )
+    ap.add_argument(
+        "--spark-ui",
+        default="http://localhost:4041",
+        help="Spark UI of the CONNECT driver (compose maps its 4040 "
+        "to 4041, because Splink's classic driver binds 4040 on "
+        "the host). Read for stage-level shuffle bytes.",
+    )
+    ap.add_argument(
+        "--shuffle-partitions",
+        type=int,
+        default=0,
+        help="spark.sql.shuffle.partitions. 0 leaves Spark's default, "
+        "-1 derives 5x total executor cores per Splink's guide. "
+        "Applied IDENTICALLY to both arms via scripts/_spark_tuning.py.",
+    )
     ap.add_argument("--out", default="")
     args = ap.parse_args()
 
@@ -553,44 +606,57 @@ def main() -> int:
     from pyspark.sql import SparkSession
 
     spark = SparkSession.builder.remote(args.remote).getOrCreate()
+    _applied_partitions = _tuning_module().apply_shuffle_partitions(
+        spark, args.shuffle_partitions, spark_ui=args.spark_ui
+    )
     install(spark, jar=find_jar())
     impl, _diagnostics, runtime = implementation(spark)
     print(f"[scale] kernel impl={impl} runtime={runtime}", flush=True)
 
     out: dict = {
-        "rows": args.rows, "dup": args.dup,
+        "rows": args.rows,
+        "dup": args.dup,
         "blocks_per_key": args.blocks_per_key,
-        "kernel_impl": impl, "kernel_runtime": runtime,
-        "stages": {}, "passes": [], "n_fields": args.fields, "value_pad": args.value_pad, "scorer_override": args.scorer or None,
+        "kernel_impl": impl,
+        "kernel_runtime": runtime,
+        # None means Spark's default was left alone. Recorded so an artifact
+        # can never be read without knowing which partition count produced it.
+        "shuffle_partitions": _applied_partitions,
+        "stages": {},
+        "passes": [],
+        "n_fields": args.fields,
+        "value_pad": args.value_pad,
+        "scorer_override": args.scorer or None,
     }
 
     t0 = time.perf_counter()
-    df = build_fixture(spark, args.rows, args.dup, args.blocks_per_key,
-                       value_pad=args.value_pad)
+    df = build_fixture(spark, args.rows, args.dup, args.blocks_per_key, value_pad=args.value_pad)
     # Materialise once so the fixture build is not re-run inside every stage
     # and charged to whichever stage happened to trigger it.
     df.cache()
     actual = df.count()
     out["stages"]["fixture_seconds"] = round(time.perf_counter() - t0, 2)
     out["actual_rows"] = actual
-    print(f"[scale] fixture: {actual:,} rows in "
-          f"{out['stages']['fixture_seconds']}s", flush=True)
+    print(f"[scale] fixture: {actual:,} rows in {out['stages']['fixture_seconds']}s", flush=True)
 
-    cfg = make_config(args.fields, args.scorer or None,
-                      match_splink_levels=args.match_splink_levels)
+    cfg = make_config(
+        args.fields, args.scorer or None, match_splink_levels=args.match_splink_levels
+    )
     mk = cfg.get_matchkeys()[0]
 
     # ── u: sampled self-join. Cost tracks the SAMPLE, not the table. ──
     t = time.perf_counter()
     u_probs = estimate_u_distributed(
-        df, mk, id_col="__row_id__",
-        scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME,
+        df,
+        mk,
+        id_col="__row_id__",
+        scorer_udf=ROW_UDF_NAME,
+        transform_udf=TRANSFORM_UDF_NAME,
         max_pairs=args.u_max_pairs,
     )
     out["stages"]["u_seconds"] = round(time.perf_counter() - t, 2)
     out["u_probs"] = {k: [round(x, 6) for x in v] for k, v in u_probs.items()}
-    print(f"[scale] u in {out['stages']['u_seconds']}s -> {out['u_probs']}",
-          flush=True)
+    print(f"[scale] u in {out['stages']['u_seconds']}s -> {out['u_probs']}", flush=True)
 
     # ── counts: the stage that scales with the data. ──
     from goldenmatch.core.probabilistic import (
@@ -610,9 +676,12 @@ def main() -> int:
         top_key, top_rows = largest_block(df, key_config)
         skew_dt = time.perf_counter() - t
         top_pairs = top_rows * (top_rows - 1) // 2
-        print(f"[scale] pass {i} on {list(fields)}: largest block "
-              f"{top_key!r} has {top_rows:,} rows -> {top_pairs:,} pairs "
-              f"({skew_dt:.2f}s)", flush=True)
+        print(
+            f"[scale] pass {i} on {list(fields)}: largest block "
+            f"{top_key!r} has {top_rows:,} rows -> {top_pairs:,} pairs "
+            f"({skew_dt:.2f}s)",
+            flush=True,
+        )
         if top_pairs > args.max_block_pairs:
             raise SystemExit(
                 f"[scale] pass {i} on {list(fields)} REFUSED: block "
@@ -629,19 +698,28 @@ def main() -> int:
         prof = None
         if args.profile_counts:
             prof = profile_counts(
-                joined, mk, scorer_udf=ROW_UDF_NAME,
-                transform_udf=TRANSFORM_UDF_NAME, cands=cands,
+                joined,
+                mk,
+                scorer_udf=ROW_UDF_NAME,
+                transform_udf=TRANSFORM_UDF_NAME,
+                cands=cands,
             )
             a = prof["attribution"]
-            print(f"[scale] pass {i} counts attribution: "
-                  f"pairs={a['pair_generation']}s join={a['record_join']}s "
-                  f"scoring={a['scoring_udf']}s groupby={a['groupby_exchange']}s",
-                  flush=True)
+            print(
+                f"[scale] pass {i} counts attribution: "
+                f"pairs={a['pair_generation']}s join={a['record_join']}s "
+                f"scoring={a['scoring_udf']}s groupby={a['groupby_exchange']}s",
+                flush=True,
+            )
 
         t = time.perf_counter()
         counts = agreement_pattern_counts(
-            joined, mk, lhs=CAND_LHS, rhs=CAND_RHS,
-            scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME,
+            joined,
+            mk,
+            lhs=CAND_LHS,
+            rhs=CAND_RHS,
+            scorer_udf=ROW_UDF_NAME,
+            transform_udf=TRANSFORM_UDF_NAME,
         )
         dt = time.perf_counter() - t
         count_wall += dt
@@ -652,31 +730,36 @@ def main() -> int:
         train_wall += time.perf_counter() - t
         sessions.append((fields, em, float(n_pairs)))
 
-        out["passes"].append({
-            "pass": i, "blocking_fields": list(fields),
-            "pairs": n_pairs, "distinct_patterns": len(counts),
-            "count_seconds": round(dt, 2),
-            # Recorded even when it passes the guard: skew that is merely bad
-            # is invisible in the totals, and this is the number that moves
-            # when a fixture change quietly reshapes the candidate set.
-            "largest_block_rows": top_rows,
-            "largest_block_key": top_key,
-            "largest_block_pairs": top_pairs,
-            # None unless --profile-counts. Present as an explicit null so a
-            # reader can tell "not profiled" from "profiled and found nothing".
-            "counts_profile": prof,
-        })
-        print(f"[scale] pass {i} on {list(fields)}: {n_pairs:,} pairs -> "
-              f"{len(counts)} distinct patterns in {dt:.2f}s", flush=True)
+        out["passes"].append(
+            {
+                "pass": i,
+                "blocking_fields": list(fields),
+                "pairs": n_pairs,
+                "distinct_patterns": len(counts),
+                "count_seconds": round(dt, 2),
+                # Recorded even when it passes the guard: skew that is merely bad
+                # is invisible in the totals, and this is the number that moves
+                # when a fixture change quietly reshapes the candidate set.
+                "largest_block_rows": top_rows,
+                "largest_block_key": top_key,
+                "largest_block_pairs": top_pairs,
+                # None unless --profile-counts. Present as an explicit null so a
+                # reader can tell "not profiled" from "profiled and found nothing".
+                "counts_profile": prof,
+            }
+        )
+        print(
+            f"[scale] pass {i} on {list(fields)}: {n_pairs:,} pairs -> "
+            f"{len(counts)} distinct patterns in {dt:.2f}s",
+            flush=True,
+        )
 
     out["stages"]["counts_seconds"] = round(count_wall, 2)
     out["stages"]["train_seconds"] = round(train_wall, 2)
 
     model = _combine_em_sessions(mk, sessions)
     out["m_probs"] = {k: [round(x, 6) for x in v] for k, v in model.m_probs.items()}
-    out["match_weights"] = {
-        k: [round(x, 4) for x in v] for k, v in model.match_weights.items()
-    }
+    out["match_weights"] = {k: [round(x, 4) for x in v] for k, v in model.match_weights.items()}
     out["proportion_matched"] = round(model.proportion_matched, 6)
 
     if args.eval_quality:
@@ -714,9 +797,9 @@ def main() -> int:
         cands = cands.dropDuplicates(["a", "b"])
 
         joined = join_candidates_to_sources(cands, df, id_col="__row_id__")
-        gammas = gamma_columns(mk, CAND_LHS, CAND_RHS,
-                               scorer_udf=ROW_UDF_NAME,
-                               transform_udf=TRANSFORM_UDF_NAME)
+        gammas = gamma_columns(
+            mk, CAND_LHS, CAND_RHS, scorer_udf=ROW_UDF_NAME, transform_udf=TRANSFORM_UDF_NAME
+        )
         # Match weight = the per-field log2(m/u) for the level the pair landed
         # on, summed. `match_weights[field][level]` IS that table, so this is a
         # lookup rather than a second derivation of the weight.
@@ -725,11 +808,11 @@ def main() -> int:
             per_level = model.match_weights[f.resolved_field]
             expr = F.lit(0.0)
             for level, val in enumerate(per_level):
-                expr = F.when(col == F.lit(level),
-                              F.lit(float(val))).otherwise(expr)
+                expr = F.when(col == F.lit(level), F.lit(float(val))).otherwise(expr)
             weight = weight + expr
-        truth = (F.col(f"{CAND_LHS}.__row_id__") % F.lit(n_entities)
-                 == F.col(f"{CAND_RHS}.__row_id__") % F.lit(n_entities))
+        truth = F.col(f"{CAND_LHS}.__row_id__") % F.lit(n_entities) == F.col(
+            f"{CAND_RHS}.__row_id__"
+        ) % F.lit(n_entities)
         # GROUP BY the weight in the ENGINE, and collect the groups.
         #
         # This used to collect one `(score, is_true)` tuple PER CANDIDATE PAIR.
@@ -757,8 +840,10 @@ def main() -> int:
             for r in (
                 joined.select(weight.alias("w"), truth.alias("is_true"))
                 .groupBy("w")
-                .agg(F.sum(F.col("is_true").cast("long")).alias("n_true"),
-                     F.count(F.lit(1)).alias("n_all"))
+                .agg(
+                    F.sum(F.col("is_true").cast("long")).alias("n_true"),
+                    F.count(F.lit(1)).alias("n_all"),
+                )
                 .collect()
             )
         ]
@@ -781,15 +866,17 @@ def main() -> int:
         # then gets deleted.
         _n_ent = max(args.rows // max(args.dup, 1), 1)
         _q, _r = divmod(args.rows, _n_ent)
-        expected_true = (_r * ((_q + 1) * _q // 2)
-                         + (_n_ent - _r) * (_q * (_q - 1) // 2))
+        expected_true = _r * ((_q + 1) * _q // 2) + (_n_ent - _r) * (_q * (_q - 1) // 2)
         q["expected_true_pairs"] = expected_true
-        q["true_pairs_match_expected"] = (q["n_true"] == expected_true)
+        q["true_pairs_match_expected"] = q["n_true"] == expected_true
         if not q["true_pairs_match_expected"]:
-            print(f"[scale] WARNING quality population is wrong: found "
-                  f"{q['n_true']:,} true pairs, fixture contains "
-                  f"{expected_true:,}. The metric below is NOT comparable to "
-                  f"the other engine's.", flush=True)
+            print(
+                f"[scale] WARNING quality population is wrong: found "
+                f"{q['n_true']:,} true pairs, fixture contains "
+                f"{expected_true:,}. The metric below is NOT comparable to "
+                f"the other engine's.",
+                flush=True,
+            )
         out["quality"] = q
         print(f"[scale] quality {out['quality']}", flush=True)
 
@@ -807,10 +894,11 @@ def main() -> int:
 
     out["total_seconds"] = round(sum(out["stages"].values()), 2)
 
-    print(f"[scale] DONE rows={actual:,} total={out['total_seconds']}s "
-          f"stages={out['stages']}", flush=True)
-    print(f"[scale] model m={out['m_probs']} weights={out['match_weights']}",
-          flush=True)
+    print(
+        f"[scale] DONE rows={actual:,} total={out['total_seconds']}s stages={out['stages']}",
+        flush=True,
+    )
+    print(f"[scale] model m={out['m_probs']} weights={out['match_weights']}", flush=True)
 
     if args.out:
         with open(args.out, "w", encoding="utf-8") as fh:

--- a/scripts/spark_fs_train_scale.py
+++ b/scripts/spark_fs_train_scale.py
@@ -622,6 +622,7 @@ def main() -> int:
         # None means Spark's default was left alone. Recorded so an artifact
         # can never be read without knowing which partition count produced it.
         "shuffle_partitions": _applied_partitions,
+        "u_max_pairs": args.u_max_pairs,
         "stages": {},
         "passes": [],
         "n_fields": args.fields,
@@ -653,6 +654,9 @@ def main() -> int:
         scorer_udf=ROW_UDF_NAME,
         transform_udf=TRANSFORM_UDF_NAME,
         max_pairs=args.u_max_pairs,
+        # The harness counted the fixture moments ago; re-counting 50M rows to
+        # derive a sampling fraction is a full pass for arithmetic we have.
+        total_rows=actual,
     )
     out["stages"]["u_seconds"] = round(time.perf_counter() - t, 2)
     out["u_probs"] = {k: [round(x, 6) for x in v] for k, v in u_probs.items()}

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -97,6 +97,7 @@ import os
 import re
 import time
 from pathlib import Path
+from typing import Any
 
 
 def _fixture_module():
@@ -134,6 +135,24 @@ def _shuffle_module():
     return mod
 
 
+def _tuning_module():
+    """The SHARED Spark tuning, imported by file path.
+
+    Same reasoning as the shuffle reader and the ranking metric: both arms have
+    to be tuned by ONE implementation, or the benchmark measures the tuning
+    rather than the engines.
+    """
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "_spark_tuning.py"
+    spec = importlib.util.spec_from_file_location("_spark_tuning", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _metrics_module():
     """The SHARED ranking metric, imported by file path.
 
@@ -156,7 +175,7 @@ def _metrics_module():
 _SIZE_SUFFIX = re.compile(r"^\s*(\d+)\s*([kKmMgGtT])[bB]?\s*$")
 
 
-def _normalize_gs_size_props(spark: object) -> None:
+def _normalize_gs_size_props(spark: Any) -> None:
     """Rewrite suffixed `fs.gs.*` sizes to plain bytes, and say what it found.
 
     Runs 32269692605 and 32277069612 both died initializing the filesystem with
@@ -420,6 +439,14 @@ def main() -> int:
         "back to `persist`, which does NOT truncate lineage "
         "and OOMs at scale.",
     )
+    ap.add_argument(
+        "--shuffle-partitions",
+        type=int,
+        default=0,
+        help="spark.sql.shuffle.partitions. 0 leaves Spark's default, "
+        "-1 derives 5x total executor cores per Splink's guide. "
+        "Applied IDENTICALLY to both arms via scripts/_spark_tuning.py.",
+    )
     ap.add_argument("--out", default="splink-train-scale.json")
     args = ap.parse_args()
 
@@ -470,6 +497,12 @@ def main() -> int:
         args.master, args.driver_host or None, args.executor_wait, args.checkpoint_dir or None
     )
     out["executors"] = n_exec
+    # Applied AFTER build_session, which waits for executors to register: the
+    # core count is read from the running cluster, and reading it before
+    # registration would derive the partition count from zero cores.
+    out["shuffle_partitions"] = _tuning_module().apply_shuffle_partitions(
+        spark, args.shuffle_partitions, spark_ui=args.spark_ui
+    )
 
     fx = _fixture_module()
     t = time.perf_counter()

--- a/scripts/spark_splink_train_scale.py
+++ b/scripts/spark_splink_train_scale.py
@@ -230,7 +230,13 @@ def _normalize_gs_size_props(spark: Any) -> None:
 
 
 def build_session(
-    master: str, driver_host: str | None, wait_s: int, checkpoint_dir: str | None = None
+    master: str,
+    driver_host: str | None,
+    wait_s: int,
+    checkpoint_dir: str | None = None,
+    executor_memory: str | None = None,
+    executor_cores: int | None = None,
+    expect_executors: int = 0,
 ):
     """A session tuned NO differently from the one GM gets.
 
@@ -266,6 +272,22 @@ def build_session(
         # also ships it to the executors, which is where the UDFs evaluate.
         .config("spark.jars", similarity_jar_location())
     )
+    # EXECUTOR SIZING, matched to GoldenMatch's. This session set neither, so it
+    # took Spark's DEFAULT `spark.executor.memory=1g` while GM's Connect server
+    # is launched by the workflow with
+    #
+    #     --conf spark.executor.cores=16 --conf spark.executor.memory=48g
+    #
+    # A 48x memory disadvantage is not a comparison. It explains the OOM
+    # (`exited with code 52`) at 50M, the executors lost and relaunched into the
+    # teens, and -- at 1M, where Splink completed -- the 4.09 GB memory / 1.88 GB
+    # disk spill against GoldenMatch's zero. That spill was previously read as a
+    # structural property of the engines; on this evidence it is an artefact of
+    # how much heap each arm was given.
+    if executor_memory:
+        b = b.config("spark.executor.memory", executor_memory)
+    if executor_cores:
+        b = b.config("spark.executor.cores", str(executor_cores))
     if driver_host:
         b = b.config("spark.driver.host", driver_host)
     if checkpoint_dir and checkpoint_dir.startswith("gs://"):
@@ -367,6 +389,14 @@ def build_session(
     # run "works" -- it just runs everything on the driver and reports a wall
     # that has nothing to do with the cluster, which is a worse outcome than a
     # failure because it looks like data.
+    # Waits for the EXPECTED count, not merely for one. `n > 0` returned on the
+    # first executor to check in, so run 32287895819 reported "2 executor(s)
+    # registered" -- a SNAPSHOT of a cluster still filling up, not its size.
+    # That number is not cosmetic: it is recorded in the artifact as the
+    # cluster Splink ran on, and the shuffle-partition tuning derives from the
+    # cores behind it, which is how that run tuned to 160 partitions instead of
+    # 320. A count taken too early under-provisions the arm and then documents
+    # the wrong reason for it.
     deadline = time.time() + wait_s
     n = 0
     while time.time() < deadline:
@@ -374,9 +404,21 @@ def build_session(
             n = spark.sparkContext._jsc.sc().getExecutorMemoryStatus().size() - 1
         except Exception:  # noqa: BLE001 - probe only
             n = 0
-        if n > 0:
+        if n >= expect_executors > 0:
+            break
+        if expect_executors <= 0 and n > 0:
             break
         time.sleep(2)
+    if 0 < n < expect_executors:
+        # Not fatal: a short cluster is still measurable, and refusing would
+        # throw away the GoldenMatch arm that already ran. But it must be LOUD,
+        # because a quietly under-provisioned arm reads as an engine limit.
+        print(
+            f"::warning::only {n}/{expect_executors} executors registered within "
+            f"{wait_s}s; this arm is under-provisioned and its wall is not "
+            f"comparable to the other's",
+            flush=True,
+        )
     if n <= 0:
         raise SystemExit(
             f"::error::no executor registered within {wait_s}s on {master}. "
@@ -399,6 +441,16 @@ def main() -> int:
     )
     ap.add_argument("--driver-host", default=os.environ.get("SPLINK_DRIVER_HOST", ""))
     ap.add_argument("--executor-wait", type=int, default=120)
+    ap.add_argument("--expect-executors", type=int, default=0,
+                    help="Wait for this many executors before proceeding. 0 waits for one. "
+                         "A snapshot taken while the cluster is still filling up both "
+                         "under-provisions this arm and mis-derives the partition count.")
+    ap.add_argument("--executor-memory", default="",
+                    help="spark.executor.memory. MUST match what the workflow gives the "
+                         "Connect server for GoldenMatch, or the arms differ by heap size "
+                         "rather than by engine. Empty leaves Spark's 1g default.")
+    ap.add_argument("--executor-cores", type=int, default=0,
+                    help="spark.executor.cores. Same symmetry requirement as memory.")
     ap.add_argument(
         "--max-pairs",
         type=int,
@@ -494,9 +546,18 @@ def main() -> int:
     t_all = time.perf_counter()
 
     spark, n_exec = build_session(
-        args.master, args.driver_host or None, args.executor_wait, args.checkpoint_dir or None
+        args.master,
+        args.driver_host or None,
+        args.executor_wait,
+        args.checkpoint_dir or None,
+        executor_memory=args.executor_memory or None,
+        executor_cores=args.executor_cores or None,
+        expect_executors=args.expect_executors,
     )
     out["executors"] = n_exec
+    out["expected_executors"] = args.expect_executors or None
+    out["executor_memory"] = args.executor_memory or "(spark default 1g)"
+    out["executor_cores"] = args.executor_cores or None
     # Applied AFTER build_session, which waits for executors to register: the
     # core count is read from the running cluster, and reading it before
     # registration would derive the partition count from zero cores.


### PR DESCRIPTION
Splink failed at 50M four times. Every failure was OUR configuration, and each one would have been published as a Splink limitation.

## What was wrong

| # | defect | effect |
|---|---|---|
| 1 | `break_lineage_method="persist"` (Splink's documented default is `parquet`) | 337s -> 104s at 1M once fixed |
| 2 | No distributed filesystem for `parquet` to write to | OOM at 50M |
| 3 | Splink started before the master released Connect's cores, and its own wait broke on `n > 0` | ran on 2 executors vs GoldenMatch's 4, and derived 160 shuffle partitions instead of 320 |
| 4 | `spark.executor.memory` left at Spark's **1g** default while GoldenMatch's Connect server got **48g** | the 50M OOMs, and the "Splink spills 4 GB where we spill zero" claim |

Number 4 is the one that matters most. With equal memory **both arms spill nothing**, and the GC gap I had reported as 5.9x is **1.19x**.

## The first valid 50M head-to-head

Run 32292243875. Both arms, one cluster, 48g executors each, 320 partitions each, 0 spill, 0 failed tasks, no executor deaths, identical 463,923,179 pairs scored.

| | GoldenMatch | Splink | ratio |
|---|---:|---:|---:|
| wall | 862.25s | 1,247.8s | 1.45x |
| u / estimate | 98.63s | 43.29s | **0.44x (Splink faster)** |
| counts vs EM | 364.66s | 631.44s | 1.73x |
| shuffle write | 128.46 GB | 212.07 GB | 1.65x |
| stages | 197 | 394 | 2.00x |
| CPU | 47,121s | 63,759s | 1.35x |
| GC | 273s | 413s | 1.51x |
| average precision | 0.700397 | 0.641803 | |
| best F1 | 0.684516 | 0.600296 | |

GoldenMatch wins wall, bytes, stages, CPU, GC and both accuracy measures. Two results that do not flatter us and are reported anyway: **Splink's `u` estimation is 2.3x faster**, and **the margin narrows with scale** (2.5x at 1M, 1.45x at 50M), so Splink scales better relatively. Do not extrapolate the 1M ratio.

## The `~20x fewer bytes` premise is retracted

The workflow header justified this lane with a single-host proxy that ran Splink the same wrong way. Real figure is ~1.65x. The old number stays in the header with its retraction attached rather than being deleted, because anyone who already quoted it needs to find this.

## Also in here

- **Shuffle partitions at 5x cluster cores for BOTH arms**, per Splink's performance guide, from one shared implementation (`scripts/_spark_tuning.py`) so the comparison can never measure a tuning difference. `spark.default.parallelism` is deliberately NOT set: it cannot be set at runtime on a Connect session, so setting it for Splink alone would hand one arm a knob the other cannot reach.
- **Cores read from the cluster**, not derived from the workflow inputs -- an executor that failed to register would otherwise silently over-shard.
- **The harness helper list is derived from what the harnesses import**, after a hand-kept scp list omitted a new module and cost a whole 50M cluster to `FileNotFoundError`.
- `fs.gs.block.size=64m` identified as the GCS `NumberFormatException` -- a Hadoop `core-default.xml` value, never ours, found by enumerating the Hadoop conf after two guesses each cost a cluster.

## Testing

Validated at 1M (run 32290866436) before spending a 50M cluster: both arms 4 executors, 320 partitions, 48g, Splink green. Then 50M (run 32292243875) green on both arms. `resolve_shuffle_partitions` unit-tested including the absent-cores case, which leaves Spark's default rather than fabricating a number.
