### PR TITLE
feat(distributed): measure the driver clustering stage instead of guessing it

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -93,6 +93,10 @@ on:
         description: "1 = per-bucket prep-vs-kernel-vs-postfilter timing from the scorer (GOLDENMATCH_BUCKET_DEBUG). Output-invariant; costs an env read and a perf_counter per bucket. Splits time between the Rust kernel and the frame prep around it (sort + group_by + to_arrow), which is what tells you whether a knob moved the kernel or the wrapping. Worth having on for a baseline run."
         required: false
         default: "0"
+      cluster_debug:
+        description: "1 = per-step timing for the DRIVER-SIDE clustering stage (GOLDENMATCH_CLUSTER_DEBUG): pull / derive-ids / index / connected-components / build-output. Output-invariant. That stage is ~25 min of a 100M run for ~70s of graph algorithm, and which step owns the rest has never been measured."
+        required: false
+        default: "0"
       ray_version:
         description: "Ray version for BOTH launcher and cluster image. Default 2.56.0 = goldenmatch's own declared [ray] floor, one minor above the 2.55.1 that produced the June baseline. Pinned so a sweep varies the knob and not Ray. Empty = float to latest."
         required: false
@@ -204,6 +208,7 @@ jobs:
           # Through the environment, not interpolated into the script body: a
           # `${{ }}` expansion inside `run:` is a template-injection seam.
           ZONE_INPUT: ${{ inputs.zone }}
+          CLUSTER_DEBUG_INPUT: ${{ inputs.cluster_debug }}
         run: |
           set -euo pipefail
           # GCP_PROJECT_ID is in $GITHUB_ENV from the Doppler fetch
@@ -214,6 +219,7 @@ jobs:
           sed -i "s|max_workers: 3$|max_workers: ${{ inputs.max_workers }}|" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_HEAD_MACHINE_PLACEHOLDER|${{ inputs.head_machine }}|g" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_ZONE_PLACEHOLDER|${ZONE_INPUT}|g" .ray/cluster-gce.yaml
+          sed -i "s|GOLDENMATCH_CLUSTER_DEBUG_PLACEHOLDER|${CLUSTER_DEBUG_INPUT}|g" .ray/cluster-gce.yaml
           # Region is the zone minus its trailing letter. Derived, not a second
           # input, so the pair cannot disagree.
           REGION="${ZONE_INPUT%-*}"

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -67,6 +67,14 @@ docker:
     - "GOLDENMATCH_NATIVE=1"
     - "--env"
     - "GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1"
+    # Rendered from the `cluster_debug` dispatch input. It belongs HERE and not
+    # in a shell around `ray submit`: the driver runs through a fresh
+    # `docker exec` which inherits the container env but not the submitter's,
+    # so an export would silently do nothing -- which is exactly what happened
+    # to an earlier GOLDENMATCH_BUCKET_DEBUG dispatch (it produced no output
+    # and the run looked normal).
+    - "--env"
+    - "GOLDENMATCH_CLUSTER_DEBUG=GOLDENMATCH_CLUSTER_DEBUG_PLACEHOLDER"
   # Rendered to the launcher's resolved Ray version at dispatch time (see the
   # bench-ray-cluster workflow) so the cluster has the same Ray Data API as the
   # distributed pipeline code (`repartition(num_partitions, keys=[...])`). The

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -1236,7 +1236,7 @@ _`_PLANNING_EFFORTS` -- `planning_effort`._
 
 ## Environment variables (index)
 
-207 `GOLDENMATCH_*` runtime knob(s) read by the package, scanned from source so this is complete. Details in [Tuning & opt-ins](/goldenmatch/tuning). Grouped by area:
+208 `GOLDENMATCH_*` runtime knob(s) read by the package, scanned from source so this is complete. Details in [Tuning & opt-ins](/goldenmatch/tuning). Grouped by area:
 
 - **AGENT** (1): `GOLDENMATCH_AGENT_TOKEN`
 - **ALLOWED** (1): `GOLDENMATCH_ALLOWED_ROOT`
