### PR TITLE
ci(bench): pin the bench environment, and record what actually resolved

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -298,6 +298,41 @@ jobs:
           set -euo pipefail
           ray submit .ray/cluster-gce.yaml scripts/verify_cluster_native.py
 
+      - name: Record the resolved environment
+        # Pins say what we ASKED for; this records what actually landed, which is
+        # the only thing a later comparison can trust. Two axes drifted silently
+        # between the June rung and the 2026-08-25 re-run, and neither was
+        # recoverable afterwards:
+        #   - every Python dependency floated (now pinned in cluster-gce.yaml)
+        #   - the two runs landed in different ZONES, and n2 spans several CPU
+        #     generations, so "same machine type" did not mean same hardware.
+        # GCE reports the actual platform per instance, so capture it rather than
+        # constrain it: minCpuPlatform costs availability, and three of four
+        # zones were already capacity-short on n2-highmem-32.
+        if: always()
+        env:
+          # Through the environment, not interpolated into the script body: a
+          # `${{ }}` expansion inside `run:` is a template-injection seam.
+          LABEL: ${{ inputs.label }}
+          CLUSTER: ${{ env.CLUSTER_NAME }}
+        run: |
+          set -uo pipefail
+          mkdir -p .profile_tmp/qis
+          OUT=".profile_tmp/qis/env_${LABEL}.md"
+          {
+            echo "### bench environment"
+            echo ""
+            echo "| node | machine type | CPU platform |"
+            echo "|---|---|---|"
+            gcloud compute instances list \
+              --filter="name~^ray-${CLUSTER}" \
+              --project="$GCP_PROJECT_ID" \
+              --format="value(name,machineType.basename(),cpuPlatform)" 2>/dev/null \
+              | while read -r nm mt cp; do echo "| $nm | $mt | $cp |"; done
+          } | tee "$OUT" >> $GITHUB_STEP_SUMMARY || true
+          # The exact resolved wheel set, from the head node itself.
+          ray rsync-down .ray/cluster-gce.yaml /tmp/bench_env.txt ".profile_tmp/qis/pipfreeze_${LABEL}.txt" || echo "could not fetch pip freeze from the head (non-fatal)"
+
       - name: Submit bench
         # `ray submit` ships the script to the head node and runs it.
         # The script writes its JSON output to /tmp on the head; we
@@ -408,7 +443,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
           name: "qis-${{ inputs.label }}"
-          path: ".profile_tmp/qis/qis_${{ inputs.label }}.json"
+          # The result AND the environment that produced it. A rung number whose
+          # environment was not captured cannot be compared to anything later --
+          # that is exactly how the June baseline became unattributable.
+          path: |
+            .profile_tmp/qis/qis_${{ inputs.label }}.json
+            .profile_tmp/qis/env_${{ inputs.label }}.md
+            .profile_tmp/qis/pipfreeze_${{ inputs.label }}.txt
           if-no-files-found: warn
 
       - name: Ray down (always)

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -82,12 +82,35 @@ initialization_commands:
 
 # Install goldenmatch from the repo's tag. The bench workflow stamps
 # this from the commit SHA so reruns hit identical code.
+# EXACT pins, not floors. Every one of these floated, and between the June 100M
+# rung and the 2026-08-25 re-run EVERY SINGLE ONE moved:
+#
+#     goldenmatch-native  0.1.6  -> 0.2.0   (11 releases)
+#     polars              1.41.2 -> 1.44.0
+#     pyarrow             24.0.0 -> 25.0.1
+#     numpy               2.4.6  -> 2.5.2
+#     pandas              3.0.3  -> 3.0.5
+#     ray                 2.55.1 -> 2.58.0  (pinned separately, workflow input)
+#
+# The re-run came back 2.43x slower on dedupe with BYTE-IDENTICAL output, and
+# with eight variables moved at once it is not attributable to any of them. A
+# benchmark whose environment floats cannot produce a comparable number, by
+# construction -- the drift is not a detail, it is the reason the lane could not
+# answer the question it exists for.
+#
+# `goldenmatch` itself is already pinned, by git SHA, and stays that way: it is
+# the thing under test.
+#
+# To bump: change a version here in its own commit, so a wall-clock change has
+# exactly one candidate cause. Do NOT loosen these back to `>=`.
 setup_commands:
   - >-
     pip install --upgrade pip &&
-    pip install "polars>=1.0" "pandas>=2,<3" "pyarrow>=10" "psutil>=5.9" "rapidfuzz>=3.0" "jellyfish>=1.0" &&
+    pip install "polars==1.44.0" "pandas==3.0.5" "pyarrow==25.0.1" "numpy==2.5.2"
+    "psutil==7.2.2" "rapidfuzz==3.14.5" "jellyfish==1.2.1" &&
     pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/python/goldenmatch" &&
-    pip install "goldenmatch-native>=0.1.3"
+    pip install "goldenmatch-native==0.2.0" &&
+    pip freeze > /tmp/bench_env.txt
 head_setup_commands: []
 worker_setup_commands: []
 


### PR DESCRIPTION
Between the June 100M rung and the 2026-08-25 re-run, **every dependency moved**:

| | June | re-run |
|---|---|---|
| `goldenmatch-native` | 0.1.6 | **0.2.0** (11 releases) |
| `polars` | 1.41.2 | 1.44.0 |
| `pyarrow` | 24.0.0 | 25.0.1 |
| `numpy` | 2.4.6 | 2.5.2 |
| `pandas` | 3.0.3 | 3.0.5 |
| `ray` | 2.55.1 | 2.58.0 (already pinned separately) |

The re-run came back **2.43x slower on dedupe with byte-identical output**. With eight variables moved at once that isn't attributable to any of them, and no amount of staring at the number fixes it. **A benchmark whose environment floats cannot produce a comparable measurement, by construction** — the drift isn't a detail, it's why the lane couldn't answer the question it exists for.

So: exact `==` pins. `goldenmatch` itself stays pinned by git SHA — it's the thing under test. **Bump one at a time, in its own commit**, so a wall-clock change has exactly one candidate cause.

## Pins are only half of it

They record what we *asked for*. A comparison needs what actually *landed*. Two axes drifted invisibly and neither was recoverable afterwards:

- **The dependency set** — now pinned, and `pip freeze` from the head node is captured into the artifact.
- **The zone.** The two runs landed in different ones, and `n2` spans several CPU generations, so "same machine type" did not mean same hardware. GCE reports the actual `cpuPlatform` per instance; the run now records it into both the step summary and the artifact.

## Why CPU platform is captured, not constrained

`minCpuPlatform` would remove the variable — but it costs availability, and **three of four `us-central1` zones were already capacity-short on `n2-highmem-32` that same day** (runs 32883530356, 32883880798, 32884663720 all died on `ZONE_RESOURCE_POOL_EXHAUSTED`).

Recording costs nothing and answers the question after the fact. Constraining would have stopped the lane running at all. If a future comparison needs the variable *gone* rather than *known*, that's the moment to add the constraint — with the capacity trade made deliberately.

## Verification

`zizmor` holds at baseline (23): the new step reads its inputs through `env:` rather than interpolating them into the run block. `bash -n` clean on every run block, YAML parses.