### PR TITLE
ci: resolve dependencies the way users do, instead of capping everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1180,6 +1180,43 @@ jobs:
       - name: Shell (pre-push hook ref parsing)
         run: sh scripts/test_pre_push_docs_check.sh
 
+  # Resolve dependencies the way USERS do -- `pip install`, no lockfile, no
+  # constraints -- and smoke the entry points.
+  #
+  # Every other Python lane installs via `uv sync`, which resolves through
+  # uv.lock. That made CI structurally blind to mcp 2.0.0 (#2715): the lock
+  # pinned 1.28.1, `Dockerfile.mcp` resolved 2.0.0, and the difference surfaced
+  # as a crashed production deploy rather than a red check. A lockfile protects
+  # CI from exactly the drift that reaches production.
+  #
+  # Deliberately NOT solved by capping every dependency. 187 of 195 requirements
+  # are uncapped and should stay so -- a library that pins `<N` on everything
+  # forces resolution conflicts on its consumers. This lane catches a breaking
+  # major in ANY of them without capping any (see scripts/audit_dep_ceilings.py).
+  #
+  # Scheduled as well as on dependency changes: the input that breaks this is an
+  # upstream RELEASE, which no push of ours corresponds to.
+  unlocked_resolution:
+    needs: changes
+    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.force_all == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      # Plain pip, no uv, no lock -- the point is to reproduce a user's resolve.
+      - name: Install goldenmatch[mcp] with a fresh resolution
+        run: pip install './packages/python/goldenmatch[mcp]'
+      - name: Smoke the entry points an upstream major would break
+        run: python scripts/smoke_unlocked_install.py
+      # Reported, never gating: the ceiling surface is a judgement call, and a
+      # count that fails a build would push people toward capping everything.
+      - name: Report the dependency ceiling surface
+        if: always()
+        run: python scripts/audit_dep_ceilings.py
+
   # Every repo path a CLAUDE.md names must exist. These files are loaded as
   # authoritative agent context, so a dead pointer does not merely fail to help --
   # it sends the reader somewhere empty and they conclude the thing was never

