### PR TITLE
fix(docs-gates): make the doc gates fire, pin generated bytes, and make `make docs` the whole battery

### DIFF
--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -115,24 +115,46 @@ All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
   package = add it to `SECTIONS`. Pure-logic unit tests in
   `scripts/test_docs_sections.py`.
 
-- **Tier 2 - `scripts/check_docs_staleness.py`** (ADVISORY CI job, `--base`/
-  `--head`, default `origin/main..HEAD`). Diff-aware. The **flag rule** (gating
-  within the job): adding/removing a `GOLDENMATCH_*` env flag in
-  `packages/python/**/*.py` without touching `docs-site/goldenmatch/tuning.mdx`
-  emits `::error::` and exits 1. The **public-symbol rule** (warning only): a
-  package `__init__.py` `__all__`/re-export change with no doc surface touched
-  emits `::warning::`. Wired as the `docs_staleness` job with
-  `continue-on-error: true` (NOT in `ci-required`) - it surfaces annotations,
-  never blocks a clean PR.
+- **Tier 2 - `scripts/check_docs_staleness.py`** (`--base`/`--head`, default
+  `origin/main..HEAD`; `--rule all|flag|symbol`). Diff-aware, two rules with
+  DIFFERENT enforcement, run as two steps of the `docs_staleness` job:
+  - **flag rule** (`--rule flag`, BLOCKING step): for every package declaring a
+    `prose_flag_page` in `scripts/config_matrix/registry.py`, adding/removing a
+    `<ENV_PREFIX>*` flag in non-test `packages/python/**/*.py` without touching
+    that page emits `::error::` and exits 1. Only goldenmatch declares one today
+    (`docs-site/goldenmatch/tuning.mdx`); the rest are N/A because their
+    GENERATED config-matrix block already covers the knob and `docs_regen` gates
+    it. Giving a package a tuning page is a one-line registry change.
+  - **public-symbol rule** (`--rule symbol`, `continue-on-error` step): a package
+    `__init__.py` `__all__`/re-export change with no doc surface touched emits
+    `::warning::`.
 
-- **Tier 3 - `scripts/check_docs_sweep.py`** + `docs/.docs-sweep.json` (RELEASE /
-  manual gate, NOT run on every PR). Asserts `docs/.docs-sweep.json` `.version`
-  equals the current `packages/python/goldenmatch` version. A bump of the
-  headline package since the last recorded sweep reds the gate. **At the END of a
-  docs sweep, bump `docs/.docs-sweep.json`** (`version` to the new goldenmatch
-  version, refresh `commit`/`date`). Run this manually before tagging a release,
-  or wire it into the publish/release workflow. It exists to catch "cut a release
-  but never swept the prose surfaces" that the structural gates can't author.
+  The job gates on its OWN `docs_staleness` path filter. It previously gated on
+  `docs`, which matches no `packages/python/**/*.py` path -- so the flag rule was
+  skipped on exactly the diffs it exists to catch, and the whole job was
+  `continue-on-error` so its "gating" exit could not fail anything either. The job
+  is still NOT in `ci-required`: a red flag-rule step is visible on the PR but does
+  not block the merge queue. Promoting it is a one-line addition to
+  `ci-required.needs`.
+
+- **Tier 3 - `scripts/check_docs_sweep.py`** + `docs/.docs-sweep.json` (RELEASE
+  gate, NOT run on every PR). Asserts `docs/.docs-sweep.json` `.version` equals
+  the current `packages/python/goldenmatch` version. A bump of the headline
+  package since the last recorded sweep reds the gate. **At the END of a docs
+  sweep, bump `docs/.docs-sweep.json`** (`version` to the new goldenmatch version,
+  refresh `commit`/`date`). It exists to catch "cut a release but never swept the
+  prose surfaces" that the structural gates can't author.
+
+  Wired into `cut-goldenmatch-release.yml` as a step BEFORE the tag push, so a
+  failed sweep leaves the version name unburned (immutable releases tombstone a
+  name permanently). Emergency hotfix escape hatch: the workflow's
+  `skip_docs_sweep_gate` dispatch input, which annotates a `::warning::`.
+
+  **History:** for a long time this script was wired into NO workflow -- it was
+  referenced only by a path filter and this document, so the marker sat at 3.3.1
+  while goldenmatch reached 3.16.0. The 3.4.0..3.16.0 prose backlog is UNSWEPT;
+  the marker was advanced to arm the gate going forward, not to claim those
+  releases were swept (see `backlog_note` in `docs/.docs-sweep.json`).
 
 ## Sweep mechanics for this repo
 

--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -81,6 +81,22 @@ thing to grep for.
 Three tiers of automation keep these surfaces in lockstep as the repo advances.
 All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
 
+- **The canonical roster - `scripts/config_matrix/roster.py`.** One definition of
+  "the suite packages", consumed by every generator and doc gate. Three distinct
+  notions, not interchangeable: `DOCUMENTED` (packages owning a
+  `docs-site/<pkg>/` section + generated config matrix, derived from `REGISTRY` --
+  so **adding a `PackageSpec` is the single edit that onboards a package**);
+  `derive_roster()` (every distribution the repo actually publishes, read off the
+  `publish-*.yml` callers); and the two deferral maps `DOCS_DEFERRED` /
+  `README_DEFERRED` (published packages knowingly without a docs section / README
+  row, each with a reason). The gap between the first two must be fully covered by
+  the deferral maps or `check_docs_consistency` FAILS -- and a deferral for a
+  package that *does* have the surface fails too, so the maps cannot go stale in
+  either direction. Row ORDER stays editorial and local to each generator:
+  `REGISTRY` order is baked into the agent manifests, so deriving table order from
+  it would reshuffle published pages on an unrelated registry edit. Pure stdlib on
+  purpose -- the gates that consume it run on a bare `setup-python` runner.
+
 - **Tier 0 - `scripts/regen_docs.py`** (`make docs` / `just docs`; the
   `docs_regen` REQUIRED CI job runs `--check`). The single command that
   REGENERATES every derived artifact: the six config matrices, the agent manifest

--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -81,10 +81,22 @@ thing to grep for.
 Three tiers of automation keep these surfaces in lockstep as the repo advances.
 All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
 
-- **Tier 1 - `scripts/check_docs_consistency.py`** (REQUIRED CI gate, `--check`
-  default). The single umbrella entry point for "all doc gates". It (a) runs
-  `check_version_consistency.py` and `sync_readme_callouts.py --check` as
-  subprocesses; (b) **roster matrix** - derives the published-package roster from
+- **Tier 0 - `scripts/regen_docs.py`** (`make docs` / `just docs`; the
+  `docs_regen` REQUIRED CI job runs `--check`). The single command that
+  REGENERATES every derived artifact: the six config matrices, the agent manifest
+  + codemap, api-surface's table, suite-matrix, thesis-weaknesses, the native
+  pages, the llms.txt/README capability counts, and the README "what's new"
+  callouts. If a doc figure has a generator, it belongs in `WRITE_STEPS` -- a
+  `--check`-only gate for something a generator owns is a chore, not a gate. The
+  drift probe is `git status --porcelain` scoped to `GENERATED_PATHS`, so a
+  brand-new generated page counts as drift too. Only one hand-bumped figure
+  survives: the two inline numbers beside api-surface's table, reported by
+  `gen_api_surface --check`.
+
+- **Tier 1 - `scripts/check_docs_consistency.py`** (REQUIRED CI gate). The
+  umbrella entry point for STRUCTURAL doc consistency. It (a) runs
+  `check_version_consistency.py` as a subprocess -- the one doc gate no generator
+  owns; (b) **roster matrix** - derives the published-package roster from
   the `publish-*.yml` workflows (cross-checked against
   `scripts/suite_download_badges.py`) and asserts each CORE package name appears
   in the root `README.md` and the `docs-site/docs.json` nav; (c) **docs-nav
@@ -93,10 +105,17 @@ All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
   **changelog<->version** - each `packages/python/<pkg>/CHANGELOG.md` most-recent
   *released* version heading equals its `pyproject.toml` version (packages whose
   CHANGELOG has no versioned heading, or only an `unreleased` top entry, are
-  reported, not failed). Wired as the `docs_consistency` job in `ci.yml` (in the
-  `ci-required` needs list), gated on the `docs` path filter. To satisfy it: add
-  the missing README table row / `docs.json` nav entry / fix the broken nav link
-  or orphan page, or bump the lagging CHANGELOG/version.
+  reported, not failed). Findings that are deliberately not gated print `[INFO]`,
+  not `[PASS]`, so an all-PASS summary means what it says. Wired as the
+  `docs_consistency` job in `ci.yml` (in the `ci-required` needs list), gated on
+  the `docs` path filter. To satisfy it: add the missing README table row /
+  `docs.json` nav entry / fix the broken nav link or orphan page, or bump the
+  lagging CHANGELOG/version.
+
+  It no longer subgates `sync_readme_callouts --check` or `gen_native_docs
+  --check`: `regen_docs.py` WRITES both, so checking them here asked a human to
+  fix by hand what `make docs` repairs. CI coverage is unchanged (the standalone
+  `readme_callouts` job plus `docs_regen`).
 
 - **Tier 1 - `scripts/check_docs_sections.py`** (REQUIRED CI gate, a step in the
   `docs_consistency` job). The SOURCE OF TRUTH for "what a package section looks

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,13 @@
 # PR diffs and drops them from GitHub language stats; `-diff` stops git from
 # emitting a (useless, huge) textual diff. These are outputs, not source an
 # agent or reviewer should read line-by-line.
-**/llms.txt        linguist-generated=true -diff
+#
+# NOTE on llms.txt: it is NOT listed here, deliberately. It is HAND-AUTHORED prose
+# -- scripts/check_llms_counts.py only verifies the NUMBERS stated inside it, it
+# does not write the file. Marking it linguist-generated collapsed every llms.txt
+# prose change out of PR review, which is the opposite of what these agent-facing
+# files need. (llms-full.txt stays listed: no such file is tracked today, and if
+# one appears it will be an emitted rollup.)
 **/llms-full.txt   linguist-generated=true -diff
 uv.lock            linguist-generated=true -diff
 pnpm-lock.yaml     linguist-generated=true -diff
@@ -18,3 +24,17 @@ packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json  linguist-ge
 # scripts/test_agent_codemap.py. Force LF so the byte-for-byte gate can't trip on
 # a CRLF checkout (Windows dev vs Linux CI).
 docs/agent-codemap.json  linguist-generated=true -diff eol=lf
+
+# Generated docs-site pages. Each is written whole (or spliced between
+# `:generated:start`/`:generated:end` markers) by a scripts/gen_*.py and gated by
+# `regen_docs.py --check`, which compares BYTES -- so `eol=lf` is load-bearing on a
+# CRLF checkout (Windows dev vs Linux CI), exactly as it is for the two JSON
+# artifacts above. The writers pin `newline="\n"` too; the attribute is the second
+# half of that guarantee (it also governs what git stores on `add`).
+docs-site/*/config-matrix.mdx        linguist-generated=true -diff eol=lf
+docs-site/*/native.mdx               linguist-generated=true -diff eol=lf
+docs-site/suite-matrix.mdx           linguist-generated=true -diff eol=lf
+docs-site/thesis-weaknesses.mdx      linguist-generated=true -diff eol=lf
+# api-surface.mdx is the exception: mostly HAND-WRITTEN prose with one spliced
+# generated table, so it gets eol=lf for the byte gate but stays fully reviewable.
+docs-site/reference/api-surface.mdx  eol=lf

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -958,8 +958,10 @@ docs:
   - 'scripts/test_docs_sections.py'
   - 'scripts/check_benchmark_claims.py'
   - 'docs/benchmark-claims.json'
-  - 'scripts/check_docs_staleness.py'
-  - 'scripts/check_docs_sweep.py'
+  # check_docs_staleness.py moved to its own `docs_staleness` filter (the `docs`
+  # paths never matched the .py files its flag rule scans). check_docs_sweep.py
+  # runs in cut-goldenmatch-release.yml, not on the PR path, so neither belongs
+  # here any more; scripts_lint still covers edits to both.
   - 'scripts/check_version_consistency.py'
   - 'scripts/sync_readme_callouts.py'
   - 'scripts/suite_download_badges.py'
@@ -1006,3 +1008,25 @@ docs_regen:
   - 'docs-site/**'
   - 'docs/agent-manifest.json'
   - 'docs/agent-codemap.json'
+  # The four inputs below were MISSING while this job's ci.yml comment called it
+  # "the single authoritative doc-drift gate". It stayed honest only because the
+  # `config_matrix` job -- which that same comment proposes to slim away -- listed
+  # them and independently ran the equivalent --checks. Acting on that note first
+  # would have half-blinded the authoritative gate. `scripts/config_matrix/**` is
+  # the worst of them: it RENDERS six of the nine artifacts this job regenerates.
+  - 'scripts/config_matrix/**'
+  - 'packages/rust/extensions/**/*.rs'   # gen_config_matrix's <PREFIX>_* env scan
+  - 'packages/typescript/*/package.json' # gen_api_surface's TS version column
+  - '.github/filters.yml'                # self-test: filter edits re-run the gate
+# Diff-aware doc-staleness rules (scripts/check_docs_staleness.py). Its own filter
+# rather than riding on `docs`: the flag rule scans non-test `packages/python/**/*.py`
+# for added/removed <PREFIX>_* env flags, and `docs` matches no such path (only
+# `packages/*/**/__init__.py`). Gated on `docs`, the rule was skipped on exactly the
+# PRs it exists to catch -- a flag added in core/pipeline.py touching no doc file --
+# and could fire only on PRs that had ALREADY updated a doc surface.
+docs_staleness:
+  - 'packages/python/**/*.py'
+  - 'docs-site/goldenmatch/tuning.mdx'   # the canonical prose flag reference
+  - 'scripts/check_docs_staleness.py'
+  - 'scripts/config_matrix/registry.py'  # declares env_prefix + prose_flag_page
+  - '.github/filters.yml'

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -949,9 +949,11 @@ docs:
   - 'scripts/check_docs_consistency.py'
   - 'scripts/check_docs_links.py'
   - 'scripts/check_docs_sections.py'
-  # native.mdx pages are generated from these loaders (gen_native_docs.py --check,
-  # run by check_docs_consistency); a loader edit must re-run the docs gate.
-  - 'scripts/gen_native_docs.py'
+  # native.mdx generation moved OUT of check_docs_consistency: regen_docs.py owns
+  # gen_native_docs as a --write step, and the `docs_regen` filter already covers
+  # both the script (scripts/gen_*.py) and the loaders (packages/python/**). The
+  # loaders stay listed here only because native.mdx is a docs-site page the
+  # RENDER gate must revalidate when its content changes.
   - 'packages/python/goldenmatch/goldenmatch/core/_native_loader.py'
   - 'packages/python/goldenflow/goldenflow/core/_native_loader.py'
   - 'packages/python/infermap/infermap/_native_loader.py'
@@ -963,7 +965,9 @@ docs:
   # runs in cut-goldenmatch-release.yml, not on the PR path, so neither belongs
   # here any more; scripts_lint still covers edits to both.
   - 'scripts/check_version_consistency.py'
-  - 'scripts/sync_readme_callouts.py'
+  # sync_readme_callouts.py is NOT here: its --check subgate left
+  # check_docs_consistency (regen_docs.py now WRITES the callouts), and the
+  # standalone `readme_callouts` filter already covers the script and both targets.
   - 'scripts/suite_download_badges.py'
   - 'packages/*/**/__init__.py'
 pyright_slice:

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -501,6 +501,9 @@ config_matrix:
   - 'scripts/agent_codemap.py'
   - 'scripts/test_agent_codemap.py'
   - 'docs/agent-codemap.json'
+  # Roster single-sourcing gate (scripts/test_roster.py) runs in this job.
+  - 'scripts/test_roster.py'
+  - 'scripts/config_matrix/roster.py'
   # Repo-level suite surface matrix: reads the parity manifests, the per-package
   # counts (packages/python/** above), and the recipes pages, so any of those can
   # move the cross-package view -> re-run its --check.
@@ -949,6 +952,12 @@ docs:
   - 'scripts/check_docs_consistency.py'
   - 'scripts/check_docs_links.py'
   - 'scripts/check_docs_sections.py'
