### PR TITLE
fix(ci): the two bespoke publish workflows had the same metadata break

### DIFF
--- a/.github/workflows/publish-golden-suite.yml
+++ b/.github/workflows/publish-golden-suite.yml
@@ -48,10 +48,25 @@ jobs:
           fi
           echo "Version OK: $PKG_VERSION"
 
-      - run: pip install build
+      - run: pip install build twine
       - run: python -m build
+      # Validate with a CURRENT twine, not the one bundled inside the publish
+      # action. Modern build backends emit `Metadata-Version: 2.5`; the
+      # action's bundled twine carries a `packaging` old enough to reject it
+      # outright --
+      #   InvalidDistribution: '2.5' is not a valid metadata version
+      # -- which is what failed goldenanalysis-v0.5.0 (run 32507401780). PyPI
+      # itself accepts 2.5, and current twine passes the wheel, so the wheel is
+      # fine and the stale validator is not. Same fix as _publish-pypi.yml;
+      # this workflow is not a caller of that template (it carries its own
+      # tag-vs-pyproject version check), so it needed the fix separately.
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/python/golden-suite/dist
           password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
+          # Already checked above with a current twine. Left on, the
+          # action re-runs the check with its stale copy and fails on 2.5.
+          verify-metadata: false

--- a/.github/workflows/publish-goldensuite-mcp.yml
+++ b/.github/workflows/publish-goldensuite-mcp.yml
@@ -47,10 +47,25 @@ jobs:
           fi
           echo "Version OK: $PKG_VERSION"
 
-      - run: pip install build
+      - run: pip install build twine
       - run: python -m build
+      # Validate with a CURRENT twine, not the one bundled inside the publish
+      # action. Modern build backends emit `Metadata-Version: 2.5`; the
+      # action's bundled twine carries a `packaging` old enough to reject it
+      # outright --
+      #   InvalidDistribution: '2.5' is not a valid metadata version
+      # -- which is what failed goldenanalysis-v0.5.0 (run 32507401780). PyPI
+      # itself accepts 2.5, and current twine passes the wheel, so the wheel is
+      # fine and the stale validator is not. Same fix as _publish-pypi.yml;
+      # this workflow is not a caller of that template (it carries its own
+      # tag-vs-pyproject version check), so it needed the fix separately.
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: packages/python/goldensuite-mcp/dist
           password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
+          # Already checked above with a current twine. Left on, the
+          # action re-runs the check with its stale copy and fails on 2.5.
+          verify-metadata: false


### PR DESCRIPTION
`_publish-pypi.yml` was fixed in #2710. The six packages that delegate to it are covered. `golden-suite` and `goldensuite-mcp` do **not** delegate -- each carries its own tag-vs-pyproject version check -- so both kept the stale-validator failure.

## Verified, not assumed

Building `golden-suite` 0.5.1 locally:

```
Successfully built golden_suite-0.5.1.tar.gz and golden_suite-0.5.1-py3-none-any.whl
Checking dist/golden_suite-0.5.1-py3-none-any.whl: PASSED
Checking dist/golden_suite-0.5.1.tar.gz: PASSED
Metadata-Version: 2.5
```

That is the exact pair -- a 2.5 wheel and the action's bundled validator -- that failed `goldenanalysis-v0.5.0` (run 32507401780).

## Why now

`golden-suite` 0.5.1 is genuinely unpublished (PyPI has 0.5.0). It is the one package in the tag back-fill that will really upload, and it uploads through this workflow.

## One detail worth reading

The `twine check` path is `dist/*`, not the full path: both jobs set `defaults.run.working-directory` to the package dir. The `packages-dir` on the publish step stays fully qualified, because `uses:` steps do not honour working-directory. Getting this backwards is what the #2710 dry run caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P