### PR TITLE
chore(docs): run the derived-doc gates before push, not after CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,3 +22,16 @@ build:
     uv build
     for d in packages/typescript/*; do npm --prefix "$d" run build --if-present; done
     cd packages/rust/extensions && cargo build --workspace --release
+
+# Regenerate every derived doc (config matrices, agent manifest + codemap, api
+# surface, suite matrix, thesis weaknesses, native docs). Run it, review the
+# diff, commit. `uv run` is required, not stylistic: the generators import the
+# config classes to introspect them, so every workspace package must be
+# importable -- run `uv sync --all-packages` first in a fresh worktree.
+docs:
+    uv run python scripts/regen_docs.py
+
+# What CI gates on: regenerate, then fail if the committed tree drifted. ~30s --
+# nine generator processes, each importing the package tree.
+docs-check:
+    uv run python scripts/regen_docs.py --check

--- a/scripts/check_docs_staleness.py
+++ b/scripts/check_docs_staleness.py
@@ -32,6 +32,7 @@ Only the flag rule can change the exit code. Everything else is informational.
 
 Run: ``python scripts/check_docs_staleness.py [--base <ref>] [--head <ref>]``
 """
+
 from __future__ import annotations
 
 import argparse
@@ -48,8 +49,19 @@ _ALL_LINE_RE = re.compile(r"__all__")
 
 
 def _git(*args: str) -> str:
+    # encoding= is load-bearing, not decoration. text=True decodes with the
+    # locale default -- cp1252 on Windows -- and tuning.mdx carries non-ASCII
+    # punctuation it cannot decode. That decode raises inside subprocess's
+    # reader thread, so stdout arrives as None with returncode 0: this function
+    # then returns None WITHOUT raising and the caller dies on None. Pinning
+    # utf-8 keeps the failure mode honest on every platform.
     proc = subprocess.run(
-        ["git", *args], cwd=ROOT, capture_output=True, text=True
+        ["git", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
     )
     if proc.returncode != 0:
         raise RuntimeError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
@@ -116,9 +128,7 @@ def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[
     py_files = [
         f
         for f in files
-        if f.startswith("packages/python/")
-        and f.endswith(".py")
-        and not _is_test_file(f)
+        if f.startswith("packages/python/") and f.endswith(".py") and not _is_test_file(f)
     ]
     if not py_files:
         return True, ["flag rule: no non-test packages/python/**/*.py changes -- skipped"]
