### PR TITLE
perf(ci): restore the rust cache before the extras install, not after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,25 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
       - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      # ORDER IS LOAD-BEARING: the rust toolchain + cache come BEFORE the
+      # `uv pip install` extras below, not after. goldenmatch-native is a
+      # marker-guarded DEFAULT dependency of goldenmatch (not an extra), with
+      # tool.uv.sources pointing at the local crate -- so `uv pip install -e
+      # 'goldenmatch[documents]'` re-resolves it and BUILDS it, undoing the
+      # `--no-install-package goldenmatch-native` on the sync above. With the
+      # cache restored AFTER that install the build ran COLD: 102s inside the
+      # extras step, then 30s for the same crate in `Build native ext` once the
+      # cache (full match) had landed. Restoring first makes the first build the
+      # warm one. Measured on a full-matrix dispatch of this change: the
+      # documents-extra step went 104s -> 69-91s, `Build native ext` 30s -> 23-29s.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: |
+            packages/rust/extensions/datafusion-udf
+            packages/rust/extensions/native
       # Scale-mode DataFusion edge stream (cluster_edges_df.py) lives behind the
       # optional `datafusion` extra; install it so the parity tests RUN rather
       # than importorskip-SKIP (a false green). Cheap (wheel download).
@@ -379,14 +398,6 @@ jobs:
       # must carry a justification noqa. goldenmatch-only gate.
       - if: matrix.shard == 1
         run: uv run python scripts/check_map_elements.py
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
-        with:
-          workspaces: |
-            packages/rust/extensions/datafusion-udf
-            packages/rust/extensions/native
       # THE BUILD-TIME WIN: cache the built FFI UDF wheel keyed on the Rust
       # sources it's compiled from (the crate + every path-dep crate). On a hit
       # (the common case — these change rarely) the ~6.5-min --release maturin


### PR DESCRIPTION
## What

Move the rust toolchain + `Swatinem/rust-cache` steps in `python_goldenmatch`
**above** the `uv pip install` extras, instead of below them.

## Why

`goldenmatch-native` is a marker-guarded **default** dependency of
`goldenmatch` (not an extra), and `[tool.uv.sources]` points it at the local
crate. So `uv pip install -e 'goldenmatch[documents]'` re-resolves it and
**builds** it -- undoing the `--no-install-package goldenmatch-native` on the
`uv sync` above.

With the cache restored *after* that install, that build ran cold. Measured on
the previous full-matrix run:

| step | before | after |
| --- | --- | --- |
| `uv pip install ... goldenmatch[documents]` | 104s | 69-91s |
| `Build native ext` | 30s | 23-29s |

## Scope change from the first revision of this PR

This PR originally also moved six "contention-sensitive" tests into a serial
step spread across shards, on the theory that they cost ~4.6x more
co-scheduled than alone.

**That diagnosis was wrong.** The 4.6x came from comparing a `--store-durations`
harvest against a CI shard -- but the harvest workflow runs pytest *without*
`--cov=goldenmatch`, while CI runs *with* it. A local A/B on one of those tests:

```
without --cov:  26.18s
with    --cov:  78.53s     3.0x
```

Coverage instrumentation, not co-scheduling, is the dominant term. The
full-matrix dispatch confirmed the fix did not work as designed: shard 1's
pytest halved (502s -> 266s) but the serial steps added 176s and 212s to
shards 2 and 3, taking the **max** shard job from 618s to 698s. Going serial
forfeits parallelism; it does not recover a contention cost that was not there.

The serial-step change and its accounting gate are dropped. What remains is the
cache-ordering fix, which was measured independently and is unaffected.

The harvest workflow's missing `--cov` is fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaapLLjB7dFxQMnWPqsZE5
