### PR TITLE
release: goldenmatch 3.14.0, golden-suite 0.5.1

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.13.1` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.14.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.5.1] - 2026-08-20
+
+### Changed
+
+- **`goldenmatch` floor raised to `>=3.14`.** 3.14.0 takes distributed
+  Fellegi-Sunter training and scoring at 250M from 2,765.8s to 669.96s (4.13x)
+  with 3.1x less executor CPU and zero spill, and the trained model is
+  byte-identical -- so there is nothing for a suite install to weigh up and no
+  reason to leave users on the slower path.
+
 ## [0.5.0] - 2026-08-15
 
 Floor bumps for the 2026-08-15 repo-wide cut. Every suite member was

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -33,7 +33,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.5.0"
+version = "0.5.1"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.5",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.13",        # entity resolution: dedupe, match, golden records (>=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.14",        # entity resolution: dedupe, match, golden records (>=3.14: distributed Fellegi-Sunter 4.13x faster at 250M with zero spill and a byte-identical model, so suite installs get the perf without opting in; >=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.5",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.2.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.7",                  # GoldenSchema: inference-driven schema mapping

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,63 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.14.0] - 2026-08-20
+
+### Changed
+
+- **Distributed Fellegi-Sunter at 250M: 2,765.8s -> 669.96s (4.13x), with 3.1x
+  less executor CPU and zero spill.** Three changes, all on the SHIPPED Spark
+  path, all producing a byte-identical trained model (`match_weights` and
+  `m_probs` unchanged, average precision 0.704939 and best F1 0.686126
+  unchanged, identical pair counts). Seconds per million pairs: **1.192 ->
+  0.289**.
+
+  1. **The candidate frame is no longer materialised.** The block self-join
+     already holds both records of every pair; the tier projected that down to
+     `(a, b)` ids and paid two more joins to fetch back the columns the
+     projection dropped -- for counting, and again for scoring. One counts pass
+     went from 7 exchanges / 3 sort-merge joins to 3 / 1, the score path from
+     8 / 4 to 4 / 2. Shuffle write 438.1 -> 113.8 GB and memory spill 201.3 GB
+     -> **0** at 250M.
+  2. **The weight lookup named the level once per level.** `when(level == 0,
+     w0).when(level == 1, w1)...` -- and `level` is the whole gamma expression
+     with the jar scorer call inside it. Catalyst's subexpression elimination
+     does not hoist a UDF out of conditionally-evaluated CASE branches, so the
+     scorer ran once per branch. Now an array index naming the level once.
+  3. **The level ladder named the similarity once per threshold.**
+     `fs_level_expr` sums `when(sim >= t, 1)` per threshold. `gamma_frame`
+     projects each similarity by name first, which removed 94% of the bucketing
+     cost. This pays in BOTH the counts and score stages.
+
+  Measured, not inferred: `--attribute-score` splits the score stage into
+  layers (join / similarities / bucketing / weight lookup) and is what found
+  (2) and (3), after three attempts at reasoning from plan shape had failed.
+  At 50M the score stage went 347.07s -> 82.20s and counts 130s -> 80.62s.
+
+### Added
+
+- **`GOLDENMATCH_SPARK_FUSED_BLOCK_JOIN`** (default `1`) -- forces the legacy
+  three-join candidate path when set to `0`, so the comparison stays takeable
+  in both directions from one build.
+- `spark.config_pipeline.pass_candidates_joined` / `pass_joined` /
+  `score_source` / `fused_pass_frames`, and `spark.em.gamma_frame`: the joined
+  and projected shapes the above is built from. `id_col` must be unique -- every
+  caller generates `__row_id__` to be exactly that.
+
+### Fixed
+
+- Multi-pass candidates de-duplicate by **pass priority** -- each pair assigned
+  to the lowest-indexed pass that produces it, tested inside the join from the
+  two records -- instead of a `distinct()` over a frame with O(pairs) rows.
+  Same candidate set; one fewer shuffle of the largest frame this tier builds.
+- The pure-Python scoring fallback combines matchkeys with `greatest` over
+  per-matchkey nulls rather than `groupBy("a", "b").agg(max(score))`, which
+  shuffled O(pairs) rows to combine values every matchkey computes from the
+  same joined row. The jar-backed path already did this.
+- A stray second `## [Unreleased]` heading in this file split 3.9.0's own
+  entries into a phantom section. Removed; the content below it shipped in
+  3.9.0.
+
 ## [3.13.1] - 2026-08-19
 
 
