### PR TITLE
fix(ci): harvest durations WITH coverage, like ci.yml runs them

### DIFF
--- a/.github/workflows/harvest-test-durations.yml
+++ b/.github/workflows/harvest-test-durations.yml
@@ -108,6 +108,13 @@ jobs:
       - name: Build native ext (reference mode -> native is the default test path)
         run: uv run python scripts/build_native.py
 
+      # --cov IS PART OF THE SHAPE, not an optional extra. ci.yml's sharded run
+      # is instrumented (`--cov=goldenmatch --cov-report=`) and coverage costs
+      # real wall: measured 26.18s vs 78.53s (3.0x) on a single test locally.
+      # A duration harvested uninstrumented cannot balance shards that run
+      # instrumented -- and worse, the gap between the two then LOOKS like a
+      # contention difference, which is exactly the wrong diagnosis to reach.
+      #
       # Harvest under the SAME shape ci.yml runs (-n auto, 3 splits, identical
       # ignore + deselect lists), because a duration measured serially would not
       # predict a wall measured under xdist contention. --store-durations records
@@ -130,6 +137,7 @@ jobs:
             --durations-path "${GITHUB_WORKSPACE}/durations_shard${{ matrix.shard }}.json" \
             --store-durations \
             --timeout=120 --timeout-method=thread \
+            --cov=goldenmatch --cov-report= \
             --ignore=packages/python/goldenmatch/benchmarks \
             --ignore=packages/python/goldenmatch/tests/test_db.py \
             --ignore=packages/python/goldenmatch/tests/test_reconcile.py \


### PR DESCRIPTION
## The bug

`harvest-test-durations.yml` runs pytest **without** `--cov`. Every
`python_goldenmatch` shard in `ci.yml` runs **with**
`--cov=goldenmatch --cov-report=`.

So every duration the harvest writes into `.test_durations` is measured under
conditions CI never uses.

## How much it matters

Local A/B, same test, back to back:

```
tests/test_allow_red_config.py::test_dedupe_df_raises_on_red_at_scale_at_real_threshold

without --cov:  26.18s
with    --cov:  78.53s     3.0x
```

Coverage instrumentation is a 3x term on this suite's slow tests. pytest-split
balances shards from these numbers, so a systematically-deflated file cannot
balance a run that is instrumented.

## The second-order harm

The gap between an uninstrumented harvest and an instrumented CI shard looks
exactly like a **contention** effect -- same tests, same commit, same runner
class, 4.6x apart. I read it that way and built a serial-execution fix on it
(the first revision of #2792), which a full-matrix dispatch then showed made
the max shard *worse*. The instrument was the variable, not the schedule.

## The fix

Add `--cov=goldenmatch --cov-report=` to the harvest invocation, and say in the
comment that `--cov` is part of the shape being mirrored -- the existing comment
listed `-n auto`, the split count and the ignore/deselect lists, and I diffed
the two commands against that list without noticing the flag that was not on it.

`.test_durations` is unchanged here; the next harvest run produces a file worth
committing. #2790 (the first harvest's output) should be closed rather than
merged -- it was produced by the uninstrumented job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaapLLjB7dFxQMnWPqsZE5