--- a/scripts/audit_dep_ceilings.py
+++ b/scripts/audit_dep_ceilings.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Report which declared dependencies have no upper bound, and why that matters.
+
+This is a REPORT, not a gate, and deliberately so. Capping every dependency is a
+known packaging anti-pattern: a library that pins `<N` on everything forces
+resolution conflicts on anyone who depends on it, and the cost lands on users
+who cannot edit our metadata. 187 of 195 requirements here are uncapped and
+most of them should stay that way.
+
+What actually broke on 2026-08-21 was not the absence of a ceiling. It was that
+CI resolves through `uv.lock` (pinning mcp 1.28.1) while the Docker image and
+every `pip install` resolve fresh (getting mcp 2.0.0). The lockfile made CI
+structurally immune to precisely the drift that reaches production. The fix for
+that is the unlocked-resolution lane, not 187 pins.
+
+So this script exists to make the surface visible and to tell the two cases
+apart:
+
+  * a dependency whose PUBLIC, documented API we use  -> leave uncapped; a major
+    bump is upstream's problem to communicate and ours to adapt to.
+  * a dependency whose object model we reach into     -> a major bump WILL break
+    us silently. `mcp` was this: we read `Tool.inputSchema`, 2.0 renamed the
+    field and kept the old name as a pydantic alias, so every construction site
+    kept working and only the reads failed -- at server startup.
+
+Usage:
+    python scripts/audit_dep_ceilings.py            # report
+    python scripts/audit_dep_ceilings.py --json     # machine-readable
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_REQ = re.compile(r'"([A-Za-z0-9_.\-]+)\s*((?:[<>=!~][^"]*)?)"')
+
+
+def declared_requirements() -> list[dict]:
+    """Every version-pinned requirement string across the Python packages."""
+    out: list[dict] = []
+    for pyproject in sorted((ROOT / "packages" / "python").glob("*/pyproject.toml")):
+        text = pyproject.read_text(encoding="utf-8")
+        for m in _REQ.finditer(text):
+            name, spec = m.group(1), m.group(2).strip()
+            if not spec or not spec[0] in "<>=!~":
+                continue
+            if name.lower() == "python":
+                continue
+            out.append({
+                "package": pyproject.parent.name,
+                "requirement": name,
+                "spec": spec,
+                "capped": "<" in spec,
+            })
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    reqs = declared_requirements()
+    capped = [r for r in reqs if r["capped"]]
+    uncapped = [r for r in reqs if not r["capped"]]
+
+    if args.json:
+        json.dump({"total": len(reqs), "capped": capped, "uncapped": uncapped},
+                  sys.stdout, indent=2)
+        print()
+        return 0
+
+    print(f"declared requirements: {len(reqs)}")
+    print(f"  with an upper bound: {len(capped)}")
+    print(f"  without:             {len(uncapped)}")
+    print()
+    print("CAPPED (each of these should say why, in a comment next to it):")
+    for r in sorted(capped, key=lambda r: (r["requirement"], r["package"])):
+        print(f"  {r['requirement']:<28} {r['spec']:<18} {r['package']}")
+    print()
+    by_req: dict[str, list[str]] = {}
+    for r in uncapped:
+        by_req.setdefault(r["requirement"], []).append(r["package"])
+    print(f"UNCAPPED ({len(by_req)} distinct):")
+    for name in sorted(by_req):
+        pkgs = ", ".join(sorted(by_req[name]))
+        print(f"  {name:<28} {pkgs}")
+    print()
+    print("Uncapped is the correct DEFAULT. Cap one only when we read into its")
+    print("object model rather than its documented API -- see the module docstring.")
+    print("The lane that actually catches a breaking major is `unlocked_resolution`")
+    print("in ci.yml, which resolves the way users do instead of through uv.lock.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_unlocked_install.py
+++ b/scripts/smoke_unlocked_install.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Smoke the entry points that a fresh, UNLOCKED resolution would break.
+
+Run inside an environment built by `pip install` with no lockfile and no
+constraints -- i.e. what `Dockerfile.mcp` does and what every user gets. CI's
+normal `uv sync` resolves through uv.lock, which made it structurally blind to
+mcp 2.0.0: the lock pinned 1.28.1, the image resolved 2.0.0, and the difference
+only showed up as a crashed production deploy.
+
+Deliberately not a pytest suite. It has to run against an env that has ONLY the
+declared dependencies -- no dev group, no fakesnow, no pytest -- because that is
+the env being tested. Adding pytest to it would change the resolution it exists
+to check.
+
+Each check targets a place a major bump has actually landed or would land
+silently: an import chain, an object model we read into, and a console script.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib.metadata import version
+
+FAILURES: list[str] = []
+
+
+def check(label: str):
+    def deco(fn):
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, not the first
+            FAILURES.append(f"{label}: {type(exc).__name__}: {exc}")
+            print(f"  FAIL  {label}: {type(exc).__name__}: {exc}")
+        else:
+            print(f"  ok    {label}")
+        return fn
+    return deco
+
+
+print("resolved versions:")
+for dist in ("goldenmatch", "mcp", "pyarrow", "numpy", "pydantic", "typer", "duckdb"):
+    try:
+        print(f"  {dist:<12} {version(dist)}")
+    except Exception:
+        print(f"  {dist:<12} (absent)")
+print()
+print("checks:")
+
+
+@check("import goldenmatch")
+def _import():
+    import goldenmatch  # noqa: F401
+
+
+@check("MCP server module imports")
+def _mcp_import():
+    import goldenmatch.mcp.server  # noqa: F401
+
+
+@check("MCP tool list builds (reads Tool.inputSchema -- the mcp 2.0 break)")
+def _mcp_tools():
+    import goldenmatch.mcp.server as s
+    aliases = s._build_alias_tools()
+    assert aliases, "alias tool list is empty"
+    schema = aliases[0].inputSchema
+    assert isinstance(schema, dict) and schema, f"unusable inputSchema: {schema!r}"
+
+
+@check("console script responds")
+def _cli():
+    out = subprocess.run(
+        [sys.executable, "-m", "goldenmatch.cli.main", "--version"],
+        capture_output=True, text=True, timeout=120,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"exit {out.returncode}: {out.stderr.strip()[:300]}")
+
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} check(s) failed under an unlocked resolution.")
+    print("An upstream major has changed something we depend on. Either adapt to")
+    print("it, or add a ceiling for THAT dependency with a comment saying why --")
+    print("do not cap everything (see scripts/audit_dep_ceilings.py).")
+    sys.exit(1)
+print("all checks passed under an unlocked resolution")


### PR DESCRIPTION
The ask was a dependency-ceiling audit. **The audit says don't do that**, and this PR does the thing that actually catches the failure.

## What the audit found

**195 declared requirements, 8 capped.** Capping the other 187 would be the packaging anti-pattern: a library that pins `<N` on everything forces resolution conflicts on every consumer, and the cost lands on people who cannot edit our metadata.

## The missing ceiling is not what broke production

| | resolves via | got |
|---|---|---|
| every CI Python lane | `uv sync` → **uv.lock** | mcp **1.28.1** |
| `Dockerfile.mcp`, and every user | plain `pip install` | mcp **2.0.0** |

The lockfile made CI structurally immune to precisely the drift that reaches users. That is why #2715 surfaced as a crashed deploy instead of a red check — and a ceiling on `mcp` fixes exactly one dependency out of 195.

## What this adds

`unlocked_resolution` installs `packages/python/goldenmatch[mcp]` with plain pip — no uv, no lock, no constraints — and smokes the entry points an upstream major actually breaks: the import chain, the MCP tool list (which reads `Tool.inputSchema`), and the console script.

**Verified against the real historical failure, not a hypothetical:**

```
goldenmatch 3.14.0 + mcp>=2   ->  exit 1, 2 failures
  FAIL  MCP server module imports:
        AttributeError: 'Tool' object has no attribute 'inputSchema'

goldenmatch 3.15.0 (published) ->  all 4 checks pass, mcp 1.28.1
```

## Two deliberate choices

**Scheduled as well as path-triggered.** The input that breaks this is an upstream *release*; no push of ours corresponds to one, so a purely path-triggered lane would only notice by accident.

**Not in `ci-required`.** An upstream major landing must not block unrelated merges. It must be visible and actionable — which is what `main-health` is for, and which #2718 just made able to distinguish a new failure from a standing one.

`scripts/audit_dep_ceilings.py` reports the surface and is explicitly **not** a gate. A count that failed a build would push people toward capping everything, which is the outcome this change argues against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P