### PR TITLE
feat(bench): make the clustering route a dispatch input

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -93,6 +93,10 @@ on:
         description: "1 = per-bucket prep-vs-kernel-vs-postfilter timing from the scorer (GOLDENMATCH_BUCKET_DEBUG). Output-invariant; costs an env read and a perf_counter per bucket. Splits time between the Rust kernel and the frame prep around it (sort + group_by + to_arrow), which is what tells you whether a knob moved the kernel or the wrapping. Worth having on for a baseline run."
         required: false
         default: "0"
+      clustering_threshold:
+        description: "Pair-count threshold above which clustering DISTRIBUTES. Empty = the harness default (2e9, i.e. never: clustering runs on the driver). 0 forces the distributed WCC. The driver path measured 707s at 100M -- 45% connected components, 35% pulling pairs across -- and the distributed alternative was rejected as a multi-hour tail before the current code existed, so that trade is due a re-measure."
+        required: false
+        default: ""
       cluster_debug:
         description: "1 = per-step timing for the DRIVER-SIDE clustering stage (GOLDENMATCH_CLUSTER_DEBUG): pull / derive-ids / index / connected-components / build-output. Output-invariant. That stage is ~25 min of a 100M run for ~70s of graph algorithm, and which step owns the rest has never been measured."
         required: false
@@ -363,6 +367,7 @@ jobs:
           SCORE_PROJECT: ${{ inputs.score_project }}
           OP_RESERVATION: ${{ inputs.op_reservation }}
           SHUFFLE_PARTS: ${{ inputs.shuffle_parts }}
+          CLUSTERING_THRESHOLD: ${{ inputs.clustering_threshold }}
           DISTRIBUTED: ${{ inputs.distributed }}
           BUCKET_DEBUG: ${{ inputs.bucket_debug }}
         run: |
@@ -379,6 +384,7 @@ jobs:
           if [ -n "$SCORE_CONCURRENCY" ]; then KNOBS+=(--score-concurrency "$SCORE_CONCURRENCY"); fi
           if [ -n "$OP_RESERVATION" ]; then KNOBS+=(--op-reservation "$OP_RESERVATION"); fi
           if [ -n "$SHUFFLE_PARTS" ]; then KNOBS+=(--shuffle-parts "$SHUFFLE_PARTS"); fi
+          if [ -n "$CLUSTERING_THRESHOLD" ]; then KNOBS+=(--clustering-threshold "$CLUSTERING_THRESHOLD"); fi
           case "$SCORE_PROJECT" in
             1) KNOBS+=(--score-project) ;;
             0) KNOBS+=(--no-score-project) ;;

--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -143,6 +143,12 @@ def effective_score_knobs() -> dict[str, Any]:
         # Not a #957 knob, but the same sweep tunes it and it is read on the
         # driver at Dataset-build time, so it belongs in the same record.
         "shuffle_parts": os.environ.get("GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS"),
+        # Not a scoring knob either, but it decides whether clustering runs on
+        # the driver or distributes -- the single largest routing choice in a
+        # distributed run, and one a result is uninterpretable without.
+        "clustering_threshold": os.environ.get(
+            "GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD"
+        ),
     }
 
 

--- a/packages/python/goldenmatch/tests/test_distributed_score_knobs.py
+++ b/packages/python/goldenmatch/tests/test_distributed_score_knobs.py
@@ -54,6 +54,7 @@ def test_effective_score_knobs_reports_what_the_run_will_use(monkeypatch):
     monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY", "60")
     monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION", "0.2")
     monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS", "512")
+    monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", raising=False)
 
     assert S.effective_score_knobs() == {
         "score_num_cpus": 4,
@@ -61,4 +62,5 @@ def test_effective_score_knobs_reports_what_the_run_will_use(monkeypatch):
         "score_concurrency": 60,
         "op_reservation": "0.2",
         "shuffle_parts": "512",
+        "clustering_threshold": None,
     }

--- a/packages/python/goldenmatch/tests/test_qis_harness.py
+++ b/packages/python/goldenmatch/tests/test_qis_harness.py
@@ -260,6 +260,7 @@ _KNOB_ENV = (
     "GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT",
     "GOLDENMATCH_DISTRIBUTED_OP_RESERVATION",
     "GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS",
+    "GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD",
 )
 
 
@@ -312,6 +313,10 @@ def test_score_knob_flags_reach_the_engine_env(_clean_knob_env):
         "score_concurrency": 60,
         "op_reservation": "0.2",
         "shuffle_parts": "512",
+        # Not a scoring knob, but it decides driver-side vs distributed
+        # clustering -- the largest routing choice in a distributed run, and one
+        # a recorded result is uninterpretable without.
+        "clustering_threshold": None,
     }
 
 
@@ -328,3 +333,36 @@ def test_score_project_flag_can_turn_the_projection_back_on(_clean_knob_env):
     args = qis._build_parser().parse_args(["--rows", "1000", "--score-project"])
     qis._apply_score_knob_flags(args)
     assert os.environ["GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT"] == "1"
