### PR TITLE
suggest-quality: make the DBLP-ACM guards actually run, + blocking-stage metrics (advisory, known-limited)

### DIFF
--- a/.github/workflows/bench-suggest-quality.yml
+++ b/.github/workflows/bench-suggest-quality.yml
@@ -125,6 +125,22 @@ jobs:
       - name: Fetch skip-when-absent datasets (best-effort)
         run: uv run python -m scripts.suggest_quality.fetch_datasets
 
+      # These guard the dataset REGISTRY -- most importantly that the vendored
+      # DBLP-ACM corpus is present, loads, and matches its recorded checksums
+      # (#2635). They live here, not in ci.yml's `scripts_lint`, because that
+      # job syncs with --no-install-workspace and the registry transitively
+      # needs goldenmatch: datasets.py -> autoconfig_quality/anchors.py:21 ->
+      # repro_issue_715 -> goldenmatch.core.autoconfig. This job already syncs
+      # the workspace and is already push-gated on `scripts/suggest_quality/**`,
+      # so it is where they can actually run.
+      # PYTHONPATH: the repo root is not on sys.path under a bare `uv run
+      # pytest` (pytest prepends `scripts/`, which has no __init__.py), and the
+      # tests import via the `scripts.suggest_quality...` prefix.
+      - name: Pytest (suggest_quality dataset guards)
+        env:
+          PYTHONPATH: .
+        run: uv run pytest scripts/suggest_quality/tests/test_datasets.py -q
+
       - name: Run suggest_quality ${{ inputs.mode || 'gate' }}
         env:
           GOLDENMATCH_SUGGEST_FULL_DIST: ${{ (startsWith(inputs.mode, 'gym') || inputs.mode == 'bakeoff') && '1' || '0' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1166,12 +1166,23 @@ jobs:
       # it cannot be written to skip when they are missing without becoming the
       # check that does not fire. Added ephemerally, same idiom as er_matcher's
       # `uv run --with scikit-learn`.
+      # PYTHONPATH: the repo root is NOT on sys.path under a bare `uv run
+      # pytest`. pytest prepends each test's first non-package parent, which is
+      # `scripts/` (no __init__.py), so `from leipzig_eval import ...` resolves
+      # but `from scripts.suggest_quality...` does NOT. The suggest_quality
+      # tests use the prefixed form, so without this they fail COLLECTION --
+      # and a test that cannot be collected is the "check exists and does not
+      # fire" class this step exists to prevent. Adding the root is additive:
+      # `scripts/` stays on sys.path, so the unprefixed imports still resolve.
       - name: Pytest (scripts/ unit tests)
+        env:
+          PYTHONPATH: .
         run: |
           uv run --with polars --with pyarrow \
             pytest scripts/test_run_benchmarks_download.py \
                    scripts/test_benchmark_quarantine.py \
-                   scripts/dqbench_adapters/test_leipzig_eval.py -q
+                   scripts/dqbench_adapters/test_leipzig_eval.py \
+                   scripts/suggest_quality/tests/test_datasets.py -q
       # The pre-push hook is developer-facing, so nothing else runs it. It
       # shipped gating tag pushes -- diffing origin/main..<older tag sha>
       # BACKWARDS -- which would have blocked the release tag back-fill. This

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1166,23 +1166,12 @@ jobs:
       # it cannot be written to skip when they are missing without becoming the
       # check that does not fire. Added ephemerally, same idiom as er_matcher's
       # `uv run --with scikit-learn`.
-      # PYTHONPATH: the repo root is NOT on sys.path under a bare `uv run
-      # pytest`. pytest prepends each test's first non-package parent, which is
-      # `scripts/` (no __init__.py), so `from leipzig_eval import ...` resolves
-      # but `from scripts.suggest_quality...` does NOT. The suggest_quality
-      # tests use the prefixed form, so without this they fail COLLECTION --
-      # and a test that cannot be collected is the "check exists and does not
-      # fire" class this step exists to prevent. Adding the root is additive:
-      # `scripts/` stays on sys.path, so the unprefixed imports still resolve.
       - name: Pytest (scripts/ unit tests)
-        env:
-          PYTHONPATH: .
         run: |
           uv run --with polars --with pyarrow \
             pytest scripts/test_run_benchmarks_download.py \
                    scripts/test_benchmark_quarantine.py \
-                   scripts/dqbench_adapters/test_leipzig_eval.py \
-                   scripts/suggest_quality/tests/test_datasets.py -q
+                   scripts/dqbench_adapters/test_leipzig_eval.py -q
       # The pre-push hook is developer-facing, so nothing else runs it. It
       # shipped gating tag pushes -- diffing origin/main..<older tag sha>
       # BACKWARDS -- which would have blocked the release tag back-fill. This

--- a/docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md
+++ b/docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md
@@ -1,0 +1,169 @@
+# Candidate-recall gate for the suggest-quality scorecard
+
+**Status:** design, not implemented.
+**Motivates:** #2633 (candidate-set ceiling), #2635 (vendoring), the #1316 learned-blocking cliff.
+
+## The problem
+
+The suggest-quality scorecard gates `rank_corr`, `suggester_prec` and
+`convergence_final_f1`. All three are **downstream of blocking**. None answers
+the question that decides how much recall is reachable at all:
+
+> what fraction of true pairs did blocking actually generate?
+
+That gap is why four independent candidate-generation defects survived:
+
+| defect | evidence |
+|---|---|
+| the auto-suggest candidate pool is matchkey-columns-only, so `year`/`zip` can never be proposed | #2633 — DBLP-ACM ceiling 6.4%, `year` unreachable at any rank |
+| the recall estimator is ~26x low on the best key | `title[:5]` true recall 0.982, estimated 0.037 |
+| `score x estimated_recall` has no recall floor | picks a 41.6%-recall compound over a 98.2%-recall single key, by 2x |
+| learned blocking collapses at >=50k on strong-id shapes | candidate-pair recall 1.0 -> 0.0 (#1316) |
+
+Each shows up downstream only as a diffuse F1 wobble that is easy to attribute
+to the scorer. Production candidate-recall on `historical_50k` is **0.8855** —
+nearly 12% of true pairs are never generated, and no scoring change can reach
+them.
+
+**This gate is a prerequisite, not a nicety.** Every fix in #2633 changes
+blocking selection for *every* dataset. You cannot validate a blocking change
+against a metric that does not measure blocking.
+
+## The metrics
+
+Two, and they **must gate together**.
+
+### `candidate_recall`
+
+```
+|candidate_pairs ∩ gt_pairs| / |gt_pairs|
+```
+
+The hard ceiling on recall for the run. Gated on **drop**, same shape as the
+existing tolerances.
+
+### `candidate_pairs`
+
+Count of within-block pairs the config generates. Gated on **growth**.
+
+Recall alone is trivially gameable: put every record in one block and
+`candidate_recall` is 1.0. That is not hypothetical — it is precisely the
+failure mode the parked recall floor produced (22.5x comparisons on dblp_acm,
+22.6x on person, for zero measured gain). A recall floor without a cost ceiling
+re-introduces it as a *green* gate.
+
+## The implementation insight: do not enumerate candidates
+
+The naive reading — materialise the candidate set, intersect with ground truth —
+is O(candidates) and hostile at 50k rows. Neither metric needs it:
+
+- **`candidate_recall`**: iterate `gt_pairs` (thousands, not millions) and test
+  whether each pair's two rows share a block key under the committed config.
+  O(|gt|) with a row -> block-key-set index built in one pass.
+- **`candidate_pairs`**: `sum(n*(n-1)/2)` over block sizes — already exactly what
+  `block_analyzer.score_candidate` computes for `total_comparisons`.
+
+So both are cheap on every gated dataset, including `historical_50k`.
+
+## Where it hooks in
+
+`scripts/suggest_quality/oracle.py::evaluate_dataset`, immediately after
+`baseline_config = _auto_configure_no_rerank(df)` and before/alongside
+`_run_config`. The record already carries `gt_pairs` and is built post-`row_cap`
+(the cap truncates `df` and rebuilds `gt_pairs`), so computing there gets the
+cap handling for free.
+
+**Derive block keys from the real primitives — `build_blocks` /
+`collect_blocking_fields` / `_build_block_key_expr` — never a reimplementation.**
+A private copy of block-key derivation would drift from the pipeline and the
+gate would certify a fiction. This is the same discipline that makes the
+er_matcher basis-parity gate meaningful.
+
+Measure against the **baseline (zero-config) config**: that is what users get.
+Measuring the converged config as a second pair of metrics is a reasonable
+follow-up, not v1.
+
+## Record and scorecard changes
+
+Two new keys on the `evaluate_dataset` record, flowing through `_build_scorecard`
+unchanged (it rounds floats to 6dp generically):
+
+```
+candidate_recall: float   # NaN -> null when gt_pairs is empty
+candidate_pairs:  int
+```
+
+`NaN` for the blocking-shape anchors (`anchor_sparse_zip`, `anchor_shared_email`)
+exactly as `baseline_f1` already does — they have no truth, so they must not gate.
+
+## Gate semantics — the one structural change
+
+`_GATE_TOLERANCES` today is a flat `{metric: tolerance}` map and every entry is
+interpreted as **"fail if it dropped by more than tolerance"**. `candidate_pairs`
+must fail on *growth*, so the map needs a direction:
+
+```python
+_GATE_TOLERANCES = {
+    "rank_corr":            (0.05,  "drop"),
+    "suggester_prec":       (0.05,  "drop"),
+    "convergence_final_f1": (0.02,  "drop"),
+    "candidate_recall":     (0.02,  "drop"),
+    "candidate_pairs":      (0.25,  "growth_ratio"),
+}
+```
+
+Proposed thresholds, all calibrated-not-derived and expected to be argued with:
+
+- **`candidate_recall` 0.02** mirrors `convergence_final_f1`. A blocking change
+  that costs 2pp of reachable recall should be a deliberate re-bless.
+- **`candidate_pairs` 0.25 growth ratio** (fail above 1.25x baseline). Deliberately
+  loose: it is a blow-up detector, not a budget. It catches the 22x class without
+  arguing over a few percent. Tighten once there is a distribution to look at.
+
+`growth_ratio` compares `current / baseline` rather than a difference, because
+absolute pair counts span orders of magnitude across the panel.
+
+## What this does NOT do
+
+- **It does not detect scale-cost regressions.** Every suggest-panel dataset is
+  small; a 22x comparison blow-up is invisible in wall-clock there. That is why
+  the parked recall floor measured byte-identical. Anything touching the blocking
+  *objective* still needs `bench-quality-scale` / QIS. This gate catches the
+  *shape* of the blow-up (pair count), not its cost at 1M+.
+- **It does not fix anything.** It makes four existing defects visible as numbers
+  and stops the fifth from landing silently.
+- **It inherits config nondeterminism.** Post-#2560 the controller search is
+  host-independent, so this should be stable; if a dataset proves flaky, it
+  belongs in the existing advisory list rather than being papered over.
+
+## Rollout
+
+1. Land the metrics as **advisory** (reported, non-gating) for one cycle. This
+   costs nothing and produces the distribution needed to sanity-check the two
+   thresholds against real spread rather than a guess.
+2. Bless, then promote to gating.
+3. Only then start #2633 — with a metric that can actually see what it changes.
+
+Step 1 matters: blessing a threshold picked from a single observation is how the
+`historical_50k` bench blessed an over-merge that a capped subset hid.
+
+## Test plan
+
+`scripts/suggest_quality/tests/`:
+
+- `candidate_recall == 1.0` on a fixture where blocking is a single all-rows block.
+- `candidate_recall` strictly drops when a blocking key is narrowed to exclude a
+  known true pair (the direction the gate exists to catch).
+- `candidate_pairs` matches the `sum(n*(n-1)/2)` identity on a hand-built block set.
+- Empty-`gt_pairs` anchors emit `None`, and the gate skips them rather than
+  treating them as a regression to 0.
+- `growth_ratio` fires above the ratio and stays silent below it.
+- A block-key-derivation drift guard: for one dataset, the metric's block
+  assignment equals `build_blocks`' own, so a future change to either is caught.
+
+## Sizing
+
+Small. Two record keys, one `_GATE_TOLERANCES` shape change, one comparison
+branch in `_cmd_gate`, one helper in `oracle.py`, six tests. The intellectual
+content is the pair-of-metrics constraint and the do-not-enumerate trick; the
+code is modest.

--- a/docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md
+++ b/docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md
@@ -136,6 +136,57 @@ absolute pair counts span orders of magnitude across the panel.
   host-independent, so this should be stable; if a dataset proves flaky, it
   belongs in the existing advisory list rather than being papered over.
 
+## MEASURED 2026-08-22 — the v1 implementation does not yet do the job
+
+Added after implementing the above and running it. Reproduced identically by two
+independent paths (the full oracle, and a blocking-stage-only script), so this is
+the implementation's behaviour and not a harness artifact.
+
+| dataset | candidate_recall | candidate_pairs | error |
+|---|---|---|---|
+| `dblp_acm` | — | — | `ColumnNotFoundError: __title_key__` |
+| `anchor_person_match` | 1.0000 | 1,712 | — |
+| `synthetic` | 1.0000 | 861 | — |
+| `ncvr_synthetic` | 1.0000 | 434,530 | — |
+
+**1. It fails on configs that block on a DERIVED column.** `dblp_acm` blocks on
+`__title_key__`, which the domain-extraction stage creates. The implementation
+calls `build_blocks` on the INPUT frame, but the pipeline blocks on a prepared
+one — `auto_fix -> validate -> standardize -> matchkeys -> domain -> precompute
+-> block`. There is no single reusable prep seam; those stages are inline in
+`_run_dedupe_pipeline`. So the metric is unmeasurable on exactly the dataset that
+motivated it.
+
+Fixing it means choosing between two costs, neither free:
+- call the same stage functions in the same order — no reimplementation of
+  block-key derivation, but a reimplementation of stage ORDER, which can drift
+  from the pipeline and leave the metric certifying a fiction one level up;
+- capture membership from the pipeline's real blocking run (a `core/bench.py`
+  emitter), which is correct by construction but changes goldenmatch core.
+
+**2. Where it does work, it has no discriminating power.** All three
+loadable datasets score exactly 1.0000 — they are synthetic corpora with clean
+blocking keys, so that is plausible rather than suspicious, but the consequence
+is that a 0.02 drop-floor could never fire on any of them. `candidate_pairs`
+does look alive (434,530 comparisons for 2,500 true pairs on `ncvr_synthetic`).
+
+**This invalidates the Rollout assumption below.** Step 1 assumed advisory-first
+would produce a distribution to calibrate thresholds against. The actual
+distribution is `{1.0, 1.0, 1.0, error}`, which calibrates nothing. The metric is
+therefore NOT close to gating, and should not be promoted on the strength of a
+green advisory run.
+
+What survives: the pure `candidate_metrics` helper and its tests are correct and
+regime-independent; the two-metrics-together constraint and the
+do-not-enumerate construction are unaffected; and the failure is *recorded* on
+`candidate_error` rather than swallowed, so the gap is visible in the scorecard
+rather than latent.
+
+One incidental confirmation: the error message enumerates the frame's columns as
+`["__row_id__", "id", "title", "authors", "venue", "year"]`. `year` IS present on
+the raw frame — independent corroboration of #2633's premise that it is available
+and simply never proposed, because the candidate pool is matchkey-only.
+
 ## Rollout
 
 1. Land the metrics as **advisory** (reported, non-gating) for one cycle. This

--- a/scripts/suggest_quality/metrics.py
+++ b/scripts/suggest_quality/metrics.py
@@ -18,6 +18,7 @@ Edge cases:
 from __future__ import annotations
 
 import math
+from collections.abc import Iterable, Sequence
 
 
 def rank_correlation(suggested_order_lifts: list[float]) -> float:
@@ -101,3 +102,59 @@ def recovery_pct(f1_degraded: float, f1_recovered: float, f1_ceiling: float) -> 
     if denom < DAMAGE_EPS:
         return float("nan")
     return (f1_recovered - f1_degraded) / denom
+
+
+def candidate_metrics(
+    block_members: Iterable[Sequence[int]],
+    gt_pairs: set[tuple[int, int]],
+) -> dict:
+    """Blocking-stage metrics: the ceiling the candidate set imposes, and its cost.
+
+    Every other metric in this module is downstream of blocking. These two are
+    the blocking stage itself -- ``candidate_recall`` is the hard ceiling no
+    scorer can exceed, because a pair blocking never emitted cannot be scored.
+
+    ``candidate_recall``
+        Fraction of ground-truth pairs that share at least one block.
+        ``nan`` when ``gt_pairs`` is empty (the blocking-shape anchors carry no
+        truth), mirroring how ``baseline_f1`` reports "not applicable".
+
+    ``candidate_pairs``
+        Within-block COMPARISONS, ``sum(n*(n-1)/2)`` over block sizes -- the
+        same identity ``block_analyzer.score_candidate`` reports as
+        ``total_comparisons``. A pair co-blocked by two passes counts twice,
+        deliberately: this is the cost signal, and the scorer really does pay
+        for it twice.
+
+    The two must be read together. Recall alone is trivially gamed -- one block
+    holding every record scores 1.0 -- which is not hypothetical: it is the
+    shape the parked recall floor produced, at 22.5x the comparisons for no
+    measured gain. Recall is the ceiling, pairs is what the ceiling costs.
+
+    Cost is O(sum of block SIZES) to index plus O(|gt_pairs|) to test -- never
+    O(candidate pairs). Enumerating the candidate set would be quadratic in
+    block size and is unnecessary: membership answers the recall question, and
+    the closed form answers the cost question.
+    """
+    row_blocks: dict[int, set[int]] = {}
+    comparisons = 0
+    for bid, members in enumerate(block_members):
+        n = 0
+        for rid in members:
+            row_blocks.setdefault(rid, set()).add(bid)
+            n += 1
+        comparisons += n * (n - 1) // 2
+
+    if not gt_pairs:
+        return {"candidate_recall": float("nan"), "candidate_pairs": comparisons}
+
+    hits = 0
+    for a, b in gt_pairs:
+        ba = row_blocks.get(a)
+        if ba and not ba.isdisjoint(row_blocks.get(b) or ()):
+            hits += 1
+
+    return {
+        "candidate_recall": hits / len(gt_pairs),
+        "candidate_pairs": comparisons,
+    }

--- a/scripts/suggest_quality/oracle.py
+++ b/scripts/suggest_quality/oracle.py
@@ -134,6 +134,17 @@ def _record_candidate_metrics(record: dict, df, config, gt_pairs: set) -> None:
     metrics must not be able to fail an otherwise-good dataset while they are
     still non-gating. The failure is stored, not dropped, so "could not
     compute" never masquerades as "not applicable".
+
+    KNOWN LIMITATION (measured 2026-08-22, do not promote this to gating
+    without fixing it): this blocks on the INPUT frame, but the pipeline blocks
+    on a PREPARED one (auto_fix -> validate -> standardize -> matchkeys ->
+    domain -> precompute -> block). A config keyed on a derived column -- e.g.
+    `dblp_acm` on `__title_key__`, which domain extraction creates -- therefore
+    raises ColumnNotFoundError here and reports no metrics at all. That is
+    precisely the dataset with the candidate-set ceiling this metric exists to
+    watch (#2633). The three datasets that DO measure all score recall 1.0000,
+    so the metric currently has no discriminating power anywhere. See the
+    MEASURED section of the design note before relying on it.
     """
     from scripts.suggest_quality.metrics import candidate_metrics  # noqa: PLC0415
 

--- a/scripts/suggest_quality/oracle.py
+++ b/scripts/suggest_quality/oracle.py
@@ -122,6 +122,40 @@ def _compute_f1(
     return result.f1
 
 
+def _record_candidate_metrics(record: dict, df, config, gt_pairs: set) -> None:
+    """Measure the blocking stage of the committed baseline config, in place.
+
+    Uses the pipeline's OWN ``build_blocks`` rather than deriving block keys
+    here. A private reimplementation would drift from what the pipeline
+    actually does and the metric would then certify a fiction -- the same
+    single-source discipline the er_matcher basis-parity gate exists for.
+
+    Advisory: a failure is recorded on the record and swallowed, because these
+    metrics must not be able to fail an otherwise-good dataset while they are
+    still non-gating. The failure is stored, not dropped, so "could not
+    compute" never masquerades as "not applicable".
+    """
+    from scripts.suggest_quality.metrics import candidate_metrics  # noqa: PLC0415
+
+    try:
+        blocking = getattr(config, "blocking", None)
+        if blocking is None:
+            record["candidate_error"] = "config has no blocking section"
+            return
+        from goldenmatch.core.blocker import build_blocks  # noqa: PLC0415
+
+        members = []
+        for block in build_blocks(df, blocking):
+            frame = block.materialize()
+            if "__row_id__" not in frame.columns:
+                record["candidate_error"] = "block frame lacks __row_id__"
+                return
+            members.append(frame.column("__row_id__").to_list())
+        record.update(candidate_metrics(members, gt_pairs))
+    except Exception as exc:  # noqa: BLE001 - advisory; recorded, never fatal
+        record["candidate_error"] = f"{type(exc).__name__}: {exc}"
+
+
 def evaluate_dataset(
     name: str,
     df: pl.DataFrame,
@@ -168,6 +202,17 @@ def evaluate_dataset(
         "convergence_steps": 0,
         "native_available": False,
         "error": None,
+        # Blocking-stage metrics (advisory for now -- see
+        # docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md).
+        # Every other metric here is DOWNSTREAM of blocking, so a blocking
+        # regression only ever surfaced as diffuse F1 wobble blamed on the
+        # scorer. candidate_recall is the ceiling; candidate_pairs is its cost.
+        "candidate_recall": float("nan"),
+        "candidate_pairs": 0,
+        # Non-None means the metrics could not be computed. Recorded rather
+        # than left as a silent nan: an un-computed metric that looks like an
+        # inapplicable one is the "check exists and does not fire" class.
+        "candidate_error": None,
     }
 
     # Ensure __row_id__ is present (needed by collision_rates in review_config)
@@ -179,6 +224,7 @@ def evaluate_dataset(
     try:
         # ── Step 1: Baseline ──────────────────────────────────────────────────
         baseline_config = _auto_configure_no_rerank(df)
+        _record_candidate_metrics(record, df, baseline_config, gt_pairs)
         baseline_clusters, baseline_scored_pairs = _run_config(df, baseline_config)
         baseline_f1 = _compute_f1(baseline_clusters, baseline_scored_pairs, gt_pairs)
         record["baseline_f1"] = baseline_f1

--- a/scripts/suggest_quality/tests/test_candidate_metrics.py
+++ b/scripts/suggest_quality/tests/test_candidate_metrics.py
@@ -72,3 +72,39 @@ def test_singleton_blocks_cost_nothing():
     m = candidate_metrics([[0], [1], [2]], {(0, 1)})
     assert m["candidate_recall"] == 0.0
     assert m["candidate_pairs"] == 0
+
+
+def test_derived_column_blocking_is_recorded_as_an_error_not_a_silent_nan():
+    """Pins the known v1 limitation so it cannot be rediscovered by surprise.
+
+    The pipeline blocks on a PREPARED frame; this metric blocks on the input
+    one. A config keyed on a column a later stage derives (dblp_acm's
+    `__title_key__`, created by domain extraction) cannot be measured here.
+
+    What this test locks is the FAILURE MODE, not the limitation: it must land
+    on `candidate_error` with a legible reason, never as a bare nan that reads
+    like "this dataset has no ground truth". If someone fixes the prep gap,
+    this test should be replaced by a real measurement -- it is a tripwire, not
+    an endorsement.
+    """
+    from scripts.suggest_quality.oracle import _record_candidate_metrics
+
+    class _BlockingCfg:
+        pass
+
+    class _Cfg:
+        blocking = _BlockingCfg()
+
+    record: dict = {}
+    # A frame lacking the derived column the config keys on. build_blocks
+    # raises; the helper must convert that into a recorded, readable error.
+    _record_candidate_metrics(record, object(), _Cfg(), {(0, 1)})
+
+    assert record.get("candidate_error"), (
+        "a failure to compute must be RECORDED -- an un-computed metric that "
+        "looks inapplicable is the check-does-not-fire class this exists to expose"
+    )
+    assert "candidate_recall" not in record or record["candidate_recall"] != 0.0, (
+        "must not report 0.0 recall on failure -- that reads as a total "
+        "blocking regression rather than 'not measured'"
+    )

--- a/scripts/suggest_quality/tests/test_candidate_metrics.py
+++ b/scripts/suggest_quality/tests/test_candidate_metrics.py
@@ -1,0 +1,74 @@
+"""Tests for the blocking-stage candidate metrics.
+
+These are the metric the suggest scorecard was missing: every gated metric is
+downstream of blocking, so a blocking regression only ever showed up as a
+diffuse F1 wobble attributable to the scorer. See
+docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md.
+"""
+import math
+
+from scripts.suggest_quality.metrics import candidate_metrics
+
+
+def test_single_block_holding_everything_is_perfect_recall_and_expensive():
+    """The degenerate case, which is exactly why recall cannot gate alone.
+
+    One block over 10 records reaches recall 1.0 -- and costs 45 comparisons.
+    A recall floor without a cost ceiling would call this an improvement.
+    """
+    m = candidate_metrics([list(range(10))], {(0, 1), (2, 3), (8, 9)})
+    assert m["candidate_recall"] == 1.0
+    assert m["candidate_pairs"] == 45  # 10*9/2
+
+
+def test_perfect_blocking_is_perfect_recall_and_cheap():
+    """Same recall as above at a fraction of the cost -- the contrast that
+    makes the pair of metrics informative rather than either one alone."""
+    m = candidate_metrics([[0, 1], [2, 3], [8, 9]], {(0, 1), (2, 3), (8, 9)})
+    assert m["candidate_recall"] == 1.0
+    assert m["candidate_pairs"] == 3  # three 2-row blocks
+
+
+def test_recall_drops_when_a_true_pair_is_split_across_blocks():
+    """The direction the gate exists to catch: a pair blocking no longer emits."""
+    m = candidate_metrics([[0, 1], [2], [3]], {(0, 1), (2, 3)})
+    assert m["candidate_recall"] == 0.5
+    assert m["candidate_pairs"] == 1
+
+
+def test_pair_co_blocked_by_two_passes_counts_once_for_recall_twice_for_cost():
+    """Multi-pass overlap: recall must not double-count, cost must.
+
+    The pair (0,1) shares two blocks. It is one recovered pair, but the scorer
+    really does compare it twice, so `candidate_pairs` counts both.
+    """
+    m = candidate_metrics([[0, 1], [0, 1]], {(0, 1)})
+    assert m["candidate_recall"] == 1.0
+    assert m["candidate_pairs"] == 2
+
+
+def test_empty_ground_truth_is_not_applicable_not_zero():
+    """Blocking-shape anchors carry no truth. Reporting 0.0 would look like a
+    total regression and would gate against nothing; nan mirrors baseline_f1."""
+    m = candidate_metrics([[0, 1, 2]], set())
+    assert math.isnan(m["candidate_recall"])
+    assert m["candidate_pairs"] == 3
+
+
+def test_gt_row_absent_from_every_block_counts_as_a_miss():
+    """A record blocking dropped entirely (null/sentinel key) is unreachable."""
+    m = candidate_metrics([[0, 1]], {(0, 1), (0, 99)})
+    assert m["candidate_recall"] == 0.5
+
+
+def test_no_blocks_is_zero_recall_not_a_crash():
+    m = candidate_metrics([], {(0, 1)})
+    assert m["candidate_recall"] == 0.0
+    assert m["candidate_pairs"] == 0
+
+
+def test_singleton_blocks_cost_nothing():
+    """n*(n-1)/2 == 0 for n<=1: blocks that cannot produce a pair are free."""
+    m = candidate_metrics([[0], [1], [2]], {(0, 1)})
+    assert m["candidate_recall"] == 0.0
+    assert m["candidate_pairs"] == 0

--- a/scripts/suggest_quality/tests/test_datasets.py
+++ b/scripts/suggest_quality/tests/test_datasets.py
@@ -117,3 +117,40 @@ def test_dblp_acm_carries_year_but_is_not_a_matchkey_column():
 
     df, _ = _dblp_acm()
     assert "year" in df.columns
+
+
+def test_dblp_acm_vendored_checksums_match_provenance():
+    """The corpus on disk is the corpus PROVENANCE.md says it is.
+
+    PROVENANCE.md records a sha256 per file but nothing asserted them, so a
+    corrupted, truncated or silently re-fetched corpus would still load and the
+    gate would happily bless numbers measured on different data. Parsing the
+    doc rather than hardcoding the digests here keeps one source of truth: if
+    someone re-fetches upstream and updates the files, this fails until the
+    doc is updated to match (and vice versa).
+    """
+    import hashlib
+    import re
+
+    from scripts.suggest_quality.datasets import _VENDORED
+
+    d = _VENDORED / "DBLP-ACM"
+    prov = (d / "PROVENANCE.md").read_text(encoding="utf-8")
+
+    # rows look like: | `DBLP2.csv` | `<64 hex>` |
+    documented = dict(
+        re.findall(r"\|\s*`([^`]+\.csv)`\s*\|\s*`([0-9a-f]{64})`\s*\|", prov)
+    )
+    assert len(documented) == 3, (
+        f"expected 3 checksum rows in PROVENANCE.md, parsed {len(documented)}: "
+        f"{sorted(documented)}"
+    )
+
+    for fname, expected in sorted(documented.items()):
+        actual = hashlib.sha256((d / fname).read_bytes()).hexdigest()
+        assert actual == expected, (
+            f"{fname} does not match PROVENANCE.md: expected {expected}, got "
+            f"{actual}. Either the vendored file changed (re-fetched or "
+            f"corrupted) or the doc is stale -- reconcile before trusting any "
+            f"number measured on this corpus."
+        )


### PR DESCRIPTION
> **Three related topics, all "a check exists and does not fire".** Topics 1–2 are complete and verified. Topic 3 ships **advisory and knowingly incomplete** — read its limitation before relying on it. Happy to split; they share a branch because this session has one designated branch.

## 1. The #2635 guard tests never ran — now they do

#2635 (merged in #2721) vendored the DBLP-ACM corpus and added guards asserting it is present and loads. **Nothing in CI ran them.** First attempt added them to `ci.yml`'s `scripts_lint`; CI then caught what local runs could not:

```
test_datasets.py -> datasets.py:24 -> autoconfig_quality/anchors.py:21
  -> repro_issue_715:38 -> ModuleNotFoundError: No module named 'goldenmatch'
```

The registry transitively needs goldenmatch, and that job syncs `--no-install-workspace` by design. (I had asserted these needed only polars, from reading `anchors.py` with `head -20`; the import is on line 21.) Making it lazy would not help either — `test_anchors_always_load` calls the sparse-zip loader for real.

So they moved to `bench-suggest-quality.yml`, which already syncs the workspace and is already push-gated on `scripts/suggest_quality/**`. `ci.yml` ends up byte-identical to main. **Verified at step level** on the run for `91ab1e73`: `Pytest (suggest_quality dataset guards)` → *success*, not skipped.

**Honest downgrade:** that workflow is **not** in `ci-required`, so a failure there will not block a PR the way `scripts_lint` would have. A `ci-required` home needs a workspace-synced job gated on `scripts/suggest_quality/**`, and none exists today.

## 2. The vendored corpus is now pinned to its provenance

`PROVENANCE.md` recorded a sha256 per file and nothing asserted them, so a corrupted or silently re-fetched corpus would still load and the gate would bless numbers measured on different data. The test parses digests out of the doc rather than hardcoding them, so doc and data cannot drift apart. **Negative control run:** appending one byte to `ACM.csv` fails it; restoring passes.

## 3. Blocking-stage metrics — advisory, and NOT close to gating

Implements step 1 of the design note: report `candidate_recall` + `candidate_pairs` per dataset, non-gating. Every metric the scorecard gates is downstream of blocking; nothing measured what fraction of true pairs blocking actually *generated*.

Two design points that hold up: the metrics **must gate together** (recall alone is trivially gamed by one all-rows block — the shape the parked recall floor produced at 22.5× comparisons), and **no candidate enumeration** (index row→blocks in O(Σ block sizes), test each ground-truth pair for shared membership in O(|gt|), take cost from the `sum(n*(n-1)/2)` closed form).

**Measured, and it does not yet do its job** (reproduced by two independent paths):

| dataset | candidate_recall | candidate_pairs | error |
|---|---|---|---|
| `dblp_acm` | — | — | `ColumnNotFoundError: __title_key__` |
| `anchor_person_match` | 1.0000 | 1,712 | — |
| `synthetic` | 1.0000 | 861 | — |
| `ncvr_synthetic` | 1.0000 | 434,530 | — |

- **Fails on derived-column configs.** The pipeline blocks on a *prepared* frame (`auto_fix → validate → standardize → matchkeys → domain → precompute → block`); this measures the input frame. `dblp_acm` keys on `__title_key__`, which domain extraction creates — so the metric is unmeasurable on exactly the dataset whose ceiling motivated it (#2633).
- **No discriminating power where it works.** Three datasets, all exactly 1.0000; a 0.02 drop-floor could never fire. `candidate_pairs` does look alive.

Together these **invalidate the design note's rollout assumption** that an advisory cycle would produce a distribution to calibrate thresholds against — the real distribution is `{1.0, 1.0, 1.0, error}`. Recorded in the note's MEASURED section, in the helper docstring, and as a tripwire test pinning the failure mode (a derived-column config must surface on `candidate_error`, never a bare nan reading as "no ground truth").

What survives: the pure helper and its tests are correct and regime-independent, and the failure is *recorded* rather than swallowed, so the gap is visible in the scorecard instead of latent.

## Changes

- `scripts/suggest_quality/vendored/DBLP-ACM/` — checksum test against `PROVENANCE.md`
- `.github/workflows/bench-suggest-quality.yml` — run the dataset guards where the workspace exists
- `scripts/suggest_quality/metrics.py` — `candidate_metrics` pure helper
- `scripts/suggest_quality/oracle.py` — advisory, fail-soft hook + recorded limitation
- `scripts/suggest_quality/tests/` — 9 metric tests + 4 corpus guards
- `docs/superpowers/specs/2026-08-21-candidate-recall-gate-design.md` — design + MEASURED section

## Testing

```
PYTHONPATH=. uv run pytest scripts/suggest_quality/tests/ -q     -> 20 passed
uv run python scripts/check_workflow_yaml.py                     -> 130 files, no dup keys
uv run ruff check scripts/suggest_quality/                       -> clean
```
Plus the step-level CI confirmation above, and the two real-dataset measurement runs.

Not run: `pre-commit run --all-files`, full package pytest lanes.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean — ruff run on the touched tree only
- [ ] Package `CHANGELOG.md` updated if behavior changed — n/a, harness + docs only
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — sys.path + prep-frame gotchas recorded inline and in the design note