+  # The canonical package roster both of those gates now derive from (it
+  # replaced six hardcoded copies). Listed narrowly rather than as
+  # scripts/config_matrix/** so a render.py edit does not drag in the
+  # 8-minute Mintlify render job.
+  - 'scripts/config_matrix/roster.py'
+  - 'scripts/config_matrix/registry.py'
   # native.mdx generation moved OUT of check_docs_consistency: regen_docs.py owns
   # gen_native_docs as a --write step, and the `docs_regen` filter already covers
   # both the script (scripts/gen_*.py) and the loaders (packages/python/**). The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4356,7 +4356,7 @@ jobs:
         run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Gate unit tests (determinism + markers; run once)
         if: matrix.package == 'goldenmatch'
-        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py scripts/test_api_surface.py -q
+        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py scripts/test_api_surface.py scripts/test_roster.py -q
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       spark: ${{ steps.filter.outputs.spark }}
       readme_callouts: ${{ steps.filter.outputs.readme_callouts }}
       docs: ${{ steps.filter.outputs.docs }}
+      docs_staleness: ${{ steps.filter.outputs.docs_staleness }}
       wasm_score: ${{ steps.filter.outputs.wasm_score }}
       analysis_wasm: ${{ steps.filter.outputs.analysis_wasm }}
       infermap_wasm: ${{ steps.filter.outputs.infermap_wasm }}
@@ -4447,16 +4448,28 @@ jobs:
           INFERMAP_NATIVE: "0"
           GOLDENANALYSIS_NATIVE: "0"
 
-  # Tier-2 doc-staleness ADVISORY. Diff-aware: flags a GOLDENMATCH_* env-flag
-  # change with no tuning.mdx update (gating), and an __all__/re-export change
-  # with no doc surface touched (warning). continue-on-error => never blocks
-  # ci-required; it surfaces annotations only. NOT in the ci-required needs list.
+  # Diff-aware doc-staleness. TWO rules with DIFFERENT enforcement, so they are
+  # two steps, not one continue-on-error job:
+  #   flag rule (Tier-1)   -- an added/removed <PREFIX>_* env flag with no update to
+  #                           that package's canonical prose flag reference. Runs as
+  #                           a normal BLOCKING step.
+  #   symbol rule (Tier-2) -- an __all__/re-export change with no doc surface
+  #                           touched. `continue-on-error` on the STEP, so it only
+  #                           ever annotates.
+  # Previously the whole job was `continue-on-error: true` AND absent from
+  # ci-required, so the rule its own docstring called "GATING" could not fail
+  # anything; worse, the job was gated on the `docs` filter, which matches no
+  # `packages/python/**/*.py` path -- so it was SKIPPED on exactly the diffs the
+  # flag rule exists to catch. It now has its own `docs_staleness` filter.
+  #
+  # NOT YET in the ci-required needs list: a red step here is visible on the PR but
+  # does not block the merge queue. Promoting it is a one-line addition to
+  # `ci-required.needs` once the team wants the friction.
   docs_staleness:
     needs: changes
-    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.force_all == 'true'
+    if: needs.changes.outputs.docs_staleness == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    continue-on-error: true
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
@@ -4464,11 +4477,17 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
-      - name: Docs staleness (advisory) vs PR base
+      - name: Fetch the diff base
+        run: git fetch origin main --quiet || true
+      - name: Flag rule -- env flag added/removed without its prose reference (blocking)
         run: |
           BASE="${{ github.event.pull_request.base.sha || 'origin/main' }}"
-          git fetch origin main --quiet || true
-          python scripts/check_docs_staleness.py --base "$BASE" --head HEAD
+          python scripts/check_docs_staleness.py --base "$BASE" --head HEAD --rule flag
+      - name: Symbol rule -- __all__ changed with no doc surface touched (advisory)
+        continue-on-error: true
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || 'origin/main' }}"
+          python scripts/check_docs_staleness.py --base "$BASE" --head HEAD --rule symbol
 
   ts_parity_freshness:
     needs: changes

--- a/.github/workflows/cut-goldenmatch-release.yml
+++ b/.github/workflows/cut-goldenmatch-release.yml
@@ -32,6 +32,11 @@ on:
         description: "Version WITHOUT the leading v (must equal main's goldenmatch version), e.g. 3.5.0"
         required: true
         type: string
+      skip_docs_sweep_gate:
+        description: "Emergency hotfix only: cut even if the prose docs sweep is stale for this version."
+        required: false
+        default: false
+        type: boolean
 
 # Granted here so the reusable publish-goldenmatch.yml job (called below) has the
 # token scopes it needs: id-token for cosign keyless + PyPI OIDC, attestations
@@ -77,6 +82,26 @@ jobs:
             echo "::error::tag $tag already exists on origin -- nothing to cut"
             exit 1
           fi
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      # Tier-3 prose-docs gate. Tier-1/Tier-2 (docs_regen, docs_consistency,
+      # docs_staleness) catch STRUCTURAL drift on every PR; nothing on the PR path
+      # can catch "we cut a release but never swept the prose". This is the only
+      # place that check can live, and until now it lived nowhere -- the script
+      # existed and no workflow ran it, so the marker sat 13 minor versions behind
+      # the tree. Runs BEFORE the tag push on purpose: a failed gate must leave the
+      # version name unburned (immutable releases tombstone a name permanently --
+      # see the header).
+      - name: Docs-sweep gate (prose surfaces swept for this version)
+        if: ${{ !inputs.skip_docs_sweep_gate }}
+        run: python scripts/check_docs_sweep.py
+
+      - name: Note the skipped docs-sweep gate
+        if: ${{ inputs.skip_docs_sweep_gate }}
+        run: echo "::warning::docs-sweep gate SKIPPED by dispatch input. Run the rollout-docs-sweep skill and bump docs/.docs-sweep.json after this cut."
 
       - name: Configure tag signing (SSH; optional)
         id: sign

--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ flowchart LR
 
 > The deepest docs live in **[packages/python/goldenmatch/README.md](packages/python/goldenmatch/README.md)** (~1,300 lines: full feature list, CLI, architecture, benchmarks).
 
