### PR TITLE
fix(ci): a `mode=bless` run must persist the scorecard it produces

### DIFF
--- a/.github/workflows/bench-suggest-quality.yml
+++ b/.github/workflows/bench-suggest-quality.yml
@@ -154,6 +154,32 @@ jobs:
           fi
           uv run python -m scripts.suggest_quality gym-gate $FILTER
 
+      # `mode=bless` regenerates scripts/suggest_quality/baselines/scorecard.json
+      # inside the runner and, until this step existed, nothing persisted it --
+      # so the procedure documented at the top of this file produced a baseline
+      # and threw it away. That is why #2635's remaining checkbox ("bless
+      # dblp_acm") could not be ticked: the dataset is CI-only (gitignored,
+      # fetched at run time), so a bless MUST happen here, and the result has to
+      # survive the run. Mirrors the gym-bless step below.
+      - name: Commit re-blessed scorecard baseline
+        if: ${{ inputs.mode == 'bless' }}
+        env:
+          # Via env, not interpolated straight into the shell: a branch name is
+          # attacker-influenceable text and `${{ }}` inside `run:` is template
+          # injection (zizmor flags it high). The gym-bless step below still
+          # interpolates directly -- pre-existing, not touched here.
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet -- scripts/suggest_quality/baselines/scorecard.json; then
+            echo "No scorecard baseline change to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add scripts/suggest_quality/baselines/scorecard.json
+          git commit -m "chore(suggest-quality): re-bless scorecard baseline [skip ci]"
+          git push origin "HEAD:$REF_NAME"
+
       - name: Commit re-blessed gym baseline
         if: ${{ inputs.mode == 'gym-bless' }}
         run: |


### PR DESCRIPTION
Unblocks the last checkbox on #2635.

## The documented bless path does not work

The top of `bench-suggest-quality.yml` says:

```
# To bless a new baseline after an intentional kernel change:
#   gh workflow run bench-suggest-quality.yml --ref <branch> -f mode=bless
```

That run regenerates `baselines/scorecard.json` **inside the runner and throws it away.** The workflow's only commit step is gated `if: inputs.mode == 'gym-bless'` and commits `gym_scorecard.json`. Nothing has ever persisted the main scorecard.

## Why this is #2635's blocker specifically

`dblp_acm` is CI-only — gitignored, fetched at run time (#2660). So a bless **must** happen on a runner, and the result has to survive. Blessing locally is exactly what that issue warns against: *"a value measured anywhere other than a CI run that loaded the data is not a safe baseline."*

## The precondition is now met, and by more than was asked

The issue wanted it stable on one nightly `main` run. There have been three:

| run | rows | gt_pairs | convergence_final_f1 |
|---|---|---|---|
| [32229858045](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32229858045) (08-19) | 4910 | 2224 | 0.7296 |
| [32346104575](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32346104575) (08-20) | 4910 | 2224 | 0.7296 |
| [32460648968](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32460648968) (08-21) | 4910 | 2224 | 0.7296 |

Identical to four decimals, and matching the PR-branch figure that prompted the issue.

## One deliberate difference from the step it mirrors

The branch goes through `env:` rather than `${{ github.ref_name }}` interpolated into the shell. A branch name is attacker-influenceable text and zizmor rates the direct form **high**; copying the existing pattern verbatim would have added a fifth high finding to this file.

Verified: **4 high before, 4 high after** — the new step adds none. The pre-existing gym-bless line still interpolates directly; I left it alone rather than widening scope, but it is worth a follow-up.

## After this merges

`gh workflow run bench-suggest-quality.yml --ref main -f mode=bless` will actually produce a committed baseline, which ticks #2635's last box. Note a dispatch also triggers the ~70-120min `gym-gate` step, so it is not a cheap run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P