### PR TITLE
fix(bench): a backtick in a COMMENT ran pip on the runner and broke the ssh

### DIFF
--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -892,7 +892,7 @@ jobs:
             #     keyword argument 'total_rows'
             #
             # because the harness is copied from the repo while the LIBRARY came
-            # from `pip install goldenmatch[spark]` -- the published 3.13.0,
+            # from pip install goldenmatch[spark] -- the published 3.13.0,
             # without the change being measured. This lane could therefore only
             # ever measure ALREADY-RELEASED code, so any performance fix had to
             # ship before it could be tested. Same family as the #688 stale-wheel
@@ -901,9 +901,9 @@ jobs:
             docker exec pyenv python -c 'import goldenmatch, inspect; from goldenmatch.spark.em import estimate_u_distributed as f; print(\"[env] goldenmatch\", goldenmatch.__version__, \"total_rows:\", \"total_rows\" in inspect.signature(f).parameters)'
 
             # A JVM, for SPLINK only. GoldenMatch does not need one here: it
-            # talks to the cluster over Spark CONNECT (`sc://`), which is a gRPC
+            # talks to the cluster over Spark CONNECT (sc://), which is a gRPC
             # client. Splink drives a CLASSIC session, which launches a local
-            # JVM driver process -- and `python:3.12-slim` has no Java, so the
+            # JVM driver process -- and python:3.12-slim has no Java, so the
             # first run that got this far died on:
             #
             #   PySparkRuntimeError: [JAVA_GATEWAY_EXITED] Java gateway process

--- a/scripts/check_workflow_yaml.py
+++ b/scripts/check_workflow_yaml.py
@@ -70,15 +70,11 @@ def _no_duplicates(loader: yaml.Loader, node: yaml.MappingNode, deep: bool = Fal
     return mapping
 
 
-StrictLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates
-)
+StrictLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates)
 
 
 def workflow_files(directory: pathlib.Path) -> list[pathlib.Path]:
-    return sorted(
-        p for p in directory.iterdir() if p.suffix in (".yml", ".yaml") and p.is_file()
-    )
+    return sorted(p for p in directory.iterdir() if p.suffix in (".yml", ".yaml") and p.is_file())
 
 
 def check(directory: pathlib.Path) -> tuple[list[tuple[pathlib.Path, str]], int]:
@@ -161,8 +157,9 @@ def _bad_run_scripts(path: pathlib.Path) -> list[tuple[pathlib.Path, str]]:
             if not isinstance(script, str):
                 continue
             # A step can select another shell; only bash is checkable here.
