### PR TITLE
refactor(docs-gates): gate the entry point, merge config_matrix into docs_regen, gate the extension tier, ADR 0063

### DIFF
--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -98,7 +98,8 @@ All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
   purpose -- the gates that consume it run on a bare `setup-python` runner.
 
 - **Tier 0 - `scripts/regen_docs.py`** (`make docs` / `just docs`; the
-  `docs_regen` REQUIRED CI job runs `--check`). The single command that
+  `docs_regen` REQUIRED CI job runs `--check`; the former 6-leg `config_matrix`
+  job is merged into it). The single command that
   REGENERATES every derived artifact: the six config matrices, the agent manifest
   + codemap, api-surface's table, suite-matrix, thesis-weaknesses, the native
   pages, the llms.txt/README capability counts, and the README "what's new"
@@ -108,6 +109,15 @@ All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
   brand-new generated page counts as drift too. Only one hand-bumped figure
   survives: the two inline numbers beside api-surface's table, reported by
   `gen_api_surface --check`.
+
+  The `docs_regen` job also carries the pieces a `--write` CANNOT assert, absorbed
+  when `config_matrix` was merged in: `gen_config_matrix.py --refs all` (no doc may
+  name a dead `<PREFIX>_*` knob, and no canonical scorer/strategy may go
+  undocumented), `check_thesis_conformance.py --check`, and the generator/roster
+  gate unit tests. Merging was only safe AFTER the `docs_regen` filter grew
+  `scripts/config_matrix/**` -- until then `config_matrix`'s filter was the only
+  thing keeping this job honest, so deleting it first would have half-blinded the
+  authoritative gate.
 
 - **Tier 1 - `scripts/check_docs_consistency.py`** (REQUIRED CI gate). The
   umbrella entry point for STRUCTURAL doc consistency. It (a) runs

--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -90,7 +90,13 @@ All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
   `publish-*.yml` callers); and the two deferral maps `DOCS_DEFERRED` /
   `README_DEFERRED` (published packages knowingly without a docs section / README
   row, each with a reason). The gap between the first two must be fully covered by
-  the deferral maps or `check_docs_consistency` FAILS -- and a deferral for a
+  the deferral maps or `check_docs_consistency` FAILS. The EXTENSION tier has
+  its own pair (`EXT_DOCS_DEFERRED` / `EXT_README_DEFERRED`) on the same
+  contract; unlike the CORE maps -- which are EMPTY, everything was onboarded
+  -- those carry real reasons, because an extension can legitimately be
+  documented inside a parent page (the SQL surfaces live in
+  `docs-site/extensions/sql.mdx`) or be a standalone library whose own README
+  is the doc. What it may not be is undocumented by accident -- and a deferral for a
   package that *does* have the surface fails too, so the maps cannot go stale in
   either direction. Row ORDER stays editorial and local to each generator:
   `REGISTRY` order is baked into the agent manifests, so deriving table order from

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -475,56 +475,6 @@ api_parity:
 # vocabularies + the GOLDENMATCH_* env scan, so it must re-check whenever any of
 # those move. The env scan reads the whole goldenmatch python + rust source, so
 # any .py/.rs change there can add/remove a knob -> re-run the gate.
-config_matrix:
-  # The generated blocks are rendered from each package's Python + Rust source
-  # (schema, vocab constants, <PREFIX>_* env scan), so any of those can move a
-  # knob -> re-run the gate. Covers all suite packages + the repo-level generator.
-  - 'docs-site/*/config-matrix.mdx'
-  - 'packages/python/*/*/**/*.py'
-  - 'packages/rust/extensions/**/*.rs'
-  - 'scripts/config_matrix/**'
-  - 'scripts/gen_config_matrix.py'
-  # The agent-navigation manifest is rendered from the same registry; a hand-edit
-  # of the committed JSON must re-run the gate so it can't be tampered out of sync.
-  - 'docs/agent-manifest.json'
-  - 'scripts/test_config_matrix.py'
-  # llms.txt / README capability-count gate: the stated counts derive from the
-  # package source (already covered above), but a hand-edit to a surface must
-  # re-run the check too.
-  - 'scripts/check_llms_counts.py'
-  - 'packages/python/*/llms.txt'
-  - 'packages/python/*/README.md'
-  - 'llms.txt'
-  # Agent code map (docs/agent-codemap.json): a static-AST structural map of the
-  # Python source, gated in the same job. Any .py move re-runs it (already covered
-  # above); these cover the generator, its gate, and a hand-edit of the committed JSON.
-  - 'scripts/agent_codemap.py'
-  - 'scripts/test_agent_codemap.py'
-  - 'docs/agent-codemap.json'
-  # Roster single-sourcing gate (scripts/test_roster.py) runs in this job.
-  - 'scripts/test_roster.py'
-  - 'scripts/config_matrix/roster.py'
-  # Gates for the entry point + the count checker themselves.
-  - 'scripts/test_regen_docs.py'
-  - 'scripts/test_llms_counts.py'
-  # Repo-level suite surface matrix: reads the parity manifests, the per-package
-  # counts (packages/python/** above), and the recipes pages, so any of those can
-  # move the cross-package view -> re-run its --check.
-  - 'scripts/gen_suite_matrix.py'
-  - 'scripts/test_suite_matrix.py'
-  - 'docs-site/suite-matrix.mdx'
-  - 'docs-site/*/recipes.mdx'
-  # Reference api-surface capability matrix: the generated table reads the package
-  # versions (pyproject / package.json) + MCP counts (parity manifests), so a
-  # version bump or a manifest change must re-run its --check.
-  - 'scripts/gen_api_surface.py'
-  - 'scripts/test_api_surface.py'
-  - 'docs-site/reference/api-surface.mdx'
-  - 'packages/python/*/pyproject.toml'
-  - 'packages/typescript/*/package.json'
-  - 'parity/*.yaml'
-  - '.github/workflows/ci.yml'
-  - '.github/filters.yml'
 # OSS ER-matcher box-safe tests (plan 2026-07-26 §Testing): the repo-root
 # scripts/er_matcher/ suite (data-gen, eval/ship-gate, P3a perf gate, P3 trainer
 # pure helpers). The shared prompt contract lives in the goldenmatch package, so a
@@ -1034,6 +984,22 @@ docs_regen:
   - 'packages/rust/extensions/**/*.rs'   # gen_config_matrix's <PREFIX>_* env scan
   - 'packages/typescript/*/package.json' # gen_api_surface's TS version column
   - '.github/filters.yml'                # self-test: filter edits re-run the gate
+  # Absorbed from the former `config_matrix` filter when that job was merged
+  # into this one. These are the entries a glob-aware diff showed were NOT
+  # already covered by the patterns above -- the rest (docs-site/*, packages/
+  # python/*, scripts/gen_*, scripts/config_matrix/*) were redundant.
+  - '.github/workflows/ci.yml'
+  - 'llms.txt'                           # suite tool total, rewritten by --write
+  - 'scripts/test_config_matrix.py'
+  - 'scripts/test_roster.py'
+  - 'scripts/test_regen_docs.py'
+  - 'scripts/test_llms_counts.py'
+  - 'scripts/test_agent_codemap.py'
+  - 'scripts/test_api_surface.py'
+  - 'scripts/test_suite_matrix.py'
+  - 'scripts/test_thesis_weaknesses.py'
+  - 'scripts/test_thesis_conformance.py'
+  - 'scripts/check_thesis_conformance.py'
 # Diff-aware doc-staleness rules (scripts/check_docs_staleness.py). Its own filter
 # rather than riding on `docs`: the flag rule scans non-test `packages/python/**/*.py`
 # for added/removed <PREFIX>_* env flags, and `docs` matches no such path (only

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -504,6 +504,9 @@ config_matrix:
   # Roster single-sourcing gate (scripts/test_roster.py) runs in this job.
   - 'scripts/test_roster.py'
   - 'scripts/config_matrix/roster.py'