+
+
+def test_clustering_threshold_flag_flips_the_route(_clean_knob_env, monkeypatch):
+    """The flag must actually change `_route_distributed`'s answer.
+
+    Setting the env is not the same as changing the routing: the harness uses
+    `os.environ.setdefault` for this var, so a value applied in the wrong place
+    is silently ignored. And the decision is `pair_count >= threshold`, so the
+    sign matters -- a flag that set the threshold the wrong way round would look
+    applied and route exactly as before.
+    """
+    from goldenmatch.distributed.clustering import _route_distributed
+
+    pair_count = 609_398_412  # the measured 100M edge set
+
+    args = qis._build_parser().parse_args(
+        ["--rows", "1000", "--distributed", "--clustering-threshold", "2000000000"]
+    )
+    qis._apply_score_knob_flags(args)
+    assert _route_distributed(pair_count) is False, "2e9 should keep clustering on the driver"
+
+    args = qis._build_parser().parse_args(
+        ["--rows", "1000", "--distributed", "--clustering-threshold", "0"]
+    )
+    qis._apply_score_knob_flags(args)
+    assert _route_distributed(pair_count) is True, "0 should route to the distributed WCC"
+
+
+def test_clustering_threshold_omitted_leaves_the_var_unset(_clean_knob_env):
+    """Omitted must write nothing, so the harness's own default still applies."""
+    args = qis._build_parser().parse_args(["--rows", "1000", "--distributed"])
+    qis._apply_score_knob_flags(args)
+    assert "GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD" not in os.environ

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -1073,6 +1073,12 @@ def _apply_score_knob_flags(args) -> None:
         os.environ["GOLDENMATCH_DISTRIBUTED_OP_RESERVATION"] = str(args.op_reservation)
     if args.shuffle_parts is not None:
         os.environ["GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS"] = str(args.shuffle_parts)
+    if args.clustering_threshold is not None:
+        # Set in main() so it wins over the `setdefault` in
+        # _run_phase5_and_collect -- setdefault only fills an UNSET var.
+        os.environ["GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD"] = str(
+            args.clustering_threshold
+        )
 
 
 def run_distributed_rung(
@@ -1180,6 +1186,14 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="Ray Data per-op object-store reservation ratio "
                          "(GOLDENMATCH_DISTRIBUTED_OP_RESERVATION). Lower (~0.2) when "
                          "_score is [backpressured:tasks(ResourceBudget)] below CPU capacity.")
+    ap.add_argument("--clustering-threshold", type=int, default=None,
+                    help="pair-count threshold above which clustering DISTRIBUTES "
+                         "(GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD). The at-scale "
+                         "default is 2e9, i.e. never distribute -- clustering runs on "
+                         "the driver, measured at 707s of which 45%% is connected "
+                         "components and 35%% is pulling pairs across. Pass 0 to force "
+                         "the distributed WCC and re-measure that trade; it was rejected "
+                         "as a multi-hour tail before the current code existed.")
     ap.add_argument("--shuffle-parts", type=int, default=None,
                     help="block-shuffle partition count "
                          "(GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS; --distributed default 512).")


### PR DESCRIPTION
Clustering runs on the **driver** at 100M because the harness sets `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=2e9` — i.e. never distribute. The recorded reason is that the distributed WCC's `gs://` checkpoint rounds were a multi-hour tail: a judgement made **before the current code**, never re-measured, and load-bearing for everything in that stage.

Now measured ([run 33074452121](https://github.com/benseverndev-oss/goldenmatch/actions/runs/33074452121), 609,398,412 pairs over 99,417,363 ids, 707.3s):

| step | time | share |
|---|---:|---:|
| **connected components** | **315.9s** | **44.7%** |
| **pull pairs to driver** | **245.5s** | **34.7%** |
| map ids to dense index | 79.8s | 11.3% |
| derive id universe | 64.7s | 9.1% |
| build output table | 1.3s | 0.2% |

**Both of the top two exist only because clustering is single-machine** — one is a graph algorithm on one core of a 32-core head, the other is moving the whole edge set to that core. So the stale rejection is worth exactly one dispatch to test.

## What this adds

`--clustering-threshold` plus a matching workflow input, so re-testing that trade is a re-dispatch rather than a code change.

It's applied in `main()`, and that matters: the harness sets this var with `os.environ.setdefault`, so a value applied anywhere later would be **silently ignored**.

The threshold now also lands in the artifact's provenance block. A recorded result is uninterpretable without it — it's the largest single routing choice in a distributed run, and nothing in the output previously revealed which side of it a run had taken.

## Tests

They assert the flag flips `_route_distributed`'s **answer**, not merely that the env is set. The decision is `pair_count >= threshold`, so a flag with the sign reversed would look applied and route exactly as before. Omitting it must write nothing, so the harness default still applies.

Both existing provenance assertions failed on the new key and were **updated rather than loosened** — they were doing their job. Suites pass in both orders, so the fixtures don't leak the new var between them.

zizmor at baseline (23); docs staleness passes.