### PR TITLE
fix(distributed): make the #957 score knobs reachable from a cluster run

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -63,6 +63,33 @@ on:
         description: "Ray Dataset partition count for the distributed run"
         required: false
         default: "64"
+      # --- #957 distributed score-tuning knobs -------------------------
+      # Leave EMPTY to keep the engine's own default. Pinning every knob to
+      # its default would silently stop testing the default. The effective
+      # values land in the artifact JSON under "score_knobs", so a run always
+      # states the configuration that produced its number.
+      # Only in force when distributed=1: these tune the block-shuffle score
+      # stage, which the legacy backend=ray path never enters.
+      score_num_cpus:
+        description: "#957: CPUs reserved per distributed scoring task (empty = engine default 2)"
+        required: false
+        default: ""
+      score_concurrency:
+        description: "#957: explicit concurrency= on the _score map_batches (empty = let Ray decide)"
+        required: false
+        default: ""
+      score_project:
+        description: "#957: project to scoring columns before the block-shuffle. 1 = on, 0 = off, empty = engine default (on)"
+        required: false
+        default: ""
+      op_reservation:
+        description: "#957: Ray Data per-op object-store reservation ratio, e.g. 0.2. Lower it when _score is [backpressured:tasks(ResourceBudget)] below CPU capacity (empty = Ray default ~0.5)"
+        required: false
+        default: ""
+      shuffle_parts:
+        description: "#957: block-shuffle partition count (empty = the harness default 512)"
+        required: false
+        default: ""
       head_machine:
         description: "Head node machine type (the driver generates the full frame in memory; highmem for distributed runs). 100M: n2-highmem-32 (256 GB); 200M: n2-highmem-64 (512 GB)."
         required: false
@@ -265,10 +292,42 @@ jobs:
         # interleaved with bench stdout. Without this, the only
         # signal mid-run is autoscaler "Resized to N CPUs" lines and
         # whatever the bench script chooses to print.
+        env:
+          # Read through the environment rather than interpolated into the
+          # script body: a `${{ }}` expansion inside `run:` is a template
+          # injection seam, and these are free-text dispatch inputs.
+          SCORE_NUM_CPUS: ${{ inputs.score_num_cpus }}
+          SCORE_CONCURRENCY: ${{ inputs.score_concurrency }}
+          SCORE_PROJECT: ${{ inputs.score_project }}
+          OP_RESERVATION: ${{ inputs.op_reservation }}
+          SHUFFLE_PARTS: ${{ inputs.shuffle_parts }}
+          DISTRIBUTED: ${{ inputs.distributed }}
         run: |
           set -euo pipefail
           mkdir -p .profile_tmp/qis
           OUT_REMOTE="/tmp/qis_${{ inputs.label }}.json"
