### PR TITLE
fix(qis): restore large_string in the harness frame

### DIFF
--- a/packages/python/goldenmatch/tests/test_qis_gen_parity.py
+++ b/packages/python/goldenmatch/tests/test_qis_gen_parity.py
@@ -89,3 +89,28 @@ def test_embedded_frozen_config_matches_file():
         "_FROZEN_CONFIG_JSON drifted from qis_realistic_frozen_config.json; "
         "re-run the embed (json.dumps(json.load(open(file)), separators=(',',':')))."
     )
+
+
+@pytest.mark.parametrize("shape", ["realistic", "phase5"])
+def test_gen_schema_is_large_string(shape: str):
+    """String columns must be `large_string`, not `string`.
+
+    The engine has always been handed the frame polars produced via
+    `.to_arrow()`, and polars emits large_string (64-bit offsets). Building the
+    table with pyarrow directly emits string (32-bit). Ray Data's
+    `_hash_partition` copes with the first and raises
+    `ValueError: output array is read-only` on the second, which killed the
+    block-shuffle ten minutes into a 100M cluster run (32976499569).
+
+    The hash tests above cannot catch this: they compare values, and `string`
+    and `large_string` are equal through `to_pylist()`. Value equality is not
+    type equality, and the type is what downstream code dispatches on.
+    """
+    import pyarrow as pa
+
+    df, _ = qis.generate_with_gt(1000, seed=0, shape=shape, corruption="light")
+    plain = [f.name for f in df.schema if pa.types.is_string(f.type)]
+    assert not plain, (
+        f"{shape}: {plain} are `string`; Ray's hash_partition needs "
+        "`large_string`. Wrap the construction in _large_str()."
+    )

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -272,6 +272,29 @@ def generate_with_gt(n_rows: int, seed: int = 0, shape: str = "realistic",
     raise ValueError(f"unknown shape {shape!r}; expected 'phase5' or 'realistic'")
 
 
+def _large_str(t: pa.Table) -> pa.Table:
+    """Cast every `string` column to `large_string`.
+
+    NOT cosmetic. The engine has always received the frame polars produced via
+    `.to_arrow()`, and polars emits `large_string` (64-bit offsets). Building
+    the table with pyarrow directly emits `string` (32-bit). Ray Data's
+    `_hash_partition` copes with the first and raises
+    `ValueError: output array is read-only` on the second, killing the
+    block-shuffle ~10 minutes into a 100M run (run 32976499569).
+
+    The VALUES are identical either way, which is exactly why this got through
+    review: the fixture was verified cell-by-cell through `to_pylist()`, and
+    `string` and `large_string` compare equal there. Value equality is not type
+    equality, and the type is what downstream code dispatches on. Pinned by
+    test_realistic_gen_schema_is_large_string.
+    """
+    fields = [
+        pa.field(f.name, pa.large_string()) if pa.types.is_string(f.type) else f
+        for f in t.schema
+    ]
+    return t.cast(pa.schema(fields))
+
+
 def _generate_phase5(n_rows: int, seed: int = 0) -> tuple[pa.Table, np.ndarray]:
     n_rows = (n_rows // ROWS_PER_CLUSTER) * ROWS_PER_CLUSTER
     n_clusters = n_rows // ROWS_PER_CLUSTER
@@ -294,13 +317,13 @@ def _generate_phase5(n_rows: int, seed: int = 0) -> tuple[pa.Table, np.ndarray]:
     )
     # `(__cid__ % 100000).cast(Utf8).str.zfill(5)`
     zip_col = np.char.zfill((cids % 100000).astype("U"), 5)
-    df = pa.table({
+    df = _large_str(pa.table({
         "id": pa.array(np.arange(n_rows, dtype=np.int64).astype("U")),
         "first_name": pa.array(first_name),
         "last_name": pa.array(last_name),
         "email": pa.array(email),
         "zip": pa.array(zip_col),
-    })
+    }))
     return df, cids
 
 
@@ -399,7 +422,7 @@ def _generate_realistic(n_rows: int, seed: int = 0, corruption: str = "light"
     else:
         email_rows = [f"{f}.{l}@example.com" for f, l in zip(first_with_typo, last_rows)]
 
-    df = pa.table({
+    df = _large_str(pa.table({
         "id": [f"r{i}" for i in range(n_rows)],
         "first_name": first_with_typo,
         "last_name": last_rows,
@@ -408,7 +431,7 @@ def _generate_realistic(n_rows: int, seed: int = 0, corruption: str = "light"
         "zip": zip_rows,
         "birth_year": year_rows,
         "email": email_rows,
-    })
+    }))
     return df, cids
 
 


### PR DESCRIPTION
#2774 took polars out of the bench harness and built the fixture with pyarrow directly. That **silently changed the Arrow schema**: polars `.to_arrow()` emits `large_string` (64-bit offsets), `pa.table({...})` emits `string` (32-bit).

Ray Data's `_hash_partition` copes with the first and raises

```
ValueError: output array is read-only
```

on the second. It killed the block-shuffle **ten minutes into a 100M cluster run** ([32976499569](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32976499569)) — after provisioning, so unlike the capacity failures this one cost real cluster time.

Every string column is now cast back to `large_string`, both shapes.

## Why the existing checks missed it

This is the part worth keeping. #2774 verified the fixture **cell-by-cell** across both shapes, both corruption levels and two row counts — and that check was sound as far as it went.

It compared values through `to_pylist()`. **`string` and `large_string` are equal there.** The data really was identical; the *type* was not, and the type is what downstream code dispatches on.

**Value equality is not type equality.**

Nothing local could have caught it either — the failure is inside Ray's shuffle, which no local test exercises, and the dev box can't run those suites reliably. So the cheap guard is a schema assertion, not a bigger integration test.

`test_gen_schema_is_large_string` pins it for both shapes, and I verified it **fails on an un-cast table** rather than trusting that it would.

## Verification

7/7 gen-parity tests pass (the 5 existing hash pins plus the 2 new schema assertions), `ruff` clean, both shapes confirmed `large_string`-only.