### PR TITLE
build: cap pydantic <3 -- the one dependency that meets the criterion

### DIFF
--- a/packages/python/goldenanalysis/pyproject.toml
+++ b/packages/python/goldenanalysis/pyproject.toml
@@ -18,7 +18,14 @@ classifiers = [
 ]
 dependencies = [
     "polars>=1.0",
-    "pydantic>=2.7",
+    # Capped deliberately, unlike the other 186 uncapped requirements. The
+    # criterion (scripts/audit_dep_ceilings.py) is whether we reach into a
+    # dependency's OBJECT MODEL rather than call its documented API: 94
+    # BaseModel subclasses across the suite, plus `model_fields`,
+    # `PrivateAttr` and `model_config` reads. That is the same shape as the
+    # mcp 2.0 break (#2715), at far larger scale, and v1->v2 is the
+    # precedent for how much a pydantic major moves.
+    "pydantic>=2.7,<3",
     "typer>=0.12",
     "rich>=13.0",
     "pyarrow>=15",

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -37,7 +37,14 @@ dependencies = [
     "typer>=0.12",
     "rich>=13.0",
     "pyyaml>=6.0",
-    "pydantic>=2.7",
+    # Capped deliberately, unlike the other 186 uncapped requirements. The
+    # criterion (scripts/audit_dep_ceilings.py) is whether we reach into a
+    # dependency's OBJECT MODEL rather than call its documented API: 94
+    # BaseModel subclasses across the suite, plus `model_fields`,
+    # `PrivateAttr` and `model_config` reads. That is the same shape as the
+    # mcp 2.0 break (#2715), at far larger scale, and v1->v2 is the
+    # precedent for how much a pydantic major moves.
+    "pydantic>=2.7,<3",
     "openpyxl>=3.1",
     "textual>=1.0",
     "goldencheck-types",

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -29,7 +29,14 @@ classifiers = [
 # uninstalled. See docs/design/2026-07-07-phase4-polars-optional-scoping.md.
 dependencies = [
     "goldenflow-native>=0.27.0",
-    "pydantic>=2.7",
+    # Capped deliberately, unlike the other 186 uncapped requirements. The
+    # criterion (scripts/audit_dep_ceilings.py) is whether we reach into a
+    # dependency's OBJECT MODEL rather than call its documented API: 94
+    # BaseModel subclasses across the suite, plus `model_fields`,
+    # `PrivateAttr` and `model_config` reads. That is the same shape as the
+    # mcp 2.0 break (#2715), at far larger scale, and v1->v2 is the
+    # precedent for how much a pydantic major moves.
+    "pydantic>=2.7,<3",
     "typer>=0.12",
     "rich>=13.0",
     "textual>=0.50",

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -29,7 +29,14 @@ dependencies = [
     "typer>=0.12",
     "rich>=13.0",
     "pyyaml>=6.0",
-    "pydantic>=2.7",
+    # Capped deliberately, unlike the other 186 uncapped requirements. The
+    # criterion (scripts/audit_dep_ceilings.py) is whether we reach into a
+    # dependency's OBJECT MODEL rather than call its documented API: 94
+    # BaseModel subclasses across the suite, plus `model_fields`,
+    # `PrivateAttr` and `model_config` reads. That is the same shape as the
+    # mcp 2.0 break (#2715), at far larger scale, and v1->v2 is the
+    # precedent for how much a pydantic major moves.
+    "pydantic>=2.7,<3",
     # metaphone for the "metaphone" transform. goldenphonetic is our owned,
     # byte-identical-to-jellyfish phonetic kernel (replaces the jellyfish runtime
     # dep; jellyfish stays a dev-only parity oracle in the workspace dev group).

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -20,7 +20,14 @@ dependencies = [
     "polars>=1.0",
     "typer>=0.12",
     "rich>=13.0",
-    "pydantic>=2.7",
+    # Capped deliberately, unlike the other 186 uncapped requirements. The
+    # criterion (scripts/audit_dep_ceilings.py) is whether we reach into a
+    # dependency's OBJECT MODEL rather than call its documented API: 94
+    # BaseModel subclasses across the suite, plus `model_fields`,
+    # `PrivateAttr` and `model_config` reads. That is the same shape as the
+    # mcp 2.0 break (#2715), at far larger scale, and v1->v2 is the
+    # precedent for how much a pydantic major moves.
+    "pydantic>=2.7,<3",
     "pyyaml>=6.0",
     "goldencheck-types",
     "infermap",

--- a/uv.lock
+++ b/uv.lock
@@ -964,7 +964,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1,<2" },
     { name = "polars", specifier = ">=1.0" },
     { name = "pyarrow", specifier = ">=15" },
-    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.7,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -1049,7 +1049,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=14" },
     { name = "pyarrow", marker = "extra == 'native'", specifier = ">=14" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14" },
-    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.7,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1178,7 +1178,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0" },
     { name = "pyarrow", marker = "extra == 'native'", specifier = ">=10" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=10" },
-    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.7,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -1218,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "goldenmatch"
-version = "3.14.0"
+version = "3.15.0"
 source = { editable = "packages/python/goldenmatch" }
 dependencies = [
     { name = "duckdb" },
@@ -1419,7 +1419,7 @@ requires-dist = [
     { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.2" },
     { name = "pyarrow", specifier = ">=10" },
     { name = "pyarrow", marker = "extra == 'bench'", specifier = ">=15" },
-    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.7,<3" },
     { name = "pylance", marker = "extra == 'lance'", specifier = ">=0.20" },
     { name = "pymupdf", marker = "extra == 'documents'", specifier = ">=1.24" },
     { name = "pymysql", marker = "extra == 'mysql'", specifier = ">=1.1" },
@@ -1596,7 +1596,7 @@ requires-dist = [
     { name = "infermap", editable = "packages/python/infermap" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1,<2" },
     { name = "polars", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.7,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-aiohttp", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },


### PR DESCRIPTION
Follow-up to #2722, which added the ceiling criterion. This applies it rather than leaving it as an assertion.

## The criterion

From `scripts/audit_dep_ceilings.py`: cap a dependency when we reach into its **object model** rather than call its documented API — because that is the shape that breaks *silently*. mcp 2.0 renamed `Tool.inputSchema` and kept the old name as an alias, so all 105 construction sites kept working and only the two reads failed, at server startup.

## Measured against the uncapped set

| dependency | evidence | verdict |
|---|---|---|
| **pydantic** | **94 `BaseModel` subclasses** suite-wide, plus `model_fields`, `PrivateAttr`, `model_config` reads | **CAP `<3`** |
| click / typer | `.params` (28), `get_command` (6), `.commands` (3) — real introspection, but the 95 `CliRunner` hits are test-only and the surface is small | leave uncapped |
| pyarrow | the `._col` / `._df` hits are **our own** private attributes on our own `frame.py` class, not pyarrow's internals | leave uncapped |

pydantic is the same failure shape as mcp at 12× the scale, and v1→v2 is the precedent for how far a pydantic major moves.

pyarrow is the one I'd most regret capping: its entire value is zero-copy interop with DuckDB, Spark, Polars and the Rust kernel, so a ceiling there propagates a conflict into every consumer's resolution.

## Result

**13 of 195 capped**, up from 8. The other 182 stay uncapped on purpose — #2722 covers them by resolving the way users do instead of through `uv.lock`.

## Verified

- `pydantic>=2.7,<3` resolves to **2.13.3**
- `goldenmatch.config.schemas` — the largest `BaseModel` surface — still loads
- `uv lock` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P