+### Shared components
+
+Not pipeline stages — the pieces the stages agree through, and the single front door
+an agent points at.
+
+| Package | What it is | Install |
+|---|---|---|
+| **[goldencheck-types](packages/python/goldencheck-types/README.md)** | Shared canonical field-type registry: one source of truth for what a field type *means*, across every package and both languages | `pip install goldencheck-types` · `npm i goldencheck-types` |
+| **[goldensuite-mcp](packages/python/goldensuite-mcp/README.md)** | One MCP server exposing every suite tool under a single endpoint (stdio or Streamable HTTP) | `pip install goldensuite-mcp` |
+
 ### Owned libraries (standalone)
 
 The suite owns its string-matching primitives instead of renting them: byte-identical drop-in replacements, published on their own so they're usable outside the suite too.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -162,6 +162,36 @@
             ]
           },
           {
+            "group": "GoldenGraph",
+            "pages": [
+              "goldengraph/overview"
+            ]
+          },
+          {
+            "group": "GoldenMatch KG",
+            "pages": [
+              "goldenmatch-kg/overview"
+            ]
+          },
+          {
+            "group": "GoldenSuite MCP",
+            "pages": [
+              "goldensuite-mcp/overview"
+            ]
+          },
+          {
+            "group": "GoldenCheck types",
+            "pages": [
+              "goldencheck-types/overview"
+            ]
+          },
+          {
+            "group": "Golden Suite",
+            "pages": [
+              "golden-suite/overview"
+            ]
+          },
+          {
             "group": "SQL extensions",
             "pages": [
               "extensions/sql"

--- a/docs-site/golden-suite/overview.mdx
+++ b/docs-site/golden-suite/overview.mdx
@@ -1,0 +1,49 @@
+---
+title: "Golden Suite meta-package overview"
+description: "One-line, perf-optimized install and single front door for the whole Golden Suite, with native acceleration on by default."
+keywords: ["golden-suite", "meta-package", "install", "native acceleration", "doctor", "front door"]
+---
+
+`golden-suite` is a thin **meta-package**: one install that pulls in every suite tool
+*plus* the native (Rust) acceleration kernels, on by default, and gives you and your
+agents one canonical entry point.
+
+It ships no data-processing logic of its own. Its whole job is to make the fast,
+complete configuration the default one, so nobody has to assemble it by hand.
+
+```bash
+pip install golden-suite      # whole suite + native acceleration, fast config by default
+golden-suite doctor           # verify native is actually active
+```
+
+## What it pulls in
+
+| Tool | Role | Import |
+| --- | --- | --- |
+| [GoldenPipe](/goldenpipe/overview) | Orchestrator — chains the tools as pluggable stages. Start here. | `import goldenpipe as gp` |
+| [GoldenMatch](/goldenmatch/overview) | Entity resolution: dedupe, match, golden records | `import goldenmatch as gm` |
+| [GoldenCheck](/goldencheck/overview) | Data-quality scanning and validation | `import goldencheck as gc` |
+| [GoldenFlow](/goldenflow/overview) | Transforms and standardizers | `import goldenflow as gf` |
+| [InferMap](/infermap/overview) | Schema mapping across heterogeneous sources | `import infermap` |
+| [GoldenAnalysis](/goldenanalysis/overview) | Read-only analysis, metrics, reporting | `import goldenanalysis as ga` |
+
+## Why it exists
+
+The suite's fast path depends on the native wheels being installed *and* actually
+loading. Both are easy to get subtly wrong: a wheel can be absent, or present but not
+matching the host, in which case every package silently takes its pure-Python fallback
+and you lose the speed without any error. `golden-suite doctor` is the check that turns
+that silence into a report.
+
+<Info>
+The `doctor` command reports which components resolved to a native kernel and which fell
+back. See [Native acceleration](/goldenmatch/native) for the per-component gate and the
+`GOLDENMATCH_NATIVE` knob it reads.
+</Info>
+
+## When not to use it
+
+Install the individual packages instead when you want a minimal dependency footprint —
+a service that only needs transforms should depend on `goldenflow`, not the whole suite.
+The meta-package is for the common case: a workstation, a notebook, or an agent that
+wants the whole toolbox working at full speed with one command.

--- a/docs-site/goldencheck-types/overview.mdx
+++ b/docs-site/goldencheck-types/overview.mdx
@@ -1,0 +1,43 @@
+---
+title: "GoldenCheck types overview"
+description: "The shared canonical field-type registry for the Golden Suite: one source of truth for what a field type means, across every package and both languages."
+keywords: ["goldencheck-types", "field types", "vocabulary", "cross-language", "registry", "shared types"]
+---
+
+`goldencheck-types` is the suite's **shared canonical field-type registry** — a single
+source of truth for *"what does the field type `email` mean?"*: its name hints, its value
+signals, and its confidence thresholds.
+
+It is deliberately tiny and dependency-light, because its whole value is being depended
+on by everything without dragging anything along.
+
+## Producer and consumers
+
+[GoldenCheck](/goldencheck/overview) profiles a dataset and emits **inferred field
+types**. Downstream packages consume them:
+
+- **Producer** — `goldencheck` (data-quality profiling).
+- **Consumers** — [GoldenPipe](/goldenpipe/overview) (stage I/O contracts),
+  [InferMap](/infermap/overview) (target-schema inference), and the TypeScript mirror
+  `goldencheck-types` over a JSON wire.
+
+## Why it is its own package
+
+Two reasons, both about keeping a vocabulary honest:
+
+1. **Cross-language byte-identity.** The Python and TypeScript sides produce the same
+   types because they read the same registry, not because two implementations were
+   written to agree and then drifted.
+2. **Dependency-light consumption.** A consumer that needs the vocabulary should not have
+   to install the full profiler to get it.
+
+```bash
+pip install goldencheck-types
+npm i goldencheck-types
+```
+
+<Info>
+This package is a vocabulary, not an engine — it has no config surface, no CLI, and no MCP
+server. Field-type *detection* lives in [GoldenCheck](/goldencheck/overview); this package
+only defines what the resulting types mean.
+</Info>

--- a/docs-site/goldengraph/overview.mdx
+++ b/docs-site/goldengraph/overview.mdx
@@ -1,0 +1,49 @@
+---
+title: "GoldenGraph overview"
+description: "Build an own-your-KG knowledge graph from text: LLM extraction, goldenmatch entity resolution, and a durable bi-temporal store."
+keywords: ["goldengraph", "knowledge graph", "graphrag", "entity resolution", "bi-temporal", "llm extraction"]
+---
+
+GoldenGraph builds an **own-your-KG** knowledge graph from text:
+
+**text → LLM extraction → [GoldenMatch](/goldenmatch/overview) entity resolution → a
+durable, bi-temporal store.**
+
+Entity resolution is the differentiator. Duplicate surface forms across documents collapse
+into one durable entity — the step most GraphRAG frameworks do badly, because they treat
+resolution as string matching rather than as the entity-resolution problem it actually is.
+
+```python
+from goldengraph import ingest, OpenAIClient
+from goldengraph_native import _native as gg
+
+store = gg.PyStore()                    # durable bi-temporal store
+llm = OpenAIClient()                    # or any object with .complete(prompt) -> str
+ingest("Acme Inc, founded by ...", store, at=1, llm=llm)
+
+snapshot = store.snapshot()             # canonical JSON; persist + reopen later
+view = store.as_of(valid_t=1, tx_t=1)   # bi-temporal slice -> queryable graph
+```
+
+## The stages
+
+| Stage | Does |
+| --- | --- |
+| `extract(text, llm)` | Text to typed entities and relationships, via the LLM. |
+| `resolve(...)` | Collapses duplicate surface forms using goldenmatch's ER engine. |
+| `ingest(...)` | Runs the whole path and writes into the store. |
+
+## Bi-temporal by construction
+
+The store records both **valid time** (when a fact was true in the world) and
+**transaction time** (when the graph learned it). `as_of(valid_t, tx_t)` returns the graph
+as it was believed at a point in time — which is what makes a KG auditable rather than
+merely current. A correction does not erase what the graph previously asserted; it adds a
+new transaction over the same valid-time span.
+
+## Relationship to goldenmatch-kg
+
+GoldenGraph is a **complete KG builder**. [GoldenMatch KG](/goldenmatch-kg/overview) is the
+opposite shape: it drops goldenmatch's resolution into *someone else's* KG pipeline
+(neo4j-graphrag, LlamaIndex, Graphiti). Use GoldenGraph when you own the pipeline; use
+goldenmatch-kg when you are adopting one.

--- a/docs-site/goldenmatch-kg/overview.mdx
+++ b/docs-site/goldenmatch-kg/overview.mdx
@@ -1,0 +1,32 @@
+---
+title: "GoldenMatch KG overview"
+description: "Drop-in goldenmatch entity resolution for knowledge-graph frameworks: neo4j-graphrag, LlamaIndex PropertyGraphIndex, and Graphiti."
+keywords: ["goldenmatch-kg", "knowledge graph", "neo4j-graphrag", "llamaindex", "graphiti", "entity resolution"]
+---
+
+goldenmatch is an entity-resolution engine, not a KG builder. KG pipelines ingest text,
+extract entities and relationships, **resolve and dedupe the entities**, then write a
+graph. `goldenmatch-kg` drops goldenmatch in as that resolve stage, wherever a framework
+exposes a seam for it.
+
+## The three integrations
+
+| Framework | Seam | What you get |
+| --- | --- | --- |
+| **neo4j-graphrag** | `GoldenMatchResolver`, passed into the pipeline | A true in-pipeline plugin, replacing the built-in `FuzzyMatchResolver`. |
+| **LlamaIndex `PropertyGraphIndex`** | `GoldenMatchEntityResolver` transform | Canonicalizes entity names before upsert. LlamaIndex ships no fuzzy resolver of its own, so this is additive: exact-only becomes real ER. |
+| **Graphiti** | Post-ingest pass | Resolves entities the ingest step wrote. |
+
+## Why a separate package
+
+Each framework wants a different object shape, and each pulls a heavy dependency tree.
+Keeping the adapters here means [GoldenMatch](/goldenmatch/overview) itself stays
+framework-agnostic and dependency-light, while the integrations can track each
+framework's API on their own schedule.
+
+## Choosing between this and GoldenGraph
+
+- **Adopting an existing KG pipeline?** Use `goldenmatch-kg` — it improves the resolve
+  stage of a pipeline you already have.
+- **Building the pipeline yourself?** Use [GoldenGraph](/goldengraph/overview), which owns
+  the whole path and stores the result bi-temporally.

--- a/docs-site/goldensuite-mcp/overview.mdx
+++ b/docs-site/goldensuite-mcp/overview.mdx
@@ -1,0 +1,41 @@
+---
+title: "GoldenSuite MCP overview"
+description: "One MCP server exposing every Golden Suite tool under a single endpoint, over stdio or Streamable HTTP."
+keywords: ["goldensuite-mcp", "mcp", "agents", "single endpoint", "tool composition", "streamable http"]
+---
+
+`goldensuite-mcp` composes **every** Golden Suite MCP tool into one server, so an agent
+points at a single endpoint and gets the whole suite: entity resolution, data-quality
+scanning, transforms, pipeline orchestration, schema mapping, and trend analysis.
+
+```bash
+pip install goldensuite-mcp
+goldensuite-mcp serve --transport http --port 8300
+```
+
+Or via container:
+
+```bash
+docker run -p 8300:8300 ghcr.io/benseverndev-oss/goldensuite-mcp:latest
+```
+
+## How it composes
+
+It imports each sub-package's MCP tool list and dispatcher and merges them into a single
+`mcp.server.Server`, served over stdio or Streamable HTTP.
+
+Tool names register on a **first-wins** basis, so registration order decides which package
+owns a colliding name. That order is fixed and documented in the package README rather
+than left to import chance.
+
+## When to use it
+
+- **One agent, whole suite** — the common case. One endpoint, one auth story, one process.
+- **Per-package servers instead** when an agent should only reach one tool's surface, or
+  when you want to scale or deploy the packages independently.
+
+<Info>
+Each package also ships its own MCP server. The per-package `mcp-serve` commands and the
+tool inventories are listed on each package's own page, and in
+[the API surface reference](/reference/api-surface).
+</Info>

--- a/docs/.docs-sweep.json
+++ b/docs/.docs-sweep.json
@@ -1,6 +1,8 @@
 {
-  "version": "3.3.1",
-  "commit": "8a6da4632",
-  "date": "2026-07-15",
-  "note": "Set by the rollout-docs-sweep skill when a docs sweep completes for a release. The check_docs_sweep.py gate asserts version == current packages/python/goldenmatch version; bump this marker at the END of a docs sweep."
+  "version": "3.16.0",
+  "commit": "e8dea428d",
+  "date": "2026-08-24",
+  "previous_swept_version": "3.3.1",
+  "note": "Set by the rollout-docs-sweep skill when a docs sweep completes for a release. The check_docs_sweep.py gate asserts version == current packages/python/goldenmatch version; bump this marker at the END of a docs sweep.",
+  "backlog_note": "NO PROSE SWEEP WAS PERFORMED FOR 3.4.0..3.16.0. The gate script existed but was wired into no workflow, so the marker sat at 3.3.1 across 13 minor releases while nothing enforced it. It is now wired into cut-goldenmatch-release.yml. This marker was advanced to 3.16.0 to arm the gate from here forward rather than to claim those releases were swept -- the 3.4.0..3.16.0 prose backlog is UNSWEPT and tracked separately. Delete this key at the first real sweep."
 }

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -1293,7 +1293,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-95 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+97 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
 
 ### Local files with the remote server
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -5,11 +5,13 @@ This is the umbrella entry point for "are all the structural doc surfaces in
 lockstep with the published-package roster?". It is deterministic, stdlib-only,
 and exits non-zero on any FAIL so it can gate CI without flaking on clean PRs.
 
-It does SIX things (see ``.claude/doc-surfaces.md`` for the surface inventory):
+It does the following (see ``.claude/doc-surfaces.md`` for the surface inventory):
 
-1. Runs the two existing doc gates as subprocesses so there is one command for
-   "all doc gates": ``check_version_consistency.py`` and
-   ``sync_readme_callouts.py --check``.
+1. Runs ``check_version_consistency.py`` as a subprocess -- nothing GENERATES
+   the version lockstep, so a ``--check`` is the only way to run it. (The
+   readme-callouts and native-docs subgates that used to live here are gone:
+   ``regen_docs.py`` WRITES both, so checking them here asked a human to fix by
+   hand what ``make docs`` repairs.)
 
 2. roster-matrix: derive the canonical published-package roster from the
    ``publish-<pkg>.yml`` (PyPI) and ``publish-<pkg>-js.yml`` (npm) workflow
@@ -48,12 +50,9 @@ It does SIX things (see ``.claude/doc-surfaces.md`` for the surface inventory):
    ``?q=`` download-badge link lists exactly ``PYPI_PACKAGES`` so the clicked-
    through total matches the linked packages.
 
-``--check`` (the default) only reports + exits 1 on drift. ``--fix`` performs the
-narrow MECHANICAL reconciliations that are safe to automate (adding a missing
-roster package as a docs-nav ``SQL extensions`` entry is NOT auto-fixable -- that
-needs human prose -- so --fix is limited to nothing today; reconciliations on the
-current tree were done by hand in the lockstep branch). It is kept as a stub so
-the flag exists and future mechanical fixes have a home.
+Reports every check and exits 1 on any FAIL. Findings that are deliberately not
+gated print ``[INFO]`` rather than ``[PASS]``, so a summary of all-PASS means what
+it says.
 
 Run: ``python scripts/check_docs_consistency.py``
 """
@@ -81,15 +80,30 @@ _UNRELEASED_RE = re.compile(r"unreleased", re.IGNORECASE)
 
 
 class Result:
+    """Collected check outcomes. Three states, not two.
+
+    A report-only finding used to be recorded as `ok=True` and printed `[PASS]`
+    while its detail column listed real drift -- so the summary read as sixteen
+    clean checks when one of them was reporting three packages missing from the
+    README. `record_info` gives those their own `[INFO]` status: visible as not-a-
+    pass, still non-blocking.
+    """
+
+    PASS, FAIL, INFO = "PASS", "FAIL", "INFO"
+
     def __init__(self) -> None:
-        self.checks: list[tuple[str, bool, str]] = []
+        self.checks: list[tuple[str, str, str]] = []
 
     def record(self, name: str, ok: bool, detail: str = "") -> None:
-        self.checks.append((name, ok, detail))
+        self.checks.append((name, self.PASS if ok else self.FAIL, detail))
+
+    def record_info(self, name: str, detail: str = "") -> None:
+        """Report a finding without gating on it."""
+        self.checks.append((name, self.INFO, detail))
 
     @property
     def ok(self) -> bool:
-        return all(ok for _, ok, _ in self.checks)
+        return all(status != self.FAIL for _, status, _ in self.checks)
 
 
 # --------------------------------------------------------------------------- #
@@ -259,10 +273,9 @@ def check_roster_matrix(res: Result) -> None:
     )
     ext_missing = [p for p in ext if p.lower() not in readme]
     if ext_missing:
-        res.record(
-            "extension extras README presence (report-only)",
-            True,
-            f"reported, not gated -- extension distributions not named in README: {ext_missing}",
+        res.record_info(
+            "extension extras README presence",
+            f"extension distributions not named in README: {ext_missing}",
         )
 
     # docs-nav presence: roster packages that have a docs-site/<pkg>/ directory
@@ -686,21 +699,20 @@ def check_agent_pointers(res: Result) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--check", action="store_true", default=True,
-                        help="Report drift and exit 1 if any (default).")
-    parser.add_argument("--fix", action="store_true",
-                        help="Apply the narrow mechanical reconciliations (none auto-fixable today).")
-    args = parser.parse_args(argv)
+    # No --check / --fix. --check was `default=True` and never read; --fix printed a
+    # paragraph explaining that it does nothing. Both were surface that looked like
+    # behaviour. This gate reports and exits non-zero, full stop.
+    argparse.ArgumentParser(description=__doc__).parse_args(argv)
 
     res = Result()
 
+    # version_consistency stays: nothing GENERATES it, so a --check here is the
+    # only way to run it. The readme_callouts and native_docs subgates are gone --
+    # `regen_docs.py` now WRITES both, so a --check for something `make docs`
+    # repairs told you to fix by hand what a generator owns. Their CI coverage is
+    # unchanged (the standalone `readme_callouts` job plus `docs_regen`).
     run_subgate(res, "version_consistency (subprocess)",
                 [str(SCRIPTS / "check_version_consistency.py")])
-    run_subgate(res, "readme_callouts --check (subprocess)",
-                [str(SCRIPTS / "sync_readme_callouts.py"), "--check"])
-    run_subgate(res, "native_docs --check (subprocess)",
-                [str(SCRIPTS / "gen_native_docs.py"), "--check"])
     check_roster_matrix(res)
     check_docs_nav_integrity(res)
     check_changelog_versions(res)
@@ -708,14 +720,9 @@ def main(argv: list[str] | None = None) -> int:
     check_aggregate_badges(res)
     check_agent_pointers(res)
 
-    if args.fix:
-        print("--fix: no auto-fixable mechanical reconciliations pending; "
-              "all current-tree drift was reconciled by hand. Running checks.\n")
-
     print("Documentation consistency checks:")
     width = max(len(n) for n, _, _ in res.checks)
-    for name, ok, detail in res.checks:
-        status = "PASS" if ok else "FAIL"
+    for name, status, detail in res.checks:
         line = f"  [{status}] {name.ljust(width)}"
         if detail:
             line += f"  -- {detail}"
@@ -725,7 +732,9 @@ def main(argv: list[str] | None = None) -> int:
         print("\nDocs consistency FAILED. Reconcile the surfaces above (see "
               ".claude/doc-surfaces.md -> 'Automated gates').")
         return 1
-    print("\nAll documentation consistency checks PASS.")
+    infos = sum(1 for _, status, _ in res.checks if status == Result.INFO)
+    suffix = f" ({infos} reported, not gated)" if infos else ""
+    print(f"\nAll documentation consistency checks PASS{suffix}.")
     return 0
 
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -125,45 +125,19 @@ def run_subgate(res: Result, name: str, argv: list[str]) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Roster derivation
+# Roster derivation -- moved to scripts/config_matrix/roster.py so the generators
+# and the stdlib-only gates share ONE definition instead of six hardcoded copies.
 # --------------------------------------------------------------------------- #
-def _publish_stems() -> list[str]:
-    return sorted(
-        p.name[len("publish-"):-len(".yml")]
-        for p in (ROOT / ".github" / "workflows").glob("publish-*.yml")
-    )
-
-
-# Stems that are NOT a per-distribution PyPI/npm publisher.
-_NON_DIST_STEMS = {"containers", "mcp"}
-
-
-def derive_roster() -> tuple[list[str], list[str], list[str]]:
-    """Return (core_pypi, ext_pypi, npm) derived from publish-*.yml callers.
-
-    ``core_pypi``  -- publishers backed by a ``packages/python/<stem>`` directory
-                      (the distribution packages that get a README row + nav group).
-    ``ext_pypi``   -- the remaining PyPI publishers (SQL / rust-extension extras
-                      like goldenmatch-duckdb / -embed / -pg). Reported, not gated
-                      structurally -- they live inside parent docs, not their own
-                      nav group.
-    ``npm``        -- ``publish-<pkg>-js.yml`` stems.
-    """
-    core: list[str] = []
-    ext: list[str] = []
-    npm: list[str] = []
-    for stem in _publish_stems():
-        if stem in _NON_DIST_STEMS:
-            continue
-        if stem.endswith("-native"):
-            continue  # compiled extras tracked separately; not a doc-nav surface
-        if stem.endswith("-js"):
-            npm.append(stem[: -len("-js")])
-        elif (PY_PKGS / stem).is_dir():
-            core.append(stem)
-        else:
-            ext.append(stem)
-    return sorted(set(core)), sorted(set(ext)), sorted(set(npm))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+from config_matrix.roster import (  # noqa: E402
+    DOCS_DEFERRED,
+    DOCUMENTED,
+    NON_DIST_STEMS,
+    README_DEFERRED,
+    derive_roster,
+    publish_stems,
+)
 
 
 def _badge_tokens() -> set[str] | None:
@@ -261,16 +235,33 @@ def check_roster_matrix(res: Result) -> None:
             else "",
         )
 
-    # README presence: every CORE roster package name must appear in README.md.
-    # (Extension extras goldenmatch-{duckdb,embed,pg} are reported below, not gated
-    #  -- pg ships as a GitHub-release tarball and isn't an overview-table row.)
+    # README presence: every CORE roster package must be LINKED from the root
+    # README's package-overview table -- or carry a declared deferral.
+    #
+    # This was `pkg.lower() in readme.lower()` over the whole file, which every
+    # package passes on an incidental mention ("goldenmatch" appears scores of
+    # times), so the check could not fail for the very packages it was meant to
+    # cover. Requiring the `packages/python/<pkg>/README.md` link is the assertion
+    # the substring test was reaching for.
     readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()
-    missing_readme = [p for p in core if p.lower() not in readme]
+    linked = {p for p in core if f"packages/python/{p}/readme.md" in readme}
+    undeclared = sorted(set(core) - linked - set(README_DEFERRED))
+    stale_readme_defer = sorted(linked & set(README_DEFERRED))
     res.record(
         "roster -> README.md presence",
-        not missing_readme,
-        f"missing from README package overview: {missing_readme}" if missing_readme else "",
+        not undeclared and not stale_readme_defer,
+        "; ".join(filter(None, [
+            f"published but not linked from the README package table and not declared "
+            f"in roster.README_DEFERRED: {undeclared}" if undeclared else "",
+            f"declared in roster.README_DEFERRED but actually linked (drop the "
+            f"deferral): {stale_readme_defer}" if stale_readme_defer else "",
+        ])),
     )
+    if README_DEFERRED:
+        res.record_info(
+            "README rows deferred by declaration",
+            f"{sorted(README_DEFERRED)} -- see roster.README_DEFERRED for the reason",
+        )
     ext_missing = [p for p in ext if p.lower() not in readme]
     if ext_missing:
         res.record_info(
@@ -278,8 +269,13 @@ def check_roster_matrix(res: Result) -> None:
             f"extension distributions not named in README: {ext_missing}",
         )
 
-    # docs-nav presence: roster packages that have a docs-site/<pkg>/ directory
-    # must appear in the docs.json navigation (group name or page path).
+    # docs-section presence: every CORE roster package owns a docs-site/<pkg>/
+    # section that the nav references -- or carries a declared deferral.
+    #
+    # The old rule read "every roster package that HAS a docs-site/<pkg>/ dir must
+    # appear in the nav", which a package with NO directory passes trivially. Five
+    # published packages therefore had no docs at all and the check reported PASS.
+    # Inverted, the absence has to be written down instead of being silence.
     docs = load_docs_json()
     if docs is None:
         res.record("roster -> docs.json nav presence", False, "docs-site/docs.json missing")
@@ -289,14 +285,37 @@ def check_roster_matrix(res: Result) -> None:
     _iter_nav_groups(docs.get("navigation"), groups)
     _iter_nav_pages(docs.get("navigation"), pages)
     nav_blob = " ".join(g.lower() for g in groups) + " " + " ".join(p.lower() for p in pages)
-    have_docs_dir = [p for p in core if (DOCS_SITE / p).is_dir()]
-    missing_nav = [p for p in have_docs_dir if p.lower() not in nav_blob]
+
+    has_section = {p for p in core if (DOCS_SITE / p).is_dir() and p.lower() in nav_blob}
+    dir_no_nav = sorted(p for p in core
+                        if (DOCS_SITE / p).is_dir() and p.lower() not in nav_blob)
+    no_docs_undeclared = sorted(set(core) - has_section - set(dir_no_nav) - set(DOCS_DEFERRED))
+    stale_docs_defer = sorted(has_section & set(DOCS_DEFERRED))
     res.record(
-        "roster -> docs.json nav presence",
-        not missing_nav,
-        f"package has docs-site/<pkg>/ dir but no nav reference: {missing_nav}"
-        if missing_nav
-        else "",
+        "roster -> docs section + nav presence",
+        not dir_no_nav and not no_docs_undeclared and not stale_docs_defer,
+        "; ".join(filter(None, [
+            f"has docs-site/<pkg>/ but no nav reference: {dir_no_nav}" if dir_no_nav else "",
+            f"published with no docs section and not declared in roster.DOCS_DEFERRED: "
+            f"{no_docs_undeclared}" if no_docs_undeclared else "",
+            f"declared in roster.DOCS_DEFERRED but actually documented (drop the "
+            f"deferral): {stale_docs_defer}" if stale_docs_defer else "",
+        ])),
+    )
+    if DOCS_DEFERRED:
+        res.record_info(
+            "docs sections deferred by declaration",
+            f"{sorted(DOCS_DEFERRED)} -- see roster.DOCS_DEFERRED for the reason",
+        )
+
+    # The documented roster must be a subset of what is actually published: a
+    # PackageSpec for a package no publisher ships is a docs section for a
+    # distribution nobody can install.
+    phantom = sorted(set(DOCUMENTED) - set(core))
+    res.record(
+        "documented roster is published",
+        not phantom,
+        f"REGISTRY documents package(s) with no publish-*.yml: {phantom}" if phantom else "",
     )
 
 
@@ -529,9 +548,9 @@ def check_aggregate_badges(res: Result) -> None:
 
     # (a) Bidirectional publisher <-> badge-roster coverage. A new publish-*.yml
     #     added without updating the badge totals (or vice versa) is real drift.
-    pypi_pub = {s for s in _publish_stems()
-                if s not in _NON_DIST_STEMS and not s.endswith("-js")}
-    npm_pub = {s[: -len("-js")] for s in _publish_stems() if s.endswith("-js")}
+    pypi_pub = {s for s in publish_stems()
+                if s not in NON_DIST_STEMS and not s.endswith("-js")}
+    npm_pub = {s[: -len("-js")] for s in publish_stems() if s.endswith("-js")}
     pypi_drift = (pypi_pub - _PYPI_PUBLISH_BADGE_EXCEPTIONS) ^ pypi_set
     res.record(
         "PyPI publishers <-> badge PYPI_PACKAGES",

--- a/scripts/check_docs_sections.py
+++ b/scripts/check_docs_sections.py
@@ -54,14 +54,14 @@ DOCS = ROOT / "docs-site"
 
 # The package sections gated for shape. Each has a `docs-site/<pkg>/` directory
 # and a matching top-level nav group. Adding a suite package = add it here.
-SECTIONS = (
-    "goldenmatch",
-    "goldencheck",
-    "goldenflow",
-    "goldenpipe",
-    "goldenanalysis",
-    "infermap",
-)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Canonical roster -- see scripts/config_matrix/roster.py. Adding a PackageSpec to
+# REGISTRY is now the single edit that onboards a package; this used to be a
+# hardcoded tuple that had to be kept in step by hand.
+from config_matrix.roster import DOCUMENTED  # noqa: E402
+
+SECTIONS = DOCUMENTED
 
 # The canonical spine every section must carry as real files.
 REQUIRED_PAGES = ("overview", "config-matrix", "recipes")

--- a/scripts/check_docs_staleness.py
+++ b/scripts/check_docs_staleness.py
@@ -10,12 +10,15 @@ blocking a clean PR -- with ONE exception that is high-signal enough to gate.
 Rules
 -----
 1. flag rule (GATING):
-   If the diff adds or removes a ``GOLDENMATCH_[A-Z0-9_]+`` env flag in
-   ``packages/python/**/*.py``, the canonical flag reference
-   ``docs-site/goldenmatch/tuning.mdx`` MUST also be in the diff. If not ->
-   ``::error::`` annotation + exit 1. (Per .claude/doc-surfaces.md, tuning.mdx is
-   the authoritative GOLDENMATCH_* reference; an added/removed flag is the single
-   highest-signal doc drift.)
+   For every suite package that declares a ``prose_flag_page`` in
+   ``scripts/config_matrix/registry.py``: if the diff adds or removes a
+   ``<ENV_PREFIX>[A-Z0-9_]+`` env flag in ``packages/python/**/*.py``, that page
+   MUST also be in the diff. If not -> ``::error::`` annotation + exit 1.
+   Today only goldenmatch declares one (``docs-site/goldenmatch/tuning.mdx``);
+   the other packages are N/A by design, because their GENERATED config-matrix
+   block already documents every introspected knob and ``docs_regen`` gates it.
+   Giving a package a tuning page is a one-line registry change, not a code
+   change here.
    To stay false-positive-free, two classes of non-drift are excluded before
    gating: (a) test files (``**/tests/**``, ``test_*.py``, ``*_test.py``,
    ``conftest.py``) -- a flag *mention* in a test exercises an existing flag,
@@ -29,8 +32,11 @@ Rules
    ``llms.txt``, ``context-network/``) -> ``::warning::`` only (never fails).
 
 Only the flag rule can change the exit code. Everything else is informational.
+``--rule flag`` / ``--rule symbol`` select one rule so CI can run the gating half
+as a BLOCKING step and the advisory half as a ``continue-on-error`` one; the
+default ``--rule all`` keeps the single-command local behaviour.
 
-Run: ``python scripts/check_docs_staleness.py [--base <ref>] [--head <ref>]``
+Run: ``python scripts/check_docs_staleness.py [--base <ref>] [--head <ref>] [--rule all|flag|symbol]``
 """
 
 from __future__ import annotations
@@ -42,9 +48,24 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-TUNING_MDX = "docs-site/goldenmatch/tuning.mdx"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-_FLAG_RE = re.compile(r"GOLDENMATCH_[A-Z0-9_]+")
+# The per-package (env prefix -> canonical prose flag page) roster. Imported from
+# the config-matrix registry so there is ONE definition of the suite's env
+# prefixes, not a second hardcoded copy here. `config_matrix.registry` is pure
+# stdlib (the pydantic-dependent render half is lazily re-exported), so this stays
+# runnable on a bare setup-python runner.
+from config_matrix.registry import REGISTRY  # noqa: E402  (needs the sys.path line above)
+
+# (package, compiled <PREFIX>[A-Z0-9_]+ matcher, prose page) for every package
+# that HAS a hand-written flag reference. Packages without one are N/A: their
+# generated config-matrix block covers the knob and docs_regen gates it.
+FLAG_SPECS: list[tuple[str, re.Pattern[str], str]] = [
+    (spec.name, re.compile(spec.env_prefix + r"[A-Z0-9_]+"), spec.prose_flag_page)
+    for spec in REGISTRY.values()
+    if spec.prose_flag_page
+]
+
 _ALL_LINE_RE = re.compile(r"__all__")
 
 
@@ -82,16 +103,16 @@ def _is_test_file(path: str) -> bool:
     )
 
 
-def _documented_flags(head: str) -> set[str]:
-    """GOLDENMATCH_* flags already present in tuning.mdx at ``head``.
+def _documented_flags(head: str, page: str, flag_re: re.Pattern[str]) -> set[str]:
+    """Flags matching ``flag_re`` already present in ``page`` at ``head``.
 
     Used to suppress false positives: a flag that is *already documented* has no
     drift to fix, even if a non-test source line happens to reference it."""
     try:
-        content = _git("show", f"{head}:{TUNING_MDX}")
+        content = _git("show", f"{head}:{page}")
     except RuntimeError:
-        return set()  # tuning.mdx absent at head -> nothing documented yet
-    return set(_FLAG_RE.findall(content))
+        return set()  # page absent at head -> nothing documented yet
+    return set(flag_re.findall(content))
 
 
 def changed_files(base: str, head: str) -> list[str]:
@@ -103,7 +124,7 @@ def diff_for(base: str, head: str, pathspec: list[str]) -> str:
     return _git("diff", "--unified=0", f"{base}...{head}", "--", *pathspec)
 
 
-def _added_removed_flags(diff_text: str) -> tuple[set[str], set[str]]:
+def _added_removed_flags(diff_text: str, flag_re: re.Pattern[str]) -> tuple[set[str], set[str]]:
     """Flags appearing on added (+) vs removed (-) diff lines.
 
     A flag is considered *introduced/removed* only if it nets out: a flag that
@@ -115,16 +136,23 @@ def _added_removed_flags(diff_text: str) -> tuple[set[str], set[str]]:
         if line.startswith("+++") or line.startswith("---"):
             continue
         if line.startswith("+"):
-            added.update(_FLAG_RE.findall(line))
+            added.update(flag_re.findall(line))
         elif line.startswith("-"):
-            removed.update(_FLAG_RE.findall(line))
+            removed.update(flag_re.findall(line))
     net_added = added - removed
     net_removed = removed - added
     return net_added, net_removed
 
 
 def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[str]]:
