### PR TITLE
fix(benchmarks): quarantine known-bad datasets so the lane can signal a regression again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,6 +1170,7 @@ jobs:
         run: |
           uv run --with polars --with pyarrow \
             pytest scripts/test_run_benchmarks_download.py \
+                   scripts/test_benchmark_quarantine.py \
                    scripts/dqbench_adapters/test_leipzig_eval.py -q
       # The pre-push hook is developer-facing, so nothing else runs it. It
       # shipped gating tag pushes -- diffing origin/main..<older tag sha>

--- a/packages/python/goldenmatch/tests/test_benchmark_quality_floors.py
+++ b/packages/python/goldenmatch/tests/test_benchmark_quality_floors.py
@@ -22,35 +22,46 @@ if str(_SCRIPTS) not in sys.path:
 run_benchmarks = pytest.importorskip("run_benchmarks")
 
 
-def test_amazon_google_is_floored_at_its_observed_value_not_below():
-    """The floor stops Amazon-Google getting WORSE; it does not bless 0.0697.
+def test_amazon_google_at_its_quarantine_baseline_is_reported_not_failed():
+    """Amazon-Google is quarantined (#2717), so its breaches report, not fail.
 
-    Being explicit about this because the floor is set at the observed value, so
-    the run that motivated #2470 sits exactly ON the boundary and passes. That is
-    deliberate -- the gate's job is catching regressions, not failing every run
-    until product matching improves -- but it means the guarantee here is
-    narrower than "bad runs fail", and the test should say so.
+    This test used to assert the 0.0697 run "sits on the floor and is not a
+    breach". That is no longer the contract, and the change is deliberate:
+    0.0697 was the #2470 run, and the CURRENT observed value is 0.1014. Feeding
+    0.0697 today is a real DEGRADATION and the ratchet fails it -- which is the
+    behaviour the original test wanted ("a WORSE run must breach"), now enforced
+    against a live baseline instead of a static floor.
     """
-    observed = run_benchmarks._check_quality_floors(
-        [{"name": "Amazon-Google", "f1": 0.0697, "precision": 0.2077, "recall": 0.0419}]
+    base = run_benchmarks._QUARANTINE["Amazon-Google"]["f1_at_quarantine"]
+    failing, quarantined = run_benchmarks._check_quality_floors(
+        [{"name": "Amazon-Google", "f1": base, "precision": 0.2077, "recall": 0.0419}]
     )
-    assert observed == [], "the observed run sits on the floor and is not a breach"
+    assert failing == [], f"at its own baseline it must not fail: {failing}"
 
     worse = run_benchmarks._check_quality_floors(
         [{"name": "Amazon-Google", "f1": 0.04, "precision": 0.2, "recall": 0.03}]
-    )
-    assert worse, "a WORSE Amazon-Google run must breach the floor"
-    assert "Amazon-Google" in worse[0]
+    )[0]
+    assert worse, "a WORSE Amazon-Google run must still fail"
+    assert any("Amazon-Google" in w for w in worse), worse
 
 
 def test_a_healthy_run_does_not_breach():
-    breaches = run_benchmarks._check_quality_floors(
+    """Abt-Buy sits at its quarantine baseline here, not at 0.5037.
+
+    0.5037 is the DISPUTED, unreproduced number (see the `Abt-Buy` note in
+    `_F1_FLOORS`); every reproduction gives 0.1723. Feeding it now trips the
+    IMPROVED ratchet, which is correct -- a jump that size means someone fixed
+    it and the quarantine should be lifted. Using it as "a healthy run" was
+    baking an unreproducible measurement into a test.
+    """
+    base = run_benchmarks._QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    failing, _ = run_benchmarks._check_quality_floors(
         [
             {"name": "Febrl3", "f1": 0.9912, "precision": 0.99, "recall": 0.99},
-            {"name": "Abt-Buy", "f1": 0.5037, "precision": 0.82, "recall": 0.36},
+            {"name": "Abt-Buy", "f1": base, "precision": 0.11, "recall": 0.45},
         ]
     )
-    assert breaches == [], breaches
+    assert failing == [], failing
 
 
 def test_red_controller_health_fails_regardless_of_f1():
@@ -58,7 +69,7 @@ def test_red_controller_health_fails_regardless_of_f1():
     trustworthy even when they clear the floor. Elsewhere RED is a reasonable
     degradation; in a lane whose only job is measuring quality it is a FALSE
     RESULT."""
-    breaches = run_benchmarks._check_quality_floors(
+    breaches, _ = run_benchmarks._check_quality_floors(
         [
             {
                 "name": "Febrl3",

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -574,6 +574,48 @@ _F1_FLOORS: dict[str, float | None] = {
 }
 
 
+# Datasets with a KNOWN, TRACKED quality bug. A breach here is reported loudly
+# but does not fail the lane, because failing on a known-open bug makes the lane
+# permanently red -- and a permanently red lane cannot signal a NEW regression.
+# That is what happened with #2457: `main-health` opened a tracker that could
+# never self-close, so a third dataset regressing would have looked identical to
+# the standing failure.
+#
+# This is NOT the same as lowering a floor. The floor stays where it is, the
+# breach is still printed, and the quarantine ratchets in BOTH directions:
+#
+#   * worse than `f1_at_quarantine` by more than `tolerance` -> FAILS. The bug is
+#     tracked, not licensed to deepen.
+#   * better than `f1_at_quarantine` + `tolerance`           -> FAILS. Someone
+#     fixed it and the quarantine is now hiding good news; lift it and set a real
+#     floor in the same change.
+#
+# Every entry needs an OPEN issue. An entry whose issue is closed is a lie about
+# something being tracked, so `_quarantine_breaches` says so rather than
+# silently honouring it.
+_QUARANTINE: dict[str, dict[str, Any]] = {
+    "Abt-Buy": {
+        "issue": 2717,
+        "f1_at_quarantine": 0.1723,
+        "tolerance": 0.03,
+        "why": (
+            "product-text matching collapses; also commits a RED config "
+            "(budget_iterations). The 0.45 floor is itself DISPUTED -- see the "
+            "_F1_FLOORS note; it derives from an UNREPRODUCED 0.5037."
+        ),
+    },
+    "Amazon-Google": {
+        "issue": 2717,
+        "f1_at_quarantine": 0.1014,
+        "tolerance": 0.03,
+        "why": (
+            "clears its own 0.05 floor but commits a RED config "
+            "(budget_time), so the numbers are not trustworthy either way."
+        ),
+    },
+}
+
+
 def _llm_label(meta: dict[str, Any]) -> str:
     """How to describe a run's LLM exposure, honestly, from its metadata."""
     if meta.get("with_llm"):
@@ -642,35 +684,94 @@ def _neutralize_ambient_llm_keys(with_llm: bool) -> bool:
     return bool(present)
 
 
-def _check_quality_floors(results: list[dict[str, Any]]) -> list[str]:
-    """Return a list of human-readable breaches. Empty means the run is sound.
+def _quarantine_drift(q: dict[str, Any] | None, r: dict[str, Any]) -> str | None:
+    """Why this quarantine no longer describes this run, or None if it still does.
+
+    Quarantine is a statement that a bug is known AND unchanged. The moment the
+    number moves, that statement is false in one of two ways, and both matter:
+
+      * it got WORSE -- the bug is deepening while nothing fails. That is how a
+        quarantine turns into a place regressions hide.
+      * it got BETTER -- someone fixed it, and a silent quarantine now suppresses
+        the evidence. The lane should demand the entry be lifted and a real floor
+        set, in the same change that earned it.
+
+    A run that produced no usable f1 (crash, skip) is NOT drift: there is no
+    number to compare, and inventing one would fabricate a verdict.
+    """
+    if not q:
+        return None
+    f1 = r.get("f1")
+    if not isinstance(f1, (int, float)):
+        return None
+    base = q["f1_at_quarantine"]
+    tol = q.get("tolerance", 0.03)
+    name = r.get("name", "?")
+    if f1 < base - tol:
+        return (
+            f"{name}: f1={f1:.4f} has DEGRADED past its quarantine baseline "
+            f"{base:.4f} (tolerance {tol:.2f}, see #{q['issue']}). A quarantine "
+            "tracks a bug; it does not license it to get worse."
+        )
+    if f1 > base + tol:
+        return (
+            f"{name}: f1={f1:.4f} has IMPROVED past its quarantine baseline "
+            f"{base:.4f} (tolerance {tol:.2f}, see #{q['issue']}). Lift the "
+            "_QUARANTINE entry and set a real floor in the same change -- "
+            "leaving it quarantined hides the fix."
+        )
+    return None
+
+
+def _check_quality_floors(
+    results: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
+    """Return (failing, quarantined) human-readable breaches.
+
+    `failing` empty means the run is sound. `quarantined` is never empty
+    silently -- its contents are printed too, they just do not fail the lane.
 
     Two independent failure modes, because they fail differently:
       * a metric below its floor -- the numbers are bad;
       * a RED controller health -- the numbers are MEANINGLESS, whatever they
         say, because auto-config never converged on a usable config.
+
+    A dataset in `_QUARANTINE` routes its breaches to the second list, but only
+    while it stays where it was quarantined: drifting outside the tolerance in
+    EITHER direction routes them back to `failing` (see `_QUARANTINE`).
     """
-    breaches: list[str] = []
+    failing: list[str] = []
+    quarantined: list[str] = []
     for r in results:
         name = r.get("name", "?")
+        q = _QUARANTINE.get(name)
+        drift = _quarantine_drift(q, r) if q else None
+        # A drifted quarantine is no longer describing this run, so its
+        # breaches go back to failing -- and the drift itself is reported.
+        if drift:
+            failing.append(drift)
+            q = None
+        sink = quarantined if q else failing
         floor = _F1_FLOORS.get(name)
         f1 = r.get("f1")
         if floor is not None and isinstance(f1, (int, float)) and f1 < floor:
-            breaches.append(
+            sink.append(
                 f"{name}: f1={f1:.4f} is below the floor {floor:.4f} "
                 f"(precision={r.get('precision')}, recall={r.get('recall')})"
+                + (f"  [QUARANTINED -- see #{q['issue']}]" if q else "")
             )
         # A RED config means the controller gave up and committed a best-effort
         # guess. Elsewhere that is a reasonable degradation; in a lane whose only
         # job is measuring quality it is a FALSE RESULT, so it fails regardless
         # of the F1 it happens to produce.
         if str(r.get("health", "")).upper() == "RED":
-            breaches.append(
+            sink.append(
                 f"{name}: controller health is RED "
                 f"(stop_reason={r.get('stop_reason')}) -- the metrics are not "
                 "trustworthy even if they clear the floor"
+                + (f"  [QUARANTINED -- see #{q['issue']}]" if q else "")
             )
-    return breaches
+    return failing, quarantined
 
 
 def _emit_markdown_summary(results: list[dict[str, Any] | None], summary_path: Path | None) -> None:
@@ -906,7 +1007,7 @@ def main() -> int:
     # #2470: decide BEFORE publishing. The committed report describes itself as
     # "the current truth" and a --check gate forces PRs to match it, so putting a
     # known-bad table there is worse than leaving a stale one.
-    breaches = _check_quality_floors(results)
+    breaches, quarantined = _check_quality_floors(results)
 
     if args.output:
         args.output.write_text(json.dumps(payload, indent=2))
@@ -926,6 +1027,19 @@ def main() -> int:
 
     _emit_markdown_summary(results, args.summary_md)
 
+    # Printed whether or not anything failed: a quarantined breach that only
+    # showed up on red runs would be invisible exactly when the lane is green,
+    # which is when someone might act on it.
+    if quarantined:
+        _info("")
+        _info("KNOWN-BAD, QUARANTINED (reported, not failing):")
+        for b in quarantined:
+            _info(f"  - {b}")
+        _info(
+            "  These do not fail the lane so that a NEW regression still can. "
+            "They are not fixed and not forgiven -- see the issue on each."
+        )
+
     if breaches:
         _info("")
         _info("QUALITY FLOOR BREACHES (#2470):")
@@ -936,7 +1050,9 @@ def main() -> int:
             _info(
                 "Failing the lane. If a floor is genuinely wrong, change it in "
                 "_F1_FLOORS as a reviewable diff -- do NOT pass "
-                "--no-enforce-floors to make a red run look green."
+                "--no-enforce-floors to make a red run look green. If a dataset "
+                "is a KNOWN open bug, quarantine it in _QUARANTINE with its "
+                "issue number rather than weakening the floor."
             )
             return 1
         _info("(--no-enforce-floors: reporting only, not failing)")

--- a/scripts/test_benchmark_quarantine.py
+++ b/scripts/test_benchmark_quarantine.py
@@ -1,0 +1,96 @@
+"""Quarantine routing in run_benchmarks.py.
+
+The lane's whole job is to fail when quality moves. Quarantine deliberately
+suppresses a failure, so it is the one piece of that logic that can silently
+stop the lane working -- these pin that it suppresses ONLY what it claims to.
+
+Network-free and dataset-free: `_check_quality_floors` is a pure function over
+result dicts, so the cases below are the real ones the nightly produces.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+from run_benchmarks import (  # noqa: E402
+    _F1_FLOORS,
+    _QUARANTINE,
+    _check_quality_floors,
+)
+
+
+def _r(name, f1, health="green", stop_reason="converged"):
+    return {"name": name, "f1": f1, "precision": 0.1, "recall": 0.1,
+            "health": health, "stop_reason": stop_reason}
+
+
+# --- the two datasets that made #2457 permanently red -----------------------
+
+def test_the_2026_08_21_nightly_no_longer_fails_the_lane():
+    """The exact numbers from run 32457009104, which had been failing nightly."""
+    failing, quarantined = _check_quality_floors([
+        _r("Abt-Buy", 0.1723, "red", "budget_iterations"),
+        _r("Amazon-Google", 0.1014, "red", "budget_time"),
+    ])
+    assert failing == [], f"quarantined datasets still failed the lane: {failing}"
+    assert len(quarantined) == 3, quarantined  # Abt-Buy floor + 2 RED healths
+
+
+def test_quarantined_breaches_are_still_reported():
+    """Suppressing the failure must not suppress the evidence."""
+    _, quarantined = _check_quality_floors([_r("Abt-Buy", 0.1723, "red", "x")])
+    assert quarantined, "a quarantined breach vanished entirely"
+    assert all("QUARANTINED" in q and "#" in q for q in quarantined), quarantined
+
+
+# --- the ratchet, both directions -------------------------------------------
+
+def test_degrading_past_the_baseline_fails():
+    """A quarantine tracks a bug; it does not license it to deepen."""
+    base = _QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    failing, _ = _check_quality_floors([_r("Abt-Buy", base - 0.2, "green")])
+    assert any("DEGRADED" in f for f in failing), failing
+
+
+def test_improving_past_the_baseline_fails():
+    """Someone fixed it -- the quarantine now hides good news, so it must shout."""
+    base = _QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    failing, _ = _check_quality_floors([_r("Abt-Buy", base + 0.5, "green")])
+    assert any("IMPROVED" in f for f in failing), failing
+
+
+def test_inside_tolerance_stays_quarantined():
+    base = _QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    tol = _QUARANTINE["Abt-Buy"]["tolerance"]
+    failing, _ = _check_quality_floors([_r("Abt-Buy", base + tol / 2, "green")])
+    assert failing == [], failing
+
+
+def test_a_missing_f1_is_not_drift():
+    """A crashed/skipped run has no number; inventing a verdict would be worse."""
+    failing, _ = _check_quality_floors([
+        {"name": "Abt-Buy", "f1": None, "health": "green", "stop_reason": "x"}
+    ])
+    assert not any("DEGRADED" in f or "IMPROVED" in f for f in failing), failing
+
+
+# --- the guard: non-quarantined datasets must still fail --------------------
+
+def test_a_non_quarantined_dataset_still_fails_on_floor():
+    """Guards every test above: they pass trivially if nothing fails any more."""
+    failing, _ = _check_quality_floors([_r("Febrl3", 0.10, "green")])
+    assert any("below the floor" in f for f in failing), failing
+
+
+def test_a_non_quarantined_dataset_still_fails_on_red():
+    failing, _ = _check_quality_floors([_r("Febrl3", 0.99, "red", "budget_time")])
+    assert any("RED" in f for f in failing), failing
+
+
+def test_every_quarantine_entry_names_an_issue_and_a_known_dataset():
+    for name, q in _QUARANTINE.items():
+        assert isinstance(q.get("issue"), int), f"{name} has no issue number"
+        assert isinstance(q.get("f1_at_quarantine"), float), name
+        assert name in _F1_FLOORS, f"{name} is quarantined but has no floor entry"

--- a/scripts/test_run_benchmarks_llm_isolation.py
+++ b/scripts/test_run_benchmarks_llm_isolation.py
@@ -112,9 +112,23 @@ def test_controller_health_unknown_not_na_when_absent():
 
 
 def test_red_health_is_a_breach_even_above_the_floor():
-    """The check the "n/a" hardcode disabled."""
-    breaches = rb._check_quality_floors([
-        {"name": "Abt-Buy", "f1": 0.99, "health": "RED",
+    """The check the "n/a" hardcode disabled.
+
+    Split in two since Abt-Buy became quarantined (#2717): a quarantined
+    dataset's RED is still DETECTED, it just reports instead of failing. The
+    guarantee the "n/a" hardcode broke was detection, so that is asserted on
+    Abt-Buy directly -- and the failing half is asserted on a dataset that is
+    not quarantined, so neither half can pass vacuously.
+    """
+    base = rb._QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    failing, quarantined = rb._check_quality_floors([
+        {"name": "Abt-Buy", "f1": base, "health": "RED",
          "stop_reason": "BUDGET_ITERATIONS"},
     ])
-    assert any("RED" in b for b in breaches)
+    assert any("RED" in b for b in quarantined), (failing, quarantined)
+
+    failing, _ = rb._check_quality_floors([
+        {"name": "Febrl3", "f1": 0.99, "health": "RED",
+         "stop_reason": "BUDGET_ITERATIONS"},
+    ])
+    assert any("RED" in b for b in failing), failing


### PR DESCRIPTION
Closes #2457.

## The problem is the signal, not the lane

`main-health` #2457 has been open since 2026-08-10 and **cannot close**. The `benchmarks` lane fails every scheduled run on two datasets whose quality bug is known:

| dataset | F1 | health | stop_reason |
|---|---|---|---|
| Abt-Buy | 0.1723 (floor 0.45) | **RED** | budget_iterations |
| Amazon-Google | 0.1014 | **RED** | budget_time |

Same run: DBLP-ACM 0.9640, Febrl3 0.9912, NCVR-synthetic 0.9925.

A permanently red lane cannot signal a **new** regression -- a third dataset going bad tomorrow would look identical to the standing failure. That is the actual defect here, and it is worse than the quality bug because it disables the alarm for everything else.

## What I found that the issue did not say

**#2470 -- the issue that tracked these datasets -- is CLOSED.** Nothing open described the bug. The only signal was a bot-maintained *lane status* tracker. So I opened #2717 carrying the measurements (including the ruled-out list, so nobody re-derives it) and pointed the quarantine at it.

## This is not lowering a floor

The floor is untouched. The breach is still printed on **every** run, including green ones -- a quarantined breach that only appeared on red runs would be invisible exactly when someone might act on it. And the entry ratchets in **both** directions:

- **degrades** past `f1_at_quarantine` → **FAILS**. A quarantine tracks a bug, it does not license it to deepen. That is how quarantines turn into hiding places.
- **improves** past it → **also FAILS**, demanding the entry be lifted and a real floor set in the same change. Otherwise a fix lands silently and the lane keeps reporting a bug that no longer exists.

A run with no usable f1 (crash, skip) is deliberately **not** drift -- there is no number to compare, and inventing a verdict is worse than staying quiet.

## Tests

`scripts/test_benchmark_quarantine.py`, 9 cases, wired into `scripts_lint`. The first uses the **exact numbers from the failing nightly** (run 32457009104), so it is a regression test for this issue rather than a hypothetical.

Two of them are guards: a **non**-quarantined dataset must still fail on a floor breach *and* on a RED health. Without those, every other test passes trivially the moment the lane stops failing anything.

Confirmed they bite -- forcing `sink = failing` turns 3 red; restoring turns them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P