### PR TITLE
fix(scripts): the pre-push doc gate must not gate tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1163,6 +1163,13 @@ jobs:
           uv run --with polars --with pyarrow \
             pytest scripts/test_run_benchmarks_download.py \
                    scripts/dqbench_adapters/test_leipzig_eval.py -q
+      # The pre-push hook is developer-facing, so nothing else runs it. It
+      # shipped gating tag pushes -- diffing origin/main..<older tag sha>
+      # BACKWARDS -- which would have blocked the release tag back-fill. This
+      # covers the ref-parsing only, through the hook's own print-plan seam,
+      # so it costs milliseconds and never invokes the generators.
+      - name: Shell (pre-push hook ref parsing)
+        run: sh scripts/test_pre_push_docs_check.sh
 
   # Every repo path a CLAUDE.md names must exist. These files are loaded as
   # authoritative agent context, so a dead pointer does not merely fail to help --

--- a/scripts/pre_push_docs_check.sh
+++ b/scripts/pre_push_docs_check.sh
@@ -46,8 +46,18 @@ zero=0000000000000000000000000000000000000000
 # A brand-new branch has no remote_sha; origin/main is then the honest base.
 base=""
 head=""
-while read -r _local_ref local_sha _remote_ref remote_sha; do
+while read -r _local_ref local_sha remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue          # branch deletion -- nothing to check
+  # Tags introduce no commits. Whatever a tag points at was already gated when
+  # the branch carrying it was pushed, so re-running the generators here only
+  # costs 30s. Worse, a tag is frequently cut at an OLDER commit -- the release
+  # back-fill tags each package at its version-bump commit -- and the flag rule
+  # below would then diff origin/main..<older sha> BACKWARDS and block the push
+  # over flags that main added after the tagged commit. Skip the ref entirely
+  # rather than trying to pick a base for it.
+  case "$remote_ref" in
+    refs/tags/*) continue ;;
+  esac
   head="$local_sha"
   if [ "$remote_sha" = "$zero" ]; then
     base=$(git rev-parse origin/main 2>/dev/null || echo "")
@@ -56,8 +66,17 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
   fi
 done
 
-# Nothing being pushed (all deletions, or empty stdin) -> nothing to gate.
+# Nothing being pushed (all deletions, all tags, or empty stdin) -> nothing to
+# gate.
 [ -n "$head" ] || exit 0
+
+# Test seam: report the range this push resolved to and stop, so the ref-parsing
+# rules above can be exercised without paying for the generators. Not read by
+# the hook.
+if [ "${GM_PREPUSH_PRINT_PLAN:-0}" = "1" ]; then
+  echo "base=$base head=$head"
+  exit 0
+fi
 
 echo "pre-push: checking derived docs (~30s; SKIP_DOCS_CHECK=1 to bypass)..." >&2
 

--- a/scripts/test_pre_push_docs_check.sh
+++ b/scripts/test_pre_push_docs_check.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Ref-parsing rules of pre_push_docs_check.sh.
+#
+# Exercises the decision the hook makes about WHICH refs to gate, via the
+# GM_PREPUSH_PRINT_PLAN seam, so it costs milliseconds instead of running the
+# doc generators. The generators are already covered by CI's config_matrix and
+# docs_regen jobs; what was never covered is this parsing, which is where the
+# tag bug lived.
+set -eu
+
+ROOT=$(git rev-parse --show-toplevel)
+HOOK="$ROOT/scripts/pre_push_docs_check.sh"
+URL="https://github.com/benseverndev-oss/goldenmatch.git"
+ZERO=0000000000000000000000000000000000000000
+
+# CI checks out at depth 1, so origin/main may not be a resolvable ref here.
+# The one case that needs it is SKIPPED and counted, never silently passed -- a
+# skip that reads as a pass is how a check stops firing without anyone noticing.
+MAIN=$(git rev-parse origin/main 2>/dev/null || echo "")
+
+fails=0
+skips=0
+
+check() {
+  name=$1; want=$2; input=$3
+  got=$(printf '%s\n' "$input" | GM_PREPUSH_PRINT_PLAN=1 sh "$HOOK" origin "$URL" 2>/dev/null || true)
+  if [ "$got" = "$want" ]; then
+    echo "ok   - $name"
+  else
+    echo "FAIL - $name"
+    echo "       want: [$want]"
+    echo "       got:  [$got]"
+    fails=$((fails + 1))
+  fi
+}
+
+# THE regression. A tag push carries no new commits, and a back-fill tag points
+# at an OLDER commit, so gating it diffs backwards against main and blocks a
+# push that adds nothing.
+check "tag push is not gated" \
+  "" \
+  "refs/tags/goldencheck-v3.5.0 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/tags/goldencheck-v3.5.0 $ZERO"
+
+check "several tags at once are not gated" \
+  "" \
+  "refs/tags/a-v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/tags/a-v1 $ZERO
+refs/tags/b-v2 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb refs/tags/b-v2 $ZERO"
+
+# The cases that must STILL be gated, so the fix above did not quietly turn the
+# hook off for everything.
+check "existing branch gates from its remote sha" \
+  "base=cccccccccccccccccccccccccccccccccccccccc head=dddddddddddddddddddddddddddddddddddddddd" \
+  "refs/heads/f dddddddddddddddddddddddddddddddddddddddd refs/heads/f cccccccccccccccccccccccccccccccccccccccc"
+
+if [ -n "$MAIN" ]; then
+  check "brand-new branch falls back to origin/main" \
+    "base=$MAIN head=dddddddddddddddddddddddddddddddddddddddd" \
+    "refs/heads/new dddddddddddddddddddddddddddddddddddddddd refs/heads/new $ZERO"
+else
+  echo "SKIP - brand-new branch falls back to origin/main (no origin/main ref)"
+  skips=$((skips + 1))
+fi
+
+check "branch deletion is not gated" \
+  "" \
+  "(delete) $ZERO refs/heads/gone cccccccccccccccccccccccccccccccccccccccc"
+
+check "empty stdin is not gated" "" ""
+
+# A tag riding along with a branch must not suppress the branch's own gate.
+check "tag alongside a branch still gates the branch" \
+  "base=cccccccccccccccccccccccccccccccccccccccc head=dddddddddddddddddddddddddddddddddddddddd" \
+  "refs/tags/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/tags/v1 $ZERO
+refs/heads/f dddddddddddddddddddddddddddddddddddddddd refs/heads/f cccccccccccccccccccccccccccccccccccccccc"
+
+# A non-goldenmatch remote exits 0 before parsing anything, so every case above
+# would pass vacuously against the wrong URL. Pin that the URL gate is the one
+# being satisfied, not bypassed.
+plan=$(printf '%s\n' "refs/heads/f dddddddddddddddddddddddddddddddddddddddd refs/heads/f cccccccccccccccccccccccccccccccccccccccc" \
+  | GM_PREPUSH_PRINT_PLAN=1 sh "$HOOK" origin "https://github.com/someone/other.git" 2>/dev/null || true)
+if [ -z "$plan" ]; then
+  echo "ok   - an unrelated remote is passed through untouched"
+else
+  echo "FAIL - an unrelated remote should not be gated, got [$plan]"
+  fails=$((fails + 1))
+fi
+
+if [ "$fails" -eq 0 ]; then
+  echo ""
+  echo "all ref-parsing cases passed ($skips skipped)"
+  exit 0
+fi
+echo ""
+echo "$fails case(s) failed"
+exit 1


### PR DESCRIPTION
## The bug

The hook from #2704 reads every ref on stdin and treats a zero `remote_sha` as "brand new, diff against `origin/main`". A tag push looks exactly like that.

Two consequences:

1. Pushing a tag paid ~30s of generators for a ref that introduces no commits.
2. **A release tag is frequently cut at an OLDER commit.** The tag back-fill points each package at its version-bump commit, so the flag rule would diff `origin/main..<older sha>` **backwards** and block the push over `GOLDENMATCH_*` flags main added *after* the tagged commit -- flags the push does not contain.

Every tag push in this session has needed `SKIP_DOCS_CHECK=1` to get through. That is the wrong way to learn this.

Tag refs are now skipped outright rather than given a different base: whatever a tag points at was already gated when its branch was pushed.

## The test

`scripts/test_pre_push_docs_check.sh`, plus a `GM_PREPUSH_PRINT_PLAN=1` seam so the ref-parsing is checkable in milliseconds without invoking the generators.

Confirmed it catches the bug -- with the tag case reverted:

```
FAIL - tag push is not gated
       want: []
       got:  [base=390f9b3cf... head=aaaaaaaa...]
```

That `got` line is the backwards range that would have blocked the back-fill.

It also pins the cases that must **still** be gated, so the fix cannot quietly turn the hook off, and pins that an unrelated remote is passed through -- without that, every case would pass vacuously against the wrong URL.

## Why it is in `scripts_lint`

That job's own comment already makes the argument: *"a test that CI only ever lints is the 'a check exists and does not fire' class."* The hook is developer-facing, so nothing else would ever run it.

The `origin/main` case **SKIPs rather than passes** under CI's depth-1 checkout, and the skip is counted and printed.

## Noted, not fixed here

In a worktree without its own synced venv -- the standard workflow in this repo -- the hook blocks every push with "the workspace is not synced". That is the designed behaviour (it refuses to pass silently) and the message is honest, but it means the escape hatch is the common path for worktree pushes. Worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P