### PR TITLE
ci(bench): derive the cluster region from the zone input

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -214,6 +214,11 @@ jobs:
           sed -i "s|max_workers: 3$|max_workers: ${{ inputs.max_workers }}|" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_HEAD_MACHINE_PLACEHOLDER|${{ inputs.head_machine }}|g" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_ZONE_PLACEHOLDER|${ZONE_INPUT}|g" .ray/cluster-gce.yaml
+          # Region is the zone minus its trailing letter. Derived, not a second
+          # input, so the pair cannot disagree.
+          REGION="${ZONE_INPUT%-*}"
+          echo "zone=${ZONE_INPUT} -> region=${REGION}"
+          sed -i "s|GOLDENMATCH_REGION_PLACEHOLDER|${REGION}|g" .ray/cluster-gce.yaml
           # Pin the cluster docker image to the launcher's resolved Ray version so
           # the cluster has the same Ray Data API (repartition keys=) as the code.
           sed -i "s|GOLDENMATCH_RAY_VERSION_PLACEHOLDER|${RAY_VER}|g" .ray/cluster-gce.yaml

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -13,7 +13,10 @@
 cluster_name: goldenmatch-bench
 provider:
   type: gcp
-  region: us-central1
+  # Derived from the `zone` input at render time, never set independently: a
+  # region that disagrees with its zone fails at instance creation, and the two
+  # drifting apart is a silent trap the moment the zone becomes selectable.
+  region: GOLDENMATCH_REGION_PLACEHOLDER
   # Rendered from the `zone` dispatch input. NOT cosmetic: GCP capacity is
   # per-zone and independent of quota -- run 32883530356 died on
   # ZONE_RESOURCE_POOL_EXHAUSTED for n2-highmem-32 in us-central1-a with


### PR DESCRIPTION
`region: us-central1` was hardcoded in `cluster-gce.yaml` while the **zone** became a dispatch input in #2771. So the lane could select a zone but not a region — and picking `us-east1-b` would have rendered a config whose region and zone disagreed. That fails at instance creation, and it's a silent trap the moment anyone uses the zone input for what it exists for.

Region is now **the zone minus its trailing letter**, derived at render time rather than added as a second input, so the pair cannot drift apart. Checked both ways: `us-east1-b → us-east1`, `us-central1-a → us-central1`. Nothing changes for a dispatch that leaves the zone at its default.

## Why now

**`us-central1` has no 256 GB-class capacity.** Eight dispatches today across all four zones, on **two independent hardware families**:

| head shape | zones tried | result |
|---|---|---|
| `n2-highmem-32` (Intel N2) | a, b, c, f | all `ZONE_RESOURCE_POOL_EXHAUSTED` |
| `c2d-highmem-32` (AMD C2D) | a, b, c, f | all `ZONE_RESOURCE_POOL_EXHAUSTED` |

Cost was **zero** — every one died at `ray up` before provisioning, teardown clean each time, nothing leaked (verified: no instances, disks or IPs in any zone). But the lane cannot run 100M in this region at present. Both shapes are offered in `us-east1`, `us-east4`, `us-west1` and `us-west4`.

## Same-region scratch

Also created `gs://gm-phase5-844-golden490919-use1` (us-east1), so a cluster there writes WCC checkpoints and assignments to a **same-region** bucket. Cross-region would have worked, but it adds egress and latency to the very stage being measured — the wrong thing to introduce into a benchmark whose entire problem has been uncontrolled variables. Pass it via the existing `wcc_scratch` input; the default stays the us-central1 bucket.

## Verification

`zizmor` holds at baseline (23). Every placeholder in `cluster-gce.yaml` still has a matching `sed` in the render step — I checked explicitly, because adding a placeholder without its render is precisely the failure this change could introduce.