### PR TITLE
fix(autoconfig): choose the blocking column by identity and the strategy by shape (#2717)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1872,6 +1872,7 @@
             "_auto_build_lsh_config",
             "_auto_semantic_blocking_enabled",
             "_autoconfig_memory_disabled",
+            "_best_sketch_column",
             "_blocking_pairs_per_row_budget",
             "_bound_probabilistic_blocking_pairs",
             "_build_compound_blocking",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1953,6 +1953,7 @@
             "_promote_facility_fullname_ne",
             "_quality_aware_blocking_enabled",
             "_rebuild_from_decisions",
+            "_require_sketch_column",
             "_resolve_effective_exclusion_overrides",
             "_route_to_probabilistic_enabled",
             "_scale_safe_bounded_compound",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,52 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+
+- **Blocking chose its sketch column by LENGTH and its strategy by branch, not
+  by measurement (#2717).** Two compounding heuristic errors on the text-corpus
+  path. `_auto_build_lsh_config` picked `max(avg_len)` -- the longest text
+  column, which is the most verbose and the LEAST identifying. And that branch
+  committed MinHash/LSH for everything it reached, where `blocking.mdx` already
+  prescribed `token` for short free text.
+
+  Abt-Buy, whose two text columns both profile as `col_type=description`:
+
+      name         avg_len= 54.3  cardinality=0.994   <- identity lives here
+      description  avg_len=178.5  cardinality=0.771   <- max(avg_len) picked this
+
+  Ground-truth blocking recall through the shipped blocker:
+
+      lsh   on 'description' (committed)   0.0009
+      lsh   on 'name'                      0.1139
+      token on 'name' (max_df 0.02)        0.9198
+
+  The sketch column is now chosen by cardinality (length kept as the
+  tie-breaker), and a chosen column at or below 120 average characters routes to
+  `token` rather than `lsh`. Weighted-path blocking recall **0.0684 -> 0.5662**,
+  and **Abt-Buy's linkage F1 0.5658 -> 0.7024** (precision 0.8529, recall
+  0.4093 -> 0.5971).
+
+  Amazon-Google never showed the bug because it carries a `manufacturer` column
+  profiling as `col_type=name`, which routes it away from this branch entirely.
+  Luck, not design -- hence a heuristic fix rather than a special case.
+
+### Changed
+
+- **Abt-Buy's dedupe quarantine baseline re-pointed DOWNWARD, to 0.0881, because
+  the engine got better.** That lane scores a concatenated frame against a
+  cross-source mapping, so better blocking surfaces more candidates, most of the
+  extra ones are same-source and unmatchable by construction, and precision
+  falls faster than recall rises (0.1068 -> 0.0470 against 0.4463 -> 0.7075).
+  It is a metric that punishes the fix. Not a floor lowered to make a lane
+  green: the quarantine is re-pointed at the current run so a genuine NEW
+  regression still trips it, and the breaches are still reported on every run.
+- **`Abt-Buy (linkage)` now carries the 0.45 floor.** That floor was DERIVED
+  from a linkage run (0.5037 / P 0.8219 / 494 emitted pairs) and then enforced
+  against the dedupe lane for months, recorded there as DISPUTED and
+  unreproducible. It is applied to the lane it describes, cleared with margin at
+  a measured 0.7024.
+
 ## [3.16.0] - 2026-08-23
 
 ### Fixed

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3582,6 +3582,51 @@ def _embedder_available(config: GoldenMatchConfig | None = None) -> bool:
     return bool(getattr(getattr(config, "embedding", None), "provider", None))
 
 
+def _best_sketch_column(profiles: list[ColumnProfile]) -> str | None:
+    """The text column a blocking sketch should be built on.
+
+    Chosen by IDENTITY (cardinality), not by LENGTH. The previous rule was
+    ``max(avg_len)`` -- the longest text column -- which is backwards: the
+    longest free-text field is the most verbose and the least identifying,
+    because it shares boilerplate with every other row.
+
+    Measured on Abt-Buy, whose two text columns BOTH profile as
+    ``col_type=description`` so neither is treated as a structured key:
+
+        name         avg_len= 54.3  cardinality=0.994   <- identity lives here
+        description  avg_len=178.5  cardinality=0.771   <- max(avg_len) picked this
+
+    Ground-truth blocking recall through the shipped blocker, on the plan
+    auto-config actually committed versus the alternatives:
+
+        lsh on 'description' (committed)   0.0009
+        lsh on 'name'                      0.1139
+        token on 'name' (max_df 0.02)      0.9198
+
+    Amazon-Google escaped this only because it carries a `manufacturer` column
+    profiling as ``col_type=name`` with cardinality 0.162, which trips
+    ``_is_text_corpus``'s blockable-name test and routes it away from this
+    branch entirely. That is luck, not design.
+
+    Length is kept as the TIE-BREAKER: with nothing to choose on identity, a
+    longer column carries more shingles for a sketch to work with, which is the
+    grain of truth the old rule was reaching for.
+    """
+    if not profiles:
+        return None
+    # NO upper ceiling on cardinality, deliberately. The first version of this
+    # capped it at 0.99 on the reasoning that a per-row-unique column "blocks
+    # nothing, every value is its own block" -- which is true of an EXACT key
+    # and false of a sketch. LSH and token blocking group by shared
+    # shingles/tokens, not by equality, so a near-unique column is the IDEAL
+    # sketch target: Abt-Buy's `name` is cardinality 0.994 and reaches 0.9198
+    # blocking recall under token blocking. The cap excluded exactly the column
+    # this function exists to pick.
+    return max(
+        profiles, key=lambda p: (round(p.cardinality_ratio, 3), p.avg_len)
+    ).name
+
+
 def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> BlockingConfig:
     """Build a MinHash/LSH blocking config over the longest description column.
 
@@ -3591,7 +3636,7 @@ def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> BlockingConfig:
     """
     from goldenmatch.config.schemas import LSHKeyConfig
     descs = [p for p in profiles if p.col_type == "description"]
-    col = max(descs, key=lambda p: p.avg_len).name
+    col = _best_sketch_column(descs)
     return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(
         column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
 
@@ -3610,10 +3655,9 @@ def _text_corpus_blocking(
     if _embedder_available(config):
         from goldenmatch.config.schemas import BlockingConfig, SimHashKeyConfig
 
-        col = max(
-            (p for p in profiles if p.col_type == "description"),
-            key=lambda p: p.avg_len,
-        ).name
+        col = _best_sketch_column(
+            [p for p in profiles if p.col_type == "description"]
+        )
         return BlockingConfig(
             strategy="simhash",
             simhash=SimHashKeyConfig(column=col, num_planes=256, num_bands=32, seed=0),
@@ -3680,13 +3724,13 @@ def _throughput_blocking(
         return _text_corpus_blocking(profiles, None, config)
     if _embedder_available(config):
         from goldenmatch.config.schemas import SimHashKeyConfig
-        col = max(text_cols, key=lambda p: p.avg_len).name
+        col = _best_sketch_column(text_cols)
         return BlockingConfig(
             strategy="simhash",
             simhash=SimHashKeyConfig(column=col, num_planes=256, num_bands=32, seed=0),
         )
     from goldenmatch.config.schemas import LSHKeyConfig
-    col = max(text_cols, key=lambda p: p.avg_len).name
+    col = _best_sketch_column(text_cols)
     return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(
         column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3582,6 +3582,13 @@ def _embedder_available(config: GoldenMatchConfig | None = None) -> bool:
     return bool(getattr(getattr(config, "embedding", None), "provider", None))
 
 
+#: Average character length at or below which a free-text column is "short
+#: free text" (a product title, a headline) rather than a document, and blocks
+#: better with `token` than with `lsh`. See `_text_corpus_blocking` for the
+#: measurement and for why this is a calibration rather than a derived value.
+_SHORT_FREE_TEXT_MAX_LEN = 120.0
+
+
 def _best_sketch_column(profiles: list[ColumnProfile]) -> str | None:
     """The text column a blocking sketch should be built on.
 
@@ -3652,12 +3659,47 @@ def _text_corpus_blocking(
     near-duplicates that share meaning but little surface text — the lexical
     fallback only catches shared shingles. See #1082.
     """
+    descs = [p for p in profiles if p.col_type == "description"]
+    col = _best_sketch_column(descs)
+
+    # SHORT free text blocks with `token`, documents with `lsh`. `blocking.mdx`
+    # already prescribed exactly this -- "use `lsh` for near-duplicate
+    # documents, `token` for short free text where only a few tokens agree" --
+    # and the text-corpus branch committed LSH for everything it reached.
+    #
+    # Ground-truth blocking recall on Abt-Buy through the shipped blocker:
+    #
+    #   lsh   on 'name'        (thr 0.5)      0.1139    5,082 comparisons
+    #   lsh   on 'name'        (thr 0.2)      0.5123   64,466
+    #   token on 'name'        (max_df 0.02)  0.9198   64,056
+    #   lsh   on 'description' (thr 0.5)      0.0009   13,071
+    #   token on 'description' (max_df 0.02)  0.3801  137,720
+    #
+    # At equal cost -- ~64k comparisons -- token nearly DOUBLES LSH's recall on
+    # the same column. The bar is read off the CHOSEN column (see
+    # `_best_sketch_column`), never off the longest one: reading it off the
+    # longest would send this shape back to LSH through the back door.
+    #
+    # `_SHORT_FREE_TEXT_MAX_LEN` is calibrated on the datasets available here
+    # and separates them with room to spare -- Abt-Buy `name` 54.3 and
+    # Amazon-Google `title` 51.1 on one side, Abt-Buy `description` 178.5 and
+    # Amazon-Google `description` 551.2 on the other. Stated as a limitation
+    # rather than presented as derived: a genuine document corpus (FineWeb-style,
+    # thousands of characters) is far above it, which is the case LSH was built
+    # for and keeps.
+    _chosen = next((p for p in descs if p.name == col), None)
+    if _chosen is not None and _chosen.avg_len <= _SHORT_FREE_TEXT_MAX_LEN:
+        from goldenmatch.config.schemas import BlockingConfig, TokenBlockingConfig
+
+        return BlockingConfig(
+            strategy="token",
+            token=TokenBlockingConfig(column=col, min_token_length=3,
+                                      max_df_ratio=0.02),
+        )
+
     if _embedder_available(config):
         from goldenmatch.config.schemas import BlockingConfig, SimHashKeyConfig
 
-        col = _best_sketch_column(
-            [p for p in profiles if p.col_type == "description"]
-        )
         return BlockingConfig(
             strategy="simhash",
             simhash=SimHashKeyConfig(column=col, num_planes=256, num_bands=32, seed=0),

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3634,6 +3634,24 @@ def _best_sketch_column(profiles: list[ColumnProfile]) -> str | None:
     ).name
 
 
+def _require_sketch_column(profiles: list[ColumnProfile]) -> str:
+    """`_best_sketch_column` for callers that already guarantee a candidate.
+
+    The sketch-config builders all run behind a check that a text column exists
+    (`_is_text_corpus`, or `sketchable_text_cols` returning non-empty), and the
+    code they replaced -- `max(profiles, key=...)` -- raised on an empty list.
+    Keeping that contract here means those call sites stay `str`-typed instead
+    of threading an `Optional` they can never actually receive.
+    """
+    col = _best_sketch_column(profiles)
+    if col is None:
+        raise ValueError(
+            "no candidate text column for a blocking sketch; the caller is "
+            "expected to check for one before building a sketch config"
+        )
+    return col
+
+
 def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> BlockingConfig:
     """Build a MinHash/LSH blocking config over the longest description column.
 
@@ -3643,7 +3661,7 @@ def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> BlockingConfig:
     """
     from goldenmatch.config.schemas import LSHKeyConfig
     descs = [p for p in profiles if p.col_type == "description"]
-    col = _best_sketch_column(descs)
+    col = _require_sketch_column(descs)
     return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(
         column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
 
@@ -3660,7 +3678,7 @@ def _text_corpus_blocking(
     fallback only catches shared shingles. See #1082.
     """
     descs = [p for p in profiles if p.col_type == "description"]
-    col = _best_sketch_column(descs)
+    col = _require_sketch_column(descs)
 
     # SHORT free text blocks with `token`, documents with `lsh`. `blocking.mdx`
     # already prescribed exactly this -- "use `lsh` for near-duplicate
@@ -3687,8 +3705,13 @@ def _text_corpus_blocking(
     # rather than presented as derived: a genuine document corpus (FineWeb-style,
     # thousands of characters) is far above it, which is the case LSH was built
     # for and keeps.
+    # `0 <` deliberately: `avg_len` defaults to 0 on a hand-built ColumnProfile,
+    # which means UNKNOWN, not "short". Routing unknown-length text to `token`
+    # would be a silent behaviour change for every caller that constructs
+    # profiles directly rather than measuring them, so an unmeasured column
+    # falls through to the prior lsh/simhash behaviour.
     _chosen = next((p for p in descs if p.name == col), None)
-    if _chosen is not None and _chosen.avg_len <= _SHORT_FREE_TEXT_MAX_LEN:
+    if _chosen is not None and 0 < _chosen.avg_len <= _SHORT_FREE_TEXT_MAX_LEN:
         from goldenmatch.config.schemas import BlockingConfig, TokenBlockingConfig
 
         return BlockingConfig(
@@ -3766,13 +3789,13 @@ def _throughput_blocking(
         return _text_corpus_blocking(profiles, None, config)
     if _embedder_available(config):
         from goldenmatch.config.schemas import SimHashKeyConfig
-        col = _best_sketch_column(text_cols)
+        col = _require_sketch_column(text_cols)
         return BlockingConfig(
             strategy="simhash",
             simhash=SimHashKeyConfig(column=col, num_planes=256, num_bands=32, seed=0),
         )
     from goldenmatch.config.schemas import LSHKeyConfig
-    col = _best_sketch_column(text_cols)
+    col = _require_sketch_column(text_cols)
     return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(
         column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
 

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -405,6 +405,9 @@ class TestBuildBlocking:
         profiles = [
             ColumnProfile("desc", "Utf8", "description", 0.7),
         ]
+        # The profile above is hand-built, so its `avg_len` is 0 -- UNKNOWN, not
+        # short -- and an unmeasured column keeps the lsh/simhash route (#2717).
+        # The df text does not drive the choice here; the passed profile does.
         df = pl.DataFrame({"desc": ["long text here"] * 3})
         blocking = build_blocking(profiles, df)
         assert blocking.strategy == "lsh"

--- a/packages/python/goldenmatch/tests/test_short_free_text_blocking.py
+++ b/packages/python/goldenmatch/tests/test_short_free_text_blocking.py
@@ -1,0 +1,77 @@
+"""Short free text blocks with `token`, documents with `lsh` (#2717).
+
+The text-corpus branch committed MinHash/LSH for anything it reached, and
+`blocking.mdx` already prescribed otherwise: "Use `lsh` for near-duplicate
+documents, `token` for short free text where only a few tokens agree." A
+product title is the second case, not the first.
+
+Ground-truth blocking recall on Abt-Buy through the shipped blocker, per column
+and strategy:
+
+    lsh   on 'name'        (thr 0.5)          0.1139   5,082 comparisons
+    lsh   on 'name'        (thr 0.2)          0.5123  64,466
+    token on 'name'        (max_df 0.02)      0.9198  64,056
+    lsh   on 'description' (thr 0.5)          0.0009  13,071
+    token on 'description' (max_df 0.02)      0.3801 137,720
+
+At equal cost -- ~64k comparisons -- token nearly doubles LSH's recall on the
+same column.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig import (
+    _SHORT_FREE_TEXT_MAX_LEN,
+    ColumnProfile,
+    _text_corpus_blocking,
+)
+
+
+def _prof(name: str, avg_len: float, cardinality: float) -> ColumnProfile:
+    return ColumnProfile(
+        name=name, dtype="String", col_type="description", confidence=1.0,
+        null_rate=0.0, cardinality_ratio=cardinality, avg_len=avg_len,
+    )
+
+
+def test_abt_buy_shape_routes_to_token_on_the_identifying_column():
+    """The measured case: product names, 54 chars, the highest-cardinality
+    column of the two."""
+    blocking = _text_corpus_blocking([
+        _prof("name", avg_len=54.3, cardinality=0.994),
+        _prof("description", avg_len=178.5, cardinality=0.771),
+    ])
+    assert blocking.strategy == "token"
+    assert blocking.token is not None
+    assert blocking.token.column == "name"
+
+
+def test_a_long_document_column_still_gets_lsh():
+    """LSH's designed case -- near-duplicate documents -- is untouched. A
+    web-crawl corpus is hundreds of characters per row, not fifty."""
+    blocking = _text_corpus_blocking([
+        _prof("body", avg_len=3200.0, cardinality=0.999),
+    ])
+    assert blocking.strategy == "lsh"
+    assert blocking.lsh is not None
+    assert blocking.lsh.column == "body"
+
+
+def test_the_bar_is_read_off_the_chosen_column_not_the_longest():
+    """Column choice happens FIRST, then the strategy follows from THAT
+    column's length. Reading the bar off the longest column would send the
+    Abt-Buy shape to LSH again via the back door."""
+    profiles = [
+        _prof("name", avg_len=54.3, cardinality=0.994),
+        _prof("description", avg_len=900.0, cardinality=0.771),
+    ]
+    blocking = _text_corpus_blocking(profiles)
+    assert blocking.strategy == "token"
+    assert blocking.token.column == "name"
+
+
+def test_the_boundary_is_inclusive_and_documented():
+    """Pin the constant so a future change to it is a deliberate act."""
+    short = _text_corpus_blocking([_prof("c", _SHORT_FREE_TEXT_MAX_LEN, 0.9)])
+    long_ = _text_corpus_blocking([_prof("c", _SHORT_FREE_TEXT_MAX_LEN + 1, 0.9)])
+    assert short.strategy == "token"
+    assert long_.strategy == "lsh"

--- a/packages/python/goldenmatch/tests/test_short_free_text_blocking.py
+++ b/packages/python/goldenmatch/tests/test_short_free_text_blocking.py
@@ -75,3 +75,15 @@ def test_the_boundary_is_inclusive_and_documented():
     long_ = _text_corpus_blocking([_prof("c", _SHORT_FREE_TEXT_MAX_LEN + 1, 0.9)])
     assert short.strategy == "token"
     assert long_.strategy == "lsh"
+
+
+def test_an_unmeasured_column_keeps_the_document_route():
+    """`avg_len` 0 means UNKNOWN, not short.
+
+    A hand-built `ColumnProfile` defaults `avg_len` to 0. Reading that as
+    "short" would silently move every caller that constructs profiles directly
+    rather than measuring them -- which is how `test_autoconfig.py` builds them,
+    and how it caught this.
+    """
+    blocking = _text_corpus_blocking([_prof("desc", avg_len=0.0, cardinality=0.7)])
+    assert blocking.strategy == "lsh"

--- a/packages/python/goldenmatch/tests/test_sketch_column_choice.py
+++ b/packages/python/goldenmatch/tests/test_sketch_column_choice.py
@@ -1,0 +1,84 @@
+"""The blocking sketch column is chosen by identity, not by length (#2717).
+
+`_auto_build_lsh_config` and friends picked `max(avg_len)` -- the LONGEST text
+column. That is backwards: the longest free-text field is the most verbose and
+the least identifying, because it shares boilerplate with every other row.
+
+Measured on Abt-Buy, whose two text columns both profile as `col_type=description`:
+
+    name         avg_len= 54.3  cardinality=0.994   <- identity lives here
+    description  avg_len=178.5  cardinality=0.771   <- picked by max(avg_len)
+
+Ground-truth blocking recall through the shipped blocker:
+
+    lsh on 'description' (committed)   0.0009
+    lsh on 'name'                      0.1139
+    token on 'name' (max_df 0.02)      0.9198
+
+Amazon-Google escaped this only because it carries a `manufacturer` column that
+profiles as `col_type=name` with cardinality 0.162, which trips
+`_is_text_corpus`'s blockable-name test and routes it away from the LSH branch
+entirely. Luck, not design -- which is why this fixes the heuristic rather than
+special-casing a dataset.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig import ColumnProfile, _best_sketch_column
+
+
+def _prof(name: str, avg_len: float, cardinality: float,
+          col_type: str = "description") -> ColumnProfile:
+    return ColumnProfile(
+        name=name, dtype="String", col_type=col_type, confidence=1.0,
+        null_rate=0.0, cardinality_ratio=cardinality, avg_len=avg_len,
+    )
+
+
+def test_picks_the_identifying_column_not_the_longest():
+    """The Abt-Buy shape, with its measured profile values."""
+    profiles = [
+        _prof("name", avg_len=54.3, cardinality=0.994),
+        _prof("description", avg_len=178.5, cardinality=0.771),
+    ]
+    assert _best_sketch_column(profiles) == "name"
+
+
+def test_length_still_breaks_a_cardinality_tie():
+    """With nothing to choose on identity, the longer column carries more
+    shingles for a sketch to work with, so the old preference stands."""
+    profiles = [
+        _prof("short", avg_len=20.0, cardinality=0.90),
+        _prof("long", avg_len=200.0, cardinality=0.90),
+    ]
+    assert _best_sketch_column(profiles) == "long"
+
+
+def test_a_near_unique_column_is_a_fine_sketch_target():
+    """There is deliberately NO upper cardinality ceiling.
+
+    The first version of this capped cardinality at 0.99, reasoning that a
+    per-row-unique column blocks nothing because every value is its own block.
+    That is true of an EXACT key and false of a sketch: LSH and token blocking
+    group by shared shingles/tokens, not by equality. Abt-Buy's `name` is
+    cardinality 0.994 -- the cap excluded the very column this function exists
+    to pick, and this test failed until it was removed.
+    """
+    profiles = [
+        _prof("blob", avg_len=500.0, cardinality=1.0),
+        _prof("title", avg_len=50.0, cardinality=0.95),
+    ]
+    assert _best_sketch_column(profiles) == "blob"
+
+
+def test_empty_input_returns_none_rather_than_raising():
+    assert _best_sketch_column([]) is None
+
+
+def test_amazon_google_shape_is_unchanged():
+    """It never reaches this path (its `manufacturer` column routes it away),
+    but if it ever did, `title` is still the right answer."""
+    profiles = [
+        _prof("title", avg_len=51.1, cardinality=0.978),
+        _prof("description", avg_len=551.2, cardinality=0.899),
+    ]
+    assert _best_sketch_column(profiles) == "title"

--- a/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
@@ -63,14 +63,30 @@ def test_multi_name_high_card_blocks_text_corpus():
 def test_build_blocking_routes_text_corpus_to_lsh():
     from goldenmatch.core.autoconfig import build_blocking, profile_columns
 
-    base = "the quick brown fox jumps over the lazy dog near the river bank"
+    # DOCUMENT-length on purpose. These fixtures used ~63-character sentences
+    # to stand in for a document corpus, which is shorter than a product title
+    # -- and short free text now routes to `token` rather than `lsh` (#2717,
+    # `_SHORT_FREE_TEXT_MAX_LEN`). The intent of these tests is "a DOCUMENT
+    # corpus gets near-duplicate blocking", so the fixture is made to match its
+    # own description rather than the assertion being flipped.
+    # No commas: comma-separated text profiles as `multi_name`, not
+    # `description`, which drops the frame out of `_is_text_corpus` entirely --
+    # a first attempt at this padding did exactly that and routed to `static`.
+    _pad = (
+        " the passage continues at length describing the surrounding landscape"
+        " and the weather over several days and the habits of the people who"
+        " live nearby in the unhurried manner of a document rather than a title"
+    )
+    base = (
+        "the quick brown fox jumps over the lazy dog near the river bank" + _pad
+    )
     variants = [
         base,
         base.replace("quick", "fast"),
         base.replace("lazy", "sleepy"),
-        "a completely different statement about astronomy and distant galaxies far away",
-        "yet another unrelated remark concerning gardening tools and spring planting",
-        "an entirely separate note discussing maritime navigation and old sailing charts",
+        "a completely different statement about astronomy and distant galaxies far away" + _pad,
+        "yet another unrelated remark concerning gardening tools and spring planting" + _pad,
+        "an entirely separate note discussing maritime navigation and old sailing charts" + _pad,
     ]
     df = pl.DataFrame({"body": variants * 5})
     profiles = profile_columns(df)
@@ -86,14 +102,30 @@ def test_build_blocking_routes_text_corpus_to_lsh():
 
 
 def _text_corpus_df() -> pl.DataFrame:
-    base = "the quick brown fox jumps over the lazy dog near the river bank"
+    # DOCUMENT-length on purpose. These fixtures used ~63-character sentences
+    # to stand in for a document corpus, which is shorter than a product title
+    # -- and short free text now routes to `token` rather than `lsh` (#2717,
+    # `_SHORT_FREE_TEXT_MAX_LEN`). The intent of these tests is "a DOCUMENT
+    # corpus gets near-duplicate blocking", so the fixture is made to match its
+    # own description rather than the assertion being flipped.
+    # No commas: comma-separated text profiles as `multi_name`, not
+    # `description`, which drops the frame out of `_is_text_corpus` entirely --
+    # a first attempt at this padding did exactly that and routed to `static`.
+    _pad = (
+        " the passage continues at length describing the surrounding landscape"
+        " and the weather over several days and the habits of the people who"
+        " live nearby in the unhurried manner of a document rather than a title"
+    )
+    base = (
+        "the quick brown fox jumps over the lazy dog near the river bank" + _pad
+    )
     variants = [
         base,
         base.replace("quick", "fast"),
         base.replace("lazy", "sleepy"),
-        "a completely different statement about astronomy and distant galaxies far away",
-        "yet another unrelated remark concerning gardening tools and spring planting",
-        "an entirely separate note discussing maritime navigation and old sailing charts",
+        "a completely different statement about astronomy and distant galaxies far away" + _pad,
+        "yet another unrelated remark concerning gardening tools and spring planting" + _pad,
+        "an entirely separate note discussing maritime navigation and old sailing charts" + _pad,
     ]
     return pl.DataFrame({"body": variants * 5})
 
@@ -410,18 +442,30 @@ def test_zero_config_text_corpus_dedupe_e2e():
     import goldenmatch
     from goldenmatch.core.autoconfig import auto_configure_df
 
-    base = "the annual budget report shows a significant increase in marketing spend"
+    # Document-length, and comma-free so the column keeps profiling as
+    # `description`. At its original ~80 characters this corpus was SHORTER
+    # than a product title, and short free text now routes to `token` rather
+    # than `lsh` (#2717). Padding it keeps this test covering the LSH path
+    # end-to-end; the short-text path has its own coverage in
+    # test_short_free_text_blocking.py.
+    _pad = (
+        " the report goes on for several more paragraphs setting out the"
+        " underlying assumptions and the methodology used to arrive at them"
+        " together with a long appendix of supporting tables and commentary"
+    )
+    base = ("the annual budget report shows a significant increase in marketing spend"
+            + _pad)
     near_dups = [
         base,
         base.replace("significant", "substantial"),
         base.replace("marketing", "advertising"),
     ]
     distinct = [
-        "weather patterns over the pacific ocean shifted dramatically this winter season",
-        "the museum unveiled a new exhibit featuring ancient pottery from coastal villages",
-        "local farmers reported record yields after an unusually wet and mild growing year",
-        "the orchestra performed a moving rendition of a forgotten romantic era symphony",
-        "engineers completed the suspension bridge two months ahead of the planned schedule",
+        "weather patterns over the pacific ocean shifted dramatically this winter season" + _pad,
+        "the museum unveiled a new exhibit featuring ancient pottery from coastal villages" + _pad,
+        "local farmers reported record yields after an unusually wet and mild growing year" + _pad,
+        "the orchestra performed a moving rendition of a forgotten romantic era symphony" + _pad,
+        "engineers completed the suspension bridge two months ahead of the planned schedule" + _pad,
     ]
     rows = near_dups + distinct
     df = pl.DataFrame({"text": rows})

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -637,7 +637,13 @@ _F1_FLOORS: dict[str, float | None] = {
     # baseline, so no floor is claimed until the lane has published one. They are
     # deliberately NOT quarantined either: a RED controller health on a lane that
     # has just been repaired is exactly the signal worth seeing.
-    "Abt-Buy (linkage)": None,
+    # The 0.45 floor above was DERIVED from a linkage run (0.5037 / P 0.8219 /
+    # 494 pairs) and then enforced against the dedupe lane for months. Now that
+    # the linkage row exists, the floor is applied to the lane it actually
+    # describes. Measured 0.7024 (P 0.8529, R 0.5971) on 2026-08-23, so 0.45
+    # leaves real margin rather than sitting on the observed value -- and a
+    # regression back toward the old blocking behaviour trips it.
+    "Abt-Buy (linkage)": 0.45,
     "Amazon-Google (linkage)": None,
 }
 
@@ -664,12 +670,24 @@ _F1_FLOORS: dict[str, float | None] = {
 _QUARANTINE: dict[str, dict[str, Any]] = {
     "Abt-Buy": {
         "issue": 2717,
-        "f1_at_quarantine": 0.1723,
+        "f1_at_quarantine": 0.0881,
         "tolerance": 0.03,
         "why": (
-            "product-text matching collapses; also commits a RED config "
-            "(budget_iterations). The 0.45 floor is itself DISPUTED -- see the "
-            "_F1_FLOORS note; it derives from an UNREPRODUCED 0.5037."
+            "RE-BASELINED 2026-08-23, DOWNWARD, because the engine got BETTER. "
+            "Weighted-path blocking recall went 0.0684 -> 0.5662 (8x) when the "
+            "sketch column stopped being chosen by length and short free text "
+            "stopped being routed to LSH. This lane's F1 FELL from 0.1723 to "
+            "0.0881 as a result: it scores a CONCATENATED frame against a "
+            "cross-source mapping, so surfacing more candidates surfaces mostly "
+            "same-source pairs that cannot be true matches -- precision "
+            "0.1068 -> 0.0470 while recall rose 0.4463 -> 0.7075. The same "
+            "change took the LINKAGE row 0.5658 -> 0.7024. "
+            "This is NOT a floor lowered to make a lane green: the number it "
+            "describes is a metric that punishes better blocking, and the "
+            "quarantine is re-pointed at the current run so a genuine NEW "
+            "regression can still trip it. What this lane should measure at all "
+            "is an open question -- see 'Abt-Buy (linkage)' below for the row "
+            "that is comparable to published figures."
         ),
     },
     "Amazon-Google": {

--- a/scripts/test_benchmark_dual_lane.py
+++ b/scripts/test_benchmark_dual_lane.py
@@ -80,12 +80,26 @@ def test_historical_row_keeps_its_exact_name(stub_lanes):
 
 
 def test_linkage_rows_are_declared_in_the_floors_table():
-    """A row with no `_F1_FLOORS` entry is silently unfloored. Declaring them
-    as None is how "no trustworthy baseline yet" is said out loud."""
+    """A row with no `_F1_FLOORS` entry is silently unfloored, so both linkage
+    rows must appear -- `None` is how "no trustworthy baseline yet" is said out
+    loud, and a number is how a real one is."""
     for key in ("abt-buy", "amazon-google"):
         label = run_benchmarks._PRODUCT_SPECS[key]["label"] + " (linkage)"
         assert label in run_benchmarks._F1_FLOORS
-        assert run_benchmarks._F1_FLOORS[label] is None
+
+
+def test_abt_buy_linkage_carries_the_floor_that_was_derived_from_it():
+    """The 0.45 floor was derived from a LINKAGE run (0.5037 / P 0.8219 / 494
+    emitted pairs) and then enforced against the dedupe lane for months, where
+    it was recorded as DISPUTED and unreproducible. Now that the linkage row
+    exists it carries its own floor, cleared with margin at a measured 0.7024."""
+    assert run_benchmarks._F1_FLOORS["Abt-Buy (linkage)"] == 0.45
+
+
+def test_amazon_google_linkage_stays_unfloored_until_ci_publishes_one():
+    """Measured 0.4636 locally, but a local Windows / native-off run is not a
+    CI baseline and no floor is claimed on the strength of it."""
+    assert run_benchmarks._F1_FLOORS["Amazon-Google (linkage)"] is None
 
 
 def test_missing_dataset_yields_no_rows(monkeypatch):

--- a/scripts/test_benchmark_quarantine.py
+++ b/scripts/test_benchmark_quarantine.py
@@ -28,11 +28,27 @@ def _r(name, f1, health="green", stop_reason="converged"):
 
 # --- the two datasets that made #2457 permanently red -----------------------
 
-def test_the_2026_08_21_nightly_no_longer_fails_the_lane():
-    """The exact numbers from run 32457009104, which had been failing nightly."""
+def _at_baseline(name: str) -> float:
+    """The f1 a quarantined dataset is currently pinned at.
+
+    Read from `_QUARANTINE` rather than hardcoded. These tests originally
+    carried the literal numbers from nightly run 32457009104 (Abt-Buy 0.1723,
+    Amazon-Google 0.1014) and silently went stale the first time a baseline
+    legitimately moved -- which it did when better blocking took Abt-Buy's
+    dedupe lane DOWN (see the `_QUARANTINE` entry). The invariant these tests
+    exist for is "a dataset sitting AT its baseline does not fail the lane",
+    and that is expressible without pinning the value twice.
+    """
+    from run_benchmarks import _QUARANTINE
+
+    return float(_QUARANTINE[name]["f1_at_quarantine"])
+
+
+def test_a_dataset_at_its_baseline_does_not_fail_the_lane():
+    """Both quarantined datasets, each sitting exactly at its own baseline."""
     failing, quarantined = _check_quality_floors([
-        _r("Abt-Buy", 0.1723, "red", "budget_iterations"),
-        _r("Amazon-Google", 0.1014, "red", "budget_time"),
+        _r("Abt-Buy", _at_baseline("Abt-Buy"), "red", "budget_iterations"),
+        _r("Amazon-Google", _at_baseline("Amazon-Google"), "red", "budget_time"),
     ])
     assert failing == [], f"quarantined datasets still failed the lane: {failing}"
     assert len(quarantined) == 3, quarantined  # Abt-Buy floor + 2 RED healths
@@ -40,7 +56,9 @@ def test_the_2026_08_21_nightly_no_longer_fails_the_lane():
 
 def test_quarantined_breaches_are_still_reported():
     """Suppressing the failure must not suppress the evidence."""
-    _, quarantined = _check_quality_floors([_r("Abt-Buy", 0.1723, "red", "x")])
+    _, quarantined = _check_quality_floors(
+        [_r("Abt-Buy", _at_baseline("Abt-Buy"), "red", "x")]
+    )
     assert quarantined, "a quarantined breach vanished entirely"
     assert all("QUARANTINED" in q and "#" in q for q in quarantined), quarantined
 


### PR DESCRIPTION
Abt-Buy's weighted-path blocking recall was **0.0684** — the quality ceiling behind everything else on #2717. Two compounding heuristic errors, both on the text-corpus path.

## 1. The sketch column was chosen by length

`_auto_build_lsh_config` picked `max(avg_len)` — the **longest** text column. That is backwards: the longest free-text field is the most verbose and the least identifying, because it shares boilerplate with every other row.

```
name         avg_len= 54.3  cardinality=0.994   <- identity lives here
description  avg_len=178.5  cardinality=0.771   <- max(avg_len) picked this
```

Now ranked by cardinality, with length kept as the **tie-breaker** — with nothing to choose on identity, a longer column carries more shingles for a sketch, which is the grain of truth the old rule was reaching for.

I got the guard wrong first: I capped cardinality at 0.99, reasoning a per-row-unique column "blocks nothing, every value is its own block". True of an **exact** key, false of a sketch — LSH and token group by shared shingles, not equality. The cap excluded `name` at 0.994, the very column the function exists to pick. Its test failed until it came out; both the reasoning and the correction are recorded.

## 2. The strategy was chosen by branch, not by shape

That branch committed MinHash/LSH for everything it reached. `blocking.mdx` already said otherwise: *"use `lsh` for near-duplicate documents, `token` for short free text where only a few tokens agree."*

Ground-truth blocking recall through the shipped blocker:

| plan | recall | comparisons |
|---|---|---|
| lsh on `description` (committed) | **0.0009** | 13,071 |
| lsh on `name`, thr 0.5 | 0.1139 | 5,082 |
| lsh on `name`, thr 0.2 | 0.5123 | 64,466 |
| **token on `name`, max_df 0.02** | **0.9198** | 64,056 |
| token on `description`, max_df 0.02 | 0.3801 | 137,720 |

At equal cost — ~64k comparisons — token nearly **doubles** LSH's recall on the same column. The bar is read off the *chosen* column, never the longest, or this shape returns to LSH through the back door. `_SHORT_FREE_TEXT_MAX_LEN = 120` is a calibration and says so: Abt-Buy `name` 54.3 and Amazon-Google `title` 51.1 one side, the two `description` columns (178.5, 551.2) the other, a real document corpus far above.

## Measured, and it is a trade

```
Weighted-path blocking recall   0.0684 -> 0.5662   (8x)
Abt-Buy (linkage)  f1 0.5658 -> 0.7024   P 0.9163 -> 0.8529  R 0.4093 -> 0.5971
Abt-Buy (dedupe)   f1 0.1723 -> 0.0881   P 0.1068 -> 0.0470  R 0.4463 -> 0.7075
```

**The dedupe lane's F1 falls because that lane punishes better blocking.** It scores a concatenated frame against a cross-source mapping, so surfacing more candidates surfaces mostly same-source pairs that cannot be true matches. Its same-source contamination also drops 93.0% → 56.1%.

Its drift check fired, which is the ratchet working. I re-pointed the quarantine at 0.0881 rather than reverting the fix: the number that fell measures a task the engine warns about on every run; the number that rose is the one comparable to published DeepMatcher / Ditto figures. **This is not a floor lowered to go green** — the quarantine still ratchets both ways from the new value, and every breach is still printed. What that lane should measure at all remains open.

## A floor finally lands where it was derived

`Abt-Buy (linkage)` now carries the **0.45** floor. That floor came from a linkage run (0.5037 / P 0.8219 / 494 emitted pairs) and was then enforced against the dedupe lane for months, recorded there as DISPUTED and unreproducible. It now guards the lane it describes, cleared with margin at 0.7024.

## Notes

- Amazon-Google never showed this bug: its `manufacturer` column profiles as `col_type=name` with cardinality 0.162, tripping `_is_text_corpus`'s blockable-name test and routing it away entirely. Luck, not design — hence a heuristic fix rather than a special case.
- Four `test_text_corpus_autoconfig` fixtures used ~63–80 character sentences to stand in for a document corpus, shorter than a product title. Their intent is "a **document** corpus gets near-duplicate blocking", so the fixtures were made document-length rather than the assertions flipped. Commas came out with them — comma-separated text profiles as `multi_name`, not `description`, which drops the frame out of `_is_text_corpus` and routed my first attempt to `static`.
- Two quarantine tests pinned literal nightly numbers and went stale the moment a baseline legitimately moved; they now read `_QUARANTINE`.

Two commits, kept separate so a `quality_gate` move is attributable to one heuristic at a time. The column fix alone is invisible on both lanes; the strategy fix is where the movement is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P