### PR TITLE
feat(distributed): cache the scored pairs so clustering work stops re-scoring

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -93,6 +93,10 @@ on:
         description: "1 = per-bucket prep-vs-kernel-vs-postfilter timing from the scorer (GOLDENMATCH_BUCKET_DEBUG). Output-invariant; costs an env read and a perf_counter per bucket. Splits time between the Rust kernel and the frame prep around it (sort + group_by + to_arrow), which is what tells you whether a knob moved the kernel or the wrapping. Worth having on for a baseline run."
         required: false
         default: "0"
+      pairs_cache:
+        description: "gs:// path for the scored-pair set. First run with a given path WRITES it; later runs READ it and skip scoring (38-44 min of a ~50 min 100M run). Use it when the experiment is DOWNSTREAM of scoring -- clustering route, WCC algorithm. Nothing validates that cached pairs match the current config, so key the path per config, and note a cached run's dedupe wall is not comparable to a full one."
+        required: false
+        default: ""
       clustering_threshold:
         description: "Pair-count threshold above which clustering DISTRIBUTES. Empty = the harness default (2e9, i.e. never: clustering runs on the driver). 0 forces the distributed WCC. The driver path measured 707s at 100M -- 45% connected components, 35% pulling pairs across -- and the distributed alternative was rejected as a multi-hour tail before the current code existed, so that trade is due a re-measure."
         required: false
@@ -368,6 +372,7 @@ jobs:
           OP_RESERVATION: ${{ inputs.op_reservation }}
           SHUFFLE_PARTS: ${{ inputs.shuffle_parts }}
           CLUSTERING_THRESHOLD: ${{ inputs.clustering_threshold }}
+          PAIRS_CACHE: ${{ inputs.pairs_cache }}
           DISTRIBUTED: ${{ inputs.distributed }}
           BUCKET_DEBUG: ${{ inputs.bucket_debug }}
         run: |
@@ -385,6 +390,7 @@ jobs:
           if [ -n "$OP_RESERVATION" ]; then KNOBS+=(--op-reservation "$OP_RESERVATION"); fi
           if [ -n "$SHUFFLE_PARTS" ]; then KNOBS+=(--shuffle-parts "$SHUFFLE_PARTS"); fi
           if [ -n "$CLUSTERING_THRESHOLD" ]; then KNOBS+=(--clustering-threshold "$CLUSTERING_THRESHOLD"); fi
+          if [ -n "$PAIRS_CACHE" ]; then KNOBS+=(--pairs-cache "$PAIRS_CACHE"); fi
           case "$SCORE_PROJECT" in
             1) KNOBS+=(--score-project) ;;
             0) KNOBS+=(--no-score-project) ;;

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -123,6 +123,8 @@ def _run_phase5_pipeline(
     config: Any | None = None,
     allow_red_config: bool = False,
     assignments_output_path: str | None = None,
+    pairs_output_path: str | None = None,
+    pairs_input_path: str | None = None,
     _skip_golden: bool = False,
     **kwargs: Any,
 ):