@@ -143,8 +153,7 @@ def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[
     tuning_touched = TUNING_MDX in files
     if tuning_touched:
         return True, [
-            f"flag rule: flags changed ({touched_flags}) and {TUNING_MDX} is in the "
-            f"diff -- OK"
+            f"flag rule: flags changed ({touched_flags}) and {TUNING_MDX} is in the diff -- OK"
         ]
     # Drift: flag changed but tuning.mdx untouched.
     msgs = [
@@ -157,10 +166,7 @@ def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[
 
 def check_public_symbol_rule(base: str, head: str, files: list[str]) -> list[str]:
     """Advisory only. Return ::warning:: messages (never affects exit code)."""
-    init_files = [
-        f for f in files
-        if f.startswith("packages/") and f.endswith("__init__.py")
-    ]
+    init_files = [f for f in files if f.startswith("packages/") and f.endswith("__init__.py")]
     if not init_files:
         return ["public-symbol rule: no __init__.py changes -- skipped"]
 
@@ -202,8 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::warning::docs-staleness: could not compute diff ({exc}); skipping.")
         return 0
 
-    print(f"Docs staleness advisory: {args.base}...{args.head} "
-          f"({len(files)} changed file(s))")
+    print(f"Docs staleness advisory: {args.base}...{args.head} ({len(files)} changed file(s))")
 
     gate_ok, flag_msgs = check_flag_rule(args.base, args.head, files)
     symbol_msgs = check_public_symbol_rule(args.base, args.head, files)
@@ -212,8 +217,7 @@ def main(argv: list[str] | None = None) -> int:
         print(m)
 
     if not gate_ok:
-        print("\nDocs staleness FAILED (flag rule). Update "
-              f"{TUNING_MDX} in the same PR.")
+        print(f"\nDocs staleness FAILED (flag rule). Update {TUNING_MDX} in the same PR.")
         return 1
     print("\nDocs staleness OK (gating flag rule passed; symbol rule advisory only).")
     return 0

--- a/scripts/pre_push_docs_check.sh
+++ b/scripts/pre_push_docs_check.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Derived-doc gate, run before a push instead of after a failed CI run.
+#
+# Two CI gates fail for reasons a generator can fix locally in ~30s, but only
+# tell you about it after a push, a full CI cycle, and a blocked merge queue:
+#
+#   config_matrix / docs_regen  -- committed generated docs drifted from source
+#   docs_staleness (flag rule)  -- a GOLDENMATCH_* flag was added without a
+#                                  tuning.mdx entry (NOT auto-fixable: a human
+#                                  has to write the entry)
+#
+# This checks both and BLOCKS. It never edits your working tree: a hook that
+# rewrites files mid-push collides with whatever state you were in.
+#
+# Install (chain it after the oss-push-guard stage, which also reads stdin --
+# so buffer stdin once and feed both):
+#
+#   # in .git/hooks/pre-push, after the guard's own loop:
+#   refs=$(cat)                                  # ONCE, at the top of the hook
+#   printf '%s\n' "$refs" | <guard logic>
+#   printf '%s\n' "$refs" | scripts/pre_push_docs_check.sh "$1" "$2" || exit 1
+#
+# Escape hatch: SKIP_DOCS_CHECK=1 git push ...
+#
+# git passes: $1 = remote name, $2 = remote URL. Ref updates arrive on stdin as
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+set -eu
+
+remote_url="${2:-}"
+case "$remote_url" in
+  *benseverndev-oss/goldenmatch*) : ;;   # the repo whose CI gates these -> check
+  *) exit 0 ;;                            # any other remote -> pass through
+esac
+
+if [ "${SKIP_DOCS_CHECK:-0}" = "1" ]; then
+  echo "pre-push: SKIP_DOCS_CHECK=1 -- skipping the derived-doc gate." >&2
+  exit 0
+fi
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+zero=0000000000000000000000000000000000000000
+
+# Pick the widest range being pushed, so a multi-ref push is still covered.
+# A brand-new branch has no remote_sha; origin/main is then the honest base.
+base=""
+head=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$zero" ] && continue          # branch deletion -- nothing to check
+  head="$local_sha"
+  if [ "$remote_sha" = "$zero" ]; then
+    base=$(git rev-parse origin/main 2>/dev/null || echo "")
+  else
+    base="$remote_sha"
+  fi
+done
+
+# Nothing being pushed (all deletions, or empty stdin) -> nothing to gate.
+[ -n "$head" ] || exit 0
+
+echo "pre-push: checking derived docs (~30s; SKIP_DOCS_CHECK=1 to bypass)..." >&2
+
+# regen_docs.py regenerates into a scratch copy and diffs; it does not touch the
+# working tree. uv run is required rather than stylistic -- the generators import
+# the config classes to introspect them, so every workspace package must be
+# importable. An unsynced workspace is a setup problem, not a clean tree: say so
+# rather than passing silently.
+if ! out=$(uv run python scripts/regen_docs.py --check 2>&1); then
+  case "$out" in
+    *ModuleNotFoundError*)
+      printf '%s\n' "$out" >&2
+      echo "" >&2
+      echo "pre-push: the workspace is not synced, so the doc check could not run." >&2
+      echo "          Run: uv sync --all-packages" >&2
+      echo "          (then re-push; or SKIP_DOCS_CHECK=1 to bypass this once)" >&2
+      exit 1
+      ;;
+  esac
+  printf '%s\n' "$out" >&2
+  echo "" >&2
+  echo "pre-push: committed generated docs are stale." >&2
+  echo "          Run: just docs      (regenerates), then review the diff and commit." >&2
+  exit 1
+fi
+
+# The flag rule. Base/head matter here: it asks what THIS push adds or removes,
+# not what the tree looks like. Nothing it finds can be auto-fixed.
+if [ -n "$base" ]; then
+  if ! out=$(uv run python scripts/check_docs_staleness.py --base "$base" --head "$head" 2>&1); then
+    printf '%s\n' "$out" >&2
+    echo "" >&2
+    echo "pre-push: a GOLDENMATCH_* flag in this push is missing from the canonical" >&2
+    echo "          reference. Add it to docs-site/goldenmatch/tuning.mdx and commit." >&2
+    exit 1
+  fi
+fi
+
+echo "pre-push: derived docs OK." >&2
+exit 0

