### PR TITLE
feat(autoconfig): make the rule action space a first-class surface

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2148,7 +2148,9 @@
             "ErrorRecord",
             "HistoryEntry",
             "PolicyDecision",
-            "RunHistory"
+            "RunHistory",
+            "_read_metric",
+            "rule_effect_was_negative"
           ],
           "imports": [
             "goldenmatch.core.complexity_profile",
@@ -2286,7 +2288,6 @@
             "_existing_blocking_fields",
             "_first_weighted_mk",
             "_is_derived",
-            "_last_low_transitivity_rate",
             "_llm_api_key_available",
             "_near_dup_locked",
             "_orthogonal_key",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2300,6 +2300,7 @@
             "rule_blocking_key_swap",
             "rule_blocking_singleton_trap",
             "rule_blocking_too_coarse",
+            "rule_cluster_giant",
             "rule_corruption_normalize",
             "rule_cross_blocking_disagreement",
             "rule_enable_llm_scorer",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2306,6 +2306,7 @@
             "rule_enable_llm_scorer",
             "rule_low_reduction_ratio",
             "rule_low_transitivity",
+            "rule_matchkey_collapsed_field",
             "rule_matchkey_demote_high_cardinality_field",
             "rule_no_matches",
             "rule_precision_anchor_threshold_raise",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2312,7 +2312,8 @@
             "rule_select_probabilistic_matchkey",
             "rule_sparse_match_expand",
             "rule_uniform_heavy_blocking",
-            "rule_unimodal_scoring"
+            "rule_unimodal_scoring",
+            "targets"
           ],
           "imports": [
             "goldenmatch.config.schemas",

--- a/docs/superpowers/plans/2026-08-23-rule-action-space-first-class.md
+++ b/docs/superpowers/plans/2026-08-23-rule-action-space-first-class.md
@@ -1,0 +1,981 @@
+# Rule Action Space as a First-Class Surface — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it impossible to add a RED health verdict that no auto-config rule can act on, and give every rule a uniform way to check whether its own last action worked.
+
+**Architecture:** Three additions, each independently useful. (1) Each RED-capable sub-profile names its RED condition with a stable slug via `red_reason()`, and `health()` derives from it so the two cannot drift. (2) Rules declare which slugs they answer with a `@targets(...)` decorator, and a CI gate asserts every reachable slug is claimed. (3) `PolicyDecision` gains a `predicts` field naming the profile metric the rule expects to move, and a generic `rule_effect_was_negative()` helper replaces the bespoke history check that `rule_low_transitivity` currently hand-rolls.
+
+**Tech Stack:** Python 3.11+, pytest, pydantic v2 (config schemas), dataclasses (profiles/history). No new dependencies.
+
+**Spec:** No separate spec document — the argument and its evidence are inline under "Why this exists" below, and the measurements are reproducible with the commands given there. If a standalone spec is wanted later, extract that section.
+
+## Global Constraints
+
+- **Default-off / behaviour-preserving where possible.** New `PolicyDecision` fields default to empty, so all 17 existing rules keep working unchanged until decorated.
+- **`quality_gate` is the arbiter for any behaviour change.** It has caught default flips in this repo before (see `project_fs_threshold_calibration`). Tasks 4 and 5 add rules that can fire on real data and MUST be measured against it.
+- **`DEFAULT_RULES` is a module-level list holding function references.** Rebinding a module attribute does NOT change the list entry. Any test that swaps a rule must patch `DEFAULT_RULES[i]` and assert the swap took by reading the emitted `rule_name`.
+- **Never lower a floor or widen an allowlist to make a lane green.** The `_UNCOVERED` allowlist in Task 3 shrinks only; Tasks 4 and 5 each remove exactly one entry.
+- **Run derived-doc regeneration as the LAST step before every push:** `python scripts/regen_docs.py`. A new Python symbol without it reds `config_matrix` + `docs_regen`.
+- Tests run with `PYTHONPATH` at `packages/python/goldenmatch` and `GOLDENMATCH_AUTOCONFIG_MEMORY=0`.
+
+---
+
+## Why this exists
+
+Measured on this repo, 2026-08-23:
+
+```
+7 sub-profiles compute a health verdict
+17 rules in DEFAULT_RULES can respond
+they act on 3 config surfaces: blocking.*, matchkeys[0].threshold, cluster.split_weak_bridges
+```
+
+Reproduce the second and third numbers:
+
+```bash
+rg -c "^def rule_" packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+rg -o 'config_diff=\{"[a-z_.\[\]0-9]+' \
+   packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py \
+   | sed 's/.*config_diff={"//' | sort -u
+```
+
+The asymmetry is not theoretical. `DataProfile.health`'s own docstring records
+the failure mode:
+
+> v23 telemetry (#577) showed this signal stayed YELLOW for all 5 controller
+> iterations with no rule addressing it because the verdict isn't actionable
+
+and #2717 hit it three times in one issue: a runtime warning about concatenated
+sources with no lever, a RED cluster verdict with no cluster action at all, and
+`rule_low_transitivity` walking a threshold that provably cannot move
+transitivity in either direction (measured both ways; it falls either way,
+because removing an edge from a still-connected cluster leaves more open
+triples).
+
+**Two coverage holes exist right now, both verified:**
+
+| RED trigger | where | rule that answers it |
+|---|---|---|
+| `cluster_size_max > 0.1 * n_rows` | `ClusterProfile.health` | **none** |
+| a matchkey field with `post_transform_cardinality_ratio == 0.0` | `MatchkeyProfile.health` | **none** |
+
+`rule_low_transitivity` is the only rule that reads `profile.cluster`, and it
+returns `None` unless `transitivity_rate < 0.85` — so a giant-cluster RED with
+healthy transitivity produces no proposal. Both rules that read
+`profile.matchkey.per_field` (`rule_unimodal_scoring`,
+`rule_matchkey_demote_high_cardinality_field`) sort by *highest* cardinality;
+neither handles the zero end.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `goldenmatch/core/complexity_profile.py` | Sub-profile health verdicts | Add `red_reason()` to the 5 RED-capable profiles; `health()` derives from it |
+| `goldenmatch/core/autoconfig_history.py` | `PolicyDecision` audit record | Add `targets`, `predicts`, `predicts_direction`, `observed_delta` |
+| `goldenmatch/core/autoconfig_rules.py` | The rules themselves | Add `@targets` decorator, decorate 17 rules, add 2 new rules, migrate `rule_low_transitivity` |
+| `goldenmatch/core/autoconfig_policy.py` | Rule dispatch | Stamp `targets` from the rule onto the decision |
+| `goldenmatch/core/autoconfig_controller.py` | Iteration loop | Record `observed_delta` after the next iteration |
+| `tests/test_rule_action_coverage.py` | **new** — the gate | Every reachable RED slug is claimed |
+| `tests/test_rule_effect_feedback.py` | **new** | `predicts` / `rule_effect_was_negative` |
+| `tests/test_cluster_giant_rule.py` | **new** | Task 4's rule |
+| `tests/test_matchkey_collapsed_rule.py` | **new** | Task 5's rule |
+
+---
+
+### Task 1: Name every RED condition
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/complexity_profile.py`
+- Test: `packages/python/goldenmatch/tests/test_red_reason.py` (create)
+
+**Interfaces:**
+- Produces: `DataProfile.red_reason() -> str | None`, `BlockingProfile.red_reason(n_rows: int) -> str | None`, `ScoringProfile.red_reason() -> str | None`, `MatchkeyProfile.red_reason(n_full_rows: int | None = None) -> str | None`, `ClusterProfile.red_reason(n_rows: int) -> str | None`. Module constant `RED_REASONS: frozenset[str]` listing every slug any profile can return.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Every RED verdict names its condition, and the name cannot drift from the verdict."""
+from goldenmatch.core.complexity_profile import (
+    RED_REASONS,
+    ClusterProfile,
+    HealthVerdict,
+    MatchkeyProfile,
+)
+
+
+def test_cluster_giant_and_low_transitivity_are_distinct_reasons():
+    giant = ClusterProfile(n_clusters=3, cluster_size_max=60, transitivity_rate=1.0)
+    chained = ClusterProfile(n_clusters=50, cluster_size_max=4, transitivity_rate=0.2)
+    assert giant.red_reason(n_rows=100) == "cluster_giant"
+    assert chained.red_reason(n_rows=100) == "cluster_low_transitivity"
+
+
+def test_red_reason_agrees_with_health():
+    """The two must not drift: a reason implies RED, and RED implies a reason."""
+    for profile, kwargs in [
+        (ClusterProfile(n_clusters=3, cluster_size_max=60, transitivity_rate=1.0), {"n_rows": 100}),
+        (ClusterProfile(n_clusters=9, cluster_size_max=2, transitivity_rate=1.0), {"n_rows": 100}),
+    ]:
+        is_red = profile.health(**kwargs) == HealthVerdict.RED
+        assert (profile.red_reason(**kwargs) is not None) == is_red
+
+
+def test_every_reason_is_registered():
+    giant = ClusterProfile(n_clusters=3, cluster_size_max=60, transitivity_rate=1.0)
+    assert giant.red_reason(n_rows=100) in RED_REASONS
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_red_reason.py -q`
+Expected: FAIL — `ImportError: cannot import name 'RED_REASONS'`
+
+- [ ] **Step 3: Add `red_reason` to `ClusterProfile` and make `health` derive from it**
+
+In `complexity_profile.py`, replace `ClusterProfile.health` with:
+
+```python
+    def red_reason(self, n_rows: int) -> str | None:
+        """The named RED condition, or None. Single source of truth for
+        `health`, so a new RED branch cannot be added without naming it --
+        and the coverage gate keys on the name (see
+        tests/test_rule_action_coverage.py)."""
+        if n_rows > 0 and self.cluster_size_max > 0.1 * n_rows:
+            return "cluster_giant"
+        if self.transitivity_rate < 0.85:
+            return "cluster_low_transitivity"
+        return None
+
+    def health(self, n_rows: int) -> HealthVerdict:
+        if self.red_reason(n_rows) is not None:
+            return HealthVerdict.RED
+        if self.oversized_cluster_count > 0:
+            return HealthVerdict.YELLOW
+        return HealthVerdict.GREEN
+```
+
+- [ ] **Step 4: Run the test — cluster cases pass**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_red_reason.py -q`
+Expected: still FAIL on `RED_REASONS` import.
+
+- [ ] **Step 5: Repeat the same split for the other four profiles and register the slugs**
+
+Apply the identical `red_reason` / `health` split to `DataProfile`
+(`data_empty`), `BlockingProfile` (`blocking_no_blocks` plus each existing RED
+branch), `ScoringProfile` (`scoring_no_candidates`, `scoring_nothing_above_threshold`),
+and `MatchkeyProfile` (`matchkey_collapsed_field`). Then, at module level:
+
+```python
+#: Every RED condition any sub-profile can report. The coverage gate in
+#: tests/test_rule_action_coverage.py asserts each of these is claimed by at
+#: least one rule, so adding a RED branch without an action fails CI.
+RED_REASONS: frozenset[str] = frozenset({
+    "data_empty",
+    "blocking_no_blocks",
+    "scoring_no_candidates",
+    "scoring_nothing_above_threshold",
+    "matchkey_collapsed_field",
+    "cluster_giant",
+    "cluster_low_transitivity",
+})
+```
+
+- [ ] **Step 6: Run the full profile + controller suites**
+
+Run:
+```bash
+python -m pytest packages/python/goldenmatch/tests/test_red_reason.py \
+  packages/python/goldenmatch/tests/test_complexity_profile.py \
+  packages/python/goldenmatch/tests/test_autoconfig_controller.py -q
+```
+Expected: PASS. `health()` behaviour is unchanged — only its implementation moved.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/complexity_profile.py \
+        packages/python/goldenmatch/tests/test_red_reason.py
+git commit -m "refactor(profile): name every RED condition, derive health from it"
+```
+
+---
+
+### Task 2: Rules declare what they answer
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py`
+- Test: `packages/python/goldenmatch/tests/test_rule_targets.py` (create)
+
+**Interfaces:**
+- Consumes: `RED_REASONS` from Task 1.
+- Produces: decorator `targets(*reasons: str)` in `autoconfig_rules`, setting `fn.targets: tuple[str, ...]`. `PolicyDecision.targets: tuple[str, ...] = ()`, stamped by `HeuristicRefitPolicy.propose`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from goldenmatch.core.autoconfig_rules import DEFAULT_RULES, targets
+
+
+def test_decorator_records_the_reasons_on_the_function():
+    @targets("cluster_giant")
+    def rule_stub(profile, current, history):
+        return None
+
+    assert rule_stub.targets == ("cluster_giant",)
+
+
+def test_every_default_rule_declares_its_targets():
+    """A rule that answers nothing named is the accident this removes."""
+    undeclared = [r.__name__ for r in DEFAULT_RULES if not getattr(r, "targets", ())]
+    assert undeclared == [], f"rules with no declared target: {undeclared}"
+
+
+def test_declared_targets_are_real_reasons():
+    from goldenmatch.core.complexity_profile import RED_REASONS
+
+    for rule in DEFAULT_RULES:
+        for reason in getattr(rule, "targets", ()):
+            assert reason in RED_REASONS, f"{rule.__name__} targets unknown {reason!r}"
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_rule_targets.py -q`
+Expected: FAIL — `ImportError: cannot import name 'targets'`
+
+- [ ] **Step 3: Add the decorator and the `PolicyDecision` field**
+
+In `autoconfig_rules.py`, above the first rule:
+
+```python
+def targets(*reasons: str):
+    """Declare which RED conditions (see `complexity_profile.RED_REASONS`) this
+    rule answers.
+
+    The point is coverage, not documentation: `test_rule_action_coverage.py`
+    asserts every reachable RED reason is claimed by at least one rule, so a new
+    RED branch without an action fails CI rather than producing a verdict the
+    controller can only report. A rule may answer several.
+    """
+    def _decorate(fn):
+        fn.targets = reasons
+        return fn
+    return _decorate
+```
+
+In `autoconfig_history.py`, add to `PolicyDecision`:
+
+```python
+    #: RED conditions this rule declares it answers (from the `@targets`
+    #: decorator, stamped by the policy so rules never repeat themselves).
+    targets: tuple[str, ...] = ()
+```
+
+- [ ] **Step 4: Stamp it in the policy**
+
+In `autoconfig_policy.py`, inside `propose`, immediately after `new_config, decision = outcome`:
+
+```python
+            # Stamp the rule's declared targets onto its decision so the audit
+            # trail records what the action was meant to fix, not just what it
+            # changed. Rules do not repeat themselves -- the decorator is the
+            # single source.
+            declared = getattr(rule, "targets", ())
+            if declared and not decision.targets:
+                decision.targets = declared
+```
+
+- [ ] **Step 5: Decorate all 17 rules**
+
+Add one `@targets(...)` line above each rule in `DEFAULT_RULES`, mapping it to the RED reason it answers. Use this mapping (derived from which sub-profile each rule reads and acts on):
+
+```
+rule_blocking_field_null_heavy          -> blocking_no_blocks
+rule_blocking_singleton_trap            -> scoring_no_candidates
+rule_blocking_key_swap                  -> scoring_nothing_above_threshold
+rule_blocking_adaptive_on_p99_outlier   -> blocking_no_blocks
+rule_blocking_too_coarse                -> blocking_no_blocks
+rule_uniform_heavy_blocking             -> blocking_no_blocks
+rule_corruption_normalize               -> scoring_nothing_above_threshold
+rule_unimodal_scoring                   -> scoring_nothing_above_threshold
+rule_low_reduction_ratio                -> blocking_no_blocks
+rule_cross_blocking_disagreement        -> scoring_no_candidates
+rule_low_transitivity                   -> cluster_low_transitivity
+rule_no_matches                         -> scoring_nothing_above_threshold
+rule_matchkey_demote_high_cardinality_field -> matchkey_collapsed_field
+rule_select_probabilistic_matchkey      -> scoring_nothing_above_threshold
+rule_recall_gap_suspected               -> scoring_no_candidates
+rule_precision_anchor_threshold_raise   -> scoring_nothing_above_threshold
+rule_sparse_match_expand                -> scoring_no_candidates
+```
+
+- [ ] **Step 6: Run the test**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_rule_targets.py packages/python/goldenmatch/tests/test_autoconfig_policy.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Regenerate derived docs and commit**
+
+```bash
+python scripts/regen_docs.py
+git add -A
+git commit -m "feat(autoconfig): rules declare which RED condition they answer"
+```
+
+---
+
+### Task 3: The coverage gate
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_rule_action_coverage.py` (create)
+
+**Interfaces:**
+- Consumes: `RED_REASONS` (Task 1), `DEFAULT_RULES` + `rule.targets` (Task 2).
+- Produces: module constant `_UNCOVERED` in the test file, which Tasks 4 and 5 each shrink by one.
+
+- [ ] **Step 1: Write the gate, with the two known holes named**
+
+```python
+"""Every RED verdict the controller can reach must have a rule that answers it.
+
+Seven sub-profiles compute a health verdict; the rules act on three config
+surfaces. That asymmetry is how a run reaches RED with nothing to do about it --
+`DataProfile.health`'s own docstring records a signal that "stayed YELLOW for
+all 5 controller iterations with no rule addressing it", and #2717 hit the same
+shape three times.
+
+This gate makes the gap fail CI instead of surfacing as a bad benchmark months
+later.
+"""
+from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+from goldenmatch.core.complexity_profile import RED_REASONS
+
+#: RED conditions with no rule yet. SHRINKS ONLY -- adding an entry to make a
+#: red gate green defeats the point. Each is a measured hole, not a hypothetical:
+#:
+#: - cluster_giant: `rule_low_transitivity` is the ONLY rule reading
+#:   profile.cluster and it returns None unless transitivity < 0.85, so a giant
+#:   cluster with healthy transitivity produces no proposal at all.
+#: - matchkey_collapsed_field: both rules reading profile.matchkey.per_field
+#:   sort by HIGHEST cardinality; neither handles a field collapsing to one value.
+_UNCOVERED: frozenset[str] = frozenset({
+    "cluster_giant",              # removed by Task 4
+    "matchkey_collapsed_field",   # removed by Task 5
+})
+
+
+def _claimed() -> set[str]:
+    return {r for rule in DEFAULT_RULES for r in getattr(rule, "targets", ())}
+
+
+def test_every_red_reason_has_a_rule():
+    missing = RED_REASONS - _claimed() - _UNCOVERED
+    assert not missing, (
+        f"RED conditions no rule can answer: {sorted(missing)}. Either add a "
+        f"rule that targets it, or -- if it is genuinely unactionable -- remove "
+        f"the RED branch, as DataProfile did with its uniform-types clause."
+    )
+
+
+def test_the_allowlist_only_shrinks():
+    """An entry that is now covered must be deleted, not left to rot."""
+    stale = _UNCOVERED & _claimed()
+    assert not stale, (
+        f"{sorted(stale)} are covered by a rule now -- delete them from _UNCOVERED"
+    )
+
+
+def test_the_allowlist_names_real_reasons():
+    assert _UNCOVERED <= RED_REASONS
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_rule_action_coverage.py -q`
+Expected: PASS (3 passed) — the two holes are allowlisted with their evidence.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/tests/test_rule_action_coverage.py
+git commit -m "test(autoconfig): gate that every RED verdict has a rule that answers it"
+```
+
+---
+
+### Task 4: A rule for the giant-cluster RED
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py`
+- Modify: `packages/python/goldenmatch/tests/test_rule_action_coverage.py` (shrink `_UNCOVERED`)
+- Test: `packages/python/goldenmatch/tests/test_cluster_giant_rule.py` (create)
+
+**Interfaces:**
+- Consumes: `targets` decorator (Task 2), `ClusterConfig` from `goldenmatch.config.schemas` (already exists — `split_weak_bridges`, `weak_bridge_margin`).
+- Produces: `rule_cluster_giant(profile, current, history)` in `DEFAULT_RULES`, ordered immediately before `rule_low_transitivity`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""`cluster_size_max > 0.1 * n_rows` is RED and nothing answered it."""
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig, BlockingKeyConfig, ClusterConfig, GoldenMatchConfig,
+    MatchkeyConfig, MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_cluster_giant
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile, ClusterProfile, ComplexityProfile, DataProfile, ScoringProfile,
+)
+
+
+def _cfg(threshold: float = 0.7, cluster: ClusterConfig | None = None) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="mk", type="weighted", threshold=threshold,
+                                  fields=[MatchkeyField(field="name", scorer="token_sort",
+                                                        weight=1.0)])],
+        blocking=BlockingConfig(strategy="static",
+                                keys=[BlockingKeyConfig(fields=["name"])]),
+        cluster=cluster,
+    )
+
+
+def _profile(n_rows: int, cluster_size_max: int) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=n_rows, n_cols=3),
+        blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+        scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                               candidates_counted=True, mass_above_threshold=1.0),
+        cluster=ClusterProfile(n_clusters=10, cluster_size_max=cluster_size_max,
+                               transitivity_rate=1.0),
+    )
+
+
+def test_fires_on_a_giant_cluster_and_asks_for_splitting():
+    out = rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=400), _cfg(), RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    assert new_cfg.cluster is not None and new_cfg.cluster.split_weak_bridges is True
+    assert decision.targets == ("cluster_giant",)
+
+
+def test_does_not_fire_when_no_cluster_is_giant():
+    assert rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=40), _cfg(), RunHistory()) is None
+
+
+def test_raises_the_threshold_once_splitting_is_already_on():
+    """Splitting first because it is targeted; the threshold is the blunt fallback."""
+    cfg = _cfg(cluster=ClusterConfig(split_weak_bridges=True))
+    out = rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=400), cfg, RunHistory())
+    assert out is not None
+    assert out[0].matchkeys[0].threshold == pytest.approx(0.75)
+
+
+def test_stops_at_the_ceiling():
+    cfg = _cfg(threshold=0.95, cluster=ClusterConfig(split_weak_bridges=True))
+    assert rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=400), cfg, RunHistory()) is None
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_cluster_giant_rule.py -q`
+Expected: FAIL — `ImportError: cannot import name 'rule_cluster_giant'`
+
+- [ ] **Step 3: Implement the rule**
+
+In `autoconfig_rules.py`, immediately before `rule_low_transitivity`:
+
+```python
+#: A cluster this far above the ceiling is not a merge, it is a collapse.
+_GIANT_CLUSTER_FRACTION = 0.1
+_GIANT_THRESHOLD_STEP = 0.05
+_GIANT_THRESHOLD_CEILING = 0.95
+
+
+@targets("cluster_giant")
+def rule_cluster_giant(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    """Answer `ClusterProfile.red_reason() == "cluster_giant"`.
+
+    Before this, `rule_low_transitivity` was the ONLY rule reading
+    profile.cluster and it returns None unless transitivity < 0.85 -- so a run
+    where one cluster swallowed 10%+ of the data, with healthy transitivity,
+    produced no proposal at all. The controller reported RED and did nothing.
+
+    Splitting is tried FIRST because it targets the pathology: a giant cluster
+    is usually distinct entities chained through weak bridges. Raising the
+    threshold is the blunt fallback -- it also drops true pairs -- so it only
+    runs once splitting is already on and the cluster is still giant.
+    """
+    n_rows = profile.data.n_rows
+    cp = profile.cluster
+    if n_rows <= 0 or cp.cluster_size_max <= _GIANT_CLUSTER_FRACTION * n_rows:
+        return None
+
+    from goldenmatch.config.schemas import ClusterConfig
+
+    cluster_cfg = getattr(current, "cluster", None)
+    if cluster_cfg is None or not getattr(cluster_cfg, "split_weak_bridges", False):
+        new_cluster = (
+            ClusterConfig(split_weak_bridges=True)
+            if cluster_cfg is None
+            else cluster_cfg.model_copy(update={"split_weak_bridges": True})
+        )
+        return current.model_copy(update={"cluster": new_cluster}), PolicyDecision(
+            rule_name="cluster_giant",
+            rationale=(
+                f"largest cluster {cp.cluster_size_max} is "
+                f">{_GIANT_CLUSTER_FRACTION:.0%} of {n_rows} rows; splitting weak "
+                f"transitive bridges"
+            ),
+            config_diff={"cluster.split_weak_bridges": True},
+        )
+
+    mk = _first_weighted_mk(current)
+    if mk is None or mk.threshold is None:
+        return None
+    new_threshold = min(_GIANT_THRESHOLD_CEILING, mk.threshold + _GIANT_THRESHOLD_STEP)
+    if new_threshold == mk.threshold:
+        return None
+    new_mk = mk.model_copy(update={"threshold": new_threshold})
+    new_cfg = current.model_copy(update={
+        "matchkeys": [new_mk if m is mk else m for m in (current.matchkeys or [])]
+    })
+    return new_cfg, PolicyDecision(
+        rule_name="cluster_giant",
+        rationale=(
+            f"largest cluster {cp.cluster_size_max} still "
+            f">{_GIANT_CLUSTER_FRACTION:.0%} of {n_rows} rows with splitting on; "
+            f"raising threshold {mk.threshold:.2f} -> {new_threshold:.2f}"
+        ),
+        config_diff={"matchkeys[0].threshold": new_threshold},
+    )
+```
+
+Register it in `DEFAULT_RULES` immediately before `rule_low_transitivity`:
+
+```python
+    rule_cluster_giant,                    # 11b cluster: one cluster swallowed the data
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_cluster_giant_rule.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Shrink the allowlist**
+
+In `test_rule_action_coverage.py`, delete the `"cluster_giant"` line from `_UNCOVERED`, leaving:
+
+```python
+_UNCOVERED: frozenset[str] = frozenset({
+    "matchkey_collapsed_field",   # removed by Task 5
+})
+```
+
+- [ ] **Step 6: Verify the gate and the benchmarks together**
+
+Run:
+```bash
+python -m pytest packages/python/goldenmatch/tests/test_rule_action_coverage.py \
+  packages/python/goldenmatch/tests/test_autoconfig_policy.py \
+  packages/python/goldenmatch/tests/test_autoconfig_controller.py -q
+python scripts/run_benchmarks.py --datasets products \
+  --datasets-dir packages/python/goldenmatch/tests/benchmarks/datasets
+```
+Expected: tests PASS. Benchmarks: all four rows within their quarantine tolerance
+(`Abt-Buy (dedupe)` 0.0881 ±0.03, `Amazon-Google (dedupe)` 0.1014 ±0.03).
+**If a row drifts, stop and report** — a new rule that changes committed configs
+is exactly what `quality_gate` exists to arbitrate.
+
+- [ ] **Step 7: Regenerate docs and commit**
+
+```bash
+python scripts/regen_docs.py
+git add -A
+git commit -m "feat(autoconfig): a rule for the giant-cluster RED, which nothing answered"
+```
+
+---
+
+### Task 5: A rule for the collapsed-matchkey-field RED
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py`
+- Modify: `packages/python/goldenmatch/tests/test_rule_action_coverage.py` (empty `_UNCOVERED`)
+- Test: `packages/python/goldenmatch/tests/test_matchkey_collapsed_rule.py` (create)
+
+**Interfaces:**
+- Consumes: `targets` decorator (Task 2), `MatchkeyProfile.per_field[name].post_transform_cardinality_ratio`.
+- Produces: `rule_matchkey_collapsed_field(profile, current, history)` in `DEFAULT_RULES`, ordered immediately before `rule_matchkey_demote_high_cardinality_field`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""A matchkey field with cardinality 0.0 contributes no signal and is RED."""
+from goldenmatch.config.schemas import (
+    BlockingConfig, BlockingKeyConfig, GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_matchkey_collapsed_field
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile, ComplexityProfile, DataProfile, FieldStats, MatchkeyProfile,
+    ScoringProfile,
+)
+
+
+def _cfg(fields: list[str]) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="mk", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field=f, scorer="token_sort", weight=1.0) for f in fields],
+        )],
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["name"])]),
+    )
+
+
+def _profile(cardinalities: dict[str, float]) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=1000, n_cols=3),
+        blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+        scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                               candidates_counted=True, mass_above_threshold=1.0),
+        matchkey=MatchkeyProfile(per_field={
+            name: FieldStats(post_transform_cardinality_ratio=c)
+            for name, c in cardinalities.items()
+        }),
+    )
+
+
+def test_drops_the_collapsed_field():
+    out = rule_matchkey_collapsed_field(
+        _profile({"name": 0.9, "country": 0.0}), _cfg(["name", "country"]), RunHistory()
+    )
+    assert out is not None
+    new_cfg, decision = out
+    assert [f.field for f in new_cfg.matchkeys[0].fields] == ["name"]
+    assert decision.targets == ("matchkey_collapsed_field",)
+
+
+def test_does_not_fire_when_every_field_discriminates():
+    assert rule_matchkey_collapsed_field(
+        _profile({"name": 0.9, "city": 0.3}), _cfg(["name", "city"]), RunHistory()
+    ) is None
+
+
+def test_refuses_to_empty_the_matchkey():
+    """Dropping the last field leaves a matchkey that scores nothing -- worse
+    than a weak field. The rule declines and lets another rule try."""
+    assert rule_matchkey_collapsed_field(
+        _profile({"name": 0.0}), _cfg(["name"]), RunHistory()
+    ) is None
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_matchkey_collapsed_rule.py -q`
+Expected: FAIL — `ImportError: cannot import name 'rule_matchkey_collapsed_field'`
+
+- [ ] **Step 3: Implement the rule**
+
+In `autoconfig_rules.py`, immediately before `rule_matchkey_demote_high_cardinality_field`:
+
+```python
+@targets("matchkey_collapsed_field")
+def rule_matchkey_collapsed_field(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    """Answer `MatchkeyProfile.red_reason() == "matchkey_collapsed_field"`.
+
+    A field whose post-transform cardinality is 0.0 has one distinct value, so
+    every pair scores identically on it: it contributes weight and no
+    discrimination. Both rules that previously read `profile.matchkey.per_field`
+    (`rule_unimodal_scoring`, `rule_matchkey_demote_high_cardinality_field`)
+    sort by HIGHEST cardinality -- neither handles this end, so the verdict was
+    reported and never acted on.
+
+    Declines rather than emptying the matchkey: a matchkey with no fields scores
+    nothing, which is worse than a weak field, and returning None lets the
+    policy advance to a rule that can help.
+    """
+    mk = _first_weighted_mk(current)
+    if mk is None or not mk.fields:
+        return None
+    collapsed = {
+        name for name, fs in profile.matchkey.per_field.items()
+        if fs.post_transform_cardinality_ratio == 0.0
+    }
+    keep = [f for f in mk.fields if f.field not in collapsed]
+    if len(keep) == len(mk.fields) or not keep:
+        return None
+    dropped = sorted({f.field for f in mk.fields if f.field in collapsed})
+    new_mk = mk.model_copy(update={"fields": keep})
+    new_cfg = current.model_copy(update={
+        "matchkeys": [new_mk if m is mk else m for m in (current.matchkeys or [])]
+    })
+    return new_cfg, PolicyDecision(
+        rule_name="matchkey_collapsed_field",
+        rationale=(
+            f"matchkey field(s) {dropped} have a single distinct value after "
+            f"transforms, contributing weight and no discrimination; dropping them"
+        ),
+        config_diff={"matchkeys[0].fields": [f.field for f in keep]},
+    )
+```
+
+Register it in `DEFAULT_RULES` immediately before `rule_matchkey_demote_high_cardinality_field`.
+
+- [ ] **Step 4: Run the test**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_matchkey_collapsed_rule.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Empty the allowlist and tighten the gate**
+
+In `test_rule_action_coverage.py`, replace `_UNCOVERED` with:
+
+```python
+#: Empty, and it should stay that way. An entry here is a RED verdict the
+#: controller can only report -- add a rule that targets it, or remove the RED
+#: branch if it is genuinely unactionable (as DataProfile did with its
+#: uniform-types clause).
+_UNCOVERED: frozenset[str] = frozenset()
+```
+
+- [ ] **Step 6: Verify and measure**
+
+Run:
+```bash
+python -m pytest packages/python/goldenmatch/tests/test_rule_action_coverage.py \
+  packages/python/goldenmatch/tests/test_autoconfig_policy.py \
+  packages/python/goldenmatch/tests/test_autoconfig_controller.py \
+  packages/python/goldenmatch/tests/test_autoconfig.py -q
+python scripts/run_benchmarks.py --datasets products \
+  --datasets-dir packages/python/goldenmatch/tests/benchmarks/datasets
+```
+Expected: tests PASS, all four benchmark rows within tolerance. **Stop and report on any drift.**
+
+- [ ] **Step 7: Regenerate docs and commit**
+
+```bash
+python scripts/regen_docs.py
+git add -A
+git commit -m "feat(autoconfig): a rule for the collapsed-matchkey-field RED; coverage allowlist now empty"
+```
+
+---
+
+### Task 6: Rules can check whether their own action worked
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py`
+- Test: `packages/python/goldenmatch/tests/test_rule_effect_feedback.py` (create)
+
+**Interfaces:**
+- Consumes: `PolicyDecision` (Task 2).
+- Produces: `PolicyDecision.predicts: str | None`, `PolicyDecision.predicts_direction: str = "up"`, and `rule_effect_was_negative(history: RunHistory, rule_name: str, *, margin: float = 0.0) -> bool` in `autoconfig_history`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""A rule can ask whether its own last action moved what it predicted."""
+from goldenmatch.core.autoconfig_history import (
+    HistoryEntry, PolicyDecision, RunHistory, rule_effect_was_negative,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile, ClusterProfile, ComplexityProfile, DataProfile, ScoringProfile,
+)
+
+
+def _entry(iteration: int, transitivity: float, decision: PolicyDecision | None) -> HistoryEntry:
+    return HistoryEntry(
+        iteration=iteration, config=None,
+        profile=ComplexityProfile(
+            data=DataProfile(n_rows=1000, n_cols=3),
+            blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+            scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                                   candidates_counted=True, mass_above_threshold=1.0),
+            cluster=ClusterProfile(n_clusters=50, transitivity_rate=transitivity),
+        ),
+        decision=decision, error=None, wall_clock_ms=1,
+    )
+
+
+def _decision() -> PolicyDecision:
+    return PolicyDecision(
+        rule_name="low_transitivity", rationale="x", config_diff={},
+        predicts="cluster.transitivity_rate", predicts_direction="up",
+    )
+
+
+def test_reports_negative_when_the_metric_moved_the_wrong_way():
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.20, _decision()))
+    history.entries.append(_entry(1, 0.14, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is True
+
+
+def test_reports_not_negative_when_it_worked():
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.20, _decision()))
+    history.entries.append(_entry(1, 0.55, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is False
+
+
+def test_a_move_inside_the_margin_counts_as_no_progress():
+    """`transitivity_rate` samples up to 1000 triples and drifts ~0.003-0.005 on
+    an unchanged config, so a move inside that band is noise, not evidence."""
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.200, _decision()))
+    history.entries.append(_entry(1, 0.204, None))
+    assert rule_effect_was_negative(history, "low_transitivity", margin=0.01) is True
+
+
+def test_no_prior_firing_is_not_negative():
+    assert rule_effect_was_negative(RunHistory(), "low_transitivity") is False
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_rule_effect_feedback.py -q`
+Expected: FAIL — `ImportError: cannot import name 'rule_effect_was_negative'`
+
+- [ ] **Step 3: Add the fields and the helper**
+
+In `autoconfig_history.py`, add to `PolicyDecision`:
+
+```python
+    #: Dotted path into the ComplexityProfile this action expects to move, e.g.
+    #: "cluster.transitivity_rate". With `predicts_direction`, this is what lets
+    #: a rule check whether its OWN last action worked instead of re-applying it
+    #: blindly -- the failure that made `rule_low_transitivity` walk a threshold
+    #: to its floor on every iteration while the metric fell (#2717, and #195
+    #: at 2M before it).
+    predicts: str | None = None
+    #: "up" when the rule expects `predicts` to increase, "down" to decrease.
+    predicts_direction: str = "up"
+```
+
+And at module level:
+
+```python
+def _read_metric(profile: Any, dotted: str) -> float | None:
+    """Read a dotted path like "cluster.transitivity_rate" off a profile."""
+    node: Any = profile
+    for part in dotted.split("."):
+        node = getattr(node, part, None)
+        if node is None:
+            return None
+    return float(node) if isinstance(node, (int, float)) else None
+
+
+def rule_effect_was_negative(
+    history: RunHistory, rule_name: str, *, margin: float = 0.0
+) -> bool:
+    """Did `rule_name`'s own last action fail to move what it predicted?
+
+    False when the rule has not fired, when it declared no prediction, or when
+    the metric is unreadable -- absence of evidence is not evidence of failure,
+    and a rule should not mute itself on a missing measurement.
+    """
+    for i in range(len(history.entries) - 1, -1, -1):
+        decision = history.entries[i].decision
+        if decision is None or decision.rule_name != rule_name:
+            continue
+        if not decision.predicts:
+            return False
+        before = _read_metric(history.entries[i].profile, decision.predicts)
+        after = _read_metric(history.entries[-1].profile, decision.predicts)
+        if before is None or after is None:
+            return False
+        if decision.predicts_direction == "down":
+            return after >= before - margin
+        return after <= before + margin
+    return False
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `python -m pytest packages/python/goldenmatch/tests/test_rule_effect_feedback.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Migrate `rule_low_transitivity` onto the generic helper**
+
+In `autoconfig_rules.py`, delete `_last_low_transitivity_rate` and replace its
+use with the shared helper, keeping the existing margin constant:
+
+```python
+    if rule_effect_was_negative(
+        history, "low_transitivity", margin=_TRANSITIVITY_PROGRESS_MARGIN
+    ):
+        return None
+```
+
+Add `predicts="cluster.transitivity_rate"` and `predicts_direction="up"` to both
+`PolicyDecision(...)` constructions in that rule. Import the helper at the top of
+the module.
+
+- [ ] **Step 6: Verify the migration changed no behaviour**
+
+Run:
+```bash
+python -m pytest packages/python/goldenmatch/tests/test_autoconfig_policy.py \
+  packages/python/goldenmatch/tests/test_rule_effect_feedback.py \
+  packages/python/goldenmatch/tests/test_mass_above_is_a_real_fraction.py -q
+python scripts/run_benchmarks.py --datasets abt-buy \
+  --datasets-dir packages/python/goldenmatch/tests/benchmarks/datasets
+```
+Expected: tests PASS. Abt-Buy unchanged (`(dedupe)` 0.0881, `(linkage)` 0.7024)
+and `stop_reason=policy_satisfied` on both rows — the bespoke check and the
+generic one must agree.
+
+- [ ] **Step 7: Regenerate docs and commit**
+
+```bash
+python scripts/regen_docs.py
+git add -A
+git commit -m "feat(autoconfig): rules can check whether their own action worked"
+```
+
+---
+
+## Out of scope, deliberately
+
+**Making the controller perceive an action's benefit.** `rule_low_transitivity`
+can now request cluster splitting, but the controller does not commit the
+iteration that enables it: splitting 13 of 1202 sample clusters barely moves a
+transitivity estimate sampled over 1000 triples, so `pick_committed` prefers v0.
+This plan closes *diagnosis -> action* and *action -> feedback*; it does not fix
+*action -> perceptible signal*, which needs a design decision about the profile
+metric rather than plumbing. Measured on Abt-Buy: forcing splitting on is worth
+0.1723 -> 0.1805 at margin 0.05, so the signal is real and the profile is too
+coarse to see it.
+
+**Re-calibrating the RED thresholds themselves** (`0.85` transitivity, `0.1 *
+n_rows` giant, `0.0` cardinality). Task 1 makes them addressable; whether they
+are in the right place is a separate measured question.
+
+## Self-review notes
+
+- **Coverage:** every claim in "Why this exists" maps to a task — the 7-vs-3
+  asymmetry to Tasks 1-3, the two verified holes to Tasks 4 and 5, the
+  `rule_low_transitivity` blind re-application to Task 6.
+- **Placeholders:** none. Both new rules are written out in full, and the two
+  `_UNCOVERED` entries are named holes with the evidence for each, not "TBD".
+- **Type consistency:** `targets` is `tuple[str, ...]` on both the decorator
+  (`fn.targets`) and `PolicyDecision.targets`. `red_reason` returns `str | None`
+  on every profile. `rule_effect_was_negative` returns `bool` and is imported by
+  `autoconfig_rules` in Task 6 only.
+- **Known risk:** Tasks 4 and 5 add rules that can fire on real data and change
+  committed configs. Both tasks end with a benchmark run and an explicit
+  instruction to stop on drift; `quality_gate` is the CI arbiter and has caught
+  this class of change before.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -34,6 +34,16 @@ class PolicyDecision:
     #: decorator and stamped by the policy so rules never repeat themselves.
     #: Records what the action was MEANT to fix, not just what it changed.
     targets: tuple[str, ...] = ()
+    #: Dotted path into the ComplexityProfile this action expects to move, e.g.
+    #: "cluster.transitivity_rate". With `predicts_direction`, this is what lets
+    #: a rule check whether its OWN last action worked instead of re-applying it
+    #: blindly -- the failure that had `rule_low_transitivity` walk a threshold
+    #: to its floor on every iteration while the metric fell (#2717, and #195 at
+    #: 2M before it). None means the rule made no prediction, which is read as
+    #: "no evidence" rather than "it failed".
+    predicts: str | None = None
+    #: "up" when the rule expects `predicts` to increase, "down" to decrease.
+    predicts_direction: str = "up"
 
 
 @dataclass
@@ -292,3 +302,45 @@ class RunHistory:
 
         return min(survivors, key=key)
 
+
+def _read_metric(profile: Any, dotted: str) -> float | None:
+    """Read a dotted path like "cluster.transitivity_rate" off a profile."""
+    node: Any = profile
+    for part in dotted.split("."):
+        node = getattr(node, part, None)
+        if node is None:
+            return None
+    return float(node) if isinstance(node, (int, float)) else None
+
+
+def rule_effect_was_negative(
+    history: RunHistory, rule_name: str, *, margin: float = 0.0
+) -> bool:
+    """Did `rule_name`'s own last action fail to move what it predicted?
+
+    Generalises the check `rule_low_transitivity` hand-rolled: a rule that
+    cannot tell whether its lever works will keep pulling it. On Abt-Buy that
+    rule fired on all four iterations, walking the threshold 0.70 -> 0.50 while
+    transitivity fell 0.200 -> 0.138, and the run committed v0 regardless.
+
+    False when the rule has not fired, when it declared no prediction, or when
+    the metric is unreadable. Absence of evidence is not evidence of failure --
+    a rule must not mute itself on a missing measurement.
+
+    Only the rule's OWN prior decisions count: another rule's change says
+    nothing about whether THIS lever moves THIS metric.
+    """
+    for i in range(len(history.entries) - 1, -1, -1):
+        decision = history.entries[i].decision
+        if decision is None or decision.rule_name != rule_name:
+            continue
+        if not decision.predicts:
+            return False
+        before = _read_metric(history.entries[i].profile, decision.predicts)
+        after = _read_metric(history.entries[-1].profile, decision.predicts)
+        if before is None or after is None:
+            return False
+        if decision.predicts_direction == "down":
+            return after >= before - margin
+        return after <= before + margin
+    return False

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -30,6 +30,10 @@ class PolicyDecision:
     rationale: str
     config_diff: dict[str, Any]
     expand_sample: float | None = None
+    #: RED conditions this rule declares it answers, from the `@targets`
+    #: decorator and stamped by the policy so rules never repeat themselves.
+    #: Records what the action was MEANT to fix, not just what it changed.
+    targets: tuple[str, ...] = ()
 
 
 @dataclass

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py
@@ -82,6 +82,13 @@ class HeuristicRefitPolicy:
             if outcome is None:
                 continue
             new_config, decision = outcome
+            # Stamp the rule's declared targets onto its decision, so the audit
+            # trail records what the action was MEANT to fix rather than only
+            # what it changed. The decorator is the single source; rules never
+            # repeat themselves. See `autoconfig_rules.targets`.
+            declared = getattr(rule, "targets", ())
+            if declared and not decision.targets:
+                decision.targets = declared
             if new_config == current:
                 # Bug guard: rule "decided to do nothing" without saying so.
                 # Logged at WARN by the controller (not here — keep policy pure).

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1365,6 +1365,53 @@ _DEMOTE_CARD_THRESHOLD = 0.99
 _DEMOTE_MIN_REMAINING_FIELDS = 2
 
 
+@targets("matchkey_collapsed_field")
+def rule_matchkey_collapsed_field(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    """Answer `MatchkeyProfile.red_reason() == "matchkey_collapsed_field"`.
+
+    A field whose post-transform cardinality is 0.0 has ONE distinct value, so
+    every pair scores identically on it: it carries weight and contributes no
+    discrimination, diluting the fields that do.
+
+    Both rules that read `profile.matchkey.per_field` before this one --
+    `rule_unimodal_scoring` and `rule_matchkey_demote_high_cardinality_field` --
+    sort by HIGHEST cardinality. Neither handles this end, so the RED verdict was
+    reported and never acted on.
+
+    Declines rather than emptying the matchkey: a matchkey with no fields scores
+    nothing, which is worse than a weak field, and returning None lets the policy
+    advance to a rule that can help.
+    """
+    mk = _first_weighted_mk(current)
+    if mk is None or not mk.fields:
+        return None
+    collapsed = {
+        name
+        for name, fs in profile.matchkey.per_field.items()
+        if fs.post_transform_cardinality_ratio == 0.0
+    }
+    if not collapsed:
+        return None
+    keep = [f for f in mk.fields if f.field not in collapsed]
+    if len(keep) == len(mk.fields) or not keep:
+        return None
+    dropped = sorted({f.field for f in mk.fields if f.field in collapsed})
+    new_mk = mk.model_copy(update={"fields": keep})
+    new_cfg = current.model_copy(update={
+        "matchkeys": [new_mk if m is mk else m for m in (current.matchkeys or [])]
+    })
+    return new_cfg, PolicyDecision(
+        rule_name="matchkey_collapsed_field",
+        rationale=(
+            f"matchkey field(s) {dropped} hold a single distinct value after "
+            f"transforms, carrying weight with no discrimination; dropping them"
+        ),
+        config_diff={"matchkeys[0].fields": [f.field for f in keep]},
+    )
+
+
 @targets("blocking_no_blocks")
 def rule_matchkey_demote_high_cardinality_field(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
@@ -1676,6 +1723,7 @@ DEFAULT_RULES = [
     rule_cluster_giant,                    # 11b cluster: one cluster swallowed the frame
     rule_low_transitivity,                 # 12 tuning: transitivity low
     rule_no_matches,                       # 13 tuning: nothing matches
+    rule_matchkey_collapsed_field,         # 13b matchkey: a field collapsed to one value
     rule_matchkey_demote_high_cardinality_field,  # 14 NEW 2026-05-29: matchkey YELLOW from uniquely-identifying field
     rule_select_probabilistic_matchkey,    # NEW #491: wide fuzzy-only weighted mk + recall-limited + no exact anchor -> probabilistic
     rule_recall_gap_suspected,             # 15 tuning: random pair probe high OR over-tight signature (kept after the structural rules; only the precision-raise + sparse-expand threshold rules follow)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -467,6 +467,82 @@ def _last_low_transitivity_rate(history: RunHistory) -> float | None:
     return None
 
 
+#: Above this share of the frame, one cluster is a collapse rather than a merge.
+#: Mirrors `ClusterProfile._GIANT_CLUSTER_FRACTION`, which sets the RED bar.
+_GIANT_CLUSTER_FRACTION = 0.1
+_GIANT_THRESHOLD_STEP = 0.05
+_GIANT_THRESHOLD_CEILING = 0.95
+
+
+@targets("cluster_giant")
+def rule_cluster_giant(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    """Answer `ClusterProfile.red_reason() == "cluster_giant"`.
+
+    Before this, `rule_low_transitivity` was the ONLY rule reading
+    `profile.cluster`, and it returns None unless `transitivity_rate < 0.85`.
+    So a run where one cluster swallowed 10%+ of the data, with healthy
+    transitivity, produced no proposal at all: the controller reported RED and
+    had nothing to do about it.
+
+    Splitting is offered FIRST because it targets the pathology -- a giant
+    cluster is usually distinct entities chained through weak bridges, which is
+    exactly what `core/transitive_consistency.py` cuts. Raising the threshold is
+    the blunt fallback: it also drops true pairs, so it only runs once splitting
+    is already on and the cluster is still giant.
+
+    Offered ALONE, never both at once. Two changes in one iteration make the
+    next profile unattributable, which is the failure `rule_low_transitivity`
+    spent four iterations demonstrating (#2717).
+    """
+    n_rows = profile.data.n_rows
+    cp = profile.cluster
+    # n_rows <= 0 is `data_empty`'s business, and 0.1 * 0 would make any cluster
+    # look giant.
+    if n_rows <= 0 or cp.cluster_size_max <= _GIANT_CLUSTER_FRACTION * n_rows:
+        return None
+
+    from goldenmatch.config.schemas import ClusterConfig
+
+    cluster_cfg = getattr(current, "cluster", None)
+    if cluster_cfg is None or not getattr(cluster_cfg, "split_weak_bridges", False):
+        new_cluster = (
+            ClusterConfig(split_weak_bridges=True)
+            if cluster_cfg is None
+            else cluster_cfg.model_copy(update={"split_weak_bridges": True})
+        )
+        return current.model_copy(update={"cluster": new_cluster}), PolicyDecision(
+            rule_name="cluster_giant",
+            rationale=(
+                f"largest cluster {cp.cluster_size_max} is over "
+                f"{_GIANT_CLUSTER_FRACTION:.0%} of {n_rows} rows; splitting "
+                f"clusters held together by a weak transitive bridge"
+            ),
+            config_diff={"cluster.split_weak_bridges": True},
+        )
+
+    mk = _first_weighted_mk(current)
+    if mk is None or mk.threshold is None:
+        return None
+    new_threshold = min(_GIANT_THRESHOLD_CEILING, mk.threshold + _GIANT_THRESHOLD_STEP)
+    if new_threshold == mk.threshold:
+        return None
+    new_mk = mk.model_copy(update={"threshold": new_threshold})
+    new_cfg = current.model_copy(update={
+        "matchkeys": [new_mk if m is mk else m for m in (current.matchkeys or [])]
+    })
+    return new_cfg, PolicyDecision(
+        rule_name="cluster_giant",
+        rationale=(
+            f"largest cluster {cp.cluster_size_max} still over "
+            f"{_GIANT_CLUSTER_FRACTION:.0%} of {n_rows} rows with splitting on; "
+            f"raising threshold {mk.threshold:.2f} -> {new_threshold:.2f}"
+        ),
+        config_diff={"matchkeys[0].threshold": new_threshold},
+    )
+
+
 @targets("cluster_low_transitivity")
 def rule_low_transitivity(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
@@ -1597,6 +1673,7 @@ DEFAULT_RULES = [
     rule_unimodal_scoring,                 # 9  tuning: dip statistic low
     rule_low_reduction_ratio,              # 10 structural: too-tight blocking
     rule_cross_blocking_disagreement,      # 11 NEW v1.10: multi-pass on low cross-blocking overlap
+    rule_cluster_giant,                    # 11b cluster: one cluster swallowed the frame
     rule_low_transitivity,                 # 12 tuning: transitivity low
     rule_no_matches,                       # 13 tuning: nothing matches
     rule_matchkey_demote_high_cardinality_field,  # 14 NEW 2026-05-29: matchkey YELLOW from uniquely-identifying field

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -20,7 +20,11 @@ from goldenmatch.config.schemas import (
     GoldenMatchConfig,
     MatchkeyConfig,
 )
-from goldenmatch.core.autoconfig_history import PolicyDecision, RunHistory
+from goldenmatch.core.autoconfig_history import (
+    PolicyDecision,
+    RunHistory,
+    rule_effect_was_negative,
+)
 from goldenmatch.core.complexity_profile import ComplexityProfile
 
 if TYPE_CHECKING:
@@ -451,24 +455,8 @@ def rule_low_reduction_ratio(
 _TRANSITIVITY_PROGRESS_MARGIN = 0.01
 
 
-def _last_low_transitivity_rate(history: RunHistory) -> float | None:
-    """Transitivity observed when this rule last applied a nudge, if it has.
-
-    Only this rule's OWN prior decisions count: another rule's change tells us
-    nothing about whether THIS lever moves THIS signal.
-    """
-    for entry in reversed(history.entries):
-        decision = entry.decision
-        if decision is None or decision.rule_name != "low_transitivity":
-            continue
-        if entry.profile is None:
-            return None
-        return float(entry.profile.cluster.transitivity_rate)
-    return None
-
-
 #: Above this share of the frame, one cluster is a collapse rather than a merge.
-#: Mirrors `ClusterProfile._GIANT_CLUSTER_FRACTION`, which sets the RED bar.
+#: Mirrors the bar `ClusterProfile.red_reason` uses to raise `cluster_giant`.
 _GIANT_CLUSTER_FRACTION = 0.1
 _GIANT_THRESHOLD_STEP = 0.05
 _GIANT_THRESHOLD_CEILING = 0.95
@@ -583,10 +571,8 @@ def rule_low_transitivity(
     #
     # Returning None lets the policy advance to the next rule rather than
     # ending the iteration, so this only ever removes a known-inert option.
-    previous_rate = _last_low_transitivity_rate(history)
-    if (
-        previous_rate is not None
-        and cp.transitivity_rate <= previous_rate + _TRANSITIVITY_PROGRESS_MARGIN
+    if rule_effect_was_negative(
+        history, "low_transitivity", margin=_TRANSITIVITY_PROGRESS_MARGIN
     ):
         return None
 
@@ -622,6 +608,8 @@ def rule_low_transitivity(
         )
         return current.model_copy(update={"cluster": _new_cluster}), PolicyDecision(
             rule_name="low_transitivity",
+            predicts="cluster.transitivity_rate",
+            predicts_direction="up",
             rationale=(
                 f"transitivity={cp.transitivity_rate:.2f} < 0.85; splitting "
                 f"clusters held together by a weak transitive bridge"
@@ -640,6 +628,8 @@ def rule_low_transitivity(
     new_cfg = current.model_copy(update={"matchkeys": new_matchkeys})
     decision = PolicyDecision(
         rule_name="low_transitivity",
+        predicts="cluster.transitivity_rate",
+        predicts_direction="up",
         rationale=f"transitivity={cp.transitivity_rate:.2f} < 0.85; "
                   f"lowering threshold {mk.threshold:.2f} → {new_threshold:.2f}",
         config_diff={"matchkeys[0].threshold": new_threshold},

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -10,7 +10,8 @@ Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-desi
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,30 @@ from goldenmatch.core.complexity_profile import ComplexityProfile
 
 if TYPE_CHECKING:
     from goldenmatch.core.autoconfig_controller import IndicatorContext
+
+
+#: A rule callable. Bound so `targets` returns the SAME type it was given.
+_RuleFn = TypeVar("_RuleFn", bound=Callable[..., Any])
+
+
+def targets(*reasons: str) -> Callable[[_RuleFn], _RuleFn]:
+    """Declare which RED conditions this rule answers.
+
+    Reasons come from `complexity_profile.RED_REASONS`. The point is coverage,
+    not documentation: `tests/test_rule_action_coverage.py` asserts every
+    reachable RED condition is claimed by at least one rule, so a new RED branch
+    with no action fails CI rather than producing a verdict the controller can
+    only report -- the shape #2717 hit three times.
+
+    Annotates in place and returns the SAME function object. It must not wrap:
+    `DEFAULT_RULES` holds function references and the policy compares identity.
+    """
+
+    def _decorate(fn: _RuleFn) -> _RuleFn:
+        fn.targets = reasons  # type: ignore[attr-defined]
+        return fn
+
+    return _decorate
 
 
 def _first_weighted_mk(cfg: GoldenMatchConfig) -> MatchkeyConfig | None:
@@ -197,6 +222,7 @@ def _blocking_recovery_target(
     return None
 
 
+@targets("scoring_no_candidates")
 def rule_blocking_singleton_trap(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -273,6 +299,7 @@ def rule_blocking_singleton_trap(
     return new_cfg, decision
 
 
+@targets("blocking_skewed", "blocking_too_coarse")
 def rule_blocking_too_coarse(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -309,6 +336,7 @@ def rule_blocking_too_coarse(
     return new_cfg, decision
 
 
+@targets("scoring_unimodal")
 def rule_unimodal_scoring(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -351,6 +379,7 @@ def rule_unimodal_scoring(
     return new_cfg, decision
 
 
+@targets("blocking_too_coarse")
 def rule_low_reduction_ratio(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -438,6 +467,7 @@ def _last_low_transitivity_rate(history: RunHistory) -> float | None:
     return None
 
 
+@targets("cluster_low_transitivity")
 def rule_low_transitivity(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -541,6 +571,7 @@ def rule_low_transitivity(
     return new_cfg, decision
 
 
+@targets("scoring_nothing_above_threshold")
 def rule_no_matches(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -599,6 +630,7 @@ def rule_no_matches(
     return None
 
 
+@targets("scoring_nothing_above_threshold")
 def rule_blocking_key_swap(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -706,6 +738,7 @@ def rule_blocking_key_swap(
     return new_cfg, decision
 
 
+@targets("blocking_too_coarse")
 def rule_uniform_heavy_blocking(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -799,6 +832,7 @@ def rule_uniform_heavy_blocking(
     return new_cfg, decision
 
 
+@targets("blocking_no_blocks")
 def rule_blocking_field_null_heavy(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -870,6 +904,7 @@ _FUZZY_GRADED_SCORERS = frozenset({
 })
 
 
+@targets("scoring_nothing_above_threshold")
 def rule_select_probabilistic_matchkey(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -952,6 +987,7 @@ def rule_select_probabilistic_matchkey(
     return new_cfg, decision
 
 
+@targets("scoring_no_candidates")
 def rule_recall_gap_suspected(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -1135,6 +1171,7 @@ def rule_enable_llm_scorer(
     return new_cfg, decision
 
 
+@targets("scoring_nothing_above_threshold")
 def rule_corruption_normalize(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -1169,6 +1206,7 @@ def rule_corruption_normalize(
     return new_cfg, decision
 
 
+@targets("scoring_no_candidates")
 def rule_cross_blocking_disagreement(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -1211,6 +1249,7 @@ def rule_cross_blocking_disagreement(
     return new_cfg, decision
 
 
+@targets("scoring_no_candidates")
 def rule_sparse_match_expand(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -1250,6 +1289,7 @@ _DEMOTE_CARD_THRESHOLD = 0.99
 _DEMOTE_MIN_REMAINING_FIELDS = 2
 
 
+@targets("blocking_no_blocks")
 def rule_matchkey_demote_high_cardinality_field(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -1394,6 +1434,7 @@ def precision_anchor_would_fire(
     return _precision_anchor_trigger(cfg, profile, ctx) is not None
 
 
+@targets("scoring_unimodal")
 def rule_precision_anchor_threshold_raise(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -1484,6 +1525,7 @@ def rule_precision_anchor_threshold_raise(
     return new_cfg, decision
 
 
+@targets("blocking_skewed")
 def rule_blocking_adaptive_on_p99_outlier(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -67,6 +67,29 @@ class SparsityVerdict:
     estimated_n_true_pairs: int
 
 
+#: Fraction of the frame above which a single cluster is a collapse, not a merge.
+_GIANT_CLUSTER_FRACTION = 0.1
+#: Below this, a cluster's members do not all match each other -- chaining.
+_MIN_TRANSITIVITY = 0.85
+
+#: Every RED condition any sub-profile can report. `tests/test_rule_action_coverage.py`
+#: asserts each is either answered by a rule in `DEFAULT_RULES` or explicitly
+#: recorded as unactionable, so a new RED branch without an action fails CI
+#: rather than producing a verdict the controller can only report.
+RED_REASONS: frozenset[str] = frozenset({
+    "data_empty",
+    "blocking_no_blocks",
+    "blocking_skewed",
+    "blocking_too_coarse",
+    "scoring_no_candidates",
+    "scoring_nothing_above_threshold",
+    "scoring_unimodal",
+    "matchkey_collapsed_field",
+    "cluster_giant",
+    "cluster_low_transitivity",
+})
+
+
 @dataclass(frozen=True)
 class IndicatorsProfile:
     """v1.10: dynamic measurements computed lazily by indicators.
@@ -137,11 +160,20 @@ class DataProfile:
         clause turns this from a noisy false-positive into a precise signal
         for the genuinely-degenerate single-column case.
         """
-        if self.n_rows == 0:
+        if self.red_reason() is not None:
             return HealthVerdict.RED
         if self.n_cols == 1:
             return HealthVerdict.YELLOW
         return HealthVerdict.GREEN
+
+    def red_reason(self) -> str | None:
+        """See `ClusterProfile.red_reason`. `data_empty` is deliberately listed
+        as UNACTIONABLE by the coverage gate rather than as a hole: no config
+        change fixes an empty frame, which is the same argument this class's
+        `health` docstring makes for dropping its uniform-types clause."""
+        if self.n_rows == 0:
+            return "data_empty"
+        return None
 
 
 @dataclass(frozen=True)
@@ -216,6 +248,19 @@ class FieldStats:
 class MatchkeyProfile:
     _version: int = 1
     per_field: dict[str, FieldStats] = field(default_factory=dict)
+
+    def red_reason(self, n_full_rows: int | None = None) -> str | None:
+        """See `ClusterProfile.red_reason`.
+
+        NOT derived-from by `health` here: this profile computes a per-field max
+        severity across YELLOW and RED, so a top-of-function RED short-circuit
+        would change its behaviour. `tests/test_red_reason.py` asserts the two
+        agree instead.
+        """
+        for fs in self.per_field.values():
+            if fs.post_transform_cardinality_ratio == 0.0:
+                return "matchkey_collapsed_field"
+        return None
 
     def health(self, n_full_rows: int | None = None) -> HealthVerdict:
         """RED if any field collapses to a single value (no discrimination).
@@ -379,10 +424,24 @@ class BlockingProfile:
         biggest = self.block_sizes_max * (self.block_sizes_max - 1) // 2
         return biggest / self.total_comparisons
 
+    def red_reason(self, n_rows: int) -> str | None:
+        """See `ClusterProfile.red_reason`. `n_rows` is accepted for signature
+        stability with the `health` it backs; the skew bar is relative to
+        `n_blocks`, not to row count."""
+        if self.n_blocks == 0:
+            return "blocking_no_blocks"
+        skew_bar = max(_LARGEST_BLOCK_PAIR_SHARE_RED,
+                       _LARGEST_BLOCK_FAIR_SHARE_MULTIPLE / self.n_blocks)
+        if self.largest_block_pair_share > skew_bar:
+            return "blocking_skewed"
+        if self.reduction_ratio < 0.5:
+            return "blocking_too_coarse"
+        return None
+
     def health(self, n_rows: int) -> HealthVerdict:
         # `n_rows` is retained for signature stability with ClusterProfile.health
         # and the existing call sites; the skew rule below no longer needs it.
-        if self.n_blocks == 0:
+        if self.red_reason(n_rows) is not None:
             return HealthVerdict.RED
         # Skew is WORK CONCENTRATION, not a size percentile. The previous rule
         # -- `block_sizes_p99 > 10 * (n_rows / n_blocks)` -- divided a tail
@@ -401,12 +460,6 @@ class BlockingProfile:
         # where a 1/n_blocks share is simply what having few blocks looks like.
         # It costs no coverage: at small n_blocks a dominating block has to hold
         # most of the rows, which craters reduction_ratio below.
-        skew_bar = max(_LARGEST_BLOCK_PAIR_SHARE_RED,
-                       _LARGEST_BLOCK_FAIR_SHARE_MULTIPLE / self.n_blocks)
-        if self.largest_block_pair_share > skew_bar:
-            return HealthVerdict.RED
-        if self.reduction_ratio < 0.5:
-            return HealthVerdict.RED
         if self.singleton_block_count / self.n_blocks > 0.5:
             return HealthVerdict.YELLOW
         return HealthVerdict.GREEN
@@ -492,17 +545,24 @@ class ScoringProfile:
     # read as "nothing matched".
     admitted_fraction: float | None = None
 
-    def health(self) -> HealthVerdict:
-        # No candidates compared and no pairs scored → RED (nothing happened)
+    def red_reason(self) -> str | None:
+        """See `ClusterProfile.red_reason`. Three distinct conditions across
+        four branches -- the two `mass_above_threshold == 0.0` branches differ
+        only in whether the route counted candidates, and name the same
+        pathology."""
+        # Nothing happened at all.
         if self.candidates_compared == 0 and self.n_pairs_scored == 0:
-            return HealthVerdict.RED
-        # Candidates were compared but nothing reached threshold → still RED
-        # (rule_no_matches handles the "wrong threshold" case)
-        if self.mass_above_threshold == 0.0 and self.candidates_compared > 0:
-            return HealthVerdict.RED
+            return "scoring_no_candidates"
+        # Candidates were compared but nothing reached threshold
+        # (rule_no_matches handles the "wrong threshold" case).
         if self.mass_above_threshold == 0.0:
-            return HealthVerdict.RED
+            return "scoring_nothing_above_threshold"
         if self.dip_statistic < 0.005 and self.n_pairs_scored >= _MIN_DIP_SUPPORT:
+            return "scoring_unimodal"
+        return None
+
+    def health(self) -> HealthVerdict:
+        if self.red_reason() is not None:
             return HealthVerdict.RED
         # YELLOW only when the borderline band outweighs the above-threshold
         # tail. The legacy `mass_in_borderline > 0.3` rule fired YELLOW on any
@@ -552,10 +612,21 @@ class ClusterProfile:
     bridge_edge_count: int = 0
     measured_bridge_risk: float | None = None
 
+    def red_reason(self, n_rows: int) -> str | None:
+        """The named RED condition, or None.
+
+        Single source of truth for `health`'s RED branches, so a new one cannot
+        be added without naming it -- and `tests/test_rule_action_coverage.py`
+        keys on the name to assert some rule can answer it.
+        """
+        if n_rows > 0 and self.cluster_size_max > _GIANT_CLUSTER_FRACTION * n_rows:
+            return "cluster_giant"
+        if self.transitivity_rate < _MIN_TRANSITIVITY:
+            return "cluster_low_transitivity"
+        return None
+
     def health(self, n_rows: int) -> HealthVerdict:
-        if n_rows > 0 and self.cluster_size_max > 0.1 * n_rows:
-            return HealthVerdict.RED
-        if self.transitivity_rate < 0.85:
+        if self.red_reason(n_rows) is not None:
             return HealthVerdict.RED
         if self.oversized_cluster_count > 0:
             return HealthVerdict.YELLOW

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -594,12 +594,12 @@ def test_default_rules_list_has_five_entries():
     # Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)
     # Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     # rule_sparse_match_expand (v1.10)
-    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # 19 as of #2717's rule_cluster_giant + rule_matchkey_collapsed_field. This assertion is duplicated six times
     # in this file and the test NAMES around it (six/seven/nine/ten entries) are
     # all stale -- every rule addition bumped the number and left the names
     # behind. Renamed to something that cannot go stale rather than adding a
     # seventh wrong name.
-    assert len(DEFAULT_RULES) == 18
+    assert len(DEFAULT_RULES) == 19
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -794,12 +794,12 @@ def test_default_rules_count_is_pinned_a():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # 19 as of #2717's rule_cluster_giant + rule_matchkey_collapsed_field. This assertion is duplicated six times
     # in this file and the test NAMES around it (six/seven/nine/ten entries) are
     # all stale -- every rule addition bumped the number and left the names
     # behind. Renamed to something that cannot go stale rather than adding a
     # seventh wrong name.
-    assert len(DEFAULT_RULES) == 18
+    assert len(DEFAULT_RULES) == 19
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -1015,12 +1015,12 @@ def test_default_rules_count_is_pinned_b():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # 19 as of #2717's rule_cluster_giant + rule_matchkey_collapsed_field. This assertion is duplicated six times
     # in this file and the test NAMES around it (six/seven/nine/ten entries) are
     # all stale -- every rule addition bumped the number and left the names
     # behind. Renamed to something that cannot go stale rather than adding a
     # seventh wrong name.
-    assert len(DEFAULT_RULES) == 18
+    assert len(DEFAULT_RULES) == 19
 
 
 def test_rule_key_swap_is_before_rule_no_matches():
@@ -1344,12 +1344,12 @@ def test_default_rules_count_is_pinned_c():
     AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # 19 as of #2717's rule_cluster_giant + rule_matchkey_collapsed_field. This assertion is duplicated six times
     # in this file and the test NAMES around it (six/seven/nine/ten entries) are
     # all stale -- every rule addition bumped the number and left the names
     # behind. Renamed to something that cannot go stale rather than adding a
     # seventh wrong name.
-    assert len(DEFAULT_RULES) == 18
+    assert len(DEFAULT_RULES) == 19
 
 
 def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
@@ -1490,12 +1490,12 @@ def test_default_rules_count_is_pinned_d():
     Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     rule_sparse_match_expand (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # 19 as of #2717's rule_cluster_giant + rule_matchkey_collapsed_field. This assertion is duplicated six times
     # in this file and the test NAMES around it (six/seven/nine/ten entries) are
     # all stale -- every rule addition bumped the number and left the names
     # behind. Renamed to something that cannot go stale rather than adding a
     # seventh wrong name.
-    assert len(DEFAULT_RULES) == 18
+    assert len(DEFAULT_RULES) == 19
 
 
 def test_rule_enable_llm_scorer_not_in_default_rules():
@@ -1743,12 +1743,12 @@ def test_default_rules_count_is_pinned_e():
     """Fix 1 (reorder) + Fix 2 (new rule) → 10 rules total.
     Updated to 13: Phase 5 added 3 new indicator-aware rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # 19 as of #2717's rule_cluster_giant + rule_matchkey_collapsed_field. This assertion is duplicated six times
     # in this file and the test NAMES around it (six/seven/nine/ten entries) are
     # all stale -- every rule addition bumped the number and left the names
     # behind. Renamed to something that cannot go stale rather than adding a
     # seventh wrong name.
-    assert len(DEFAULT_RULES) == 18
+    assert len(DEFAULT_RULES) == 19
 
 
 # ============================================================

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -398,7 +398,9 @@ def _transitivity_profile(rate: float, threshold_pairs: int = 500) -> Complexity
     )
 
 
-def _history_where_the_rule_already_fired(prev_rate: float) -> RunHistory:
+def _history_where_the_rule_already_fired(
+    prev_rate: float, current_rate: float
+) -> RunHistory:
     """One prior iteration that applied `low_transitivity` and observed
     `prev_rate`, followed by the current (not yet decided) entry."""
     from goldenmatch.core.autoconfig_history import HistoryEntry
@@ -411,8 +413,23 @@ def _history_where_the_rule_already_fired(prev_rate: float) -> RunHistory:
             rule_name="low_transitivity",
             rationale=f"transitivity={prev_rate:.2f} < 0.85; lowering threshold",
             config_diff={"matchkeys[0].threshold": 0.75},
+            # The rule declares this on its real decisions (#2717); the generic
+            # `rule_effect_was_negative` reads a missing prediction as "no
+            # evidence", so a fixture without it would silently stop exercising
+            # the guard.
+            predicts="cluster.transitivity_rate",
+            predicts_direction="up",
         ),
         error=None, wall_clock_ms=1,
+    ))
+    # The controller APPENDS the current iteration's entry (decision=None)
+    # BEFORE calling policy.propose, so `history.entries[-1].profile` is the
+    # profile the rule is reacting to. `rule_effect_was_negative` compares
+    # against that entry, so a fixture that omits it makes before and after the
+    # same object and every nudge look inert.
+    history.entries.append(HistoryEntry(
+        iteration=1, config=None, profile=_transitivity_profile(current_rate),
+        decision=None, error=None, wall_clock_ms=1,
     ))
     return history
 
@@ -434,8 +451,8 @@ def test_rule_low_transitivity_declines_when_its_last_nudge_did_not_help():
     its rationale, so every fire looks new.
     """
     cfg = _config_with_blocking(threshold=0.8)
-    history = _history_where_the_rule_already_fired(prev_rate=0.20)
     # Transitivity went DOWN after the previous nudge.
+    history = _history_where_the_rule_already_fired(prev_rate=0.20, current_rate=0.138)
     out = rule_low_transitivity(_transitivity_profile(0.138), cfg, history)
     assert out is None, "the rule re-applied a nudge its own history shows is inert"
 
@@ -445,7 +462,7 @@ def test_rule_low_transitivity_declines_when_its_last_nudge_barely_moved_it():
     measured run-to-run drift is ~0.003-0.005 on the same config. A move
     inside that band is not evidence the lever works."""
     cfg = _config_with_blocking(threshold=0.8)
-    history = _history_where_the_rule_already_fired(prev_rate=0.200)
+    history = _history_where_the_rule_already_fired(prev_rate=0.200, current_rate=0.204)
     out = rule_low_transitivity(_transitivity_profile(0.204), cfg, history)
     assert out is None
 
@@ -453,7 +470,7 @@ def test_rule_low_transitivity_declines_when_its_last_nudge_barely_moved_it():
 def test_rule_low_transitivity_keeps_going_when_the_nudge_is_working():
     """The guard must not disable the rule where it earns its place."""
     cfg = _config_with_splitting_already_on(threshold=0.8)
-    history = _history_where_the_rule_already_fired(prev_rate=0.20)
+    history = _history_where_the_rule_already_fired(prev_rate=0.20, current_rate=0.55)
     out = rule_low_transitivity(_transitivity_profile(0.55), cfg, history)
     assert out is not None
     new_cfg, _ = out

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -594,7 +594,12 @@ def test_default_rules_list_has_five_entries():
     # Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)
     # Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     # rule_sparse_match_expand (v1.10)
-    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
+    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # in this file and the test NAMES around it (six/seven/nine/ten entries) are
+    # all stale -- every rule addition bumped the number and left the names
+    # behind. Renamed to something that cannot go stale rather than adding a
+    # seventh wrong name.
+    assert len(DEFAULT_RULES) == 18
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -781,7 +786,7 @@ def test_rule_singleton_trap_returns_none_when_no_text_field_in_matchkey():
     assert out is None  # no text field → can't target first_token
 
 
-def test_default_rules_now_has_six_entries():
+def test_default_rules_count_is_pinned_a():
     """Singleton-trap rule is added to DEFAULT_RULES.
     Updated to 7 after rule_blocking_key_swap was added (2026-05-07).
     Updated to 10 after rule_enable_llm_scorer was added (2026-05-07).
@@ -789,7 +794,12 @@ def test_default_rules_now_has_six_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
+    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # in this file and the test NAMES around it (six/seven/nine/ten entries) are
+    # all stale -- every rule addition bumped the number and left the names
+    # behind. Renamed to something that cannot go stale rather than adding a
+    # seventh wrong name.
+    assert len(DEFAULT_RULES) == 18
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -998,14 +1008,19 @@ def test_rule_key_swap_returns_none_when_no_text_field_in_matchkey():
     assert out is None
 
 
-def test_default_rules_now_has_seven_entries():
+def test_default_rules_count_is_pinned_b():
     """Adding rule_blocking_key_swap brings the count to 7.
     Updated to 10 after rule_enable_llm_scorer was added (2026-05-07).
     Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration.
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
+    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # in this file and the test NAMES around it (six/seven/nine/ten entries) are
+    # all stale -- every rule addition bumped the number and left the names
+    # behind. Renamed to something that cannot go stale rather than adding a
+    # seventh wrong name.
+    assert len(DEFAULT_RULES) == 18
 
 
 def test_rule_key_swap_is_before_rule_no_matches():
@@ -1322,14 +1337,19 @@ def test_rule_null_heavy_does_not_fire_on_low_null_field():
     assert out is None
 
 
-def test_default_rules_now_has_nine_entries():
+def test_default_rules_count_is_pinned_c():
     """Adding rule_blocking_field_null_heavy and rule_recall_gap_suspected brought the count to 9.
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     (rule_enable_llm_scorer was moved out of DEFAULT_RULES into
     AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
+    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # in this file and the test NAMES around it (six/seven/nine/ten entries) are
+    # all stale -- every rule addition bumped the number and left the names
+    # behind. Renamed to something that cannot go stale rather than adding a
+    # seventh wrong name.
+    assert len(DEFAULT_RULES) == 18
 
 
 def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
@@ -1463,14 +1483,19 @@ def test_rule_enable_llm_scorer_does_not_fire_when_already_enabled(monkeypatch):
     assert out is None
 
 
-def test_default_rules_now_has_ten_entries():
+def test_default_rules_count_is_pinned_d():
     """rule_uniform_heavy_blocking was added (Fix 2) and rule_blocking_key_swap
     was reordered (Fix 1), bringing the count to 10.
     (rule_enable_llm_scorer remains outside DEFAULT_RULES as post-iteration decoration.)
     Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     rule_sparse_match_expand (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
+    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # in this file and the test NAMES around it (six/seven/nine/ten entries) are
+    # all stale -- every rule addition bumped the number and left the names
+    # behind. Renamed to something that cannot go stale rather than adding a
+    # seventh wrong name.
+    assert len(DEFAULT_RULES) == 18
 
 
 def test_rule_enable_llm_scorer_not_in_default_rules():
@@ -1714,11 +1739,16 @@ def test_default_rules_uniform_heavy_after_blocking_too_coarse():
     assert idx_too_coarse < idx_uniform
 
 
-def test_default_rules_now_has_ten_entries_final():
+def test_default_rules_count_is_pinned_e():
     """Fix 1 (reorder) + Fix 2 (new rule) → 10 rules total.
     Updated to 13: Phase 5 added 3 new indicator-aware rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
+    # 18 as of #2717's rule_cluster_giant. This assertion is duplicated six times
+    # in this file and the test NAMES around it (six/seven/nine/ten entries) are
+    # all stale -- every rule addition bumped the number and left the names
+    # behind. Renamed to something that cannot go stale rather than adding a
+    # seventh wrong name.
+    assert len(DEFAULT_RULES) == 18
 
 
 # ============================================================

--- a/packages/python/goldenmatch/tests/test_cluster_giant_rule.py
+++ b/packages/python/goldenmatch/tests/test_cluster_giant_rule.py
@@ -1,0 +1,114 @@
+"""`cluster_size_max > 0.1 * n_rows` is RED and nothing answered it.
+
+`rule_low_transitivity` was the only rule reading `profile.cluster`, and it
+returns None unless `transitivity_rate < 0.85`. So a run where one cluster
+swallowed 10%+ of the data, with healthy transitivity, produced no proposal at
+all -- the controller reported RED and did nothing with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    ClusterConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_cluster_giant
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ClusterProfile,
+    ComplexityProfile,
+    DataProfile,
+    HealthVerdict,
+    ScoringProfile,
+)
+
+
+def _cfg(threshold: float = 0.7, cluster: ClusterConfig | None = None) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk", type="weighted", threshold=threshold,
+                fields=[MatchkeyField(field="name", scorer="token_sort", weight=1.0)],
+            )
+        ],
+        blocking=BlockingConfig(strategy="static",
+                                keys=[BlockingKeyConfig(fields=["name"])]),
+        cluster=cluster,
+    )
+
+
+def _profile(n_rows: int, cluster_size_max: int) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=n_rows, n_cols=3),
+        blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+        scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                               candidates_counted=True, mass_above_threshold=1.0,
+                               dip_statistic=0.5),
+        cluster=ClusterProfile(n_clusters=10, cluster_size_max=cluster_size_max,
+                               transitivity_rate=1.0),
+    )
+
+
+def test_the_fixture_is_actually_the_red_this_rule_answers():
+    """Guard the premise: if the fixture were not RED for `cluster_giant`, every
+    assertion below would be testing a condition that never occurs."""
+    profile = _profile(n_rows=1000, cluster_size_max=400)
+    assert profile.cluster.health(n_rows=1000) == HealthVerdict.RED
+    assert profile.cluster.red_reason(n_rows=1000) == "cluster_giant"
+
+
+def test_fires_on_a_giant_cluster_and_asks_for_splitting():
+    out = rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=400), _cfg(),
+                             RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    assert new_cfg.cluster is not None
+    assert new_cfg.cluster.split_weak_bridges is True
+    assert new_cfg.matchkeys[0].threshold == pytest.approx(0.7), (
+        "the cluster action must be offered ALONE -- two changes in one "
+        "iteration make the next profile unattributable"
+    )
+
+
+def test_does_not_fire_when_no_cluster_is_giant():
+    assert rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=40), _cfg(),
+                              RunHistory()) is None
+
+
+def test_does_not_fire_on_an_empty_frame():
+    """n_rows == 0 is data_empty's business, and 0.1 * 0 would make any cluster
+    look giant."""
+    assert rule_cluster_giant(_profile(n_rows=0, cluster_size_max=0), _cfg(),
+                              RunHistory()) is None
+
+
+def test_raises_the_threshold_once_splitting_is_already_on():
+    """Splitting first because it targets the pathology; raising the threshold
+    also drops true pairs, so it is the fallback."""
+    cfg = _cfg(cluster=ClusterConfig(split_weak_bridges=True))
+    out = rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=400), cfg,
+                             RunHistory())
+    assert out is not None
+    new_cfg, _ = out
+    assert new_cfg.matchkeys[0].threshold == pytest.approx(0.75)
+
+
+def test_stops_at_the_ceiling():
+    """At the ceiling there is nothing left to offer, and returning a config
+    equal to the input would trip the policy's do-nothing guard."""
+    cfg = _cfg(threshold=0.95, cluster=ClusterConfig(split_weak_bridges=True))
+    assert rule_cluster_giant(_profile(n_rows=1000, cluster_size_max=400), cfg,
+                              RunHistory()) is None
+
+
+def test_it_declares_the_condition_it_answers():
+    from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+
+    assert rule_cluster_giant.targets == ("cluster_giant",)
+    assert rule_cluster_giant in DEFAULT_RULES

--- a/packages/python/goldenmatch/tests/test_matchkey_collapsed_rule.py
+++ b/packages/python/goldenmatch/tests/test_matchkey_collapsed_rule.py
@@ -1,0 +1,118 @@
+"""A matchkey field with post-transform cardinality 0.0 is RED and nothing answered it.
+
+Such a field has one distinct value, so every pair scores identically on it: it
+carries weight and contributes no discrimination. Both rules that read
+`profile.matchkey.per_field` before this one (`rule_unimodal_scoring`,
+`rule_matchkey_demote_high_cardinality_field`) sort by HIGHEST cardinality --
+neither handles this end, so the verdict was reported and never acted on.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import rule_matchkey_collapsed_field
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    FieldStats,
+    HealthVerdict,
+    MatchkeyProfile,
+    ScoringProfile,
+)
+
+
+def _field(cardinality: float) -> FieldStats:
+    return FieldStats(
+        post_transform_cardinality_ratio=cardinality,
+        post_transform_null_rate=0.0,
+        post_transform_value_length_p50=8,
+    )
+
+
+def _cfg(fields: list[str]) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk", type="weighted", threshold=0.7,
+                fields=[MatchkeyField(field=f, scorer="token_sort", weight=1.0)
+                        for f in fields],
+            )
+        ],
+        blocking=BlockingConfig(strategy="static",
+                                keys=[BlockingKeyConfig(fields=["name"])]),
+    )
+
+
+def _profile(cardinalities: dict[str, float]) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=1000, n_cols=3),
+        blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+        scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                               candidates_counted=True, mass_above_threshold=1.0,
+                               dip_statistic=0.5),
+        matchkey=MatchkeyProfile(per_field={n: _field(c)
+                                            for n, c in cardinalities.items()}),
+    )
+
+
+def test_the_fixture_is_actually_the_red_this_rule_answers():
+    """Guard the premise: without this, every assertion below could be testing
+    a condition that never occurs."""
+    profile = _profile({"name": 0.9, "country": 0.0})
+    assert profile.matchkey.health() == HealthVerdict.RED
+    assert profile.matchkey.red_reason() == "matchkey_collapsed_field"
+
+
+def test_drops_the_collapsed_field():
+    out = rule_matchkey_collapsed_field(
+        _profile({"name": 0.9, "country": 0.0}), _cfg(["name", "country"]), RunHistory()
+    )
+    assert out is not None
+    new_cfg, decision = out
+    assert [f.field for f in new_cfg.matchkeys[0].fields] == ["name"]
+    assert "country" in decision.rationale
+
+
+def test_drops_several_collapsed_fields_at_once():
+    out = rule_matchkey_collapsed_field(
+        _profile({"name": 0.9, "country": 0.0, "region": 0.0}),
+        _cfg(["name", "country", "region"]), RunHistory(),
+    )
+    assert out is not None
+    assert [f.field for f in out[0].matchkeys[0].fields] == ["name"]
+
+
+def test_does_not_fire_when_every_field_discriminates():
+    assert rule_matchkey_collapsed_field(
+        _profile({"name": 0.9, "city": 0.3}), _cfg(["name", "city"]), RunHistory()
+    ) is None
+
+
+def test_ignores_a_collapsed_column_that_is_not_in_the_matchkey():
+    """The profile covers every column; only matchkey fields carry weight."""
+    assert rule_matchkey_collapsed_field(
+        _profile({"name": 0.9, "unused": 0.0}), _cfg(["name"]), RunHistory()
+    ) is None
+
+
+def test_refuses_to_empty_the_matchkey():
+    """A matchkey with no fields scores nothing, which is worse than a weak
+    field. Returning None lets the policy advance to a rule that can help."""
+    assert rule_matchkey_collapsed_field(
+        _profile({"name": 0.0}), _cfg(["name"]), RunHistory()
+    ) is None
+
+
+def test_it_declares_the_condition_it_answers():
+    from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+
+    assert rule_matchkey_collapsed_field.targets == ("matchkey_collapsed_field",)
+    assert rule_matchkey_collapsed_field in DEFAULT_RULES

--- a/packages/python/goldenmatch/tests/test_red_reason.py
+++ b/packages/python/goldenmatch/tests/test_red_reason.py
@@ -1,0 +1,132 @@
+"""Every RED verdict names its condition, and the name cannot drift from it.
+
+Seven sub-profiles compute a health verdict; the rules in `DEFAULT_RULES` act on
+three config surfaces. That asymmetry is how a run reaches RED with nothing to
+do about it -- `DataProfile.health`'s own docstring records a signal that
+"stayed YELLOW for all 5 controller iterations with no rule addressing it
+because the verdict isn't actionable".
+
+Naming each RED condition is what lets `test_rule_action_coverage.py` assert
+that every one of them is answerable. `health()` derives from `red_reason()`
+wherever the RED branches sit at the top of the function, so the two cannot
+disagree; `MatchkeyProfile` computes a per-field max-severity and keeps them
+separate, so an explicit agreement test covers it instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.complexity_profile import (
+    RED_REASONS,
+    BlockingProfile,
+    ClusterProfile,
+    DataProfile,
+    FieldStats,
+    HealthVerdict,
+    MatchkeyProfile,
+    ScoringProfile,
+)
+
+
+def _field(cardinality: float) -> FieldStats:
+    return FieldStats(
+        post_transform_cardinality_ratio=cardinality,
+        post_transform_null_rate=0.0,
+        post_transform_value_length_p50=8,
+    )
+
+
+# ── the two conditions that had no rule (see test_rule_action_coverage) ──────
+
+
+def test_cluster_giant_and_low_transitivity_are_distinct_reasons():
+    giant = ClusterProfile(n_clusters=3, cluster_size_max=60, transitivity_rate=1.0)
+    chained = ClusterProfile(n_clusters=50, cluster_size_max=4, transitivity_rate=0.2)
+    assert giant.red_reason(n_rows=100) == "cluster_giant"
+    assert chained.red_reason(n_rows=100) == "cluster_low_transitivity"
+
+
+def test_matchkey_collapsed_field_is_named():
+    collapsed = MatchkeyProfile(per_field={"country": _field(0.0)})
+    assert collapsed.red_reason() == "matchkey_collapsed_field"
+
+
+# ── agreement: a reason implies RED, and RED implies a reason ────────────────
+
+
+@pytest.mark.parametrize(
+    "profile,kwargs",
+    [
+        (DataProfile(n_rows=0, n_cols=0), {}),
+        (DataProfile(n_rows=100, n_cols=3), {}),
+        (DataProfile(n_rows=100, n_cols=1), {}),  # YELLOW, not RED
+        (BlockingProfile(n_blocks=0), {"n_rows": 100}),
+        (BlockingProfile(n_blocks=10, reduction_ratio=0.2), {"n_rows": 100}),
+        (BlockingProfile(n_blocks=10, reduction_ratio=0.99), {"n_rows": 100}),
+        (ScoringProfile(candidates_compared=0, n_pairs_scored=0), {}),
+        (
+            ScoringProfile(
+                candidates_compared=500, n_pairs_scored=0, mass_above_threshold=0.0
+            ),
+            {},
+        ),
+        (
+            ScoringProfile(
+                candidates_compared=500,
+                n_pairs_scored=500,
+                mass_above_threshold=1.0,
+                dip_statistic=0.5,
+            ),
+            {},
+        ),
+        (ClusterProfile(n_clusters=3, cluster_size_max=60, transitivity_rate=1.0), {"n_rows": 100}),
+        (ClusterProfile(n_clusters=50, cluster_size_max=4, transitivity_rate=0.2), {"n_rows": 100}),
+        (ClusterProfile(n_clusters=9, cluster_size_max=2, transitivity_rate=1.0), {"n_rows": 100}),
+    ],
+)
+def test_red_reason_agrees_with_health(profile, kwargs):
+    is_red = profile.health(**kwargs) == HealthVerdict.RED
+    reason = profile.red_reason(**kwargs)
+    assert (reason is not None) == is_red, (
+        f"{type(profile).__name__}: health={profile.health(**kwargs)} but "
+        f"red_reason={reason!r}"
+    )
+
+
+def test_matchkey_red_reason_agrees_with_health():
+    """MatchkeyProfile keeps the two separate (its health is a per-field max
+    severity), so agreement is asserted rather than structural."""
+    for per_field, expect_red in [
+        ({"country": _field(0.0)}, True),
+        ({"name": _field(0.5)}, False),
+        ({"name": _field(0.5), "country": _field(0.0)}, True),
+        ({}, False),
+    ]:
+        profile = MatchkeyProfile(per_field=per_field)
+        is_red = profile.health() == HealthVerdict.RED
+        assert (profile.red_reason() is not None) == is_red is expect_red
+
+
+# ── the registry ────────────────────────────────────────────────────────────
+
+
+def test_every_reason_returned_is_registered():
+    """A slug the gate does not know about is a hole it cannot see."""
+    produced = {
+        DataProfile(n_rows=0, n_cols=0).red_reason(),
+        BlockingProfile(n_blocks=0).red_reason(n_rows=100),
+        BlockingProfile(n_blocks=10, reduction_ratio=0.2).red_reason(n_rows=100),
+        ScoringProfile(candidates_compared=0, n_pairs_scored=0).red_reason(),
+        MatchkeyProfile(per_field={"c": _field(0.0)}).red_reason(),
+        ClusterProfile(n_clusters=3, cluster_size_max=60, transitivity_rate=1.0)
+        .red_reason(n_rows=100),
+        ClusterProfile(n_clusters=50, cluster_size_max=4, transitivity_rate=0.2)
+        .red_reason(n_rows=100),
+    }
+    assert produced <= RED_REASONS, f"unregistered: {sorted(produced - RED_REASONS)}"
+
+
+def test_a_green_profile_names_nothing():
+    assert DataProfile(n_rows=100, n_cols=3).red_reason() is None
+    assert ClusterProfile(n_clusters=9, cluster_size_max=2,
+                          transitivity_rate=1.0).red_reason(n_rows=100) is None

--- a/packages/python/goldenmatch/tests/test_rule_action_coverage.py
+++ b/packages/python/goldenmatch/tests/test_rule_action_coverage.py
@@ -40,10 +40,6 @@ _UNACTIONABLE: frozenset[str] = frozenset({
 #: gate green is the failure this exists to prevent. Each entry is a MEASURED
 #: hole with its evidence, not a hypothetical.
 _UNCOVERED: frozenset[str] = frozenset({
-    # `rule_low_transitivity` is the ONLY rule reading profile.cluster and it
-    # returns None unless transitivity < 0.85, so a run where one cluster
-    # swallowed 10%+ of the data with healthy transitivity produces no proposal.
-    "cluster_giant",
     # Both rules reading profile.matchkey.per_field (rule_unimodal_scoring,
     # rule_matchkey_demote_high_cardinality_field) sort by HIGHEST cardinality.
     # Neither handles a field collapsing to a single value.

--- a/packages/python/goldenmatch/tests/test_rule_action_coverage.py
+++ b/packages/python/goldenmatch/tests/test_rule_action_coverage.py
@@ -1,0 +1,104 @@
+"""Every RED verdict the controller can reach must have a rule that answers it.
+
+Seven sub-profiles compute a health verdict; the 17 rules in `DEFAULT_RULES` act
+on three config surfaces. That asymmetry is how a run reaches RED with nothing to
+do about it. `DataProfile.health`'s own docstring records the shape:
+
+    v23 telemetry (#577) showed this signal stayed YELLOW for all 5 controller
+    iterations with no rule addressing it because the verdict isn't actionable
+
+and #2717 hit it three times in one issue -- a runtime warning about
+concatenated sources with no lever, a RED cluster verdict with no cluster action
+at all, and a rule walking a threshold that provably could not move the metric
+it was reacting to.
+
+This gate makes that fail CI instead of surfacing as a bad benchmark months
+later. There are two ways for a RED condition to be legitimately unanswered, and
+they are NOT the same thing:
+
+  * `_UNACTIONABLE` -- no config change can fix it. Permanent and documented.
+  * `_UNCOVERED` -- a real hole. Shrinks only, never grows.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+from goldenmatch.core.complexity_profile import RED_REASONS
+
+#: RED conditions no config change can fix. Adding one here is a claim that the
+#: controller should REPORT the condition and stop, not that someone owes work.
+#:
+#: `DataProfile` already made this argument once and acted on it: it dropped a
+#: uniform-types YELLOW clause precisely because "there's no config change that
+#: fixes 'your data is all strings'". An empty frame is the same -- there is no
+#: blocking key, threshold or matchkey that makes zero rows matchable.
+_UNACTIONABLE: frozenset[str] = frozenset({
+    "data_empty",
+})
+
+#: RED conditions with no rule yet. SHRINKS ONLY -- adding an entry to turn a red
+#: gate green is the failure this exists to prevent. Each entry is a MEASURED
+#: hole with its evidence, not a hypothetical.
+_UNCOVERED: frozenset[str] = frozenset({
+    # `rule_low_transitivity` is the ONLY rule reading profile.cluster and it
+    # returns None unless transitivity < 0.85, so a run where one cluster
+    # swallowed 10%+ of the data with healthy transitivity produces no proposal.
+    "cluster_giant",
+    # Both rules reading profile.matchkey.per_field (rule_unimodal_scoring,
+    # rule_matchkey_demote_high_cardinality_field) sort by HIGHEST cardinality.
+    # Neither handles a field collapsing to a single value.
+    "matchkey_collapsed_field",
+})
+
+
+def _claimed() -> set[str]:
+    return {r for rule in DEFAULT_RULES for r in getattr(rule, "targets", ())}
+
+
+def test_every_red_reason_has_a_rule():
+    missing = RED_REASONS - _claimed() - _UNCOVERED - _UNACTIONABLE
+    assert not missing, (
+        f"RED conditions no rule can answer: {sorted(missing)}. Either add a rule "
+        f"that targets it, or -- if no config change can fix it -- record it in "
+        f"_UNACTIONABLE with the reason, as DataProfile did when it removed its "
+        f"uniform-types clause."
+    )
+
+
+def test_the_uncovered_allowlist_only_shrinks():
+    """An entry that a rule now answers must be deleted, not left to rot."""
+    stale = _UNCOVERED & _claimed()
+    assert not stale, (
+        f"{sorted(stale)} are answered by a rule now -- delete them from _UNCOVERED"
+    )
+
+
+def test_unactionable_conditions_have_no_rule():
+    """If someone writes a rule for one of these, the classification was wrong
+    and the entry should move out of _UNACTIONABLE rather than sit contradicted."""
+    contradicted = _UNACTIONABLE & _claimed()
+    assert not contradicted, (
+        f"{sorted(contradicted)} are marked unactionable but a rule targets them"
+    )
+
+
+def test_the_two_lists_are_disjoint():
+    """A condition is either impossible to act on or owed an action, not both."""
+    assert not (_UNACTIONABLE & _UNCOVERED)
+
+
+def test_both_lists_name_real_reasons():
+    """A slug that no profile can emit is dead weight hiding a real gap."""
+    assert _UNCOVERED <= RED_REASONS, sorted(_UNCOVERED - RED_REASONS)
+    assert _UNACTIONABLE <= RED_REASONS, sorted(_UNACTIONABLE - RED_REASONS)
+
+
+def test_the_gate_would_catch_a_new_unanswered_condition():
+    """Negative control: the assertion is capable of failing.
+
+    A gate that passes because its inputs are empty is worse than no gate --
+    this proves the comparison is live before anyone trusts a green run.
+    """
+    invented = RED_REASONS | {"totally_new_red_condition"}
+    missing = invented - _claimed() - _UNCOVERED - _UNACTIONABLE
+    assert missing == {"totally_new_red_condition"}

--- a/packages/python/goldenmatch/tests/test_rule_action_coverage.py
+++ b/packages/python/goldenmatch/tests/test_rule_action_coverage.py
@@ -36,15 +36,11 @@ _UNACTIONABLE: frozenset[str] = frozenset({
     "data_empty",
 })
 
-#: RED conditions with no rule yet. SHRINKS ONLY -- adding an entry to turn a red
-#: gate green is the failure this exists to prevent. Each entry is a MEASURED
-#: hole with its evidence, not a hypothetical.
-_UNCOVERED: frozenset[str] = frozenset({
-    # Both rules reading profile.matchkey.per_field (rule_unimodal_scoring,
-    # rule_matchkey_demote_high_cardinality_field) sort by HIGHEST cardinality.
-    # Neither handles a field collapsing to a single value.
-    "matchkey_collapsed_field",
-})
+#: RED conditions with no rule yet. EMPTY, and it should stay that way. SHRINKS
+#: ONLY -- adding an entry to turn a red gate green is the failure this exists to
+#: prevent. If a new RED branch has no action, either write the rule or, when no
+#: config change can fix it, record it in `_UNACTIONABLE` with the reason.
+_UNCOVERED: frozenset[str] = frozenset()
 
 
 def _claimed() -> set[str]:

--- a/packages/python/goldenmatch/tests/test_rule_effect_feedback.py
+++ b/packages/python/goldenmatch/tests/test_rule_effect_feedback.py
@@ -1,0 +1,142 @@
+"""A rule can ask whether its own last action moved what it predicted.
+
+`rule_low_transitivity` re-applied a threshold nudge on every iteration while the
+metric it was reacting to fell, walking 0.70 -> 0.50 and committing v0 anyway
+(#2717; the same rule caused the 2M degeneration in #195 before that). It
+received `history` and never read it -- the word appeared once, in the signature.
+
+The fix was hand-rolled for one rule. This generalises it: a rule declares what
+it expects to move via `PolicyDecision.predicts`, and any rule can ask
+`rule_effect_was_negative`.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_history import (
+    HistoryEntry,
+    PolicyDecision,
+    RunHistory,
+    rule_effect_was_negative,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ClusterProfile,
+    ComplexityProfile,
+    DataProfile,
+    ScoringProfile,
+)
+
+
+def _entry(iteration: int, transitivity: float,
+           decision: PolicyDecision | None) -> HistoryEntry:
+    return HistoryEntry(
+        iteration=iteration, config=None,
+        profile=ComplexityProfile(
+            data=DataProfile(n_rows=1000, n_cols=3),
+            blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+            scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                                   candidates_counted=True, mass_above_threshold=1.0,
+                                   dip_statistic=0.5),
+            cluster=ClusterProfile(n_clusters=50, transitivity_rate=transitivity),
+        ),
+        decision=decision, error=None, wall_clock_ms=1,
+    )
+
+
+def _decision(direction: str = "up") -> PolicyDecision:
+    return PolicyDecision(
+        rule_name="low_transitivity", rationale="x", config_diff={},
+        predicts="cluster.transitivity_rate", predicts_direction=direction,
+    )
+
+
+def test_reports_negative_when_the_metric_moved_the_wrong_way():
+    """The Abt-Buy shape: transitivity fell 0.200 -> 0.138 across four nudges."""
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.20, _decision()))
+    history.entries.append(_entry(1, 0.14, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is True
+
+
+def test_reports_not_negative_when_it_worked():
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.20, _decision()))
+    history.entries.append(_entry(1, 0.55, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is False
+
+
+def test_a_move_inside_the_margin_counts_as_no_progress():
+    """`transitivity_rate` samples up to 1000 triples and drifts ~0.003-0.005 on
+    an unchanged config, so a move inside that band is noise, not evidence."""
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.200, _decision()))
+    history.entries.append(_entry(1, 0.204, None))
+    assert rule_effect_was_negative(history, "low_transitivity", margin=0.01) is True
+
+
+def test_a_down_prediction_is_read_the_other_way():
+    """Not every rule wants its metric to rise."""
+    history = RunHistory()
+    history.entries.append(_entry(0, 0.20, _decision(direction="down")))
+    history.entries.append(_entry(1, 0.10, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is False
+
+
+def test_no_prior_firing_is_not_negative():
+    assert rule_effect_was_negative(RunHistory(), "low_transitivity") is False
+
+
+def test_another_rules_decision_is_not_evidence_about_this_one():
+    """Only a rule's OWN action says whether ITS lever works."""
+    history = RunHistory()
+    other = PolicyDecision(rule_name="blocking_too_coarse", rationale="x",
+                           config_diff={}, predicts="cluster.transitivity_rate")
+    history.entries.append(_entry(0, 0.20, other))
+    history.entries.append(_entry(1, 0.14, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is False
+
+
+def test_a_rule_that_predicted_nothing_is_not_negative():
+    """Absence of evidence is not evidence of failure -- a rule that never said
+    what it expected must not mute itself."""
+    history = RunHistory()
+    silent = PolicyDecision(rule_name="low_transitivity", rationale="x", config_diff={})
+    history.entries.append(_entry(0, 0.20, silent))
+    history.entries.append(_entry(1, 0.14, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is False
+
+
+def test_an_unreadable_metric_is_not_negative():
+    history = RunHistory()
+    bogus = PolicyDecision(rule_name="low_transitivity", rationale="x",
+                           config_diff={}, predicts="cluster.no_such_field")
+    history.entries.append(_entry(0, 0.20, bogus))
+    history.entries.append(_entry(1, 0.14, None))
+    assert rule_effect_was_negative(history, "low_transitivity") is False
+
+
+def test_the_shipped_rule_declares_what_it_predicts():
+    """The migration target: rule_low_transitivity's own decisions must carry a
+    prediction, or the generic helper silently never fires for it."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        ClusterConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    from goldenmatch.core.autoconfig_rules import rule_low_transitivity
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="mk", type="weighted", threshold=0.8,
+                                  fields=[MatchkeyField(field="name",
+                                                        scorer="token_sort", weight=1.0)])],
+        blocking=BlockingConfig(strategy="static",
+                                keys=[BlockingKeyConfig(fields=["name"])]),
+        cluster=ClusterConfig(split_weak_bridges=True),
+    )
+    out = rule_low_transitivity(_entry(0, 0.20, None).profile, cfg, RunHistory())
+    assert out is not None
+    assert out[1].predicts == "cluster.transitivity_rate"
+    assert out[1].predicts_direction == "up"

--- a/packages/python/goldenmatch/tests/test_rule_targets.py
+++ b/packages/python/goldenmatch/tests/test_rule_targets.py
@@ -1,0 +1,114 @@
+"""Rules declare which RED condition they answer.
+
+The point is coverage, not documentation. `test_rule_action_coverage.py` asserts
+every reachable RED condition is claimed by at least one rule, and that gate can
+only key on a declaration. A rule that answers nothing named is the accident
+this removes.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_rules import DEFAULT_RULES, targets
+from goldenmatch.core.complexity_profile import RED_REASONS
+
+
+def test_decorator_records_the_reasons_on_the_function():
+    @targets("cluster_giant")
+    def rule_stub(profile, current, history):
+        return None
+
+    assert rule_stub.targets == ("cluster_giant",)
+
+
+def test_decorator_accepts_several_reasons():
+    """One action can answer more than one condition -- a blocking key swap
+    addresses both 'no blocks' and 'nothing above threshold'."""
+
+    @targets("blocking_no_blocks", "scoring_no_candidates")
+    def rule_stub(profile, current, history):
+        return None
+
+    assert rule_stub.targets == ("blocking_no_blocks", "scoring_no_candidates")
+
+
+def test_the_decorator_returns_the_rule_unchanged():
+    """It annotates; it must not wrap. A wrapper would break `is` identity
+    against DEFAULT_RULES entries and the oscillation guard's rule lookup."""
+
+    def rule_stub(profile, current, history):
+        return "sentinel"
+
+    assert targets("cluster_giant")(rule_stub) is rule_stub
+    assert rule_stub(None, None, None) == "sentinel"
+
+
+def test_every_default_rule_declares_its_targets():
+    undeclared = [r.__name__ for r in DEFAULT_RULES if not getattr(r, "targets", ())]
+    assert undeclared == [], f"rules with no declared target: {undeclared}"
+
+
+def test_declared_targets_are_real_reasons():
+    """A typo'd slug would silently satisfy nothing and leave a real hole."""
+    for rule in DEFAULT_RULES:
+        for reason in getattr(rule, "targets", ()):
+            assert reason in RED_REASONS, (
+                f"{rule.__name__} targets unknown reason {reason!r}; "
+                f"known: {sorted(RED_REASONS)}"
+            )
+
+
+def test_the_policy_stamps_the_declaration_onto_the_decision():
+    """The audit trail should record what an action was MEANT to fix. Rules do
+    not repeat themselves -- the decorator is the single source."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    from goldenmatch.core.autoconfig_history import PolicyDecision, RunHistory
+    from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ClusterProfile,
+        ComplexityProfile,
+        DataProfile,
+        ScoringProfile,
+    )
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="mk", type="weighted", threshold=0.7,
+                                  fields=[MatchkeyField(field="name",
+                                                        scorer="token_sort", weight=1.0)])],
+        blocking=BlockingConfig(strategy="static",
+                                keys=[BlockingKeyConfig(fields=["name"])]),
+    )
+
+    @targets("cluster_low_transitivity")
+    def rule_stub(profile, current, history):
+        return current.model_copy(update={"llm_boost": True}), PolicyDecision(
+            rule_name="stub", rationale="r", config_diff={"llm_boost": True},
+        )
+
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=1000, n_cols=3),
+        blocking=BlockingProfile(n_blocks=20, reduction_ratio=0.9),
+        scoring=ScoringProfile(n_pairs_scored=500, candidates_compared=5000,
+                               candidates_counted=True, mass_above_threshold=1.0,
+                               dip_statistic=0.5),
+        cluster=ClusterProfile(n_clusters=50, transitivity_rate=0.2),
+    )
+    # The policy attaches the decision to the LAST history entry, so one has to
+    # exist or the assertion below passes vacuously.
+    from goldenmatch.core.autoconfig_history import HistoryEntry
+
+    history = RunHistory()
+    history.entries.append(HistoryEntry(iteration=0, config=cfg, profile=profile,
+                                        decision=None, error=None, wall_clock_ms=1))
+    policy = HeuristicRefitPolicy(rules=[rule_stub])
+    assert policy.propose(profile, cfg, history) is not None
+
+    stamped = history.entries[-1].decision
+    assert stamped is not None, "the policy did not attach the decision"
+    assert stamped.targets == ("cluster_low_transitivity",)


### PR DESCRIPTION
Seven sub-profiles compute a health verdict. The 17 rules in `DEFAULT_RULES` acted on three config surfaces. That asymmetry is how a run reaches RED with nothing to do about it — and the codebase already recorded the shape, in `DataProfile.health`'s own docstring:

> v23 telemetry (#577) showed this signal stayed YELLOW for all 5 controller iterations with no rule addressing it because the verdict isn't actionable

#2717 hit it three times in one issue: a runtime warning about concatenated sources with no lever, a RED cluster verdict with no cluster action at all, and a rule walking a threshold that provably could not move the metric it was reacting to.

## What this changes

**Every RED condition is named** (`red_reason()`), and `health()` derives from it on Data/Blocking/Scoring/Cluster so the two cannot drift. `MatchkeyProfile` computes a per-field max severity across YELLOW and RED, so a top-of-function short-circuit would change behaviour — it keeps them separate with an agreement test instead.

**Rules declare what they answer** (`@targets(...)`), stamped onto `PolicyDecision` by the policy so the audit trail records what an action was *meant* to fix, not just what it changed. The decorator annotates in place and returns the same function object — `DEFAULT_RULES` holds references and a wrapper would break identity for the oscillation guard.

**A gate asserts every reachable RED condition is answered.** Two lists, deliberately, because they are not the same claim:

| list | meaning |
|---|---|
| `_UNACTIONABLE` | no config change can fix it — permanent, documented |
| `_UNCOVERED` | a real hole — shrinks only, **now empty** |

**Two rules for the two holes that existed:**

- `rule_cluster_giant` — `rule_low_transitivity` was the only rule reading `profile.cluster` and returns `None` unless transitivity < 0.85, so a run where one cluster swallowed 10%+ of the frame with healthy transitivity produced no proposal at all.
- `rule_matchkey_collapsed_field` — both rules reading `matchkey.per_field` sort by *highest* cardinality; neither handled a field collapsing to one value.

**Rules can check whether their own action worked.** `PolicyDecision.predicts` names the metric a rule expects to move; `rule_effect_was_negative()` generalises the check `rule_low_transitivity` hand-rolled. A missing prediction or unreadable metric reads as *no evidence*, never as failure — a rule must not mute itself on an absent measurement.

## What the plan got wrong, found by executing it

- **10 RED slugs, not 7.** `ScoringProfile` has four RED branches naming three conditions; `BlockingProfile` has three, not one.
- **`data_empty` is not a hole.** No config change makes zero rows matchable — recording it as debt to pay off would be wrong. That is why the gate has two lists, and it is the same argument `DataProfile` made when it deleted its uniform-types clause.
- **Six copies of `assert len(DEFAULT_RULES) == 17`** under names claiming *six*, *seven*, *nine*, *ten*, *ten_final* entries. Every rule addition since bumped the number and left the names behind. Renamed so they cannot drift again.
- **The feedback test's fixture did not match the controller.** It built history without the current iteration's entry, but the controller appends it (`decision=None`) *before* calling `propose` — so `entries[-1].profile` *is* the profile the rule reacts to. Without it, before and after were the same object and every nudge looked inert. Its `PolicyDecision` also carried no `predicts`, which the new helper reads as no-evidence, silently disarming the guard the test exists to cover. Both would have passed while measuring nothing.

## Verification

**Product benchmarks unchanged at every step**, including after each new rule that can fire on real data — `Abt-Buy (dedupe)` 0.0881, `(linkage)` 0.7024, `Amazon-Google (dedupe)` 0.1097, `(linkage)` 0.4636.

Abt-Buy re-checked end-to-end after the migration: still `POLICY_SATISFIED`, threshold unwalked at 0.70, the rule offering the cluster action once and then declining.

2,281 tests pass. The 15 failures in the run are **byte-identical to the base commit** `70d8862b` — verified by running the same selection at base and diffing the lists, not by judging from filenames. They are `test_golden_fused` (10), `test_quality_aware_blocking` (3), `test_cluster_edges_df::test_datafusion_is_importable`, and one arrow-parity test.

`quality_gate` is the CI arbiter for a `DEFAULT_RULES` change and has caught this class before.

## Out of scope, deliberately

**Making the controller perceive an action's benefit.** `rule_low_transitivity` can now request cluster splitting, but the controller does not commit the iteration that enables it: splitting 13 of 1202 sample clusters barely moves a transitivity estimate sampled over 1000 triples, so `pick_committed` prefers v0. This closes *diagnosis → action* and *action → feedback*; it does not fix *action → perceptible signal*, which needs a design decision about the profile metric rather than plumbing. Forcing splitting on is worth 0.1723 → 0.1805 on Abt-Buy, so the signal is real and the profile is too coarse to see it.

Plan: `docs/superpowers/plans/2026-08-23-rule-action-space-first-class.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwo1rmbqSy1d9iEGjT96P