### PR TITLE
fix(ci): make the ray bench lane measure one variable, and actually run native

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -89,6 +89,10 @@ on:
         description: "#957: block-shuffle partition count (empty = the harness default 512)"
         required: false
         default: ""
+      ray_version:
+        description: "Ray version for BOTH launcher and cluster image. Default 2.56.0 = goldenmatch's own declared [ray] floor, one minor above the 2.55.1 that produced the June baseline. Pinned so a sweep varies the knob and not Ray. Empty = float to latest."
+        required: false
+        default: "2.56.0"
       head_machine:
         description: "Head node machine type (the driver generates the full frame in memory; highmem for distributed runs). 100M: n2-highmem-32 (256 GB); 200M: n2-highmem-64 (512 GB)."
         required: false
@@ -100,14 +104,13 @@ permissions:
 jobs:
   ray-cluster-bench:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       # We render `.ray/cluster-gce.yaml` from the placeholder template
       # at workflow runtime so each dispatch sees a fresh cluster name
       # (avoids collisions if two dispatches overlap) and the right
       # project_id + git SHA.
       CLUSTER_NAME: "goldenmatch-bench-${{ github.run_id }}"
-      RAY_RELEASE: "2.43.0"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
@@ -120,14 +123,22 @@ jobs:
         # version pin matches the cluster.yaml docker image. The Doppler
         # CLI fetches GCP creds at runtime so the GCP secrets stay in
         # one place instead of accumulating GH-Actions copies.
+        env:
+          RAY_VERSION_INPUT: ${{ inputs.ray_version }}
         run: |
           pip install --upgrade pip
-          # Install the LATEST Ray (matches CI's `ray[default]>=2.0`), then render
+          # Install the requested Ray (matches CI's `ray[default]>=2.0`), then render
           # the cluster's docker image to the SAME version so launcher==cluster and
           # both carry the Ray Data API the distributed pipeline needs
           # (`repartition(num_partitions, keys=[...])`, added after 2.43 -- the old
           # pin made the golden/WCC steps TypeError on `keys`).
-          pip install "ray[default]" "google-api-python-client"
+          if [ -n "${RAY_VERSION_INPUT:-}" ]; then
+            echo "Pinning Ray to $RAY_VERSION_INPUT (dispatch input)"
+            pip install "ray[default]==$RAY_VERSION_INPUT" "google-api-python-client"
+          else
+            echo "::warning::ray_version empty -- floating to latest. Pin it instead: a sweep against a moving Ray varies two things at once."
+            pip install "ray[default]" "google-api-python-client"
+          fi
           pip install pyyaml
           RAY_VER=$(python -c "import ray; print(ray.__version__)")
           echo "RAY_VER=$RAY_VER" >> "$GITHUB_ENV"

--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -89,6 +89,10 @@ on:
         description: "#957: block-shuffle partition count (empty = the harness default 512)"
         required: false
         default: ""
+      bucket_debug:
+        description: "1 = per-bucket prep-vs-kernel-vs-postfilter timing from the scorer (GOLDENMATCH_BUCKET_DEBUG). Output-invariant; costs an env read and a perf_counter per bucket. Splits time between the Rust kernel and the frame prep around it (sort + group_by + to_arrow), which is what tells you whether a knob moved the kernel or the wrapping. Worth having on for a baseline run."
+        required: false
+        default: "0"
       ray_version:
         description: "Ray version for BOTH launcher and cluster image. Default 2.56.0 = goldenmatch's own declared [ray] floor, one minor above the 2.55.1 that produced the June baseline. Pinned so a sweep varies the knob and not Ray. Empty = float to latest."
         required: false
@@ -305,6 +309,7 @@ jobs:
           OP_RESERVATION: ${{ inputs.op_reservation }}
           SHUFFLE_PARTS: ${{ inputs.shuffle_parts }}
           DISTRIBUTED: ${{ inputs.distributed }}
+          BUCKET_DEBUG: ${{ inputs.bucket_debug }}
         run: |
           set -euo pipefail
           mkdir -p .profile_tmp/qis
@@ -325,6 +330,14 @@ jobs:
             "") ;;
             *) echo "::error::score_project must be 1, 0, or empty (got '$SCORE_PROJECT')"; exit 1 ;;
           esac
