### PR TITLE
chore(ci): collapse the nine native publish workflows onto a shared template

### DIFF
--- a/.github/workflows/_publish-native.yml
+++ b/.github/workflows/_publish-native.yml
@@ -1,0 +1,148 @@
+# Reusable native-publish template for the maturin/abi3 compiled runtimes. Each
+# has a thin `publish-<pkg>-native.yml` caller that fires on its
+# `release: published` (filtered to the `<pkg>-native-v*` tag) and delegates
+# here -- so this single body replaces the ~142 near-identical lines copy-pasted
+# across nine workflows (goldenmatch, goldencheck, goldenflow, goldenpipe,
+# infermap, goldenanalysis, goldengraph, goldenprofile natives, plus
+# goldenmatch-hnsw).
+#
+# Between those nine, exactly ONE value varied that belongs here: the path to
+# the crate's Cargo.toml. The other variation was the workflow name and a tag
+# prefix repeated in four separate per-job `if:` conditions -- 36 hand-maintained
+# copies across the nine files, which is what made the drift below possible.
+#
+# Follows _publish-pypi.yml's contract deliberately: the tag-prefix gate stays in
+# the CALLER (it is per-package and may need sibling-tag exclusions), callers use
+# `secrets: inherit`, and the varying value arrives as an input.
+#
+# goldenmatch itself is intentionally NOT a caller of any template: its
+# publish-goldenmatch.yml carries the bespoke web-build + cosign/sigstore +
+# draft-release flow from ADR 0019.
+name: _publish-native (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      manifest-path:
+        description: "Path to the crate's Cargo.toml (one manifest drives every job)"
+        required: true
+        type: string
+      ref:
+        description: "Tag or commit to build (default: the triggering ref)"
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: "Upload to PyPI (false = build-matrix dry run)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheels (maturin, abi3, manylinux)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: "2_28"
+          args: --release --out dist -m ${{ inputs.manifest-path }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: x64
+          args: --release --out dist -m ${{ inputs.manifest-path }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  macos:
+    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
+    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
+    # indefinitely in this org, so we don't depend on them.
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m ${{ inputs.manifest-path }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          command: sdist
+          args: --out dist -m ${{ inputs.manifest-path }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    needs: [linux, windows, macos, sdist]
+    # The caller decides: a release passes publish=true; a workflow_dispatch
+    # passes its checkbox through, so unchecking it is a build-matrix dry run.
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          # Merge every wheels-* artifact into a single dist/ for upload.
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-goldenanalysis-native.yml
+++ b/.github/workflows/publish-goldenanalysis-native.yml
@@ -1,14 +1,11 @@
 name: Publish goldenanalysis-native to PyPI
 
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
 # Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
-# publishes to PyPI. The pure-Python `goldenanalysis` frontend is published by its
-# own workflow; this is its native-runtime counterpart, mirroring
-# publish-goldencheck-native.yml.
+# publishes to PyPI: the native-runtime counterpart to publish-goldenanalysis.yml.
 #
-# Fires on a release tagged `goldenanalysis-native-v*` (kept distinct from the
-# Python `v*`, TS `goldenanalysis-js-v*`, and the other *-native tags so the
-# publish workflows never cross-trigger). workflow_dispatch with a `ref` allows a
-# manual/retro build.
+# Fires on a release tagged `goldenanalysis-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -27,116 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/analysis-native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenanalysis-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenanalysis-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenanalysis-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
-    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
-    # indefinitely in this org, so we don't depend on them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenanalysis-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldenanalysis-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenanalysis-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/analysis-native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldencheck-native.yml
+++ b/.github/workflows/publish-goldencheck-native.yml
@@ -1,14 +1,11 @@
 name: Publish goldencheck-native to PyPI
 
-# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms
-# and publishes to PyPI. The pure-Python `goldencheck` frontend is published by
-# its own workflow; this is its native-runtime counterpart, mirroring
-# publish-goldenmatch-native.yml.
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI: the native-runtime counterpart to publish-goldencheck.yml.
 #
-# Fires on a release tagged `goldencheck-native-v*` (kept distinct from the
-# Python `v*`, TS `goldencheck-js-v*`, and goldenmatch-native tags so the
-# publish workflows never cross-trigger). workflow_dispatch with a `ref` allows
-# a manual/retro build.
+# Fires on a release tagged `goldencheck-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -27,116 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/goldencheck-native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldencheck-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldencheck-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldencheck-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
-    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
-    # indefinitely in this org, so we don't depend on them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldencheck-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldencheck-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldencheck-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/goldencheck-native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenflow-native.yml
+++ b/.github/workflows/publish-goldenflow-native.yml
@@ -1,15 +1,11 @@
 name: Publish goldenflow-native to PyPI
 
-# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms
-# and publishes to PyPI. The pure-Python `goldenflow` frontend is published by
-# publish-goldenflow.yml; this is its optional-native counterpart (mirrors
-# publish-goldenmatch-native.yml).
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI: the native-runtime counterpart to publish-goldenflow.yml.
 #
-# Fires on a release tagged `goldenflow-native-v*` (kept distinct from the
-# Python `goldenflow-v*` and TS `goldenflow-js-v*` tags so the publish workflows
-# never cross-trigger). workflow_dispatch with a `ref` allows a manual/retro
-# build (and reads the workflow from main, sidestepping the tag-predates-
-# workflow trigger trap noted in the root CLAUDE.md).
+# Fires on a release tagged `goldenflow-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -28,116 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/native-flow/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenflow-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenflow-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenflow-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
-    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
-    # indefinitely in this org, so we don't depend on them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenflow-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldenflow-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenflow-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/native-flow/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldengraph-native.yml
+++ b/.github/workflows/publish-goldengraph-native.yml
@@ -1,18 +1,11 @@
 name: Publish goldengraph-native to PyPI
 
-# Builds the compiled knowledge-graph engine (maturin/abi3 wheels) across
-# platforms and publishes to PyPI. `goldengraph-native` is the PyO3 binding for
-# the pyo3-free `goldengraph-core` crate (PyStore / build_graph / neighborhood /
-# communities + the 7 JSON-boundary symbols). Unlike goldenmatch, goldengraph is
-# native-authoritative -- the store / resolution engine is Rust-only with NO
-# pure-Python fallback -- so this wheel is a hard runtime prerequisite for the
-# `goldengraph` frontend, not an optional accelerator.
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI: the native-runtime counterpart to publish-goldengraph.yml.
 #
-# Fires on a release tagged `goldengraph-native-v*` (kept distinct from the
-# Python `goldengraph-v*` and TS `goldengraph-js-v*` tags so the publish
-# workflows never cross-trigger). workflow_dispatch with a `ref` allows a
-# manual/retro build. Callable by cut-goldengraph-native.yml so one dispatch can
-# cut the tag AND publish in the same run.
+# Fires on a release tagged `goldengraph-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -27,6 +20,9 @@ on:
         type: boolean
         required: false
         default: true
+  # Callable by cut-native-release.yml so one dispatch can cut the tag AND
+  # publish in the same run -- no cross-workflow trigger (GITHUB_TOKEN can't
+  # re-trigger a workflow) to depend on.
   workflow_call:
     inputs:
       ref:
@@ -41,116 +37,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/goldengraph-native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile.
-    # macos-13 (Intel) runners queue indefinitely in this org, so we don't
-    # depend on them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name == 'release' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldengraph-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/goldengraph-native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenmatch-hnsw.yml
+++ b/.github/workflows/publish-goldenmatch-hnsw.yml
@@ -1,18 +1,11 @@
 name: Publish goldenmatch-hnsw to PyPI
 
-# Builds the SEPARATE native HNSW ANN wheel (maturin/abi3, pure Rust, ZERO C
-# deps) across platforms and publishes to PyPI. The pure-Python `goldenmatch`
-# frontend is published by publish-goldenmatch.yml; this is the goldenhnsw-rs
-# `IndexHNSWFlat` counterpart that backs the native ANN path in ann_blocker.
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI: the optional HNSW ANN index runtime.
 #
-# Fires on a release tagged `goldenmatch-hnsw-v*` (kept distinct from the Python
-# `v*`, TS `goldenmatch-js-v*`, native `goldenmatch-native-v*`, and embed
-# `goldenmatch-embed-v*` tags so the publish workflows never cross-trigger).
-# workflow_dispatch with a `ref` allows a manual/retro build.
-#
-# Unlike publish-goldenmatch-embed.yml there is NO `before-script-linux`: the
-# crate has no `ort`/openssl build dependency, so the manylinux containers need
-# nothing extra, and macOS builds BOTH arches (no prebuilt-runtime constraint).
+# Fires on a release tagged `goldenmatch-hnsw-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -31,116 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/hnsw-py/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-hnsw-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-hnsw-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-hnsw-v')
-    # Both arches: pure Rust, so the x86_64 cross-compile links cleanly (no
-    # prebuilt-runtime constraint like goldenmatch-embed's ort). macos-14 is
-    # Apple Silicon; it cross-builds the x86_64 wheel too.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [aarch64, x86_64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-hnsw-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldenmatch-hnsw-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenmatch-hnsw-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/hnsw-py/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenmatch-native.yml
+++ b/.github/workflows/publish-goldenmatch-native.yml
@@ -1,12 +1,11 @@
 name: Publish goldenmatch-native to PyPI
 
-# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms
-# and publishes to PyPI. The pure-Python `goldenmatch` frontend is published by
-# publish-goldenmatch.yml; this is its polars-runtime counterpart.
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
+# publishes to PyPI: the polars-runtime counterpart to publish-goldenmatch.yml.
 #
-# Fires on a release tagged `goldenmatch-native-v*` (kept distinct from the
-# Python `v*` and TS `goldenmatch-js-v*` tags so the publish workflows never
-# cross-trigger). workflow_dispatch with a `ref` allows a manual/retro build.
+# Fires on a release tagged `goldenmatch-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -38,116 +37,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
-    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
-    # indefinitely in this org, so we don't depend on them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name == 'release' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldenmatch-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenpipe-native.yml
+++ b/.github/workflows/publish-goldenpipe-native.yml
@@ -1,24 +1,11 @@
 name: Publish goldenpipe-native to PyPI
 
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
 # Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
-# publishes to PyPI. goldenpipe-native is the optional Rust/PyO3 binding that
-# exposes the pyo3-free `goldenpipe-core` planner kernel to Python
-# (`pip install goldenpipe[native]`). Per its own README it is NOT an
-# accelerator -- it makes the Rust core the reference the pure-Python planner is
-# gated against. Mirrors publish-goldenprofile-native.yml exactly.
+# publishes to PyPI: the native-runtime counterpart to publish-goldenpipe.yml.
 #
-# This workflow did not exist until the 2026-08-15 repo-wide cut, and that is
-# WHY goldenpipe-native had never been published. The crate has carried a
-# Cargo.toml + pyproject.toml at 0.1.0 for months with no pipeline to build it,
-# so there was no tag to miss and no red run to notice -- it was absent from
-# PyPI silently. Every sibling (goldenprofile-native, infermap-native,
-# goldenanalysis-native, goldencheck-native, goldengraph-native,
-# goldenflow-native) already had one.
-#
-# Fires on a release tagged `goldenpipe-native-v*` (kept distinct from every
-# other Python/TS/native tag so the publishers never cross-trigger).
-# workflow_dispatch with a `ref` allows a manual/retro build; leave `publish`
-# unchecked for a build-matrix dry run.
+# Fires on a release tagged `goldenpipe-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -37,115 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/goldenpipe-native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile.
-    # macos-13 (Intel) runners queue indefinitely in this org, so we don't use them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldenpipe-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenpipe-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/goldenpipe-native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenprofile-native.yml
+++ b/.github/workflows/publish-goldenprofile-native.yml
@@ -1,15 +1,11 @@
 name: Publish goldenprofile-native to PyPI
 
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
 # Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
-# publishes to PyPI. goldenprofile-native is the optional Semantic-Signature
-# resolution engine; goldengraph gates on it (`import goldenprofile_native`) and
-# turns its anti-shatter matcher ON when the wheel is importable, else falls back.
-# Mirrors publish-infermap-native.yml / publish-goldenanalysis-native.yml exactly.
+# publishes to PyPI: the native-runtime counterpart to publish-goldenprofile-js.yml's Python sibling.
 #
-# Fires on a release tagged `goldenprofile-native-v*` (kept distinct from every
-# other Python/TS/native tag so the publishers never cross-trigger).
-# workflow_dispatch with a `ref` allows a manual/retro build; leave `publish`
-# unchecked for a build-matrix dry run.
+# Fires on a release tagged `goldenprofile-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -28,115 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/goldenprofile-native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile.
-    # macos-13 (Intel) runners queue indefinitely in this org, so we don't use them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for goldenprofile-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenprofile-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/goldenprofile-native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit

--- a/.github/workflows/publish-infermap-native.yml
+++ b/.github/workflows/publish-infermap-native.yml
@@ -1,14 +1,11 @@
 name: Publish infermap-native to PyPI
 
+# Thin caller -> .github/workflows/_publish-native.yml (the shared template).
 # Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms and
-# publishes to PyPI. The pure-Python `infermap` frontend is published by its own
-# workflow; this is its native-runtime counterpart, mirroring
-# publish-goldenanalysis-native.yml.
+# publishes to PyPI: the native-runtime counterpart to publish-infermap.yml.
 #
-# Fires on a release tagged `infermap-native-v*` (kept distinct from the Python
-# `infermap-v*`, TS `infermap-js-v*`, and the other *-native tags so the publish
-# workflows never cross-trigger). workflow_dispatch with a `ref` allows a
-# manual/retro build.
+# Fires on a release tagged `infermap-native-v*`, kept distinct from sibling tags so the
+# publish workflows never cross-trigger.
 on:
   release:
     types: [published]
@@ -27,116 +24,15 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/infermap-native/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'infermap-native-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'infermap-native-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'infermap-native-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
-    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
-    # indefinitely in this org, so we don't depend on them.
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'infermap-native-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   publish:
-    needs: [linux, windows, macos, sdist]
-    # Release events always publish; a workflow_dispatch publishes only when the
-    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          # Merge every wheels-* artifact into a single dist/ for upload.
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    # Only run for infermap-native-v* tags. The four per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'infermap-native-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/infermap-native/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit


### PR DESCRIPTION
Nine maturin/abi3 publish workflows were **~90% identical** -- 142-156 lines each, of which exactly **one** value legitimately varied: the path to the crate `Cargo.toml`. The rest was the workflow name and a tag prefix repeated in **four** per-job `if:` conditions -- **36 hand-maintained copies of a tag prefix across nine files**.

**Net -949 lines** (1,083 deleted, 134 added) plus the ~150-line shared template.

## Finishing something already started

This repo already has `_publish-pypi.yml` and `_publish-js.yml`, and **18 packages already delegate to them**. These nine never migrated. Measured across all 39 publish workflows (4,087 lines) the tiers are:

| Tier | Files | Lines each | State |
|---|---|---|---|
| Thin callers | 18 | 31-38 | already delegate |
| **Native** | **9** | **142-156** | **this PR** |
| PyPI+signing pair | 2 | 175 | follow-up |
| Bespoke | 4 | 236-335 | leave alone |

`_publish-native.yml` follows `_publish-pypi.yml`'s contract deliberately: **the tag gate stays in the caller** (its header explains why -- per-package sibling-tag exclusions), callers use `secrets: inherit`, the varying value is an input.

`publish-goldenmatch.yml` is untouched. It is 175 lines but genuinely distinct (292 differing lines vs its nearest neighbour) -- it carries the ADR-0019 draft-release + cosign flow.

## Two drifts the duplication had allowed

Both found by diffing all nine rather than trusting one pair, and both silently resolved by consolidating:

- **`goldenmatch-hnsw` pinned `actions/download-artifact` at v4** while every sibling was on **v8.0.1** -- four majors behind. It now matches. This is an unrequested change; naming it because it is a real behaviour difference, not a formatting one.
- **`goldencheck-native` gated publish on `event_name != workflow_dispatch`**, `goldenmatch-native` on `event_name == release`. I worked the truth table: for the triggers actually configured (`release`, `workflow_dispatch`, `workflow_call`) these are **equivalent**; they would only diverge on `push`/`schedule`, which none use. Standardised on one form.

## Preserved on purpose

`publish-goldenmatch-native.yml` and `publish-goldengraph-native.yml` keep their `workflow_call` trigger -- **`cut-native-release.yml:105` calls the former**, so removing it would break tag-cutting. `goldengraph-native`'s is currently unused but kept; deleting an interface is a separate decision.

## `secrets: inherit` -- a deliberate non-change

zizmor flags this medium. Explicit `secrets: PYPI_TOKEN` would be least-privilege and clear it. I did **not** do that here: 18 sibling callers use `inherit`, and changing 9 of 27 would create exactly the stalled-halfway split this PR exists to fix. Better as a follow-up moving all 27 together. (zizmor is not in CI; the pre-existing `publish-goldencheck.yml` gets the same finding.)

## Verification

- `pytest scripts/test_workflow_yaml.py` -- **10 passed**
- **Dry-run dispatches** of `publish-goldencheck-native` (plain caller) and `publish-goldenmatch-native` (the `workflow_call` one) on this branch with `publish=false`, exercising the full build matrix without uploading. Results linked below.
- Manifest paths and tag prefixes extracted from the workflows being replaced, not retyped.

These publish real packages, so a broken conversion would only surface at the next release. Hence dry runs before merge, and the pair (`goldenfuzz`/`goldenphonetic`) left for a second PR rather than swept in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P