### PR TITLE
fix(bench): pin pandas back inside its major-version cap

### DIFF
--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -92,7 +92,23 @@ initialization_commands:
 #     polars              1.41.2 -> 1.44.0
 #     pyarrow             24.0.0 -> 25.0.1
 #     numpy               2.4.6  -> 2.5.2
-#     pandas              3.0.3  -> 3.0.5
+#     pandas              2.x    -> 2.3.3   (see the correction below)
+#
+# CORRECTION to that table, kept because the mistake is instructive: pandas was
+# NEVER on 3.x here. The constraint was `pandas>=2,<3`, capped below 3 on
+# purpose, so the lane resolved 2.3.3. I built the drift table by asking PyPI
+# for each package's newest release WITHOUT applying the constraint already in
+# this file, read 3.0.5, and pinned it -- crossing the major version the cap
+# existed to prevent.
+#
+# It fails ~10 minutes in, after provisioning, inside Ray's shuffle:
+#   ValueError: output array is read-only
+#   ray/data/_internal/arrow_ops/transform_pyarrow.py, _hash_partition
+# Ray 2.56.0 does `np.mod(hashes, num_partitions, out=hashes)` where `hashes`
+# came from `hash_pandas_object(table.to_pandas(types_mapper=pd.ArrowDtype))
+# .values`. Under pandas 3.x that `.values` is a READ-ONLY view of the Arrow
+# buffer, so the in-place write raises. Under 2.x it is writable.
+# Runs 32976499569 and 32983663609, both us-east1-b, both after provisioning.
 #     ray                 2.55.1 -> 2.58.0  (pinned separately, workflow input)
 #
 # The re-run came back 2.43x slower on dedupe with BYTE-IDENTICAL output, and
@@ -109,7 +125,7 @@ initialization_commands:
 setup_commands:
   - >-
     pip install --upgrade pip &&
-    pip install "polars==1.44.0" "pandas==3.0.5" "pyarrow==25.0.1" "numpy==2.5.2"
+    pip install "polars==1.44.0" "pandas==2.3.3" "pyarrow==25.0.1" "numpy==2.5.2"
     "psutil==7.2.2" "rapidfuzz==3.14.5" "jellyfish==1.2.1" &&
     pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/python/goldenmatch" &&
     pip install "goldenmatch-native==0.2.0" &&


### PR DESCRIPTION
**I broke this in #2776.** The lane's constraint was `pandas>=2,<3` — capped below 3 deliberately — and I replaced it with `pandas==3.0.5`, crossing the major version the cap existed to prevent.

## How

I produced the "everything drifted" table by asking PyPI for each package's newest release **without applying the constraint already sitting in that file**. It reported 3.0.3 for June and 3.0.5 for now, so I pinned 3.0.5.

pandas was never on 3.x here. `>=2,<3` resolved **2.3.3** in both runs. The drift I "discovered" for this package didn't exist, and the fix for it caused the first real failure.

## Symptom

~10 minutes in and **after provisioning** — so unlike the eight capacity misses at $0, this cost cluster time (runs [32976499569](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32976499569) and [32983663609](https://github.com/benseverndev-oss/goldenmatch/actions/runs/32983663609), both us-east1-b):

```
ValueError: output array is read-only
  ray/data/_internal/arrow_ops/transform_pyarrow.py, in _hash_partition
```

Ray 2.56.0 computes `hash_pandas_object(table.to_pandas(types_mapper=pd.ArrowDtype)).values` and then `np.mod(hashes, num_partitions, out=hashes)`. Under **pandas 3.x that `.values` is a read-only view of the Arrow buffer**, so the in-place write raises. Under 2.x it's writable.

Ray was identical (2.56.0) across the successful run and both failures, so the Ray version was never the differentiator — I checked that before concluding, having already been wrong twice about this crash.

## What settled it

The environment capture added in that same PR. The failing run's own `pip freeze` artifact says `pandas==3.0.5` in one line. **That's the first time this lane could answer "what actually ran" from the run itself** — the capability was added for exactly this and paid for itself on its first real use.

## Also in this PR

The pinning comment now carries the wrong drift-table entry **and why it was wrong**, corrected in place rather than quietly deleted. The reasoning error — reading a version resolver without the constraints in force — is more reusable than the pin.

## Not related to #2779

That `large_string` cast was my *second* wrong diagnosis of this same crash. It's still correct on its own terms (the engine has always been handed `large_string`), but it was never what broke the shuffle: `_has_unhashable_pandas_types` branches on **nested** types, not string width.