### PR TITLE
refactor(er_matcher): do not return a procedure's None (CodeQL)

### DIFF
--- a/scripts/er_matcher/interp/modal_interp.py
+++ b/scripts/er_matcher/interp/modal_interp.py
@@ -1112,10 +1112,11 @@ def faithfulness_eval(per_class: int = 400, seed: int = 0, negatives: str = "har
         split = "deepmatcher-train/test"
         print(f"[faith] dataset={dataset} train={len(tr)} test={len(te)} "
               f"fields={len(fields)} split={split} link={link}", flush=True)
-        return _faithfulness_core(
+        _faithfulness_core(
             tok, model, dev, true_id, false_id, tr, te, rows, fields,
             dataset=dataset, split=split, negatives="n/a", seed=seed, link=link,
         )
+        return
 
     fields = FIELDS
     raw = pl.from_arrow(pq.read_table(DATA))
@@ -1163,7 +1164,7 @@ def faithfulness_eval(per_class: int = 400, seed: int = 0, negatives: str = "har
     print(f"[faith] train={len(tr)} test={len(te)} negatives={negatives} "
           f"split={split}-disjoint link={link}", flush=True)
 
-    return _faithfulness_core(
+    _faithfulness_core(
         tok, model, dev, true_id, false_id, tr, te, rows, fields,
         dataset=dataset,
         split=f"{split}-disjoint" + ("-corrmatched" if corruption_matched else ""),


### PR DESCRIPTION
## What and why

`_faithfulness_core` is annotated `-> None`, but `faithfulness_eval` did `return _faithfulness_core(...)` in **both** of its branches, propagating a meaningless value.

`github-code-quality[bot]` flagged this three times on #2369. It landed with that PR because the finding is advisory and blocking a deliberate auto-merge for a zero-behaviour-change style fix was not a trade worth making. This is the follow-up.

Worth recording for anyone who sees a green CodeQL suite and reads it as coverage: these findings post as advisory **review comments**, not failing checks. The `github-advanced-security` suite reported success on every head while the finding stood. A green run is not evidence a CodeQL comment was addressed.

## Changes

`scripts/er_matcher/interp/modal_interp.py`, both call sites:

- the `dataset != "person"` **early exit** becomes a statement followed by an explicit bare `return`, preserving the same early-exit control flow;
- the **final call** needs nothing after it — it is the last statement in the function, so control falls off the end and returns `None` exactly as before.

3 insertions, 2 deletions. Zero behaviour change.

## Testing

```
uv run --with scikit-learn pytest scripts/er_matcher/ -q   -> 303 passed
uv run ruff check scripts/er_matcher/interp/modal_interp.py -> clean
python3 -m py_compile ...                                   -> ok
```

That pytest invocation matches how the `er_matcher` CI job runs these (`--with scikit-learn`), so the local run exercises the same path CI will.

## Checklist

- [x] Tests added/updated and passing locally for the changed package — existing suite; no new tests, this is a no-op refactor with no new behaviour to cover
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets) — ruff run on the changed file only
- [ ] Package `CHANGELOG.md` updated if behavior changed — n/a, no behaviour change
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8LFfCN5WULzTzKd8vaU6C)_