@@ -1587,8 +1644,6 @@ in-RAM sequential Arrow-native batch scorer with end-WCC.
 - `docs-site/reference/api-surface.mdx` prose was stale beyond the generated block: it
   listed all 7 primitives as TS-only and claimed "~31 Python-only tools" when the real
   figure is 7. Corrected alongside the counts.
-
-## [Unreleased]
 
 ### Fixed
 - **Threshold perturbation no longer shifts an inert field on probabilistic matchkeys (#2483).** `zero_label_confidence.threshold_perturbations` and `config_edits.ThresholdShift` both shifted `mk.threshold` to build "variant" configs. A probabilistic matchkey cuts on `link_threshold`, so those variants matched **identically** to the baseline -- and the zero-label stability signal derived from them saw zero change and reported maximum confidence. A falsely confident number is worse than none. Both now perturb `mk.cutoff_field`, and a matchkey whose operative cutoff was never set is correctly reported NOT perturbable rather than perturbed through a field that does nothing. Weighted matchkeys are unaffected.

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -46,7 +46,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.13.1"
+__version__ = "3.14.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.13.1"
+version = "3.14.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.13.1",
+      "version": "3.14.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Cuts **goldenmatch 3.14.0** and **golden-suite 0.5.1** for the Spark perf work
merged in #2698 and #2700.

## What users get

**Distributed Fellegi-Sunter at 250M: 2,765.8s -> 669.96s (4.13x)**, with 3.1x
less executor CPU, shuffle write 438.1 -> 113.8 GB, and memory spill 201.3 GB
-> **0**. Seconds per million pairs: **1.192 -> 0.289**.

The trained model is **byte-identical** -- `match_weights` and `m_probs`
unchanged, average precision 0.704939 and best F1 0.686126 unchanged, identical
pair counts. Nothing to re-validate; it is the same answer, faster.

Three changes, all on the shipped path:

1. The candidate frame is no longer materialised. A counts pass goes from 7
   exchanges / 3 sort-merge joins to 3 / 1; the score path from 8 / 4 to 4 / 2.
2. The weight lookup named the level once per level, and `level` carries the jar
   scorer call. Catalyst does not hoist a UDF out of conditionally-evaluated
   CASE branches, so the scorer ran once per branch.
3. The level ladder named the similarity once per threshold. Projecting it by
   name first removed 94% of the bucketing cost -- and pays in the counts stage
   as well as the score stage.

## Why MINOR rather than PATCH

The perf is behaviour-preserving, but the release adds public API
(`pass_candidates_joined`, `pass_joined`, `score_source`, `fused_pass_frames`,
`gamma_frame`) and a runtime knob (`GOLDENMATCH_SPARK_FUSED_BLOCK_JOIN`, default
on, `0` for the legacy path).

## golden-suite 0.5.1

Floor raised to `goldenmatch>=3.14`. The model is byte-identical, so there is
nothing for a suite install to weigh up and no reason to leave users on the
slower path.

## Two things fixed on the way in

- A stray second `## [Unreleased]` heading in goldenmatch's CHANGELOG split
  3.9.0's own entries into a phantom section. Checked against the code before
  touching it -- `cutoff_field` is present, so those entries shipped in 3.9.0 and
  the heading was the error.
- `check_version_consistency` caught `golden_suite/__init__.py` still on 0.5.0
  after pyproject moved. Fixed rather than overridden; that gate exists because
  goldenflow 1.1.x shipped without it.

## After merge

Tag `v3.14.0` to fire `publish-goldenmatch.yml` (which owns the GitHub Release
-- no manual `gh release create`), and the suite tag for 0.5.1. `publish-mcp.yml`
syncs the registry listing off the same release event; `server.json` is already
on 3.14.0 so the version it reads from the tag matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P