### PR TITLE
chore(scoreboard): nightly adoption snapshot

### DIFF
--- a/context-network/planning/scoreboard.jsonl
+++ b/context-network/planning/scoreboard.jsonl
@@ -10,3 +10,4 @@
 {"date": "2026-08-19", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 5495}
 {"date": "2026-08-20", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 5483}
 {"date": "2026-08-21", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 5483}
+{"date": "2026-08-22", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 5487}

--- a/context-network/planning/scoreboard.md
+++ b/context-network/planning/scoreboard.md
@@ -5,14 +5,14 @@
 [north-star-roadmap.md](./north-star-roadmap.md): *is GoldenMatch becoming the
 tool developers reach for by default?* Trend > snapshot.
 
-**Latest: 2026-08-21** (vs previous snapshot)
+**Latest: 2026-08-22** (vs previous snapshot)
 
 | Signal | Now | WoW | North Star reading |
 |---|---|---|---|
 | GitHub stars | 129 | 129 (▬0) | discovery momentum |
 | Forks | 13 | 13 (▬0) | intent-to-use |
 | PyPI downloads (30d, suite) | — | — | actual reach |
-| npm downloads (30d, suite) | 5.5k | 5.5k (▬0) | actual reach (TS) |
+| npm downloads (30d, suite) | 5.5k | 5.5k (▲+4) | actual reach (TS) |
 | Open issues, non-maintainer | 1 | 1 (▬0) | "someone reached for it"† |
 
 † Raw count — still needs human triage to exclude badge-marketing bots
@@ -23,6 +23,7 @@ GENUINE inbound issue from a stranger**; a bot filing a promo badge does not cou
 
 | Date | Stars | Forks | PyPI 30d | npm 30d | Ext. issues |
 |---|---|---|---|---|---|
+| 2026-08-22 | 129 | 13 | — | 5.5k | 1 |
 | 2026-08-21 | 129 | 13 | — | 5.5k | 1 |
 | 2026-08-20 | 129 | 13 | — | 5.5k | 1 |
 | 2026-08-19 | 129 | 13 | — | 5.5k | 1 |


### PR DESCRIPTION
Nightly North Star adoption snapshot: stars, forks, PyPI/npm 30-day
downloads and non-maintainer inbound issues, appended to the trend.

Generated by `scripts/scoreboard.py` via `.github/workflows/scoreboard.yml`.
The `.md` is rewritten wholesale from the `.jsonl` each run; the new
data is the single appended row.
