### PR TITLE
fix(rust): unwedge the merge queue -- rustc 1.98 clippy lints

### DIFF
--- a/packages/rust/extensions/goldenembed-core/tests/project_parity.rs
+++ b/packages/rust/extensions/goldenembed-core/tests/project_parity.rs
@@ -37,10 +37,8 @@ fn f32s(b64: &str) -> Vec<f32> {
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(b64)
         .expect("valid base64");
-    bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect()
+    let (words, _tail) = bytes.as_chunks::<4>();
+    words.iter().copied().map(f32::from_le_bytes).collect()
 }
 
 #[test]

--- a/packages/rust/extensions/goldenembed/src/cache.rs
+++ b/packages/rust/extensions/goldenembed/src/cache.rs
@@ -51,10 +51,8 @@ fn to_bytes(vec: &[f32]) -> Vec<u8> {
 }
 
 fn from_bytes(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect()
+    let (words, _tail) = bytes.as_chunks::<4>();
+    words.iter().copied().map(f32::from_le_bytes).collect()
 }
 
 impl EmbedCache {

--- a/packages/rust/extensions/goldenembed/src/weights.rs
+++ b/packages/rust/extensions/goldenembed/src/weights.rs
@@ -90,8 +90,6 @@ fn parse_npy_f32(buf: &[u8], name: &str) -> Result<Vec<f32>> {
     if !data.len().is_multiple_of(4) {
         bail!("{name}: data length {} is not a multiple of 4", data.len());
     }
-    Ok(data
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect())
+    let (words, _tail) = data.as_chunks::<4>();
+    Ok(words.iter().copied().map(f32::from_le_bytes).collect())
 }

--- a/packages/rust/extensions/goldenfuzz-core/src/lib.rs
+++ b/packages/rust/extensions/goldenfuzz-core/src/lib.rs
@@ -329,6 +329,17 @@ fn levenshtein_distance_sw<T: Copy>(s1: &[T], s2: &[T], get: impl Fn(T) -> u64) 
 /// Single-word FlaggedChars Jaro. Caller guarantees `s1.len() <= 64` (and, via
 /// the `len1 == 1 && len2 == 1` short-circuit in the dispatcher, `len2 >= 2` when
 /// `len1 == 1`). Same match/transposition order as the multiword path.
+// rustc 1.98 (2026-08-18) added `clippy::manual_isolate_lowest_one`, which
+// flags the `x & x.wrapping_neg()` blsi idiom below and suggests the std
+// `isolate_lowest_one()`. Silenced rather than adopted, deliberately: this is
+// the inner loop of the bit-parallel Jaro, `x & -x` is the canonical blsi form
+// and lowers to the single instruction the comment names, and the std method
+// is `isolate_most_least_significant_one`-gated -- unstable before 1.98 -- so
+// taking the suggestion would silently raise this crate's toolchain floor to a
+// release that is days old. `unknown_lints` is allowed alongside it so the
+// attribute is also inert on toolchains that predate the lint.
+#[allow(unknown_lints)]
+#[allow(clippy::manual_isolate_lowest_one)]
 fn jaro_similarity_sw<T: Copy + PartialEq>(s1: &[T], s2: &[T], get: impl Fn(T) -> u64) -> f64 {
     let len1 = s1.len();
     let len2 = s2.len();

--- a/packages/rust/extensions/goldenhnsw/src/lib.rs
+++ b/packages/rust/extensions/goldenhnsw/src/lib.rs
@@ -108,15 +108,19 @@ impl SplitMix64 {
 fn inner_product(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = [0.0f32; 8];
-    let mut ai = a.chunks_exact(8);
-    let mut bi = b.chunks_exact(8);
-    for (ca, cb) in ai.by_ref().zip(bi.by_ref()) {
+    // `as_chunks::<8>` rather than `chunks_exact(8)`: same split, same order,
+    // same remainder -- so the accumulation sequence, and therefore the
+    // 1e-6 golden-parity result above, is unchanged. It just hands back the
+    // tail directly instead of via `remainder()`.
+    let (a_lanes, a_tail) = a.as_chunks::<8>();
+    let (b_lanes, b_tail) = b.as_chunks::<8>();
+    for (ca, cb) in a_lanes.iter().zip(b_lanes) {
         for lane in 0..8 {
             acc[lane] += ca[lane] * cb[lane];
         }
     }
     let mut tail = 0.0f32;
-    for (x, y) in ai.remainder().iter().zip(bi.remainder()) {
+    for (x, y) in a_tail.iter().zip(b_tail) {
         tail += x * y;
     }
     ((acc[0] + acc[1]) + (acc[2] + acc[3])) + ((acc[4] + acc[5]) + (acc[6] + acc[7])) + tail

--- a/packages/rust/extensions/hnsw-py/src/lib.rs
+++ b/packages/rust/extensions/hnsw-py/src/lib.rs
@@ -26,10 +26,8 @@ fn bytes_to_f32(data: &[u8]) -> PyResult<Vec<f32>> {
             "goldenmatch-hnsw: byte buffer length is not a multiple of 4 (expected float32)",
         ));
     }
-    Ok(data
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect())
+    let (words, _tail) = data.as_chunks::<4>();
+    Ok(words.iter().copied().map(f32::from_le_bytes).collect())
 }
 
 /// Native HNSW index over `dim`-dimensional float32 vectors, inner-product

--- a/packages/rust/extensions/native/src/featurize.rs
+++ b/packages/rust/extensions/native/src/featurize.rs
@@ -154,10 +154,11 @@ pub fn char_ngram_project<'py>(
     seed: u64,
 ) -> Bound<'py, PyBytes> {
     let seed_le = seed.to_le_bytes();
-    let w: Vec<f32> = weights
-        .as_bytes()
-        .chunks_exact(4)
-        .map(|c| f32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
+    let (weight_words, _tail) = weights.as_bytes().as_chunks::<4>();
+    let w: Vec<f32> = weight_words
+        .iter()
+        .copied()
+        .map(f32::from_ne_bytes)
         .collect();
     let floats: Vec<f32> = py.detach(|| {
         texts


### PR DESCRIPTION
**The merge queue is wedged for the whole repo, and nothing in this repo caused it.**

`rustc 1.98.0` shipped 2026-08-18. The runner's cached toolchain rolled from 1.97.1 to it:

```
stable-x86_64-unknown-linux-gnu updated - rustc 1.98.0 (88d9e12ae 2026-08-18)
                                          (from rustc 1.97.1 (8bab26f4f 2026-07-14))
```

1.98's clippy added two lints that `-D warnings` turns into build failures:

| Lint | Crate |
|---|---|
| using `chunks_exact` with a constant chunk size | `goldenhnsw`, `goldenembed-core` |
| manual implementation of `isolate_lowest_one` | `goldenfuzz-core` |

## Why it was invisible until now

`ci.yml` gates the rust jobs behind path filters, so a PR touching no Rust never runs them -- and neither does a push to main. A `merge_group` sets `force_all=true` and runs **everything**.

So the break fired **only inside the merge queue**. #2707 and #2712 each bounced twice with `reason=failed_checks` from `github-merge-queue`, while `gh pr checks` on both showed **zero** failures, because those checks run against the PR head and the queue runs a separate merge ref. Neither PR touches a single Rust file.

This is a general blind spot, not a one-off: any lint or toolchain regression in a path-filtered job is undetectable until it dequeues someone.

## The fixes

**The two `chunks_exact` sites take the suggestion.** `as_chunks::<N>` is the same split, same order, same remainder. That matters in `inner_product`, which is hand-vectorized into 8 lanes with an explicit summation tree and a documented 1e-6 golden-parity tolerance -- the accumulation sequence is unchanged, and `project_parity` still passes.

**`goldenfuzz-core` allows the lint rather than taking it.** `x & x.wrapping_neg()` is the canonical blsi form in the inner loop of the bit-parallel Jaro, and std's `isolate_lowest_one` is feature-gated unstable before 1.98 -- I confirmed that by compiling it here and getting `error[E0658]: use of unstable library feature 'isolate_most_least_significant_one'`. Adopting it would silently raise the crate's toolchain floor to a release three days old, which is the wrong trade for a lint fix. `unknown_lints` is allowed alongside so the attribute is inert on older toolchains.

## Verification, and its limit

On rustc 1.95 locally: `cargo clippy -D warnings` clean on all three crates, and `cargo test` green -- goldenhnsw 6, goldenembed-core 4 (including `project_parity`), goldenfuzz-core 9.

**The 1.98-only lints can only be confirmed by CI.** This box cannot reach 1.98 -- `rustup update` fails on the D: drive with the known directory-rename error -- so what I verified locally is that the changes compile, behave identically, and do not misfire on an older toolchain. Whether they satisfy 1.98's clippy is what this PR's own merge-queue run will establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P