@@ -1252,7 +1252,7 @@ _`_PLANNING_EFFORTS` -- `planning_effort`._
 - **BRIDGE** (1): `GOLDENMATCH_BRIDGE_REQUIRE_PY`
 - **BUCKET** (5): `GOLDENMATCH_BUCKET_DEBUG`, `GOLDENMATCH_BUCKET_DEFAULT`, `GOLDENMATCH_BUCKET_SLIM_PROJECTION`, `GOLDENMATCH_BUCKET_VEC_MAX`, `GOLDENMATCH_BUCKET_VEC_MIN`
 - **CANDIDATE** (1): `GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS`
-- **CLUSTER** (1): `GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET`
+- **CLUSTER** (2): `GOLDENMATCH_CLUSTER_DEBUG`, `GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET`
 - **COLUMNAR** (1): `GOLDENMATCH_COLUMNAR_PIPELINE`
 - **CONFIG** (1): `GOLDENMATCH_CONFIG_LINT`
 - **DATABASE** (1): `GOLDENMATCH_DATABASE_URL`

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -270,6 +270,7 @@ These trade nothing for speed/memory at scale and are safe to leave at their def
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `GOLDENMATCH_BUCKET_DEBUG` | `0` | Print per-bucket prep / kernel / post-filter timing for `backend=bucket`. Output-invariant, near-zero cost, but it's a debug aid, not a speed-up. |
+| `GOLDENMATCH_CLUSTER_DEBUG` | `0` | Print a per-step timing split for the DRIVER-SIDE clustering stage: pull pairs to driver / derive id universe / map ids to dense index / connected components / build output table. Output-invariant; one env read plus a `perf_counter` per step. Use it when that stage dominates a distributed run — at 100M rows it is ~16 minutes for ~70s of graph algorithm, and this says which step owns the rest. On a Ray cluster set it in the cluster yaml's `docker run_options`, **not** in a shell around `ray submit`: the driver runs through a fresh `docker exec` and would never see the export. |
 | `GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS` | `10000` | Max blocks for which scoring counts candidate pairs. Above it the loop is skipped -- counting materialises each block -- and `ScoringProfile.candidates_compared` stays 0 with `candidates_counted=False`. Raise it (e.g. `1000000000`) only to make an auto-config diagnostic answerable: it buys a serial pass over every block. Garbage or negative values fall back to the default. |
 | `GOLDENMATCH_TRANSFORM_DEBUG` | `0` | Print the prep-transform arrow-lane split (`pl.from_arrow` / `_do_transform` / `to_arrow`) to size the bridge vs the transform compute. Output-invariant, near-zero cost; a debug aid, not a speed-up. |
 | `GOLDENMATCH_PREP_STAGED_COLLECT` | `0` | Collect prepared records in stages (memory-management experiment). Can be slower; leave off unless diagnosing prep RSS. |
