### PR TITLE
chore(ci): goldenfuzz and goldenphonetic delegate their wheels to the native template

### DIFF
--- a/.github/workflows/publish-goldenfuzz.yml
+++ b/.github/workflows/publish-goldenfuzz.yml
@@ -1,18 +1,14 @@
 name: Publish goldenfuzz (PyPI + crates.io)
 
-# Publishes the standalone `goldenfuzz` fuzzy-string product on BOTH surfaces:
-#   * PyPI: the `goldenfuzz` maturin/abi3 wheel (pure Rust, zero C deps) built
-#     across platforms, wrapping the pyo3-free `goldenfuzz-core` crate.
-#   * crates.io: the `goldenfuzz-core` Rust crate itself (zero deps, so it
-#     publishes standalone).
+# Two independent publish targets:
+#   * PyPI: the maturin/abi3 wheels, delegated to the shared
+#     .github/workflows/_publish-native.yml template.
+#   * crates.io: the pyo3-free `goldenfuzz-core` Rust crate itself (zero deps, so it
+#     publishes standalone). Kept HERE rather than in the template -- only this
+#     package and its sibling publish a crate, so it is not shared behaviour.
 #
-# Fires on a release tagged `goldenfuzz-v*` (kept distinct from every other
-# publish tag so nothing cross-triggers). workflow_dispatch with a `ref` allows a
-# manual/retro build; the `publish` toggle turns the matrix into a dry run.
-#
-# Secrets required (configure once): PYPI_TOKEN (already used by the suite) and
-# CRATES_IO_TOKEN (crates.io API token). Both jobs `skip-existing`/tolerate an
-# already-published version so a re-run is safe.
+# Secrets: PYPI_TOKEN (via secrets: inherit) and CRATES_IO_TOKEN. Both targets
+# tolerate an already-published version so a re-run is idempotent.
 on:
   release:
     types: [published]