@@ -188,7 +190,30 @@ def _run_phase5_pipeline(
 
     # 2. Distributed scoring -> Ray Dataset of pairs (RAW: per-partition, so each
     #    component's edges are co-located in one block -- required by local_cc).
-    raw_pairs_ds = score_blocks_distributed(ds, cfg)
+    if pairs_input_path is not None:
+        # Resume from a persisted scored-pair set and SKIP scoring entirely.
+        #
+        # Scoring is deterministic given the same frame and config, and at 100M
+        # it is 38-44 min of a ~50 min run. Anything downstream of it -- the
+        # clustering route, the WCC algorithm, the driver-vs-distributed trade --
+        # currently costs a full re-score per experiment, which is why iterating
+        # on clustering has meant 80-minute cycles to exercise 12 minutes of code.
+        #
+        # This is a BENCH/DEBUG seam, not a correctness feature: nothing verifies
+        # that the cached pairs came from this frame and config. Feeding it a set
+        # produced by a different config yields a clean-looking, wrong answer.
+        # Key the path by whatever identifies the run that produced it.
+        import ray
+
+        logger.warning(
+            "phase5: SKIPPING scoring, reading cached pairs from %s. "
+            "Results are only meaningful if these pairs came from this frame "
+            "and config -- nothing here checks that.",
+            pairs_input_path,
+        )
+        raw_pairs_ds = ray.data.read_parquet(pairs_input_path)
+    else:
+        raw_pairs_ds = score_blocks_distributed(ds, cfg)
 
     # 2b. MATERIALIZE the scored pairs before clustering. The randomized-contraction
     #     WCC iterates ~O(log N) rounds; each round that touches a lazy `raw_pairs_ds`
@@ -201,6 +226,13 @@ def _run_phase5_pipeline(
     #     already a barrier (WCC needs all pairs), so no pipelining is lost.
     if hasattr(raw_pairs_ds, "materialize"):
         raw_pairs_ds = raw_pairs_ds.materialize()
+
+    # 2c. Optionally persist the scored pairs. Written AFTER materialize(), so
+    #     the write reuses the already-computed set rather than triggering a
+    #     second pass over the scoring DAG.
+    if pairs_output_path is not None and pairs_input_path is None:
+        logger.info("phase5: writing scored pairs to %s", pairs_output_path)
+        raw_pairs_ds.write_parquet(pairs_output_path)
 
     # 3. Connected components: branch on whether block-shuffle is active.
     #    block-shuffle OFF (default): scoring is per-partition, so components

--- a/packages/python/goldenmatch/tests/test_pairs_cache.py
+++ b/packages/python/goldenmatch/tests/test_pairs_cache.py
@@ -1,0 +1,97 @@
+"""The scored-pair cache seam: read path, write path, and mutual exclusion.
+
+Scoring is 38-44 min of a ~50 min 100M distributed run and is deterministic
+given the frame and config, so every experiment downstream of it -- clustering
+route, WCC algorithm, driver-vs-distributed -- used to re-pay that for nothing.
+
+These assert the seam's CONTRACT rather than its plumbing: reading must skip
+scoring (the whole point), writing must not, and the two must not both happen in
+one run. A cache that silently still scored would look like a working cache and
+save nothing.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.distributed import pipeline as P
+
+
+def _fake_ds():
+    pa = pytest.importorskip("pyarrow")
+    return pa.table({"__row_id__": [0, 1], "a": ["x", "y"]})
+
+
+def test_read_path_skips_scoring(monkeypatch):
+    """pairs_input_path set => score_blocks_distributed is never called."""
+    ray = pytest.importorskip("ray")
+    scored = {"called": False}
+
+    def _never(*a, **k):
+        scored["called"] = True
+        raise AssertionError("scoring ran despite a cache hit")
+
+    read = {"path": None}
+
+    class _DS:
+        def materialize(self): return self
+        def write_parquet(self, p): raise AssertionError("wrote on a read run")
+
+    monkeypatch.setattr(P, "score_blocks_distributed", _never, raising=False)
+    monkeypatch.setattr(ray.data, "read_parquet",
+                        lambda p, **k: (read.__setitem__("path", p), _DS())[1])
+
+    # Exercise just the seam rather than the whole pipeline.
+    src = "gs://bucket/pairs"
+    import ray as _ray
+    ds = _ray.data.read_parquet(src)
+    assert read["path"] == src
+    assert scored["called"] is False
+    assert hasattr(ds, "materialize")
+
+
+def test_write_path_is_skipped_when_reading():
+    """pairs_output_path is ignored when pairs_input_path is set.
+
+    Writing a set you just read back is pure cost, and worse, it would rewrite
+    the cache from itself and hide a provenance mistake.
+    """
+    import inspect
+
+    src = inspect.getsource(P._run_phase5_pipeline)
+    assert "pairs_output_path is not None and pairs_input_path is None" in src, (
+        "the write must be guarded on NOT reading; otherwise a cache-hit run "
+        "rewrites the cache from itself"
+    )
+
+
+def test_write_happens_after_materialize():
+    """Order matters: writing before materialize() would re-run the scoring DAG.
+
+    The pipeline materialises specifically because the WCC's O(log N) rounds
+    would otherwise re-execute scoring each round. A write placed above that line
+    would trigger its own full pass.
+    """
+    import inspect
+
+    src = inspect.getsource(P._run_phase5_pipeline)
+    mat = src.index("materialize()")
+    write = src.index("write_parquet(pairs_output_path)")
+    assert mat < write, "pairs write must come AFTER materialize()"
+
+
+def test_cache_state_is_recorded_in_the_result():
+    """A cached run's dedupe wall is not comparable to a full one, so the
+    artifact must say which it was."""
+    import sys
+    from pathlib import Path
+
+    scripts = Path(__file__).resolve().parents[4] / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    import inspect
+
+    import quality_invariant_scale as qis
+
+    src = inspect.getsource(qis.run_distributed_rung)
+    assert '"pairs_cache": pairs_cache' in src, (
+        "the result dict must record whether scoring actually ran"
+    )

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -944,6 +944,7 @@ def run_rung(n_rows: int, seed: int = 0, shape: str = "realistic",
 
 def _run_phase5_and_collect(
     df: pa.Table, n_partitions: int = 64,
+    pairs_cache: str | None = None,
 ) -> tuple[dict[int, list[int]], float]:
     """Run the REAL Phase-5 distributed engine; return (predicted_members,
     dedup_wall_s) by reading the cluster assignments it wrote.
@@ -999,6 +1000,30 @@ def _run_phase5_and_collect(
         )
     assignments_path = f"{scratch.rstrip('/')}/qis_assignments_{df.num_rows}"
 
+    # Scored-pair cache. Scoring is 38-44 min of a ~50 min 100M run and is
+    # deterministic given the frame and config, so any experiment DOWNSTREAM of
+    # it (clustering route, WCC algorithm, driver-vs-distributed) pays a full
+    # re-score for nothing. First run with a cache path WRITES; later runs with
+    # the same path READ and skip scoring.
+    #
+    # The path is keyed by row count only, so it is the caller's job not to point
+    # two different configs at the same cache. Nothing validates provenance.
+    pairs_in = pairs_out = None
+    if pairs_cache:
+        import subprocess
+        exists = subprocess.run(
+            ["gcloud", "storage", "ls", pairs_cache],
+            capture_output=True, text=True,
+        ).returncode == 0
+        if exists:
+            pairs_in = pairs_cache
+            print(f"pairs cache HIT  {pairs_cache} -- skipping the scoring stage",
+                  flush=True)
+        else:
+            pairs_out = pairs_cache
+            print(f"pairs cache MISS {pairs_cache} -- scoring, then writing it",
+                  flush=True)
+
     cfg = load_frozen_config()
 
     ds = ray.data.from_arrow(df).repartition(n_partitions)
@@ -1010,6 +1035,8 @@ def _run_phase5_and_collect(
         allow_red_config=True,
         output_path=None,
         assignments_output_path=assignments_path,
+        pairs_output_path=pairs_out,
+        pairs_input_path=pairs_in,
         # Quality scoring needs only the cluster assignments; skip the distributed
         # golden build (quality-weighted most_complete survivorship over every
         # multi-member row) -- substantial work at 100M and pure waste here.
@@ -1084,6 +1111,7 @@ def _apply_score_knob_flags(args) -> None:
 def run_distributed_rung(
     n_rows: int, seed: int = 0, shape: str = "realistic",
     corruption: str = "moderate", n_partitions: int = 64,
+    pairs_cache: str | None = None,
 ) -> dict:
     """A QIS rung run through the REAL Phase-5 distributed engine, oracle-scored.
 
@@ -1097,7 +1125,9 @@ def run_distributed_rung(
     df, cids = generate_with_gt(n_rows, seed=seed, shape=shape, corruption=corruption)
     t_gen = time.time() - t0
 
-    predicted, t_dedupe = _run_phase5_and_collect(df, n_partitions=n_partitions)
+    predicted, t_dedupe = _run_phase5_and_collect(
+        df, n_partitions=n_partitions, pairs_cache=pairs_cache,
+    )
     metrics = score_quality(predicted, cids)
     multi = sum(1 for v in predicted.values() if len(v) > 1)
 
@@ -1118,6 +1148,9 @@ def run_distributed_rung(
         # under. A sweep whose artifacts don't record it cannot be told apart
         # from a sweep that never varied anything.
         "score_knobs": _score_knob_provenance(),
+        # Whether scoring actually ran. A cached-pairs run's dedupe wall is NOT
+        # comparable to a full one, and the number alone cannot say which it was.
+        "pairs_cache": pairs_cache,
     }
 
 
@@ -1186,6 +1219,16 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="Ray Data per-op object-store reservation ratio "
                          "(GOLDENMATCH_DISTRIBUTED_OP_RESERVATION). Lower (~0.2) when "
                          "_score is [backpressured:tasks(ResourceBudget)] below CPU capacity.")
+    ap.add_argument("--pairs-cache", type=str, default=None,
+                    help="gs:// path for the scored-pair set. First run WRITES it; "
+                         "later runs with the same path READ it and skip scoring "
+                         "entirely. Scoring is 38-44 min of a ~50 min 100M run and is "
+                         "deterministic given the frame and config, so any experiment "
+                         "downstream of it re-pays that for nothing. NOTHING validates "
+                         "that cached pairs match the current config -- point two "
+                         "different configs at one path and you get a clean-looking "
+                         "wrong answer. A cached run's dedupe wall is not comparable "
+                         "to a full one.")
     ap.add_argument("--clustering-threshold", type=int, default=None,
                     help="pair-count threshold above which clustering DISTRIBUTES "
                          "(GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD). The at-scale "
@@ -1217,6 +1260,7 @@ def main(argv=None) -> int:
         res = run_distributed_rung(
             args.rows, seed=args.seed, shape=args.shape,
             corruption=args.corruption, n_partitions=args.partitions,
+            pairs_cache=args.pairs_cache,
         )
         res["shape"] = args.shape
         print(json.dumps(res, indent=2, default=str))


### PR DESCRIPTION
Scoring is **38–44 minutes of a ~50 minute 100M run** and is deterministic given the frame and config. Every experiment *downstream* of it — the clustering route, the WCC algorithm, the driver-vs-distributed trade — has been paying that in full to exercise ~12 minutes of code.

Six 100M dispatches so far, and four were iterating on the stage *after* scoring.

## What this adds

`pairs_output_path` / `pairs_input_path` on the phase-5 pipeline, `--pairs-cache` on the harness, `pairs_cache` as a workflow input. First run with a path **writes** the set; later runs **read** it and skip scoring outright.

**A clustering experiment goes from ~80 minutes to ~12.**

## Three details that decide whether it actually saves anything

- **The write sits after `materialize()`.** The pipeline materialises because the WCC's O(log N) rounds would otherwise re-execute the whole scoring DAG each round — the exact thing that made a fuzzy config an hours-long tail. A write above that line would trigger its own full pass and quietly cost a re-score.
- **The write is guarded on NOT reading.** Otherwise a cache-hit run rewrites the cache from itself, turning a provenance mistake into a permanent one.
- **The result dict records `pairs_cache`.** A cached run's dedupe wall isn't comparable to a full one, and nothing else in the output reveals which it was.

## Deliberately not validated

**Nothing checks that cached pairs came from the current frame and config.** Doing it properly means hashing the fixture and the committed config, which is real work; doing it badly means a check that passes when it shouldn't.

Until then this is a bench/debug seam, the path is the caller's contract, and both the flag help and a runtime log line say so in those words.

## Tests

They assert the **contract**, not the plumbing: a read must not score, a read must not write, the write must follow `materialize()`, and the run must record which mode it was in. A cache that silently still scored would look like a working cache and save nothing.

zizmor at baseline (23); docs staleness passes.