### PR TITLE
release: goldenmatch 3.15.0

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.14.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.15.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.15.0] - 2026-08-21
+
+### Fixed
+
+- **`mcp` 2.0 broke every MCP server (#2715).** `mcp` 2.0.0 renamed
+  `Tool.inputSchema` to `input_schema`, keeping the old name as a pydantic
+  ALIAS. Construction sites therefore kept working and only the two places that
+  READ the attribute back failed -- one of them at server startup, so
+  `goldenmatch mcp-serve` died with `AttributeError: 'Tool' object has no
+  attribute 'inputSchema'`. All seven packages declared `mcp>=1.28.1` with no
+  upper bound, so the major walked in; now pinned `<2`. `pip install
+  goldenmatch[mcp]` had been landing users on 2.0 and crashing.
+
+### Security
+
+- **The hosted MCP endpoint now requires a bearer token.** It had been serving
+  77 tools unauthenticated -- 25 taking filesystem paths, 18 mutating an
+  identity DB by `db_path`, and `documents_ingest` accepting both a server-side
+  read path and an `out_path`. `/mcp/` returns 401 without
+  `Authorization: Bearer <GOLDENMATCH_MCP_TOKEN>`; the server card stays public
+  as the healthcheck target. Self-hosting on loopback needs no token, and a
+  public bind without one is refused rather than served open.
+
+### Added
+
 - **Snowflake-native `IdentityStore` backend (#2699).** `IdentityStore(backend="snowflake")`
   keeps the identity graph in Snowflake tables rather than a SQLite file, so it
   survives a UDF / stored-procedure worker. Writes are `MERGE`-based: Snowflake
@@ -13,7 +38,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   duplicate rows. The `bulk_*` fast path stages every write through a transient
   table loaded by `write_pandas`, then applies it with a `MERGE` --- except
   `bulk_emit_events`, which finishes with `INSERT ... SELECT` because the
-  append-only event log has no dedupe key for a `MERGE` to match on. Configure
+  append-only event log has no dedupe key for a `MERGE` to match on. `pandas`
+  is NOT required: `write_pandas` ships behind
+  `snowflake-connector-python[pandas]`, which this package's `snowflake` extra
+  deliberately does not pull, so every `bulk_*` path falls back to a row-wise
+  `MERGE` when it is absent -- same statement shape, same NULL-safe `ON`, same
+  `PARSE_JSON`, so a replay still cannot duplicate. Configure
   the target with `identity.database` / `identity.schema`. `resolve_clusters`
   now selects the bulk path by capability (`store.supports_bulk`) rather than by
   backend name.

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -47,7 +47,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.14.0"
+__version__ = "3.15.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.14.0"
+version = "3.15.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
MINOR by the derivation rule in `docs/superpowers/specs/2026-08-21-structured-release-process-design.md`: 16 commits since `v3.14.0`, several `feat` (Snowflake-native IdentityStore, Snowflake partitioned execution, Spark distributed column profiling, fail-closed MCP auth).

## Two entries carry weight beyond the usual

**`mcp<2` (#2715) — this release is what fixes it for package users.** mcp 2.0.0 renamed `Tool.inputSchema` to `input_schema` and kept the old name as a pydantic alias, so all 105 construction sites kept working and only the two READ sites failed — one at server startup. `pip install goldenmatch[mcp]` has been resolving 2.0 and crashing with `AttributeError: 'Tool' object has no attribute 'inputSchema'`. The hosted deployment was already fixed by rebuilding from source; **PyPI users are still broken until this ships.**

**The hosted MCP endpoint now requires a bearer token.** Filed under `### Security` because it changes how an already-published endpoint behaves for anyone who had it configured — it was serving 77 tools unauthenticated.

## A correction folded in

The Snowflake changelog entry predated the pandas fallback landing in #2707 and still implied `write_pandas` was required. It is not: the `snowflake` extra deliberately does not pull pandas, so every `bulk_*` path degrades to a row-wise `MERGE` — same statement shape, same NULL-safe `ON`, same `PARSE_JSON`, so a replay still cannot duplicate. Left uncorrected, the changelog would have told users to expect a hard dependency that was removed before it ever shipped.

## Verification

- Every version carrier bumped: `pyproject.toml`, `__init__.py`, `server.json` (×2). `import goldenmatch` reports `3.15.0`; `server.json` parses.
- The publish workflow's tag-vs-pyproject check simulated: `tag=3.15.0 pyproject=3.15.0 match=YES`.
- `regen_docs.py --check` → `Docs are current`. It caught a real one: `docs-site/reference/api-surface.mdx` embeds each package's published version, so the bump is a derived-doc change too.

## After merge

Tagging `v3.15.0` fires `publish-goldenmatch.yml` (the bespoke ADR-0019 draft-release + cosign flow, not the shared template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P