### PR TITLE
docs: the hosted MCP endpoint requires a bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,11 +320,17 @@ pip install goldenmatch[mcp]               # + MCP server     (also: [agent] A2A
 
 ## Deploy
 
-**Remote MCP (nothing to install).** Hosted on [Smithery](https://smithery.ai/servers/benzsevern/goldenmatch); connect any MCP client:
+**Remote MCP.** The hosted endpoint requires a bearer token -- it exposes tools that read and write files on the server, so it is not open. Ask the maintainer for one, or self-host: `goldenmatch mcp-serve --transport http` is the same server.
 
 ```json
-{ "mcpServers": { "goldenmatch": { "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/" } } }
+{ "mcpServers": { "goldenmatch": {
+    "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/",
+    "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+} } }
 ```
+
+Self-hosting on loopback needs no token; binding to a public interface without
+`GOLDENMATCH_MCP_TOKEN` is refused rather than served open.
 
 **Containers.** Every package ships as a multi-arch image (linux/amd64 + arm64) on GHCR, pull anonymously:
 

--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -62,7 +62,8 @@ Add the remote MCP server to Claude Desktop or Claude Code:
 {
   "mcpServers": {
     "goldenmatch": {
-      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/"
+      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
     }
   }
 }

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -21,7 +21,7 @@ GoldenMatch provides an MCP (Model Context Protocol) server for integration with
 
 ## Remote Server (no install required)
 
-GoldenMatch is available as a hosted remote MCP server on Smithery. Connect from Claude Desktop, Claude Code, or any MCP client without installing anything locally.
+GoldenMatch runs as a remote MCP server. The hosted endpoint **requires a bearer token** -- several of its tools read and write files on the server, so it is not open to anonymous callers. Ask the maintainer for a token, or run your own (below).
 
 Add to your `claude_desktop_config.json`:
 
@@ -29,11 +29,18 @@ Add to your `claude_desktop_config.json`:
 {
     "mcpServers": {
         "goldenmatch": {
-            "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/"
+            "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/",
+            "headers": {
+                "Authorization": "Bearer YOUR_TOKEN"
+            }
         }
     }
 }
 ```
+
+To self-host, `goldenmatch mcp-serve --transport http --port 8200` serves the
+same tools. A loopback bind needs no token; binding to a public interface
+without `GOLDENMATCH_MCP_TOKEN` set is refused rather than served open.
 
 Or browse on Smithery: [https://smithery.ai/servers/benzsevern/goldenmatch](https://smithery.ai/servers/benzsevern/goldenmatch)
 

--- a/packages/python/goldenmatch/AGENTS.md
+++ b/packages/python/goldenmatch/AGENTS.md
@@ -168,7 +168,8 @@
 Hosted on Railway, registered on Smithery:
 - **Endpoint:** `https://goldenmatch-mcp-production.up.railway.app/mcp/`
 - **Smithery:** `https://smithery.ai/servers/benzsevern/goldenmatch`
-- **Server card:** `https://goldenmatch-mcp-production.up.railway.app/.well-known/mcp/server-card.json`
+- **Auth:** bearer token REQUIRED (`Authorization: Bearer <GOLDENMATCH_MCP_TOKEN>`). Locked down 2026-08-21; it had been serving 77 tools -- 25 of them taking filesystem paths -- unauthenticated. `/mcp/` returns 401 without it.
+- **Server card:** `https://goldenmatch-mcp-production.up.railway.app/.well-known/mcp/server-card.json` (stays PUBLIC -- it is the healthcheck target)
 - **Transport:** Streamable HTTP (via `StreamableHTTPSessionManager`)
 - **Dockerfile:** `Dockerfile.mcp` (Python 3.12-slim, installs `.[mcp]`)
 - **Railway project:** `golden-suite-mcp` (service: `goldenmatch-mcp`, port 8200)

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -105,7 +105,8 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 Hosted on Railway, registered on Smithery:
 - **Endpoint:** `https://goldenmatch-mcp-production.up.railway.app/mcp/`
 - **Smithery:** `https://smithery.ai/servers/benzsevern/goldenmatch`
-- **Server card:** `https://goldenmatch-mcp-production.up.railway.app/.well-known/mcp/server-card.json`
+- **Auth:** bearer token REQUIRED (`Authorization: Bearer <GOLDENMATCH_MCP_TOKEN>`). Locked down 2026-08-21; it had been serving 77 tools -- 25 of them taking filesystem paths -- unauthenticated. `/mcp/` returns 401 without it.
+- **Server card:** `https://goldenmatch-mcp-production.up.railway.app/.well-known/mcp/server-card.json` (stays PUBLIC -- it is the healthcheck target)
 - **Transport:** Streamable HTTP (via `StreamableHTTPSessionManager`)
 - **Dockerfile:** `Dockerfile.mcp` (Python 3.12-slim, installs `.[mcp]`)
 - **Railway project:** `golden-suite-mcp` (service: `goldenmatch-mcp`, port 8200)

--- a/packages/python/goldenmatch/LAUNCHGUIDE.md
+++ b/packages/python/goldenmatch/LAUNCHGUIDE.md
@@ -54,4 +54,6 @@ entity-resolution, deduplication, record-matching, golden-record, data-quality, 
 https://docs.bensevern.dev/docs/
 
 ## Health Check URL
-https://goldenmatch-mcp-production.up.railway.app/mcp/
+https://goldenmatch-mcp-production.up.railway.app/.well-known/mcp/server-card.json
+(`/mcp/` returns 401 without a bearer token, so it cannot serve as a health
+check; the server card stays public for exactly this purpose.)

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -1280,7 +1280,8 @@ GoldenMatch is available as a hosted MCP server on [Smithery](https://smithery.a
 {
   "mcpServers": {
     "goldenmatch": {
-      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/"
+      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
     }
   }
 }

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -8,7 +8,8 @@ AUTHORITATIVE SOURCES (read these instead of inferring behaviour from source):
     telemetry contract.
   * https://docs.bensevern.dev/docs/goldenmatch -- full docs.
   * MCP (queryable): ``goldenmatch mcp-serve``, or hosted at
-    https://goldenmatch-mcp-production.up.railway.app/mcp/
+    https://goldenmatch-mcp-production.up.railway.app/mcp/ -- the hosted one
+    requires an ``Authorization: Bearer`` token; a local loopback bind does not.
   * https://github.com/benseverndev-oss/goldenmatch -- source + issues.
 
 Why this block exists: much of GoldenMatch's behaviour is *decided*, not

--- a/packages/python/goldenmatch/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/goldenmatch/llms.txt
@@ -7,7 +7,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 
 ## Interfaces
 - MCP Server: `goldenmatch mcp-serve` (97 tools across data, agent, identity, memory, routing, and document groups)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (97 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (97 tools; requires `Authorization: Bearer <token>` -- returns 401 without it. Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (51 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~202 exports

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -23,7 +23,15 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/"
+      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token for the hosted endpoint. It exposes tools that read and write files on the server, so anonymous access is refused (401). Ask the maintainer, or self-host with `goldenmatch mcp-serve`.",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
     }
   ]
 }

--- a/packages/python/goldenmatch/smithery.yaml
+++ b/packages/python/goldenmatch/smithery.yaml
@@ -1,3 +1,9 @@
+# NOTE (2026-08-21): the hosted endpoint now requires an
+# `Authorization: Bearer <GOLDENMATCH_MCP_TOKEN>` header and returns 401
+# without one. It exposes tools that read and write files on the server,
+# so it is no longer served open. The Smithery listing itself is a manual
+# dashboard action -- this file does not drive it -- so the listing must be
+# updated there to carry the header, or it will 401 for every visitor.
 url: https://goldenmatch-mcp-production.up.railway.app/mcp/
 name: goldenmatch
 description: Stop wrestling with duplicate records -- deduplicate, match, and merge entities across messy datasets.


### PR DESCRIPTION
The hosted `goldenmatch-mcp` endpoint was serving **77 tools unauthenticated** -- 25 taking filesystem paths, 18 mutating an identity DB by `db_path`, and `documents_ingest` accepting both a server-side read path and an `out_path`. It is locked down as of 2026-08-21: `/mcp/` returns **401** without `Authorization: Bearer <GOLDENMATCH_MCP_TOKEN>`.

Ten surfaces still told readers to connect anonymously. This is the sweep.

## Framing

Self-hosting is now the default path. `goldenmatch mcp-serve --transport http` is the same server, needs no token on loopback, and refuses to start on a public bind without one -- so the docs point there first and treat the hosted endpoint as token-gated.

## Two that mattered more than the config snippets

**`LAUNCHGUIDE.md` listed `/mcp/` as the Health Check URL.** That endpoint now 401s, so it would have read as permanently unhealthy. Repointed at `/.well-known/mcp/server-card.json`, which stays public precisely so the healthcheck keeps working — verified live: card `200`, `/mcp/` `401`.

**`server.json` declares the header properly, not in prose.** The registry schema's `StreamableHttpTransport` takes a `headers` array of `KeyValueInput`, so the entry is `isRequired` + `isSecret`. I fetched the live schema and validated the file against it rather than guessing the shape:

```
server.json VALIDATES against the registry schema
```

## What this PR cannot fix

`smithery.yaml` carries a note but is decorative — the Smithery listing is a manual dashboard action and no repo file drives it. **It will 401 for every visitor until the header is added there.**

## Verification

- Live endpoint: `unauth tools/list -> 401`, `server-card -> 200`, deploy `SUCCESS`
- `regen_docs.py --check` → `Docs are current`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P