### PR TITLE
chore(release): goldenmatch 3.16.0

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.15.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.16.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.16.0] - 2026-08-23
+
 ### Fixed
 
 - **Auto-config spent its whole iteration budget on a lever that cannot move

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -47,7 +47,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.15.0"
+__version__ = "3.16.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.15.0"
+version = "3.16.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "goldenmatch"
-version = "3.15.0"
+version = "3.16.0"
 source = { editable = "packages/python/goldenmatch" }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
MINOR — the `Unreleased` section carries an `Added` (segment labels #2574, and `ClusterConfig` from #2732) alongside the fixes.

**Why cut now rather than keep accumulating:** zero-config `match_df` committed a RED config on *every* auto-config iteration for any two frames whose columns differ. The GoldenCheck exclusions were dropped from the target frame only, so the two frames reached `run_match_df` at different widths and its polars lane concatenates with a strict `pl.concat`. That is the ordinary case of linking two sources with slightly different schemas — everyone on 3.15.0 hits it, and the fix has been sitting on main since #2730.

Version carriers bumped in lockstep, which `cut-goldenmatch-release.yml` guards on:

- `packages/python/goldenmatch/pyproject.toml`
- `packages/python/goldenmatch/goldenmatch/__init__.py`
- `packages/python/goldenmatch/server.json` (×2)
- `uv.lock`

After this lands, the release is cut with `gh workflow run cut-goldenmatch-release.yml -f version=3.16.0` — **not** `gh release create`, which would publish an immutable release immediately and permanently tombstone the tag name (the v3.5.0 / v2.1.0 incidents).

Follow-up, per the suite lockstep rule: `golden-suite` pins `goldenmatch[polars]>=3.14` and its floor should move once 3.16.0 is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P