### PR TITLE
fix(ci): make the bench lane's zone a dispatch input

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -97,6 +97,10 @@ on:
         description: "Ray version for BOTH launcher and cluster image. Default 2.56.0 = goldenmatch's own declared [ray] floor, one minor above the 2.55.1 that produced the June baseline. Pinned so a sweep varies the knob and not Ray. Empty = float to latest."
         required: false
         default: "2.56.0"
+      zone: 
+        description: "GCE zone. Capacity is per-zone and independent of quota -- on ZONE_RESOURCE_POOL_EXHAUSTED, retry in another zone rather than waiting. n2-highmem-32/-64 and n2-standard-16 are offered in us-central1-{a,b,c,f}."
+        required: false
+        default: "us-central1-a"
       head_machine:
         description: "Head node machine type (the driver generates the full frame in memory; highmem for distributed runs). 100M: n2-highmem-32 (256 GB); 200M: n2-highmem-64 (512 GB)."
         required: false
@@ -196,6 +200,10 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-sa.json" >> $GITHUB_ENV
 
       - name: Render cluster.yaml with project + git SHA
+        env:
+          # Through the environment, not interpolated into the script body: a
+          # `${{ }}` expansion inside `run:` is a template-injection seam.
+          ZONE_INPUT: ${{ inputs.zone }}
         run: |
           set -euo pipefail
           # GCP_PROJECT_ID is in $GITHUB_ENV from the Doppler fetch
@@ -205,6 +213,7 @@ jobs:
           sed -i "s|cluster_name: goldenmatch-bench$|cluster_name: ${{ env.CLUSTER_NAME }}|" .ray/cluster-gce.yaml
           sed -i "s|max_workers: 3$|max_workers: ${{ inputs.max_workers }}|" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_HEAD_MACHINE_PLACEHOLDER|${{ inputs.head_machine }}|g" .ray/cluster-gce.yaml
+          sed -i "s|GOLDENMATCH_ZONE_PLACEHOLDER|${ZONE_INPUT}|g" .ray/cluster-gce.yaml
           # Pin the cluster docker image to the launcher's resolved Ray version so
           # the cluster has the same Ray Data API (repartition keys=) as the code.
           sed -i "s|GOLDENMATCH_RAY_VERSION_PLACEHOLDER|${RAY_VER}|g" .ray/cluster-gce.yaml

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -14,7 +14,15 @@ cluster_name: goldenmatch-bench
 provider:
   type: gcp
   region: us-central1
-  availability_zone: us-central1-a
+  # Rendered from the `zone` dispatch input. NOT cosmetic: GCP capacity is
+  # per-zone and independent of quota -- run 32883530356 died on
+  # ZONE_RESOURCE_POOL_EXHAUSTED for n2-highmem-32 in us-central1-a with
+  # N2_CPUS quota at 0/200. Quota says what you are ALLOWED, capacity says what
+  # exists right now, and only the second one was the problem. With the zone
+  # hardcoded the only recovery was editing this file, so a transient capacity
+  # dip blocked the lane entirely. n2-highmem-32/-64 and n2-standard-16 are all
+  # offered in us-central1-{a,b,c,f}.
+  availability_zone: GOLDENMATCH_ZONE_PLACEHOLDER
   # project_id is injected by the workflow at dispatch time so the same
   # cluster.yaml works across MJH GCP projects.
   project_id: GOLDENMATCH_GCP_PROJECT_PLACEHOLDER


### PR DESCRIPTION
Run [32883530356](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32883530356) died 88 seconds in:

```
ZONE_RESOURCE_POOL_EXHAUSTED: A n2-highmem-32 VM instance is currently
unavailable in the us-central1-a zone.
```

…with `N2_CPUS` quota sitting at **0/200**.

**Quota says what you're allowed to run; capacity says what actually exists in that zone right now.** Only the second was the problem, and a pre-flight quota check cannot see it — I'd checked quota before dispatching and it told me nothing about this.

The zone was hardcoded in `cluster-gce.yaml`, so the only recovery was editing a committed file and waiting for it to merge — a transient capacity dip blocked the lane completely. It's now a dispatch input, so the answer to an exhausted zone is a re-dispatch. `n2-highmem-32`/`-64` and `n2-standard-16` are all offered in `us-central1-{a,b,c,f}`. Default stays `us-central1-a`, so nothing changes for a run that doesn't set it.

Read through `env:` rather than interpolated into the run block — the inline form is a template-injection seam and put zizmor one finding above baseline; via `env:` it's back at parity (23). Verified every placeholder in `cluster-gce.yaml` still has a matching `sed` in the render step.

## The shortage is sustained, not momentary

A retry ([32883880798](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32883880798)) into the same zone **failed identically** ~2 minutes later — same `ZONE_RESOURCE_POOL_EXHAUSTED`, same `n2-highmem-32`, same `us-central1-a`, dead at 81 seconds.

That upgrades this change from convenient to **required**: waiting it out is not currently a working strategy, so the lane has no way to run 100M until the zone is selectable.

## Incidental

This is the same class as the existing note in that file about `n2-standard-16` spot capacity being intermittent in `us-central1-a`, which I'd been treating as unproven. Zone capacity there is genuinely flaky for these shapes — worth remembering before reaching for a quota explanation next time.