### PR TITLE
chore(scoreboard): nightly adoption snapshot

### DIFF
--- a/context-network/planning/scoreboard.jsonl
+++ b/context-network/planning/scoreboard.jsonl
@@ -15,3 +15,4 @@
 {"date": "2026-08-24", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": 164867, "npm_30d": 5367}
 {"date": "2026-08-25", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": 166307, "npm_30d": 5434}
 {"date": "2026-08-26", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": null, "npm_30d": 5472}
+{"date": "2026-08-28", "stars": 129, "forks": 13, "open_issues_nonmaintainer": 1, "pypi_30d": 164789, "npm_30d": 4838}

--- a/context-network/planning/scoreboard.md
+++ b/context-network/planning/scoreboard.md
@@ -5,14 +5,14 @@
 [north-star-roadmap.md](./north-star-roadmap.md): *is GoldenMatch becoming the
 tool developers reach for by default?* Trend > snapshot.
 
-**Latest: 2026-08-26** (vs previous snapshot)
+**Latest: 2026-08-28** (vs previous snapshot)
 
 | Signal | Now | WoW | North Star reading |
 |---|---|---|---|
 | GitHub stars | 129 | 129 (▬0) | discovery momentum |
 | Forks | 13 | 13 (▬0) | intent-to-use |
-| PyPI downloads (30d, suite) | — | — | actual reach |
-| npm downloads (30d, suite) | 5.5k | 5.5k (▲+38) | actual reach (TS) |
+| PyPI downloads (30d, suite) | 164.8k | 164.8k | actual reach |
+| npm downloads (30d, suite) | 4.8k | 4.8k (▼-634) | actual reach (TS) |
 | Open issues, non-maintainer | 1 | 1 (▬0) | "someone reached for it"† |
 
 † Raw count — still needs human triage to exclude badge-marketing bots
@@ -23,6 +23,7 @@ GENUINE inbound issue from a stranger**; a bot filing a promo badge does not cou
 
 | Date | Stars | Forks | PyPI 30d | npm 30d | Ext. issues |
 |---|---|---|---|---|---|
+| 2026-08-28 | 129 | 13 | 164.8k | 4.8k | 1 |
 | 2026-08-26 | 129 | 13 | — | 5.5k | 1 |
 | 2026-08-25 | 129 | 13 | 166.3k | 5.4k | 1 |
 | 2026-08-24 | 129 | 13 | 164.9k | 5.4k | 1 |
@@ -38,7 +39,6 @@ GENUINE inbound issue from a stranger**; a bot filing a promo badge does not cou
 | 2026-08-14 | 128 | 13 | — | 4.9k | 1 |
 | 2026-08-13 | 128 | 13 | — | 4.9k | 1 |
 | 2026-08-11 | 128 | 13 | — | 4.9k | 2 |
-| 2026-08-10 | 128 | 13 | 96.4k | 4.9k | 2 |
 
 ## The gates (from the roadmap)
 


### PR DESCRIPTION
Nightly North Star adoption snapshot: stars, forks, PyPI/npm 30-day
downloads and non-maintainer inbound issues, appended to the trend.

Generated by `scripts/scoreboard.py` via `.github/workflows/scoreboard.yml`.
The `.md` is rewritten wholesale from the `.jsonl` each run; the new
data is the single appended row.
