### PR TITLE
fix(ci): unbreak PyPI publishing -- validate metadata with a current twine

### DIFF
--- a/.github/workflows/_publish-pypi.yml
+++ b/.github/workflows/_publish-pypi.yml
@@ -63,8 +63,11 @@ jobs:
       # passes both wheels, so the wheel is fine and the stale validator is not.
       # Keep the check rather than dropping it: it is what catches an unrenderable
       # README before it reaches PyPI.
+      # Path is relative to defaults.run.working-directory above (the package
+      # dir). The action below needs the full path instead, because `uses:`
+      # steps do not honour working-directory -- hence the two differing forms.
       - name: Validate distribution metadata
-        run: python -m twine check packages/python/${{ inputs.package }}/dist/*
+        run: python -m twine check dist/*
       - name: Publish to PyPI
         if: inputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2

--- a/.github/workflows/_publish-pypi.yml
+++ b/.github/workflows/_publish-pypi.yml
@@ -52,8 +52,19 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
-      - run: pip install build
+      - run: pip install build twine
       - run: python -m build
+      # Validate with a CURRENT twine, not the one bundled inside the publish
+      # action. Modern build backends emit `Metadata-Version: 2.5`; the action's
+      # bundled twine carries a `packaging` old enough to reject it outright --
+      #   InvalidDistribution: '2.5' is not a valid metadata version
+      # -- which failed goldenanalysis-v0.5.0 (run 32507401780). PyPI itself
+      # accepts 2.5 (goldenmatch 3.14.0 is published with it), and current twine
+      # passes both wheels, so the wheel is fine and the stale validator is not.
+      # Keep the check rather than dropping it: it is what catches an unrenderable
+      # README before it reaches PyPI.
+      - name: Validate distribution metadata
+        run: python -m twine check packages/python/${{ inputs.package }}/dist/*
       - name: Publish to PyPI
         if: inputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
@@ -61,3 +72,6 @@ jobs:
           packages-dir: packages/python/${{ inputs.package }}/dist
           password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
+          # Already checked above with a current twine. Left on, the action
+          # re-runs the check with its stale copy and fails on 2.5.
+          verify-metadata: false


### PR DESCRIPTION
Every package publishing through `_publish-pypi.yml` currently fails. This is not a latent risk; it is broken right now.

```
InvalidDistribution: Invalid distribution metadata:
'2.5' is not a valid metadata version
```

## What is actually wrong

Modern build backends emit `Metadata-Version: 2.5`. The twine bundled *inside* `pypa/gh-action-pypi-publish@v1.14.2` carries a `packaging` too old to parse it, so its pre-flight check rejects the wheel before upload. **v1.14.2 is the latest action release**, so bumping it does not help.

Neither the wheel nor PyPI is the problem:

- **goldenmatch 3.14.0 is on PyPI with `Metadata-Version: 2.5`** — uploaded today, verified from the published artifact.
- **Current twine (7.0.0 / packaging 26.2) passes both wheels locally** — goldenmatch's and goldenanalysis's.

So the wheel is fine, PyPI is fine, and the stale validator is not.

## The fix

Run `twine check` ourselves with a current twine, then tell the action to stop re-running it with its stale copy (`verify-metadata: false`).

**The check is kept, not dropped.** It is what catches an unrenderable README before it reaches PyPI, and losing that to work around a version-parsing bug would be a bad trade.

## How it was found

Back-filling missing release tags. Nine packages are published on PyPI but were never tagged, so they have no GitHub release and no signed assets. The first back-fill attempt — `goldenanalysis-v0.5.0`, [run 32507401780](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32507401780) — failed on this. It is the first release attempted through this template since the backends started emitting 2.5.

Worth stating plainly: **the missing tags and this break are probably the same story.** A repo-wide cut on 2026-08-15 (#2596) bumped every package, merged, and reached PyPI — with no tags pushed. If the tag-and-release path was already failing this way, publishing by another route and skipping the tag is the obvious workaround.

## Verification

`pytest scripts/test_workflow_yaml.py` — 10 passed. A `dry_run=true` dispatch through the amended template follows before anything is back-filled for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P