### PR TITLE
fix(suggest-quality): do not fetch a dataset that is already vendored

### DIFF
--- a/scripts/suggest_quality/fetch_datasets.py
+++ b/scripts/suggest_quality/fetch_datasets.py
@@ -6,13 +6,26 @@
 `scripts/suggest_quality/datasets.py` loads real datasets from
 `packages/python/goldenmatch/tests/benchmarks/datasets`, which is gitignored.
 On a developer's machine they are usually there; in CI they never are. So
-`dblp_acm` has always reported `skipped: dblp_acm (absent)` and **cannot be
+`dblp_acm` used to report `skipped: dblp_acm (absent)` and **could not be
 blessed in `scorecard.json`**: blessing a dataset CI cannot load converts a
 legitimate skip into a permanent MISSING failure on every run (attempted in
 #2566, caught by the gate, reverted).
 
 The gate is right to refuse, and softening it would be the wrong fix. The
 missing piece is the data, so this fetches it.
+
+**UPDATE (#2721): `dblp_acm` is now VENDORED** at
+`scripts/suggest_quality/vendored/DBLP-ACM/`, and `_dblp_acm_dir()` prefers the
+vendored copy over the runtime-download location this writes to. So its fetch
+is shadowed in the normal case, and `_already_loadable` below skips it rather
+than spending a network round-trip on a result nothing reads.
+
+The fetcher is deliberately KEPT rather than deleted. Vendoring is the
+guarantee -- deterministic, offline, and the only thing that can support a
+bless, because a best-effort fetch cannot (that is the #2566 failure again).
+This is the fallback beneath it: if a vendored corpus is ever removed, or a
+future dataset is too large to commit, the path still exists. One mechanism for
+availability, one subordinate to it, and the subordination is explicit.
 
 Note the trap #2635 records: a pre-bless run on a laptop cannot warn about
 this, because locally the dataset IS present. Local reported 2 skipped where
@@ -51,11 +64,32 @@ _FETCHERS = {
 }
 
 
+def _already_loadable(name: str) -> bool:
+    """True when the gate can already load this dataset without fetching.
+
+    Post-#2721 `dblp_acm` is vendored and `_dblp_acm_dir()` prefers the
+    vendored copy, so fetching it would download a corpus nothing subsequently
+    reads. Asking the REGISTRY rather than checking a path keeps this honest:
+    the question is "can the gate load it", which is what actually matters and
+    is not the same as "does some file exist".
+    """
+    entry = next((d for d in REGISTRY if d.name == name), None)
+    if entry is None:
+        return False
+    try:
+        return entry.loader() is not None
+    except Exception:  # noqa: BLE001 - a broken loader means "fetch and see"
+        return False
+
+
 def main() -> int:
     _DATASETS_ROOT.mkdir(parents=True, exist_ok=True)
     print(f"datasets root: {_DATASETS_ROOT}")
 
     for name, fetch in _FETCHERS.items():
+        if _already_loadable(name):
+            print(f"  {name}: already loadable (vendored) -- skipping fetch")
+            continue
         try:
             ok = fetch(_DATASETS_ROOT)
         except Exception as exc:  # noqa: BLE001 - best-effort by design

--- a/scripts/suggest_quality/tests/test_fetch_datasets.py
+++ b/scripts/suggest_quality/tests/test_fetch_datasets.py
@@ -1,0 +1,39 @@
+"""Tests for the fetch-skip guard.
+
+`dblp_acm` is vendored (#2721) and `_dblp_acm_dir()` prefers the vendored copy,
+so fetching it downloads a corpus nothing reads. `_already_loadable` suppresses
+that. A skip guard that skips the wrong thing -- or fails to skip -- is the same
+class of defect as a check that does not fire, so both directions are tested.
+"""
+from scripts.suggest_quality import fetch_datasets as fd
+
+
+def test_skips_a_dataset_the_gate_can_already_load():
+    """The live case: dblp_acm is vendored, so no fetch should be attempted."""
+    assert fd._already_loadable("dblp_acm") is True
+
+
+def test_does_not_skip_a_dataset_that_is_genuinely_absent():
+    """ncvr_real has no public URL and is not vendored -- it must stay
+    fetch-eligible rather than being silently treated as satisfied."""
+    assert fd._already_loadable("ncvr_real") is False
+
+
+def test_unknown_dataset_is_not_treated_as_satisfied():
+    """A name absent from the REGISTRY must not report loadable; that would
+    silently suppress a fetch for something nothing can load."""
+    assert fd._already_loadable("no_such_dataset") is False
+
+
+def test_a_raising_loader_is_not_treated_as_satisfied(monkeypatch):
+    """A broken loader means 'fetch and see', never 'already fine' -- treating
+    an exception as satisfied would suppress the fetch that might fix it."""
+    class _Boom:
+        name = "boom"
+
+        @staticmethod
+        def loader():
+            raise RuntimeError("loader exploded")
+
+    monkeypatch.setattr(fd, "REGISTRY", [_Boom()])
+    assert fd._already_loadable("boom") is False


### PR DESCRIPTION
## What and why

Two mechanisms landed in parallel for the same problem (#2635), by different sessions:

1. **The vendored DBLP-ACM corpus** (#2721) — `scripts/suggest_quality/vendored/DBLP-ACM/` + `PROVENANCE.md`.
2. **`fetch_datasets.py`** — a best-effort runtime fetch reusing `run_benchmarks._fetch_dblp_acm`.

They are **not in conflict**: `_dblp_acm_dir()` prefers the vendored copy, so behaviour is deterministic either way. But that is exactly what makes the fetch **shadowed** — every suggest-quality run spent a network round-trip on a corpus nothing subsequently read.

## The change

`_already_loadable` asks the **REGISTRY** whether the gate can load the dataset, and skips the fetch when it can. Asking the registry rather than probing a path keeps the question honest: *"can the gate load it"* is what matters, and is not the same as *"does some file exist"*.

**The fetcher is kept, not deleted — which reverses my initial recommendation.** Vendoring is the guarantee: deterministic, offline, and the only thing that can support a bless, since a best-effort fetch cannot without recreating the #2566 permanent-`MISSING` failure. This is the fallback beneath it — if a vendored corpus is ever removed, or a future dataset is too large to commit, the path still exists. One mechanism for availability, one explicitly subordinate to it, and the subordination documented rather than accidental.

Also corrects the module docstring, whose premise (*"`dblp_acm` has always reported `skipped` … and cannot be blessed"*) stopped being true at #2721.

## Testing

```
PYTHONPATH=. uv run python -m scripts.suggest_quality.fetch_datasets
  dblp_acm: already loadable (vendored) -- skipping fetch
  ...
  dblp_acm               present  rows=4910 gt_pairs=2224

PYTHONPATH=. uv run pytest scripts/suggest_quality/tests/ -q   -> 57 passed
uv run ruff check scripts/suggest_quality/                     -> clean
```

Tests cover **both directions**, because a skip guard that skips the wrong thing is the same class of defect as a check that does not fire:

| case | expected |
|---|---|
| vendored (`dblp_acm`) | skip the fetch |
| genuinely absent (`ncvr_real`) | still fetch-eligible |
| unknown name | not satisfied |
| loader raises | not satisfied — "fetch and see", never "already fine" |

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets) — ruff run on the touched tree only
- [ ] Package `CHANGELOG.md` updated if behavior changed — n/a, CI harness only
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — the vendored-vs-fetched relationship is documented in the module docstring

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8LFfCN5WULzTzKd8vaU6C)_