@@ -31,120 +27,23 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every wheel job; abi3 = one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/goldenfuzz-py/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
-    # macos-14 (Apple Silicon) cross-builds the x86_64 wheel too; pure Rust, so
-    # the cross-compile links cleanly (no prebuilt-runtime constraint).
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [aarch64, x86_64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
-  pypi:
-    needs: [linux, windows, macos, sdist]
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+  wheels:
+    # Only run for goldenfuzz-v* tags. The per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/goldenfuzz-py/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit
 
   crates_io:
     # Publish the pyo3-free `goldenfuzz-core` Rust crate to crates.io. Zero deps,
     # so it publishes standalone. Independent of the PyPI wheel jobs.
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenfuzz-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6

--- a/.github/workflows/publish-goldenphonetic.yml
+++ b/.github/workflows/publish-goldenphonetic.yml
@@ -1,18 +1,14 @@
 name: Publish goldenphonetic (PyPI + crates.io)
 
-# Publishes the standalone `goldenphonetic` fuzzy-string product on BOTH surfaces:
-#   * PyPI: the `goldenphonetic` maturin/abi3 wheel (pure Rust, zero C deps) built
-#     across platforms, wrapping the pyo3-free `goldenphonetic-core` crate.
-#   * crates.io: the `goldenphonetic-core` Rust crate itself (zero deps, so it
-#     publishes standalone).
+# Two independent publish targets:
+#   * PyPI: the maturin/abi3 wheels, delegated to the shared
+#     .github/workflows/_publish-native.yml template.
+#   * crates.io: the pyo3-free `goldenphonetic-core` Rust crate itself (zero deps, so it
+#     publishes standalone). Kept HERE rather than in the template -- only this
+#     package and its sibling publish a crate, so it is not shared behaviour.
 #
-# Fires on a release tagged `goldenphonetic-v*` (kept distinct from every other
-# publish tag so nothing cross-triggers). workflow_dispatch with a `ref` allows a
-# manual/retro build; the `publish` toggle turns the matrix into a dry run.
-#
-# Secrets required (configure once): PYPI_TOKEN (already used by the suite) and
-# CRATES_IO_TOKEN (crates.io API token). Both jobs `skip-existing`/tolerate an
-# already-published version so a re-run is safe.
+# Secrets: PYPI_TOKEN (via secrets: inherit) and CRATES_IO_TOKEN. Both targets
+# tolerate an already-published version so a re-run is idempotent.
 on:
   release:
     types: [published]
@@ -31,120 +27,23 @@ on:
 permissions:
   contents: read
 
-env:
-  # One manifest drives every wheel job; abi3 = one wheel per platform (3.11+).
-  MANIFEST: packages/rust/extensions/goldenphonetic-py/Cargo.toml
-
 jobs:
-  linux:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheels (maturin, abi3, manylinux)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          manylinux: "2_28"
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist
-
-  windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: x64
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-windows-x64
-          path: dist
-
-  macos:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
-    # macos-14 (Apple Silicon) cross-builds the x86_64 wheel too; pure Rust, so
-    # the cross-compile links cleanly (no prebuilt-runtime constraint).
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [aarch64, x86_64]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Build wheel (maturin, abi3)
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-macos-${{ matrix.target }}
-          path: dist
-
-  sdist:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
-        with:
-          command: sdist
-          args: --out dist -m ${{ env.MANIFEST }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: wheels-sdist
-          path: dist
-
-  pypi:
-    needs: [linux, windows, macos, sdist]
-    if: github.event_name != 'workflow_dispatch' || inputs.publish
-    runs-on: ubuntu-latest
-    environment: pypi
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-        with:
-          packages-dir: dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+  wheels:
+    # Only run for goldenphonetic-v* tags. The per-job copies of this gate in the
+    # pre-template version collapse to one here.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
+    uses: ./.github/workflows/_publish-native.yml
+    with:
+      manifest-path: packages/rust/extensions/goldenphonetic-py/Cargo.toml
+      ref: ${{ inputs.ref || '' }}
+      # A release always publishes; a dispatch passes its checkbox through.
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
+    secrets: inherit
 
   crates_io:
     # Publish the pyo3-free `goldenphonetic-core` Rust crate to crates.io. Zero deps,
     # so it publishes standalone. Independent of the PyPI wheel jobs.
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldenphonetic-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6


### PR DESCRIPTION
Second and final consolidation PR, following #2705. **Net -202 lines.**

## The plan for these two was wrong, and looking changed it

#2705 said these would fold into `_publish-pypi.yml` with a signing input. They do not. **Neither is a pure-Python package** -- both are maturin/abi3 native builds (linux x2, windows, macos x2, sdist) *plus* a crates.io publish. `_publish-pypi.yml` is a 3-step pure-Python publish: a different shape entirely.

They are actually near-copies of `_publish-native.yml`, which #2705 had just created, with one extra job. So no third template: they become **callers of `_publish-native.yml`** for the wheels and keep their own `crates_io` job.

That job stays in the caller deliberately -- only these two packages publish a Rust crate, so it is not shared behaviour and does not belong in a template.

## Preserved verbatim

The `cargo publish` step, including the comment recording why it must not swallow failures:

> Tolerate ONLY the idempotent "already on crates.io" case. Any other non-zero -- auth, unverified email, metadata, network -- is a real failure and MUST fail the job loudly. The old `cargo publish || echo warning` swallowed a genuine 400 (unverified email) and showed green; never disguise a real failure as success again.

## Same drift closed again

Both pinned `actions/download-artifact` at **v4** in the removed code; the template is on **v8.0.1**. That is the third instance of this drift (`goldenmatch-hnsw` was the first) -- which is the argument for the template, not just a tidy-up.

## Verification

- `pytest scripts/test_workflow_yaml.py` -- 10 passed
- Dry-run dispatch of `publish-goldenfuzz` with `publish=false` on this branch, linked below. Note this exercises the **wheels** path; the `crates_io` job is gated on `inputs.publish` too, so a dry run does not touch crates.io.
- Manifest paths, tag prefixes and crate directories extracted from the files being replaced, not retyped.

## Still unproven until a real release

The tag-prefix gate itself. Dry runs exercise `workflow_dispatch`; only an actual `*-v*` tagged release exercises `startsWith(github.event.release.tag_name, ...)`. Same caveat as #2705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P