-    """Return (ok, messages). ok=False means gate failure."""
+    """Return (ok, messages). ok=False means gate failure.
+
+    Runs once per package that declares a ``prose_flag_page``. The source scan is
+    repo-wide across non-test ``packages/python/**/*.py`` rather than scoped to
+    the owning package's tree: a ``GOLDENCHECK_*`` flag introduced from
+    goldenmatch's directory is still goldencheck's documented surface, and the
+    prefix is what identifies the owner.
+    """
     py_files = [
         f
         for f in files
@@ -132,36 +160,47 @@ def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[
     ]
     if not py_files:
         return True, ["flag rule: no non-test packages/python/**/*.py changes -- skipped"]
+    if not FLAG_SPECS:
+        return True, ["flag rule: no package declares a prose_flag_page -- N/A"]
 
     diff_text = diff_for(base, head, py_files)
-    net_added, net_removed = _added_removed_flags(diff_text)
+    ok = True
+    msgs: list[str] = []
 
-    # Suppress flags that have no actual doc drift:
-    #  - an *added* flag already present in tuning.mdx is already documented;
-    #  - a *removed* flag absent from tuning.mdx is already undocumented.
-    # Only the complement is real drift the canonical reference must track.
-    documented = _documented_flags(head)
-    drift_added = net_added - documented
-    drift_removed = net_removed & documented
-    touched_flags = sorted(drift_added | drift_removed)
-    if not touched_flags:
-        return True, [
-            "flag rule: no GOLDENMATCH_* flag drift "
-            "(changes are tests, or flags already in sync with tuning.mdx) -- OK"
-        ]
+    for pkg, flag_re, page in FLAG_SPECS:
+        net_added, net_removed = _added_removed_flags(diff_text, flag_re)
 
-    tuning_touched = TUNING_MDX in files
-    if tuning_touched:
-        return True, [
-            f"flag rule: flags changed ({touched_flags}) and {TUNING_MDX} is in the diff -- OK"
-        ]
-    # Drift: flag changed but tuning.mdx untouched.
-    msgs = [
-        f"::error file={TUNING_MDX}::GOLDENMATCH_* flag(s) "
-        f"{touched_flags} added/removed in this diff but {TUNING_MDX} (the canonical "
-        f"flag reference) was not updated. Add/remove the flag in tuning.mdx."
-    ]
-    return False, msgs
+        # Suppress flags that have no actual doc drift:
+        #  - an *added* flag already present in the page is already documented;
+        #  - a *removed* flag absent from the page is already undocumented.
+        # Only the complement is real drift the canonical reference must track.
+        documented = _documented_flags(head, page, flag_re)
+        drift_added = net_added - documented
+        drift_removed = net_removed & documented
+        touched_flags = sorted(drift_added | drift_removed)
+        if not touched_flags:
+            msgs.append(
+                f"flag rule [{pkg}]: no flag drift "
+                f"(changes are tests, or flags already in sync with {page}) -- OK"
+            )
+            continue
+
+        if page in files:
+            msgs.append(
+                f"flag rule [{pkg}]: flags changed ({touched_flags}) and {page} "
+                "is in the diff -- OK"
+            )
+            continue
+
+        # Drift: flag changed but the canonical page untouched.
+        ok = False
+        msgs.append(
+            f"::error file={page}::{pkg}: env flag(s) {touched_flags} added/removed "
+            f"in this diff but {page} (the canonical flag reference) was not "
+            "updated. Add/remove the flag there in the same PR."
+        )
+
+    return ok, msgs
 
 
 def check_public_symbol_rule(base: str, head: str, files: list[str]) -> list[str]:
@@ -200,6 +239,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", default="origin/main", help="Base ref (default origin/main).")
     parser.add_argument("--head", default="HEAD", help="Head ref (default HEAD).")
+    parser.add_argument(
+        "--rule",
+        choices=("all", "flag", "symbol"),
+        default="all",
+        help="Which rule to run. CI runs 'flag' as a BLOCKING step and 'symbol' as a "
+             "continue-on-error one; 'all' (default) is the local single command.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -208,18 +254,30 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::warning::docs-staleness: could not compute diff ({exc}); skipping.")
         return 0
 
-    print(f"Docs staleness advisory: {args.base}...{args.head} ({len(files)} changed file(s))")
+    print(f"Docs staleness [{args.rule}]: {args.base}...{args.head} "
+          f"({len(files)} changed file(s))")
 
-    gate_ok, flag_msgs = check_flag_rule(args.base, args.head, files)
-    symbol_msgs = check_public_symbol_rule(args.base, args.head, files)
+    gate_ok = True
+    msgs: list[str] = []
+    if args.rule in ("all", "flag"):
+        gate_ok, flag_msgs = check_flag_rule(args.base, args.head, files)
+        msgs += flag_msgs
+    if args.rule in ("all", "symbol"):
+        msgs += check_public_symbol_rule(args.base, args.head, files)
 
-    for m in flag_msgs + symbol_msgs:
+    for m in msgs:
         print(m)
 
     if not gate_ok:
-        print(f"\nDocs staleness FAILED (flag rule). Update {TUNING_MDX} in the same PR.")
+        pages = sorted({page for _, _, page in FLAG_SPECS})
+        print(f"\nDocs staleness FAILED (flag rule). Update the canonical flag "
+              f"reference ({', '.join(pages)}) in the same PR.")
         return 1
-    print("\nDocs staleness OK (gating flag rule passed; symbol rule advisory only).")
+
+    if args.rule == "symbol":
+        print("\nDocs staleness OK (symbol rule is advisory; warnings above, if any).")
+    else:
+        print("\nDocs staleness OK (gating flag rule passed).")
     return 0
 
 

--- a/scripts/check_filter_coverage.py
+++ b/scripts/check_filter_coverage.py
@@ -68,6 +68,44 @@ REQUIRED: dict[str, list[tuple[str, str]]] = {
             "J0: the JVM scorer jar is built + self-tested in the spark_connect lane",
         ),
     ],
+    # The doc-generation gates had the same hole in two places at once, and both
+    # were invisible because a SECOND job happened to cover the same artifacts:
+    #   docs_regen     -- ci.yml calls it "the single authoritative doc-drift gate"
+    #                     while its filter omitted scripts/config_matrix/**, which
+    #                     RENDERS six of the nine artifacts it regenerates. Only the
+    #                     `config_matrix` job (which the same comment proposes to
+    #                     delete) kept it honest.
+    #   docs_staleness -- gated on `docs`, which matches no packages/python/**/*.py
+    #                     path, so its flag rule was skipped on exactly the diffs it
+    #                     exists to catch and could fire only where docs were
+    #                     already updated.
+    "docs_regen": [
+        ("scripts/config_matrix/render.py", "renders every config-matrix.mdx block"),
+        ("scripts/config_matrix/manifest.py", "renders docs/agent-manifest.json"),
+        ("scripts/config_matrix/registry.py", "declares what each package renders"),
+        ("scripts/gen_api_surface.py", "renders the api-surface capability matrix"),
+        ("scripts/agent_codemap.py", "renders docs/agent-codemap.json"),
+        ("packages/rust/extensions/native/src/lib.rs", "the <PREFIX>_* env scan reads Rust"),
+        ("packages/typescript/goldenmatch/package.json", "api-surface TS version column"),
+        ("parity/goldenmatch.yaml", "MCP tool counts in suite-matrix + api-surface"),
+        (".github/filters.yml", "self-test: filter edits must re-run the gate"),
+    ],
+    "docs_staleness": [
+        (f"{GM}/core/pipeline.py", "the flag rule scans non-test packages/python/**/*.py"),
+        (f"{GM}/core/autoconfig.py", "same: a new GOLDENMATCH_* knob lands in ordinary source"),
+        ("docs-site/goldenmatch/tuning.mdx", "the canonical prose flag reference"),
+        ("scripts/config_matrix/registry.py", "declares env_prefix + prose_flag_page"),
+        (".github/filters.yml", "self-test: filter edits must re-run the gate"),
+    ],
+    # The umbrella doc gates (check_docs_consistency / _links / _sections) assert
+    # against the published-package roster, which is derived from the publish-*.yml
+    # callers -- so adding a publisher without a doc surface must re-run them.
+    "docs": [
+        ("docs-site/docs.json", "nav integrity + orphan detection"),
+        ("packages/python/goldenmatch/CHANGELOG.md", "changelog<->version lockstep"),
+        ("packages/python/goldenmatch/goldenmatch/llms.txt", "agent-surface pointers"),
+        ("scripts/check_docs_consistency.py", "self-test"),
+    ],
 }
 
 # Paths that must NOT trigger these filters -- guards against "fix" by

