### PR TITLE
docs(vendor): the distributed Spark head-to-head, and what it does NOT change

### DIFF
--- a/docs/er-vendor-comparison.md
+++ b/docs/er-vendor-comparison.md
@@ -1,6 +1,6 @@
 # ER vendor comparison — GoldenMatch vs the field
 
-**Last updated:** 2026-06-12
+**Last updated:** 2026-08-20
 **Scope:** entity-resolution **engines**, both OSS and commercial. This is a reference doc, not marketing. Every claim about GoldenMatch is reproducible from this repo; claims about other vendors are sourced from their public docs as of mid-2026 and may lag behind their current release.
 **Sister doc:** `docs/superpowers/specs/2026-05-08-competitive-strategy-review.md` — what we *do* with these comparisons.
 
@@ -22,14 +22,14 @@ A "win" in the matrix below means *materially ahead with evidence*. Ties stay bl
 
 ## GoldenMatch — the baseline of this doc
 
-Before comparing, the column we're comparing *against*. Numbers are as of `goldenmatch` v1.30.0 (2026-06-12) — the prior revision of this doc was pinned to v1.9.0; reference data, the identity graph, probabilistic/Splink parity, and distributed throughput have all moved since.
+Before comparing, the column we're comparing *against*. Numbers are as of `goldenmatch` v3.13.1 (2026-08-20). The prior revision was pinned to v1.30.0; since then the distributed Spark tier gained a measured head-to-head against Splink (see [Splink](#1-splink-uk-ministry-of-justice)), and a `u`-estimation fix cut Fellegi-Sunter training wall at 50M by 1.56x.
 
 | Axis | GoldenMatch |
 |---|---|
 | **License** | MIT (every package in the suite) |
 | **Languages** | Python (headline) + TypeScript (parity) + Rust (Postgres/DuckDB extension) |
 | **Runtimes** | Polars (≤500K), DuckDB (500K–50M), Ray + DataFusion/Sail distributed tier (≥50M); Postgres via pgrx; DuckDB UDFs; edge JS (Vercel Edge / Cloudflare Workers / Deno) |
