### PR TITLE
chore(ci): cut the last three Infisical consumers over to Doppler

### DIFF
--- a/.github/benchmarks/README.md
+++ b/.github/benchmarks/README.md
@@ -67,7 +67,7 @@ That's it — no new workflow file.
 Not every bench fits the generic runner. These keep their own file:
 
 - **Secret / remote orchestration** — `bench-distributed-stack` (`RAY_ADDRESS`),
-  `bench-ray-cluster` (Infisical), `bench-sail-100m` (`SAIL_REMOTE`),
+  `bench-ray-cluster` (`DOPPLER_TOKEN`), `bench-sail-100m` (`SAIL_REMOTE`),
   `bench-phase5-*` (Ray cluster). Bespoke secret + service wiring.
 - **Push/PR gates** — e.g. `bench-graphiti-smoke` (runs on path changes),
   `bench-probabilistic` (panel regression gate). They aren't dispatch-only.

--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -5,14 +5,13 @@
 # config (1 head + 3 preemptible workers). The tear-down step runs in
 # `if: always()` so a failed bench still releases the instances.
 #
-# Required GitHub secrets (provision once per repo):
-#   INFISICAL_CLIENT_ID      — Universal Auth client id for a Machine
-#                              Identity scoped to the goldenmatch
-#                              Infisical project (a99885f0-c5af-4ae1-9dc8-255cc60aa129) with read
-#                              access on the `dev` environment.
-#   INFISICAL_CLIENT_SECRET  — companion secret for the same identity.
+# Required GitHub secret (provision once per repo):
+#   DOPPLER_TOKEN — read-only Doppler service token scoped to
+#                   project `showcase`, config `dev`. One secret, not
+#                   two: the token carries its own project/config, so
+#                   there is no login step and no scope flags.
 #
-# Pulled FROM Infisical project a99885f0-c5af-4ae1-9dc8-255cc60aa129, env=dev, at runtime:
+# Pulled FROM Doppler showcase/dev at runtime:
 #   GCP_RAY_BENCH_PROJECT_ID  — GCP project that holds the bench SA +
 #                                APIs (golden-490919). NOT the same as
 #                                GOOGLE_CLOUD_PROJECT, which the team
@@ -25,10 +24,10 @@
 #   - roles/compute.admin       (create/delete instances + disks)
 #   - roles/iam.serviceAccountUser (let Ray attach the SA to instances)
 #
-# Pattern: any future Infisical-backed secret reuses the same auth
-# pair instead of accumulating GH secrets. See
-# docs/distributed/ray-gce-cluster.md for the one-time Infisical
-# Machine Identity setup commands.
+# Pattern: any future Doppler-backed secret rides the same token
+# instead of accumulating GH secrets. See
+# docs/distributed/ray-gce-cluster.md for the one-time service-token
+# setup command.
 
 name: bench-ray-cluster
 
@@ -89,9 +88,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Ray + gcloud helpers + Infisical CLI
+      - name: Install Ray + gcloud helpers + Doppler CLI
         # Ray drives `ray up` / `ray submit` / `ray down` locally; the
-        # version pin matches the cluster.yaml docker image. Infisical
+        # version pin matches the cluster.yaml docker image. The Doppler
         # CLI fetches GCP creds at runtime so the GCP secrets stay in
         # one place instead of accumulating GH-Actions copies.
         run: |
@@ -106,52 +105,45 @@ jobs:
           RAY_VER=$(python -c "import ray; print(ray.__version__)")
           echo "RAY_VER=$RAY_VER" >> "$GITHUB_ENV"
           echo "Resolved Ray version: $RAY_VER (launcher + cluster docker image)"
-          # Infisical CLI: official apt repo. The 0.43.x series ships
-          # `infisical login --method=universal-auth` and
-          # `infisical secrets get --plain` which we both use.
-          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
-          sudo apt-get update && sudo apt-get install -y infisical
+          # Doppler CLI: official install script. We use only
+          # `doppler secrets get --plain`, which a service token authorizes
+          # directly -- no login step.
+          curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh | sudo sh -s -- --no-package-manager
+          doppler --version
 