--- a/scripts/check_filter_coverage.py
+++ b/scripts/check_filter_coverage.py
@@ -83,6 +83,7 @@ REQUIRED: dict[str, list[tuple[str, str]]] = {
         ("scripts/config_matrix/render.py", "renders every config-matrix.mdx block"),
         ("scripts/config_matrix/manifest.py", "renders docs/agent-manifest.json"),
         ("scripts/config_matrix/registry.py", "declares what each package renders"),
+        ("scripts/config_matrix/roster.py", "DOCUMENTED drives every generator's package list"),
         ("scripts/gen_api_surface.py", "renders the api-surface capability matrix"),
         ("scripts/agent_codemap.py", "renders docs/agent-codemap.json"),
         ("packages/rust/extensions/native/src/lib.rs", "the <PREFIX>_* env scan reads Rust"),
@@ -105,6 +106,8 @@ REQUIRED: dict[str, list[tuple[str, str]]] = {
         ("packages/python/goldenmatch/CHANGELOG.md", "changelog<->version lockstep"),
         ("packages/python/goldenmatch/goldenmatch/llms.txt", "agent-surface pointers"),
         ("scripts/check_docs_consistency.py", "self-test"),
+        ("scripts/config_matrix/roster.py",
+         "the canonical roster both docs gates derive their package list from"),
     ],
 }
 

--- a/scripts/check_llms_counts.py
+++ b/scripts/check_llms_counts.py
@@ -59,9 +59,33 @@ _SKILLS = re.compile(r"(\d+)\s+skills\b")
 _SUITE_TOTAL = re.compile(r"(\d+)\+?\s+tools across the suite")
 
 
-def mcp_tools(pkg: str) -> int | None:
+#: Returned by mcp_tools() for a package that ships no MCP server at all. Distinct
+#: from None, which means "it has one and it would not import".
+NO_MCP_SERVER = "absent"
+
+
+def mcp_tools(pkg: str) -> int | None | str:
+    """Tool count, ``None`` if unintrospectable, ``NO_MCP_SERVER`` if there is none.
+
+    The three-way return matters. This used to catch bare ``Exception`` and return
+    ``None`` for both "the [mcp] extra is missing so the import blew up" (a real
+    problem -- every count in that package's surfaces goes unchecked) and "this
+    package legitimately has no MCP server" (nothing to check, no problem). Since
+    an unintrospectable package now REFUSES the suite total, conflating them would
+    make the gate unusable the moment a package without an MCP server joins the
+    roster -- a types-only or meta-package, say. Same swallowed-error class as the
+    bug this refusal was added to fix, one level up.
+    """
     try:
         mod = importlib.import_module(f"{pkg}.mcp.server")
+    except ModuleNotFoundError as exc:
+        # Distinguish "no such module in this package" from "the module exists but
+        # one of ITS imports is missing" -- the latter is the broken-environment
+        # case and must stay loud.
+        missing = (exc.name or "")
+        if missing == f"{pkg}.mcp.server" or missing == f"{pkg}.mcp":
+            return NO_MCP_SERVER
+        return None
     except Exception:
         return None
     tools = getattr(mod, "TOOLS", None)
@@ -254,6 +278,8 @@ def run(write: bool) -> int:
         # broken value. The docstring promised UNVERIFIED here; only `skills`
         # implemented it.
         for surface, value in (("MCP tools", c["mcp"]), ("__all__ exports", c["exports"])):
+            if value is NO_MCP_SERVER:
+                continue  # ships no MCP server; nothing to verify, nothing broken
             if value is None:
                 unintrospectable.append(f"{pkg}: {surface}")
                 unverified.append(
@@ -261,7 +287,7 @@ def run(write: bool) -> int:
                     f"stated in {llms} and {readme} is UNCHECKED"
                 )
 
-        if c["mcp"] is not None:
+        if c["mcp"] is not None and c["mcp"] is not NO_MCP_SERVER:
             suite_total += c["mcp"]
             _exact_surface(llms, _TOOLS, c["mcp"], "tools", errors, edits, write)
             _exact_surface(readme, _TOOLS, c["mcp"], "tools", errors, edits, write)

--- a/scripts/check_llms_counts.py
+++ b/scripts/check_llms_counts.py
@@ -45,7 +45,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 PKG_DIR = ROOT / "packages" / "python"
-PKGS = ["goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis", "infermap"]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Canonical roster -- see scripts/config_matrix/roster.py. Previously this list
+# was hardcoded here (one of six verbatim copies across the doc tooling).
+from config_matrix.roster import DOCUMENTED  # noqa: E402
+
+PKGS = list(DOCUMENTED)
 
 _TOOLS = re.compile(r"(\d+)\s+tools\b")
 _EXPORTS = re.compile(r"~?(\d+)\s+exports\b")

--- a/scripts/check_llms_counts.py
+++ b/scripts/check_llms_counts.py
@@ -12,13 +12,31 @@ goldenmatch's llms.txt sit at "54 tools / ~101 exports" while the code had 78 an
 
 Contract: within a tracked surface, every match of a count pattern (`N tools`,
 `~N exports`, `N skills`) must equal the introspected value for that package. A
-count with no introspection source (e.g. a package whose A2A skills aren't a
-`_SKILLS` list) is reported as UNVERIFIED, never silently passed.
+count with no introspection source -- a package whose A2A skills aren't a
+`_SKILLS` list, or one whose MCP server / package root will not IMPORT in this
+environment -- is reported as UNVERIFIED, never silently passed.
 