+  # Gates for the entry point + the count checker themselves.
+  - 'scripts/test_regen_docs.py'
+  - 'scripts/test_llms_counts.py'
   # Repo-level suite surface matrix: reads the parity manifests, the per-package
   # counts (packages/python/** above), and the recipes pages, so any of those can
   # move the cross-package view -> re-run its --check.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4356,7 +4356,7 @@ jobs:
         run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Gate unit tests (determinism + markers; run once)
         if: matrix.package == 'goldenmatch'
-        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py scripts/test_api_surface.py scripts/test_roster.py -q
+        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py scripts/test_api_surface.py scripts/test_roster.py scripts/test_regen_docs.py scripts/test_llms_counts.py -q
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
       api_parity: ${{ steps.filter.outputs.api_parity }}
       native_symbols: ${{ steps.filter.outputs.native_symbols }}
       downstream_symbols: ${{ steps.filter.outputs.downstream_symbols }}
-      config_matrix: ${{ steps.filter.outputs.config_matrix }}
       er_matcher: ${{ steps.filter.outputs.er_matcher }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
@@ -4331,100 +4330,19 @@ jobs:
       - name: Broken internal links + anchors
         run: mint broken-links --check-anchors
 
-  # Config-matrix drift gate (BLOCKING), one leg per suite package. Each package's
-  # config-matrix.mdx generated block is rendered from its live surface (pydantic
-  # tree / constructor kwargs / vocab constants / <PREFIX>_* env scan) by the
-  # repo-level scripts/gen_config_matrix.py; this fails if the committed page is
-  # stale. Needs the packages importable (introspection) + the source tree (env
-  # scan), so it uv-syncs like api_parity.
-  config_matrix:
-    needs: changes
-    if: needs.changes.outputs.config_matrix == 'true' || needs.changes.outputs.force_all == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 12
-    strategy:
-      fail-fast: false
-      matrix:
-        package: [goldenmatch, goldencheck, goldenflow, goldenpipe, infermap, goldenanalysis]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - name: Sync workspace (importable packages for introspection)
-        run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
-      - name: Gate unit tests (determinism + markers; run once)
-        if: matrix.package == 'goldenmatch'
-        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py scripts/test_api_surface.py scripts/test_roster.py scripts/test_regen_docs.py scripts/test_llms_counts.py -q
-        env:
-          POLARS_SKIP_CPU_CHECK: "1"
-          GOLDENMATCH_NATIVE: "0"
-          GOLDENCHECK_NATIVE: "0"
-          GOLDENFLOW_NATIVE: "0"
-          GOLDENPIPE_NATIVE: "0"
-          INFERMAP_NATIVE: "0"
-      - name: llms.txt / README capability counts match code (run once; all pkgs synced)
-        if: matrix.package == 'goldenmatch'
-        run: uv run python scripts/check_llms_counts.py
-        env:
-          POLARS_SKIP_CPU_CHECK: "1"
-          GOLDENMATCH_NATIVE: "0"
-          GOLDENCHECK_NATIVE: "0"
-          GOLDENFLOW_NATIVE: "0"
-          GOLDENPIPE_NATIVE: "0"
-          INFERMAP_NATIVE: "0"
-          GOLDENANALYSIS_NATIVE: "0"
-      - name: Suite surface matrix current (cross-package drift; run once, all pkgs synced)
-        if: matrix.package == 'goldenmatch'
-        run: |
-          uv run python scripts/gen_suite_matrix.py --check
-          uv run pytest scripts/test_suite_matrix.py -q
-          uv run python scripts/gen_thesis_weaknesses.py --check
-          uv run pytest scripts/test_thesis_weaknesses.py -q
-          # T1 default-routing auditor: HARD-fails on an owner-default kernel that
-          # regressed to opt-in (the fs-default class); advisory on the rest.
-          uv run python scripts/check_thesis_conformance.py --check
-          uv run pytest scripts/test_thesis_conformance.py -q
-          uv run python scripts/gen_api_surface.py --check
-        env:
-          POLARS_SKIP_CPU_CHECK: "1"
-          GOLDENMATCH_NATIVE: "0"
-          GOLDENCHECK_NATIVE: "0"
-          GOLDENFLOW_NATIVE: "0"
-          GOLDENPIPE_NATIVE: "0"
-          INFERMAP_NATIVE: "0"
-          GOLDENANALYSIS_NATIVE: "0"
-      - name: Config-matrix drift check (${{ matrix.package }})
-        run: uv run python scripts/gen_config_matrix.py --check ${{ matrix.package }}
-        env:
-          POLARS_SKIP_CPU_CHECK: "1"
-          GOLDENMATCH_NATIVE: "0"
-          GOLDENCHECK_NATIVE: "0"
-          GOLDENFLOW_NATIVE: "0"
-          GOLDENPIPE_NATIVE: "0"
-          INFERMAP_NATIVE: "0"
-          GOLDENANALYSIS_NATIVE: "0"
-      - name: Docs cross-reference vs the matrix (${{ matrix.package }})
-        # The other docs must not name an env knob the code no longer reads.
-        run: uv run python scripts/gen_config_matrix.py --refs ${{ matrix.package }}
-        env:
-          POLARS_SKIP_CPU_CHECK: "1"
-          GOLDENMATCH_NATIVE: "0"
-          GOLDENCHECK_NATIVE: "0"
-          GOLDENFLOW_NATIVE: "0"
-          GOLDENPIPE_NATIVE: "0"
-          INFERMAP_NATIVE: "0"
-          GOLDENANALYSIS_NATIVE: "0"
-
-  # Single authoritative doc-drift gate (in ci-required). Regenerates the WHOLE
-  # derived-docs battery -- config-matrix, agent-manifest, agent-codemap,
-  # api-surface, suite-matrix, thesis-weaknesses, native docs + the prose count
-  # checks -- via ONE command and fails if the working tree drifted, printing the
-  # exact diff to commit. Collapses "did you regenerate all N artifacts?" (a chore
-  # that reddened this repo's config_matrix gate repeatedly) into `make docs` /
-  # `python scripts/regen_docs.py`. The per-artifact `--check`s in config_matrix
-  # remain (they also assert non-drift invariants); slimming those is a follow-up.
+  # THE doc gate (in ci-required). Regenerates the WHOLE derived-docs battery via
+  # ONE command and fails if the working tree drifted, printing exactly what to
+  # commit. Collapses "did you regenerate all N artifacts?" (a chore that reddened
+  # this repo's doc gates repeatedly) into `make docs`.
+  #
+  # The former `config_matrix` job -- a 6-leg, ~12-minute matrix -- is MERGED in
+  # here. It re-ran per-artifact `--check`s that `regen_docs.py --check` already
+  # covers for every package in one process; only its non-redundant steps survive
+  # below (the dead-env-knob crossref, the thesis auditor, the gate unit tests).
+  # The merge was blocked until the docs_regen filter listed
+  # scripts/config_matrix/** -- which RENDERS six of the nine artifacts -- because
+  # until then config_matrix's filter was the only thing keeping this job honest.
+  # Order matters: close the filter gap first, consolidate second.
   docs_regen:
     needs: changes
     if: needs.changes.outputs.docs_regen == 'true' || needs.changes.outputs.force_all == 'true'
@@ -4437,8 +4355,64 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
       - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+
+      # THE drift gate. Regenerates every derived artifact -- six config matrices,
+      # agent manifest + codemap, api-surface's table, suite-matrix,
+      # thesis-weaknesses, native pages, llms.txt/README capability counts, README
+      # callouts -- and fails if the tree moved, printing what to commit.
       - name: Regenerate the derived-docs battery; fail if the tree drifted
         run: uv run python scripts/regen_docs.py --check
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENMATCH_NATIVE: "0"
+          GOLDENCHECK_NATIVE: "0"
+          GOLDENFLOW_NATIVE: "0"
+          GOLDENPIPE_NATIVE: "0"
+          INFERMAP_NATIVE: "0"
+          GOLDENANALYSIS_NATIVE: "0"
+
+      # Everything below asserts something --write CANNOT. The former
+      # `config_matrix` job (a 6-leg, ~12-minute matrix) also re-ran the per-artifact
+      # `--check`s, which the step above already covers for every package at once;
+      # only these non-redundant pieces survived the merge.
+
+      # Dead-env-knob crossref: the OTHER docs must not name a <PREFIX>_* knob the
+      # code no longer reads, and must not omit a canonical scorer/strategy. Not a
+      # drift check -- regenerating the matrix cannot detect a stale mention
+      # elsewhere -- and `--refs all` covers every package in one process, which is
+      # what made the per-package matrix unnecessary.
+      - name: Docs cross-reference vs the matrix (all packages)
+        run: uv run python scripts/gen_config_matrix.py --refs all
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENMATCH_NATIVE: "0"
+          GOLDENCHECK_NATIVE: "0"
+          GOLDENFLOW_NATIVE: "0"
+          GOLDENPIPE_NATIVE: "0"
+          INFERMAP_NATIVE: "0"
+          GOLDENANALYSIS_NATIVE: "0"
+
+      # T1 default-routing auditor: HARD-fails on an owner-default kernel that
+      # regressed to opt-in (the fs-default class); advisory on the rest.
+      - name: Thesis conformance (default-routing auditor)
+        run: uv run python scripts/check_thesis_conformance.py --check
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENMATCH_NATIVE: "0"
+          GOLDENCHECK_NATIVE: "0"
+          GOLDENFLOW_NATIVE: "0"
+          GOLDENPIPE_NATIVE: "0"
+          INFERMAP_NATIVE: "0"
+          GOLDENANALYSIS_NATIVE: "0"
+
+      - name: Gate unit tests (generators, roster, entry point, count checker)
+        run: |
+          uv run pytest \
+            scripts/test_config_matrix.py scripts/test_agent_codemap.py \
+            scripts/test_docs_sections.py scripts/test_api_surface.py \
+            scripts/test_roster.py scripts/test_regen_docs.py \
+            scripts/test_llms_counts.py scripts/test_suite_matrix.py \
+            scripts/test_thesis_weaknesses.py scripts/test_thesis_conformance.py -q
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"
@@ -4777,7 +4751,6 @@ jobs:
       - downstream_symbols
       - claude_refs
       - scripts_lint
-      - config_matrix
       - docs_regen
       - er_matcher
     if: always()

--- a/context-network/decisions/0063-generated-api-reference.md
+++ b/context-network/decisions/0063-generated-api-reference.md
@@ -1,0 +1,70 @@
+# 0063 — Generated API reference (Python static, REST OpenAPI, TypeScript deferred)
+
+**Status:** accepted (design); implementation staged, not yet started.
+**Design:** `docs/superpowers/specs/2026-08-24-generated-api-reference-design.md`
+**Related:** 0058 (single docs-regen command and gate), 0047 (one product, two engines)
+
+## Context
+
+The derived-docs battery covers capability surfaces exhaustively and the **API**
+not at all. Measured 2026-08-24: **330 exported symbols** across the six documented
+packages (202 of them goldenmatch's) with no generated reference of any kind.
+`docs-site/reference/api-surface.mdx` is a capability matrix — versions and MCP tool
+counts — not a reference.
+
+Three packages ship FastAPI REST services and no OpenAPI spec is committed;
+`docs_render` runs `mint validate --disable-openapi`, so a docs-site capability is
+switched off because nothing feeds it.
+
+The only gate on this surface is `check_llms_counts`, which asserts a number in
+prose equals `len(__all__)`. It catches "the count moved" and cannot catch a renamed
+parameter, a changed return type, or a docstring describing behaviour the function
+no longer has.
+
+## Decision
+
+1. **Python: generate statically with `griffe`.** No importing. The repo has already
+   paid for this lesson — `gen_suite_matrix` deliberately avoids importing
+   `<pkg>.mcp.server` because it needs the `[mcp]` extra and flaps between a dev box
+   and CI. At 330 symbols across trees with optional torch / aiohttp / ray / spark
+   dependencies, an import-based generator (sphinx-autodoc, pdoc) would inherit that
+   trap everywhere. griffe parses with `ast`.
+2. **Scope to `__all__`**, one page per package, driven by
+   `config_matrix.roster.DOCUMENTED`, wired as a `WRITE_STEPS` entry in
+   `regen_docs.py` with outputs in `GENERATED_PATHS`.
+3. **REST: emit OpenAPI from the FastAPI apps**, commit the specs, drop
+   `--disable-openapi`. This one imports, which is acceptable for three known
+   service modules — constructing the app is what the service does at startup, so a
+   failure there is a real defect, not a missing extra.
+4. **TypeScript: deferred, explicitly.** The TS public surface is already gated
+   cross-language by `parity/<pkg>.yaml` + `api_parity`, which is the property that
+   matters. Recorded as a decision rather than left as an omission.
+5. **Ship in four stages**, each green on its own; the documented-symbol *floor*
+   (ratchet) lands last, because a ratchet on an unmeasured backlog is red on
+   arrival.
+
+## Conformance to the two-engines frame (0047)
+
+- **One authoritative semantic owner** — the reference is derived from the code and
+  adds no second source of truth; it renders the existing owner.
+- **Conformance defines correctness** — this does *not* become a parity surface.
+  `parity/<pkg>.yaml` + `api_parity` remain the cross-language contract; this renders
+  the Python side for humans and agents and does not adjudicate parity.
+- **Arrow at bulk boundaries / compute-vs-control / kernelize on measurement** — not
+  applicable; build-time tooling with no runtime data path.
+
+## Consequences / honest flags
+
+- **Adds one dev dependency** (`griffe`). It is the only new tool in the plan and is
+  the standard one for this job.
+- **Surfaces the docstring backlog.** Stage 2 will render a lot of thin docstrings.
+  That is the tool working; stage 4's floor is how it gets paid down without
+  blocking a green build.
+- **Page weight is a measurement question.** goldenmatch's 202-symbol page may slow
+  `mint validate`; splitting by module is the escape hatch, taken on measurement.
+- **Static analysis cannot resolve a runtime-built `__all__`.** Any package doing
+  that must be found in stage 1 and either made static or excluded with a stated
+  reason, using the deferral-map pattern already established in
+  `config_matrix/roster.py`.
+- **Not doing this leaves the largest doc surface ungated** — every other surface in
+  the battery is generated and drift-checked; the API is the one that is neither.

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,21 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-08-24 -- ADR 0063: generated API reference (Python static, REST OpenAPI, TS deferred)
+- Added **[ADR 0063](../decisions/0063-generated-api-reference.md)** + design
+  `docs/superpowers/specs/2026-08-24-generated-api-reference-design.md`. The derived-docs battery
+  covers capability surfaces exhaustively and the API not at all: **330 exported symbols** across the
+  six documented packages (202 of them goldenmatch's) with no generated reference, and three FastAPI
+  services with no committed OpenAPI spec -- `docs_render` runs `--disable-openapi` because nothing
+  feeds it. Decision: generate the Python side STATICALLY with `griffe` (no importing -- the
+  `gen_suite_matrix` lesson, where importing `<pkg>.mcp.server` needs the `[mcp]` extra and flaps
+  between a dev box and CI; at 330 symbols behind optional torch/aiohttp/ray/spark deps an
+  import-based generator inherits that trap everywhere); scope to `__all__`, one page per package,
+  driven by `config_matrix.roster.DOCUMENTED`, wired as a `regen_docs.py` WRITE step. REST: emit
+  OpenAPI from the apps and drop `--disable-openapi`. TypeScript: DEFERRED explicitly -- its public
+  surface is already gated cross-language by `parity/<pkg>.yaml` + `api_parity`. Four stages, with
+  the documented-symbol floor LAST (a ratchet on an unmeasured backlog is red on arrival).
+
 ## 2026-07-28 -- ADR 0048: own the string-matching primitives (goldenfuzz, goldenphonetic)
 - Added **[ADR 0048](../decisions/0048-own-string-matching-primitives.md)** recording the decision
   to OWN the two third-party string-matching deps as byte-identical, pyo3-free, published products:

--- a/docs/superpowers/specs/2026-08-24-generated-api-reference-design.md
+++ b/docs/superpowers/specs/2026-08-24-generated-api-reference-design.md
@@ -1,0 +1,141 @@
+# Generated API reference — design
+
+**Status:** design, not yet implemented. Decision recorded in
+`context-network/decisions/0063-generated-api-reference.md`.
+
+## The gap
+
+The doc-generation battery covers *capability* surfaces exhaustively — config
+matrices, agent manifest + codemap, suite matrix, native pages, capability counts.
+It covers the **API** not at all.
+
+Measured on 2026-08-24:
+
+| Surface | Symbols | Generated reference |
+| --- | --- | --- |
+| goldenmatch | 202 exports | none |
+| goldencheck | 44 | none |
+| goldenflow | 36 | none |
+| goldenpipe | 20 | none |
+| infermap | 20 | none |
+| goldenanalysis | 8 | none |
+| **total** | **330** | **none** |
+
+`docs-site/reference/api-surface.mdx` is a *capability matrix* — per-package
+versions and MCP tool counts — not a reference. Nothing anywhere renders what a
+function does, what it takes, or what it returns.
+
+Three packages ship FastAPI REST services (`goldenmatch/web/app.py`,
+`goldenflow/api/server.py`, and the goldenpipe service) and **no OpenAPI spec is
+committed**; `docs_render` runs `mint validate --disable-openapi`, so the docs site
+has an OpenAPI capability that is switched off because there is nothing to feed it.
+
+The only current gate on the API surface is `check_llms_counts`, which asserts that
+a *number* stated in prose equals `len(__all__)`. That catches "the count moved". It
+cannot catch a renamed parameter, a changed return type, or a symbol whose docstring
+describes behaviour it no longer has.
+
+## Constraints this repo has already paid for
+
+These are not hypotheticals — each is a lesson already recorded elsewhere in the
+battery, and a design that ignores one will fail the same way.
+
+1. **Environment-stable, or it flaps.** `gen_suite_matrix` explicitly does *not*
+   `import <pkg>.mcp.server`, because that needs the `[mcp]` extra and the output
+   then differs between a dev box and CI. Any API-reference generator that
+   **imports** the packages inherits that trap at 330-symbol scale, where optional
+   extras (torch, aiohttp, ray, spark) decide whether a module is importable at all.
+   → the generator must be **static-analysis**, not import-based.
+2. **Byte-deterministic.** `regen_docs.py --check` compares bytes, so output must be
+   ordered deterministically and written with `newline="\n"`, and the pages need
+   `eol=lf` + `linguist-generated` in `.gitattributes` (Phase 2's lesson).
+3. **One entry point.** It must be a `WRITE_STEPS` entry in `regen_docs.py`, with
+   its outputs covered by `GENERATED_PATHS` — `test_regen_docs.py` now enforces
+   both, so a generator added outside the entry point fails.
+4. **The docs site must still render.** `docs_render` runs `mint validate` in strict
+   mode over every page. Hundreds of new pages is a build-time and nav-integrity
+   question, not just a generation question — and `check_docs_consistency`'s orphan
+   detection requires every `.mdx` to be reachable from `docs.json`.
+5. **Docstring quality is the real bottleneck.** A generated reference makes the
+   *current* docstrings visible at scale. That is the point, but it means stage 1
+   will surface a large prose backlog, and the gate must not be "all 330 symbols
+   documented" on day one or it can never go green.
+
+## Design
+
+### Python — griffe, static
+
+[griffe](https://mkdocstrings.github.io/griffe/) parses source with `ast` and never
+imports the package, which satisfies constraint 1 directly. It resolves `__all__`,
+signatures, type annotations, and docstrings (Google/NumPy/Sphinx styles).
+
+- **Scope: `__all__` only.** Not every module member. `__all__` is already the
+  package's declared public contract, it is already what `check_llms_counts` counts,
+  and it keeps the reference to the 330 symbols that are actually promised.
+- **Output: one page per package**, `docs-site/reference/python/<pkg>.mdx`, symbols
+  in `__all__` order (deterministic, and it is the order the package author chose).
+  One page per *module* is the obvious alternative and is rejected for now: it
+  multiplies nav entries and orphan-detection surface for no reader benefit at this
+  size. Revisit if goldenmatch's page becomes unwieldy.
+- **Driven by the roster.** `config_matrix.roster.DOCUMENTED` decides which packages
+  get a page — the same single edit that onboards a package everywhere else.
+- **New dependency:** `griffe`, dev-only (workspace dev group, not a package
+  runtime dep). This is the one genuinely new tool in the plan.
+
+### REST — emit OpenAPI from the apps
+
+FastAPI already builds the spec: `app.openapi()` returns it. Emit to
+`docs-site/reference/openapi/<service>.json`, commit it, and drop
+`--disable-openapi` from `docs_render` so Mintlify renders it.
+
+This one **does** import — a FastAPI app cannot be constructed statically. It is
+acceptable here and not in the Python case because the surface is three known
+service modules rather than six package trees, and the import is exactly what the
+service does at startup, so a failure is a real defect rather than a missing extra.
+
+### TypeScript — deferred, explicitly
+
+`typedoc` → MDX is the obvious path, but the TS packages' public surface is already
+gated by `parity/<pkg>.yaml` + `api_parity`, which is the property that matters
+cross-language. A TS reference is real work for a smaller readership. **Deferred**,
+recorded here so it is a decision rather than an omission.
+
+## Staging
+
+Each stage lands green on its own and is independently revertable.
+
+| Stage | Ships | Gate |
+| --- | --- | --- |
+| 1 | griffe generator + one page for the smallest package (goldenanalysis, 8 exports) | `regen_docs --check` covers it |
+| 2 | All six packages; nav entries; `.gitattributes`; coverage *reported*, not gated | orphan + render gates |
+| 3 | OpenAPI emission for the three services; drop `--disable-openapi` | `docs_render` |
+| 4 | Ratchet: a *floor* on documented public symbols per package, raised as prose lands | new gate, floor-style like the coverage floors in `parity/` |
+
+Stage 4 is the one that makes it stick, and it is deliberately last: a ratchet on a
+backlog you have not measured yet is a gate that is red on arrival.
+
+## Conformance to the two-engines frame (0047)
+
+- **One authoritative semantic owner.** The reference is *derived from* the code, so
+  it adds no second source of truth. It is a rendering of the existing owner.
+- **Arrow at bulk boundaries.** Not applicable — this is build-time tooling, no
+  runtime data path.
+- **Compute vs control stay distinct.** Not applicable.
+- **Kernelize on measurement.** Not applicable; no hot path.
+- **Conformance defines correctness.** The reference does not become a parity
+  surface: `parity/<pkg>.yaml` + `api_parity` remain the cross-language contract.
+  This renders the Python side for humans and agents; it does not adjudicate parity.
+
+## Honest flags
+
+- **Page weight.** goldenmatch's page will be large (202 symbols). If `mint validate`
+  slows materially, split by module — that is the escape hatch, taken on measurement
+  rather than pre-emptively.
+- **Dynamic exports.** Static analysis cannot resolve an `__all__` built at runtime.
+  Any package doing that must be found in stage 1 and either made static or
+  explicitly excluded with a reason (the deferral-map pattern used elsewhere).
+- **This surfaces the docstring backlog.** Expect stage 2 to render a lot of thin
+  docstrings. That is the tool working, not failing; stage 4's floor is how it gets
+  paid down without blocking.
+- **griffe is a new dependency.** It is the only one, it is dev-only, and it is the
+  standard tool for exactly this job.

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -133,6 +133,8 @@ if str(SCRIPTS) not in sys.path:
 from config_matrix.roster import (  # noqa: E402
     DOCS_DEFERRED,
     DOCUMENTED,
+    EXT_DOCS_DEFERRED,
+    EXT_README_DEFERRED,
     NON_DIST_STEMS,
     README_DEFERRED,
     derive_roster,
@@ -262,12 +264,24 @@ def check_roster_matrix(res: Result) -> None:
             "README rows deferred by declaration",
             f"{sorted(README_DEFERRED)} -- see roster.README_DEFERRED for the reason",
         )
-    ext_missing = [p for p in ext if p.lower() not in readme]
-    if ext_missing:
-        res.record_info(
-            "extension extras README presence",
-            f"extension distributions not named in README: {ext_missing}",
-        )
+    # The EXTENSION tier, gated the same way -- it used to print [INFO] while
+    # listing packages it had found missing, which is the silence the CORE maps
+    # exist to remove, one tier down. Name-mention rather than link here: the owned
+    # libraries live under packages/rust/extensions/, so the CORE link-path rule
+    # would not generalise.
+    ext_missing = sorted(p for p in ext if p.lower() not in readme)
+    ext_undeclared = [p for p in ext_missing if p not in EXT_README_DEFERRED]
+    ext_stale = sorted(set(EXT_README_DEFERRED) - set(ext_missing))
+    res.record(
+        "extension -> README.md presence",
+        not ext_undeclared and not ext_stale,
+        "; ".join(filter(None, [
+            f"published but not named in the README and not declared in "
+            f"roster.EXT_README_DEFERRED: {ext_undeclared}" if ext_undeclared else "",
+            f"declared in roster.EXT_README_DEFERRED but actually named (drop the "
+            f"deferral): {ext_stale}" if ext_stale else "",
+        ])),
+    )
 
     # docs-section presence: every CORE roster package owns a docs-site/<pkg>/
     # section that the nav references -- or carries a declared deferral.
@@ -307,6 +321,20 @@ def check_roster_matrix(res: Result) -> None:
             "docs sections deferred by declaration",
             f"{sorted(DOCS_DEFERRED)} -- see roster.DOCS_DEFERRED for the reason",
         )
+
+    ext_has_section = {p for p in ext if (DOCS_SITE / p).is_dir()}
+    ext_docs_undeclared = sorted(set(ext) - ext_has_section - set(EXT_DOCS_DEFERRED))
+    ext_docs_stale = sorted(ext_has_section & set(EXT_DOCS_DEFERRED))
+    res.record(
+        "extension -> docs section presence",
+        not ext_docs_undeclared and not ext_docs_stale,
+        "; ".join(filter(None, [
+            f"published with no docs section and not declared in "
+            f"roster.EXT_DOCS_DEFERRED: {ext_docs_undeclared}" if ext_docs_undeclared else "",
+            f"declared in roster.EXT_DOCS_DEFERRED but actually has a section (drop "
+            f"the deferral): {ext_docs_stale}" if ext_docs_stale else "",
+        ])),
+    )
 
     # The documented roster must be a subset of what is actually published: a
     # PackageSpec for a package no publisher ships is a docs section for a

--- a/scripts/check_filter_coverage.py
+++ b/scripts/check_filter_coverage.py
@@ -90,6 +90,15 @@ REQUIRED: dict[str, list[tuple[str, str]]] = {
         ("packages/typescript/goldenmatch/package.json", "api-surface TS version column"),
         ("parity/goldenmatch.yaml", "MCP tool counts in suite-matrix + api-surface"),
         (".github/filters.yml", "self-test: filter edits must re-run the gate"),
+        # Absorbed when the 6-leg `config_matrix` job was merged into docs_regen.
+        # A glob-aware diff of the two filters showed these were the only entries
+        # not already covered; losing them would have silently narrowed the gate.
+        ("llms.txt", "the suite tool total, rewritten by check_llms_counts --write"),
+        ("scripts/test_config_matrix.py", "gate unit tests now run in this job"),
+        ("scripts/test_roster.py", "gate unit tests now run in this job"),
+        ("scripts/test_regen_docs.py", "gate unit tests now run in this job"),
+        ("scripts/test_llms_counts.py", "gate unit tests now run in this job"),
+        ("scripts/check_thesis_conformance.py", "the thesis auditor now runs in this job"),
     ],
     "docs_staleness": [
         (f"{GM}/core/pipeline.py", "the flag rule scans non-test packages/python/**/*.py"),

--- a/scripts/config_matrix/roster.py
+++ b/scripts/config_matrix/roster.py
@@ -38,6 +38,8 @@ from .registry import REGISTRY
 __all__ = [
     "DOCS_DEFERRED",
     "DOCUMENTED",
+    "EXT_DOCS_DEFERRED",
+    "EXT_README_DEFERRED",
     "NON_DIST_STEMS",
     "README_DEFERRED",
     "derive_roster",
@@ -117,3 +119,74 @@ DOCS_DEFERRED: dict[str, str] = {}
 # CURRENTLY EMPTY -- goldencheck-types and goldensuite-mcp, provisionally deferred
 # when the check landed, now have rows in the README's "Shared components" table.
 README_DEFERRED: dict[str, str] = {}
+
+
+# --------------------------------------------------------------------------- #
+# The EXTENSION tier
+#
+# `derive_roster()`'s `ext` list -- SQL/rust extras and standalone libraries -- had
+# no gating at all: no docs check, and a README check that printed [INFO] while
+# listing packages it had found missing. That is the same silence the CORE maps
+# above were created to remove, one tier down. These two maps close it.
+#
+# Unlike the CORE maps, these are NOT provisional. Every entry states a real
+# reason, because an extension genuinely can be documented inside a parent page
+# instead of owning a section -- what it cannot be is undocumented by accident.
+# --------------------------------------------------------------------------- #
+
+#: Extension distributions with no `docs-site/<pkg>/` section of their own.
+EXT_DOCS_DEFERRED: dict[str, str] = {
+    "goldenmatch-duckdb": (
+        "documented in docs-site/extensions/sql.mdx, which covers the DuckDB surface "
+        "in situ; a separate section would split one SQL story across two pages"
+    ),
+    "goldenmatch-pg": (
+        "documented in docs-site/extensions/sql.mdx alongside the DuckDB surface; "
+        "ships as a GitHub-release tarball rather than a normal wheel"
+    ),
+    "goldenmatch-embed": (
+        "documented in docs-site/extensions/sql.mdx as part of the SQL embedding "
+        "surface it exists to serve"
+    ),
+    "goldenfuzz": (
+        "standalone owned library (the rapidfuzz replacement); its package README is "
+        "the doc surface and the root README links it from 'Owned libraries'"
+    ),
+    "goldenphonetic": (
+        "standalone owned library (the jellyfish replacement); package README is the "
+        "doc surface, linked from the root README's 'Owned libraries' table"
+    ),
+    "goldenmatch-hnsw": (
+        "standalone owned library (the FAISS IndexHNSWFlat replacement); package "
+        "README is the doc surface, linked from 'Owned libraries'"
+    ),
+    "goldenmatch-spark-jar": (
+        "a JVM jar published for the Spark tier, not a Python-importable surface; "
+        "the Spark story lives in the goldenmatch section"
+    ),
+    "er-matcher": (
+        "publish-er-matcher.yml releases a quantized GGUF MODEL artifact, not a "
+        "Python distribution -- there is no package here to document"
+    ),
+}
+
+#: Extension distributions not named anywhere in the root README.
+#:
+#: Weaker than the CORE rule on purpose: CORE requires a LINK to
+#: `packages/python/<pkg>/README.md`, but the owned libraries live under
+#: `packages/rust/extensions/`, so a link-path rule would not generalise. A name
+#: mention is the honest floor for this tier.
+EXT_README_DEFERRED: dict[str, str] = {
+    "goldenmatch-pg": (
+        "ships as a GitHub-release tarball, not a pip install; the SQL extensions "
+        "page is where a reader would look for it"
+    ),
+    "goldenmatch-spark-jar": (
+        "a JVM build artifact consumed via the Spark tier's own setup, not something "
+        "a reader installs from the README"
+    ),
+    "er-matcher": (
+        "a GGUF model release, not an installable package; naming it in the package "
+        "overview would imply a dist that does not exist"
+    ),
+}

--- a/scripts/test_llms_counts.py
+++ b/scripts/test_llms_counts.py
@@ -1,0 +1,115 @@
+"""Gate for the capability-count checker (scripts/check_llms_counts.py).
+
+Two behaviours here are load-bearing and were both, at different times, wrong in a
+way that produced a CONFIDENTLY WRONG remediation instruction rather than a
+visible failure. That is the class worth pinning:
+
+  * `mcp_tools()` swallowing an ImportError returned None, which skipped the
+    package silently AND summed its tools as zero -- so the only symptom was the
+    suite total failing short, telling you to edit llms.txt DOWN to the broken
+    number. Unintrospectable packages now REFUSE the total.
+  * That refusal then had to distinguish "no MCP server" from "MCP server will not
+    import", or onboarding a types-only package would break the gate.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_llms_counts as clc
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# --------------------------------------------------------------------------- #
+# mcp_tools(): three-way, not two-way
+# --------------------------------------------------------------------------- #
+def test_real_package_returns_a_count():
+    n = clc.mcp_tools("goldenmatch")
+    assert isinstance(n, int) and n > 0
+
+
+def test_package_without_an_mcp_server_is_absent_not_broken():
+    """goldencheck-types ships no MCP server. That is not a failure to introspect.
+
+    Conflating the two is what would break the gate the moment a types-only or
+    meta-package joins the roster -- the suite total would be refused forever.
+    """
+    assert clc.mcp_tools("goldencheck_types") is clc.NO_MCP_SERVER
+
+
+def test_broken_mcp_import_is_none_not_absent(monkeypatch):
+    """A module that EXISTS but whose own imports fail must stay loud."""
+    real = clc.importlib.import_module
+
+    def broken(name, *a, **k):
+        if name == "goldenanalysis.mcp.server":
+            raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(clc.importlib, "import_module", broken)
+    assert clc.mcp_tools("goldenanalysis") is None
+
+
+def test_unintrospectable_package_refuses_the_suite_total(monkeypatch, capsys):
+    """The whole point of the refusal: never emit a total built on partial data."""
+    real = clc.importlib.import_module
+
+    def broken(name, *a, **k):
+        if name == "goldenanalysis.mcp.server":
+            raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(clc.importlib, "import_module", broken)
+    rc = clc.run(write=False)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "UNVERIFIED" in out
+    assert "suite total REFUSED" in out
+    # And it must NOT tell you to edit llms.txt down to the short number.
+    assert "do NOT edit llms.txt" in out
+
+
+# --------------------------------------------------------------------------- #
+# --write
+# --------------------------------------------------------------------------- #
+def test_write_round_trips_injected_drift():
+    """--write must repair a stale count to exactly what the code reports."""
+    rel = "packages/python/goldenmatch/goldenmatch/llms.txt"
+    path = ROOT / rel
+    original = path.read_bytes()
+    real = clc.mcp_tools("goldenmatch")
+    try:
+        path.write_bytes(original.replace(f"{real} tools".encode(), b"3 tools"))
+        assert clc.run(write=False) == 1, "injected drift was not detected"
+        assert clc.run(write=True) == 0, "--write did not repair the drift"
+        assert clc.run(write=False) == 0, "tree still stale after --write"
+        assert path.read_bytes() == original, "--write did not restore byte-identically"
+    finally:
+        path.write_bytes(original)
+
+
+def test_declared_subcount_is_left_alone():
+    """The one real per-category sub-count must not be rewritten to the total.
+
+    goldencheck's README annotates its mcp/ source directory with "(7 tools)" inside
+    a tree diagram. Before _SUBCOUNT_ALLOW the rule allowed ANY value below the
+    total, which is what let a stale SECOND statement of the total hide.
+    """
+    rel = "packages/python/goldencheck/README.md"
+    assert rel in clc._SUBCOUNT_ALLOW
+    before = (ROOT / rel).read_bytes()
+    assert clc.run(write=True) == 0
+    assert (ROOT / rel).read_bytes() == before, "a declared sub-count was rewritten"
+
+
+def test_subcount_allowlist_markers_still_match():
+    """A declared exception whose marker no longer matches silently re-gates a line."""
+    for rel, markers in clc._SUBCOUNT_ALLOW.items():
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for marker, reason in markers:
+            assert marker in text, f"{rel}: sub-count marker {marker!r} no longer matches"
+            assert len(reason) > 20, f"{rel}: sub-count reason is too thin to review"

--- a/scripts/test_regen_docs.py
+++ b/scripts/test_regen_docs.py
@@ -1,0 +1,114 @@
+"""Gate for the derived-docs entry point itself (scripts/regen_docs.py).
+
+`regen_docs.py` is a hand-maintained registry of hand-maintained registries:
+WRITE_STEPS lists the generators, GENERATED_PATHS lists what they write, and
+nothing checked either. Both rot the same silent way -- a new generator lands
+outside the entry point, or a generator starts writing a path the drift probe
+does not watch, and `make docs` quietly stops covering it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest
+from regen_docs import GENERATED_PATHS, PROSE_CHECKS, WRITE_STEPS, _drifted_paths
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+
+
+def _step_scripts() -> set[str]:
+    return {step[0] for step in WRITE_STEPS}
+
+
+def test_every_write_capable_generator_is_a_write_step():
+    """A generator outside WRITE_STEPS is one `make docs` silently does not run.
+
+    Scoped to scripts that actually expose `--write`; the golden-fixture emitters
+    (gen_simhash_golden, gen_sketch_golden, ...) write test fixtures, not docs, and
+    take no such flag, so they exclude themselves.
+    """
+    missing = []
+    for path in sorted(SCRIPTS.glob("gen_*.py")) + [SCRIPTS / "agent_codemap.py"]:
+        if "--write" not in path.read_text(encoding="utf-8"):
+            continue
+        rel = f"scripts/{path.name}"
+        if rel not in _step_scripts():
+            missing.append(rel)
+    assert not missing, (
+        "generator(s) support --write but are not in regen_docs.WRITE_STEPS, so "
+        f"`make docs` does not run them: {missing}"
+    )
+
+
+def test_generated_paths_all_resolve():
+    """A typo'd pathspec matches nothing and silently narrows the drift probe.
+
+    `:(glob)` magic is easy to get subtly wrong (and a PLAIN pathspec's `*` crosses
+    `/`, which is why the magic is there at all), so assert each entry names real
+    tracked files rather than trusting it by eye.
+    """
+    empty = []
+    for spec in GENERATED_PATHS:
+        out = subprocess.run(
+            ["git", "ls-files", "--", spec],
+            cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=True,
+        ).stdout.strip()
+        if not out:
+            empty.append(spec)
+    assert not empty, f"GENERATED_PATHS entries match no tracked file: {empty}"
+
+
+def test_prose_checks_never_write():
+    """PROSE_CHECKS is the report-only tail; a --write there would be invisible."""
+    for check in PROSE_CHECKS:
+        assert "--check" in check, f"PROSE_CHECKS entry is not a --check: {check}"
+        assert "--write" not in check, f"PROSE_CHECKS entry writes: {check}"
+
+
+def _tree_is_clean() -> bool:
+    return not _drifted_paths()
+
+
+@pytest.mark.skipif(
+    not _tree_is_clean(),
+    reason="working tree already has uncommitted generated-doc changes",
+)
+def test_drift_probe_detects_a_modified_tracked_file():
+    page = ROOT / "docs-site" / "suite-matrix.mdx"
+    original = page.read_bytes()
+    try:
+        page.write_bytes(original + b"\ndrift\n")
+        assert _drifted_paths(), "a modified generated page was not detected as drift"
+    finally:
+        page.write_bytes(original)
+    assert not _drifted_paths(), "tree not restored after the modification probe"
+
+
+@pytest.mark.skipif(
+    not _tree_is_clean(),
+    reason="working tree already has uncommitted generated-doc changes",
+)
+def test_drift_probe_detects_a_brand_new_untracked_file():
+    """The Phase-1 regression: `git diff` sees only TRACKED changes.
+
+    A generator emitting a page that has never been committed -- the "onboard a
+    package" case -- left the gate green with the file sitting uncommitted. The
+    probe is `git status --porcelain` for exactly this.
+    """
+    scratch = ROOT / "docs-site" / "reference" / "_drift_probe.mdx"
+    assert not scratch.exists()
+    try:
+        scratch.write_text("probe\n", encoding="utf-8")
+        drifted = _drifted_paths()
+        assert any("_drift_probe" in line for line in drifted), (
+            f"a brand-new generated page was not detected as drift: {drifted}"
+        )
+    finally:
+        scratch.unlink(missing_ok=True)
+    assert not _drifted_paths(), "tree not restored after the untracked probe"

--- a/scripts/test_roster.py
+++ b/scripts/test_roster.py
@@ -50,19 +50,60 @@ def test_roster_importable_without_pydantic():
     assert proc.returncode == 0, proc.stderr
 
 
-def test_ci_config_matrix_leg_matches_the_roster():
-    """ci.yml's config_matrix job runs one leg per package, as a literal list.
+# Every per-package job matrix in ci.yml, and what it is allowed to be. A matrix
+# that should equal the roster is a copy of it and drifts like one; a deliberate
+# SUBSET is fine but has to say so here.
+_PACKAGE_MATRICES: dict[str, str] = {
+    "api_parity": "roster",   # gates every documented package's cross-language surface
+    "native_symbols": "subset",  # only packages that ship a native kernel
+}
 
-    A package added to REGISTRY but not to that list gets a generated page nothing
-    gates -- the drift class this whole battery exists to prevent.
-    """
+
+def _ci_package_matrices() -> dict[str, set[str]]:
+    """job name -> the package set in its `package: [...]` matrix."""
     ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    m = re.search(r"config_matrix:.*?matrix:\s*\n\s*package:\s*\[([^\]]+)\]", ci, re.S)
-    assert m, "could not locate the config_matrix job's package matrix in ci.yml"
-    legs = {p.strip() for p in m.group(1).split(",") if p.strip()}
-    assert legs == set(DOCUMENTED), (
-        f"ci.yml config_matrix legs {sorted(legs)} != roster {sorted(DOCUMENTED)}"
+    out: dict[str, set[str]] = {}
+    job = None
+    for line in ci.splitlines():
+        m = re.match(r"^  ([a-z_][a-z0-9_]*):\s*$", line)
+        if m:
+            job = m.group(1)
+        m = re.match(r"^\s*package:\s*\[([^\]]+)\]\s*$", line)
+        if m and job:
+            out[job] = {p.strip() for p in m.group(1).split(",") if p.strip()}
+    return out
+
+
+def test_ci_package_matrices_are_declared_and_track_the_roster():
+    """A hardcoded per-package job matrix is another copy of the roster.
+
+    The `config_matrix` job's 6-leg matrix used to be one; that job was merged into
+    `docs_regen`, which covers every package in ONE process, so the list is gone.
+    Two matrices remain and they are NOT the same kind of thing: `api_parity` gates
+    every documented package (so it must equal the roster), while `native_symbols`
+    is a deliberate subset (only packages shipping a native kernel). Anything new
+    has to declare which it is rather than quietly becoming a stale copy.
+    """
+    found = _ci_package_matrices()
+    undeclared = sorted(set(found) - set(_PACKAGE_MATRICES))
+    assert not undeclared, (
+        f"ci.yml grew a per-package matrix in job(s) {undeclared}. Declare it in "
+        "_PACKAGE_MATRICES as 'roster' or 'subset' -- an undeclared one is a "
+        "hardcoded roster copy waiting to drift."
     )
+    for job, kind in _PACKAGE_MATRICES.items():
+        if job not in found:
+            continue  # job removed; nothing to drift
+        pkgs = found[job]
+        if kind == "roster":
+            assert pkgs == set(DOCUMENTED), (
+                f"ci.yml `{job}` matrix {sorted(pkgs)} != roster {sorted(DOCUMENTED)}"
+            )
+        else:
+            assert pkgs <= set(DOCUMENTED), (
+                f"ci.yml `{job}` matrix names non-roster package(s): "
+                f"{sorted(pkgs - set(DOCUMENTED))}"
+            )
 
 
 def test_no_script_rehardcodes_the_roster():

--- a/scripts/test_roster.py
+++ b/scripts/test_roster.py
@@ -18,6 +18,8 @@ from config_matrix.registry import REGISTRY
 from config_matrix.roster import (
     DOCS_DEFERRED,
     DOCUMENTED,
+    EXT_DOCS_DEFERRED,
+    EXT_README_DEFERRED,
     README_DEFERRED,
     derive_roster,
 )
@@ -145,9 +147,45 @@ def test_deferrals_are_live_and_complete():
     )
 
 
+def test_ext_deferrals_are_live_and_complete():
+    """Same contract for the EXTENSION tier, which had no gating at all.
+
+    Its README check printed [INFO] while listing packages it had found missing,
+    and nothing checked docs sections. An extension may legitimately be documented
+    inside a parent page -- what it may not be is undocumented by accident.
+    """
+    _, ext, _ = derive_roster()
+    docs_site = ROOT / "docs-site"
+
+    no_section = {p for p in ext if not (docs_site / p).is_dir()}
+    assert no_section == set(EXT_DOCS_DEFERRED), (
+        f"EXT_DOCS_DEFERRED out of step: "
+        f"undeclared={sorted(no_section - set(EXT_DOCS_DEFERRED))}, "
+        f"stale={sorted(set(EXT_DOCS_DEFERRED) - no_section)}"
+    )
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()
+    unnamed = {p for p in ext if p.lower() not in readme}
+    assert unnamed == set(EXT_README_DEFERRED), (
+        f"EXT_README_DEFERRED out of step: "
+        f"undeclared={sorted(unnamed - set(EXT_README_DEFERRED))}, "
+        f"stale={sorted(set(EXT_README_DEFERRED) - unnamed)}"
+    )
+
+
 def test_every_deferral_carries_a_reason():
-    for name, reason in {**DOCS_DEFERRED, **README_DEFERRED}.items():
+    """A reason has to be reviewable prose, not a shrug.
+
+    The CORE maps are empty (everything was onboarded); the EXT maps are not, and
+    their entries are the ones a reader will actually have to judge.
+    """
+    every = {**DOCS_DEFERRED, **README_DEFERRED,
+             **EXT_DOCS_DEFERRED, **EXT_README_DEFERRED}
+    for name, reason in every.items():
         assert len(reason.strip()) > 30, f"{name}: deferral reason is too thin to review"
+        assert "TODO" not in reason, (
+            f"{name}: deferral still says TODO -- decide it or write the real reason"
+        )
 
 
 def test_documented_roster_is_actually_published():


### PR DESCRIPTION
## What and why

Follow-up to #2746. That PR made the doc gates able to fire and made `make docs` the whole battery; this one gates the machinery itself, removes the job that #2746 made redundant, closes the last ungated doc tier, and records the decision for the one remaining gap.

Four commits, each independently revertable:

| | |
|---|---|
| `38ebff7` | tests for the derived-docs entry point and the count checker |
| `deb08de` | merge the 6-leg `config_matrix` job into `docs_regen` |
| `a9631df` | gate the extension tier the same way as core |
| `8d643fd` | ADR 0063 — generated API reference (design only) |

## Changes

### Tests for the registries that rot

`regen_docs.py` is a hand-maintained registry of hand-maintained registries — `WRITE_STEPS` lists the generators, `GENERATED_PATHS` lists what they write — and nothing checked either. Both rot the same silent way: a generator lands outside the entry point, or starts writing a path the drift probe does not watch, and `make docs` quietly stops covering it.

`test_regen_docs.py` pins that every `--write`-capable generator is in `WRITE_STEPS` (the golden-fixture emitters take no such flag, so they exclude themselves), that every `GENERATED_PATHS` pathspec matches real tracked files (a typo matches nothing and silently narrows the probe — and the `:(glob)` magic these need is easy to get subtly wrong), and that the probe catches **both** a modified tracked page and a brand-new untracked one.

`test_llms_counts.py` pins the two behaviours that were each, at different times, wrong in a way that produced a confidently **wrong** remediation instruction rather than a visible failure — the class most worth a test. `mcp_tools()` is three-way: a count, `NO_MCP_SERVER`, or `None`, and only `None` refuses the suite total. `--write` round-trips injected drift byte-identically, the one declared sub-count is provably left alone, and a third test asserts the allowlist **markers** still match their lines — a stale marker silently re-gates the line it was meant to exempt.

### Job consolidation

The 6-leg, ~12-minute `config_matrix` job is merged into `docs_regen`. Its per-artifact `--check`s were all things `regen_docs.py --check` already covers for every package in one process; only the non-redundant steps survive — `gen_config_matrix.py --refs all` (regenerating the matrix cannot detect a stale mention *elsewhere*), the thesis auditor, and the gate unit tests.

**Order mattered.** ci.yml's own comment proposed slimming these `--check`s as a follow-up, but doing that first would have half-blinded the authoritative gate: until #2746 added `scripts/config_matrix/**` to the `docs_regen` filter — the directory that *renders six of the nine artifacts* — `config_matrix`'s filter was the only thing making `docs_regen` re-run on a generator change.

The filter merge was computed **glob-aware, not by string diff**: of 22 `config_matrix`-only entries, most were already covered by broader patterns; nine were not. `check_filter_coverage` then caught three more I had missed — `test_roster`, `test_regen_docs` and `test_llms_counts` were listed only in the filter being deleted. That check earning its keep on the exact change it was written for.

`test_roster`'s ci.yml assertion is rewritten rather than dropped. The matrix it pinned is gone, but the drift class is not: `api_parity`'s matrix was an **eighth** hardcoded roster copy. Both remaining matrices are now declared as `roster` (must equal) or `subset` (native kernels only).

### Extension tier gated

The `ext` tier had no gating at all — its README check printed `[INFO]` while listing three packages it had just found missing, and nothing checked docs sections. Same silence the core maps removed, one tier down.

Two new maps on the identical contract. Unlike the core maps — now empty, everything was onboarded — these entries are **not** provisional and none says TODO, because the reasons are real and were established by looking: `docs-site/extensions/sql.mdx` already documents duckdb/pg/embed in situ; `goldenfuzz`/`goldenphonetic`/`goldenmatch-hnsw` are standalone libraries whose package README is the doc surface; `goldenmatch-spark-jar` is a JVM jar; and `publish-er-matcher.yml` releases a quantized **GGUF model**, not a Python distribution.

The EXT README rule is deliberately weaker than core's (name mention, not link) because the owned libraries live under `packages/rust/extensions/`, so a link-path rule would not generalise — and the code says so.

`check_docs_consistency` now reports **zero `[INFO]` lines**: every finding is a pass or a declared decision.

### ADR 0063 — generated API reference

Design only; no generator ships here. Measured: **330 exported symbols** across the six documented packages (202 of them goldenmatch's) with no generated reference, and three FastAPI services with no committed OpenAPI spec — `docs_render` runs `--disable-openapi` because nothing feeds it.

Decision: generate the Python side **statically** with `griffe` (no importing — `gen_suite_matrix` already avoids importing `<pkg>.mcp.server` because it needs the `[mcp]` extra and flaps between a dev box and CI; at 330 symbols behind optional torch/aiohttp/ray/spark deps an import-based generator inherits that trap everywhere). Scope to `__all__`, one page per package, driven by `roster.DOCUMENTED`, wired as a `regen_docs` WRITE step. REST: emit OpenAPI from the apps and drop `--disable-openapi`. TypeScript: **deferred explicitly** — its public surface is already gated cross-language by `parity/<pkg>.yaml` + `api_parity`.

Four stages with the documented-symbol floor **last**: a ratchet on a backlog nobody has measured is red on arrival.

## Testing

Re-run after rebasing onto the merged `main` (`9582419`), not just before:

| Check | Result |
|---|---|
| `regen_docs --check` | pass |
| `gen_config_matrix --refs all` | pass |
| `check_thesis_conformance --check` | pass |
| `docs_consistency` / `_links` / `_sections` | pass |
| `check_workflow_yaml` (130 files) | pass |
| `check_filter_coverage` | pass — 47 required paths across 6 filters |
| `check_context_budget`, `check_claude_refs` | pass |
| doc-gate unit tests | **100 passed** |
| `ruff check scripts/` | clean |

Negative tests, so the new guards are known rather than assumed:

- Removing `gen_native_docs` from `WRITE_STEPS` fails naming it.
- Typo'ing a `GENERATED_PATHS` entry fails naming the pathspec that matches nothing.
- Dropping `goldenanalysis` from the `api_parity` matrix fails naming the difference.
- Dropping `goldenfuzz` from `EXT_DOCS_DEFERRED` fails naming it.
- The `__all__` test caught the two new roster exports immediately — the guard added for the CodeQL follow-up in #2746 earning its keep.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` clean on every touched file (pre-commit is not installed in this container; the commit-msg skip-directive rule was checked by hand and all four messages are clean)
- [ ] Package `CHANGELOG.md` updated if behavior changed — n/a, no shipped package behavior changes
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed — `.claude/doc-surfaces.md` updated for the consolidation and the EXT tier

## Not in this PR

ADR 0063's implementation (stages 1–4). Also unchanged from #2746: the `docs_staleness` flag rule is still out of `ci-required` (a one-line flip when the friction is wanted), and the `3.4.0..3.16.0` prose-sweep backlog is recorded in `docs/.docs-sweep.json` but not paid down — that is a docs-sweep pass, not a tooling task.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8LFfCN5WULzTzKd8vaU6C)_