### PR TITLE
fix(cluster): count oversized clusters before the split, so the field is not 0 by construction (#2755)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+- **`oversized_cluster_count` reports a condition that can actually occur.** It was 0 by construction on every auto-split run -- `build_clusters` re-derives the `oversized` flag from `size > max_cluster_size` AFTER splitting, so every surviving piece is under the cap and the post-split count is necessarily zero (measured 0 across all 72 configs in `docs/measurements/`). The field is now counted BEFORE the split, on both the dict and frames paths, from a list the code already had in hand. Two consumers were reading that constant: `ClusterProfile.health()` (YELLOW when > 0) and `zero_label_confidence.score_cluster_confidence`, where the term carries half the weight of `cluster_size_risk`. `auto_split=False` is untouched -- there the post-hoc flag is a real observation about clusters nobody tried to split, and the fix passes no pre-split count on that path. **Measured neutral**: all four product lanes unchanged (Abt-Buy linkage 0.7024 and dedupe 0.2253, Amazon-Google linkage 0.4636 and dedupe 0.1490), verified under `GOLDENMATCH_AUTOCONFIG_DETERMINISTIC=1` because a first wall-clock run showed a 0.1490 -> 0.1097 drop on one lane that turned out to be host speed, not the change. Stated plainly: the field now varies across candidates (1,1,0,0,1 on Abt-Buy dedupe) where it was always 0, but `health()` still reads RED on that lane from `red_reason` before the YELLOW branch is reached, and the confidence contribution is 1/669. This removes a lie from the telemetry; it does not currently move anything. (#2755)
+
+
 ### Changed
 
 - **The two product benchmark `(dedupe)` rows are retired (#2717, #2748).**

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -461,12 +461,22 @@ def _measure_bridges_frames(
 
 def _emit_cluster_profile(
     clusters: dict[int, dict], max_cluster_size: int = 0,
+    required_split_count: int | None = None,
 ) -> None:
     """Emit ClusterProfile to current emitter. No-op when no capture is active.
 
     `max_cluster_size` is recorded so `cluster_size_max` can be read relative
     to the ceiling it saturates against; 0 means "not recorded" and the
     over-merge check is skipped rather than guessed (#2750).
+
+    ``required_split_count`` is the number of clusters that EXCEEDED the cap and
+    had to be split, counted BEFORE the split ran. Passing it is what makes
+    ``oversized_cluster_count`` mean anything on the auto-split paths: the flag
+    is re-derived from ``size > max_cluster_size`` after splitting, so every
+    surviving piece is under the cap by definition and a post-split count is 0
+    by construction (#2755). ``None`` keeps the post-split count, which is the
+    correct reading when ``auto_split=False`` -- there the flag is a real
+    observation about clusters nobody tried to split.
     """
     import math
     if not _emitter_stack.get():
@@ -516,7 +526,11 @@ def _emit_cluster_profile(
         transitivity_rate=transitivity_rate(members_by_cluster, aggregated_scores, threshold),
         edge_confidence_p50=confidences[len(confidences) // 2] if confidences else 0.0,
         edge_confidence_min=confidences[0] if confidences else 0.0,
-        oversized_cluster_count=sum(1 for c in clusters.values() if c.get("oversized")),
+        oversized_cluster_count=(
+            required_split_count
+            if required_split_count is not None
+            else sum(1 for c in clusters.values() if c.get("oversized"))
+        ),
         bridge_edge_count=bridge_edge_count,
         measured_bridge_risk=measured_bridge_risk,
         max_cluster_size=max_cluster_size,
@@ -790,6 +804,9 @@ def build_cluster_frames(
                 "avg_edge": _pa.array(m_avg),
             })
 
+    # #2755: counted BEFORE the split, because the flag is re-derived afterwards.
+    _required_split: int | None = None
+
     if auto_split:
         # Frames-native auto-split: the per-cluster dict (the SP1 bench loss) is
         # confined to the rare oversized MINORITY. Mirrors _finalize_clusters's
@@ -805,6 +822,7 @@ def build_cluster_frames(
         oversized = sorted(
             _mf.filter_mask(_mf.column("oversized")).column("cluster_id").to_list()
         )
+        _required_split = len(oversized)
         if oversized:
             _af = _tf2(assignments)
             members_by_cid = {
@@ -898,12 +916,14 @@ def build_cluster_frames(
     if _emitter_stack.get():
         _emit_cluster_profile_frames(
             metadata, assignments, _pairs_list(), max_cluster_size,
+            required_split_count=_required_split,
         )
     return ClusterFrames(assignments=assignments, metadata=metadata)
 
 
 def _emit_cluster_profile_frames(
     metadata: Any, assignments: Any, pairs: Any = None, max_cluster_size: int = 0,
+    required_split_count: int | None = None,
 ) -> None:
     """Frames-path twin of ``_emit_cluster_profile``. Telemetry only -- no-op
     when no capture is active. Builds the ``ClusterProfile`` from the metadata +
@@ -967,8 +987,10 @@ def _emit_cluster_profile_frames(
                 aggregated_scores[(min(a, b), max(a, b))] = s
     threshold = min(aggregated_scores.values()) if aggregated_scores else 0.5
 
-    oversized_count = int(
-        _mf.filter_mask(_mf.column("oversized")).height
+    oversized_count = (
+        required_split_count
+        if required_split_count is not None
+        else int(_mf.filter_mask(_mf.column("oversized")).height)
     )
 
     # These were hardcoded to (0, 0.0). This emitter runs LAST on the paths that
@@ -1202,7 +1224,10 @@ def _finalize_clusters(
                 cinfo["cluster_quality"] = "strong"
             cinfo.pop("_was_split", None)
 
-    _emit_cluster_profile(result, max_cluster_size)
+    _emit_cluster_profile(
+        result, max_cluster_size,
+        required_split_count=len(oversized_cids) if auto_split else None,
+    )
     return result
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -637,6 +637,16 @@ class ClusterProfile:
     #: skipped rather than guessed.
     max_cluster_size: int = 0
 
+    # KNOWN LIMITATION, recorded here rather than filed (#2755): no cluster
+    # profile is emitted on the LINKAGE path at all, so every field on this
+    # class is at its default on a `match_df` run and every cluster-derived
+    # signal -- `health()`, `red_reason()`, the `cluster_size_risk` term in
+    # zero-label confidence -- is silent there. Whether linkage SHOULD emit one
+    # is a genuine design question and not obviously yes: linkage "clusters"
+    # are all pairs, so `cluster_size_max` is degenerate and the answer may be
+    # a different profile rather than this one. No failing case today, and
+    # nothing to measure a design against, so it is a note and not a ticket.
+
     def red_reason(self, n_rows: int) -> str | None:
         """The named RED condition, or None.
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -4581,6 +4581,15 @@ def _run_dedupe_pipeline(
     if cluster_frames is not None:
         # Stats from frame aggregates (no dict materialization). Matches the
         # dict path's len(clusters) / size>1 / oversized counts exactly.
+        #
+        # `oversized_cluster_count` here is 0 whenever auto_split is on, for the
+        # same reason #2755 fixed in `ClusterProfile`: the flag is re-derived
+        # from `size > max_cluster_size` after the split, so every surviving
+        # piece is under the cap. NOT fixed here, deliberately -- this is the
+        # run-metrics surface, not the controller's, and reaching the pre-split
+        # count would mean changing what `build_clusters` returns for a number
+        # nothing gates on. Recorded where the next reader is standing rather
+        # than filed as a ticket nobody would pick up.
         from goldenmatch.core.frame import to_frame as _tf_d4
 
         _m = _tf_d4(cluster_frames.metadata)

--- a/packages/python/goldenmatch/tests/test_cluster_profile_after_split.py
+++ b/packages/python/goldenmatch/tests/test_cluster_profile_after_split.py
@@ -50,16 +50,19 @@ def _run_with_spies(monkeypatch, *, splitting: bool):
     real_frames = cluster_mod._emit_cluster_profile_frames
     real_split = tc_mod.materialize_and_split
 
-    # Signatures mirror the emitters', including `max_cluster_size` (#2750) --
-    # the call sites pass it positionally, so a spy that omits it fails with a
-    # TypeError that looks like an ordering bug rather than a stale stub.
-    def dict_spy(clusters, max_cluster_size=0):
+    # The spies pass every argument STRAIGHT THROUGH. They used to mirror the
+    # emitters' signatures explicitly, which meant each new emitter parameter
+    # (`max_cluster_size` in #2750, `required_split_count` in #2755) broke all
+    # three tests here with a TypeError that reads like an ordering bug rather
+    # than a stale stub. These tests observe call ORDER; the arguments are none
+    # of their business.
+    def dict_spy(clusters, *args, **kwargs):
         order.append(("emit", len(clusters)))
-        return real_dict(clusters, max_cluster_size)
+        return real_dict(clusters, *args, **kwargs)
 
-    def frames_spy(metadata, assignments, pairs=None, max_cluster_size=0):
+    def frames_spy(metadata, assignments, *args, **kwargs):
         order.append(("emit", None))
-        return real_frames(metadata, assignments, pairs, max_cluster_size)
+        return real_frames(metadata, assignments, *args, **kwargs)
 
     def split_spy(clusters, all_pairs, margin=None):
         out, report = real_split(clusters, all_pairs, margin)
@@ -113,3 +116,55 @@ def test_nothing_extra_runs_when_splitting_is_off(monkeypatch):
     assert [step[0] for step in order].count("emit") == 1
     assert profile is not None
     assert profile.n_clusters == len(result.clusters)
+
+
+# ── #2755: oversized_cluster_count must report a condition that can occur ────
+
+def _clique_pairs(n: int) -> list[tuple[int, int, float]]:
+    return [(a, b, 0.95) for a in range(n) for b in range(a + 1, n)]
+
+
+def test_oversized_count_reports_clusters_that_required_splitting():
+    """The count is taken BEFORE the split, or it is 0 by construction.
+
+    `build_clusters` re-derives `oversized` from `size > max_cluster_size`
+    AFTER splitting, so every surviving piece is under the cap by definition.
+    The field therefore reported 0 on every auto-split run -- measured 0 across
+    all 72 configs in `docs/measurements/` -- while naming a condition that had
+    just occurred. Two consumers read it: `ClusterProfile.health()` (YELLOW when
+    > 0) and `zero_label_confidence.score_cluster_confidence` (half the weight
+    of `cluster_size_risk`). Both were reading a constant.
+
+    One 8-member clique against a cap of 3 is exactly one cluster that had to
+    be split.
+    """
+    from goldenmatch.core.cluster import build_cluster_frames, build_clusters
+
+    with profile_capture() as emitter:
+        build_clusters(_clique_pairs(8), list(range(8)), max_cluster_size=3,
+                       auto_split=True)
+    assert emitter.cluster.oversized_cluster_count == 1
+    assert emitter.cluster.cluster_size_max == 3, "the split did happen"
+
+    # The frames path is the arrow-native default; the two must agree.
+    with profile_capture() as emitter:
+        build_cluster_frames(_clique_pairs(8), list(range(8)), max_cluster_size=3,
+                             weak_cluster_threshold=0.3, auto_split=True)
+    assert emitter.cluster.oversized_cluster_count == 1
+
+
+def test_without_auto_split_the_post_hoc_count_is_still_the_right_answer():
+    """`auto_split=False` leaves the flag as a real observation, not a leftover.
+
+    Nobody tried to split these, so "clusters currently over the cap" and
+    "clusters that required splitting" are the same set. The #2755 fix must not
+    disturb this path -- it passes no pre-split count and keeps the post-hoc
+    one.
+    """
+    from goldenmatch.core.cluster import build_clusters
+
+    with profile_capture() as emitter:
+        build_clusters(_clique_pairs(8), list(range(8)), max_cluster_size=3,
+                       auto_split=False)
+    assert emitter.cluster.oversized_cluster_count == 1
+    assert emitter.cluster.cluster_size_max == 8, "nothing was split"


### PR DESCRIPTION
Closes #2755.

## The fix

`build_clusters` re-derives the `oversized` flag from `size > max_cluster_size` **after** splitting, so every surviving piece is under the cap and the post-split count is necessarily zero. Measured 0 across all 72 configs in `docs/measurements/`. The field named a condition it could never report.

It is now counted **before** the split, on both the dict and frames paths, from a list the code already had in hand (`oversized_cids` / `oversized`). `auto_split=False` is untouched — there the post-hoc flag is a real observation about clusters nobody tried to split, so that path passes no pre-split count and keeps the old reading.

Two consumers were reading the constant: `ClusterProfile.health()` (YELLOW when > 0) and `zero_label_confidence.score_cluster_confidence`, where the term carries half the weight of `cluster_size_risk`.

## Benchmark lanes: neutral

| lane | before | after |
|---|---|---|
| Abt-Buy (linkage) | 0.7024 | 0.7024 |
| Abt-Buy (dedupe) | 0.2253 | 0.2253 |
| Amazon-Google (linkage) | 0.4636 | 0.4636 |
| Amazon-Google (dedupe) | 0.1490 | 0.1490 |

**Verified under `GOLDENMATCH_AUTOCONFIG_DETERMINISTIC=1`, and that mattered.** The first wall-clock run showed Amazon-Google dedupe at **0.1097** against a 0.1490 baseline — which reads exactly like a regression of exactly the magnitude #2756 is about. It was host speed: the box was slower (28.9s wall vs 23.1s on the baseline run), the 15s budget bound, and the lane got cut to one iteration. The deterministic re-run gives 0.1490 with *and* without the change. This is the #2532 nondeterminism doing precisely what its docstring warns about, and it would have been easy to ship a false regression report or, worse, revert a correct change over it.

## What this does not do

Stated plainly rather than dressed up. The field now varies across candidates — `(1, 1, 0, 0, 1)` across the controller's five entries on Abt-Buy dedupe, where it was `0` everywhere — but:

* `health()` still reads **RED** on that lane, from `red_reason` firing before the YELLOW branch is ever reached. The YELLOW branch remains masked in practice on every lane I can measure.
* The confidence contribution is `1/669` of `cluster_size_risk`, at half weight.

So this removes a lie from the telemetry and makes two dead branches reachable on data where they would matter. It does not currently move anything, and I am not claiming it does.

## Test repair

The three spies in `test_cluster_profile_after_split.py` mirrored the emitters' signatures explicitly, so every new emitter parameter broke all three with a `TypeError` that reads like an ordering bug. The file's own docstring warned about this after #2750 did it once already, and #2755 did it again. They now pass arguments straight through — those tests observe call **order**; the arguments are none of their business.

## Two pieces recorded as comments, not filed

Per the correction on issue proliferation:

* The **same 0-by-construction defect on the run-metrics surface** (`pipeline.py`). Nothing gates on it, and reaching the pre-split count would mean changing what `build_clusters` returns for a number nobody reads. Noted at the site.
* **The linkage path emits no cluster profile at all**, so every field on `ClusterProfile` is at its default on a `match_df` run. This was #2755's second half. It is a genuine design question and not obviously a bug — linkage "clusters" are all pairs, so `cluster_size_max` is degenerate and the answer may be a different profile rather than this one. No failing case, nothing to measure a design against. Noted on the dataclass where a reader would look.

## Verification

- 215 passed across all 34 cluster/split/transitive test files (one pre-existing failure, `test_datafusion_is_importable`, is a missing optional dep)
- 166 passed across the affected-consumer suites (`complexity_profile`, `zero_label_confidence`, `autoconfig_history`, `autoconfig_controller`, `postflight_signals_migration`, `chao1_cardinality`)
- `ruff` clean; codemap, `regen_docs.py --check`, `check_docs_staleness.py` all pass