-            shell = str(step.get("shell") or job.get("defaults", {})
-                        .get("run", {}).get("shell") or "bash")
+            shell = str(
+                step.get("shell") or job.get("defaults", {}).get("run", {}).get("shell") or "bash"
+            )
             if not shell.startswith("bash") and shell != "sh":
                 continue
             with tempfile.NamedTemporaryFile(
@@ -171,36 +168,95 @@ def _bad_run_scripts(path: pathlib.Path) -> list[tuple[pathlib.Path, str]]:
                 fh.write(script)
                 tmp = fh.name
             try:
-                proc = subprocess.run(
-                    [bash, "-n", tmp], capture_output=True, text=True
-                )
+                proc = subprocess.run([bash, "-n", tmp], capture_output=True, text=True)
             finally:
                 pathlib.Path(tmp).unlink(missing_ok=True)
             label = step.get("name") or f"step {i}"
             if proc.returncode != 0:
                 detail = (proc.stderr or "").strip().replace(tmp, "<step>")
-                out.append((
-                    path,
-                    f"job `{job_name}` step `{label}`: `run:` is not valid bash "
-                    f"-- {detail}",
-                ))
+                out.append(
+                    (
+                        path,
+                        f"job `{job_name}` step `{label}`: `run:` is not valid bash -- {detail}",
+                    )
+                )
             for lineno, line in enumerate(script.splitlines(), 1):
                 m = _MANGLED_CONTINUATION.search(line)
                 if m:
-                    out.append((
-                        path,
-                        f"job `{job_name}` step `{label}` line {lineno}: a literal "
-                        f"`\\n` with whitespace on both sides -- almost certainly a "
-                        f"line continuation that collapsed, so bash gets `n` as an "
-                        f"argument. `bash -n` calls this VALID. In: "
-                        f"{line.strip()[:70]!r}",
-                    ))
+                    out.append(
+                        (
+                            path,
+                            f"job `{job_name}` step `{label}` line {lineno}: a literal "
+                            f"`\\n` with whitespace on both sides -- almost certainly a "
+                            f"line continuation that collapsed, so bash gets `n` as an "
+                            f"argument. `bash -n` calls this VALID. In: "
+                            f"{line.strip()[:70]!r}",
+                        )
+                    )
     return out
 
 
 #: Backslash-n with whitespace both sides: a collapsed line continuation.
 #: A deliberate escape sits next to non-space (``f"{a}\nb"``) and is not matched.
 _MANGLED_CONTINUATION = re.compile(r"\s\\n\s")
+
+
+def _backticks_in_remote_commands(path: pathlib.Path) -> list[str]:
+    """Backticks inside an ssh ``--command "..."`` string, which the RUNNER runs.
+
+    Everything between ``--command "`` and its closing quote is a double-quoted
+    string evaluated on the RUNNER, so backticks and ``$( )`` inside it are
+    command substitutions. That INCLUDES lines beginning with ``#``, because the
+    comment marker means nothing to the runner's string parsing.
+
+    Run 32312785745 died on a comment written to explain an earlier failure. It
+    quoted a pip invocation in backticks; the runner executed it and spliced
+    pip's stdout into the command sent to the remote host, which then tried to
+    run ``Collecting`` and exited 127.
+
+    The insidious part is that most such mistakes are SILENT. A backticked
+    ``sc://`` substitutes to nothing and only prints to stderr, so the same
+    block had carried backticks for months without incident. Only a
+    substitution that SUCCEEDS corrupts the command, which is why this cannot be
+    caught by "it worked last time" and is worth a gate.
+
+    Detection tracks QUOTE STATE rather than line shapes. A first attempt
+    matched the closing quote as a line of its own, which silently leaked: real
+    blocks here also close with ``" &`` and ``" || true``, so the scanner stayed
+    "inside" for hundreds of lines and flagged ordinary runner-side comments.
+    A gate with false positives is worse than no gate.
+    """
+    problems: list[str] = []
+    inside = False
+    for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not inside:
+            m = re.search(r'--command "\s*$', line)
+            if m:
+                inside = True
+            continue
+
+        # Walk the line and close on the first UNESCAPED double quote.
+        closed_at = None
+        k = 0
+        while k < len(line):
+            c = line[k]
+            if c == "\\":
+                k += 2
+                continue
+            if c == '"':
+                closed_at = k
+                break
+            k += 1
+
+        segment = line if closed_at is None else line[:closed_at]
+        if "`" in segment:
+            problems.append(
+                f"line {n}: backtick inside an ssh --command string. The RUNNER "
+                f"substitutes it, even in a # comment: {line.strip()[:80]}"
+            )
+        if closed_at is not None:
+            inside = False
+    return problems
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -232,6 +288,10 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+
+    for wf in sorted(pathlib.Path(args.dir).glob("*.yml")):
+        for problem in _backticks_in_remote_commands(wf):
+            problems.append((wf, problem))
 
     print(f"workflow YAML: {scanned} file(s) scanned for parse errors + duplicate keys")
     if problems:


### PR DESCRIPTION
Run 32312785745 died with `bash: line 13: Collecting: command not found` (exit 127) before measuring anything.

Everything between `--command "` and its closing quote is a double-quoted string on the RUNNER, so backticks inside it are command substitutions -- **including on `#` comment lines**, because the comment marker means nothing to string parsing. A comment I wrote to explain the PREVIOUS failure quoted a pip invocation in backticks. The runner ran it and spliced pip's stdout into the command sent to the master.

Two backticked comments had sat in that block for months without incident, because `sc://` and `python:3.12-slim` substitute to NOTHING and only print to stderr. Only a substitution that SUCCEEDS corrupts the command, so "it always worked" proves nothing.

`check_workflow_yaml.py` now gates on this across all 129 workflows.

**The first version of the guard was wrong too, and that is in the commit message.** It matched the closing quote as its own line, but blocks here also close with `" &` and `" || true`, so it leaked and flagged 13 lines of which 10 were fabricated. It now tracks quote state character by character with backslash handling. Verified zero findings on the fixed file, and that it catches the exact offending line when reintroduced.