--- a/scripts/test_docs_staleness.py
+++ b/scripts/test_docs_staleness.py
@@ -1,0 +1,46 @@
+"""Gate for the doc-staleness checker itself (scripts/check_docs_staleness.py).
+
+The flag rule is the only doc gate that a generator cannot fix -- adding a
+``GOLDENMATCH_*`` flag means a human has to write the ``tuning.mdx`` entry. So
+the checker being *silently* wrong is worse than it being absent: a broken read
+of tuning.mdx makes every flag look undocumented, or (as on Windows) crashes
+with a ``TypeError`` that reads like a real negative.
+
+``tuning.mdx`` contains non-ASCII punctuation. ``subprocess.run(text=True)``
+decodes with the locale default -- cp1252 on Windows -- which cannot decode it.
+That decode raises inside subprocess's reader thread, so ``proc.stdout`` comes
+back ``None`` with returncode 0, ``_git`` returns ``None`` without raising, and
+the caller blows up on ``None``. These tests pin the encoding contract.
+"""
+
+from __future__ import annotations
+
+from check_docs_staleness import TUNING_MDX, _documented_flags, _git
+
+
+def test_git_returns_text_for_non_ascii_content():
+    """``_git`` must decode as UTF-8, not the platform's locale encoding.
+
+    ``tuning.mdx`` is the file the flag rule reads and it carries non-ASCII
+    punctuation, so it is the exact input that breaks a locale-default decode.
+    """
+    out = _git("show", f"HEAD:{TUNING_MDX}")
+    assert isinstance(out, str), (
+        f"_git returned {type(out).__name__}, not str -- a decode error inside "
+        "subprocess's reader thread silently yields None with returncode 0"
+    )
+    assert out, "_git returned empty content for a file known to be non-empty"
+
+
+def test_documented_flags_finds_the_canonical_reference():
+    """The flag rule is only sound if it can actually read tuning.mdx.
+
+    If this returns an empty set, every flag in a diff looks undocumented and
+    the gate fails every PR that touches one.
+    """
+    flags = _documented_flags("HEAD")
+    assert flags, f"no GOLDENMATCH_* flags parsed from {TUNING_MDX}"
+    assert "GOLDENMATCH_NATIVE" in flags, (
+        "GOLDENMATCH_NATIVE is the most-documented flag in the reference; its "
+        f"absence means {TUNING_MDX} was not read correctly"
+    )


### PR DESCRIPTION
Two CI gates fail for reasons a generator fixes locally in ~30s, but only say so after a push, a full CI cycle and a blocked merge queue. That is exactly what happened to #2694 and #2701 today: both sat BLOCKED on `config_matrix` + `docs_regen`, and #2694 then failed a second time on `docs_staleness` for an undocumented flag.

## The bug this uncovered

`check_docs_staleness._git` calls `subprocess.run(..., text=True)`, which decodes with the **locale default** -- cp1252 on Windows. `tuning.mdx` carries non-ASCII punctuation cp1252 cannot decode. That decode raises **inside subprocess reader thread**, so `proc.stdout` arrives as `None` with returncode 0. `_git` then returns `None` without raising, and the caller dies on `findall(None)`.

The failure mode is the bad kind: a `TypeError` that reads like a real negative rather than a crash. The flag rule -- the one doc gate no generator can fix, because a human has to write the `tuning.mdx` entry -- was **silently unusable on Windows**. `scripts/test_docs_staleness.py` pins the contract.

## What is here

| | |
|---|---|
| `scripts/check_docs_staleness.py` | pin `encoding="utf-8"` on the git subprocess |
| `scripts/test_docs_staleness.py` | new -- fails on the pre-fix code with the exact `UnicodeDecodeError` |
| `justfile` | `just docs` / `just docs-check` wrapping `regen_docs.py` |
| `scripts/pre_push_docs_check.sh` | new -- the pre-push gate |

`regen_docs.py` already orchestrated all seven generators; nothing new was written to generate docs.

## The hook

**Checks and blocks. It never edits your working tree** -- a hook that rewrites files mid-push collides with whatever state you were in. On drift it prints `just docs`; on a flag it prints the file to edit.

**Opt-in.** Nothing installs it. Chain it from `.git/hooks/pre-push` after the existing `oss-push-guard` stage -- note both read stdin, so buffer the ref lines once and feed both. Install notes are in the script header. `SKIP_DOCS_CHECK=1 git push` bypasses.

An unsynced workspace is reported as a setup problem (`uv sync --all-packages`) rather than passing silently -- `uv run` is required because the generators **import** the config classes to introspect them.

## Cost, measured

~30s with a synced workspace. 13s is the seven generators, 4s the two prose checks; the remaining ~15s is nine Python processes each importing the package tree. Collapsing that would mean running `regen_docs.py` in-process -- a real change to a shared tool, deliberately out of scope here.

## Verified

Both gates were checked by making them fail, not by watching them pass:

- **drift** -- injected a key into `agent-codemap.json`, committed: exit 1, `just docs` message
- **flag rule** -- committed an undocumented `GOLDENMATCH_HOOK_PROBE_FLAG`: exit 1, names the flag and `tuning.mdx`
- non-matching remote, `SKIP_DOCS_CHECK=1`, and branch-deletion refs all pass through without work
- clean tree: exit 0 in 30s

A first drift attempt appended to `config-matrix.mdx` and did **not** trip the gate -- that file has hand-authored prose after the generated block, so it was a bad probe rather than a bad gate. Worth knowing before anyone retests it that way.

`ruff` clean; `pytest scripts/test_docs_staleness.py` 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P