### PR TITLE
chore(benchmarks): retire the two product dedupe rows

### DIFF
--- a/docs/benchmarks/latest-results.json
+++ b/docs/benchmarks/latest-results.json
@@ -44,21 +44,6 @@
       "raw_output_tail": "\u2502 T3   \u2502 88.8%     \u2502 100.0% \u2502 94.1% \u2502 212.82s \u2502 105.0 MB \u2502\n\u2502 T4   \u2502 85.1%     \u2502 100.0% \u2502 92.0% \u2502 32.47s  \u2502 10.9 MB  \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\n\nDQBench ER Score: 83.16 / 100\n\n            Confusion Matrix (pairs) & B\u00b3 (clusters)            \n\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n\u2502 Tier \u2502   TP \u2502  FP \u2502 FN \u2502       TN \u2502 B\u00b3 Prec \u2502 B\u00b3 Rec \u2502 B\u00b3 F1 \u2502\n\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n\u2502 T1   \u2502  100 \u2502  24 \u2502  0 \u2502   499376 \u2502   98.1% \u2502 100.0% \u2502 99.1% \u2502\n\u2502 T2   \u2502  750 \u2502 668 \u2502  0 \u2502 12496082 \u2502   90.2% \u2502 100.0% \u2502 94.8% \u2502\n\u2502 T3   \u2502 2000 \u2502 252 \u2502  0 \u2502 49992748 \u2502   98.8% \u2502 100.0% \u2502 99.4% \u2502\n\u2502 T4   \u2502   80 \u2502  14 \u2502  0 \u2502   319506 \u2502   98.5% \u2502 100.0% \u2502 99.2% \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\n\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nauto-config committed best-effort RED config (iter=v0, stop_reason=BUDGET_TIME, failing_subprofile=scoring); downstream pipeline will run but output may be low-precision\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nauto-config committed best-effort RED config (iter=v0, stop_reason=BUDGET_TIME, failing_subprofile=scoring); downstream pipeline will run but output may be low-precision"
     },
     {
-      "name": "Abt-Buy (dedupe)",
-      "f1": 0.0881,
-      "precision": 0.047,
-      "recall": 0.7075,
-      "tp": 791,
-      "fp": 16050,
-      "fn": 327,
-      "elapsed_seconds": 37.77,
-      "health": "red",
-      "stop_reason": "policy_satisfied",
-      "domain": "product",
-      "lane": "dedupe",
-      "planning_effort": "normal"
-    },
-    {
       "name": "Abt-Buy (linkage)",
       "f1": 0.7024,
       "precision": 0.8529,
@@ -71,21 +56,6 @@
       "stop_reason": "policy_satisfied",
       "domain": "product",
       "lane": "linkage",
-      "planning_effort": "normal"
-    },
-    {
-      "name": "Amazon-Google (dedupe)",
-      "f1": 0.1097,
-      "precision": 0.0609,
-      "recall": 0.5551,
-      "tp": 862,
-      "fp": 13298,
-      "fn": 691,
-      "elapsed_seconds": 65.15,
-      "health": "red",
-      "stop_reason": "budget_time",
-      "domain": "product",
-      "lane": "dedupe",
       "planning_effort": "normal"
     },
     {

--- a/docs/benchmarks/latest-results.md
+++ b/docs/benchmarks/latest-results.md
@@ -14,9 +14,7 @@ current truth, not a stale copy pasted from a case study.
 | Febrl3 | record | 0.9912 | 0.9992 | 0.9833 | 8.94s |
 | NCVR-synthetic | record | 0.9925 | 0.9854 | 0.9996 | 19.32s |
 | DQbench | benchmark-suite | composite=83.16 | — | — | 362.2s |
-| Abt-Buy (dedupe) | product | 0.0881 | 0.0470 | 0.7075 | 37.77s |
 | Abt-Buy (linkage) | product | 0.7024 | 0.8529 | 0.5971 | 8.24s |
-| Amazon-Google (dedupe) | product | 0.1097 | 0.0609 | 0.5551 | 65.15s |
 | Amazon-Google (linkage) | product | 0.4636 | 0.5961 | 0.3792 | 36.35s |
 
 ## Reading these numbers

--- a/docs/reproducing-benchmarks.md
+++ b/docs/reproducing-benchmarks.md
@@ -154,11 +154,12 @@ benchmark test the v1.8 number was measured against.
 | Property | Value |
 |---|---|
 | Runner | `scripts/run_benchmarks.py --datasets abt-buy` (or `amazon-google`, or `products` for both) |
-| Helper | `scripts/dqbench_adapters/leipzig_eval.py::run_two_source_dedupe_zeroconfig` |
+| Helper | `scripts/dqbench_adapters/leipzig_eval.py::run_two_source_link_zeroconfig` |
 | Datasets | Leipzig Abt-Buy + Amazon-GoogleProducts (two-source, heterogeneous schemas) |
 | Drop location | `packages/python/goldenmatch/tests/benchmarks/datasets/{Abt-Buy,Amazon-Google}/` (auto-pulled by `--download`) |
 | Source URL | https://dbs.uni-leipzig.de/de/research/projects/object_matching/benchmark_datasets_for_entity_resolution |
-| GT construction | ID-joined perfect mapping → connected-components cluster truth → pairwise-F1 |
+| GT construction | ID-joined perfect mapping, scored as raw cross-source pairs (record linkage) |
+| Retired lane | A `(dedupe)` row concatenated both sources and scored `dedupe_df` against the transitive closure of the same mapping. Retired 2026-08-24: 98.1% of that truth is cross-source, so it measured linkage through the wrong API while spending half its candidate budget on same-source pairs (1,630 emitted, 9 correct). Genuine dedupe coverage is NCVR and Febrl3. |
 
 These are deliberately the engine's HARD domain: short product titles resist
 blocking (see issue #715), so zero-config recall is low. We publish them to

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,6 +8,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ### Changed
 
+- **The two product benchmark `(dedupe)` rows are retired (#2717, #2748).**
+  They were not measuring deduplication. Measured on Abt-Buy at the committed
+  config, 98.1% of the row's ground truth is CROSS-source (1,097 of 1,118
+  pairs), so it was record linkage wearing a dedupe API.
+
+  It was also mis-RUN rather than merely mis-scored: half the engine's
+  candidate budget went to a within-source hunt containing 21 findable pairs,
+  of which it found 9. Emitting 1,630 same-source pairs to find 9 is 99.4%
+  waste, and it polluted the score distribution the threshold calibrates
+  against. That is why the row scored 0.2253 where LINKAGE over the same
+  records scores 0.7024.
+
+  Real deduplication on these datasets means finding duplicates WITHIN Abt (or
+  within Amazon); neither carries ground truth for that, so no honest dedupe
+  row can be built from them. **Genuine dedupe coverage is unaffected and
+  strong** -- NCVR (single source, synthetic duplicates) scores 0.9828 and
+  Febrl3 0.9443. Reporting 0.2253 beside a 0.7024 linkage row made the engine
+  look far worse at products than it is.
+
+  The surviving linkage rows are also the ones comparable to published
+  DeepMatcher / Ditto figures, which measure the cross-source task.
+
+  Consequences: `_QUARANTINE` is now empty (both entries were these rows), both
+  product lanes report `health=yellow` and pass on merit rather than being
+  suppressed, and `--datasets products` drops from ~200s to ~47s.
+
 - **Both product benchmark lanes now carry an explicit name (#2717).**
   `Abt-Buy` / `Amazon-Google` became `Abt-Buy (dedupe)` /
   `Amazon-Google (dedupe)`; the bare name read as THE number for the dataset

--- a/packages/python/goldenmatch/tests/test_benchmark_quality_floors.py
+++ b/packages/python/goldenmatch/tests/test_benchmark_quality_floors.py
@@ -22,43 +22,53 @@ if str(_SCRIPTS) not in sys.path:
 run_benchmarks = pytest.importorskip("run_benchmarks")
 
 
-def test_amazon_google_at_its_quarantine_baseline_is_reported_not_failed():
-    """Amazon-Google is quarantined (#2717), so its breaches report, not fail.
+#: A synthetic quarantined lane. These tests used to borrow the live entries
+#: for "Amazon-Google (dedupe)" / "Abt-Buy (dedupe)", but those rows were
+#: RETIRED 2026-08-24 -- measurement showed 98.1% of their ground truth was
+#: cross-source, so they were linkage wearing a dedupe API and were not
+#: measuring deduplication at all. `_QUARANTINE` is empty as a result.
+#:
+#: The gate these tests exist for is not tied to any particular lane, so drive
+#: it with a fixture instead. Borrowing live entries is what coupled the
+#: MECHANISM's tests to whichever rows happened to be quarantined, and it is
+#: why retiring two rows broke a test file that has nothing to do with them.
+_LANE = "Synthetic (quarantined)"
+_BASE = 0.20
 
-    This test used to assert the 0.0697 run "sits on the floor and is not a
-    breach". That is no longer the contract, and the change is deliberate:
-    0.0697 was the #2470 run, and the CURRENT observed value is 0.1014. Feeding
-    0.0697 today is a real DEGRADATION and the ratchet fails it -- which is the
-    behaviour the original test wanted ("a WORSE run must breach"), now enforced
-    against a live baseline instead of a static floor.
-    """
-    base = run_benchmarks._QUARANTINE["Amazon-Google (dedupe)"]["f1_at_quarantine"]
-    failing, quarantined = run_benchmarks._check_quality_floors(
-        [{"name": "Amazon-Google (dedupe)", "f1": base, "precision": 0.2077, "recall": 0.0419}]
+
+@pytest.fixture
+def quarantined_lane(monkeypatch):
+    monkeypatch.setattr(run_benchmarks, "_QUARANTINE", {
+        _LANE: {"issue": 2748, "f1_at_quarantine": _BASE, "tolerance": 0.03,
+                "why": "synthetic fixture for the quality-gate tests"},
+    })
+    monkeypatch.setattr(run_benchmarks, "_F1_FLOORS", {_LANE: None, "Febrl3": 0.90})
+
+
+def test_a_quarantined_lane_at_its_baseline_is_reported_not_failed(quarantined_lane):
+    """A quarantined lane's breaches report rather than fail -- but the ratchet
+    still fails a run that DEGRADES past the baseline, which is the behaviour
+    #2470 wanted ("a WORSE run must breach"), enforced against a live baseline
+    instead of a static floor."""
+    failing, _quarantined = run_benchmarks._check_quality_floors(
+        [{"name": _LANE, "f1": _BASE, "precision": 0.2077, "recall": 0.0419}]
     )
     assert failing == [], f"at its own baseline it must not fail: {failing}"
 
     worse = run_benchmarks._check_quality_floors(
-        [{"name": "Amazon-Google (dedupe)", "f1": 0.04, "precision": 0.2, "recall": 0.03}]
+        [{"name": _LANE, "f1": _BASE - 0.16, "precision": 0.2, "recall": 0.03}]
     )[0]
-    assert worse, "a WORSE Amazon-Google run must still fail"
-    assert any("Amazon-Google" in w for w in worse), worse
+    assert worse, "a WORSE run must still fail"
+    assert any(_LANE in w for w in worse), worse
 
 
-def test_a_healthy_run_does_not_breach():
-    """Abt-Buy sits at its quarantine baseline here, not at 0.5037.
-
-    0.5037 is the DISPUTED, unreproduced number (see the `Abt-Buy` note in
-    `_F1_FLOORS`); every reproduction gives 0.1723. Feeding it now trips the
-    IMPROVED ratchet, which is correct -- a jump that size means someone fixed
-    it and the quarantine should be lifted. Using it as "a healthy run" was
-    baking an unreproducible measurement into a test.
-    """
-    base = run_benchmarks._QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
+def test_a_healthy_run_does_not_breach(quarantined_lane):
+    """A clean lane above its floor, alongside a quarantined lane sitting
+    exactly at its baseline, must produce no breaches at all."""
     failing, _ = run_benchmarks._check_quality_floors(
         [
             {"name": "Febrl3", "f1": 0.9912, "precision": 0.99, "recall": 0.99},
-            {"name": "Abt-Buy (dedupe)", "f1": base, "precision": 0.11, "recall": 0.45},
+            {"name": _LANE, "f1": _BASE, "precision": 0.11, "recall": 0.45},
         ]
     )
     assert failing == [], failing

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -208,34 +208,43 @@ def _fetch_leipzig_product(datasets_dir: Path, key: str) -> bool:
 
 
 def _measure_product(datasets_dir: Path, key: str) -> list[dict[str, Any]]:
-    """Zero-config matching on a Leipzig two-source product dataset; pairwise F1.
+    """Zero-config RECORD LINKAGE on a Leipzig two-source product dataset.
 
-    Returns TWO rows, because the dataset supports two genuinely different
-    tasks and reporting one number for both was a framing error (#2717):
+    Returns ONE row. The `<label> (dedupe)` row was RETIRED 2026-08-24 -- it was
+    not measuring deduplication.
 
-      * ``<label> (dedupe)`` -- both sources concatenated into one frame,
-        everything compared to everything, scored against the transitive
-        closure of the mapping. RENAMED from the bare ``<label>`` (#2717): the
-        unsuffixed name read as THE number for the dataset when it is the
-        harder and far less comparable of the two lanes.
-      * ``<label> (linkage)`` -- record linkage via ``match_df(a, b)``, scored
-        against the raw cross-source mapping. This is the task the published
-        DeepMatcher / Ditto figures measure, so it is the row to compare
-        against them.
+    That row concatenated both sources into one frame and scored `dedupe_df`
+    against the transitive closure of a CROSS-SOURCE mapping. Measured on
+    Abt-Buy at the committed config:
 
-    Measured on Amazon-Google with token blocking committed: 67.5% of the
-    dedupe lane's candidates are same-source pairs, which against a
-    cross-source mapping cannot be true matches and land entirely in the
-    false-positive column. The engine already prints a warning naming this and
-    recommending ``match_df(left, right)``. Neither lane is wrong; they answer
-    different questions, and a reader cannot tell which one a bare number
-    answers. Hence both, labelled.
+        ground truth   1,097 cross-source (98.1%)  vs  21 same-source (1.9%)
+        emitted        1,530 cross-source (48.4%)  vs  1,630 same-source (51.6%)
+        false pos      1,057 cross-source          vs  1,621 same-source
+
+    So the task was linkage wearing a dedupe API: 98.1% of the truth is
+    cross-source, while half the engine's candidate budget went to a
+    within-source hunt containing 21 findable pairs, of which it got 9. Emitting
+    1,630 same-source pairs to find 9 is 99.4% waste, and it also polluted the
+    score distribution the threshold calibrates against -- which is why the
+    lane scored 0.2253 while LINKAGE over the same records scored 0.7024.
+
+    Real deduplication on Abt-Buy would mean finding duplicates WITHIN Abt.
+    This dataset carries no ground truth for that, so no honest dedupe row can
+    be built from it.
+
+    The suite keeps genuine dedupe coverage where real ground truth exists:
+    NCVR (single source, synthetic duplicate pairs) scores 0.9828 and Febrl3
+    0.9443. The engine deduplicates well; the retired row was mislabelled, and
+    reporting it beside a 0.7024 linkage row invited reading the engine as far
+    worse at products than it is.
+
+    The linkage row is also the one comparable to published DeepMatcher / Ditto
+    figures, which measure the cross-source task.
     """
     from dqbench_adapters.leipzig_eval import (
-        run_two_source_dedupe_zeroconfig,
         run_two_source_link_zeroconfig,
     )
-    from goldenmatch import dedupe_df, match_df
+    from goldenmatch import match_df
 
     spec = _PRODUCT_SPECS[key]
     shared_kwargs = dict(
@@ -264,30 +273,6 @@ def _measure_product(datasets_dir: Path, key: str) -> list[dict[str, Any]]:
             "planning_effort": _PLANNING_EFFORT,
         }
 
-    # ---- dedupe lane (historical row; keeps the bare label) ----------------
-    # The shared helper returns only the score, so the controller verdict would be
-    # lost -- and this function used to hardcode `health: "n/a"`, which made the
-    # RED-config check in `_check_quality_floors` unable to fire on the two
-    # datasets in the worst shape. Both committed RED configs in the 2026-08-18
-    # nightly and neither tripped it (#2457). Capture it off the result instead of
-    # widening the helper's contract for one caller.
-    dedupe_captured: dict[str, Any] = {}
-
-    def _dedupe(frame):
-        res = dedupe_df(frame, planning_effort=_PLANNING_EFFORT)
-        dedupe_captured["result"] = res
-        return res
-
-    start = time.time()
-    res = run_two_source_dedupe_zeroconfig(datasets_dir, _dedupe, **shared_kwargs)
-    elapsed = time.time() - start
-    if res is None:
-        _info(f"  {spec['label']}: dataset files missing - skipping")
-        return []
-    rows.append(
-        _row(f"{spec['label']} (dedupe)", "dedupe", res, elapsed, dedupe_captured)
-    )
-
     # ---- linkage lane ------------------------------------------------------
     link_captured: dict[str, Any] = {}
 
@@ -299,10 +284,14 @@ def _measure_product(datasets_dir: Path, key: str) -> list[dict[str, Any]]:
     start = time.time()
     link = run_two_source_link_zeroconfig(datasets_dir, _match, **shared_kwargs)
     elapsed = time.time() - start
-    if link is not None:
-        rows.append(
-            _row(f"{spec['label']} (linkage)", "linkage", link, elapsed, link_captured)
-        )
+    if link is None:
+        # The retired dedupe lane used to carry this message; it has to stay or
+        # a missing dataset becomes a silently empty result rather than a skip.
+        _info(f"  {spec['label']}: dataset files missing - skipping")
+        return []
+    rows.append(
+        _row(f"{spec['label']} (linkage)", "linkage", link, elapsed, link_captured)
+    )
     return rows
 
 
@@ -625,33 +614,10 @@ _F1_FLOORS: dict[str, float | None] = {
     # Kept here at 0.45 for the DEDUPE row it currently gates -- raising or
     # retiring it belongs with the same-source framing decision, not with this
     # change -- and see "Abt-Buy (linkage)" below for where it actually applies.
-    # RENAMED to "Abt-Buy (linkage)" below (#2717). The 0.45 was DERIVED from a
-    # linkage run and enforced here for months; it now guards the lane it
-    # describes.
-    #
-    # REPAIRED 2026-08-24: 0.0881 -> 0.2253 (+156%) across three fixes --
-    # the over-merge detector could not fire (#2750), its rule kept a private
-    # copy of the dead bar, and commit discarded the better candidate (#2748).
-    # A fourth change scaled the rule's threshold step by saturation severity,
-    # carrying 0.1361 -> 0.2253: a flat +0.05 could not cross a 0.25 gap inside
-    # the iteration budget.
-    #
-    # Floor set BELOW the observed 0.2253 on purpose -- this is a local
-    # Windows / native-off measurement, and the convention in this file is to
-    # leave margin rather than sit on the number (see the 0.45 note above). 0.15
-    # sits above BOTH the 0.0881 this lane used to score and the 0.1361 of the
-    # first repair, so losing either fix trips it while run-to-run variance
-    # does not.
-    #
-    # Reachable headroom is far higher: a threshold sweep puts this lane at
-    # 0.4059 at thr=0.95 (docs/measurements/). Raise this floor as the
-    # controller learns to get there.
-    "Abt-Buy (dedupe)": 0.15,
-    # KNOWN BAD (#2470). Measured 0.0697 / recall 0.0419. The floor is set at the
-    # observed value ONLY to stop it getting worse; it is not an endorsement, and
-    # this dataset should be treated as an open quality bug rather than a passing
-    # lane. Raise it as the matcher improves.
-    "Amazon-Google (dedupe)": 0.05,
+    # The two `(dedupe)` rows were RETIRED 2026-08-24 -- see `_measure_product`.
+    # They scored a concatenated frame against a mapping that is 98.1%
+    # cross-source, so they measured linkage through the wrong API rather than
+    # deduplication. Genuine dedupe coverage lives in NCVR and Febrl3.
     # No trustworthy baseline recorded yet -- these have not completed in CI.
     "DBLP-ACM": None,
     "NCVR": None,
@@ -691,56 +657,6 @@ _F1_FLOORS: dict[str, float | None] = {
 # something being tracked, so `_quarantine_breaches` says so rather than
 # silently honouring it.
 _QUARANTINE: dict[str, dict[str, Any]] = {
-    "Abt-Buy (dedupe)": {
-        # RE-BASELINED UPWARD 2026-08-24, and re-pointed from the CLOSED #2717.
-        # 0.0881 -> 0.1361 (+55%) once the over-merge detector could fire
-        # (#2750: its bar sat above a cap `cluster_size_max` can never exceed,
-        # and `rule_cluster_giant` kept a private copy of that dead bar) and
-        # commit stopped discarding the better candidate (#2748). The controller
-        # now commits iter=3 at threshold 0.75 rather than falling back to v0.
-        #
-        # STILL QUARANTINED, deliberately: the lane's controller health is RED
-        # because the detector correctly reports it is STILL over-merging
-        # (cluster_size_max 58 against a cap of 100). A threshold sweep puts the
-        # reachable optimum at 0.4059 (thr=0.95, docs/measurements/), so 0.1361
-        # is a real repair and nowhere near a healthy number. Un-quarantining it
-        # here would claim a finished job.
-        #
-        # The baseline moves UP so the gain cannot be silently lost: a run below
-        # 0.1361 - 0.03 now trips this, where the old 0.0881 baseline would have
-        # absorbed a full regression of the fix.
-        "issue": 2748,
-        "f1_at_quarantine": 0.2253,
-        "tolerance": 0.03,
-        "why": (
-            "REPAIRED but not healthy. 0.0881 -> 0.2253 (+156%) via #2750, "
-            "#2748 and a saturation-scaled threshold step. Controller health "
-            "is still RED because the lane is still over-merging (precision "
-            "0.1525), and the measured reachable optimum is 0.4059 at "
-            "thr=0.95 -- the rule stops raising once saturation falls below "
-            "its bar, which is short of that. Quarantined until the "
-            "controller can walk the rest of the way."
-        ),
-    },
-    "Amazon-Google (dedupe)": {
-        # RE-POINTED from #2717, which is CLOSED. An entry whose issue is closed
-        # is a lie about something being tracked (see this dict's own contract),
-        # and the reason this lane is still quarantined is now precisely
-        # understood: it stops on `budget_time` after too few iterations to move
-        # its threshold, so the fixes that repaired Abt-Buy (#2750, #2748) leave
-        # it at 0.1097. Its measured optimum is 0.2211 at thr=0.75.
-        "issue": 2748,
-        "f1_at_quarantine": 0.1097,
-        "tolerance": 0.03,
-        "why": (
-            "clears its own 0.05 floor but commits a RED config "
-            "(budget_time), so the numbers are not trustworthy either way. "
-            "Unlike Abt-Buy (dedupe), which this change repaired, this lane "
-            "never gets enough iterations to reach a better threshold -- the "
-            "time budget truncates exploration before the over-merge rule can "
-            "walk it up. Measured headroom: 0.2211 at thr=0.75."
-        ),
-    },
 }
 
 

--- a/scripts/test_benchmark_dual_lane.py
+++ b/scripts/test_benchmark_dual_lane.py
@@ -1,18 +1,28 @@
-"""`_measure_product` reports both lanes, labelled (#2717).
+"""`_measure_product` reports the LINKAGE lane only (dedupe retired 2026-08-24).
 
-The product datasets support two genuinely different tasks over the same files,
-and a bare F1 does not say which one it answers:
+The `(dedupe)` rows were introduced in #2717 to stop one bare number standing
+for two different tasks. Measuring them properly showed the dedupe row was not
+measuring deduplication at all. On Abt-Buy at the committed config:
 
-  * dedupe -- both sources concatenated, everything compared to everything,
-    scored against the transitive closure of the mapping;
-  * linkage -- `match_df(a, b)`, scored against the raw cross-source mapping,
-    which is the task the published DeepMatcher / Ditto figures measure.
+    ground truth   1,097 cross-source (98.1%)  vs     21 same-source (1.9%)
+    emitted        1,530 cross-source (48.4%)  vs  1,630 same-source (51.6%)
+    false pos      1,057 cross-source          vs  1,621 same-source
 
-Measured on Amazon-Google, 67.5% of the dedupe lane's candidate pairs are
-same-source and therefore unmatchable against a cross-source mapping. Reporting
-one number for both was the framing error; these tests pin that both are
-reported and that the historical row keeps its exact name, because
-`_F1_FLOORS` and `_QUARANTINE` key on it.
+98.1% of the truth is cross-source, so the row was linkage wearing a dedupe
+API -- while half the engine's candidate budget went to a within-source hunt
+holding 21 findable pairs, of which it found 9. That waste also polluted the
+score distribution the threshold calibrates against, which is why the row
+scored 0.2253 where LINKAGE over the same records scored 0.7024.
+
+Real deduplication on Abt-Buy means finding duplicates WITHIN Abt, and this
+dataset carries no ground truth for that. Genuine dedupe coverage lives where
+real labels exist: NCVR (single source, synthetic duplicates) at 0.9828 and
+Febrl3 at 0.9443 -- the engine deduplicates well, and the retired row made it
+look otherwise.
+
+These tests pin that the dedupe row is GONE and that the surviving linkage row
+is still declared in the floors table, because `_F1_FLOORS` keys on the name
+and an undeclared row is a silently unfloored one.
 """
 
 from __future__ import annotations
@@ -43,15 +53,9 @@ def _result(f1: float) -> SimpleNamespace:
 
 @pytest.fixture
 def stub_lanes(monkeypatch):
-    """Stub both eval helpers and the engine entry points they are handed."""
+    """Stub the linkage helper and the engine entry point it is handed."""
     import dqbench_adapters.leipzig_eval as leipzig  # type: ignore[import-not-found]
 
-    monkeypatch.setattr(
-        leipzig,
-        "run_two_source_dedupe_zeroconfig",
-        lambda datasets_dir, fn, **kw: _result(0.10),
-        raising=True,
-    )
     monkeypatch.setattr(
         leipzig,
         "run_two_source_link_zeroconfig",
@@ -63,26 +67,31 @@ def stub_lanes(monkeypatch):
     )
 
 
-def test_returns_one_row_per_lane(stub_lanes):
+def test_returns_only_the_linkage_row(stub_lanes):
     rows = run_benchmarks._measure_product(Path("."), "amazon-google")
-    assert [r["name"] for r in rows] == [
-        "Amazon-Google (dedupe)", "Amazon-Google (linkage)",
-    ]
-    assert [r["lane"] for r in rows] == ["dedupe", "linkage"]
-    assert [r["f1"] for r in rows] == [0.1, 0.46]
+    assert [r["name"] for r in rows] == ["Amazon-Google (linkage)"]
+    assert [r["lane"] for r in rows] == ["linkage"]
+    assert [r["f1"] for r in rows] == [0.46]
 
 
-def test_every_emitted_row_is_declared_in_the_tables(stub_lanes):
-    """`_F1_FLOORS` / `_QUARANTINE` key on the row NAME, so a rename that misses
-    one silently unfloors it. Both dedupe rows carry an explicit `(dedupe)`
-    suffix now (#2717) -- the bare name read as THE number for the dataset when
-    it is the harder and less comparable lane -- and this pins that the tables
-    followed the rename."""
-    rows = run_benchmarks._measure_product(Path("."), "amazon-google")
-    dedupe = rows[0]["name"]
-    assert dedupe == "Amazon-Google (dedupe)"
-    assert dedupe in run_benchmarks._F1_FLOORS
-    assert dedupe in run_benchmarks._QUARANTINE
+def test_no_dedupe_row_is_emitted_for_either_dataset(stub_lanes):
+    """The retirement, stated so it cannot silently come back: a reinstated
+    dedupe row would need a ground truth this dataset does not have."""
+    for key in ("abt-buy", "amazon-google"):
+        rows = run_benchmarks._measure_product(Path("."), key)
+        assert not [r for r in rows if r["lane"] == "dedupe"], (
+            f"{key} emitted a dedupe row: {[r['name'] for r in rows]}"
+        )
+
+
+def test_the_retired_rows_are_gone_from_the_tables():
+    """`_F1_FLOORS` / `_QUARANTINE` key on the row NAME. A retired row left in
+    either table is a floor or a quarantine guarding something nothing emits --
+    and a quarantine entry in particular claims an open issue is being tracked."""
+    for key in ("abt-buy", "amazon-google"):
+        label = run_benchmarks._PRODUCT_SPECS[key]["label"] + " (dedupe)"
+        assert label not in run_benchmarks._F1_FLOORS
+        assert label not in run_benchmarks._QUARANTINE
 
 
 def test_linkage_rows_are_declared_in_the_floors_table():
@@ -97,8 +106,8 @@ def test_linkage_rows_are_declared_in_the_floors_table():
 def test_abt_buy_linkage_carries_the_floor_that_was_derived_from_it():
     """The 0.45 floor was derived from a LINKAGE run (0.5037 / P 0.8219 / 494
     emitted pairs) and then enforced against the dedupe lane for months, where
-    it was recorded as DISPUTED and unreproducible. Now that the linkage row
-    exists it carries its own floor, cleared with margin at a measured 0.7024."""
+    it was recorded as DISPUTED and unreproducible. It now guards the lane it
+    describes, cleared with margin at a measured 0.7024."""
     assert run_benchmarks._F1_FLOORS["Abt-Buy (linkage)"] == 0.45
 
 
@@ -114,19 +123,8 @@ def test_missing_dataset_yields_no_rows(monkeypatch):
 
     monkeypatch.setattr(
         leipzig,
-        "run_two_source_dedupe_zeroconfig",
+        "run_two_source_link_zeroconfig",
         lambda datasets_dir, fn, **kw: None,
         raising=True,
     )
-    assert run_benchmarks._measure_product(Path("."), "abt-buy") == []
-
-
-def test_a_missing_linkage_lane_does_not_lose_the_dedupe_row(stub_lanes, monkeypatch):
-    """The lanes fail independently; one going missing must not take the other."""
-    import dqbench_adapters.leipzig_eval as leipzig  # type: ignore[import-not-found]
-
-    monkeypatch.setattr(
-        leipzig, "run_two_source_link_zeroconfig", lambda datasets_dir, fn, **kw: None, raising=True
-    )
-    rows = run_benchmarks._measure_product(Path("."), "amazon-google")
-    assert [r["name"] for r in rows] == ["Amazon-Google (dedupe)"]
+    assert run_benchmarks._measure_product(Path("."), "amazon-google") == []

--- a/scripts/test_benchmark_quarantine.py
+++ b/scripts/test_benchmark_quarantine.py
@@ -6,19 +6,47 @@ stop the lane working -- these pin that it suppresses ONLY what it claims to.
 
 Network-free and dataset-free: `_check_quality_floors` is a pure function over
 result dicts, so the cases below are the real ones the nightly produces.
+
+These used to borrow the live `_QUARANTINE` entries as fixtures. That coupled
+the MECHANISM's tests to whichever lanes happened to be quarantined, and when
+the two product `(dedupe)` rows were retired 2026-08-24 the dict emptied and
+every test here would have gone vacuous -- passing while testing nothing, at
+exactly the moment nothing else covered the mechanism. They now drive a
+SYNTHETIC entry, so the routing stays under test whether or not any real lane
+is quarantined.
 """
 from __future__ import annotations
 
 import pathlib
 import sys
 
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
+import run_benchmarks  # type: ignore[import-not-found]  # noqa: E402
 from run_benchmarks import (  # noqa: E402
     _F1_FLOORS,
     _QUARANTINE,
     _check_quality_floors,
 )
+
+_LANE = "Synthetic (quarantined)"
+_BASE = 0.20
+_TOL = 0.03
+
+
+@pytest.fixture(autouse=True)
+def synthetic_quarantine(monkeypatch):
+    """One quarantined lane and one un-quarantined lane, both floored."""
+    monkeypatch.setattr(run_benchmarks, "_QUARANTINE", {
+        _LANE: {"issue": 2748, "f1_at_quarantine": _BASE, "tolerance": _TOL,
+                "why": "synthetic fixture for the routing tests"},
+    })
+    monkeypatch.setattr(run_benchmarks, "_F1_FLOORS", {
+        _LANE: None,
+        "Synthetic (floored)": 0.50,
+    })
 
 
 def _r(name, f1, health="green", stop_reason="converged"):
@@ -26,42 +54,17 @@ def _r(name, f1, health="green", stop_reason="converged"):
             "health": health, "stop_reason": stop_reason}
 
 
-# --- the two datasets that made #2457 permanently red -----------------------
-
-def _at_baseline(name: str) -> float:
-    """The f1 a quarantined dataset is currently pinned at.
-
-    Read from `_QUARANTINE` rather than hardcoded. These tests originally
-    carried the literal numbers from nightly run 32457009104 (Abt-Buy 0.1723,
-    Amazon-Google 0.1014) and silently went stale the first time a baseline
-    legitimately moved -- which it did when better blocking took Abt-Buy's
-    dedupe lane DOWN (see the `_QUARANTINE` entry). The invariant these tests
-    exist for is "a dataset sitting AT its baseline does not fail the lane",
-    and that is expressible without pinning the value twice.
-    """
-    from run_benchmarks import _QUARANTINE
-
-    return float(_QUARANTINE[name]["f1_at_quarantine"])
-
-
 def test_a_dataset_at_its_baseline_does_not_fail_the_lane():
-    """Both quarantined datasets, each sitting exactly at its own baseline."""
     failing, quarantined = _check_quality_floors([
-        _r("Abt-Buy (dedupe)", _at_baseline("Abt-Buy (dedupe)"), "red", "budget_iterations"),
-        _r("Amazon-Google (dedupe)", _at_baseline("Amazon-Google (dedupe)"), "red", "budget_time"),
+        _r(_LANE, _BASE, "red", "budget_iterations"),
     ])
-    assert failing == [], f"quarantined datasets still failed the lane: {failing}"
-    # 2, not 3: the Abt-Buy dedupe row no longer carries a floor of its own.
-    # Its 0.45 moved to "Abt-Buy (linkage)", the lane it was derived from
-    # (#2717), so what remains here is the two RED controller healths.
-    assert len(quarantined) == 2, quarantined
+    assert failing == [], f"quarantined dataset still failed the lane: {failing}"
+    assert len(quarantined) == 1, quarantined
 
 
 def test_quarantined_breaches_are_still_reported():
     """Suppressing the failure must not suppress the evidence."""
-    _, quarantined = _check_quality_floors(
-        [_r("Abt-Buy (dedupe)", _at_baseline("Abt-Buy (dedupe)"), "red", "x")]
-    )
+    _, quarantined = _check_quality_floors([_r(_LANE, _BASE, "red", "x")])
     assert quarantined, "a quarantined breach vanished entirely"
     assert all("QUARANTINED" in q and "#" in q for q in quarantined), quarantined
 
@@ -70,29 +73,30 @@ def test_quarantined_breaches_are_still_reported():
 
 def test_degrading_past_the_baseline_fails():
     """A quarantine tracks a bug; it does not license it to deepen."""
-    base = _QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
-    failing, _ = _check_quality_floors([_r("Abt-Buy (dedupe)", base - 0.2, "green")])
+    failing, _ = _check_quality_floors([_r(_LANE, _BASE - 0.2, "green")])
     assert any("DEGRADED" in f for f in failing), failing
 
 
 def test_improving_past_the_baseline_fails():
-    """Someone fixed it -- the quarantine now hides good news, so it must shout."""
-    base = _QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
-    failing, _ = _check_quality_floors([_r("Abt-Buy (dedupe)", base + 0.5, "green")])
+    """Someone fixed it -- the quarantine now hides good news, so it must shout.
+
+    This is the check that drove the Abt-Buy dedupe row's baseline up twice as
+    the controller improved, and then flagged that leaving it quarantined would
+    hide the fix at all.
+    """
+    failing, _ = _check_quality_floors([_r(_LANE, _BASE + 0.5, "green")])
     assert any("IMPROVED" in f for f in failing), failing
 
 
 def test_inside_tolerance_stays_quarantined():
-    base = _QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
-    tol = _QUARANTINE["Abt-Buy (dedupe)"]["tolerance"]
-    failing, _ = _check_quality_floors([_r("Abt-Buy (dedupe)", base + tol / 2, "green")])
+    failing, _ = _check_quality_floors([_r(_LANE, _BASE + _TOL / 2, "green")])
     assert failing == [], failing
 
 
 def test_a_missing_f1_is_not_drift():
     """A crashed/skipped run has no number; inventing a verdict would be worse."""
     failing, _ = _check_quality_floors([
-        {"name": "Abt-Buy (dedupe)", "f1": None, "health": "green", "stop_reason": "x"}
+        {"name": _LANE, "f1": None, "health": "green", "stop_reason": "x"}
     ])
     assert not any("DEGRADED" in f or "IMPROVED" in f for f in failing), failing
 
@@ -101,17 +105,34 @@ def test_a_missing_f1_is_not_drift():
 
 def test_a_non_quarantined_dataset_still_fails_on_floor():
     """Guards every test above: they pass trivially if nothing fails any more."""
-    failing, _ = _check_quality_floors([_r("Febrl3", 0.10, "green")])
+    failing, _ = _check_quality_floors([_r("Synthetic (floored)", 0.10, "green")])
     assert any("below the floor" in f for f in failing), failing
 
 
 def test_a_non_quarantined_dataset_still_fails_on_red():
-    failing, _ = _check_quality_floors([_r("Febrl3", 0.99, "red", "budget_time")])
+    failing, _ = _check_quality_floors([_r("Synthetic (floored)", 0.99, "red", "budget_time")])
     assert any("RED" in f for f in failing), failing
 
 
-def test_every_quarantine_entry_names_an_issue_and_a_known_dataset():
+# --- the real table's own invariants ----------------------------------------
+
+def test_every_real_quarantine_entry_names_an_issue_and_a_known_dataset():
+    """Runs against the LIVE tables, not the fixture.
+
+    Vacuous today -- `_QUARANTINE` is empty since the product dedupe rows were
+    retired -- and deliberately kept: the moment someone quarantines a lane
+    again, it has to carry an issue number and a floor entry.
+    """
     for name, q in _QUARANTINE.items():
         assert isinstance(q.get("issue"), int), f"{name} has no issue number"
         assert isinstance(q.get("f1_at_quarantine"), float), name
         assert name in _F1_FLOORS, f"{name} is quarantined but has no floor entry"
+
+
+def test_the_invariant_above_would_actually_catch_a_bad_entry(monkeypatch):
+    """Pins that the check is real, since the live dict it reads is empty."""
+    monkeypatch.setattr(run_benchmarks, "_QUARANTINE",
+                        {"Bogus": {"f1_at_quarantine": 0.1, "tolerance": 0.03}})
+    with pytest.raises(AssertionError):
+        for name, q in run_benchmarks._QUARANTINE.items():
+            assert isinstance(q.get("issue"), int), f"{name} has no issue number"

--- a/scripts/test_run_benchmarks_llm_isolation.py
+++ b/scripts/test_run_benchmarks_llm_isolation.py
@@ -114,17 +114,31 @@ def test_controller_health_unknown_not_na_when_absent():
 def test_red_health_is_a_breach_even_above_the_floor():
     """The check the "n/a" hardcode disabled.
 
-    Split in two since Abt-Buy became quarantined (#2717): a quarantined
-    dataset's RED is still DETECTED, it just reports instead of failing. The
-    guarantee the "n/a" hardcode broke was detection, so that is asserted on
-    Abt-Buy directly -- and the failing half is asserted on a dataset that is
-    not quarantined, so neither half can pass vacuously.
+    Split in two: a quarantined dataset's RED is still DETECTED, it just
+    reports instead of failing. The guarantee the "n/a" hardcode broke was
+    detection, so that is asserted on a quarantined lane -- and the failing
+    half on an un-quarantined one, so neither can pass vacuously.
+
+    Driven by a SYNTHETIC quarantine entry. This used to borrow
+    "Abt-Buy (dedupe)", which was retired 2026-08-24 when measurement showed it
+    was linkage wearing a dedupe API (98.1% of its ground truth is
+    cross-source). `_QUARANTINE` is empty now, so a real entry cannot carry
+    this.
     """
-    base = rb._QUARANTINE["Abt-Buy (dedupe)"]["f1_at_quarantine"]
-    failing, quarantined = rb._check_quality_floors([
-        {"name": "Abt-Buy (dedupe)", "f1": base, "health": "RED",
-         "stop_reason": "BUDGET_ITERATIONS"},
-    ])
+    import pytest as _pytest  # noqa: F401  (kept local; this module is not a fixture user)
+
+    lane = "Synthetic (quarantined)"
+    saved_q, saved_f = rb._QUARANTINE, rb._F1_FLOORS
+    rb._QUARANTINE = {lane: {"issue": 2748, "f1_at_quarantine": 0.20,
+                             "tolerance": 0.03, "why": "synthetic fixture"}}
+    rb._F1_FLOORS = {lane: None}
+    try:
+        failing, quarantined = rb._check_quality_floors([
+            {"name": lane, "f1": 0.20, "health": "RED",
+             "stop_reason": "BUDGET_ITERATIONS"},
+        ])
+    finally:
+        rb._QUARANTINE, rb._F1_FLOORS = saved_q, saved_f
     assert any("RED" in b for b in quarantined), (failing, quarantined)
 
     failing, _ = rb._check_quality_floors([


### PR DESCRIPTION
The `Abt-Buy (dedupe)` and `Amazon-Google (dedupe)` rows were not measuring deduplication. Retiring them.

## The measurement

Abt-Buy at the committed config:

```
emitted=3160  truth=1118   tp=482  fp=2678  fn=636

TRUTH    cross-source 1097 (98.1%)   same-source   21 ( 1.9%)
EMITTED  cross-source 1530 (48.4%)   same-source 1630 (51.6%)
FP       cross-source 1057 (39.5%)   same-source 1621 (60.5%)
```

**98.1% of the ground truth is cross-source.** The row was record linkage wearing a dedupe API.

It was also mis-**run**, not merely mis-scored. Half the engine's candidate budget went to a within-source hunt containing 21 findable pairs, of which it found 9 — emitting **1,630 same-source pairs to find 9** is 99.4% waste, and it polluted the score distribution the threshold calibrates against. That is why the row scored **0.2253** where linkage over the same records scores **0.7024**.

Restricted to cross-source pairs only the row would score 0.3601, so the framing costs ~0.135 F1 directly and the rest indirectly through the wasted candidate budget.

## Why not just fix it

Real deduplication on these datasets means finding duplicates *within* Abt (or within Amazon). Neither carries ground truth for that, so no honest dedupe row can be built from them.

## The engine deduplicates fine — the row said otherwise

Genuine dedupe coverage lives where real labels exist:

| lane | shape | F1 |
|---|---|---|
| NCVR-synthetic | single source, synthetic duplicates | **0.9828** |
| Febrl3 | single source, known duplicate pairs | **0.9443** |

Reporting 0.2253 beside a 0.7024 linkage row invited reading the engine as far worse at products than it is. The surviving linkage rows are also the ones comparable to published DeepMatcher / Ditto figures, which measure the cross-source task.

## What else this removed

- **`_QUARANTINE` is now empty** — both entries were these rows. Every lane either clears a real floor or honestly declares no baseline yet. Nothing is suppressed.
- **Both product lanes report `health=yellow`** and pass on merit; the RED that made #2457 permanently red is gone with the framing that caused it.
- **`--datasets products` drops ~200s → ~47s.** The retired rows were also the expensive ones.

## Tests

`test_benchmark_dual_lane.py` had the dual lane as its premise; rewritten to pin that no dedupe row is emitted and that the retired names are gone from both tables — a stale floor guards something nothing emits, and a stale quarantine claims an open issue is being tracked.

`test_benchmark_quarantine.py` and `test_run_benchmarks_llm_isolation.py` borrowed the live `_QUARANTINE` entries as fixtures. Emptying the dict would have left every routing test **passing while testing nothing**, exactly when nothing else covered the mechanism. Both now drive a synthetic entry, plus a test pinning that the live-table invariant would still catch a bad entry given the dict it reads is empty.

## Results SoT

`docs/benchmarks/latest-results.{md,json}` still advertised the retired rows. The `.md` can't be hand-edited (`ci.yml` gates it with `--report --check`, re-rendering from the `.json` byte-for-byte), so the rows were dropped from the JSON and the markdown re-rendered. `--check` reports current; zero `dedupe` references remain. No benchmark run implied — remaining rows keep their last real numbers and the nightly refreshes normally.

Refs #2717, #2748.