-      - name: Fetch GCP creds from Infisical
-        # Authenticate the Machine Identity, then pull GCP_PROJECT_ID
-        # and GCP_SA_KEY from the goldenmatch Infisical project
-        # (a99885f0-c5af-4ae1-9dc8-255cc60aa129, dev env). The values are masked in subsequent
-        # logs via ::add-mask::. The SA JSON is written to disk and
-        # GOOGLE_APPLICATION_CREDENTIALS points at it; the project id
-        # is exported as a job-scope env var so the render + sweep
-        # steps see it without ${{ secrets.* }}.
+      - name: Fetch GCP creds from Doppler
+        # Pull GCP_PROJECT_ID and the SA key from Doppler project `showcase`,
+        # config `dev`. Both live in the service token, so no project/config
+        # flags and no login round-trip -- the token IS the scope. The values
+        # are masked in later logs via ::add-mask::; the SA JSON is written to
+        # disk and GOOGLE_APPLICATION_CREDENTIALS points at it, and the project
+        # id is exported job-scope so the render + sweep steps see it without
+        # reaching for ${{ secrets.* }} again.
         env:
-          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
-          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${INFISICAL_CLIENT_ID:-}" ] || [ -z "${INFISICAL_CLIENT_SECRET:-}" ]; then
-            echo "::error::INFISICAL_CLIENT_ID or INFISICAL_CLIENT_SECRET not set; see docs/distributed/ray-gce-cluster.md"
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN not set; see docs/distributed/ray-gce-cluster.md"
             exit 1
           fi
-          INFISICAL_TOKEN=$(infisical login --silent --plain \
-            --method=universal-auth \
-            --client-id="$INFISICAL_CLIENT_ID" \
-            --client-secret="$INFISICAL_CLIENT_SECRET")
-          echo "::add-mask::$INFISICAL_TOKEN"
 
