### PR TITLE
feat(security): fail-closed HTTP auth on the sibling MCP servers, + goldensuite (rebase of #2330)

### DIFF
--- a/docs-site/goldenanalysis/config-matrix.mdx
+++ b/docs-site/goldenanalysis/config-matrix.mdx
@@ -116,8 +116,9 @@ _`_FALLBACK` -- `analyze(analyzers=...)`._
 
 ## Environment variables (index)
 
-1 `GOLDENANALYSIS_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
+3 `GOLDENANALYSIS_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
 
+- **MCP** (2): `GOLDENANALYSIS_MCP_ALLOW_PUBLIC`, `GOLDENANALYSIS_MCP_TOKEN`
 - **NATIVE** (1): `GOLDENANALYSIS_NATIVE`
 
 {/* config-matrix:generated:end */}

--- a/docs-site/goldencheck/config-matrix.mdx
+++ b/docs-site/goldencheck/config-matrix.mdx
@@ -280,11 +280,12 @@ _`CHECK_TYPES` -- `Finding.check`._
 
 ## Environment variables (index)
 
-6 `GOLDENCHECK_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
+8 `GOLDENCHECK_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
 
 - **AGENT** (1): `GOLDENCHECK_AGENT_TOKEN`
 - **FORCE** (1): `GOLDENCHECK_FORCE_TUI`
 - **LLM** (2): `GOLDENCHECK_LLM_BUDGET`, `GOLDENCHECK_LLM_MODEL`
+- **MCP** (2): `GOLDENCHECK_MCP_ALLOW_PUBLIC`, `GOLDENCHECK_MCP_TOKEN`
 - **NATIVE** (1): `GOLDENCHECK_NATIVE`
 - **SCAN** (1): `GOLDENCHECK_SCAN_THREADS`
 

--- a/docs-site/goldenpipe/config-matrix.mdx
+++ b/docs-site/goldenpipe/config-matrix.mdx
@@ -178,9 +178,10 @@ _`BUILTIN_STAGES` -- `StageSpec.use`._
 
 ## Environment variables (index)
 
-2 `GOLDENPIPE_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
+4 `GOLDENPIPE_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
 
 - **ALLOWED** (1): `GOLDENPIPE_ALLOWED_ROOT`
+- **MCP** (2): `GOLDENPIPE_MCP_ALLOW_PUBLIC`, `GOLDENPIPE_MCP_TOKEN`
 - **NATIVE** (1): `GOLDENPIPE_NATIVE`
 
 {/* config-matrix:generated:end */}

--- a/docs-site/infermap/config-matrix.mdx
+++ b/docs-site/infermap/config-matrix.mdx
@@ -125,8 +125,9 @@ _`SEMANTIC_TYPES` -- pattern-type detection._
 
 ## Environment variables (index)
 
-1 `INFERMAP_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
+3 `INFERMAP_*` runtime knob(s) read by the package, scanned from source so this is complete. Grouped by area:
 
+- **MCP** (2): `INFERMAP_MCP_ALLOW_PUBLIC`, `INFERMAP_MCP_TOKEN`
 - **NATIVE** (1): `INFERMAP_NATIVE`
 
 {/* config-matrix:generated:end */}

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -10322,6 +10322,7 @@
             "_tool_scan",
             "_tool_validate",
             "create_server",
+            "resolve_http_auth_token",
             "run_server",
             "run_server_http"
           ],
@@ -12820,6 +12821,7 @@
             "create_server",
             "explain_pipeline_tool",
             "list_stages_tool",
+            "resolve_http_auth_token",
             "run_pipeline_tool",
             "run_server",
             "run_server_http",
@@ -13238,6 +13240,7 @@
             "_handle_map",
             "_handle_validate",
             "create_server",
+            "resolve_http_auth_token",
             "run_server",
             "run_server_http"
           ],
@@ -13794,6 +13797,7 @@
             "detect_regressions_tool",
             "get_trend_tool",
             "list_analyzers_tool",
+            "resolve_http_auth_token",
             "run_server",
             "run_server_http"
           ],

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -7515,6 +7515,10 @@
           "GOLDENCHECK_LLM_BUDGET",
           "GOLDENCHECK_LLM_MODEL"
         ],
+        "MCP": [
+          "GOLDENCHECK_MCP_ALLOW_PUBLIC",
+          "GOLDENCHECK_MCP_TOKEN"
+        ],
         "NATIVE": [
           "GOLDENCHECK_NATIVE"
         ],
@@ -9195,6 +9199,10 @@
         "ALLOWED": [
           "GOLDENPIPE_ALLOWED_ROOT"
         ],
+        "MCP": [
+          "GOLDENPIPE_MCP_ALLOW_PUBLIC",
+          "GOLDENPIPE_MCP_TOKEN"
+        ],
         "NATIVE": [
           "GOLDENPIPE_NATIVE"
         ]
@@ -9583,6 +9591,10 @@
         }
       ],
       "env_vars": {
+        "MCP": [
+          "INFERMAP_MCP_ALLOW_PUBLIC",
+          "INFERMAP_MCP_TOKEN"
+        ],
         "NATIVE": [
           "INFERMAP_NATIVE"
         ]
@@ -9870,6 +9882,10 @@
         }
       ],
       "env_vars": {
+        "MCP": [
+          "GOLDENANALYSIS_MCP_ALLOW_PUBLIC",
+          "GOLDENANALYSIS_MCP_TOKEN"
+        ],
         "NATIVE": [
           "GOLDENANALYSIS_NATIVE"
         ]

--- a/packages/python/goldenanalysis/goldenanalysis/mcp/server.py
+++ b/packages/python/goldenanalysis/goldenanalysis/mcp/server.py
@@ -9,6 +9,8 @@ stays light -- the aggregator + smoke tests only touch ``TOOLS`` / ``HANDLERS``.
 from __future__ import annotations
 
 import json
+import os
+import secrets
 from pathlib import Path
 from typing import Any
 
@@ -219,6 +221,29 @@ def run_server() -> None:
     asyncio.run(main())
 
 
+def resolve_http_auth_token(host: str) -> str | None:
+    """Return the MCP HTTP bearer token, enforcing the fail-closed bind rule.
+
+    Raises ``RuntimeError`` when binding to a non-loopback host without
+    ``GOLDENANALYSIS_MCP_TOKEN`` set, so an exposed server is never started
+    unauthenticated by accident. Returns the token (or ``None`` for an
+    intentionally-open loopback bind). Escape hatch: set
+    ``GOLDENANALYSIS_MCP_ALLOW_PUBLIC=1`` to intentionally run an open public server.
+    """
+    token = os.environ.get("GOLDENANALYSIS_MCP_TOKEN")
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    allow_public = os.environ.get("GOLDENANALYSIS_MCP_ALLOW_PUBLIC", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if not token and not is_loopback and not allow_public:
+        raise RuntimeError(
+            f"Refusing to start an unauthenticated MCP HTTP server on host {host!r}. "
+            "Set GOLDENANALYSIS_MCP_TOKEN, bind to 127.0.0.1 for local use, or set "
+            "GOLDENANALYSIS_MCP_ALLOW_PUBLIC=1 to intentionally run an open public server."
+        )
+    return token
+
+
 def run_server_http(host: str = "0.0.0.0", port: int = 8300) -> None:
     """Start the MCP server over Streamable HTTP transport (A2A port 8300)."""
     import contextlib
@@ -227,9 +252,12 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8300) -> None:
     import uvicorn
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount, Route
 
+    token = resolve_http_auth_token(host)  # fail closed before any server setup
     server = create_server()
     session_manager = StreamableHTTPSessionManager(app=server, json_response=False, stateless=False)
 
@@ -248,6 +276,16 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8300) -> None:
             }
         )
 
+    class _BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            if request.url.path.startswith("/.well-known/"):
+                return await call_next(request)
+            if token:
+                header = request.headers.get("Authorization", "")
+                if not header.startswith("Bearer ") or not secrets.compare_digest(header[7:], token):
+                    return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            return await call_next(request)
+
     starlette_app = Starlette(
         debug=False,
         routes=[
@@ -255,6 +293,7 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8300) -> None:
             Mount("/mcp", app=session_manager.handle_request),
         ],
         lifespan=lifespan,
+        middleware=[Middleware(_BearerAuthMiddleware)],
     )
 
     uvicorn.run(starlette_app, host=host, port=port)

--- a/packages/python/goldenanalysis/tests/test_mcp_auth.py
+++ b/packages/python/goldenanalysis/tests/test_mcp_auth.py
@@ -1,0 +1,43 @@
+"""Fail-closed HTTP-auth guard on the goldenanalysis MCP server (run_server_http).
+
+Binding a non-loopback host without GOLDENANALYSIS_MCP_TOKEN is refused at startup so
+the public remote MCP is never started unauthenticated by accident.
+"""
+import pytest
+
+try:
+    from goldenanalysis.mcp.server import resolve_http_auth_token
+    HAS_MCP = True
+except ImportError:  # pragma: no cover - mcp optional dep
+    HAS_MCP = False
+
+pytestmark = pytest.mark.skipif(not HAS_MCP, reason="mcp not installed")
+
+_TOKEN = "GOLDENANALYSIS_MCP_TOKEN"
+_ALLOW = "GOLDENANALYSIS_MCP_ALLOW_PUBLIC"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_TOKEN, raising=False)
+    monkeypatch.delenv(_ALLOW, raising=False)
+
+
+def test_loopback_without_token_is_allowed():
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert resolve_http_auth_token(host) is None
+
+
+def test_public_bind_without_token_is_refused():
+    with pytest.raises(RuntimeError):
+        resolve_http_auth_token("0.0.0.0")
+
+
+def test_public_bind_with_token_returns_it(monkeypatch):
+    monkeypatch.setenv(_TOKEN, "s3cr3t-token")
+    assert resolve_http_auth_token("0.0.0.0") == "s3cr3t-token"
+
+
+def test_allow_public_opt_out(monkeypatch):
+    monkeypatch.setenv(_ALLOW, "1")
+    assert resolve_http_auth_token("0.0.0.0") is None

--- a/packages/python/goldencheck/goldencheck/mcp/server.py
+++ b/packages/python/goldencheck/goldencheck/mcp/server.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import secrets
 from dataclasses import asdict
 from pathlib import Path
 
@@ -604,6 +606,29 @@ async def run_server() -> None:
         await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
+def resolve_http_auth_token(host: str) -> str | None:
+    """Return the MCP HTTP bearer token, enforcing the fail-closed bind rule.
+
+    Raises ``RuntimeError`` when binding to a non-loopback host without
+    ``GOLDENCHECK_MCP_TOKEN`` set, so an exposed server is never started
+    unauthenticated by accident. Returns the token (or ``None`` for an
+    intentionally-open loopback bind). Escape hatch: set
+    ``GOLDENCHECK_MCP_ALLOW_PUBLIC=1`` to intentionally run an open public server.
+    """
+    token = os.environ.get("GOLDENCHECK_MCP_TOKEN")
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    allow_public = os.environ.get("GOLDENCHECK_MCP_ALLOW_PUBLIC", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if not token and not is_loopback and not allow_public:
+        raise RuntimeError(
+            f"Refusing to start an unauthenticated MCP HTTP server on host {host!r}. "
+            "Set GOLDENCHECK_MCP_TOKEN, bind to 127.0.0.1 for local use, or set "
+            "GOLDENCHECK_MCP_ALLOW_PUBLIC=1 to intentionally run an open public server."
+        )
+    return token
+
+
 def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
     """Run the MCP server over Streamable HTTP (for Railway / remote deployment)."""
     import contextlib
@@ -612,9 +637,12 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
     import uvicorn
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount, Route
 
+    token = resolve_http_auth_token(host)  # fail closed before any server setup
     server = create_server()
     session_manager = StreamableHTTPSessionManager(
         app=server,
@@ -635,6 +663,16 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })
 
+    class _BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            if request.url.path.startswith("/.well-known/"):
+                return await call_next(request)
+            if token:
+                header = request.headers.get("Authorization", "")
+                if not header.startswith("Bearer ") or not secrets.compare_digest(header[7:], token):
+                    return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            return await call_next(request)
+
     starlette_app = Starlette(
         debug=False,
         routes=[
@@ -642,6 +680,7 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
             Mount("/mcp", app=session_manager.handle_request),
         ],
         lifespan=lifespan,
+        middleware=[Middleware(_BearerAuthMiddleware)],
     )
 
     logger.info("Starting MCP HTTP server on %s:%s", host, port)

--- a/packages/python/goldencheck/tests/test_mcp_auth.py
+++ b/packages/python/goldencheck/tests/test_mcp_auth.py
@@ -1,0 +1,43 @@
+"""Fail-closed HTTP-auth guard on the goldencheck MCP server (run_server_http).
+
+Binding a non-loopback host without GOLDENCHECK_MCP_TOKEN is refused at startup so
+the public remote MCP is never started unauthenticated by accident.
+"""
+import pytest
+
+try:
+    from goldencheck.mcp.server import resolve_http_auth_token
+    HAS_MCP = True
+except ImportError:  # pragma: no cover - mcp optional dep
+    HAS_MCP = False
+
+pytestmark = pytest.mark.skipif(not HAS_MCP, reason="mcp not installed")
+
+_TOKEN = "GOLDENCHECK_MCP_TOKEN"
+_ALLOW = "GOLDENCHECK_MCP_ALLOW_PUBLIC"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_TOKEN, raising=False)
+    monkeypatch.delenv(_ALLOW, raising=False)
+
+
+def test_loopback_without_token_is_allowed():
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert resolve_http_auth_token(host) is None
+
+
+def test_public_bind_without_token_is_refused():
+    with pytest.raises(RuntimeError):
+        resolve_http_auth_token("0.0.0.0")
+
+
+def test_public_bind_with_token_returns_it(monkeypatch):
+    monkeypatch.setenv(_TOKEN, "s3cr3t-token")
+    assert resolve_http_auth_token("0.0.0.0") == "s3cr3t-token"
+
+
+def test_allow_public_opt_out(monkeypatch):
+    monkeypatch.setenv(_ALLOW, "1")
+    assert resolve_http_auth_token("0.0.0.0") is None

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
 from typing import Any
 
 try:
@@ -335,6 +336,29 @@ def run_server() -> None:
     asyncio.run(main())
 
 
+def resolve_http_auth_token(host: str) -> str | None:
+    """Return the MCP HTTP bearer token, enforcing the fail-closed bind rule.
+
+    Raises ``RuntimeError`` when binding to a non-loopback host without
+    ``GOLDENPIPE_MCP_TOKEN`` set, so an exposed server is never started
+    unauthenticated by accident. Returns the token (or ``None`` for an
+    intentionally-open loopback bind). Escape hatch: set
+    ``GOLDENPIPE_MCP_ALLOW_PUBLIC=1`` to intentionally run an open public server.
+    """
+    token = os.environ.get("GOLDENPIPE_MCP_TOKEN")
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    allow_public = os.environ.get("GOLDENPIPE_MCP_ALLOW_PUBLIC", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if not token and not is_loopback and not allow_public:
+        raise RuntimeError(
+            f"Refusing to start an unauthenticated MCP HTTP server on host {host!r}. "
+            "Set GOLDENPIPE_MCP_TOKEN, bind to 127.0.0.1 for local use, or set "
+            "GOLDENPIPE_MCP_ALLOW_PUBLIC=1 to intentionally run an open public server."
+        )
+    return token
+
+
 def run_server_http(host: str = "0.0.0.0", port: int = 8250) -> None:
     """Start the MCP server over Streamable HTTP transport."""
     import contextlib
@@ -343,9 +367,12 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8250) -> None:
     import uvicorn
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount, Route
 
+    token = resolve_http_auth_token(host)  # fail closed before any server setup
     server = create_server()
     session_manager = StreamableHTTPSessionManager(
         app=server,
@@ -366,6 +393,16 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8250) -> None:
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })
 
+    class _BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            if request.url.path.startswith("/.well-known/"):
+                return await call_next(request)
+            if token:
+                header = request.headers.get("Authorization", "")
+                if not header.startswith("Bearer ") or not secrets.compare_digest(header[7:], token):
+                    return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            return await call_next(request)
+
     starlette_app = Starlette(
         debug=False,
         routes=[
@@ -373,6 +410,7 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8250) -> None:
             Mount("/mcp", app=session_manager.handle_request),
         ],
         lifespan=lifespan,
+        middleware=[Middleware(_BearerAuthMiddleware)],
     )
 
     uvicorn.run(starlette_app, host=host, port=port)

--- a/packages/python/goldenpipe/tests/test_mcp_auth.py
+++ b/packages/python/goldenpipe/tests/test_mcp_auth.py
@@ -1,0 +1,43 @@
+"""Fail-closed HTTP-auth guard on the goldenpipe MCP server (run_server_http).
+
+Binding a non-loopback host without GOLDENPIPE_MCP_TOKEN is refused at startup so
+the public remote MCP is never started unauthenticated by accident.
+"""
+import pytest
+
+try:
+    from goldenpipe.mcp.server import resolve_http_auth_token
+    HAS_MCP = True
+except ImportError:  # pragma: no cover - mcp optional dep
+    HAS_MCP = False
+
+pytestmark = pytest.mark.skipif(not HAS_MCP, reason="mcp not installed")
+
+_TOKEN = "GOLDENPIPE_MCP_TOKEN"
+_ALLOW = "GOLDENPIPE_MCP_ALLOW_PUBLIC"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_TOKEN, raising=False)
+    monkeypatch.delenv(_ALLOW, raising=False)
+
+
+def test_loopback_without_token_is_allowed():
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert resolve_http_auth_token(host) is None
+
+
+def test_public_bind_without_token_is_refused():
+    with pytest.raises(RuntimeError):
+        resolve_http_auth_token("0.0.0.0")
+
+
+def test_public_bind_with_token_returns_it(monkeypatch):
+    monkeypatch.setenv(_TOKEN, "s3cr3t-token")
+    assert resolve_http_auth_token("0.0.0.0") == "s3cr3t-token"
+
+
+def test_allow_public_opt_out(monkeypatch):
+    monkeypatch.setenv(_ALLOW, "1")
+    assert resolve_http_auth_token("0.0.0.0") is None

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -7515,6 +7515,10 @@
           "GOLDENCHECK_LLM_BUDGET",
           "GOLDENCHECK_LLM_MODEL"
         ],
+        "MCP": [
+          "GOLDENCHECK_MCP_ALLOW_PUBLIC",
+          "GOLDENCHECK_MCP_TOKEN"
+        ],
         "NATIVE": [
           "GOLDENCHECK_NATIVE"
         ],
@@ -9195,6 +9199,10 @@
         "ALLOWED": [
           "GOLDENPIPE_ALLOWED_ROOT"
         ],
+        "MCP": [
+          "GOLDENPIPE_MCP_ALLOW_PUBLIC",
+          "GOLDENPIPE_MCP_TOKEN"
+        ],
         "NATIVE": [
           "GOLDENPIPE_NATIVE"
         ]
@@ -9583,6 +9591,10 @@
         }
       ],
       "env_vars": {
+        "MCP": [
+          "INFERMAP_MCP_ALLOW_PUBLIC",
+          "INFERMAP_MCP_TOKEN"
+        ],
         "NATIVE": [
           "INFERMAP_NATIVE"
         ]
@@ -9870,6 +9882,10 @@
         }
       ],
       "env_vars": {
+        "MCP": [
+          "GOLDENANALYSIS_MCP_ALLOW_PUBLIC",
+          "GOLDENANALYSIS_MCP_TOKEN"
+        ],
         "NATIVE": [
           "GOLDENANALYSIS_NATIVE"
         ]

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/cli.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
+import secrets
 import sys
 
 
@@ -20,6 +22,34 @@ def _serve_stdio() -> None:
     asyncio.run(main())
 
 
+def resolve_http_auth_token(host: str) -> str | None:
+    """Return the MCP HTTP bearer token, enforcing the fail-closed bind rule.
+
+    Raises ``RuntimeError`` when binding to a non-loopback host without
+    ``GOLDENSUITE_MCP_TOKEN`` set, so an exposed server is never started
+    unauthenticated by accident. Returns the token (or ``None`` for an
+    intentionally-open loopback bind). Escape hatch: set
+    ``GOLDENSUITE_MCP_ALLOW_PUBLIC=1`` to intentionally run an open public server.
+
+    This server matters more than its siblings, not less: it aggregates EVERY
+    Golden Suite tool -- goldenmatch, goldencheck, goldenflow, goldenpipe,
+    infermap -- behind one endpoint, so an unauthenticated bind exposes the
+    union of five tool surfaces rather than one.
+    """
+    token = os.environ.get("GOLDENSUITE_MCP_TOKEN")
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    allow_public = os.environ.get("GOLDENSUITE_MCP_ALLOW_PUBLIC", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if not token and not is_loopback and not allow_public:
+        raise RuntimeError(
+            f"Refusing to start an unauthenticated MCP HTTP server on host {host!r}. "
+            "Set GOLDENSUITE_MCP_TOKEN, bind to 127.0.0.1 for local use, or set "
+            "GOLDENSUITE_MCP_ALLOW_PUBLIC=1 to intentionally run an open public server."
+        )
+    return token
+
+
 def _serve_http(host: str, port: int) -> None:
     import contextlib
     from collections.abc import AsyncIterator
@@ -27,11 +57,14 @@ def _serve_http(host: str, port: int) -> None:
     import uvicorn
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount, Route
 
     from goldensuite_mcp.server import create_server
 
+    token = resolve_http_auth_token(host)  # fail closed before any server setup
     server = create_server()
     # Stateful sessions (NOT stateless): the 8 stateful goldenmatch tools
     # (list_clusters/get_cluster/get_golden_record/explain_match/evaluate/
@@ -65,12 +98,27 @@ def _serve_http(host: str, port: int) -> None:
             }
         )
 
+    class _BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            # `/.well-known/` stays public: it is the discovery card, and health
+            # checks read it. Everything else needs the bearer.
+            if request.url.path.startswith("/.well-known/"):
+                return await call_next(request)
+            if token:
+                header = request.headers.get("Authorization", "")
+                if not header.startswith("Bearer ") or not secrets.compare_digest(
+                    header[7:], token
+                ):
+                    return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            return await call_next(request)
+
     app = Starlette(
         lifespan=lifespan,
         routes=[
             Route("/.well-known/mcp/server-card.json", server_card),
             Mount("/mcp", app=session_manager.handle_request),
         ],
+        middleware=[Middleware(_BearerAuthMiddleware)],
     )
 
     uvicorn.run(app, host=host, port=port)

--- a/packages/python/goldensuite-mcp/tests/test_mcp_auth.py
+++ b/packages/python/goldensuite-mcp/tests/test_mcp_auth.py
@@ -1,0 +1,49 @@
+"""Fail-closed HTTP-auth guard on the goldensuite MCP server (`_serve_http`).
+
+Binding a non-loopback host without GOLDENSUITE_MCP_TOKEN is refused at startup
+so the public remote MCP is never started unauthenticated by accident.
+
+This server was missing from the original sweep (PR #2330 covered goldenpipe,
+goldenanalysis, infermap and goldencheck), and it is the one that matters most:
+it aggregates EVERY Golden Suite tool behind one endpoint, so an unauthenticated
+bind exposes the union of five tool surfaces rather than one. It was found live
+and unauthenticated on Railway on 2026-08-20.
+"""
+import pytest
+
+try:
+    from goldensuite_mcp.cli import resolve_http_auth_token
+    HAS_MCP = True
+except ImportError:  # pragma: no cover - mcp optional dep
+    HAS_MCP = False
+
+pytestmark = pytest.mark.skipif(not HAS_MCP, reason="mcp not installed")
+
+_TOKEN = "GOLDENSUITE_MCP_TOKEN"
+_ALLOW = "GOLDENSUITE_MCP_ALLOW_PUBLIC"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_TOKEN, raising=False)
+    monkeypatch.delenv(_ALLOW, raising=False)
+
+
+def test_loopback_without_token_is_allowed():
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert resolve_http_auth_token(host) is None
+
+
+def test_public_bind_without_token_is_refused():
+    with pytest.raises(RuntimeError):
+        resolve_http_auth_token("0.0.0.0")
+
+
+def test_public_bind_with_token_returns_it(monkeypatch):
+    monkeypatch.setenv(_TOKEN, "s3cr3t-token")
+    assert resolve_http_auth_token("0.0.0.0") == "s3cr3t-token"
+
+
+def test_allow_public_opt_out(monkeypatch):
+    monkeypatch.setenv(_ALLOW, "1")
+    assert resolve_http_auth_token("0.0.0.0") is None

--- a/packages/python/infermap/infermap/mcp/server.py
+++ b/packages/python/infermap/infermap/mcp/server.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import secrets
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -544,6 +546,29 @@ async def run_server() -> None:
         await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
+def resolve_http_auth_token(host: str) -> str | None:
+    """Return the MCP HTTP bearer token, enforcing the fail-closed bind rule.
+
+    Raises ``RuntimeError`` when binding to a non-loopback host without
+    ``INFERMAP_MCP_TOKEN`` set, so an exposed server is never started
+    unauthenticated by accident. Returns the token (or ``None`` for an
+    intentionally-open loopback bind). Escape hatch: set
+    ``INFERMAP_MCP_ALLOW_PUBLIC=1`` to intentionally run an open public server.
+    """
+    token = os.environ.get("INFERMAP_MCP_TOKEN")
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    allow_public = os.environ.get("INFERMAP_MCP_ALLOW_PUBLIC", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if not token and not is_loopback and not allow_public:
+        raise RuntimeError(
+            f"Refusing to start an unauthenticated MCP HTTP server on host {host!r}. "
+            "Set INFERMAP_MCP_TOKEN, bind to 127.0.0.1 for local use, or set "
+            "INFERMAP_MCP_ALLOW_PUBLIC=1 to intentionally run an open public server."
+        )
+    return token
+
+
 def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
     """Run the MCP server over Streamable HTTP (for Railway / remote deployment)."""
     import contextlib
@@ -552,9 +577,12 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
     import uvicorn
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount, Route
 
+    token = resolve_http_auth_token(host)  # fail closed before any server setup
     server = create_server()
     session_manager = StreamableHTTPSessionManager(
         app=server,
@@ -575,6 +603,16 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
             "iconUrl": "https://avatars.githubusercontent.com/u/198941534",
         })
 
+    class _BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            if request.url.path.startswith("/.well-known/"):
+                return await call_next(request)
+            if token:
+                header = request.headers.get("Authorization", "")
+                if not header.startswith("Bearer ") or not secrets.compare_digest(header[7:], token):
+                    return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            return await call_next(request)
+
     starlette_app = Starlette(
         debug=False,
         routes=[
@@ -582,6 +620,7 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8100) -> None:
             Mount("/mcp", app=session_manager.handle_request),
         ],
         lifespan=lifespan,
+        middleware=[Middleware(_BearerAuthMiddleware)],
     )
 
     logger.info("Starting MCP HTTP server on %s:%s", host, port)

--- a/packages/python/infermap/tests/test_mcp_auth.py
+++ b/packages/python/infermap/tests/test_mcp_auth.py
@@ -1,0 +1,43 @@
+"""Fail-closed HTTP-auth guard on the infermap MCP server (run_server_http).
+
+Binding a non-loopback host without INFERMAP_MCP_TOKEN is refused at startup so
+the public remote MCP is never started unauthenticated by accident.
+"""
+import pytest
+
+try:
+    from infermap.mcp.server import resolve_http_auth_token
+    HAS_MCP = True
+except ImportError:  # pragma: no cover - mcp optional dep
+    HAS_MCP = False
+
+pytestmark = pytest.mark.skipif(not HAS_MCP, reason="mcp not installed")
+
+_TOKEN = "INFERMAP_MCP_TOKEN"
+_ALLOW = "INFERMAP_MCP_ALLOW_PUBLIC"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_TOKEN, raising=False)
+    monkeypatch.delenv(_ALLOW, raising=False)
+
+
+def test_loopback_without_token_is_allowed():
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert resolve_http_auth_token(host) is None
+
+
+def test_public_bind_without_token_is_refused():
+    with pytest.raises(RuntimeError):
+        resolve_http_auth_token("0.0.0.0")
+
+
+def test_public_bind_with_token_returns_it(monkeypatch):
+    monkeypatch.setenv(_TOKEN, "s3cr3t-token")
+    assert resolve_http_auth_token("0.0.0.0") == "s3cr3t-token"
+
+
+def test_allow_public_opt_out(monkeypatch):
+    monkeypatch.setenv(_ALLOW, "1")
+    assert resolve_http_auth_token("0.0.0.0") is None


### PR DESCRIPTION
Rebase of #2330 (308 commits behind), **extended to cover `goldensuite-mcp`** which the original sweep missed.

## goldensuite-mcp was the gap that mattered

It is live on Railway and was found **unauthenticated** on 2026-08-20. It aggregates every Golden Suite tool — goldenmatch, goldencheck, goldenflow, goldenpipe, infermap — behind one endpoint, so an unauthenticated bind exposes the **union of five tool surfaces**, not one. Its HTTP entry is `cli.py::_serve_http` rather than `server.py::run_server_http`, which is likely why it was skipped.

## The original HOLD was mostly guarding services that do not exist

#2330 warned that merging would crash-loop the live `goldenpipe-mcp` / `goldenanalysis-mcp` / `infermap-mcp` services. Checked 2026-08-20: **none of those three are deployed.** `golden-suite-mcp` contains `goldensuite-mcp`, `goldenmatch-mcp`, `goldencheck-mcp`, `goldenmatch-bench-gen`.

So of the four original targets only goldencheck is live — and the real exposure, goldensuite, was not covered.

## Rollout state — both tokens are already set

| service | state |
|---|---|
| `goldencheck-mcp` | `GOLDENCHECK_MCP_TOKEN` **set** ✅ |
| `goldensuite-mcp` | `GOLDENSUITE_MCP_TOKEN` **set** ✅ |
| `goldenmatch-mcp` | deliberately open (`GOLDENMATCH_MCP_ALLOW_PUBLIC`), untouched — worth a decision |
| goldenpipe / goldenanalysis / infermap | not deployed |

Both live services carry tokens, so **this is safe to merge and deploy now**. That was the original HOLD condition and it is satisfied.

## How it was rebased

By re-applying **source**, not by merging generated files. The branch touched six derived artifacts (four config matrices, agent manifest, codemap, suite manifest); after 308 commits those conflict on regenerable content, so the `mcp/server.py` changes and tests were re-applied and the derived docs **regenerated**.

`infermap/mcp/server.py` had moved on main (#2581, identity layers), so it was taken from **main** and the auth patch applied with `--3way` rather than overwritten. It now carries both.

Opened as a new branch rather than force-pushing #2330: the pre-push guard scans the diff for employer-internal terms, and force-pushing onto a 308-behind ref makes it re-scan 308 already-merged commits — it flagged a base64 WASM blob in `35d54d20`, which is already on `main`. Pushing a fresh branch keeps the guard scanning only new work rather than bypassing it.

## Not included, deliberately

The two `GOLDENSUITE_MCP_*` vars have no generated config-matrix entry because `goldensuite-mcp` is not in that generator's roster. Adding it is a docs change, not a security one.

## Testing

4 tests per package across 5 packages. 12 pass locally; 8 skip where `mcp` is not installed in the local interpreter (the packages' own `skipif(not HAS_MCP)` guard). `ruff` clean across all five.

Supersedes #2330.