-| **Throughput** | 1M dedupe in 12.3 min on 4-core / 16 GB Linux (Round 5, 2026-05-12); **100M distributed dedupe in 9.2 min on a 5-node Ray cluster** (block-shuffle scoring + randomized-contraction WCC, byte-exact 20M-cluster recovery, #844); 100K fuzzy ~39 s |
+| **Throughput** | 1M dedupe in 12.3 min on 4-core / 16 GB Linux (Round 5, 2026-05-12); **100M distributed dedupe in 9.2 min on a 5-node Ray cluster** (block-shuffle scoring + randomized-contraction WCC, byte-exact 20M-cluster recovery, #844); **distributed Fellegi-Sunter training at 50M in 551s on a 5-node Spark cluster** (463.9M pairs, zero spill; 1.45x faster than Splink on the same cluster when measured, before the v3.13.1 `u` fix) [^spark50m]; 100K fuzzy ~39 s |
 | **Accuracy, PII (Febrl)** | F1 0.971 (zero-config 0.944 on Febrl3) [^bench] |
 | **Accuracy, bibliographic (DBLP-ACM)** | F1 0.964 zero-config (hand-tuned ceiling 0.918) [^bench] |
 | **Accuracy, product (Abt-Buy)** | F1 0.722 +$0.04 LLM; 0.817 with Vertex AI + GPT-4o-mini [^bench] |
@@ -43,7 +43,7 @@ Before comparing, the column we're comparing *against*. Numbers are as of `golde
 | **Reference data** | Bundled (`goldenmatch.refdata`, strategy dir #8): reference-people (US Census-2010 top-10K surnames + frequency-weighted JW scorer; curated given-name alias table + alias-aware JW), reference-business (legal-form strip, NAICS-2022 normalization), reference-address (USPS Pub-28 normalization) — plus 7 domain rule packs. Still narrower than Senzing/LexisNexis curated data depth. |
 | **Explainability** | Per-pair NL prose explanations; per-field score breakdown; lineage tracking |
 | **AI-native surface** | 50+ MCP tools (agent + memory + identity-graph + base), A2A agent skills, REST API, Smithery-hosted MCP. **Only OSS ER engine with native MCP/A2A surface.** |
-| **Active dev** | Tracks daily; v1.30.0 (June 2026) |
+| **Active dev** | Tracks daily; v3.13.1 (August 2026) |
 
 The rest of this doc is "but what about X?".
 
@@ -80,6 +80,14 @@ Observations from the matrix:
 
 1. **Nobody else publishes zero-config benchmark numbers.** Every "GM" in that row reflects that this is currently uncontested ground.
 2. **Throughput at ≥10M on a *single node* is still the universal "V" against us.** Almost every paid vendor and several OSS engines (Splink/DuckDB, Zingg/Spark, Senzing) win here. Distributed has closed fast — **100M dedupe now runs in 9.2 min on a 5-node Ray cluster** (block-shuffle scoring + randomized-contraction WCC, #844) — but the single-node ≥10M column is unmoved. Closing it remains direction #1 of the strategy review.
+   **Distributed has now gone further than "closed":** on a like-for-like Spark
+   cluster at 50M, GoldenMatch is 1.45x faster than Splink on wall and moves
+   1.65x fewer bytes, with both engines correctly configured [^spark50m]. That
+   is the first axis where we beat Splink on *speed* rather than on tuning
+   effort — but note the shape of it: **single-node throughput remains their
+   win, distributed is ours, and the margin narrows as scale grows.** The
+   scorecard row above stays "V" because it says *single node* and that is
+   still true.
 3. **MCP/A2A surface is unique to us.** This is the AI-native wedge — nobody else has it because nobody else built an engine for AI agents to drive end-to-end.
 4. **The Splink "V" on PII F1 has flipped (note ‡).** Zero-tuning probabilistic auto-config now matches/beats hand-rolled Splink pairwise F1 under a shared evaluator — the first time an auto-config engine has done so against an expert-tuned F-S spec.
 
@@ -106,8 +114,47 @@ Observations from the matrix:
 **AI / active learning.** No LLM integration. Active learning via manual labelling helpers; threshold calibration tools.
 
 **Where Splink beats GoldenMatch:**
-- Raw speed: 3-19x faster per node on the bake-off, 1B+ rows on Spark, plus a mature interactive m/u comparison-viewer UI. (We now match/beat on accuracy and reach 100M in 9.2 min distributed — but Splink stays faster per node.)
+- Raw speed **on a single node**: 3-19x faster on the bake-off (DuckDB backend), plus a mature interactive m/u comparison-viewer UI. Splink also publicly demos 1B-row Spark runs; our largest measured Spark run is 50M, so the top of their range is untested by us rather than disproven.
+- **Splink's `u` estimation is faster to set up conceptually** and, until 2026-08-19, was faster in our own harness — see the note below for how that changed.
 - DuckDB-native by default; we treat it as a backend option.
+
+**Distributed Spark, measured head-to-head (2026-08-19, run `32292243875`).** Both
+engines on the *same* 5-node GCE cluster, same fixture, same shared metric
+implementation, same 48 GB executors and 320 shuffle partitions, and Splink
+configured the way its own performance guide prescribes (`parquet` lineage
+breaks onto HDFS). 50M rows, **463,923,179 candidate pairs scored identically
+by both**:
+
+| | GoldenMatch | Splink | ratio |
+|---|---:|---:|---:|
+| wall | **862s** | 1,248s | 1.45x |
+| shuffle write | **128.5 GB** | 212.1 GB | 1.65x |
+| stages | **197** | 394 | 2.00x |
+| executor CPU | **47,121s** | 63,759s | 1.35x |
+| spill | 0 | 0 | — |
+
+This is the first evidence that the "Splink is faster" line does **not** hold on
+the distributed tier, on Splink's own strongest runtime. Read it with its
+limits: **N=1**, a synthetic fixture, and an unavoidable session-type confound
+(GM runs Spark Connect because `addArtifact` is Connect-only; Splink drives a
+classic session because it needs `sparkContext`). The margin also **narrows with
+scale** — 2.54x at 1M, 1.45x at 50M — so it must not be extrapolated upward.
+Full method and caveats: [50M head-to-head][^spark50m].
+
+Two honest footnotes to that table. **The accuracy figures from that run are not
+an accuracy verdict** (both harnesses say so in their own docstrings; the config
+exists to exercise the EM bound for a scale test) — accuracy claims come from the
+bake-off below. And **GoldenMatch's side improved after it was measured**: a
+`u`-estimation fix in v3.13.1 took that stage from 98.63s to 3.39s and the total
+from 862s to 551s, which would put the ratio near 2.26x. Splink has **not** been
+re-run, so the table above stays as measured rather than mixing two builds.
+
+**Four earlier attempts at this comparison were invalid, and all four were our
+fault** — `persist` instead of Splink's documented `parquet` lineage break, no
+distributed filesystem for it to write to, Splink starting on half the cluster,
+and Splink running on 1 GB executors against our 48 GB. Each would have
+published as a Splink limitation. The write-up documents every one, because a
+benchmark whose failures were never wrong is not evidence.
 
 **Where GoldenMatch beats Splink:**
 - **Accuracy with zero tuning.** GM's probabilistic auto-config matches/beats hand-rolled Splink pairwise F1 on every dataset Splink scores, under one shared evaluator: febrl3 0.996 vs 0.965, historical_50k 0.827 vs 0.757, synthetic_person 1.000 vs 0.996 [^bakeoff]. Splink requires an expert comparison spec per field; we ship a controller. (The often-cited Splink ~0.97/0.998 Febrl figure is a *cluster* metric, not within-cluster pairwise.)
@@ -680,6 +727,8 @@ Splink (MIT) and dedupe (BSD) have outgrown Zingg (AGPL) and Senzing (closed cor
 ## Footnotes
 
 [^bench]: GoldenMatch zero-config numbers come from `docs/reproducing-benchmarks.md` (per-dataset runner + expected output) and the entries in `packages/python/goldenmatch/CHANGELOG.md` for v1.8 through v1.30. Verified-stamp dates accompany each row in the reproducing-benchmarks doc (DBLP-ACM 0.9641, Febrl3 0.9443, NCVR 0.9719, all verified 2026-05-11 and flat since).
+
+[^spark50m]: The distributed Spark head-to-head lives at `docs/benchmarks/2026-08-19-spark-50m-head-to-head.md` -- both engines on ONE 5-node GCE cluster (4x `n2-standard-16` + master), the same fixture built by the same function, the same shared metric implementation, the same 48 GB executors and 320 shuffle partitions, and Splink configured per its own performance guide (`parquet` lineage breaks onto HDFS). Run `32292243875`, 50M rows / 463,923,179 pairs scored identically by both, zero spill and zero failed tasks on either side. Limits stated in the doc rather than implied: N=1, synthetic fixture, an unavoidable Connect-vs-classic session confound, a margin that NARROWS with scale (2.54x at 1M to 1.45x at 50M), and accuracy figures that are explicitly not an accuracy verdict. It also documents the four misconfigurations of OURS that invalidated the four preceding attempts.
 
 [^bakeoff]: The autoconfig-vs-hand-rolled bake-off lives at `docs/benchmarks/2026-06-09-splink-bakeoff.md` — three engines (GM zero-config, GM probabilistic auto-config, hand-rolled Splink) per dataset, each self-timed in its own subprocess, all judged by ONE shared `evaluate.evaluate` pairwise evaluator on the same `record_id` key space. Run on `large-new-64GB` at commit `970aab61` (deterministic EM training-pair sampling, #829), reproduces run-to-run within 0.002. Honest framing in that doc: Splink stays 3-19x faster per node, retains 1B-row Spark + the m/u comparison-viewer UI; GM's edge is zero tuning at accuracy parity.
 


### PR DESCRIPTION
`er-vendor-comparison.md` was pinned to v1.30.0 and carried one line about Splink and speed: *"3-19x faster per node"*. Still true, still there. What was missing is that it had never been tested on the tier Splink is strongest on.

Adds the 2026-08-19 measurement (run `32292243875`) — both engines on one 5-node cluster, same fixture, same shared metric code, same 48 GB executors and 320 partitions, Splink configured per its own guide, 50M rows / 463,923,179 pairs scored identically:

| | GoldenMatch | Splink | ratio |
|---|---:|---:|---:|
| wall | **862s** | 1,248s | 1.45x |
| shuffle write | **128.5 GB** | 212.1 GB | 1.65x |
| stages | **197** | 394 | 2.00x |
| CPU | **47,121s** | 63,759s | 1.35x |

## What this deliberately does NOT change

- **"3-19x faster per node" is the single-box DuckDB bake-off.** Unchanged, left in place. Conflating it with a distributed Spark result is the easiest way to make this doc wrong.
- **The scorecard's "Throughput ≥10M single node" stays V for Splink.** It says single node, and single node is still theirs.
- **Splink demos 1B-row Spark runs.** Our largest measured run is 50M, so the top of their range is untested by us, not disproven.
- **The margin narrows with scale** (2.54x at 1M → 1.45x at 50M) and the cross-cutting note says so.
- **The accuracy figures in that run are not an accuracy verdict** — both harnesses say so in their docstrings. Accuracy still cites the bake-off.
- **GM improved after measurement** (v3.13.1 `u` fix: 862s → 551s, ratio would be ~2.26x), but Splink was not re-run, so the table stays as measured rather than mixing builds.

Also records that four earlier attempts were invalid and all four were our misconfiguration. A benchmark whose failures were never wrong is not evidence.

Every figure cross-checked against the run artifact; `check_docs_consistency` passes.