-          # GCP_RAY_BENCH_PROJECT_ID is the project where the bench SA
-          # lives and the required APIs are enabled (golden-490919).
-          # The team's GOOGLE_CLOUD_PROJECT secret points elsewhere
-          # (gen-lang-client-* Vertex project) -- using it would 403
-          # the SA on every cloudresourcemanager call. Surfaces it
-          # locally as GCP_PROJECT_ID for the rest of this workflow.
-          GCP_PROJECT_ID=$(infisical secrets get GCP_RAY_BENCH_PROJECT_ID \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN")
+          # GCP_RAY_BENCH_PROJECT_ID is the project where the bench SA lives
+          # and the required APIs are enabled (golden-490919). The team's
+          # GOOGLE_CLOUD_PROJECT points elsewhere (a gen-lang-client-* Vertex
+          # project) -- using it would 403 the SA on every
+          # cloudresourcemanager call. Surfaced locally as GCP_PROJECT_ID.
+          GCP_PROJECT_ID=$(doppler secrets get GCP_RAY_BENCH_PROJECT_ID --plain)
+          if [ -z "$GCP_PROJECT_ID" ]; then
+            echo "::error::GCP_RAY_BENCH_PROJECT_ID came back empty from Doppler."
+            exit 1
+          fi
           echo "::add-mask::$GCP_PROJECT_ID"
 
           # SA key is stored base64-encoded under GCP_SA_KEY_B64. Decode
-          # straight to disk (never echo). base64 -d is GNU coreutils;
-          # uses --ignore-garbage to tolerate any leading whitespace
-          # the Infisical CLI might emit alongside the value.
-          infisical secrets get GCP_SA_KEY_B64 \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN" \
-            | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
+          # straight to disk (never echo). `--ignore-garbage` tolerates any
+          # stray whitespace around the value.
+          doppler secrets get GCP_SA_KEY_B64 --plain             | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
           chmod 600 "$HOME/gcp-sa.json"
 
           # Sanity: the decoded file must be a JSON object. Validates the
@@ -164,7 +156,7 @@ jobs:
       - name: Render cluster.yaml with project + git SHA
         run: |
           set -euo pipefail
-          # GCP_PROJECT_ID is in $GITHUB_ENV from the Infisical fetch
+          # GCP_PROJECT_ID is in $GITHUB_ENV from the Doppler fetch
           # step. Inject project_id, git SHA, cluster_name, max_workers.
           sed -i "s|GOLDENMATCH_GCP_PROJECT_PLACEHOLDER|$GCP_PROJECT_ID|g" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_GIT_SHA_PLACEHOLDER|${{ github.sha }}|g" .ray/cluster-gce.yaml
@@ -342,9 +334,9 @@ jobs:
         if: always()
         run: |
           # $GCP_PROJECT_ID + $GOOGLE_APPLICATION_CREDENTIALS were
-          # exported in $GITHUB_ENV by the Infisical fetch step.
+          # exported in $GITHUB_ENV by the Doppler fetch step.
           if [ -z "${GCP_PROJECT_ID:-}" ]; then
-            echo "GCP_PROJECT_ID not in env -- earlier step failed before Infisical fetch; nothing to sweep."
+            echo "GCP_PROJECT_ID not in env -- earlier step failed before the Doppler fetch; nothing to sweep."
             exit 0
           fi
           gcloud auth activate-service-account \

--- a/.github/workflows/bench-spark-gce-cluster.yml
+++ b/.github/workflows/bench-spark-gce-cluster.yml
@@ -90,9 +90,10 @@
 # the master VM puts both drivers inside the cluster's own network and keeps
 # the two engines symmetric -- which is the whole point of a comparison.
 #
-# Required GitHub secrets: INFISICAL_CLIENT_ID / INFISICAL_CLIENT_SECRET.
-# Everything GCP is pulled from Infisical at runtime, exactly as
-# bench-ray-cluster.yml does it -- no new GH secrets.
+# Required GitHub secret: DOPPLER_TOKEN (read-only, showcase/dev).
+# Everything GCP is pulled from Doppler (project `showcase`, config
+# `dev`) at runtime, exactly as bench-ray-cluster.yml does it -- one
+# shared token, no new GH secrets.
 name: bench-spark-gce-cluster
 
 on:
@@ -181,72 +182,49 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
-      - name: Fetch GCP creds from Infisical
-        # Identical mechanism to bench-ray-cluster.yml -- same Machine Identity,
+      - name: Fetch GCP creds from Doppler
+        # Identical mechanism to bench-ray-cluster.yml -- same service token,
         # same project, same masking. Reusing it rather than adding GH secrets
         # keeps one auth path to audit.
         env:
-          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
-          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${INFISICAL_CLIENT_ID:-}" ] || [ -z "${INFISICAL_CLIENT_SECRET:-}" ]; then
-            echo "::error::INFISICAL_CLIENT_ID / INFISICAL_CLIENT_SECRET not set; see docs/distributed/ray-gce-cluster.md"
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN not set; see docs/distributed/ray-gce-cluster.md"
             exit 1
           fi
-          # Infisical's REST API directly, NOT the CLI. Installing the CLI needs
-          # apt, and apt on a GitHub-hosted runner needs a lock the runner's own
-          # housekeeping holds: runs 32271581601, 32273435168, 32276315793 and
-          # 32278438000 all died there, the last one with
+          # Doppler's REST API directly, NOT the CLI -- this job installs no
+          # package manager on purpose. Installing a CLI via apt needs a lock
+          # the runner's own housekeeping holds: runs 32271581601, 32273435168,
+          # 32276315793 and 32278438000 all died there, the last one with
           #
           #     apt lock still held after 450s
           #     E: Could not get lock /var/lib/apt/lists/lock.
           #        It is held by process 2199 (apt-get)
           #
-          # after waiting for it and retrying three times. There is no published
-          # standalone binary to fall back to (checked: the CLI's releases carry
-          # no assets), so the way to stop losing runs to a package manager is
-          # to stop needing one. `curl` and `jq` are preinstalled.
+          # after waiting for it and retrying three times. `curl` and `jq` are
+          # preinstalled, so needing neither apt nor a downloaded binary keeps
+          # this job's dependency surface at zero.
           #
-          # Same Machine Identity, same project, same secrets, same masking --
-          # only the transport changes. Routes verified against the live API
-          # before this was written, using NO credentials: an empty POST to the
-          # login route returns 422 and a bogus one returns 401 "Invalid
-          # credentials", which proves both the path and the field names; the
-          # secret routes return 401 rather than 404, which proves they exist.
-          API="${INFISICAL_API:-https://app.infisical.com}"
-          PROJECT_ID=a99885f0-c5af-4ae1-9dc8-255cc60aa129
-          ENV_SLUG=dev
-
-          # Built with jq rather than string interpolation so a quote or
-          # backslash in the client secret cannot break the JSON.
-          LOGIN_BODY=$(jq -nc --arg id "$INFISICAL_CLIENT_ID" \
-                              --arg sec "$INFISICAL_CLIENT_SECRET" \
-                              '{clientId:$id, clientSecret:$sec}')
-          LOGIN=$(curl -sS --max-time 60 -X POST "$API/api/v1/auth/universal-auth/login" \
-                    -H 'Content-Type: application/json' -d "$LOGIN_BODY")
-          TOKEN=$(jq -r '.accessToken // empty' <<<"$LOGIN")
-          if [ -z "$TOKEN" ]; then
-            echo "::error::Infisical login failed: $(jq -r '.message // "no accessToken in response"' <<<"$LOGIN")"
+          # A Doppler service token authenticates as HTTP Basic with the token
+          # as the username and an empty password, and carries its own
+          # project/config -- so this is ONE unauthenticated-looking request
+          # with no login round-trip, where Infisical needed a login POST plus
+          # a per-secret GET with two API-version fallbacks.
+          BODY=$(curl -sS --max-time 60 --retry 3 -u "$DOPPLER_TOKEN:"                    "https://api.doppler.com/v3/configs/config/secrets/download?format=json")
+          if ! jq -e . >/dev/null 2>&1 <<<"$BODY"; then
+            echo "::error::Doppler returned a non-JSON response (token invalid or revoked?)"
             exit 1
           fi
-          echo "::add-mask::$TOKEN"
 
-          # v3-raw first, v4 as fallback: both are live today and the pair
-          # survives either being retired. Only the VALUE goes to stdout, so a
-          # diagnostic can never be captured as a secret.
+          # Only the VALUE reaches a variable; a diagnostic can never be
+          # captured as a secret.
           get_secret() {
-            local name="$1" out val
-            out=$(curl -sS --max-time 60 -H "Authorization: Bearer $TOKEN" \
-                  "$API/api/v3/secrets/raw/$name?workspaceId=$PROJECT_ID&environment=$ENV_SLUG&secretPath=%2F") || true
-            val=$(jq -r '.secret.secretValue // empty' <<<"$out")
+            local name="$1" val
+            val=$(jq -r --arg n "$name" '.[$n] // empty' <<<"$BODY")
             if [ -z "$val" ]; then
-              out=$(curl -sS --max-time 60 -H "Authorization: Bearer $TOKEN" \
-                    "$API/api/v4/secrets/$name?projectId=$PROJECT_ID&environment=$ENV_SLUG&secretPath=%2F") || true
-              val=$(jq -r '.secret.secretValue // empty' <<<"$out")
-            fi
-            if [ -z "$val" ]; then
-              echo "::error::could not read $name from Infisical: $(jq -r '.message // "empty value from both v3 and v4"' <<<"$out")" >&2
+              echo "::error::could not read $name from Doppler showcase/dev" >&2
               return 1
             fi
             printf '%s' "$val"
@@ -255,14 +233,9 @@ jobs:
           PROJ=$(get_secret GCP_RAY_BENCH_PROJECT_ID)
           echo "::add-mask::$PROJ"
 
-          get_secret GCP_SA_KEY_B64 \
-            | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
+          get_secret GCP_SA_KEY_B64             | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
           chmod 600 "$HOME/gcp-sa.json"
           python3 -c "import json; json.load(open('$HOME/gcp-sa.json'))"
-
-          echo "GCP_PROJECT_ID=$PROJ" >> $GITHUB_ENV
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-sa.json" >> $GITHUB_ENV
-
       - name: Authenticate gcloud
         run: |
           set -euo pipefail
@@ -1164,8 +1137,9 @@ jobs:
           # fails BEFORE provisioning never sets it. Under `set -u` the bare
           # expansion aborts the step on line 1, which also skipped the GCS
           # cleanup below -- teardown failing open is the one thing it must
-          # never do. Surfaced by run 32276315793, where the Infisical step
-          # failed early for the first time and teardown died with
+          # never do. Surfaced by run 32276315793, where the creds-fetch step
+          # (Infisical, at the time) failed early for the first time and
+          # teardown died with
           # `NODE_NAMES: unbound variable`.
           if [ -z "${NODE_NAMES:-}" ]; then
             echo "no instances were provisioned; nothing to delete"

--- a/.github/workflows/score-distributed-assignments.yml
+++ b/.github/workflows/score-distributed-assignments.yml
@@ -33,30 +33,31 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install scorer deps + Infisical CLI
+      - name: Install scorer deps + Doppler CLI
         run: |
           pip install --upgrade pip
           pip install "polars>=1.25" "numpy>=1.26"
-          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
-          sudo apt-get update && sudo apt-get install -y infisical
+          curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh | sudo sh -s -- --no-package-manager
+          doppler --version
 
-      - name: Fetch GCP creds from Infisical
+      - name: Fetch GCP creds from Doppler
+        # Doppler project `showcase`, config `dev`. The service token carries
+        # its own scope, so there is no login step and no project/config flags.
         env:
-          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
-          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           set -euo pipefail
-          INFISICAL_TOKEN=$(infisical login --silent --plain \
-            --method=universal-auth \
-            --client-id="$INFISICAL_CLIENT_ID" \
-            --client-secret="$INFISICAL_CLIENT_SECRET")
-          echo "::add-mask::$INFISICAL_TOKEN"
-          GCP_PROJECT_ID=$(infisical secrets get GCP_RAY_BENCH_PROJECT_ID \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN")
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN not set; see docs/distributed/ray-gce-cluster.md"
+            exit 1
+          fi
+          GCP_PROJECT_ID=$(doppler secrets get GCP_RAY_BENCH_PROJECT_ID --plain)
+          if [ -z "$GCP_PROJECT_ID" ]; then
+            echo "::error::GCP_RAY_BENCH_PROJECT_ID came back empty from Doppler."
+            exit 1
+          fi
           echo "::add-mask::$GCP_PROJECT_ID"
-          infisical secrets get GCP_SA_KEY_B64 \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN" \
-            | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
+          doppler secrets get GCP_SA_KEY_B64 --plain             | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
           chmod 600 "$HOME/gcp-sa.json"
           gcloud auth activate-service-account --key-file="$HOME/gcp-sa.json" --project="$GCP_PROJECT_ID"
 

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -57,38 +57,36 @@ gcloud iam service-accounts keys create gm-ray-bench-key.json \
     --iam-account="$SA_EMAIL"
 ```
 
-### 3. Store the GCP creds in Infisical
+### 3. Store the GCP creds in Doppler
 
-The workflow pulls these at runtime from Infisical project
-`a99885f0-c5af-4ae1-9dc8-255cc60aa129`, env `dev`, under the team's
-existing naming convention:
+The workflows pull these at runtime from Doppler project `showcase`,
+config `dev`:
 
-| Infisical secret name | Format | Decoded form |
+| Doppler secret name | Format | Decoded form |
 |---|---|---|
-| `GCP_RAY_BENCH_PROJECT_ID` | plain string | the GCP project id where the bench SA lives (e.g. `golden-490919`) |
-| `GCP_SA_KEY_B64` | base64-encoded | service account JSON |
+| `GCP_RAY_BENCH_PROJECT_ID` | plain string | the GCP project id where the bench SA lives (`golden-490919`) |
+| `GCP_SA_KEY_B64` | base64-encoded | service account JSON (`goldenmatch-vertex-bench@golden-490919`) |
 
 `GCP_RAY_BENCH_PROJECT_ID` is a Ray-bench-specific name on purpose -- the
-team's existing `GOOGLE_CLOUD_PROJECT` secret points at a different
-project used for Vertex AI work. Reusing it would 403 the bench SA on
-every cloudresourcemanager call.
+existing `GOOGLE_CLOUD_PROJECT` secret points at a different project used
+for Vertex AI work. Reusing it would 403 the bench SA on every
+cloudresourcemanager call.
 
-The workflow base64-decodes `GCP_SA_KEY_B64` and writes the JSON
-straight to disk; the raw bytes never round-trip through env vars.
+The workflows base64-decode `GCP_SA_KEY_B64` and write the JSON straight
+to disk; the raw bytes never round-trip through env vars.
 
-Set them with `infisical secrets set` (redirect stdout to `$null` so
-values don't echo into the terminal):
+Set them by piping the value in, never as an argument -- an argument
+lands in shell history and in the process table:
 
 ```powershell
 # Project id (plain)
-$projectId = (gcloud config get-value project)
-infisical.cmd secrets set --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev `
-    GOOGLE_CLOUD_PROJECT=$projectId > $null
+gcloud config get-value project | doppler secrets set GCP_RAY_BENCH_PROJECT_ID `
+    --scope "D:\personal" -p showcase -c dev --silent
 
 # Service account JSON: base64-encode locally, store the encoded form
 $saB64 = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("gm-ray-bench-key.json"))
-infisical.cmd secrets set --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev `
-    GCP_SA_KEY_B64=$saB64 > $null
+$saB64 | doppler secrets set GCP_SA_KEY_B64 `
+    --scope "D:\personal" -p showcase -c dev --silent
 Remove-Variable saB64
 Remove-Item gm-ray-bench-key.json   # don't keep the JSON on disk
 ```
@@ -96,39 +94,51 @@ Remove-Item gm-ray-bench-key.json   # don't keep the JSON on disk
 Verify by name only (no values):
 
 ```powershell
-infisical.cmd secrets --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev | Select-String "GOOGLE_CLOUD_PROJECT|GCP_SA_KEY_B64"
+doppler secrets --scope "D:\personal" -p showcase -c dev --only-names |
+    Select-String "GCP_RAY_BENCH_PROJECT_ID|GCP_SA_KEY_B64"
 ```
 
-### 4. Create a Machine Identity for GitHub Actions
+### 4. Create the Doppler service token for GitHub Actions
 
-The workflow authenticates to Infisical via a dedicated Machine
-Identity using Universal Auth (client id + secret pair):
-
-1. Infisical web UI → `goldenmatch` project → Access Control →
-   Machine Identities → Create.
-2. Name: `goldenmatch-bench-ray-cluster`. Auth method: **Universal
-   Auth**. Trusted IPs: `0.0.0.0/0` (Actions runners are dynamic;
-   restrict later if needed).
-3. Project permissions: read-only on env `dev` for
-   `GOOGLE_CLOUD_PROJECT` and `GCP_SA_KEY_B64` (the only two secrets
-   the workflow fetches).
-4. Copy the generated **Client ID** and **Client Secret**. The
-   secret is shown ONCE.
-
-### 5. Set the two GitHub Actions secrets
+A service token carries its own project and config, so the workflows need
+no login step and no scope flags -- the token *is* the scope. Create it
+read-only:
 
 ```sh
-gh secret set INFISICAL_CLIENT_ID \
-    --repo benseverndev-oss/goldenmatch \
-    --body "<paste client id>"
-
-gh secret set INFISICAL_CLIENT_SECRET \
-    --repo benseverndev-oss/goldenmatch \
-    --body "<paste client secret>"
+doppler configs tokens create gh-actions-goldenmatch \
+    --scope "D:\personal" -p showcase -c dev --access read --plain
 ```
 
-These two are the ONLY GH-Actions secrets the workflow needs. Future
-Infisical-backed secrets reuse the same auth pair.
+The value is printed ONCE. Pipe it straight into the GitHub secret rather
+than pasting it, so it never reaches the terminal or shell history:
+
+```sh
+doppler configs tokens create gh-actions-goldenmatch \
+    --scope "D:\personal" -p showcase -c dev --access read --plain \
+  | gh secret set DOPPLER_TOKEN --repo benseverndev-oss/goldenmatch
+```
+
+Confirm the token can read both secrets and cannot write, before relying
+on it -- a token that silently fails looks exactly like a workflow bug:
+
+```sh
+doppler secrets get GCP_RAY_BENCH_PROJECT_ID --plain --token "$TOK"   # -> golden-490919
+printf '%s' x | doppler secrets set CANARY --silent --token "$TOK"    # must be REFUSED
+```
+
+### 5. Set the GitHub Actions secret
+
+`DOPPLER_TOKEN` is the ONLY GH-Actions secret these workflows need --
+one, where the previous Infisical setup needed a client id and secret
+pair. Future Doppler-backed secrets ride the same token.
+
+Rotate by creating a replacement token, updating the GH secret, then
+revoking the old one by slug:
+
+```sh
+doppler configs tokens --scope "D:\personal" -p showcase -c dev --json
+doppler configs tokens revoke <slug> --scope "D:\personal" -p showcase -c dev
+```
 
 ### 6. Dispatch the workflow
 


### PR DESCRIPTION
The secrets moved on 2026-08-21 — personal Doppler carries a `showcase` project whose own description reads *"Migrated from the shared Infisical workspace a99885f0"* — but the workflows never followed. `GCP_RAY_BENCH_PROJECT_ID` and `GCP_SA_KEY_B64` have been sitting in Doppler `showcase/dev` the whole time while three workflows kept reading them from Infisical.

| Workflow | Was | Now |
|---|---|---|
| `bench-ray-cluster.yml` | Infisical CLI, apt install | Doppler CLI, no package manager |
| `score-distributed-assignments.yml` | Infisical CLI, apt install | Doppler CLI, no package manager |
| `bench-spark-gce-cluster.yml` | raw Infisical REST (deliberately no package manager) | raw Doppler REST |

A service token carries its own project and config, so each workflow loses its login round-trip and its scope flags. **One GH secret (`DOPPLER_TOKEN`) replaces the `INFISICAL_CLIENT_ID`/`INFISICAL_CLIENT_SECRET` pair.**

## Two things worth calling out

**The installs now pass `--no-package-manager`.** `bench-spark` deliberately used raw curl because apt on a GitHub runner needs a lock the runner's own housekeeping holds — four runs died there (32271581601, 32273435168, 32276315793, 32278438000), the last after waiting 450s and retrying three times. Doppler's installer can skip the package manager entirely, so that constraint is now satisfied *by construction* rather than by avoiding the CLI. `bench-spark` still uses REST, which for Doppler is a **single** basic-auth request against `/v3/configs/config/secrets/download?format=json` — no login POST, no per-secret GET with two API-version fallbacks.

**Every fetch now fails loudly on an empty value.** A silently-empty credential is indistinguishable from a workflow bug and would otherwise surface as a GCP 403 several steps later.

## Verified, not assumed

- A throwaway token proved the REST shape: returns JSON, both keys present, `GCP_RAY_BENCH_PROJECT_ID` → `golden-490919`, and `GCP_SA_KEY_B64` base64-decodes to `goldenmatch-vertex-bench@golden-490919.iam.gserviceaccount.com`.
- The shipped token was separately confirmed to **read** both secrets and to have a **write refused** — it is genuinely read-only.
- Both probe tokens were revoked; one read-only token remains.
- `bash -n` on every changed run block.
- `zizmor` finding counts go **down by one on all three files** (one fewer secret to handle), with none added.

## Deliberately not done

The `INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET` repo secrets are **not** deleted here. They should go after a green dispatch proves the Doppler path, not before it — deleting them first turns a fixable misconfiguration into a locked-out lane.

Historical Infisical references in `docs/superpowers/{specs,plans}` are left alone: those are records of past work and rewriting them would falsify history. `bench-er-kg.yml` and `docs/oss-llm-usage.md` mention Infisical for *different* credentials (OpenAI, Modal) and are out of scope for this change.