+
+          # #957 score-tuning knobs. They travel as FLAGS in the argv the
+          # submit already ships, because `ray submit` hands the driver a fresh
+          # shell -- exporting them in this step would never reach it. An empty
+          # input contributes no flag, so the engine default stays in force.
+          KNOBS=()
+          if [ -n "$SCORE_NUM_CPUS" ]; then KNOBS+=(--score-num-cpus "$SCORE_NUM_CPUS"); fi
+          if [ -n "$SCORE_CONCURRENCY" ]; then KNOBS+=(--score-concurrency "$SCORE_CONCURRENCY"); fi
+          if [ -n "$OP_RESERVATION" ]; then KNOBS+=(--op-reservation "$OP_RESERVATION"); fi
+          if [ -n "$SHUFFLE_PARTS" ]; then KNOBS+=(--shuffle-parts "$SHUFFLE_PARTS"); fi
+          case "$SCORE_PROJECT" in
+            1) KNOBS+=(--score-project) ;;
+            0) KNOBS+=(--no-score-project) ;;
+            "") ;;
+            *) echo "::error::score_project must be 1, 0, or empty (got '$SCORE_PROJECT')"; exit 1 ;;
+          esac
+          # `${KNOBS[@]+...}` guards the empty-array case under `set -u`.
+          echo "score knobs -> ${KNOBS[*]+${KNOBS[*]}}"
+          if [ "$DISTRIBUTED" != "1" ] && [ ${#KNOBS[@]} -gt 0 ]; then
+            echo "::error::score knobs were set but distributed=0. The legacy backend=ray path never enters the block-shuffle score stage, so they would measure nothing. Re-dispatch with distributed=1."
+            exit 1
+          fi
 
           # Background poller. Runs in a subshell so we can trap-kill
           # it cleanly on bench completion regardless of exit code.
@@ -302,6 +361,7 @@ jobs:
                  --distributed \
                  --partitions ${{ inputs.partitions }} \
                  --wcc-scratch "${{ inputs.wcc_scratch }}/${{ github.run_id }}" \
+                 ${KNOBS[@]+"${KNOBS[@]}"} \
                  --out "$OUT_REMOTE"
           else
             # Legacy: in-memory backend=ray (does NOT distribute; head-only).
@@ -381,6 +441,13 @@ jobs:
           rss_gb = d.get("rss_mb_peak", 0) / 1024
           f1 = d.get("pairwise", {}).get("f1", "?")
           print(f"## bench-ray-cluster: {rows:,} rows")
+          # #957: state the score-tuning configuration alongside the number.
+          # A run that reports only its wall cannot be told apart from a run
+          # that silently fell back to the defaults.
+          knobs = d.get("score_knobs")
+          if knobs:
+              print("- score knobs: " + ", ".join(
+                  f"{k}={v}" for k, v in knobs.items()))
           print(f"- wall: {wall}")
           print(f"- peak RSS: {rss_gb:.2f} GB (driver-side; per-node varies)")
           print(f"- pairwise F1: {f1}")

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -205,6 +205,18 @@ This is the knob most people get wrong, so read the contract before you run a 10
 | `GOLDENMATCH_DISTRIBUTED_OP_RESERVATION` | unset (Ray default ~0.5) | Ray Data per-op object-store reservation ratio. **Lower it** (e.g. `0.2`) to hand the running `_score` op more object-store budget when it's `ResourceBudget`-backpressured below CPU capacity (idle workers, object store not full). Tune at scale. |
 | `GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY` | unset | Explicit `concurrency=` on the `_score` map_batches. Pins the task-pool size once blocks are narrow; the object-store reservation/shuffle-parts knobs above govern the actual `ResourceBudget` cap. |
 
+<Warning>
+  **On a Ray cluster, exporting these four in your shell does not reach the run.**
+  `ray submit` hands the driver a fresh shell, so a value set around the submit
+  never arrives. Pass them as flags on the driver script instead --
+  `--score-num-cpus`, `--score-concurrency`, `--score-project` /
+  `--no-score-project`, `--op-reservation`, `--shuffle-parts` -- which travel in
+  the argv the submit already ships. The engine reads all four at call time, so
+  a driver that sets them after importing `goldenmatch.distributed` is fine.
+  `scripts/quality_invariant_scale.py` carries these flags and records the
+  effective values in its output JSON under `score_knobs`.
+</Warning>
+
 <Note>
   **If the distributed score stage leaves workers idle** (`MapBatches(_score): … [backpressured:tasks(ResourceBudget)]` with the object store well under capacity), `_score` is reservation-capped, not CPU-bound. Lower `GOLDENMATCH_DISTRIBUTED_OP_RESERVATION` (→ `0.2`) and/or raise `GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS`, then re-measure. The optimal pair is cluster-shaped. (Shrinking Ray Data's `target_max_block_size` is **not** a safe lever: `_score` keeps each co-located partition whole via `batch_size=None`, so a split block would split a group and under-score.)
 </Note>

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5871,13 +5871,18 @@
             "_fs_training_sample",
             "_has_colocation_plan",
             "_native_worker_baseline",
+            "_op_reservation",
             "_prepare_fs_models",
             "_project_to_scoring_columns",
             "_score_blocks_block_shuffle",
             "_score_blocks_legacy",
             "_score_colocated_groups",
+            "_score_concurrency",
+            "_score_num_cpus",
+            "_score_project",
             "_warn_worker_slow_path",
             "dedup_pairs_distributed",
+            "effective_score_knobs",
             "score_blocks_distributed"
           ],
           "imports": [

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -143,6 +143,29 @@ gh workflow run bench-ray-cluster.yml \
 The workflow's step summary shows the wall / RSS / F1 numbers when it
 completes; the full JSON artifact is downloadable from the run page.
 
+### Sweeping the #957 score-tuning knobs
+
+The four score knobs only apply to the **distributed** engine, so a sweep needs
+`distributed=1`; the legacy `backend=ray` path never enters the block-shuffle
+score stage. The workflow refuses a dispatch that sets a knob with
+`distributed=0` rather than running a bench that measures nothing.
+
+```sh
+gh workflow run bench-ray-cluster.yml     --repo benseverndev-oss/goldenmatch     -f rows=100000000     -f distributed=1     -f head_machine=n2-highmem-32     -f label=957-conc60-res02     -f score_concurrency=60     -f op_reservation=0.2
+```
+
+Leave a knob **empty** to keep the engine's own default: pinning every knob to
+its default silently stops testing the default. Each run's effective values are
+recorded in its artifact JSON under `score_knobs` and echoed in the step
+summary, so a null result is attributable to a configuration rather than to a
+sweep that never varied anything.
+
+The knobs reach the run as **flags**, not environment variables: `ray submit`
+gives the driver a fresh shell, so anything exported around the submit is lost.
+(That was the whole reason #957's experiment could not be run for a release
+cycle -- the engine also captured the values at import time, before the driver
+could set them. Both halves are fixed; the flags are the transport.)
+
 ## Verifying teardown
 
 If a run misbehaves, double-check no instances are leaked:

--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -45,7 +45,18 @@ logger = logging.getLogger(__name__)
 # This setting is the practical knob until then.
 #
 # Override via GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS for different shapes.
-_SCORE_NUM_CPUS = int(os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS", "2"))
+#
+# READ LAZILY (#957). These four score-tuning knobs used to be import-time
+# module constants, which made them unreachable on the one path that needs
+# them: `ray submit` hands the driver a FRESH shell, so nothing exported around
+# the submit survives, and the driver imports `goldenmatch.distributed.*`
+# before it gets a chance to set anything itself. A cluster bench therefore
+# could not vary its own independent variable -- every sweep silently ran the
+# defaults, which is indistinguishable from a sweep that found no effect.
+# Reading at call time matches this module's own existing idiom for
+# `_block_shuffle_enabled()` and GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS.
+def _score_num_cpus() -> int:
+    return int(os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS", "2"))
 
 # #957: project to scoring-relevant columns BEFORE the block-shuffle so the
 # shuffle moves narrow blocks, not full records. The block-shuffle `_explode`
@@ -54,15 +65,20 @@ _SCORE_NUM_CPUS = int(os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS", "
 # few tasks (~6 of 80 CPU at 100M) while workers sit idle. Scoring reads only
 # __row_id__ + config-referenced columns, so dropping unreferenced raw columns
 # is output-invariant (parity-tested). Kill via GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT=0.
-_SCORE_PROJECT = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT", "1") != "0"
+# Read on the DRIVER and captured into the `_explode` closure, so the driver's
+# setting is what applies. As a module constant this was read independently in
+# each WORKER process, where the cluster's env -- not the submitter's -- decides.
+def _score_project() -> bool:
+    return os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT", "1") != "0"
 
 # #957: optional explicit concurrency for the `_score` map_batches. Ray Data's
 # streaming executor otherwise caps in-flight tasks by object-store budget; the
 # projection above relieves that, and this pins the target task count to
 # saturate worker CPU. Unset (default) = let Ray decide; the optimal value is
 # cluster-shaped, tuned at the 100M re-measure.
-_raw_score_conc = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY")
-_SCORE_CONCURRENCY = int(_raw_score_conc) if _raw_score_conc else None
+def _score_concurrency() -> int | None:
+    raw = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY")
+    return int(raw) if raw else None
 
 # #957 (ResourceBudget backpressure follow-up). Ray Data's streaming executor
 # RESERVES a fraction of the cluster object store (default ~0.5, split across
@@ -78,14 +94,16 @@ _SCORE_CONCURRENCY = int(_raw_score_conc) if _raw_score_conc else None
 # partition count (GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS). Unset (default) = Ray
 # default, no change. Tune at scale; ~0.2 frees most of the store for the
 # running op. Version-guarded: no-op on a Ray without the attribute.
-_OP_RESERVATION = os.environ.get("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION")
+def _op_reservation() -> str | None:
+    return os.environ.get("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION")
 
 
 def _apply_ray_data_resource_tuning() -> None:
     """Apply opt-in Ray Data object-store budget tuning for the distributed score
     path (#957 ResourceBudget backpressure). No-op unless the env knob is set;
     version-guarded so it never breaks on a Ray that lacks the attribute."""
-    if _OP_RESERVATION is None:
+    reservation = _op_reservation()
+    if reservation is None:
         return
     try:
         from ray.data import DataContext
@@ -97,7 +115,7 @@ def _apply_ray_data_resource_tuning() -> None:
                 "DataContext.op_resource_reservation_ratio -- ignored."
             )
             return
-        ratio = max(0.0, min(1.0, float(_OP_RESERVATION)))
+        ratio = max(0.0, min(1.0, float(reservation)))
         ctx.op_resource_reservation_ratio = ratio
         logger.info(
             "Ray Data op_resource_reservation_ratio=%.2f "
@@ -107,6 +125,25 @@ def _apply_ray_data_resource_tuning() -> None:
         )
     except Exception as e:  # never let a tuning knob break the run
         logger.warning("Ray Data resource tuning failed (ignored): %s", e)
+
+
+def effective_score_knobs() -> dict[str, Any]:
+    """The #957 score-tuning knobs as THIS process will actually use them.
+
+    Recorded into bench output so the artifact states the configuration that
+    produced the number. Without it a sweep whose runs all silently fell back
+    to the defaults is indistinguishable from a sweep that found no effect --
+    which is precisely how these knobs sat unmeasurable for a release cycle.
+    """
+    return {
+        "score_num_cpus": _score_num_cpus(),
+        "score_project": _score_project(),
+        "score_concurrency": _score_concurrency(),
+        "op_reservation": _op_reservation(),
+        # Not a #957 knob, but the same sweep tunes it and it is read on the
+        # driver at Dataset-build time, so it belongs in the same record.
+        "shuffle_parts": os.environ.get("GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS"),
+    }
 
 
 def _native_worker_baseline() -> dict[str, dict[str, int]]:
@@ -380,15 +417,16 @@ def _score_blocks_legacy(
             "score": [float(s) for _a, _b, s in pairs],
         })
 
+    num_cpus = _score_num_cpus()
     logger.info(
         "score_blocks_distributed: dispatching with num_cpus=%d per task "
         "(GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS to override)",
-        _SCORE_NUM_CPUS,
+        num_cpus,
     )
     return df_ds.map_batches(
         _score_partition,
         batch_format="pyarrow",
-        num_cpus=_SCORE_NUM_CPUS,
+        num_cpus=num_cpus,
     )
 
 
@@ -587,11 +625,15 @@ def _score_blocks_block_shuffle(
     n_parts = (max(1, int(_parts_override)) if _parts_override
                else min(256, max(4, cpu * 4)))
 
+    # Driver-side read, captured into the closure below so the submitter's
+    # setting travels to the workers with the function.
+    project = _score_project()
+
     def _explode(batch: Any) -> Any:  # pa.Table -> pa.Table
         import polars as pl
         df = pl.from_arrow(batch)
         assert isinstance(df, pl.DataFrame)
-        if _SCORE_PROJECT:
+        if project:
             df = _project_to_scoring_columns(df, config)
         return _attach_colocation_keys(df, config).to_arrow()
 
@@ -613,20 +655,22 @@ def _score_blocks_block_shuffle(
 
     exploded = df_ds.map_batches(_explode, batch_format="pyarrow")
     colocated = exploded.repartition(n_parts, keys=["__keyid__", "__block_key__"])
+    num_cpus = _score_num_cpus()
+    concurrency = _score_concurrency()
     logger.info(
         "score_blocks_distributed: BLOCK-SHUFFLE path (opt-in via "
         "GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE); %d shuffle partitions, "
         "num_cpus=%d per task, project=%s, concurrency=%s",
-        n_parts, _SCORE_NUM_CPUS, _SCORE_PROJECT,
-        _SCORE_CONCURRENCY if _SCORE_CONCURRENCY is not None else "auto",
+        n_parts, num_cpus, project,
+        concurrency if concurrency is not None else "auto",
     )
     _mb_kwargs: dict[str, Any] = {
         "batch_format": "pyarrow",
         "batch_size": None,
-        "num_cpus": _SCORE_NUM_CPUS,
+        "num_cpus": num_cpus,
     }
-    if _SCORE_CONCURRENCY is not None:
-        _mb_kwargs["concurrency"] = _SCORE_CONCURRENCY
+    if concurrency is not None:
+        _mb_kwargs["concurrency"] = concurrency
     return colocated.map_batches(_score, **_mb_kwargs)
 
 

--- a/packages/python/goldenmatch/tests/test_distributed_fs_e2e.py
+++ b/packages/python/goldenmatch/tests/test_distributed_fs_e2e.py
@@ -29,6 +29,7 @@ FS config builder are inline, not imported from scripts/.
 from __future__ import annotations
 
 import itertools
+import os
 import random
 
 import polars as pl
@@ -46,16 +47,18 @@ def _ray_local():
       * ``num_cpus`` is oversubscribed (6 logical slots on a smaller box). The
         block-shuffle path spawns long-lived ``HashShuffleAggregator`` actors
         that each hold a CPU slot; with too few slots those actors starve the
-        ``_score`` op (which reserves ``_SCORE_NUM_CPUS``) and the run deadlocks
+        ``_score`` op (which reserves the per-task CPU knob) and the run deadlocks
         with ~0% CPU. The data here is tiny, so oversubscribing slots only
         relieves scheduling, it does not overcommit real work.
-      * ``_SCORE_NUM_CPUS`` is pinned to 1 (its module default of 2 is tuned for
-        a 64 GB / many-core distributed box). Saved/restored around the module.
+      * the per-task CPU reservation is pinned to 1 (its default of 2 is tuned
+        for a 64 GB / many-core distributed box). Saved/restored around the
+        module. Set through the env, which the scoring module now reads at call
+        time -- it used to be an import-time constant only a monkeypatched
+        module attribute could reach.
     """
-    from goldenmatch.distributed import scoring
-
-    saved_cpus = scoring._SCORE_NUM_CPUS
-    scoring._SCORE_NUM_CPUS = 1
+    _KNOB = "GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS"
+    saved_cpus = os.environ.get(_KNOB)
+    os.environ[_KNOB] = "1"
     ray.init(
         local_mode=False, ignore_reinit_error=True,
         num_cpus=6, logging_level="WARNING",
@@ -64,7 +67,10 @@ def _ray_local():
         yield
     finally:
         ray.shutdown()
-        scoring._SCORE_NUM_CPUS = saved_cpus
+        if saved_cpus is None:
+            os.environ.pop(_KNOB, None)
+        else:
+            os.environ[_KNOB] = saved_cpus
 
 
 def _gen_fs_data(

--- a/packages/python/goldenmatch/tests/test_distributed_score_knobs.py
+++ b/packages/python/goldenmatch/tests/test_distributed_score_knobs.py
@@ -1,0 +1,64 @@
+"""#957: the four distributed score-tuning knobs must be readable AFTER import.
+
+They were import-time module constants, which made them unreachable on the one
+path that needs them. `ray submit` hands the driver a fresh shell, so nothing
+exported around the submit survives; and the bench driver imports
+`goldenmatch.distributed.*` before it sets any env of its own. The result was a
+cluster bench that could not vary its own independent variable -- every sweep
+silently ran the defaults, which looks exactly like a sweep that found no effect.
+
+These tests import the module FIRST and set the environment SECOND, which is the
+ordering the bug made impossible. They need no Ray: the accessors are plain env
+reads, so the regression is guarded in ordinary CI rather than only on a cluster.
+"""
+from __future__ import annotations
+
+import goldenmatch.distributed.scoring as S  # imported before any env is set
+
+
+def test_num_cpus_reads_env_after_import(monkeypatch):
+    assert S._score_num_cpus() == 2  # documented default
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS", "7")
+    assert S._score_num_cpus() == 7
+
+
+def test_project_reads_env_after_import(monkeypatch):
+    assert S._score_project() is True  # default-on (#957 projection)
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT", "0")
+    assert S._score_project() is False
+
+
+def test_concurrency_reads_env_after_import(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY", raising=False)
+    assert S._score_concurrency() is None  # unset = let Ray decide
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY", "48")
+    assert S._score_concurrency() == 48
+
+
+def test_op_reservation_reads_env_after_import(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", raising=False)
+    assert S._op_reservation() is None
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", "0.2")
+    assert S._op_reservation() == "0.2"
+
+
+def test_effective_score_knobs_reports_what_the_run_will_use(monkeypatch):
+    """The bench artifact's provenance record must track the live env.
+
+    A sweep that reports no per-run configuration cannot be told apart from a
+    sweep that never varied anything -- so this record is what makes a null
+    result on the cluster believable.
+    """
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS", "4")
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT", "0")
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY", "60")
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", "0.2")
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS", "512")
+
+    assert S.effective_score_knobs() == {
+        "score_num_cpus": 4,
+        "score_project": False,
+        "score_concurrency": 60,
+        "op_reservation": "0.2",
+        "shuffle_parts": "512",
+    }

--- a/packages/python/goldenmatch/tests/test_distributed_scoring_tuning.py
+++ b/packages/python/goldenmatch/tests/test_distributed_scoring_tuning.py
@@ -23,8 +23,9 @@ def test_op_reservation_knob_sets_datacontext(monkeypatch):
 
     ctx = _ctx_or_skip()
     orig = ctx.op_resource_reservation_ratio
-    # The knob is read at import time into a module constant; patch the constant.
-    monkeypatch.setattr(S, "_OP_RESERVATION", "0.2")
+    # Read at CALL time, so setting the env is the real path (it used to be an
+    # import-time constant that only an attribute patch could reach).
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", "0.2")
     try:
         S._apply_ray_data_resource_tuning()
         assert ctx.op_resource_reservation_ratio == pytest.approx(0.2)
@@ -36,7 +37,7 @@ def test_op_reservation_knob_noop_when_unset(monkeypatch):
     import goldenmatch.distributed.scoring as S
 
     ctx = _ctx_or_skip()
-    monkeypatch.setattr(S, "_OP_RESERVATION", None)
+    monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", raising=False)
     orig = ctx.op_resource_reservation_ratio
     S._apply_ray_data_resource_tuning()
     assert ctx.op_resource_reservation_ratio == orig  # unchanged
@@ -47,7 +48,7 @@ def test_op_reservation_knob_clamps_to_unit_interval(monkeypatch):
 
     ctx = _ctx_or_skip()
     orig = ctx.op_resource_reservation_ratio
-    monkeypatch.setattr(S, "_OP_RESERVATION", "5")  # out of range -> clamp to 1.0
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", "5")  # out of range -> clamp
     try:
         S._apply_ray_data_resource_tuning()
         assert ctx.op_resource_reservation_ratio == pytest.approx(1.0)

--- a/packages/python/goldenmatch/tests/test_qis_harness.py
+++ b/packages/python/goldenmatch/tests/test_qis_harness.py
@@ -243,3 +243,85 @@ def test_qis_native_parity(tmp_path):
     assert nat["native"]["available"] is True
     assert py["pairwise"]["f1"] == pytest.approx(nat["pairwise"]["f1"], abs=1e-9)
     assert py["clusters_signature"] == nat["clusters_signature"]
+
+
+# --- #957: score-tuning knobs must survive the ray-submit boundary --------
+# `ray submit` gives the driver a FRESH shell, so a value exported around the
+# submit never reaches the rung. These flags are the transport that does work,
+# for the same reason --wcc-scratch is a flag. Exercised through the real
+# parser so a renamed or dropped flag fails here rather than on a paid cluster.
+
+_KNOB_ENV = (
+    "GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS",
+    "GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY",
+    "GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT",
+    "GOLDENMATCH_DISTRIBUTED_OP_RESERVATION",
+    "GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS",
+)
+
+
+@pytest.fixture
+def _clean_knob_env():
+    """Snapshot and restore explicitly rather than via monkeypatch.
+
+    ``_apply_score_knob_flags`` writes ``os.environ`` directly (it has to --
+    that IS the transport under test). ``monkeypatch.delenv(..., raising=False)``
+    records nothing when the variable was already absent, so it has no undo to
+    run and those raw writes leak into whatever test module the worker picks up
+    next. Caught by exactly that: these tests turned the score-knob defaults
+    non-default for a later module in the same process.
+    """
+    saved = {k: os.environ.get(k) for k in _KNOB_ENV}
+    for k in _KNOB_ENV:
+        os.environ.pop(k, None)
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_score_knob_flags_reach_the_engine_env(_clean_knob_env):
+    args = qis._build_parser().parse_args([
+        "--rows", "1000", "--distributed",
+        "--score-num-cpus", "4",
+        "--score-concurrency", "60",
+        "--no-score-project",
+        "--op-reservation", "0.2",
+        "--shuffle-parts", "512",
+    ])
+    qis._apply_score_knob_flags(args)
+
+    assert os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS"] == "4"
+    assert os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY"] == "60"
+    assert os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT"] == "0"
+    assert os.environ["GOLDENMATCH_DISTRIBUTED_OP_RESERVATION"] == "0.2"
+    assert os.environ["GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS"] == "512"
+
+    # ...and the engine, imported long before these flags were parsed, sees them.
+    from goldenmatch.distributed.scoring import effective_score_knobs
+    assert effective_score_knobs() == {
+        "score_num_cpus": 4,
+        "score_project": False,
+        "score_concurrency": 60,
+        "op_reservation": "0.2",
+        "shuffle_parts": "512",
+    }
+
+
+def test_score_knob_flags_omitted_leave_engine_defaults_alone(_clean_knob_env):
+    """Unset flags must not write the env: a bench that pins every knob to a
+    default silently stops testing the default."""
+    args = qis._build_parser().parse_args(["--rows", "1000", "--distributed"])
+    qis._apply_score_knob_flags(args)
+    for k in _KNOB_ENV:
+        assert k not in os.environ, f"{k} was written despite no flag"
+
+
+def test_score_project_flag_can_turn_the_projection_back_on(_clean_knob_env):
+    args = qis._build_parser().parse_args(["--rows", "1000", "--score-project"])
+    qis._apply_score_knob_flags(args)
+    assert os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT"] == "1"

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -1109,6 +1109,41 @@ def _run_phase5_and_collect(
     return predicted, dedup_wall
 
 
+def _score_knob_provenance() -> dict:
+    """The #957 score-tuning knobs as the engine will really read them.
+
+    Falls back to the raw env if goldenmatch is too old to expose the helper,
+    so a stale wheel on the head node degrades the record rather than the run.
+    """
+    try:
+        from goldenmatch.distributed.scoring import effective_score_knobs
+        return effective_score_knobs()
+    except Exception:
+        return {k: os.environ.get(f"GOLDENMATCH_DISTRIBUTED_{k.upper()}")
+                for k in ("score_num_cpus", "score_project", "score_concurrency",
+                          "op_reservation", "shuffle_parts")}
+
+
+def _apply_score_knob_flags(args) -> None:
+    """Turn the --score-* flags into the env the engine reads.
+
+    These exist for the same reason --wcc-scratch does: `ray submit` gives the
+    driver a FRESH shell, so a value exported around the submit never arrives.
+    A flag travels in the argv the submit already ships. Set before the engine
+    reads them -- which it now does at call time rather than at import (#957).
+    """
+    if args.score_num_cpus is not None:
+        os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS"] = str(args.score_num_cpus)
+    if args.score_concurrency is not None:
+        os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY"] = str(args.score_concurrency)
+    if args.score_project is not None:
+        os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT"] = "1" if args.score_project else "0"
+    if args.op_reservation is not None:
+        os.environ["GOLDENMATCH_DISTRIBUTED_OP_RESERVATION"] = str(args.op_reservation)
+    if args.shuffle_parts is not None:
+        os.environ["GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS"] = str(args.shuffle_parts)
+
+
 def run_distributed_rung(
     n_rows: int, seed: int = 0, shape: str = "realistic",
     corruption: str = "moderate", n_partitions: int = 64,
@@ -1142,10 +1177,16 @@ def run_distributed_rung(
         "rss_mb_peak": _peak_rss_mb(),
         **metrics,
         "multi_member_clusters": multi,
+        # #957: state the score-tuning configuration this rung actually ran
+        # under. A sweep whose artifacts don't record it cannot be told apart
+        # from a sweep that never varied anything.
+        "score_knobs": _score_knob_provenance(),
     }
 
 
-def main(argv=None) -> int:
+def _build_parser() -> argparse.ArgumentParser:
+    """Split out from ``main`` so tests can exercise the real flag strings
+    without running a rung."""
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--rows", type=int, default=1000)
     ap.add_argument("--seed", type=int, default=0)
@@ -1187,11 +1228,40 @@ def main(argv=None) -> int:
                          "(--distributed only). Sets GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH so "
                          "the head process has it (env vars don't propagate through ray submit). "
                          "MUST be gs:// on multi-node.")
+    # --- #957 distributed score-tuning knobs -----------------------------
+    # Flags, not env vars, because `ray submit` hands the driver a fresh shell
+    # (same reason --wcc-scratch above is a flag). Each maps to the
+    # GOLDENMATCH_DISTRIBUTED_* var the scoring engine reads; unset = leave the
+    # engine's own default alone. The effective values are recorded in the
+    # output JSON under "score_knobs".
+    ap.add_argument("--score-num-cpus", type=int, default=None,
+                    help="CPUs reserved per distributed scoring task "
+                         "(GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS; engine default 2).")
+    ap.add_argument("--score-concurrency", type=int, default=None,
+                    help="explicit concurrency= on the _score map_batches "
+                         "(GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY; default: let Ray decide).")
+    ap.add_argument("--score-project", dest="score_project", default=None,
+                    action=argparse.BooleanOptionalAction,
+                    help="project to scoring-relevant columns before the block-shuffle "
+                         "(GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT; engine default on). "
+                         "--no-score-project restores the full-record shuffle.")
+    ap.add_argument("--op-reservation", type=float, default=None,
+                    help="Ray Data per-op object-store reservation ratio "
+                         "(GOLDENMATCH_DISTRIBUTED_OP_RESERVATION). Lower (~0.2) when "
+                         "_score is [backpressured:tasks(ResourceBudget)] below CPU capacity.")
+    ap.add_argument("--shuffle-parts", type=int, default=None,
+                    help="block-shuffle partition count "
+                         "(GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS; --distributed default 512).")
     ap.add_argument("--out", type=Path, default=None, help="write per-rung JSON here")
-    args = ap.parse_args(argv)
+    return ap
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
 
     if args.wcc_scratch:
         os.environ["GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH"] = args.wcc_scratch
+    _apply_score_knob_flags(args)
 
     if args.rebuild_frozen_config:
         build_frozen_config(seed=args.seed, corruption="moderate")


### PR DESCRIPTION
Closes the precondition that blocked #957's actual experiment.

## The defect

The four distributed score-tuning knobs were **import-time module constants**, which made them unreachable on the one path that needs them:

- `ray submit` hands the driver a **fresh shell**, so a value exported around the submit never arrives.
- The bench driver imports `goldenmatch.distributed.*` **before** it can set anything itself.

So the sweep #957 asks for could not be run at all. Every dispatch silently used the defaults — which is indistinguishable from a sweep that found no effect.

A second, quieter bug: `_SCORE_PROJECT` was read independently in **each worker process**, where the cluster's env decides — so the submitter's setting never applied to it even in principle.

## The fix — three parts, none needing a cluster

1. **`scoring.py` reads all four at call time**, matching this module's own existing idiom for `_block_shuffle_enabled()` and `SHUFFLE_PARTS`. `_score_project()` is read on the **driver** and captured into the `_explode` closure, so the submitter's setting travels to the workers with the function.
2. **`quality_invariant_scale.py` gains `--score-num-cpus` / `--score-concurrency` / `--score-project|--no-score-project` / `--op-reservation` / `--shuffle-parts`** — for the same reason `--wcc-scratch` is already a flag: argv survives the submit boundary, env does not. An omitted flag writes nothing, so the engine default stays under test.
3. **`bench-ray-cluster.yml` exposes them as dispatch inputs** (read via `env:`, not interpolated into the run block) and **refuses a dispatch that sets a knob with `distributed=0`** — the legacy `backend=ray` path never enters the block-shuffle score stage, so those runs would measure nothing.

## Provenance

Every run records its effective knob values in the artifact JSON under `score_knobs` and echoes them in the step summary. Without that, a sweep whose runs all silently fell back to the defaults reads exactly like a sweep that found no effect.

## Verification

- The regression guard imports the module **first** and sets the environment **second** — the ordering the bug made impossible. It needs no Ray, so it runs in ordinary CI rather than only on a cluster.
- Checked against a reconstruction of the old import-time capture: it reports `2` where the test demands `7`. The test catches the real defect, not just its own absence.
- The two existing tests that reached in to patch module constants now use the env, which is the real path.
- The workflow's shell logic was exercised in bash for all three cases (no knobs / knobs+distributed=1 / knobs+distributed=0 → guard fires). `zizmor` finding count is **identical to the baseline** (24), so the new inputs add no template-injection seam.
- `ruff`, `regen_docs.py --check`, `gen_config_matrix.py --refs all`, `agent_codemap.py --check`: all green.

**Not verified locally:** the heavy Ray e2e modules. Local runs died with `(raylet) Task _shuffle_block failed` — a Ray-on-Windows worker crash, not an assertion — including on tests my diff does not touch. Leaving those to CI on Linux.

## What this does NOT do

No knob value is changed and no default moves. This makes the experiment *possible*; the sweep itself is the next step and is a separate, paid cluster dispatch.