### PR TITLE
release: golden-suite 0.5.2 -- goldenmatch floor to >=3.16

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.5.2] - 2026-08-23
+
+### Changed
+
+- **`goldenmatch` floor raised to `>=3.16`.** 3.16.0 fixes a defect that hits
+  the ordinary case rather than an edge one: zero-config `match_df` committed a
+  RED config on EVERY auto-config iteration whenever the two frames' columns
+  differed -- linking two sources with slightly different schemas -- because
+  column exclusions were dropped from the target frame only, leaving the two
+  frames at different widths for a strict `pl.concat`. It also stops postflight
+  silently re-cutting the match threshold using a score distribution that was
+  already truncated at that cut, which on one benchmark took 1,646 qualifying
+  pairs down to 120.
+
+  Only the `goldenmatch` floor moves; every other member is already at its
+  published version (goldencheck 3.5.0, goldenflow 2.2.0, goldenpipe 1.5.0,
+  goldenanalysis 0.5.0, infermap 0.7.0).
+
 ## [0.5.1] - 2026-08-20
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -33,7 +33,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.5.1"
+version = "0.5.2"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.5",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.14",        # entity resolution: dedupe, match, golden records (>=3.14: distributed Fellegi-Sunter 4.13x faster at 250M with zero spill and a byte-identical model, so suite installs get the perf without opting in; >=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.16",        # entity resolution: dedupe, match, golden records (>=3.16: zero-config `match_df` committed a RED config on EVERY auto-config iteration whenever the two frames' columns differed -- the ordinary case of linking two sources with slightly different schemas -- because column exclusions were dropped from the target frame only and the polars lane concatenates strictly; also stops postflight silently re-cutting the match threshold from a distribution truncated at that cut; >=3.14: distributed Fellegi-Sunter 4.13x faster at 250M with zero spill and a byte-identical model, so suite installs get the perf without opting in; >=3.10: MCP surface parity both directions -- +8 MCP tools across 3.9/3.10 (82->90), mcp_tools.ts_only now empty; retains the >=3.7 zero-config FS scale-recall fix + out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.5",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.2.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.7",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
Lockstep: goldenmatch 3.16.0 is published, so the suite floor follows.

## Why `>=3.16` is worth a floor

It guarantees a fix that hits the **ordinary** case, not an edge one. Zero-config `match_df` committed a RED config on *every* auto-config iteration whenever the two frames' columns differed — which is what linking two sources with slightly different schemas looks like. Auto-config dropped its column exclusions from the target frame only, leaving the two frames at different widths for a strict `pl.concat`; every iteration raised `ShapeError` and the run fell back to v0 + a RED sentinel.

3.16.0 also stops postflight silently re-cutting the match threshold from a score distribution already truncated at that cut — on one benchmark, 1,646 qualifying pairs down to 120.

## Only the goldenmatch floor moves

Checked each member against PyPI rather than bumping on principle:

| member | published | floor |
|---|---|---|
| goldenmatch | 3.16.0 | `>=3.14` → **`>=3.16`** |
| goldencheck | 3.5.0 | `>=3.5` ✓ |
| goldenflow | 2.2.0 | `>=2.2.0` ✓ |
| goldenpipe | 1.5.0 | `>=1.5` ✓ |
| goldenanalysis | 0.5.0 | `>=0.5` ✓ |
| infermap | 0.7.0 | `>=0.7` ✓ |

**PATCH**, matching this CHANGELOG's own convention: 0.5.0 → 0.5.1 was a single-member floor bump; 0.4.0 → 0.5.0 was a repo-wide cut.

## What `>=3.16` does not include

The blocking column/strategy fix (#2734 — weighted-path blocking recall 0.0684 → 0.5662, Abt-Buy linkage F1 0.5658 → 0.7024) merged **after** 3.16.0 was cut and is unreleased. A floor is a minimum, not a ceiling, so fresh installs still resolve the latest; a later goldenmatch release will drag this floor again.

## Mechanics

Version carriers in lockstep: `pyproject.toml`, `golden_suite/__init__.py`. `uv.lock` carries no entry for this package (it is the workspace root's extras) and the api-surface matrix does not list the suite — both confirmed against the previous bump, `c6247768b`.

After merge the release is cut by tagging `golden-suite-v0.5.2`, which `publish-golden-suite.yml` fires on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P