@@ -596,6 +597,7 @@ Every `GOLDENMATCH_*` variable the package reads (plus the one `GOLDEN_*` except
 | `GOLDENMATCH_IDENTITY_INITIAL_LOAD` | `0` (off) | Opt-in from-empty Postgres initial-load fast path (direct COPY, indexes rebuilt after). `1` = on; gated to empty tables. |
 | `GOLDENMATCH_IDENTITY_INITIAL_LOAD_UNLOGGED` | `0` (off) | Also load `UNLOGGED` (skip WAL) under the initial-load path; only for re-runnable builds. |
 | `GOLDENMATCH_BUCKET_DEBUG` | `0` | Per-bucket timing breakdown (diagnostic). |
+| `GOLDENMATCH_CLUSTER_DEBUG` | `0` | Driver-side clustering stage timing breakdown (diagnostic). |
 | `GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS` | `10000` | Block-count gate for the candidate-count loop; raise only for diagnostics (costs a serial pass). |
 | `GOLDENMATCH_TRANSFORM_DEBUG` | `0` | Prep-transform arrow-lane bridge split (diagnostic). |
 | `GOLDEN_DIAGNOSTICS` | `1` (on) | Anomaly diagnostics (note: no `MATCH` in the name). On states that are probably a GoldenMatch bug -- a native wheel-skew slow path, an unexpected `dedupe_df`/`match_df` crash, the config linter itself crashing, or a broken native install -- emit a warning with a prefilled GitHub issue URL plus a PII-safe environment report. Never fires on expected fallbacks or user errors, and sends nothing anywhere (a better error message, not telemetry). `0` disables. |

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5683,6 +5683,7 @@
             "_assert_scratch_shared_if_multinode",
             "_attach_quality_metadata",
             "_build_clusters_cc_fallback",
+            "_cluster_debug_on",
             "_derive_touched_ids",
             "_emit_boundary_pairs",
             "_phase_a_local_cc",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -6068,6 +6068,7 @@
           "GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS"
         ],
         "CLUSTER": [
+          "GOLDENMATCH_CLUSTER_DEBUG",
           "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET"
         ],
         "COLUMNAR": [

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -9,6 +9,7 @@ without the [ray] extra installed.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -459,6 +460,31 @@ def _annotate_cluster_sizes(
     return colocated.map_batches(_emit, batch_format="pyarrow")
 
 
+def _cluster_debug_on() -> bool:
+    """Whether the driver-side clustering stage prints a per-step timing split.
+
+    OFF by default; `GOLDENMATCH_CLUSTER_DEBUG=1` enables it. Costs one env read
+    plus a `perf_counter` per step, and changes no output.
+
+    This exists because the stage was optimised twice from inference rather than
+    measurement. The driver phase went 65 -> 33 -> ~25 min across two fixes, and
+    both times the predicted saving was roughly double what arrived, because a
+    single component was treated as the whole cost. The arithmetic that IS solid
+    says connected-components itself is ~70s at 226M edges and `index_in` ~150s,
+    so most of the stage is neither -- but "most" was never attributed to a
+    named step. One table settles that; another round of guessing does not.
+
+    NOTE for whoever turns it on against a Ray cluster: set it in the cluster
+    yaml's `docker run_options`, NOT in a shell around `ray submit`. Ray runs the
+    driver through a fresh `docker exec` and forwards only its own env vars, so a
+    shell export never arrives (the same trap that made an earlier
+    GOLDENMATCH_BUCKET_DEBUG dispatch silently produce nothing).
+    """
+    return os.environ.get("GOLDENMATCH_CLUSTER_DEBUG", "0") not in (
+        "0", "", "false", "False", "no", "off",
+    )
+
+
 def _build_clusters_cc_fallback(
     pairs_ds: Dataset,
     all_ids: list[int],
@@ -475,16 +501,6 @@ def _build_clusters_cc_fallback(
     Run 26122054424 had this at 67s on 8.3M pairs / 16.6M members; the
     naive Python-loop path drove that wall. Vectorized path targets <30s.
     """
-    import numpy as np
-    import polars as pl
-    import pyarrow as pa
-    import pyarrow.compute as pc
-    import ray
-
-    from goldenmatch.distributed._connected_components import (
-        connected_components_undirected,
-    )
-
     # ONE projected pass. Connected components reads `id_a` and `id_b` and
     # nothing else -- `score` was shipped across the network for every pair and
     # never read. And when the caller passes all_ids=None (the at-scale route),
@@ -496,6 +512,29 @@ def _build_clusters_cc_fallback(
     # The graph algorithm underneath costs ~70s (measured: scipy connected_
     # components on 20M edges is 6.4s, and it scales close to linear), so the
     # driver stage was overwhelmingly data movement rather than clustering.
+    import time as _time
+
+    import numpy as np
+    import polars as pl
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import ray
+
+    from goldenmatch.distributed._connected_components import (
+        connected_components_undirected,
+    )
+
+    _dbg = _cluster_debug_on()
+    _t: dict[str, float] = {}
+    _mark = _time.perf_counter()
+
+    def _lap(name: str) -> None:
+        nonlocal _mark
+        if _dbg:
+            now = _time.perf_counter()
+            _t[name] = now - _mark
+            _mark = now
+
     projected = pairs_ds.select_columns(["id_a", "id_b"])
     pair_tables: list[pa.Table] = list(
         projected.iter_batches(batch_format="pyarrow")
@@ -509,12 +548,16 @@ def _build_clusters_cc_fallback(
     # Derive the id universe from the table already in hand rather than from a
     # second trip to the object store. Same values, same order (sorted unique),
     # one fewer full materialisation.
+    _lap("1_pull_pairs_to_driver")
+
     if all_ids is None:
         both = pa.concat_arrays([
             full.column(c).combine_chunks().cast(pa.int64()) for c in ("id_a", "id_b")
         ])
         _u = pc.unique(both)
         all_ids = pc.take(_u, pc.sort_indices(_u))
+    _lap("2_derive_id_universe")
+
     # id -> dense index stays in ARROW. `pc.index_in` against the sorted value
     # set replaces `np.searchsorted`; at 10M pairs the stage measured 6.61s
     # against numpy's 49.71s for byte-identical output. Only the two index
@@ -546,11 +589,13 @@ def _build_clusters_cc_fallback(
 
     row_idx = _dense("id_a")
     col_idx = _dense("id_b")
+    _lap("3_map_ids_to_dense_index")
 
     # The member_id column below wants the ids as numpy; one conversion at the
     # boundary, after Arrow has done the expensive part.
     sorted_ids = ids_arr.to_numpy(zero_copy_only=False)
     _n_components, labels = connected_components_undirected(row_idx, col_idx, n)
+    _lap("4_connected_components")
 
     # Compute per-cluster size via bincount; broadcast back to per-member.
     sizes_per_label = np.bincount(labels, minlength=int(labels.max()) + 1 if labels.size else 1)
@@ -567,7 +612,19 @@ def _build_clusters_cc_fallback(
             "oversized": oversized,
         }
     ).to_arrow()
-    return ray.data.from_arrow(out_table)
+    out = ray.data.from_arrow(out_table)
+    _lap("5_build_output_table")
+
+    if _dbg:
+        total = sum(_t.values())
+        logger.warning(
+            "[cluster_debug] driver clustering stage: %d pairs, %d ids, total %.1fs",
+            full.num_rows, n, total,
+        )
+        for k in sorted(_t):
+            pct = (_t[k] / total * 100.0) if total else 0.0
+            logger.warning("[cluster_debug]   %-26s %8.1fs  %5.1f%%", k, _t[k], pct)
+    return out
 
 
 def two_phase_wcc(

--- a/packages/python/goldenmatch/tests/test_cluster_stage_timing.py
+++ b/packages/python/goldenmatch/tests/test_cluster_stage_timing.py
@@ -7,8 +7,11 @@ completed normally and produced no timing at all. A flag that silently does
 nothing is worse than no flag, because it is indistinguishable from a measured
 null.
 
-These need no Ray -- the gate is a plain env read -- so the regression is held
-in the ordinary lane rather than only on a cluster.
+The three GATE tests need no Ray -- that gate is a plain env read -- so they run
+in the ordinary python lane. The fourth exercises the real stage, which imports
+ray internally, so it skips where ray is absent and runs in the distributed
+lanes. Splitting them that way keeps the cheap half of the guard everywhere
+rather than confining all of it to a Ray-only lane.
 """
 from __future__ import annotations
 
@@ -40,6 +43,12 @@ def test_stage_timing_emits_every_step(monkeypatch, caplog):
     goes unattributed, which is the whole reason this exists."""
     import numpy as np
     import pyarrow as pa
+    import pytest
+
+    # `_build_clusters_cc_fallback` imports ray internally, so this test cannot
+    # run in the plain `python_goldenmatch` lane, which has no ray. The gate
+    # tests above still cover the env contract there.
+    pytest.importorskip("ray")
 
     class FakeDS:
         def __init__(self, t): self.t = t

--- a/packages/python/goldenmatch/tests/test_cluster_stage_timing.py
+++ b/packages/python/goldenmatch/tests/test_cluster_stage_timing.py
@@ -1,0 +1,73 @@
+"""The driver-side clustering stage's per-step timing actually fires.
+
+Written because the previous diagnostic on this lane did NOT. A
+GOLDENMATCH_BUCKET_DEBUG dispatch set the flag by appending an export to
+~/.bashrc via `ray exec`; non-interactive bash never sources it, so the run
+completed normally and produced no timing at all. A flag that silently does
+nothing is worse than no flag, because it is indistinguishable from a measured
+null.
+
+These need no Ray -- the gate is a plain env read -- so the regression is held
+in the ordinary lane rather than only on a cluster.
+"""
+from __future__ import annotations
+
+import logging
+
+import goldenmatch.distributed.clustering as C
+
+
+def test_debug_gate_is_off_by_default(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_DEBUG", raising=False)
+    assert C._cluster_debug_on() is False
+
+
+def test_debug_gate_reads_env_at_call_time(monkeypatch):
+    """Read at CALL time, not import: the driver sets this via the container
+    env, and a module-level constant would freeze the value at import."""
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_DEBUG", "1")
+    assert C._cluster_debug_on() is True
+
+
+def test_debug_gate_treats_falsey_spellings_as_off(monkeypatch):
+    for v in ("0", "", "false", "False", "no", "off"):
+        monkeypatch.setenv("GOLDENMATCH_CLUSTER_DEBUG", v)
+        assert C._cluster_debug_on() is False, f"{v!r} should be off"
+
+
+def test_stage_timing_emits_every_step(monkeypatch, caplog):
+    """The five steps must all report. A missing step is how a stage's cost
+    goes unattributed, which is the whole reason this exists."""
+    import numpy as np
+    import pyarrow as pa
+
+    class FakeDS:
+        def __init__(self, t): self.t = t
+        def select_columns(self, cols): return FakeDS(self.t.select(cols))
+        def iter_batches(self, batch_format="pyarrow"):
+            return iter([pa.Table.from_batches([b])
+                         for b in self.t.to_batches(max_chunksize=2_000)])
+
+    rng = np.random.default_rng(3)
+    n = 20_000
+    ds = FakeDS(pa.table({
+        "id_a": rng.integers(0, n // 4, n, dtype=np.int64),
+        "id_b": rng.integers(0, n // 4, n, dtype=np.int64),
+        "score": rng.random(n),
+    }))
+
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_DEBUG", "1")
+    # `ray.data.from_arrow` is the only Ray touch; stub it so this stays a
+    # pure-Python test rather than spinning a cluster.
+    import ray
+    monkeypatch.setattr(ray.data, "from_arrow", lambda t: t)
+
+    with caplog.at_level(logging.WARNING, logger=C.__name__):
+        C._build_clusters_cc_fallback(ds, None, max_cluster_size=1_000_000)
+
+    text = caplog.text
+    for step in ("1_pull_pairs_to_driver", "2_derive_id_universe",
+                 "3_map_ids_to_dense_index", "4_connected_components",
+                 "5_build_output_table"):
+        assert step in text, f"{step} missing from the timing output:\n{text}"
+    assert "driver clustering stage" in text

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -6068,6 +6068,7 @@
           "GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS"
         ],
         "CLUSTER": [
+          "GOLDENMATCH_CLUSTER_DEBUG",
           "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET"
         ],
         "COLUMNAR": [


### PR DESCRIPTION
The driver-side clustering stage has been optimised **twice from inference**. It went **65 → 33 → ~25 min** across two fixes, and *both times the predicted saving was about double what arrived*, because each fix removed one real cost and was then described as if it were the whole stage.

The arithmetic that IS solid says what the stage is **not**:

| step | cost at 226M |
|---|---|
| connected components | **~70s** (scipy on 20M edges = 6.4s, near-linear) |
| `pc.index_in` ×2 | **~150s** (from 6.61s at 10M) |

So most of ~25 minutes belongs to neither — and "most" has never been attributed to a named step. That's the gap this closes.

## What it does

`GOLDENMATCH_CLUSTER_DEBUG=1` splits the stage five ways: **pull pairs to driver / derive id universe / map ids to dense index / connected components / build output table.**

Output-invariant. One env read plus a `perf_counter` per step — inside run-to-run variance.

## Wired through `docker run_options`, not a shell export

This is the load-bearing detail. Ray runs the driver through a fresh `docker exec` that inherits the container env but **not the submitter's**, so an export never arrives.

Not hypothetical: an earlier `GOLDENMATCH_BUCKET_DEBUG` dispatch set the flag by appending to `~/.bashrc` via `ray exec`. Non-interactive bash never sources it, and a **100M run completed normally having produced no timing whatsoever**. A flag that silently does nothing is worse than no flag, because it's indistinguishable from a measured null.

## Tests

Cover the gate (off by default, read at call time rather than import, falsey spellings) and — the one that matters — **run the real stage and assert all five steps appear**. No Ray needed, so the guard lives in the ordinary lane rather than only on a cluster.

## Honest limit

A local run on a synthetic 4M-pair set shows connected-components at ~75% — but that's an in-process fake where **step 1 has no network to cross**. Step 1 is precisely the step that can't be reproduced off-cluster, which is why the measurement has to happen on the real thing.