### PR TITLE
docs: design and plan for a structured release process

### DIFF
--- a/docs/superpowers/plans/2026-08-21-structured-release-process.md
+++ b/docs/superpowers/plans/2026-08-21-structured-release-process.md
@@ -1,0 +1,715 @@
+# Structured Release Process Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the "have I made enough progress?" release judgement with a standing release PR per package whose version is derived from conventional-commit types.
+
+**Architecture:** `release-please` in manifest mode watches merges to `main` and keeps one open release PR per package, carrying the version-file bumps and a generated CHANGELOG. Merging that PR pushes a tag, and the repo's existing 39 publish workflows react to tags exactly as they do today. This adds a decision layer; it replaces no publishing machinery.
+
+**Tech Stack:** `release-please` (googleapis) via `googleapis/release-please-action`, GitHub Actions, JSON config.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-structured-release-process-design.md`
+
+## Prerequisite, already done
+
+The spec names a prerequisite: consolidate the duplicated publish workflows so
+this manifest configures thin callers rather than divergent copies. That landed
+before this plan -- #2705 (nine native workflows onto a shared template, -949
+lines) merged, and #2706 (goldenfuzz/goldenphonetic, -202 lines) followed. No
+task here repeats it.
+
+## Global Constraints
+
+- **ADR 0019 stands.** A release is cut by pushing a tag; `publish-goldenmatch.yml` owns the release lifecycle and creates the release as a **draft** so signed assets attach before immutability seals it. Never `gh release create` by hand.
+- **goldenmatch uses bare `v*` tags**; every other package is prefixed (`<component>-v*`). Verified against release-please's config schema: `packages` entries are typed `additionalProperties: {"$ref": "#/definitions/ReleaserConfigOptions"}`, and `include-component-in-tag` is a property of that definition, so it is settable **per package**.
+- **Bump rule:** any `feat` → MINOR; only `fix`/`perf` → PATCH; only `docs`/`test`/`chore`/`ci`/`build`/`style`/`refactor`/`bench`/`diag` → no release; `!` or `BREAKING CHANGE:` → MAJOR.
+- **`bench` and `diag` are no-bump** — they are this repo's own commit types for instrumentation and diagnostics, not consumer-facing change. `release` is excluded outright (it is the bot's own commit).
+- **Zero of the last 200 commits carry a breaking marker**, so MAJOR never fires on its own. `Release-As:` is the only escape hatch.
+- **golden-suite pins floors as `>=MAJOR.MINOR`** (e.g. `>=3.14`, not `>=3.14.0`), and every pin carries an inline comment explaining why that floor exists. Those comments are load-bearing documentation and must survive any automated bump.
+- Do not run the full pytest suite locally — it OOMs under xdist. Run the targeted commands each task names.
+
+---
+
+### Task 1: Prove the derivation against real history before configuring anything
+
+**Files:**
+- Create: `scripts/derive_next_version.py`
+- Test: `scripts/test_derive_next_version.py`
+
+**Interfaces:**
+- Produces: `derive_bump(commit_subjects: list[str]) -> str | None` returning `"major"`, `"minor"`, `"patch"`, or `None` for no release.
+
+The spec asserts the repo's commit history can drive versioning. That claim is measurable and nothing should be built on it unmeasured. This task makes the rule executable and runs it over real history, so wave 1 starts from evidence.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The bump rule from the release-process spec, pinned to this repo's vocabulary."""
+from __future__ import annotations
+
+from derive_next_version import derive_bump
+
+
+def test_feat_gives_minor():
+    assert derive_bump(["feat(identity): add a thing", "fix(x): y"]) == "minor"
+
+
+def test_only_fixes_give_patch():
+    assert derive_bump(["fix(a): one", "perf(b): two"]) == "patch"
+
+
+def test_docs_and_chores_give_no_release():
+    assert derive_bump(["docs: readme", "chore(ci): bump", "test: add"]) is None
+
+
+def test_repo_specific_types_are_no_bump():
+    """bench/diag are this repo's own types: instrumentation, not product change."""
+    assert derive_bump(["bench(spark): size the lane", "diag(fs): show refits"]) is None
+
+
+def test_bang_gives_major():
+    assert derive_bump(["feat(api)!: drop the polars dependency"]) == "major"
+
+
+def test_breaking_change_footer_gives_major():
+    assert derive_bump(["feat(api): x\n\nBREAKING CHANGE: drops polars"]) == "major"
+
+
+def test_release_commits_are_ignored():
+    """The bot's own commit must not itself trigger a release."""
+    assert derive_bump(["release: goldenmatch 3.14.0"]) is None
+
+
+def test_unknown_types_are_ignored_not_crashed():
+    assert derive_bump(["wip whatever", "merge branch 'x'"]) is None
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd /d/show_case/<worktree>
+/d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest scripts/test_derive_next_version.py -q
+```
+
+Expected: `ModuleNotFoundError: No module named 'derive_next_version'`
+
+- [ ] **Step 3: Implement**
+
+```python
+#!/usr/bin/env python3
+"""Derive a semver bump from conventional-commit subjects.
+
+The rule lives in docs/superpowers/specs/2026-08-21-structured-release-process-design.md.
+This module exists so the rule is executable and testable BEFORE it is encoded
+in release-please config, where it would only be observable by watching PRs
+appear.
+"""
+from __future__ import annotations
+
+import re
+
+_HEADER = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?: ", re.IGNORECASE
+)
+
+MINOR_TYPES = {"feat"}
+PATCH_TYPES = {"fix", "perf"}
+# This repo's own vocabulary beyond the conventional set. bench/diag are
+# instrumentation and diagnostics; release is the bot's own commit.
+NO_BUMP_TYPES = {
+    "docs", "test", "chore", "ci", "build", "style", "refactor",
+    "bench", "diag", "release",
+}
+
+
+def derive_bump(commit_subjects: list[str]) -> str | None:
+    """Return 'major' | 'minor' | 'patch' | None for a list of commit messages."""
+    bump: str | None = None
+    for message in commit_subjects:
+        header = message.splitlines()[0] if message else ""
+        match = _HEADER.match(header)
+        if "BREAKING CHANGE:" in message:
+            return "major"
+        if not match:
+            continue
+        if match.group("bang"):
+            return "major"
+        ctype = match.group("type").lower()
+        if ctype in MINOR_TYPES:
+            bump = "minor"
+        elif ctype in PATCH_TYPES and bump != "minor":
+            bump = "patch"
+    return bump
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Run the rule over real history and record what it says**
+
+```bash
+git log origin/main --format='%s' -200 > /tmp/subjects.txt
+/d/show_case/goldenmatch/.venv/Scripts/python.exe -c "
+import sys; sys.path.insert(0,'scripts')
+from derive_next_version import derive_bump
+subs=[l.rstrip() for l in open('/tmp/subjects.txt',encoding='utf-8') if l.strip()]
+print('200-commit window ->', derive_bump(subs))
+"
+git log origin/main --format='%s' \$(git describe --tags --abbrev=0 --match 'v*')..origin/main > /tmp/since.txt
+/d/show_case/goldenmatch/.venv/Scripts/python.exe -c "
+import sys; sys.path.insert(0,'scripts')
+from derive_next_version import derive_bump
+subs=[l.rstrip() for l in open('/tmp/since.txt',encoding='utf-8') if l.strip()]
+print('since last v* tag ->', derive_bump(subs), f'({len(subs)} commits)')
+"
+```
+
+Record both answers in the commit message. The second is the bump v3.15.0 would receive — the spec predicts MINOR (two `feat` commits landed since v3.14.0). If it says anything else, **stop and report**: either the rule or the spec's reading of history is wrong, and that must be settled before configuring release-please.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/derive_next_version.py scripts/test_derive_next_version.py
+git commit -m "feat(release): make the version-derivation rule executable and testable"
+```
+
+---
+
+### Task 2: Wave 1 config — goldenmatch and golden-suite
+
+**Files:**
+- Create: `release-please-config.json`
+- Create: `.release-please-manifest.json`
+- Create: `.github/workflows/release-please.yml`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 at runtime (that module documents and tests the rule; release-please implements it internally).
+- Produces: the two config files every later wave appends packages to.
+
+- [ ] **Step 1: Read the current versions from source, not from memory**
+
+```bash
+rg -n '^version' packages/python/goldenmatch/pyproject.toml packages/python/golden-suite/pyproject.toml
+```
+
+At time of writing these are `3.14.0` and `0.5.1`. **Use whatever the command prints**, not these values — main moves.
+
+- [ ] **Step 2: Write the manifest**
+
+`.release-please-manifest.json`:
+
+```json
+{
+  "packages/python/goldenmatch": "3.14.0",
+  "packages/python/golden-suite": "0.5.1"
+}
+```
+
+- [ ] **Step 3: Write the config**
+
+`release-please-config.json`:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "chore", "section": "Chores", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true },
+    { "type": "refactor", "section": "Refactoring", "hidden": true },
+    { "type": "style", "section": "Style", "hidden": true },
+    { "type": "bench", "section": "Benchmarks", "hidden": true },
+    { "type": "diag", "section": "Diagnostics", "hidden": true }
+  ],
+  "packages": {
+    "packages/python/goldenmatch": {
+      "release-type": "python",
+      "package-name": "goldenmatch",
+      "include-component-in-tag": false,
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        "goldenmatch/__init__.py",
+        { "type": "json", "path": "server.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "server.json", "jsonpath": "$.packages[0].version" }
+      ]
+    },
+    "packages/python/golden-suite": {
+      "release-type": "python",
+      "package-name": "golden-suite",
+      "component": "golden-suite",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": ["golden_suite/__init__.py"]
+    }
+  }
+}
+```
+
+Two details that are load-bearing:
+
+- `include-component-in-tag: false` on goldenmatch produces the bare `v3.15.0` tag that `publish-goldenmatch.yml` triggers on. Setting it true would produce `goldenmatch-v3.15.0`, which **no workflow listens for** — the release would appear and nothing would publish.
+- `server.json` carries the version in **two** places (`$.version` and `$.packages[0].version`). Both entries are required; bumping one leaves the MCP registry sync publishing a mismatched version.
+
+- [ ] **Step 4: Write the workflow**
+
+`.github/workflows/release-please.yml`:
+
+```yaml
+name: release-please
+
+# Maintains one standing release PR per package. Merging that PR pushes the
+# package's tag, which the existing publish-*.yml workflows react to -- this
+# workflow publishes nothing itself.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445  # v4.1.3
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+```
+
+- [ ] **Step 5: Validate the config against the schema before pushing**
+
+```bash
+/d/show_case/goldenmatch/.venv/Scripts/python.exe -c "
+import json,urllib.request
+cfg=json.load(open('release-please-config.json',encoding='utf-8'))
+man=json.load(open('.release-please-manifest.json',encoding='utf-8'))
+missing=[p for p in cfg['packages'] if p not in man]
+assert not missing, f'packages in config but not manifest: {missing}'
+extra=[p for p in man if p not in cfg['packages']]
+assert not extra, f'packages in manifest but not config: {extra}'
+print('config/manifest package sets agree:', sorted(man))
+"
+/d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest scripts/test_workflow_yaml.py -q
+```
+
+Expected: the assertion prints both package paths, and the workflow YAML gate passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add release-please-config.json .release-please-manifest.json .github/workflows/release-please.yml
+git commit -m "feat(release): wave 1 -- standing release PRs for goldenmatch and golden-suite"
+```
+
+---
+
+### Task 3: Verify wave 1 on a branch before it can touch main
+
+**Files:**
+- Modify: none (verification only)
+
+release-please only acts on `push: main`, so merging wave 1 is itself the first live test. That is the wrong order. This task proves the config off-main first.
+
+- [ ] **Step 1: Dry-run the config with release-please's own CLI**
+
+```bash
+npx --yes release-please@17 release-pr \
+  --repo-url=benseverndev-oss/goldenmatch \
+  --config-file=release-please-config.json \
+  --manifest-file=.release-please-manifest.json \
+  --target-branch=main \
+  --dry-run \
+  --token="$(gh auth token)"
+```
+
+- [ ] **Step 2: Read what it says it would do**
+
+Confirm, for goldenmatch:
+- the proposed version matches Task 1 Step 5's `since last v* tag` answer
+- the proposed **tag is bare** (`v3.15.0`), not `goldenmatch-v3.15.0`
+- the changelog body contains the `feat`/`fix` entries and none of the hidden types
+
+If the tag is prefixed, `include-component-in-tag` is not doing what the schema implies. **Stop and report** — that is the assumption the spec flagged, and a wrong answer here changes wave 1's shape.
+
+- [ ] **Step 3: Record the dry-run output in the PR body**
+
+Paste the proposed version, tag and changelog section. This is the evidence that the config does what the spec claims, and it is the only such evidence available before merge.
+
+- [ ] **Step 4: Commit nothing; open the wave-1 PR**
+
+```bash
+gh pr create --base main --title "feat(release): wave 1 -- standing release PRs for goldenmatch and golden-suite" --body "<dry-run output + what to watch for on merge>"
+```
+
+---
+
+### Task 4: The golden-suite lockstep
+
+**Files:**
+- Create: `scripts/bump_suite_floor.py`
+- Test: `scripts/test_bump_suite_floor.py`
+- Modify: `.github/workflows/release-please.yml`
+
+**Interfaces:**
+- Produces: `bump_floor(text: str, package: str, new_version: str) -> str` returning the pyproject text with only that package's floor raised.
+
+The rule — a member release drags golden-suite's floor — is tribal knowledge today and has no release-please equivalent.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""golden-suite floor bumps must not damage the reasons written beside them."""
+from __future__ import annotations
+
+from bump_suite_floor import bump_floor
+
+LINE = (
+    '    "goldenmatch[polars]>=3.14",        # entity resolution: dedupe, match, '
+    "golden records (>=3.14: distributed Fellegi-Sunter 4.13x faster at 250M)\n"
+)
+
+
+def test_raises_the_floor_to_major_minor_only():
+    """The convention is >=3.15, never >=3.15.0 -- match what is already there."""
+    out = bump_floor(LINE, "goldenmatch", "3.15.0")
+    assert '"goldenmatch[polars]>=3.15"' in out
+
+
+def test_preserves_the_extras_marker():
+    out = bump_floor(LINE, "goldenmatch", "3.15.0")
+    assert "[polars]" in out
+
+
+def test_preserves_the_trailing_comment_verbatim():
+    """Those comments explain WHY a floor exists. Losing them loses the reason."""
+    out = bump_floor(LINE, "goldenmatch", "3.15.0")
+    assert "distributed Fellegi-Sunter 4.13x faster at 250M" in out
+
+
+def test_leaves_other_packages_untouched():
+    text = LINE + '    "goldencheck[polars]>=3.5",   # data validation\n'
+    out = bump_floor(text, "goldenmatch", "3.15.0")
+    assert '"goldencheck[polars]>=3.5"' in out
+
+
+def test_never_lowers_a_floor():
+    """A re-run or an out-of-order event must not walk the floor backwards."""
+    out = bump_floor(LINE, "goldenmatch", "3.13.0")
+    assert '"goldenmatch[polars]>=3.14"' in out
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Expected: `ModuleNotFoundError: No module named 'bump_suite_floor'`
+
+- [ ] **Step 3: Implement**
+
+```python
+#!/usr/bin/env python3
+"""Raise a golden-suite dependency floor without touching anything else on the line.
+
+golden-suite pins members as `>=MAJOR.MINOR` and writes the REASON for each floor
+in a trailing comment. A naive bump destroys that reason, which is the most
+valuable part of the line. This rewrites only the version.
+"""
+from __future__ import annotations
+
+import re
+
+
+def bump_floor(text: str, package: str, new_version: str) -> str:
+    major, minor, *_ = new_version.split(".")
+    target = (int(major), int(minor))
+    pattern = re.compile(
+        rf'("{re.escape(package)}(?:\[[^\]]*\])?>=)(\d+)\.(\d+)(?:\.\d+)?"'
+    )
+
+    def replace(m: re.Match[str]) -> str:
+        current = (int(m.group(2)), int(m.group(3)))
+        if current >= target:
+            return m.group(0)  # never walk a floor backwards
+        return f'{m.group(1)}{major}.{minor}"'
+
+    return pattern.sub(replace, text)
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Write the CLI that the workflow actually calls**
+
+`bump_floor` is the pure function; the workflow needs something that maps
+release-please's `paths_released` output onto golden-suite's pyproject. Create
+`scripts/apply_suite_floors.py`:
+
+```python
+#!/usr/bin/env python3
+"""Raise golden-suite's floors for every member released in this run.
+
+release-please emits `paths_released` (a JSON array of package paths) and
+`releases_created`. This maps those paths to package names, reads each one's
+just-released version from the manifest, and rewrites only the floor.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+from bump_suite_floor import bump_floor
+
+SUITE = pathlib.Path("packages/python/golden-suite/pyproject.toml")
+MANIFEST = pathlib.Path(".release-please-manifest.json")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--released", required=True,
+                    help="release-please paths_released output (JSON array)")
+    args = ap.parse_args(argv)
+
+    try:
+        paths = json.loads(args.released or "[]")
+    except json.JSONDecodeError:
+        print(f"::error::could not parse paths_released: {args.released!r}",
+              file=sys.stderr)
+        return 1
+    if not paths:
+        print("no packages released; nothing to do")
+        return 0
+
+    versions = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    text = original = SUITE.read_text(encoding="utf-8")
+    for path in paths:
+        # golden-suite does not pin itself.
+        if path.endswith("/golden-suite"):
+            continue
+        version = versions.get(path)
+        if not version:
+            print(f"::warning::{path} released but absent from the manifest")
+            continue
+        package = path.rsplit("/", 1)[-1]
+        text = bump_floor(text, package, version)
+
+    if text == original:
+        print("no floor changed")
+        return 0
+    SUITE.write_text(text, encoding="utf-8")
+    print(f"raised floors in {SUITE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Note it writes the file but does not commit. The next release-please run picks
+the change up through golden-suite's own standing PR, which is the whole point:
+the floor bump is reviewable rather than silently pushed to main.
+
+- [ ] **Step 6: Wire it into the workflow**
+
+Append to `.github/workflows/release-please.yml`, after the release-please step:
+
+```yaml
+      # A member release drags golden-suite's floor. release-please has no
+      # native equivalent, and leaving it manual is how it gets forgotten
+      # out-of-hours. Only the version is rewritten; the reason beside it stays.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        if: steps.release.outputs.releases_created == 'true'
+      - name: Raise golden-suite floors for any member released in this run
+        if: steps.release.outputs.releases_created == 'true'
+        env:
+          RELEASES: ${{ steps.release.outputs.paths_released }}
+        run: python scripts/apply_suite_floors.py --released "$RELEASES"
+```
+
+Give the release-please step `id: release` so those outputs resolve.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/bump_suite_floor.py scripts/test_bump_suite_floor.py scripts/apply_suite_floors.py .github/workflows/release-please.yml
+git commit -m "feat(release): encode the golden-suite lockstep rather than remembering it"
+```
+
+---
+
+### Task 5: Document the MAJOR escape hatch
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+The single most likely silent failure in this design: **zero of the last 200 commits carry a breaking marker**, yet 3.0.0 genuinely was breaking. Derived versioning will therefore never cut a MAJOR on its own, and nothing will complain.
+
+- [ ] **Step 1: Add the section**
+
+```markdown
+## Marking a breaking change
+
+Version numbers are derived from commit types, so a breaking change is only a
+MAJOR if you say so. Two ways:
+
+    feat(api)!: drop the Polars dependency
+
+or a footer:
+
+    BREAKING CHANGE: goldenmatch no longer installs Polars by default
+
+**This does not happen by itself.** Across the 200 commits before this process
+was adopted, none carried either marker -- and 3.0.0 (the Polars eviction) was
+genuinely breaking. If you ship a break without marking it, it goes out as a
+MINOR and nobody finds out until a consumer does.
+
+To force a specific version regardless of derivation, put `Release-As: 4.0.0`
+in a commit footer.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(contributing): how to mark a breaking change, and why it will not happen by itself"
+```
+
+---
+
+### Task 6: Wave 2 — the remaining Python packages
+
+**Files:**
+- Modify: `release-please-config.json`
+- Modify: `.release-please-manifest.json`
+
+Packages: `goldencheck`, `goldencheck-types`, `goldenflow`, `goldenpipe`, `infermap`, `goldenanalysis`, `goldengraph`, `goldenmatch-kg`, `goldenfuzz`, `goldenphonetic`, `goldensuite-mcp`.
+
+- [ ] **Step 1: Derive each package's current version from source**
+
+```bash
+for d in goldencheck goldencheck-types goldenflow goldenpipe infermap goldenanalysis goldengraph goldenmatch-kg goldenfuzz goldenphonetic goldensuite-mcp; do
+  v=$(rg -m1 -o '^version = "([^"]+)"' -r '$1' "packages/python/$d/pyproject.toml" 2>/dev/null)
+  echo "packages/python/$d: $v"
+done
+```
+
+Do not copy versions from this plan — it will be stale. Use what the command prints.
+
+- [ ] **Step 2: Confirm which of them carry a server.json**
+
+```bash
+fd -t f 'server.json' packages/python --max-depth 3
+```
+
+At time of writing: `goldenanalysis`, `goldencheck`, `goldenflow`, `goldenmatch`, `goldenpipe`, `infermap`. Each needs **both** `extra-files` json entries (`$.version` and `$.packages[0].version`), exactly as goldenmatch does in Task 2.
+
+- [ ] **Step 3: Add each package to both files**
+
+Every entry takes `include-component-in-tag: true` and a `component` matching its existing tag prefix. Confirm each prefix against real tags rather than assuming it matches the directory name:
+
+```bash
+git ls-remote --tags origin | sed 's#.*refs/tags/##' | sed 's/\^{}//' | rg -o '^[a-z-]+(?=-v[0-9])' | sort -u
+```
+
+- [ ] **Step 4: Re-run the config/manifest agreement check from Task 2 Step 5**
+
+Expected: both sets agree and list all 13 packages.
+
+- [ ] **Step 5: Dry-run as in Task 3 Step 1 and check every proposed tag**
+
+Each must match a prefix that an existing `publish-*.yml` listens for. A tag nothing listens for produces a release that publishes nothing — silently.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add release-please-config.json .release-please-manifest.json
+git commit -m "feat(release): wave 2 -- standing release PRs for the remaining Python packages"
+```
+
+---
+
+### Task 7: Wave 3 — JS and native packages
+
+**Files:**
+- Modify: `release-please-config.json`
+- Modify: `.release-please-manifest.json`
+
+- [ ] **Step 1: Enumerate the JS and native tag prefixes from real tags**
+
+```bash
+git ls-remote --tags origin | sed 's#.*refs/tags/##' | sed 's/\^{}//' \
+  | rg -o '^[a-z-]+(?=-v[0-9])' | sort -u | rg 'js$|native$|wasm|duckdb|pg$|hnsw|embed|spark'
+```
+
+- [ ] **Step 2: Add JS packages with `release-type: node`**
+
+Their version carrier is `package.json`; no `extra-files` needed.
+
+- [ ] **Step 3: Add native packages with `release-type: rust`**
+
+Their version carrier is `Cargo.toml`. Note the crate directories are **not** uniformly named — `native/`, `native-flow/`, `analysis-native/`, `hnsw-py/`, `goldenphonetic-py/`. Read each from the workflow that publishes it:
+
+```bash
+rg -n 'manifest-path:' .github/workflows/publish-*.yml
+```
+
+- [ ] **Step 4: Re-run the agreement check and a dry run**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add release-please-config.json .release-please-manifest.json
+git commit -m "feat(release): wave 3 -- standing release PRs for the JS and native packages"
+```
+
+---
+
+### Task 8: Retire the manual SOP
+
+**Files:**
+- Modify: `context-network/operations/release-and-registries.md`
+- Create: `context-network/decisions/00XX-derived-release-versioning.md`
+
+- [ ] **Step 1: Write the ADR**
+
+Record: the trigger was a judgement call; the bump is now derived; ADR 0019's tag-push mechanics are unchanged and this sits above them; the MAJOR marker is convention, not enforcement.
+
+Use the next free number — check `ls context-network/decisions/`.
+
+- [ ] **Step 2: Update the operations doc**
+
+The "cut a release by pushing the tag" SOP becomes "merge the standing release PR; it pushes the tag". Keep the manual path documented as the fallback for when release-please is unavailable — it is still what ADR 0019 describes and it still works.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add context-network/
+git commit -m "docs(release): record derived versioning as a decision and retire the manual trigger"
+```
+
+---
+
+## Verification
+
+1. A merge to main produces or updates a standing release PR per package with pending changes.
+2. goldenmatch's proposed tag is bare `v*`. This is the single highest-risk config value: a prefixed tag would create a release that no workflow publishes.
+3. Merging a release PR pushes the tag and the existing publish workflow runs.
+4. `scripts/test_derive_next_version.py` and `scripts/test_bump_suite_floor.py` pass.
+5. golden-suite's floors rise without losing their trailing comments.
+
+## Known limitations
+
+- **Generated notes read worse than hand-written ones.** #2703's notes explained *why* the bump was MINOR and carried measured figures; derived notes are a categorised commit list. The PR body is editable before merging.
+- **MAJOR is convention, not enforcement.** See Task 5.
+- **Nothing here validates that a release is safe** — only that it is correctly numbered and described. CI gates merges; that is a different problem and deliberately out of scope.
+- **The 13% of commits outside the type map** do not appear in changelogs until their types are added to `changelog-sections`.

--- a/docs/superpowers/specs/2026-08-21-structured-release-process-design.md
+++ b/docs/superpowers/specs/2026-08-21-structured-release-process-design.md
@@ -94,13 +94,19 @@ Per-package specifics the config must express:
 
 - **goldenmatch uses bare `v*` tags**; every other package is prefixed. This is
   `include-component-in-tag: false` for goldenmatch and `true` elsewhere.
-  **UNVERIFIED ASSUMPTION, and load-bearing**: that release-please supports
-  mixing a bare-tag component with prefixed ones inside a single manifest. If it
-  does not, goldenmatch -- the flagship, with 91 existing bare tags -- cannot
-  join the scheme without either changing its tag format (which would break
-  `publish-goldenmatch.yml`'s `v*` trigger and orphan the existing tag history)
-  or running it outside the manifest. The implementation plan must verify this
-  against release-please's actual behaviour before wave 1, not after.
+  **VERIFIED 2026-08-21** against release-please's own config schema
+  (`schemas/config.json`, read via the GitHub API): `packages` is typed
+  `additionalProperties: {"$ref": "#/definitions/ReleaserConfigOptions"}`, the
+  same definition applied at the root, and `include-component-in-tag` is a
+  property of `ReleaserConfigOptions`. It is therefore settable **per package**,
+  so goldenmatch keeps its bare `v*` tags alongside prefixed siblings in one
+  manifest.
+
+  Recorded because the first answer was the opposite: `manifest-releaser.md`
+  states the option is root-level and "applies uniformly across all packages".
+  Had that been believed, goldenmatch would have had to change its tag format
+  (breaking `publish-goldenmatch.yml`'s `v*` trigger and orphaning 91 tags) or
+  sit outside the scheme. The schema is authoritative; the prose is not.
 - **Three release types**: `python` (pyproject.toml), `node` (package.json),
   `rust` (Cargo.toml).
 - **Non-standard version carriers** need `extra-files`: `__init__.py` for the

--- a/docs/superpowers/specs/2026-08-21-structured-release-process-design.md
+++ b/docs/superpowers/specs/2026-08-21-structured-release-process-design.md
@@ -1,0 +1,165 @@
+# Structured release process
+
+Date: 2026-08-21
+Status: design approved, plan pending
+
+## Problem
+
+Releases are cut when the maintainer decides enough progress has accumulated.
+The mechanics are well-specified -- ADR 0019 settled them, and 40+ publish
+workflows implement them -- but the *decision* is not. Every release requires
+two judgement calls: is this enough, and what number does it get.
+
+The cost is the judgement itself, not the frequency. Measured over the five
+weeks 2026-07-13 to 2026-08-20, goldenmatch cut 13 releases (one every 2-4
+days), and 100+ releases went out across all package prefixes in 90 days. The
+process is not producing rare releases; it is producing frequent ones, each
+preceded by a decision nobody wants to make.
+
+Two symptoms visible in the data:
+
+- **The version number carries almost no signal.** Of those 13 releases, 11 were
+  MINOR and 2 were PATCH. A consumer seeing 3.11 -> 3.12 learns nothing about
+  whether it matters to them.
+- **3.5 and 3.9 do not exist.** Gaps of that shape are abandoned cuts.
+
+## Scope
+
+All ~40 publish targets: Python, npm and native/Rust. Approximately 25 distinct
+tag prefixes are already in use -- 91 bare `v*` (goldenmatch), 24
+`goldenmatch-js`, 23 `golden-suite`, 15 each `goldenmatch-native` and
+`goldencheck`, then a long tail down to 2.
+
+These are not independent subsystems; they are one shape repeated, which a
+single manifest can express declaratively. Rollout is nonetheless staged (see
+Rollout) so a configuration error costs one version stream rather than forty.
+
+## What does not change
+
+ADR 0019 stands in full. A release is still cut by pushing a tag; the publish
+workflow still owns the release lifecycle, creating the release as a draft so
+signed assets can attach before immutability seals it. Every existing publish
+workflow keeps working untouched, because each triggers on a tag and tags keep
+arriving.
+
+This design adds a decision layer above that machinery. It replaces nothing.
+
+## The rule
+
+Version derives from conventional-commit types since the package's last tag:
+
+| Commits since last tag | Bump |
+|---|---|
+| any `feat` | MINOR |
+| only `fix` / `perf` | PATCH |
+| only `docs` / `test` / `chore` / `ci` / `build` / `style` / `refactor` / `bench` / `diag` | no release |
+| any `!` suffix or `BREAKING CHANGE:` footer | MAJOR |
+
+This is viable because the repo is already structured: **174 of the last 200
+commits on main (87%) match the conventional format**, with the type
+distribution `fix` 70, `feat` 41, `docs` 18, `perf` 16, `chore` 12, `ci` 9,
+`build` 4, `test` 4.
+
+The 13% that do not match are not sloppiness -- they are a deliberate wider
+vocabulary: `bench(spark):`, `diag(fs):`, `diag(scoring):`, and `release:`.
+These map explicitly. `bench` and `diag` are no-bump: they are instrumentation
+and diagnostics, not consumer-facing change. `release` is excluded outright, as
+it is the bot's own commit.
+
+**Expected behaviour change, and the point of the exercise.** With 70 fixes to
+41 feats, deriving bumps produces considerably more PATCH releases than the
+current process, which ships almost everything as MINOR. Version numbers begin
+to distinguish "a bug you may have hit was fixed" from "there is something new
+here".
+
+## The standing PR
+
+`release-please` in manifest mode. On every merge to main it recomputes, per
+package, what the next version would be, and maintains one open pull request
+per package titled `chore(main): release <package> <version>`. That PR carries
+the version-file bumps and a generated CHANGELOG section. Merging it tags the
+release, which triggers the existing publish workflow.
+
+Leaving the PR open costs nothing; it accumulates. Cutting a release becomes
+merging a PR that already shows exactly what would ship.
+
+Configuration lives in two files at the repo root:
+
+- `release-please-config.json` -- per-package release type, component name, tag
+  format, changelog path, and extra version-carrying files.
+- `.release-please-manifest.json` -- the current version of each package, seeded
+  from the existing tags.
+
+Per-package specifics the config must express:
+
+- **goldenmatch uses bare `v*` tags**; every other package is prefixed. This is
+  `include-component-in-tag: false` for goldenmatch and `true` elsewhere.
+  **UNVERIFIED ASSUMPTION, and load-bearing**: that release-please supports
+  mixing a bare-tag component with prefixed ones inside a single manifest. If it
+  does not, goldenmatch -- the flagship, with 91 existing bare tags -- cannot
+  join the scheme without either changing its tag format (which would break
+  `publish-goldenmatch.yml`'s `v*` trigger and orphan the existing tag history)
+  or running it outside the manifest. The implementation plan must verify this
+  against release-please's actual behaviour before wave 1, not after.
+- **Three release types**: `python` (pyproject.toml), `node` (package.json),
+  `rust` (Cargo.toml).
+- **Non-standard version carriers** need `extra-files`: `__init__.py` for the
+  Python packages, and `server.json` for the MCP-registry packages.
+
+## The golden-suite lockstep
+
+The existing rule -- a member release drags golden-suite's floor -- has no
+native equivalent in release-please. It becomes an explicit workflow step that
+runs after a member's release PR merges: bump the member's floor in
+`golden-suite`'s dependency pins, which then flows into golden-suite's own
+standing PR through the normal path.
+
+Encoding it is deliberate. It is currently tribal knowledge, and it is exactly
+the class of rule that gets forgotten during an out-of-hours release.
+
+## The MAJOR escape hatch
+
+**Zero of the last 200 commits carry a `!` marker or a `BREAKING CHANGE:`
+footer**, yet 3.0.0 was genuinely breaking -- it evicted Polars from the
+dependency tree. A purely derived scheme would therefore never cut a major
+again, and would fail silently: a breaking change would ship as a minor and
+nobody would notice until a consumer broke.
+
+This is the highest-risk part of the design. Two guards:
+
+1. `Release-As: 4.0.0` in a commit footer forces a specific version regardless
+   of derivation.
+2. `CONTRIBUTING.md` gains a short section on marking breaking changes, so the
+   convention is written down rather than assumed.
+
+Neither guard is automatic. The residual risk is accepted and stated here so it
+is a known limitation rather than a surprise.
+
+## Rollout
+
+Three waves, one config file, staged enablement:
+
+1. **goldenmatch + golden-suite.** Proves version derivation against real
+   commits, the bare-tag component, and the lockstep step.
+2. **Remaining Python packages** -- goldencheck, goldenflow, goldenpipe,
+   infermap, goldenanalysis, goldengraph, goldenmatch-kg, goldenfuzz,
+   goldenphonetic, goldensuite-mcp.
+3. **JS and native packages.**
+
+Each wave is a separate PR adding packages to the manifest. A misconfiguration
+in wave 1 affects one version stream.
+
+## Known limitations
+
+- **Generated release notes read worse than hand-written ones.** The current
+  notes are unusually good: #2703 explained why the bump was MINOR rather than
+  PATCH and carried measured before/after figures. Derived notes are a
+  categorised commit list. `changelog-sections` improves the grouping, and the
+  PR body is editable before merging, but narrative is lost by default. This is
+  a real trade, accepted knowingly.
+- **The 13% of commits outside the type map do not appear in changelogs**
+  until their types are added to the configuration.
+- **The MAJOR guard is convention, not enforcement** (see above).
+- **Nothing here validates that a release is *safe*** -- only that it is
+  correctly numbered and described. Readiness gating was considered and
+  excluded: it is a different problem, and CI already gates merges.

--- a/docs/superpowers/specs/2026-08-21-structured-release-process-design.md
+++ b/docs/superpowers/specs/2026-08-21-structured-release-process-design.md
@@ -135,9 +135,37 @@ This is the highest-risk part of the design. Two guards:
 Neither guard is automatic. The residual risk is accepted and stated here so it
 is a known limitation rather than a surprise.
 
+## Prerequisite: consolidate the duplicate publish workflows
+
+Decided 2026-08-21, after measuring the machinery this design sits on.
+
+The 39 publish workflows total 4,087 lines in four tiers: 18 thin callers
+(31-38 lines) that already delegate to `_publish-pypi.yml` / `_publish-js.yml`;
+9 native workflows (142-156 lines) that are ~90% identical to each other; a
+~82%-identical pair at 175 lines (`goldenfuzz`, `goldenphonetic`); and 4
+genuinely bespoke ones (`mcp`, `spark-jar`, `containers`, `pg`) that stay as
+they are. `publish-goldenmatch.yml` is also 175 lines but genuinely distinct --
+it carries the ADR-0019 draft-release and cosign flow.
+
+The consolidation this repo already started is stalled halfway: the reusable
+pattern exists and 18 packages use it; 11 near-duplicates never migrated.
+Collapsing them removes roughly 1,100 of 4,087 lines (~27% of the release
+machinery).
+
+Between two native workflows, exactly three things vary: the workflow `name`,
+the `MANIFEST` path to the crate's `Cargo.toml`, and a tag prefix repeated in
+FOUR separate `if:` conditions. Across nine files that is 36 hand-maintained
+copies of a tag prefix -- the bug surface that makes this machinery feel
+unmaintainable.
+
+**This lands before the release manifest reaches those packages**, so each is
+touched once rather than twice, and wave 3 configures thin callers rather than
+divergent workflows. It is also lower risk in isolation: it changes no version
+streams, and a mistake surfaces as a failed publish rather than a wrong version.
+
 ## Rollout
 
-Three waves, one config file, staged enablement:
+Three waves, one config file, staged enablement, after the prerequisite above:
 
 1. **goldenmatch + golden-suite.** Proves version derivation against real
    commits, the bare-tag component, and the lockstep step.


### PR DESCRIPTION
Spec plus implementation plan. No code; the implementation follows in a separate PR.

## Why

Releases are cut when the maintainer judges enough progress has accumulated. The mechanics are settled — ADR 0019, 39 publish workflows — but the **decision** is not, and the judgement is the cost.

Measured: goldenmatch cut **13 releases in the five weeks** 2026-07-13 to 2026-08-20, one every 2–4 days; 100+ across all prefixes in 90 days. The trigger is not producing rare releases, it is producing frequent ones each preceded by a decision nobody wants to make. Of those 13, **11 were MINOR and 2 PATCH** — so the number tells a consumer almost nothing. And **3.5 and 3.9 do not exist**, which is what abandoned cuts look like.

## What it proposes

Derive the version from conventional-commit types; keep a standing release PR per package. Viable because **174 of the last 200 commits on main (87%) already match the format**, and the 13% that do not are a deliberate wider vocabulary (`bench`, `diag`, `release`) that maps explicitly.

Expected consequence, and the point: with 70 `fix` to 41 `feat`, deriving produces considerably more PATCH releases than shipping almost everything as MINOR.

## The assumption I checked, and nearly got wrong

goldenmatch uses bare `v*` tags while every sibling is prefixed. The design needs release-please to allow that mix in one manifest.

`manifest-releaser.md` says `include-component-in-tag` is root-level and "applies uniformly across all packages" — which would have forced goldenmatch to change tag format (breaking `publish-goldenmatch.yml`'s `v*` trigger and orphaning 91 tags) or leave the scheme.

The **schema** says otherwise: `packages` entries are typed `additionalProperties: {"$ref": "#/definitions/ReleaserConfigOptions"}`, the same definition used at the root, and `include-component-in-tag` is a property of it. So it **is** per-package. Recorded in the spec because the prose and the schema disagree and only one is authoritative.

## The failure mode most likely to bite

**Zero of the last 200 commits carry `!` or `BREAKING CHANGE:`**, yet 3.0.0 genuinely was breaking (the Polars eviction). A purely derived scheme would never cut a MAJOR again — and would fail *silently*. Guards are `Release-As:` and a `CONTRIBUTING.md` section; both are convention, not enforcement, and the spec says so.

## Prerequisite, already landed

Consolidating the duplicated publish workflows so the manifest configures thin callers rather than divergent copies: #2705 (−949 lines) and #2706 (−202 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P