+          if [ "$BUCKET_DEBUG" = "1" ]; then
+            # The scorer runs inside the Ray WORKERS, so this has to be set on
+            # the cluster rather than in this shell. Written into the container's
+            # bashrc so every later `docker exec` -- including the ray submit
+            # driver and the raylet's children -- picks it up.
+            echo "enabling GOLDENMATCH_BUCKET_DEBUG on all nodes"
+            ray exec .ray/cluster-gce.yaml               "echo 'export GOLDENMATCH_BUCKET_DEBUG=1' >> ~/.bashrc" ||               echo "::warning::could not set BUCKET_DEBUG on the cluster; continuing without it"
+          fi
           # `${KNOBS[@]+...}` guards the empty-array case under `set -u`.
           echo "score knobs -> ${KNOBS[*]+${KNOBS[*]}}"
           if [ "$DISTRIBUTED" != "1" ] && [ ${#KNOBS[@]} -gt 0 ]; then

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -42,6 +42,20 @@ rsync_exclude:
 # series; the bench container layer installs goldenmatch on top via
 # pip.
 docker:
+  # Container-wide env, set at `docker run`. This is the ONLY placement that
+  # reaches every process: `head_start_ray_commands` exports below cover the
+  # raylet and the workers it spawns, but `ray submit` runs the DRIVER through a
+  # fresh `docker exec`, and Ray's `with_docker_exec` forwards only its OWN env
+  # vars (RAY_HEAD_IP and friends) -- so a shell export never arrives there.
+  # Same failure shape as the #957 score knobs. Without this the driver runs
+  # under NATIVE=auto, which is the GATED ALLOWLIST rather than full native
+  # acceleration, and a missing kernel degrades silently there instead of
+  # raising. Belt and braces with the exports below: harmless if both are set.
+  run_options:
+    - "--env"
+    - "GOLDENMATCH_NATIVE=1"
+    - "--env"
+    - "GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1"
   # Rendered to the launcher's resolved Ray version at dispatch time (see the
   # bench-ray-cluster workflow) so the cluster has the same Ray Data API as the
   # distributed pipeline code (`repartition(num_partitions, keys=[...])`). The


### PR DESCRIPTION
Auditing the lane before spending on a 100M dispatch. Four problems, each of which would have cost a run or quietly invalidated one.

## 1. The driver was never running full native

`GOLDENMATCH_NATIVE=1` was exported in `head_start_ray_commands` — which covers the raylet and the workers it spawns, but **not the driver**. `ray submit` runs the driver through a fresh `docker exec`, and Ray's `with_docker_exec` forwards only its *own* env vars (`RAY_HEAD_IP` and friends). Confirmed from Ray's source, not inferred.

This is the same failure shape as the score knobs in #2768: **a value set around the submit does not survive the submit.**

So the driver ran under `NATIVE=auto` — the *gated allowlist*, not full native acceleration — and a missing kernel would have degraded silently there instead of raising, which is the exact thing `GOLDENMATCH_NATIVE=1` exists to prevent. Fixed with docker `run_options`, which apply at `docker run` and are inherited by every later `docker exec`. The existing exports stay: harmless, and they still work if the docker block is bypassed.

## 2. Ray floated, so a sweep would vary two things

`pip install "ray[default]"` resolved whatever was newest and the cluster image is rendered from it. The June 100M baseline was **2.55.1**; today that resolves **2.58.0**, and `rayproject/ray:2.58.0-py312` exists — so it wouldn't have failed loudly, it would have quietly measured a different engine.

Now a `ray_version` input pins both launcher and image, defaulting to **2.56.0** — goldenmatch's own declared `[ray]` floor, one minor above the baseline rather than three.

## 3. `RAY_RELEASE: "2.43.0"` was dead

Nothing had read it since the image tag started rendering from the resolved version. A stale pin next to a floating install reads as a pin that isn't one.

## 4. 120 minutes wasn't enough headroom

The 100M baseline used **74** of them. A knob that makes the run slower is a legitimate result, but at 120 min a ~60% regression is lost to a timeout — paying for the cluster and learning nothing. Raised to 180.

Plus a `bucket_debug` input that splits each bucket into kernel vs frame-prep vs post-filter, so a sweep can say whether a knob moved the Rust kernel or the work around it. Output-invariant. It has to be set on the cluster rather than in the dispatching shell, for the same reason as everything above.

## Verified, not assumed

- **No wheel/caller symbol skew.** Extracted the `.so` from the published `goldenmatch-native 0.2.0` wheel and grepped it for all **25** symbols the Python reaches through the `AttributeError` fallback — all present. Crate version matches the published wheel, with only a clippy fix and a `Cargo.lock` regen since.
- **The config already qualifies for the arrow kernel.** Every scorer in the frozen config is `jaro_winkler` or `exact` (native ids 0 and 3), so the whole matchkey set takes the single `score_block_pairs_arrow` call per bucket.
- Live project state: machine types available in `us-central1-a`; `N2_CPUS` quota 200 vs the 80 needed; scratch bucket exists and the node SA holds `storage.objectAdmin` on it; `ubuntu-2204-lts` resolves to a READY image.
- `zizmor` finding count identical to baseline (23); `bash -n` clean on every changed run block.

## Deliberately not touched

The frozen config's matchkeys are `exact` + `weighted`, so the **44 `GOLDENMATCH_FS_*` knobs do not apply** to this run. `COLUMNAR_PIPELINE` stays off — measured slower with higher RSS.

**No Polars added anywhere** (`git diff` for added polars lines is empty). The distributed hot path does still require it — `_explode` and `_score` call `pl.from_arrow(...)` with no pyarrow fallback — which is why the cluster installs it. That's a pre-existing island already counted in `docs/superpowers/plans/2026-08-10-arrow-seam-hardening.md` (6 sites in `distributed/scoring.py`), and porting it is that plan's work, not a bench-config change.