### PR TITLE
refactor(benchmarks): name both product lanes explicitly (#2717)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Changed
+
+- **Both product benchmark lanes now carry an explicit name (#2717).**
+  `Abt-Buy` / `Amazon-Google` became `Abt-Buy (dedupe)` /
+  `Amazon-Google (dedupe)`; the bare name read as THE number for the dataset
+  when it is the harder and far less comparable of the two lanes.
+
+  The dedupe framing existed for a reason that no longer holds. Its own comment
+  said so: *"Unlike DBLP-ACM (identical schemas, run through match_df), product
+  sources have heterogeneous schemas and the perf path is a UNIFIED dedupe."*
+  Heterogeneous schemas defeated `match_df` because auto-config applied its
+  column exclusions to the target frame only, so two frames of differing width
+  hit a strict `pl.concat` and every controller iteration raised `ShapeError`.
+  That was fixed earlier in this release; the workaround outlived its cause.
+
+  `_F1_FLOORS` and `_QUARANTINE` follow the rename, and `Abt-Buy`'s 0.45 floor
+  is not reinstated on the dedupe row -- it was derived from a linkage run and
+  now guards `Abt-Buy (linkage)`, which clears it at 0.7024.
+
 ### Fixed
 
 - **Blocking chose its sketch column by LENGTH and its strategy by branch, not

--- a/packages/python/goldenmatch/tests/test_benchmark_quality_floors.py
+++ b/packages/python/goldenmatch/tests/test_benchmark_quality_floors.py
@@ -32,14 +32,14 @@ def test_amazon_google_at_its_quarantine_baseline_is_reported_not_failed():
     behaviour the original test wanted ("a WORSE run must breach"), now enforced
     against a live baseline instead of a static floor.
     """
-    base = run_benchmarks._QUARANTINE["Amazon-Google"]["f1_at_quarantine"]
+    base = run_benchmarks._QUARANTINE["Amazon-Google (dedupe)"]["f1_at_quarantine"]
     failing, quarantined = run_benchmarks._check_quality_floors(
-        [{"name": "Amazon-Google", "f1": base, "precision": 0.2077, "recall": 0.0419}]
+        [{"name": "Amazon-Google (dedupe)", "f1": base, "precision": 0.2077, "recall": 0.0419}]
     )
     assert failing == [], f"at its own baseline it must not fail: {failing}"
 
     worse = run_benchmarks._check_quality_floors(
-        [{"name": "Amazon-Google", "f1": 0.04, "precision": 0.2, "recall": 0.03}]
+        [{"name": "Amazon-Google (dedupe)", "f1": 0.04, "precision": 0.2, "recall": 0.03}]
     )[0]
     assert worse, "a WORSE Amazon-Google run must still fail"
     assert any("Amazon-Google" in w for w in worse), worse
@@ -54,11 +54,11 @@ def test_a_healthy_run_does_not_breach():
     it and the quarantine should be lifted. Using it as "a healthy run" was
     baking an unreproducible measurement into a test.
     """
-    base = run_benchmarks._QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    base = run_benchmarks._QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
     failing, _ = run_benchmarks._check_quality_floors(
         [
             {"name": "Febrl3", "f1": 0.9912, "precision": 0.99, "recall": 0.99},
-            {"name": "Abt-Buy", "f1": base, "precision": 0.11, "recall": 0.45},
+            {"name": "Abt-Buy (dedupe)", "f1": base, "precision": 0.11, "recall": 0.45},
         ]
     )
     assert failing == [], failing

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -213,11 +213,11 @@ def _measure_product(datasets_dir: Path, key: str) -> list[dict[str, Any]]:
     Returns TWO rows, because the dataset supports two genuinely different
     tasks and reporting one number for both was a framing error (#2717):
 
-      * ``<label>`` -- dedupe. Both sources concatenated into one frame,
-        everything compared to everything. Scored against the transitive
-        closure of the mapping. This is the historical row; its name is
-        unchanged so `_F1_FLOORS`, `_QUARANTINE` and the committed report's
-        series all keep applying to the same measurement.
+      * ``<label> (dedupe)`` -- both sources concatenated into one frame,
+        everything compared to everything, scored against the transitive
+        closure of the mapping. RENAMED from the bare ``<label>`` (#2717): the
+        unsuffixed name read as THE number for the dataset when it is the
+        harder and far less comparable of the two lanes.
       * ``<label> (linkage)`` -- record linkage via ``match_df(a, b)``, scored
         against the raw cross-source mapping. This is the task the published
         DeepMatcher / Ditto figures measure, so it is the row to compare
@@ -284,7 +284,9 @@ def _measure_product(datasets_dir: Path, key: str) -> list[dict[str, Any]]:
     if res is None:
         _info(f"  {spec['label']}: dataset files missing - skipping")
         return []
-    rows.append(_row(spec["label"], "dedupe", res, elapsed, dedupe_captured))
+    rows.append(
+        _row(f"{spec['label']} (dedupe)", "dedupe", res, elapsed, dedupe_captured)
+    )
 
     # ---- linkage lane ------------------------------------------------------
     link_captured: dict[str, Any] = {}
@@ -623,12 +625,16 @@ _F1_FLOORS: dict[str, float | None] = {
     # Kept here at 0.45 for the DEDUPE row it currently gates -- raising or
     # retiring it belongs with the same-source framing decision, not with this
     # change -- and see "Abt-Buy (linkage)" below for where it actually applies.
-    "Abt-Buy": 0.45,
+    # RENAMED to "Abt-Buy (linkage)" below (#2717). The 0.45 was DERIVED from a
+    # linkage run and enforced here for months; it now guards the lane it
+    # describes. This lane keeps no floor of its own -- see its _QUARANTINE
+    # entry for why its F1 is not a usable target.
+    "Abt-Buy (dedupe)": None,
     # KNOWN BAD (#2470). Measured 0.0697 / recall 0.0419. The floor is set at the
     # observed value ONLY to stop it getting worse; it is not an endorsement, and
     # this dataset should be treated as an open quality bug rather than a passing
     # lane. Raise it as the matcher improves.
-    "Amazon-Google": 0.05,
+    "Amazon-Google (dedupe)": 0.05,
     # No trustworthy baseline recorded yet -- these have not completed in CI.
     "DBLP-ACM": None,
     "NCVR": None,
@@ -668,7 +674,7 @@ _F1_FLOORS: dict[str, float | None] = {
 # something being tracked, so `_quarantine_breaches` says so rather than
 # silently honouring it.
 _QUARANTINE: dict[str, dict[str, Any]] = {
-    "Abt-Buy": {
+    "Abt-Buy (dedupe)": {
         "issue": 2717,
         "f1_at_quarantine": 0.0881,
         "tolerance": 0.03,
@@ -690,7 +696,7 @@ _QUARANTINE: dict[str, dict[str, Any]] = {
             "that is comparable to published figures."
         ),
     },
-    "Amazon-Google": {
+    "Amazon-Google (dedupe)": {
         "issue": 2717,
         "f1_at_quarantine": 0.1014,
         "tolerance": 0.03,

--- a/scripts/test_benchmark_dual_lane.py
+++ b/scripts/test_benchmark_dual_lane.py
@@ -65,16 +65,22 @@ def stub_lanes(monkeypatch):
 
 def test_returns_one_row_per_lane(stub_lanes):
     rows = run_benchmarks._measure_product(Path("."), "amazon-google")
-    assert [r["name"] for r in rows] == ["Amazon-Google", "Amazon-Google (linkage)"]
+    assert [r["name"] for r in rows] == [
+        "Amazon-Google (dedupe)", "Amazon-Google (linkage)",
+    ]
     assert [r["lane"] for r in rows] == ["dedupe", "linkage"]
     assert [r["f1"] for r in rows] == [0.1, 0.46]
 
 
-def test_historical_row_keeps_its_exact_name(stub_lanes):
-    """`_F1_FLOORS` / `_QUARANTINE` key on the name -- renaming the dedupe row
-    would silently drop both, so the series must survive the split."""
+def test_every_emitted_row_is_declared_in_the_tables(stub_lanes):
+    """`_F1_FLOORS` / `_QUARANTINE` key on the row NAME, so a rename that misses
+    one silently unfloors it. Both dedupe rows carry an explicit `(dedupe)`
+    suffix now (#2717) -- the bare name read as THE number for the dataset when
+    it is the harder and less comparable lane -- and this pins that the tables
+    followed the rename."""
     rows = run_benchmarks._measure_product(Path("."), "amazon-google")
     dedupe = rows[0]["name"]
+    assert dedupe == "Amazon-Google (dedupe)"
     assert dedupe in run_benchmarks._F1_FLOORS
     assert dedupe in run_benchmarks._QUARANTINE
 
@@ -123,4 +129,4 @@ def test_a_missing_linkage_lane_does_not_lose_the_dedupe_row(stub_lanes, monkeyp
         leipzig, "run_two_source_link_zeroconfig", lambda datasets_dir, fn, **kw: None, raising=True
     )
     rows = run_benchmarks._measure_product(Path("."), "amazon-google")
-    assert [r["name"] for r in rows] == ["Amazon-Google"]
+    assert [r["name"] for r in rows] == ["Amazon-Google (dedupe)"]

--- a/scripts/test_benchmark_quarantine.py
+++ b/scripts/test_benchmark_quarantine.py
@@ -47,17 +47,20 @@ def _at_baseline(name: str) -> float:
 def test_a_dataset_at_its_baseline_does_not_fail_the_lane():
     """Both quarantined datasets, each sitting exactly at its own baseline."""
     failing, quarantined = _check_quality_floors([
-        _r("Abt-Buy", _at_baseline("Abt-Buy"), "red", "budget_iterations"),
-        _r("Amazon-Google", _at_baseline("Amazon-Google"), "red", "budget_time"),
+        _r("Abt-Buy (dedupe)", _at_baseline("Abt-Buy (dedupe)"), "red", "budget_iterations"),
+        _r("Amazon-Google (dedupe)", _at_baseline("Amazon-Google (dedupe)"), "red", "budget_time"),
     ])
     assert failing == [], f"quarantined datasets still failed the lane: {failing}"
-    assert len(quarantined) == 3, quarantined  # Abt-Buy floor + 2 RED healths
+    # 2, not 3: the Abt-Buy dedupe row no longer carries a floor of its own.
+    # Its 0.45 moved to "Abt-Buy (linkage)", the lane it was derived from
+    # (#2717), so what remains here is the two RED controller healths.
+    assert len(quarantined) == 2, quarantined
 
 
 def test_quarantined_breaches_are_still_reported():
     """Suppressing the failure must not suppress the evidence."""
     _, quarantined = _check_quality_floors(
-        [_r("Abt-Buy", _at_baseline("Abt-Buy"), "red", "x")]
+        [_r("Abt-Buy (dedupe)", _at_baseline("Abt-Buy (dedupe)"), "red", "x")]
     )
     assert quarantined, "a quarantined breach vanished entirely"
     assert all("QUARANTINED" in q and "#" in q for q in quarantined), quarantined
@@ -67,29 +70,29 @@ def test_quarantined_breaches_are_still_reported():
 
 def test_degrading_past_the_baseline_fails():
     """A quarantine tracks a bug; it does not license it to deepen."""
-    base = _QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
-    failing, _ = _check_quality_floors([_r("Abt-Buy", base - 0.2, "green")])
+    base = _QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
+    failing, _ = _check_quality_floors([_r("Abt-Buy (dedupe)", base - 0.2, "green")])
     assert any("DEGRADED" in f for f in failing), failing
 
 
 def test_improving_past_the_baseline_fails():
     """Someone fixed it -- the quarantine now hides good news, so it must shout."""
-    base = _QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
-    failing, _ = _check_quality_floors([_r("Abt-Buy", base + 0.5, "green")])
+    base = _QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
+    failing, _ = _check_quality_floors([_r("Abt-Buy (dedupe)", base + 0.5, "green")])
     assert any("IMPROVED" in f for f in failing), failing
 
 
 def test_inside_tolerance_stays_quarantined():
-    base = _QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
-    tol = _QUARANTINE["Abt-Buy"]["tolerance"]
-    failing, _ = _check_quality_floors([_r("Abt-Buy", base + tol / 2, "green")])
+    base = _QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
+    tol = _QUARANTINE["Abt-Buy (dedupe)"]["tolerance"]
+    failing, _ = _check_quality_floors([_r("Abt-Buy (dedupe)", base + tol / 2, "green")])
     assert failing == [], failing
 
 
 def test_a_missing_f1_is_not_drift():
     """A crashed/skipped run has no number; inventing a verdict would be worse."""
     failing, _ = _check_quality_floors([
-        {"name": "Abt-Buy", "f1": None, "health": "green", "stop_reason": "x"}
+        {"name": "Abt-Buy (dedupe)", "f1": None, "health": "green", "stop_reason": "x"}
     ])
     assert not any("DEGRADED" in f or "IMPROVED" in f for f in failing), failing
 

--- a/scripts/test_run_benchmarks_llm_isolation.py
+++ b/scripts/test_run_benchmarks_llm_isolation.py
@@ -120,9 +120,9 @@ def test_red_health_is_a_breach_even_above_the_floor():
     Abt-Buy directly -- and the failing half is asserted on a dataset that is
     not quarantined, so neither half can pass vacuously.
     """
-    base = rb._QUARANTINE["Abt-Buy"]["f1_at_quarantine"]
+    base = rb._QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
     failing, quarantined = rb._check_quality_floors([
-        {"name": "Abt-Buy", "f1": base, "health": "RED",
+        {"name": "Abt-Buy (dedupe)", "f1": base, "health": "RED",
          "stop_reason": "BUDGET_ITERATIONS"},
     ])
     assert any("RED" in b for b in quarantined), (failing, quarantined)


### PR DESCRIPTION
`Abt-Buy` / `Amazon-Google` → `Abt-Buy (dedupe)` / `Amazon-Google (dedupe)`.

The bare name read as **the** number for the dataset when it is the harder and far less comparable of the two lanes — and it is the number #2717 was opened about.

## The dedupe framing existed for a reason that no longer holds

The harness says so itself:

> Unlike DBLP-ACM (identical schemas, run through match_df), **product sources have heterogeneous schemas** and the perf path is a UNIFIED dedupe

Heterogeneous schemas defeated `match_df` because auto-config applied its column exclusions to the **target frame only**, so two frames of differing width reached `run_match_df` and its strict `pl.concat` raised `ShapeError` on every controller iteration, falling back to v0 + RED.

**That was fixed in #2730.** The workaround outlived its cause by one release — and #2717's premise, *"product-text matching collapses"*, was measured on a task the engine warns against on every run, chosen to dodge a defect that no longer exists.

## Nothing is hidden

Both lanes are still measured and reported. The dedupe rows stay quarantined with their structural explanation — 56% of Abt-Buy's candidates are same-source and cannot be true matches against a cross-source mapping. What changes is that neither row can be read as the dataset's number without saying which task it answers.

```
| Abt-Buy (dedupe)       | 0.0881 | 0.0470 | 0.7075 | red    |
| Abt-Buy (linkage)      | 0.7024 | 0.8529 | 0.5971 | yellow |
| Amazon-Google (dedupe) | 0.1097 | 0.0609 | 0.5551 | red    |
| Amazon-Google (linkage)| 0.4636 | 0.5961 | 0.3792 | yellow |
```

`_F1_FLOORS` and `_QUARANTINE` follow the rename. Abt-Buy's 0.45 is **not** reinstated on the dedupe row: it was derived from a linkage run, sat on the dedupe lane for months marked DISPUTED and unreproducible, and now guards `Abt-Buy (linkage)`, which clears it at 0.7024.

## Note on the sweep

Four test files needed the rename and my first pass caught one. I grepped `"Abt-Buy"` narrowly rather than every row-name literal — the third time today a too-narrow sweep under-covered, after missing a `build_blocking` caller earlier in #2734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P