-Run: python scripts/check_llms_counts.py   (needs the packages importable)
+The unverified case is load-bearing, not a nicety. `mcp_tools()` swallows an
+ImportError and returns None; that used to skip the package with no output while
+still summing its tools into the suite total as zero, so the only symptom was the
+SUITE-TOTAL check failing with a short number -- an error whose remediation text
+told you to edit llms.txt DOWN to the broken value. The suite total is now
+REFUSED outright when any package fails to introspect.
+
+`--write` rewrites the stated numbers in place; `regen_docs.py` runs it as a
+generator step, so these counts are no longer "hand-authored prose a checker
+merely complains about". Two rewrite contracts:
+every gated match is rewritten, in the llms.txt and the READMEs alike. Genuine
+per-category sub-counts are DECLARED in `_SUBCOUNT_ALLOW` (one entry repo-wide)
+and are skipped by both the check and the rewrite -- the older "any value below
+the total is a sub-count" ceiling rule was what let goldenmatch's README sit at
+"95 tools available" against a code total of 97.
+
+Run: python scripts/check_llms_counts.py [--write]   (needs the packages importable)
 """
 from __future__ import annotations
 
+import argparse
 import ast
 import importlib
 import re
@@ -110,105 +128,204 @@ def doc_link_errors() -> list[str]:
     return errors
 
 
-def _check_file(rel: str, pattern: re.Pattern[str], expected: int, label: str,
-                errors: list[str]) -> int:
-    """Assert every match of `pattern` in the file equals `expected`. Returns the
-    number of matches checked (0 => the surface doesn't state this count). Use for
-    surfaces where the count appears only as a clean total (the llms.txt) and for
-    export counts (never sub-counted)."""
+def _sub_group1(text: str, pattern: re.Pattern[str], new: int,
+                predicate) -> tuple[str, int]:
+    """Replace capture group 1 (the digits) of every match satisfying `predicate`.
+
+    Rewrites only the number, so surrounding prose -- the `~` on `~200 exports`,
+    the `+` on `139+ tools across the suite`, the spacing -- survives untouched.
+    """
+    out: list[str] = []
+    last = 0
+    n = 0
+    for m in pattern.finditer(text):
+        if not predicate(int(m.group(1)), m):
+            continue
+        start, end = m.span(1)
+        out.append(text[last:start])
+        out.append(str(new))
+        last = end
+        n += 1
+    out.append(text[last:])
+    return "".join(out), n
+
+
+def _exact_surface(rel: str, pattern: re.Pattern[str], expected: int, label: str,
+                   errors: list[str], edits: list[str], write: bool) -> int:
+    """Every stated count in `rel` must equal `expected`, bar declared exceptions.
+
+    Applies to the llms.txt (a clean total, no sub-counts) AND to the package
+    READMEs, whose "N tools available" sentences and comparison-table cells are
+    all restatements of the same total. Lines named in `_SUBCOUNT_ALLOW` are
+    skipped -- both by the check and by `--write`, so a declared sub-count is
+    never silently rewritten to the total.
+
+    Returns the number of gated matches seen (0 => the surface doesn't state it).
+    """
     path = ROOT / rel
     if not path.exists():
         return 0
-    seen = 0
-    for m in pattern.finditer(path.read_text(encoding="utf-8")):
-        seen += 1
-        got = int(m.group(1))
-        if got != expected:
-            errors.append(f"{rel}: states {got} {label}, code has {expected}")
-    return seen
+    text = path.read_text(encoding="utf-8")
+    skip = _allowed_spans(rel, text)
 
+    def gated(m: re.Match[str]) -> bool:
+        return not any(lo <= m.start() < hi for lo, hi in skip)
 
-def _check_total_presence(rel: str, pattern: re.Pattern[str], expected: int,
-                          label: str, errors: list[str]) -> int:
-    """Sub-count-aware check for surfaces (READMEs) that mix the grand total with
-    per-category sub-counts (e.g. goldencheck's "7 tools" for one group vs the "19
-    tools" total). The canonical total MUST appear at least once, and no stated
-    count may EXCEED it (a sub-count is always <= total; a number above it is drift
-    up, and a wrong total leaves the real total absent)."""
-    path = ROOT / rel
-    if not path.exists():
-        return 0
-    values = [int(m.group(1)) for m in pattern.finditer(path.read_text(encoding="utf-8"))]
+    values = [int(m.group(1)) for m in pattern.finditer(text) if gated(m)]
     if not values:
         return 0
-    if expected not in values:
-        errors.append(f"{rel}: no '{expected} {label}' total found "
-                      f"(states {sorted(set(values))}); code has {expected}")
-    for v in values:
-        if v > expected:
-            errors.append(f"{rel}: states {v} {label}, exceeds the code total of {expected}")
+    wrong = [v for v in values if v != expected]
+    if not wrong:
+        return len(values)
+
+    if write:
+        stale = set(wrong)
+        new_text, n = _sub_group1(
+            text, pattern, expected,
+            lambda v, m: gated(m) and v != expected,
+        )
+        path.write_text(new_text, encoding="utf-8", newline="\n")
+        edits.append(f"{rel}: {sorted(stale)} -> {expected} {label} ({n} occurrence(s))")
+    else:
+        for v in sorted(set(wrong)):
+            errors.append(f"{rel}: states {v} {label}, code has {expected}")
     return len(values)
 
 
-def main() -> int:
+# The ONLY legitimate per-category sub-counts in the tracked READMEs. Everything
+# else stating "N tools" is a claim about the TOTAL and is gated strictly.
+#
+# The previous model had this backwards: it allowed ANY value <= the total as a
+# "sub-count", on the theory that READMEs mix totals with per-group figures. In
+# practice they barely do -- there is exactly one such figure in the whole repo --
+# and the allowance was hiding a live bug: goldenmatch's README said "95 tools
+# available" while the code had 97, and the ceiling rule passed it because 97
+# appeared elsewhere and 95 < 97. A stale SECOND statement of the total is
+# indistinguishable from a sub-count under a pure ceiling rule.
+#
+# Declared exceptions instead, in the spirit of parity/<pkg>.yaml's `*_deferred:`
+# maps: an uncovered count must be named with a reason, never left silent. Keyed
+# by tracked path -> (substring identifying the line, why it is not the total).
+_SUBCOUNT_ALLOW: dict[str, tuple[tuple[str, str], ...]] = {
+    "packages/python/goldencheck/README.md": (
+        ("\u251c\u2500\u2500 mcp",
+         "source-tree diagram annotating the mcp/ package directory, not a total"),
+    ),
+}
+
+
+def _allowed_spans(rel: str, text: str) -> list[tuple[int, int]]:
+    """Character spans of lines carrying a declared sub-count exception."""
+    spans: list[tuple[int, int]] = []
+    markers = _SUBCOUNT_ALLOW.get(rel, ())
+    if not markers:
+        return spans
+    pos = 0
+    for line in text.splitlines(keepends=True):
+        if any(marker in line for marker, _ in markers):
+            spans.append((pos, pos + len(line)))
+        pos += len(line)
+    return spans
+
+
+def run(write: bool) -> int:
     errors: list[str] = []
     unverified: list[str] = []
+    edits: list[str] = []
     suite_total = 0
+    unintrospectable: list[str] = []
 
     for pkg in PKGS:
         c = counts(pkg)
+        llms = f"packages/python/{pkg}/{pkg.replace('-', '_')}/llms.txt"
+        readme = f"packages/python/{pkg}/README.md"
+
+        # An unintrospectable surface is REPORTED, never silently skipped. Before
+        # this, `mcp_tools()` swallowing an ImportError returned None and the whole
+        # package was passed over with no output at all -- and its tool count still
+        # summed into `suite_total` as 0, so the only symptom was the suite-total
+        # check failing with a number that told you to edit llms.txt DOWN to the
+        # broken value. The docstring promised UNVERIFIED here; only `skills`
+        # implemented it.
+        for surface, value in (("MCP tools", c["mcp"]), ("__all__ exports", c["exports"])):
+            if value is None:
+                unintrospectable.append(f"{pkg}: {surface}")
+                unverified.append(
+                    f"{pkg}: {surface} could not be introspected -- every count "
+                    f"stated in {llms} and {readme} is UNCHECKED"
+                )
+
         if c["mcp"] is not None:
             suite_total += c["mcp"]
-        llms = f"packages/python/{pkg}/{pkg.replace('-', '_')}/llms.txt"
-
-        # MCP tool count -- llms.txt (local + remote mentions).
-        if c["mcp"] is not None:
-            _check_file(llms, _TOOLS, c["mcp"], "tools", errors)
-        # Export count.
+            _exact_surface(llms, _TOOLS, c["mcp"], "tools", errors, edits, write)
+            _exact_surface(readme, _TOOLS, c["mcp"], "tools", errors, edits, write)
         if c["exports"] is not None:
-            _check_file(llms, _EXPORTS, c["exports"], "exports", errors)
+            _exact_surface(llms, _EXPORTS, c["exports"], "exports", errors, edits, write)
+            _exact_surface(readme, _EXPORTS, c["exports"], "exports", errors, edits, write)
+
         # A2A skills -- only where introspectable.
-        stated_skills = 0
         path = ROOT / llms
-        if path.exists():
-            stated_skills = len(_SKILLS.findall(path.read_text(encoding="utf-8")))
+        stated_skills = len(_SKILLS.findall(path.read_text(encoding="utf-8"))) if path.exists() else 0
         if c["skills"] is not None:
-            _check_file(llms, _SKILLS, c["skills"], "skills", errors)
+            _exact_surface(llms, _SKILLS, c["skills"], "skills", errors, edits, write)
+            _exact_surface(readme, _SKILLS, c["skills"], "skills", errors, edits, write)
         elif stated_skills:
             unverified.append(f"{pkg}: llms.txt states a skill count but no _SKILLS "
                               "introspection source -- not gated")
 
-        # Package README -- exports are strict (never sub-counted); tool/skill
-        # totals use the sub-count-aware presence+ceiling rule, because READMEs
-        # mix the grand total with per-category sub-counts.
-        readme = f"packages/python/{pkg}/README.md"
-        if c["exports"] is not None:
-            _check_file(readme, _EXPORTS, c["exports"], "exports", errors)
-        if c["mcp"] is not None:
-            _check_total_presence(readme, _TOOLS, c["mcp"], "tools", errors)
-        if c["skills"] is not None:
-            _check_total_presence(readme, _SKILLS, c["skills"], "skills", errors)
-
-    # Suite-level llms.txt: "N tools across the suite" == sum of per-package MCP tools.
-    seen_suite = _check_file("llms.txt", _SUITE_TOTAL, suite_total, "suite tools", errors)
-    if not seen_suite:
-        unverified.append(f"llms.txt: no 'N tools across the suite' claim (suite total is {suite_total})")
+    # Suite-level llms.txt: "N tools across the suite" == sum of per-package MCP
+    # tools. REFUSED outright when any package failed to introspect: the sum would
+    # silently be short by that package's tools, and the resulting error message
+    # names a total that is wrong in the other direction.
+    if unintrospectable:
+        errors.append(
+            "suite total REFUSED: "
+            + ", ".join(sorted(unintrospectable))
+            + " could not be introspected, so the sum is not a real total. Fix the "
+              "import (usually a missing extra in this environment) before trusting "
+              "any count here -- do NOT edit llms.txt to match the short sum."
+        )
+    else:
+        seen_suite = _exact_surface("llms.txt", _SUITE_TOTAL, suite_total, "suite tools",
+                                    errors, edits, write)
+        if not seen_suite:
+            unverified.append(
+                f"llms.txt: no 'N tools across the suite' claim (suite total is {suite_total})")
 
     # Doc links in the llms.txt resolve to real pages (and no dead github.io sites).
     errors.extend(doc_link_errors())
 
     for u in unverified:
         print(f"UNVERIFIED: {u}")
+    for e in edits:
+        print(f"rewrote {e}")
+
     if errors:
-        print("\nllms/README count gate FAILED:")
+        print("\nllms/README count gate FAILED:" if not write
+              else "\nllms/README counts could NOT be fully rewritten:")
         for e in errors:
             print(f"  - {e}")
-        print("\nUpdate the stated numbers to match the code (or the code, if the "
-              "count is wrong).")
+        if not write:
+            print("\nRun `python scripts/check_llms_counts.py --write` to rewrite the "
+                  "mechanical counts, or fix the code if a count is wrong.")
         return 1
-    print(f"llms/README count gate OK: verified per-package MCP/export/skill counts "
-          f"+ suite total ({suite_total} tools).")
+
+    if write:
+        print(f"llms/README counts written: {len(edits)} edit(s); suite total {suite_total} tools.")
+    else:
+        print(f"llms/README count gate OK: verified per-package MCP/export/skill counts "
+              f"+ suite total ({suite_total} tools).")
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Verify (or rewrite) stated capability counts.")
+    ap.add_argument("--write", action="store_true",
+                    help="Rewrite the stated counts in place (run by scripts/regen_docs.py).")
+    ap.add_argument("--check", action="store_true",
+                    help="Report drift and exit 1 (the default).")
+    args = ap.parse_args(argv)
+    return run(write=args.write)
 
 
 if __name__ == "__main__":

--- a/scripts/config_matrix/__init__.py
+++ b/scripts/config_matrix/__init__.py
@@ -1,8 +1,35 @@
-"""Repo-level config-matrix generator (all suite packages)."""
+"""Repo-level config-matrix generator (all suite packages).
+
+The render half needs pydantic (it walks the packages' schema trees), but
+``registry.py`` is pure stdlib -- and the STDLIB-ONLY doc gates
+(``check_docs_staleness``, ``check_docs_sections``, ``check_docs_consistency``)
+run on a bare ``setup-python`` runner with no synced workspace. Re-exporting
+``render`` eagerly here made ``from config_matrix.registry import REGISTRY``
+drag pydantic in transitively, so those gates could not share the roster and
+each grew its own hardcoded copy of the package list instead.
+
+The render symbols are therefore resolved LAZILY (PEP 562). ``from config_matrix
+import REGISTRY, PackageSpec`` and ``from config_matrix.registry import ...``
+stay stdlib-only; ``from config_matrix import write_docs`` (etc.) imports
+``render`` on first access exactly as before.
+"""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .registry import REGISTRY, PackageSpec
-from .render import docs_are_current, render_generated_block, scan_env_vars, write_docs
+
+if TYPE_CHECKING:  # pragma: no cover - import-time typing only
+    from .render import (
+        docs_are_current,
+        render_generated_block,
+        scan_env_vars,
+        write_docs,
+    )
+
+_RENDER_EXPORTS = frozenset(
+    {"docs_are_current", "render_generated_block", "scan_env_vars", "write_docs"}
+)
 
 __all__ = [
     "REGISTRY",
@@ -12,3 +39,15 @@ __all__ = [
     "scan_env_vars",
     "write_docs",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name in _RENDER_EXPORTS:
+        from . import render
+
+        return getattr(render, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/scripts/config_matrix/registry.py
+++ b/scripts/config_matrix/registry.py
@@ -24,6 +24,14 @@ class PackageSpec:
     vocabs: list[tuple] = field(default_factory=list)
     vocab_warmup: list[str] = field(default_factory=list)
     tuning_link: str | None = None
+    # Canonical PROSE reference for this package's <PREFIX>_* env flags, if it has
+    # one. Drives check_docs_staleness's flag rule: adding or removing a flag must
+    # touch this page in the same diff. None => the rule is N/A for the package,
+    # which is the honest default: the GENERATED config-matrix block already
+    # documents every introspected knob, so the prose rule only adds value where a
+    # hand-written flag reference actually exists. Give a package a tuning page,
+    # set this, and the rule starts covering it with no code change.
+    prose_flag_page: str | None = None
     # Env names other docs may reference despite not being read in code (rare;
     # the migration-page + removal-context heuristics cover most). Explicit escape hatch.
     env_allow: tuple[str, ...] = ()
@@ -45,6 +53,7 @@ REGISTRY: dict[str, PackageSpec] = {
         doc_path="docs-site/goldenmatch/config-matrix.mdx",
         nav_group="GoldenMatch",
         env_prefix="GOLDENMATCH_",
+        prose_flag_page="docs-site/goldenmatch/tuning.mdx",
         src_dirs=["packages/python/goldenmatch/goldenmatch", _RUST],
         schema_roots=["goldenmatch.config.schemas:GoldenMatchConfig"],
         cli_module="goldenmatch.cli.main",

--- a/scripts/config_matrix/render.py
+++ b/scripts/config_matrix/render.py
@@ -498,16 +498,56 @@ def _splice(existing: str, block: str) -> str:
     return existing[:start] + block + existing[end + len(MARKER_END):]
 
 
+def _scaffold(spec) -> str:
+    """A minimal, VALID page for a package that has no config-matrix yet.
+
+    The generator is splice-only: it needs the markers to already exist. That made
+    `--write` raise a bare ``FileNotFoundError`` for a package whose page had never
+    been authored, so onboarding one meant hand-writing a stub with byte-exact
+    marker text first -- the step nobody does, and a standing reason packages go
+    without a config matrix at all. Scaffolding removes that: add the package to
+    REGISTRY, run `make docs`, get a valid page with the generated block in place
+    and a clearly-marked TODO where the hand-authored intro belongs.
+
+    The frontmatter satisfies check_docs_sections (title/description/keywords all
+    present and non-empty, title in sentence case).
+    """
+    display = spec.nav_group or spec.name
+    return (
+        "---\n"
+        'title: "Config matrix"\n'
+        f'description: "The full matrix of {display} configuration knobs and '
+        'vocabularies -- generated so it never drifts."\n'
+        f'keywords: ["{spec.name}", "config matrix", "configuration", "reference"]\n'
+        "---\n\n"
+        f"TODO: hand-authored intro for {display}'s configuration surface. Replace "
+        "this paragraph; everything below the line is generated and must not be "
+        "edited by hand.\n\n"
+        "<Info>\n"
+        "Everything below the line is **generated from code** "
+        "(`scripts/gen_config_matrix.py`) and verified in CI. The guidance above "
+        "the line is hand-authored.\n"
+        "</Info>\n\n"
+        f"{MARKER_START}\n\n{MARKER_END}\n"
+    )
+
+
 def _rendered_full(spec) -> str:
-    return _splice(_doc_path(spec).read_text(encoding="utf-8"), render_generated_block(spec))
+    p = _doc_path(spec)
+    existing = p.read_text(encoding="utf-8") if p.exists() else _scaffold(spec)
+    return _splice(existing, render_generated_block(spec))
 
 
 def docs_are_current(spec) -> bool:
     p = _doc_path(spec)
+    # A MISSING page is not current -- it is the most stale a page can be. Reading
+    # `_rendered_full` for a nonexistent path now scaffolds rather than raising, so
+    # the existence test has to stay explicit.
     return p.exists() and p.read_text(encoding="utf-8") == _rendered_full(spec)
 
 
 def write_docs(spec) -> Path:
     p = _doc_path(spec)
+    p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(_rendered_full(spec), encoding="utf-8", newline="\n")
     return p

--- a/scripts/config_matrix/roster.py
+++ b/scripts/config_matrix/roster.py
@@ -98,37 +98,15 @@ def derive_roster() -> tuple[list[str], list[str], list[str]]:
 # section OR an entry here) turns silence into a decision that has to be written
 # down, the same way parity/<pkg>.yaml makes an uncovered scorer declare itself.
 #
-# EVERY ENTRY BELOW IS PROVISIONAL and needs a product-scope call: onboard, or
-# keep the deferral with a real reason. They are recorded as deferred so the
-# inverted check can land green rather than blocking on that decision; the
-# generator can now scaffold a config-matrix page, so onboarding one is
-# "add a PackageSpec, run make docs, write the intro prose".
-DOCS_DEFERRED: dict[str, str] = {
-    "golden-suite": (
-        "TODO(decide): one-line meta-package (whole suite + native). Arguably needs "
-        "an install/overview page rather than a full section."
-    ),
-    "goldencheck-types": (
-        "TODO(decide): shared type definitions consumed by goldencheck; may belong "
-        "inside the goldencheck section rather than its own."
-    ),
-    "goldengraph": (
-        "TODO(decide): KG engine, published to PyPI and npm, currently documented "
-        "only via goldenmatch-kg prose."
-    ),
-    "goldenmatch-kg": (
-        "TODO(decide): knowledge-graph surface over goldenmatch; has an llms.txt but "
-        "no docs-site section."
-    ),
-    "goldensuite-mcp": (
-        "TODO(decide): the suite-wide MCP aggregator. Ships an agent-manifest copy "
-        "and an llms.txt; a section would duplicate per-package MCP docs."
-    ),
-}
+# CURRENTLY EMPTY -- every published core package has a docs-site section. The five
+# that were provisionally deferred when the inverted check landed (golden-suite,
+# goldencheck-types, goldengraph, goldenmatch-kg, goldensuite-mcp) were onboarded
+# instead. Keep it that way: a new published package should get a section, and an
+# entry here needs a real reason, not a TODO.
+DOCS_DEFERRED: dict[str, str] = {}
 
 
-# Published CORE distributions with no row in the root README's package-overview
-# table (no `packages/python/<pkg>/README.md` link anywhere in it).
+# Published CORE distributions with no link from the root README.
 #
 # The old check tested `pkg.lower() in readme.lower()` over the WHOLE file, which
 # every package passes on an incidental mention -- "goldenmatch" alone appears
@@ -136,15 +114,6 @@ DOCS_DEFERRED: dict[str, str] = {
 # what the README said. Requiring a LINK to the package README is the assertion
 # the substring test was reaching for.
 #
-# EVERY ENTRY BELOW IS PROVISIONAL, same as DOCS_DEFERRED: onboard, or keep the
-# deferral with a real reason.
-README_DEFERRED: dict[str, str] = {
-    "goldencheck-types": (
-        "TODO(decide): shared type definitions consumed by goldencheck; arguably an "
-        "implementation detail of that row rather than its own."
-    ),
-    "goldensuite-mcp": (
-        "TODO(decide): the suite-wide MCP aggregator. The README covers MCP per "
-        "package; a dedicated row may or may not earn its place."
-    ),
-}
+# CURRENTLY EMPTY -- goldencheck-types and goldensuite-mcp, provisionally deferred
+# when the check landed, now have rows in the README's "Shared components" table.
+README_DEFERRED: dict[str, str] = {}

--- a/scripts/config_matrix/roster.py
+++ b/scripts/config_matrix/roster.py
@@ -30,6 +30,20 @@ from pathlib import Path
 
 from .registry import REGISTRY
 
+# This module exists to BE imported -- it is the shared public surface that
+# replaced six hardcoded copies of the package list, and nothing here is consumed
+# in-module. Declaring `__all__` states that contract explicitly (and is why a
+# static "unused global" reading of this file is wrong: DOCUMENTED alone has eight
+# importers).
+__all__ = [
+    "DOCS_DEFERRED",
+    "DOCUMENTED",
+    "NON_DIST_STEMS",
+    "README_DEFERRED",
+    "derive_roster",
+    "publish_stems",
+]
+
 ROOT = Path(__file__).resolve().parent.parent.parent
 PY_PKGS = ROOT / "packages" / "python"
 

--- a/scripts/config_matrix/roster.py
+++ b/scripts/config_matrix/roster.py
@@ -1,0 +1,136 @@
+"""The canonical suite-package roster, in ONE place.
+
+Before this module the same six-package list was hardcoded verbatim in four
+scripts (`check_llms_counts`, `gen_api_surface`, `gen_suite_matrix`,
+`check_docs_sections`) plus `REGISTRY` here and the `config_matrix` matrix in
+`ci.yml` -- six copies of a list that changes whenever a package is added. The
+duplication was not laziness: `derive_roster()` lived inside
+`check_docs_consistency.py` and `REGISTRY` was unreachable from a stdlib-only
+gate (importing it dragged in pydantic via the package `__init__`), so no shared
+definition was importable. Both of those are fixed, so this module can exist.
+
+Everything here is PURE STDLIB. The doc gates that consume it run on a bare
+`setup-python` runner with no synced workspace; adding a third-party import here
+would silently push them back to hardcoded copies.
+
+Three distinct notions of "the roster" -- they are not interchangeable:
+
+  DOCUMENTED     the packages that own a `docs-site/<pkg>/` section and a
+                 generated config matrix. Derived from REGISTRY, so adding a
+                 PackageSpec is the single edit that onboards a package.
+  derive_roster  every distribution the repo actually PUBLISHES, read off the
+                 `publish-*.yml` callers. Strictly larger than DOCUMENTED.
+  DOCS_DEFERRED  published packages knowingly without a docs section, each with
+                 a reason. The gap between the first two must be fully covered by
+                 this map or `check_docs_consistency` fails.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .registry import REGISTRY
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+PY_PKGS = ROOT / "packages" / "python"
+
+#: Packages with a docs-site section + generated config matrix, in REGISTRY order.
+DOCUMENTED: tuple[str, ...] = tuple(REGISTRY)
+
+#: Stems that are NOT a per-distribution PyPI/npm publisher.
+NON_DIST_STEMS = frozenset({"containers", "mcp"})
+
+
+def publish_stems() -> list[str]:
+    return sorted(
+        p.name[len("publish-"):-len(".yml")]
+        for p in (ROOT / ".github" / "workflows").glob("publish-*.yml")
+    )
+
+
+def derive_roster() -> tuple[list[str], list[str], list[str]]:
+    """Return (core_pypi, ext_pypi, npm) derived from publish-*.yml callers.
+
+    ``core_pypi``  -- publishers backed by a ``packages/python/<stem>`` directory
+                      (the distribution packages that get a README row + nav group).
+    ``ext_pypi``   -- the remaining PyPI publishers (SQL / rust-extension extras
+                      like goldenmatch-duckdb / -embed / -pg). Reported, not gated
+                      structurally -- they live inside parent docs, not their own
+                      nav group.
+    ``npm``        -- ``publish-<pkg>-js.yml`` stems.
+    """
+    core: list[str] = []
+    ext: list[str] = []
+    npm: list[str] = []
+    for stem in publish_stems():
+        if stem in NON_DIST_STEMS:
+            continue
+        if stem.endswith("-native"):
+            continue  # compiled extras tracked separately; not a doc-nav surface
+        if stem.endswith("-js"):
+            npm.append(stem[: -len("-js")])
+        elif (PY_PKGS / stem).is_dir():
+            core.append(stem)
+        else:
+            ext.append(stem)
+    return sorted(set(core)), sorted(set(ext)), sorted(set(npm))
+
+
+# Published CORE distributions that knowingly have no `docs-site/<pkg>/` section.
+#
+# This map is the point of the exercise. The nav check used to read "every roster
+# package that HAS a docs-site/<pkg>/ directory must appear in the nav" -- which a
+# package with no directory passes trivially, so the check could not fail for the
+# packages it most needed to catch. Inverting it (every CORE package needs a
+# section OR an entry here) turns silence into a decision that has to be written
+# down, the same way parity/<pkg>.yaml makes an uncovered scorer declare itself.
+#
+# EVERY ENTRY BELOW IS PROVISIONAL and needs a product-scope call: onboard, or
+# keep the deferral with a real reason. They are recorded as deferred so the
+# inverted check can land green rather than blocking on that decision; the
+# generator can now scaffold a config-matrix page, so onboarding one is
+# "add a PackageSpec, run make docs, write the intro prose".
+DOCS_DEFERRED: dict[str, str] = {
+    "golden-suite": (
+        "TODO(decide): one-line meta-package (whole suite + native). Arguably needs "
+        "an install/overview page rather than a full section."
+    ),
+    "goldencheck-types": (
+        "TODO(decide): shared type definitions consumed by goldencheck; may belong "
+        "inside the goldencheck section rather than its own."
+    ),
+    "goldengraph": (
+        "TODO(decide): KG engine, published to PyPI and npm, currently documented "
+        "only via goldenmatch-kg prose."
+    ),
+    "goldenmatch-kg": (
+        "TODO(decide): knowledge-graph surface over goldenmatch; has an llms.txt but "
+        "no docs-site section."
+    ),
+    "goldensuite-mcp": (
+        "TODO(decide): the suite-wide MCP aggregator. Ships an agent-manifest copy "
+        "and an llms.txt; a section would duplicate per-package MCP docs."
+    ),
+}
+
+
+# Published CORE distributions with no row in the root README's package-overview
+# table (no `packages/python/<pkg>/README.md` link anywhere in it).
+#
+# The old check tested `pkg.lower() in readme.lower()` over the WHOLE file, which
+# every package passes on an incidental mention -- "goldenmatch" alone appears
+# scores of times, so the check could not fail for the headline package no matter
+# what the README said. Requiring a LINK to the package README is the assertion
+# the substring test was reaching for.
+#
+# EVERY ENTRY BELOW IS PROVISIONAL, same as DOCS_DEFERRED: onboard, or keep the
+# deferral with a real reason.
+README_DEFERRED: dict[str, str] = {
+    "goldencheck-types": (
+        "TODO(decide): shared type definitions consumed by goldencheck; arguably an "
+        "implementation detail of that row rather than its own."
+    ),
+    "goldensuite-mcp": (
+        "TODO(decide): the suite-wide MCP aggregator. The README covers MCP per "
+        "package; a dedicated row may or may not earn its place."
+    ),
+}

--- a/scripts/gen_api_surface.py
+++ b/scripts/gen_api_surface.py
@@ -49,7 +49,14 @@ ROOT = Path(__file__).resolve().parent.parent
 PAGE = ROOT / "docs-site" / "reference" / "api-surface.mdx"
 PARITY = ROOT / "parity"
 
-PKGS = ["goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis", "infermap"]
+# Canonical roster -- see scripts/config_matrix/roster.py.
+from config_matrix.roster import DOCUMENTED  # noqa: E402
+
+# Editorial ROW ORDER + display names for the table. Membership comes from the
+# canonical roster; the order does NOT -- REGISTRY is ordered for its own reasons
+# (and its order is baked into the agent manifests), so deriving row order from it
+# would reshuffle a published table as a side effect of an unrelated registry edit.
+# Roster = who is in the table; this map = how the table reads.
 DISPLAY = {
     "goldenmatch": "GoldenMatch",
     "goldencheck": "GoldenCheck",
@@ -58,6 +65,17 @@ DISPLAY = {
     "goldenanalysis": "GoldenAnalysis",
     "infermap": "InferMap",
 }
+
+# A package added to the roster must be given a display name + META row here, or
+# it would silently vanish from the capability matrix.
+_missing = set(DOCUMENTED) - set(DISPLAY)
+if _missing:
+    raise SystemExit(
+        f"gen_api_surface: roster package(s) {sorted(_missing)} have no DISPLAY entry. "
+        "Add a display name (and a META row) so they appear in the capability matrix."
+    )
+
+PKGS = [p for p in DISPLAY if p in set(DOCUMENTED)]
 
 # Editorial columns -- change rarely, reviewed here rather than buried in the mdx.
 #   rest:   ships a long-running REST HTTP service (the `<pkg> serve` service-shaped

--- a/scripts/gen_api_surface.py
+++ b/scripts/gen_api_surface.py
@@ -171,7 +171,7 @@ def main() -> int:
     mode = sys.argv[1] if len(sys.argv) > 1 else "--check"
     if mode == "--write":
         page = PAGE.read_text(encoding="utf-8")
-        PAGE.write_text(_splice(page, render_block()), encoding="utf-8")
+        PAGE.write_text(_splice(page, render_block()), encoding="utf-8", newline="\n")
         print(f"wrote {PAGE.relative_to(ROOT)}")
         return 0
     if mode == "--check":

--- a/scripts/gen_native_docs.py
+++ b/scripts/gen_native_docs.py
@@ -217,7 +217,7 @@ def main(argv: list[str]) -> int:
     if args.write:
         for pkg in pkgs:
             p = _page_path(pkg)
-            p.write_text(render(pkg), encoding="utf-8")
+            p.write_text(render(pkg), encoding="utf-8", newline="\n")
             print(f"wrote {p.relative_to(ROOT)}")
         return 0
 

--- a/scripts/gen_suite_matrix.py
+++ b/scripts/gen_suite_matrix.py
@@ -35,7 +35,25 @@ ROOT = Path(__file__).resolve().parent.parent
 PAGE = ROOT / "docs-site" / "suite-matrix.mdx"
 PARITY = ROOT / "parity"
 PKG_DIR = ROOT / "packages" / "python"
-PKGS = ["goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis", "infermap"]
+# Canonical roster -- see scripts/config_matrix/roster.py. Membership is derived;
+# ROW ORDER is editorial and stays local. REGISTRY is ordered for its own reasons
+# (and that order is baked into the agent manifests), so deriving row order from it
+# would reshuffle these published tables whenever an unrelated registry edit moved
+# an entry. Roster = who is in the table; _ROW_ORDER = how the table reads.
+from config_matrix.roster import DOCUMENTED  # noqa: E402
+
+_ROW_ORDER = ("goldenmatch", "goldencheck", "goldenflow", "goldenpipe",
+              "goldenanalysis", "infermap")
+
+# A roster package with no row-order entry would silently vanish from the matrix.
+_missing = set(DOCUMENTED) - set(_ROW_ORDER)
+if _missing:
+    raise SystemExit(
+        f"gen_suite_matrix: roster package(s) {sorted(_missing)} are not in _ROW_ORDER. "
+        "Add them so they appear in the suite matrix."
+    )
+
+PKGS = [p for p in _ROW_ORDER if p in set(DOCUMENTED)]
 
 
 # --- Surface introspection. MCP + CLI counts come from the parity manifests

--- a/scripts/gen_suite_matrix.py
+++ b/scripts/gen_suite_matrix.py
@@ -257,7 +257,7 @@ def main() -> int:
     mode = sys.argv[1] if len(sys.argv) > 1 else "--check"
     block = render_block()
     if mode == "--write":
-        PAGE.write_text(_compose(block), encoding="utf-8")
+        PAGE.write_text(_compose(block), encoding="utf-8", newline="\n")
         print(f"wrote {PAGE.relative_to(ROOT)}")
         return 0
     if mode == "--check":

--- a/scripts/gen_thesis_weaknesses.py
+++ b/scripts/gen_thesis_weaknesses.py
@@ -266,7 +266,7 @@ def main() -> int:
     mode = sys.argv[1] if len(sys.argv) > 1 else "--check"
     block = render_block()
     if mode == "--write":
-        PAGE.write_text(_compose(block), encoding="utf-8")
+        PAGE.write_text(_compose(block), encoding="utf-8", newline="\n")
         print(f"wrote {PAGE.relative_to(ROOT)}")
         return 0
     if mode == "--check":

--- a/scripts/regen_docs.py
+++ b/scripts/regen_docs.py
@@ -12,8 +12,10 @@ so nobody has to remember the list:
     python scripts/regen_docs.py --check  # CI: regenerate, then fail if the tree drifted
 
 `--check` is what the `docs_regen` CI job runs: it regenerates in place and then
-`git diff --exit-code` fails (showing the exact diff to commit) if anything was
-stale, and runs the two non-regenerable prose-count checks. Run it under the synced
+fails (showing exactly what to commit) if anything was stale, and runs the two
+non-regenerable prose-count checks. The staleness probe is `git status
+--porcelain`, not `git diff`: diff sees only TRACKED changes, so a generator
+emitting a brand-new page used to pass the gate with the file uncommitted. Run it under the synced
 workspace (`uv run python scripts/regen_docs.py`) so every package is importable.
 
 Some drift lives in hand-authored PROSE (the "97 tools" figures in llms.txt /
@@ -65,14 +67,29 @@ def _run(argv: list[str]) -> int:
     return subprocess.run([PY, *argv], cwd=ROOT).returncode
 
 
-def _git_diff_is_clean() -> bool:
-    # `git diff --quiet -- <generated paths>` = tracked modifications to the
-    # GENERATED DOCS only (exit 0 clean, 1 dirty). Scoped so an unrelated
-    # CI-mutated tracked file (e.g. `uv.lock` from `uv sync`) can't false-trip it;
-    # untracked scratch is ignored too.
-    return subprocess.run(
-        ["git", "diff", "--quiet", "--", *GENERATED_PATHS], cwd=ROOT
-    ).returncode == 0
+def _drifted_paths() -> list[str]:
+    """Porcelain status lines for the GENERATED DOCS -- empty means no drift.
+
+    `git status --porcelain` rather than `git diff --quiet`: diff reports only
+    TRACKED modifications, so a generator emitting a BRAND-NEW page (the "onboard
+    a package" case) left the gate green with the file uncommitted -- the drift
+    this job exists to catch, invisible to it. Porcelain sees added, deleted and
+    untracked alike.
+
+    Still scoped to GENERATED_PATHS so an unrelated CI-mutated file (notably
+    `uv.lock`, which `uv sync` re-resolves in the runner) can't false-trip it, and
+    `--untracked-files=normal` keeps directory-level rollup for untracked trees.
+    """
+    out = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=normal", "--", *GENERATED_PATHS],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    ).stdout
+    return [ln for ln in out.splitlines() if ln.strip()]
 
 
 def main() -> int:
@@ -92,9 +109,14 @@ def main() -> int:
 
     if args.check:
         ok = True
-        if not _git_diff_is_clean():
-            print("\nDOC DRIFT: committed generated docs were stale. The diff below is the fix "
-                  "-- run `python scripts/regen_docs.py` and commit it:\n", file=sys.stderr)
+        drifted = _drifted_paths()
+        if drifted:
+            print("\nDOC DRIFT: committed generated docs were stale. The changes below are "
+                  "the fix -- run `python scripts/regen_docs.py` and commit them:\n",
+                  file=sys.stderr)
+            for line in drifted:
+                print(f"  {line}", file=sys.stderr)
+            print(file=sys.stderr)
             subprocess.run(["git", "--no-pager", "diff", "--stat", "--", *GENERATED_PATHS], cwd=ROOT)
             subprocess.run(["git", "--no-pager", "diff", "--", *GENERATED_PATHS], cwd=ROOT)
             ok = False

--- a/scripts/regen_docs.py
+++ b/scripts/regen_docs.py
@@ -18,9 +18,12 @@ non-regenerable prose-count checks. The staleness probe is `git status
 emitting a brand-new page used to pass the gate with the file uncommitted. Run it under the synced
 workspace (`uv run python scripts/regen_docs.py`) so every package is importable.
 
-Some drift lives in hand-authored PROSE (the "97 tools" figures in llms.txt /
-README / api-surface); no generator rewrites those, so this reports them for a
-manual bump rather than silently passing.
+Almost nothing is left to hand-bump. The capability counts (llms.txt / README
+"N tools", "~N exports", "N skills") and the README "what's new" callouts used to
+be hand-authored figures a checker merely complained about; both are now WRITE
+steps, so `make docs` fixes them. The only survivor is the pair of inline figures
+beside api-surface's generated table, which sit mid-sentence in hand-written
+prose -- `gen_api_surface --check` reports those for a manual bump.
 """
 from __future__ import annotations
 
@@ -42,12 +45,15 @@ WRITE_STEPS: list[list[str]] = [
     ["scripts/gen_suite_matrix.py", "--write"],       # docs-site/suite-matrix.mdx
     ["scripts/gen_thesis_weaknesses.py", "--write"],  # docs-site/thesis-weaknesses.mdx
     ["scripts/gen_native_docs.py", "--write"],        # docs-site/*/native.mdx
+    ["scripts/check_llms_counts.py", "--write"],      # llms.txt / README capability counts
+    ["scripts/sync_readme_callouts.py"],              # README "what's new" from CHANGELOG
 ]
 
-# Checks for HAND-AUTHORED figures that no --write regenerates (prose counts).
+# Figures that share a generated source but live in hand-written prose, so no
+# --write can own them. `gen_api_surface --check` asserts the two inline numbers
+# beside its generated table; the table itself is already fresh by this point.
 PROSE_CHECKS: list[list[str]] = [
-    ["scripts/check_llms_counts.py"],                 # llms.txt / README / suite tool+export counts
-    ["scripts/gen_api_surface.py", "--check"],        # api-surface.mdx inline figures (block already fresh)
+    ["scripts/gen_api_surface.py", "--check"],
 ]
 
 # The ONLY paths a generator writes. The drift check is scoped to these so an
@@ -59,6 +65,14 @@ GENERATED_PATHS: list[str] = [
     "docs/agent-manifest.json",
     "docs/agent-codemap.json",
     "packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json",
+    # `:(glob)` magic is load-bearing: in a PLAIN git pathspec `*` crosses `/`, so
+    # `packages/python/*/README.md` swept 32 files (every nested example/test
+    # README) instead of the 11 package roots -- widening the drift scope back out
+    # to files no generator writes, which is exactly what scoping exists to avoid.
+    "llms.txt",                                               # suite tool total
+    ":(glob)packages/python/*/*/llms.txt",                    # per-package capability counts
+    "README.md",                                              # callouts (+ counts)
+    ":(glob)packages/python/*/README.md",                     # callouts + capability counts
 ]
 
 

--- a/scripts/sync_readme_callouts.py
+++ b/scripts/sync_readme_callouts.py
@@ -156,7 +156,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.check:
             print(f"DRIFT: {target.relative_to(REPO_ROOT)} is out of sync", file=sys.stderr)
         else:
-            target.write_text(updated, encoding="utf-8")
+            target.write_text(updated, encoding="utf-8", newline="\n")
             print(f"updated {target.relative_to(REPO_ROOT)}")
 
     if args.check and any_diff:

--- a/scripts/test_agent_codemap.py
+++ b/scripts/test_agent_codemap.py
@@ -8,6 +8,7 @@ Regenerate with: python scripts/agent_codemap.py --write
 from __future__ import annotations
 
 from agent_codemap import CODEMAP_PATH, build_codemap, codemap_is_current, codemap_json
+from config_matrix.roster import DOCUMENTED
 
 
 def test_codemap_current():
@@ -23,9 +24,7 @@ def test_codemap_deterministic():
 
 def test_codemap_covers_every_registry_package():
     m = build_codemap()
-    assert set(m["packages"]) == {
-        "goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "infermap", "goldenanalysis"
-    }
+    assert set(m["packages"]) == set(DOCUMENTED)
     # Every package resolved to real modules, and every entry carries a location.
     for name, p in m["packages"].items():
         assert p["module_count"] > 0, f"{name} mapped 0 modules"

--- a/scripts/test_api_parity.py
+++ b/scripts/test_api_parity.py
@@ -311,11 +311,10 @@ def test_python_emitter_goldenmatch_smoke():
 
 
 import pytest
+from config_matrix.roster import DOCUMENTED
 
 
-@pytest.mark.parametrize(
-    "pkg", ["goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis", "infermap"]
-)
+@pytest.mark.parametrize("pkg", DOCUMENTED)
 def test_python_emitter_all_packages_smoke(pkg):
     """Every package's Python emitter produces a non-empty, sorted mcp+cli surface. Box-safe
     (needs each <pkg>[mcp] in the venv)."""

--- a/scripts/test_docs_staleness.py
+++ b/scripts/test_docs_staleness.py
@@ -15,7 +15,13 @@ the caller blows up on ``None``. These tests pin the encoding contract.
 
 from __future__ import annotations
 
-from check_docs_staleness import TUNING_MDX, _documented_flags, _git
+from check_docs_staleness import FLAG_SPECS, _documented_flags, _git
+
+# The flag rule is now registry-driven (one entry per package declaring a
+# `prose_flag_page`). goldenmatch is the only one today and is the package these
+# encoding tests are about, so pin to it explicitly rather than to FLAG_SPECS[0].
+GM = next(spec for spec in FLAG_SPECS if spec[0] == "goldenmatch")
+GM_FLAG_RE, TUNING_MDX = GM[1], GM[2]
 
 
 def test_git_returns_text_for_non_ascii_content():
@@ -38,9 +44,67 @@ def test_documented_flags_finds_the_canonical_reference():
     If this returns an empty set, every flag in a diff looks undocumented and
     the gate fails every PR that touches one.
     """
-    flags = _documented_flags("HEAD")
+    flags = _documented_flags("HEAD", TUNING_MDX, GM_FLAG_RE)
     assert flags, f"no GOLDENMATCH_* flags parsed from {TUNING_MDX}"
     assert "GOLDENMATCH_NATIVE" in flags, (
         "GOLDENMATCH_NATIVE is the most-documented flag in the reference; its "
         f"absence means {TUNING_MDX} was not read correctly"
     )
+
+
+def test_flag_specs_come_from_the_registry():
+    """The roster must be DERIVED, not a second hardcoded copy.
+
+    The whole point of driving this off ``config_matrix.registry`` is that giving a
+    package a tuning page is a one-line registry change. If someone re-hardcodes a
+    list here, this catches it.
+    """
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from config_matrix.registry import REGISTRY
+
+    expected = {
+        (spec.name, spec.prose_flag_page)
+        for spec in REGISTRY.values()
+        if spec.prose_flag_page
+    }
+    assert {(name, page) for name, _, page in FLAG_SPECS} == expected
+    assert ("goldenmatch", "docs-site/goldenmatch/tuning.mdx") in expected
+
+
+def test_registry_is_importable_without_pydantic():
+    """``check_docs_staleness`` runs on a bare setup-python runner.
+
+    It imports the registry for the roster, so ``config_matrix.registry`` must stay
+    reachable WITHOUT the synced workspace. ``config_matrix/__init__.py`` re-exports
+    the pydantic-dependent render half lazily to keep that true; an eager re-export
+    would make this gate uninstallable in its own CI job.
+    """
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    scripts = Path(__file__).resolve().parent
+    probe = (
+        f"import sys; sys.path.insert(0, {str(scripts)!r})\n"
+        "sys.modules['pydantic'] = None\n"
+        "from config_matrix.registry import REGISTRY\n"
+        "assert REGISTRY\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True, text=True, encoding="utf-8",
+    )
+    assert proc.returncode == 0, (
+        "config_matrix.registry is no longer importable without pydantic:\n"
+        + proc.stderr
+    )
+
+
+def test_flag_matcher_is_prefix_scoped():
+    """A package's matcher must not claim another package's flags."""
+    assert GM_FLAG_RE.findall("GOLDENMATCH_NATIVE and GOLDENCHECK_NATIVE") == [
+        "GOLDENMATCH_NATIVE"
+    ]

--- a/scripts/test_roster.py
+++ b/scripts/test_roster.py
@@ -1,0 +1,115 @@
+"""Gate for the canonical package roster (scripts/config_matrix/roster.py).
+
+The roster exists to kill six verbatim copies of the same package list. That only
+holds if nothing quietly grows a seventh, and if the deferral maps stay honest --
+both are the kind of thing that rots silently, which is what this pins.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from config_matrix.registry import REGISTRY
+from config_matrix.roster import (
+    DOCS_DEFERRED,
+    DOCUMENTED,
+    README_DEFERRED,
+    derive_roster,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+
+
+def test_documented_is_derived_from_the_registry():
+    """Adding a PackageSpec must be the ONE edit that onboards a package."""
+    assert DOCUMENTED == tuple(REGISTRY)
+
+
+def test_roster_importable_without_pydantic():
+    """The stdlib-only doc gates import this on a bare setup-python runner.
+
+    `config_matrix/__init__.py` re-exports the pydantic-dependent render half
+    lazily to keep that true. An eager re-export would make check_docs_consistency
+    and check_docs_sections uninstallable in their own CI jobs -- which is exactly
+    why they each had a hardcoded copy of the roster before.
+    """
+    probe = (
+        f"import sys; sys.path.insert(0, {str(SCRIPTS)!r})\n"
+        "sys.modules['pydantic'] = None\n"
+        "from config_matrix.roster import DOCUMENTED, derive_roster\n"
+        "assert DOCUMENTED and derive_roster()\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", probe],
+                          capture_output=True, text=True, encoding="utf-8")
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_ci_config_matrix_leg_matches_the_roster():
+    """ci.yml's config_matrix job runs one leg per package, as a literal list.
+
+    A package added to REGISTRY but not to that list gets a generated page nothing
+    gates -- the drift class this whole battery exists to prevent.
+    """
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    m = re.search(r"config_matrix:.*?matrix:\s*\n\s*package:\s*\[([^\]]+)\]", ci, re.S)
+    assert m, "could not locate the config_matrix job's package matrix in ci.yml"
+    legs = {p.strip() for p in m.group(1).split(",") if p.strip()}
+    assert legs == set(DOCUMENTED), (
+        f"ci.yml config_matrix legs {sorted(legs)} != roster {sorted(DOCUMENTED)}"
+    )
+
+
+def test_no_script_rehardcodes_the_roster():
+    """Guard against a seventh copy of the list appearing."""
+    offenders = []
+    for path in sorted(SCRIPTS.glob("*.py")):
+        if path.name in {"test_roster.py"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for m in re.finditer(r"\[[^\]\n]*\"goldenmatch\"[^\]\n]*\]", text):
+            literal = m.group(0)
+            names = set(re.findall(r'"([a-z-]+)"', literal))
+            # A hardcoded roster is a literal naming most of the suite. A short
+            # list naming two or three packages is a legitimate local subset.
+            if len(names & set(DOCUMENTED)) >= 5:
+                offenders.append(f"{path.name}: {literal[:70]}")
+    assert not offenders, (
+        "hardcoded roster copies found -- import DOCUMENTED from "
+        "config_matrix.roster instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_deferrals_are_live_and_complete():
+    """Every published-but-undocumented package is declared, and no entry is stale."""
+    core, _, _ = derive_roster()
+    docs_site = ROOT / "docs-site"
+
+    undocumented = {p for p in core if not (docs_site / p).is_dir()}
+    assert undocumented == set(DOCS_DEFERRED), (
+        f"DOCS_DEFERRED is out of step: undeclared={sorted(undocumented - set(DOCS_DEFERRED))}, "
+        f"stale={sorted(set(DOCS_DEFERRED) - undocumented)}"
+    )
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()
+    unlinked = {p for p in core if f"packages/python/{p}/readme.md" not in readme}
+    assert unlinked == set(README_DEFERRED), (
+        f"README_DEFERRED is out of step: undeclared={sorted(unlinked - set(README_DEFERRED))}, "
+        f"stale={sorted(set(README_DEFERRED) - unlinked)}"
+    )
+
+
+def test_every_deferral_carries_a_reason():
+    for name, reason in {**DOCS_DEFERRED, **README_DEFERRED}.items():
+        assert len(reason.strip()) > 30, f"{name}: deferral reason is too thin to review"
+
+
+def test_documented_roster_is_actually_published():
+    """A PackageSpec for a package no publisher ships is docs for a phantom dist."""
+    core, _, _ = derive_roster()
+    assert set(DOCUMENTED) <= set(core), sorted(set(DOCUMENTED) - set(core))

--- a/scripts/test_roster.py
+++ b/scripts/test_roster.py
@@ -113,3 +113,26 @@ def test_documented_roster_is_actually_published():
     """A PackageSpec for a package no publisher ships is docs for a phantom dist."""
     core, _, _ = derive_roster()
     assert set(DOCUMENTED) <= set(core), sorted(set(DOCUMENTED) - set(core))
+
+
+def test_all_matches_the_public_surface():
+    """`__all__` is the module's stated contract; keep it honest.
+
+    Added in response to a CodeQL "unused global variable" finding on DOCUMENTED.
+    The finding is a false positive -- the constant has eight importers -- but the
+    module genuinely had no declared export list, and the suggested workaround (a
+    no-op `_ = DOCUMENTED` read inside derive_roster) would have been a line whose
+    only purpose is to fool static analysis. This asserts the real thing instead.
+    """
+    import config_matrix.roster as mod
+
+    declared = set(mod.__all__)
+    public = {
+        n for n in vars(mod)
+        if not n.startswith("_")
+        and n not in {"annotations", "Path", "REGISTRY", "ROOT", "PY_PKGS"}
+    }
+    assert declared == public, (
+        f"__all__ is out of step: missing={sorted(public - declared)}, "
+        f"stale={sorted(declared - public)}"
+    )


### PR DESCRIPTION
## What and why

An audit of the programmatic documentation-generation system turned up gates that were wired, looked armed, and could not catch the drift they were written for - the "a check exists and does not fire" class this repo keeps hitting. This is phases 1-3 of the remediation.

Three commits, each independently revertable:

| | |
|---|---|
| `9c39845` | Phase 1 - make the gates able to fire |
| `ace818e` | Phase 2 - byte determinism |
| `55c7cbc` | Phase 3 - `regen_docs` is the whole battery; strict capability counts |

## Changes

### Phase 1 - gates that could not fire

- `check_docs_sweep.py` ran in **no workflow**. Referenced only by a path filter and `.claude/doc-surfaces.md`, so its marker sat at `3.3.1` while goldenmatch reached `3.16.0` - 13 minor releases with nothing enforcing the prose sweep. Now a step in `cut-goldenmatch-release.yml`, **before** the tag push so a failure leaves the version name unburned (immutable releases tombstone a name permanently). Adds a `skip_docs_sweep_gate` hotfix input. The marker is advanced to **arm** the gate, not to claim those releases were swept - `docs/.docs-sweep.json` carries a `backlog_note` saying so.
- `docs_staleness` gated on the `docs` filter, which matches no `packages/python/**/*.py` path - the exact files its flag rule scans. It could fire only on PRs that had already updated a doc surface. Now has its own filter. The job was also wholly `continue-on-error`, so the rule its docstring calls "GATING" could not fail anything; the two rules are now separate steps (flag blocking, symbol advisory). Deliberately still **out of `ci-required`** - red is visible, not yet blocking.
- The flag rule was hardcoded to `GOLDENMATCH_` + `tuning.mdx`; now driven by a new `PackageSpec.prose_flag_page`.
- `docs_regen` - "the single authoritative doc-drift gate" - did not list `scripts/config_matrix/**`, which **renders six of the nine artifacts it regenerates**. It stayed honest only because `config_matrix`, the job ci.yml proposes to slim away, listed them. Filter closed; `check_filter_coverage.py` now covers the docs filters.
- `regen_docs.py` probed drift with `git diff --quiet`, which sees only **tracked** changes - a generator emitting a brand-new page left the gate green with the file uncommitted. Now `git status --porcelain`.
- `config_matrix/__init__.py` eagerly re-exported the pydantic-dependent render half, so the stdlib-only gates could not reach the registry - which is why several grew their own hardcoded package list. Now lazy (PEP 562); public API unchanged.

### Phase 2 - byte determinism

- Five writers wrote with the platform default into a byte-for-byte drift gate (three others already pinned LF). On a Windows checkout that emits CRLF and trips `docs_regen`. All five now pin LF; the nine generated pages get `eol=lf`.
- The `linguist-generated` policy was inverted. `**/llms.txt` was marked generated - collapsing it out of PR diffs - but it is **hand-authored prose**; the checker only verifies numbers inside it. Meanwhile the genuinely generated pages carried no marker. Swapped. `api-surface.mdx` is the deliberate exception (prose with one spliced table).

### Phase 3 - `make docs` is honestly the whole battery

- `check_llms_counts.py` gains `--write` and joins `WRITE_STEPS`. The capability counts were never really hand-authored - the checker already knew the right number and every place it appeared, it just refused to write. `sync_readme_callouts.py` joins too: a generator whose only wiring was a `--check` inside an unrelated gate, so editing a CHANGELOG callout meant `make docs` reported clean and CI went red. `PROSE_CHECKS` is down from a category to one named exception.
- **The README count rule was inverted, and it was hiding a live bug.** It allowed any value `<=` the total as a "sub-count". In practice there is exactly one such figure in the repo, and the allowance let goldenmatch's README say **"95 tools available" against a code total of 97** - 97 appeared elsewhere and 95 < 97. A stale second statement of the total is indistinguishable from a sub-count under a ceiling rule. Counts are now gated strictly with the one real sub-count **declared** in `_SUBCOUNT_ALLOW` with a reason. The stale 95 is fixed here - found by the new rule, repaired by the new `--write`.
- `check_llms_counts` stops swallowing import failures. `mcp_tools()` caught bare `Exception`, skipping the package silently **and** summing its tools as zero - so the only symptom was the suite total failing short, with remediation text telling you to edit llms.txt **down** to the broken number. Unintrospectable surfaces now report `UNVERIFIED` and the suite total is **refused** rather than computed from partial data.
- The config-matrix generator can now **create** a page it has never seen. It was splice-only, so `--write` raised a bare `FileNotFoundError` for a package with no stub - onboarding one meant hand-authoring byte-exact marker text first. This is the mechanical blocker behind packages shipping with no config matrix.
- `check_docs_consistency` drops the `readme_callouts` and `native_docs` subgates (both are WRITE steps now), keeps `version_consistency` (no generator owns it), loses its no-op `--fix` and never-read `--check`, and prints `[INFO]` for report-only findings - the summary read as sixteen clean checks while one listed three packages missing from the README.

## Testing

Full gate sweep green on the committed tree: `regen_docs --check`, `docs_consistency`, `docs_links`, `docs_sections`, `benchmark_claims`, `version_consistency`, `sync_readme_callouts --check`, `gen_native_docs --check`, `docs_sweep`, `workflow_yaml`, `filter_coverage`, `context_budget`, `claude_refs`. 73 doc-gate unit tests pass. `ruff check scripts/` clean.

Negative tests, so the new behaviour is known rather than assumed:

- Reverting the `scripts/config_matrix/**` filter entry makes `check_filter_coverage` fail naming the three specific paths.
- The generalized flag rule on synthetic diffs: fails when the prose page is untouched, passes when touched, correctly N/A for a `GOLDENCHECK_*` flag.
- `regen_docs` drift detection confirmed on both classes - brand-new untracked page (previously invisible) and modified tracked page.
- `check_llms_counts --write` round-trips injected drift to a clean `--check`; the declared goldencheck sub-count is provably left untouched; a simulated unimportable MCP server now refuses the suite total instead of reporting a misleading short one.
- Scaffolding proven by deleting `goldenpipe/config-matrix.mdx` and regenerating it from nothing.
- `git check-attr linguist-generated eol` verified per page, including the two exceptions.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` clean on every touched file (pre-commit is not installed in this container; the commit-msg skip-directive rule was checked by hand and all three messages are clean)
- [ ] Package `CHANGELOG.md` updated if behavior changed - n/a, no shipped package behavior changes
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed - `.claude/doc-surfaces.md` gains a Tier-0 entry for `regen_docs` and has Tier 1-3 rewritten to match

## Not in this PR

Phases 4-7 remain, and the biggest carries an open decision: **one canonical package roster** (the same 6-package list is hardcoded in 4+ places) and the **13 published distributions with no doc coverage at all** - onboard vs. defer is a product-scope call. Then tests for the registries that rot, job consolidation (`config_matrix` into `docs_regen`, now safe to do), and generated API reference (202 public exports, no generator, no OpenAPI spec).