### PR TITLE
fix(distributed): calibrate the clustering-route estimator, and stop the bench pinning the route

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -232,10 +232,10 @@ The single most expensive distributed-tuning mistake is distributing a *stage* t
 | Stage | Fits one node at 100M? | Fast path | Slow trap |
 |-------|------------------------|-----------|-----------|
 | Scoring | No: 100M rows | **Distributed** across workers, **native kernel on** (`GOLDENMATCH_NATIVE=1` + `goldenmatch-native` installed on every node) | pure-Python (cluster installs plain `goldenmatch`); ~6 of 80 CPU if the shuffle blocks are oversized |
-| Clustering (WCC) | **Yes**: the scored pair set is small (~1.76 GB / 110M edges at 100M) | **In-memory** driver-side `scipy.csgraph` connected-components (~60s) | the distributed randomized-contraction WCC: its O(log N) `gs://`-checkpoint rounds are a multi-hour tail when forced on a pair set that fits |
+| Clustering (WCC) | **Usually**: far smaller than the records, but not small -- 609.4M edges at 100M, ~81 GB driver peak measured | **In-memory** driver-side `scipy.csgraph` connected-components (~60s) | the distributed randomized-contraction WCC: its O(log N) `gs://`-checkpoint rounds are a multi-hour tail when forced on a pair set that fits |
 | Golden | depends | distributed groupby, or **skip it** if you only need cluster membership | building golden you then discard |
 
-**Concrete: don't force the distributed WCC on a pair set that fits.** By default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is **unset and the routing is memory-aware**, clustering stays on the fast in-memory `scipy.csgraph` path whenever the scored pair set fits available driver RAM, and only distributes when it genuinely won't. So at 100M (~110M pairs / ~1.76 GB) the default keeps clustering in-memory on a 64–256 GB head. Set an explicit integer only if you want to force a hard pair-count boundary either way:
+**Concrete: don't force the distributed WCC on a pair set that fits.** By default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is **unset and the routing is memory-aware**, clustering stays on the fast in-memory `scipy.csgraph` path whenever the scored pair set fits available driver RAM, and only distributes when it genuinely won't. At 100M the scored pair set measures 609.4M pairs and the in-memory route's driver peak measures ~81 GB, so the default keeps clustering in-memory on a 128-256 GB head and distributes on a 64 GB one. Set an explicit integer only if you want to force a hard pair-count boundary either way:
 
 ```bash
 export GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=2000000000  # force in-memory WCC below 2B pairs
@@ -270,7 +270,7 @@ These trade nothing for speed/memory at scale and are safe to leave at their def
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `GOLDENMATCH_BUCKET_DEBUG` | `0` | Print per-bucket prep / kernel / post-filter timing for `backend=bucket`. Output-invariant, near-zero cost, but it's a debug aid, not a speed-up. |
-| `GOLDENMATCH_CLUSTER_DEBUG` | `0` | Print a per-step timing split for the DRIVER-SIDE clustering stage: pull pairs to driver / derive id universe / map ids to dense index / connected components / build output table. Output-invariant; one env read plus a `perf_counter` per step. Use it when that stage dominates a distributed run — at 100M rows it is ~16 minutes for ~70s of graph algorithm, and this says which step owns the rest. On a Ray cluster set it in the cluster yaml's `docker run_options`, **not** in a shell around `ray submit`: the driver runs through a fresh `docker exec` and would never see the export. |
+| `GOLDENMATCH_CLUSTER_DEBUG` | `0` | Print a per-step timing split for the DRIVER-SIDE clustering stage: pull pairs to driver / derive id universe / map ids to dense index / connected components / build output table. Output-invariant; one env read plus a `perf_counter` per step. Use it when that stage dominates a distributed run — at 100M rows it measured 707s, of which connected components is 315.9s (44.7%) and pulling pairs to the driver 245.5s (34.7%) -- it is not the pure-transport stage an earlier ~70s estimate for the algorithm implied. On a Ray cluster set it in the cluster yaml's `docker run_options`, **not** in a shell around `ray submit`: the driver runs through a fresh `docker exec` and would never see the export. |
 | `GOLDENMATCH_CANDIDATE_COUNT_MAX_BLOCKS` | `10000` | Max blocks for which scoring counts candidate pairs. Above it the loop is skipped -- counting materialises each block -- and `ScoringProfile.candidates_compared` stays 0 with `candidates_counted=False`. Raise it (e.g. `1000000000`) only to make an auto-config diagnostic answerable: it buys a serial pass over every block. Garbage or negative values fall back to the default. |
 | `GOLDENMATCH_TRANSFORM_DEBUG` | `0` | Print the prep-transform arrow-lane split (`pl.from_arrow` / `_do_transform` / `to_arrow`) to size the bridge vs the transform compute. Output-invariant, near-zero cost; a debug aid, not a speed-up. |
 | `GOLDENMATCH_PREP_STAGED_COLLECT` | `0` | Collect prepared records in stages (memory-management experiment). Can be slower; leave off unless diagnosing prep RSS. |
@@ -388,7 +388,7 @@ Read these before a big run. Each is a real trap that produces a slow or wrong r
     The per-row Python address-normalize plugin is a real bottleneck at scale. Set `GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1` to use the Polars-native expression instead. It's off by default, so you have to opt in.
   </Accordion>
   <Accordion title="A distributed 100M run took hours instead of minutes">
-    The scored pair set is small (~1.76 GB at 100M) and fits one node. By default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is unset and routing is **memory-aware**, clustering stays in-memory (`scipy.csgraph`, ~60s) whenever the pair set fits driver RAM, so a 100M run should already keep clustering on the fast path. The multi-hour tail happens if something forces the *distributed* WCC (whose `gs://`-checkpoint rounds are slow): check you haven't set the threshold to `0` (forces the slow path on everything) or to a value **below** your pair count. See [Fast path at scale](#fast-path-at-scale-distribute-only-what-doesnt-fit). Distribute the *scoring* (the rows don't fit), not the *clustering* (the pairs do).
+    The scored pair set fits one node on a large head (609.4M pairs at 100M, ~81 GB driver peak measured -- fits 128-256 GB, not 64 GB). By default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is unset and routing is **memory-aware**, clustering stays in-memory (`scipy.csgraph`, ~60s) whenever the pair set fits driver RAM, so a 100M run should already keep clustering on the fast path. The multi-hour tail happens if something forces the *distributed* WCC (whose `gs://`-checkpoint rounds are slow): check you haven't set the threshold to `0` (forces the slow path on everything) or to a value **below** your pair count. See [Fast path at scale](#fast-path-at-scale-distribute-only-what-doesnt-fit). Distribute the *scoring* (the rows don't fit), not the *clustering* (the pairs do).
   </Accordion>
   <Accordion title="Results changed between runs for no reason">
     Cross-run auto-config memory (`GOLDENMATCH_AUTOCONFIG_MEMORY=1`, the default) lets a prior run influence the next. For reproducible benchmarks set `GOLDENMATCH_AUTOCONFIG_MEMORY=0`.
@@ -781,7 +781,7 @@ working set exceeds the driver-RAM budget (`available_ram_gb × 0.6`):
 
 - **Clustering / WCC** distributes when the projected edge set
   (`estimated_pair_count × 16 bytes`) exceeds the budget. At 100M rows the
-  ~1.76 GB edge set fits, so WCC runs in-memory (scipy): forcing the
+  609.4M-pair edge set fits a large head, so WCC runs in-memory (scipy): forcing the
   distributed path there is a multi-hour tail.
 - **Scoring** and **golden** distribute when the row-frame estimate
   (`n_rows × 512 bytes`) exceeds the budget. The same data therefore distributes

--- a/docs/distributed/ray-optimal-setup.md
+++ b/docs/distributed/ray-optimal-setup.md
@@ -156,12 +156,36 @@ it can set anything.
 
 ## 6. The clustering trade, stated honestly
 
-At 100M the at-scale config sets `CLUSTERING_THRESHOLD=2000000000`, routing
-clustering to the **driver** rather than the distributed WCC. The reason recorded
-in the code is that the distributed WCC's `gs://` checkpoint rounds were a
-multi-hour tail.
+The at-scale config used to pin `CLUSTERING_THRESHOLD=2000000000` -- "never
+distribute" -- to dodge the distributed WCC's `gs://` checkpoint rounds. That pin
+is gone. The harness now leaves the threshold unset so the memory-aware route
+decides, and the route is sized against a measured per-pair cost rather than a
+modelled one.
 
-That is a choice between two poor options, not evidence the driver path is good.
+The trade, measured at 100M across four runs of the same shape (realistic /
+moderate / frozen config / 64 partitions / shuffle_parts=512):
+
+| route | dedupe | driver peak RSS | run |
+| --- | --- | --- | --- |
+| in-memory `scipy.csgraph` | 3236.95s | 125.2 GB | 32992647463 |
+| in-memory `scipy.csgraph` | 2906.07s | 132.0 GB | 33006980567 |
+| in-memory `scipy.csgraph` | 3284.24s | 132.0 GB | 33074452121 |
+| distributed WCC | 3686.03s | 50.9 GB | 33087786765 |
+
+Output was identical: pairwise F1 `0.9265507059539793` to 16 digits, cluster F1
+and `multi_member_clusters` (18,880,989) byte-identical.
+
+So distributing costs roughly **+14% dedupe wall** (3686s against a 3237s median)
+and returns **-61% driver peak RSS**. Read the wall number with care: the three
+in-memory runs spread 378s (12%) among themselves, so the penalty is about one
+noise band at n=3 vs n=1, and it is not worth a paid run to pin down because
+nothing downstream turns on it.
+
+The RSS gap has no overlap, and it is the half that decides anything. The head is
+an n2-highmem-32 (256 GB) and the in-memory route already uses 52% of it at 100M
+on 609,398,412 pairs. Pairs scale with rows, so **the in-memory route runs out of
+head before it runs out of speed** -- which is why the route keys on memory and
+not on wall.
 
 **Measured split** (`GOLDENMATCH_CLUSTER_DEBUG=1`, 100M rung, run 33074452121 —
 609,398,412 pairs over 99,417,363 ids, 707.3s total):

--- a/docs/quality-invariant-scale.md
+++ b/docs/quality-invariant-scale.md
@@ -212,7 +212,7 @@ Identical to four decimals (18.88M multi-member clusters recovered vs 20M GT; 17
 exact-match). So **the distributed engine holds quality** — the residual precision
 drift above is a property of the *config*, not the engine, and is invariant across
 engines. Two harness lessons worth recording: (1) **only scoring needs
-distribution** — the scored pair set is ~1.76 GB and fits one node, so clustering
+distribution** — the scored pair set (609.4M pairs, ~81 GB driver peak at 100M) fits a large head, so clustering
 runs in-memory (driver-side `scipy.csgraph` connected-components, ~60s); forcing the
 distributed WCC on it was a multi-hour mistake. (2) The connected-components result
 is independent of the WCC algorithm, so a completed run's cluster *assignments* are

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -150,20 +150,53 @@ def _wcc_algorithm() -> str:
     return os.environ.get("GOLDENMATCH_DISTRIBUTED_WCC", "two_phase").lower()
 
 
-# Peak driver bytes per scored pair on the in-memory connected-components route: ~24 B for the
-# (id_a, id_b, score) = (int64, int64, f64) triple, times ~4 because the arrow
-# table, the numpy id arrays, the symmetrized edge arrays, and the labels array
-# are all live at once. Deliberately conservative -- routing in-memory must not
-# OOM the driver.
-_PAIR_PEAK_BYTES = 96
+# Peak driver bytes per scored pair on the in-memory connected-components route.
+#
+# MEASURED, not modelled. Two 100M-row bench-ray-cluster runs of the same shape
+# (realistic / moderate / frozen config / 64 partitions / shuffle_parts=512)
+# differing only in the clustering route:
+#
+#   run 33074452121  in-memory (scipy)   peak RSS 132.0 GB   dedupe 3284s
+#   run 33087786765  distributed WCC     peak RSS  50.9 GB   dedupe 3686s
+#
+# The distributed route has no driver collect, so 50.9 GB is the non-clustering
+# baseline and the 81.2 GB gap IS this route's driver cost. Run 33074452121 also
+# carried GOLDENMATCH_CLUSTER_DEBUG=1, so its pair count comes from the same
+# execution: 609,398,412 pairs over 99,417,363 ids. 81.2 GB / 609,398,412 =
+# 143 B/pair.
+#
+# TAKE THE DENOMINATOR FROM THE STAGE BEING SIZED. The tempting number is the
+# artifact's tp+fp (226,579,648) -- that is the PREDICTED-PAIR count used for
+# quality scoring, and it is 2.7x smaller than the edge set that reaches the
+# router. `build_clusters_distributed` routes on `pairs_ds.count()`, and
+# `_build_clusters_cc_fallback` reports that same count. Calibrating on tp+fp
+# yields 385 B/pair -- a number that is wrong by exactly the ratio of the two
+# denominators, and looks plausible while being so.
+#
+# The old 96 was also wrong at its base, not just its factor: it modelled a 24 B
+# (id_a, id_b, score) triple, but the driver pulls
+# `select_columns(["id_a", "id_b"])` -- 16 B, no score. 143 B/pair is ~8.9 live
+# copies of that 16 B, which the arrow concat, the dense-index map, the
+# symmetrized edge arrays and the CSR structure account for.
+#
+# Revise UP, not down, if another shape measures higher: under-estimating OOMs
+# the driver and kills the run, while over-estimating distributes unnecessarily
+# and cost +12.2% dedupe wall here, against a 12% run-to-run spread. `available`
+# at decision time already nets off what the process holds, so this constant
+# needs to cover only the INCREMENTAL clustering allocation -- which is what the
+# inter-route gap measures.
+_PAIR_PEAK_BYTES = 143
 
 
 def _route_distributed(pair_count: int) -> bool:
     """Decide the clustering route: True => distributed WCC, False => in-memory connected-components.
 
     The scored pair set fits one node far more often than the legacy fixed 50M
-    threshold assumed (110M pairs ~= 1.76 GB raw), so the slow distributed WCC
-    was the default well below where it was actually needed (#956).
+    threshold assumed, so the slow distributed WCC was the default well below
+    where it was actually needed (#956). "Fits" is not "is small", though: the
+    measured 100M rung is 609,398,412 pairs and ~81 GB of driver peak. It fits a
+    256 GB head and does not fit a 64 GB one, which is exactly why this routes on
+    measured memory rather than on a pair count.
 
     Precedence:
       * ``force_label_propagation`` (handled by the caller) always distributes.
@@ -229,10 +262,12 @@ def _derive_touched_ids(pairs_ds: Dataset) -> pa.Array:
 
     This used to ``.to_pylist()`` both id columns into a Python ``set`` and
     ``sorted()`` it. The docstring justified that with "gated below the 50M-pair
-    threshold, so the set is bounded" -- but the at-scale QIS config raises
-    GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD to 2e9 deliberately (to dodge
-    the distributed WCC's multi-hour checkpoint tail), which routes ~226M pairs
-    straight here: 4.5x past the bound that safety argument rested on. That is
+    threshold, so the set is bounded" -- but nothing holds the pair count under
+    that bound. The memory-aware route sends whatever fits driver RAM here, and
+    the measured 100M run is 609M pairs: 12x past the bound that safety argument
+    rested on. (The at-scale QIS harness used to pin the threshold to 2e9, which
+    forced the same exposure by hand; the pin is gone, the exposure is not.)
+    That is
     ~452M boxed ints into a 100M-entry set plus a 100M-element Python sort, on
     one core.
 
@@ -469,10 +504,19 @@ def _cluster_debug_on() -> bool:
     This exists because the stage was optimised twice from inference rather than
     measurement. The driver phase went 65 -> 33 -> ~25 min across two fixes, and
     both times the predicted saving was roughly double what arrived, because a
-    single component was treated as the whole cost. The arithmetic that IS solid
-    says connected-components itself is ~70s at 226M edges and `index_in` ~150s,
-    so most of the stage is neither -- but "most" was never attributed to a
-    named step. One table settles that; another round of guessing does not.
+    single component was treated as the whole cost.
+
+    It has since settled the question, and overturned the estimate written here.
+    Run 33074452121 at the 100M rung, 609,398,412 pairs over 99,417,363 ids,
+    707.3s total: connected components 315.9s (44.7%), pull pairs to driver
+    245.5s (34.7%), map ids to dense index 79.8s (11.3%), derive id universe
+    64.7s (9.1%), build output 1.3s (0.2%).
+
+    The estimate this replaced said CC was "~70s at 226M edges", so it was wrong
+    4.5x, and wrong two ways at once: 226M is `tp + fp`, the predicted-pair count
+    used for quality scoring, not the 609M edge set that reaches this stage; and
+    the shipped kernel is `connected_components_undirected`, not scipy, which is
+    what the 70s was benchmarked on. Size this stage from the instrument.
 
     NOTE for whoever turns it on against a Ray cluster: set it in the cluster
     yaml's `docker run_options`, NOT in a shell around `ray submit`. Ray runs the
@@ -507,11 +551,16 @@ def _build_clusters_cc_fallback(
     # `_derive_touched_ids` used to make its OWN full pass first, so the whole
     # edge set crossed to the driver TWICE.
     #
-    # At the 100M rung that is 226M pairs: 2 passes x (int64, int64, float64)
-    # = ~10.8 GB, against ~3.6 GB for one pass of the two columns actually used.
-    # The graph algorithm underneath costs ~70s (measured: scipy connected_
-    # components on 20M edges is 6.4s, and it scales close to linear), so the
-    # driver stage was overwhelmingly data movement rather than clustering.
+    # At the 100M rung that is 609,398,412 pairs: 2 passes x (int64, int64,
+    # float64) = ~27.2 GB, against ~9.1 GB for one pass of the two columns
+    # actually used.
+    #
+    # That saving is real, but the conclusion once drawn from it -- "the driver
+    # stage is overwhelmingly data movement rather than clustering" -- was not.
+    # It rested on a ~70s estimate for the graph algorithm, extrapolated from
+    # scipy on 20M edges. GOLDENMATCH_CLUSTER_DEBUG measured the shipped kernel
+    # at 315.9s of a 707.3s stage (44.7%), against 245.5s (34.7%) for the pull.
+    # Clustering is the largest single item; transport is about a third.
     import time as _time
 
     import numpy as np

--- a/packages/python/goldenmatch/tests/test_distributed_clustering.py
+++ b/packages/python/goldenmatch/tests/test_distributed_clustering.py
@@ -237,7 +237,7 @@ def test_route_distributed_memory_aware_default(monkeypatch):
 
     monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", raising=False)
 
-    # 200 GB available: 110M pairs (the #956 case, ~10 GB peak) FITS -> in-memory.
+    # 200 GB available: 110M pairs (the #956 case, ~15 GB peak) FITS -> in-memory.
     monkeypatch.setattr(
         psutil, "virtual_memory", lambda: types.SimpleNamespace(available=200 * 1024 ** 3)
     )
@@ -256,6 +256,75 @@ def test_route_distributed_memory_aware_default(monkeypatch):
     )
     assert _route_distributed(avail // _PAIR_PEAK_BYTES + 1) is True
     assert _route_distributed(avail // _PAIR_PEAK_BYTES - 1) is False
+
+
+def test_pair_peak_bytes_matches_the_measurement_it_cites():
+    """The constant is a measured claim, so it gets a test.
+
+    Its comment cites two 100M bench-ray-cluster runs. The sibling routing tests
+    reference the constant symbolically, so they pass for ANY value -- including
+    the 96 the measurement refuted. This pins the number against those runs.
+
+    Denominator note, because getting it wrong is the easy mistake here: the pair
+    count is 609,398,412 (GOLDENMATCH_CLUSTER_DEBUG on run 33074452121, the same
+    count `build_clusters_distributed` routes on), NOT the artifact's tp+fp of
+    226,579,648, which is the predicted-pair count used for quality scoring.
+    """
+    from goldenmatch.distributed.clustering import _PAIR_PEAK_BYTES
+
+    in_memory_peak_mb = 135198.75   # run 33074452121
+    distributed_peak_mb = 52077.27  # run 33087786765
+    pairs = 609_398_412             # cluster_debug, == pairs_ds.count()
+
+    gap_bytes = (in_memory_peak_mb - distributed_peak_mb) * 1024 ** 2
+    assert round(gap_bytes / pairs) == _PAIR_PEAK_BYTES == 143, (
+        f"measurement says {gap_bytes / pairs:.0f} B/pair; constant is "
+        f"{_PAIR_PEAK_BYTES}. Revise UP only -- see the constant's comment."
+    )
+
+    # Guard the denominator itself: tp+fp yields 385, and a future edit that
+    # "re-derives" the constant from the quality metrics lands on that number.
+    tp_plus_fp = 197_623_837 + 28_955_811
+    assert round(gap_bytes / tp_plus_fp) == 385
+    assert _PAIR_PEAK_BYTES != 385, (
+        "385 B/pair comes from tp+fp, the quality-scoring pair count -- not the "
+        "edge set that reaches the router. Use pairs_ds.count()."
+    )
+
+
+def test_route_distributes_the_measured_100m_shape_on_a_64gb_head(monkeypatch):
+    """Regression for an estimator too low to protect the driver.
+
+    This is the case the old 96 B got wrong: at the measured 100M shape a 64 GB
+    head cannot hold the in-memory route's ~81 GB of clustering allocation, but
+    96 B/pair estimated only 54.5 GB and would have kept it on the driver -- an
+    OOM, not a slow run. Written as the measured shape rather than as arithmetic
+    on the constant, so lowering the constant fails this test.
+    """
+    import types
+
+    import psutil
+    from goldenmatch.distributed.clustering import _route_distributed
+
+    monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", raising=False)
+    pairs = 609_398_412  # the measured 100M scored-pair set
+
+    # 60 GB free on a 64 GB head: the measured ~81 GB does not fit -> distribute.
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: types.SimpleNamespace(available=60 * 1024 ** 3)
+    )
+    assert _route_distributed(pairs) is True, (
+        "the measured 100M pair set must NOT be routed in-memory on a 64 GB head"
+    )
+
+    # 241 GB free (the n2-highmem-32 head these runs used): it fits, and three
+    # in-memory runs completing on that head is the evidence that it does.
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: types.SimpleNamespace(available=241 * 1024 ** 3)
+    )
+    assert _route_distributed(pairs) is False, (
+        "on the 256 GB head the in-memory route measurably fits; do not distribute"
+    )
 
 
 def test_route_distributed_env_override_wins(monkeypatch):

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -977,15 +977,28 @@ def _run_phase5_and_collect(
     os.environ.setdefault("GOLDENMATCH_ENABLE_DISTRIBUTED_RAY", "1")
     os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = "2"
     os.environ["GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE"] = "1"
-    # Cluster the scored pairs with the FAST in-memory WCC (driver-side
-    # scipy.csgraph), NOT the distributed randomized-contraction. The scored edge
-    # set is small (~110M pairs ~1.76 GB at 100M, ~3.5 GB at 200M) and fits the
-    # highmem head, where connected-components is ~30-60s. The previous value "0"
-    # FORCED the distributed WCC (pair_count >= 0), whose ~log(N) gs://-checkpoint
-    # rounds were the multi-hour tail. Only SCORING needs distribution; the WCC
-    # does not. Setting the threshold above the pair count routes to scipy
-    # (build_clusters_distributed: pair_count < threshold -> scipy.csgraph).
-    os.environ.setdefault("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "2000000000")
+    # CLUSTERING ROUTE: left UNSET on purpose, so the shipped memory-aware
+    # decision (`_route_distributed`) is what the bench measures.
+    #
+    # This used to pin the threshold to 2e9 -- "never distribute" -- as a
+    # workaround for the distributed WCC's log(N) gs://-checkpoint tail, back
+    # when the alternative was a fixed 50M-pair threshold that distributed far
+    # below where it was needed. #956 then made the unset default memory-aware:
+    # the same judgement the pin was making by hand, but sized against the actual
+    # head rather than a round number. The pin outlived its cause AND took
+    # precedence over its replacement -- an explicit threshold wins over the
+    # memory-aware route -- so every at-scale run since has measured a route the
+    # product would not choose. A harness that pins the decision under test
+    # cannot report on it.
+    #
+    # Unsetting is behaviour-preserving on the cluster these runs use: 609.4M
+    # pairs * 143 B = 81 GB estimated against ~241 GB available on the
+    # n2-highmem-32 head -> in-memory, the same route the pin forced. It differs
+    # exactly where it should: a smaller head, or a larger rung.
+    #
+    # --clustering-threshold still forces either route for a deliberate A/B, and
+    # the effective value reaches the artifact's score_knobs (None = memory-
+    # aware), so a run states which route produced its number.
     # Many small shuffle partitions so the block-shuffle's wide exploded records
     # don't form giant blocks that backpressure _score onto a single node (the
     # default cpu*4 from the driver gave ~540 MiB blocks -> pinned to 16 CPU,
@@ -1231,12 +1244,13 @@ def _build_parser() -> argparse.ArgumentParser:
                          "to a full one.")
     ap.add_argument("--clustering-threshold", type=int, default=None,
                     help="pair-count threshold above which clustering DISTRIBUTES "
-                         "(GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD). The at-scale "
-                         "default is 2e9, i.e. never distribute -- clustering runs on "
-                         "the driver, measured at 707s of which 45%% is connected "
-                         "components and 35%% is pulling pairs across. Pass 0 to force "
-                         "the distributed WCC and re-measure that trade; it was rejected "
-                         "as a multi-hour tail before the current code existed.")
+                         "(GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD). Unset by "
+                         "default so the shipped memory-aware route decides; this "
+                         "harness no longer pins it. Pass a value only to force one "
+                         "route for an A/B: 0 always distributes, a value above the "
+                         "pair count never does. Measured at 100M: in-memory 3284s / "
+                         "132.0 GB driver peak, distributed 3686s / 50.9 GB, output "
+                         "identical.")
     ap.add_argument("--shuffle-parts", type=int, default=None,
                     help="block-shuffle partition count "
                          "(GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS; --distributed default 512).")


### PR DESCRIPTION
## Two changes, one cause

`_route_distributed` decides whether clustering runs on the driver or distributes. Both its estimator and the harness that was supposed to exercise it were wrong.

## 1. The estimator was calibrated on nothing

`_PAIR_PEAK_BYTES = 96` modelled "a 24 B `(id_a, id_b, score)` triple x ~4 live copies". The driver actually pulls `select_columns(["id_a","id_b"])` -- **16 B, no score** -- and the real factor is ~8.9x.

Measured against two 100M runs of the same shape (realistic / moderate / frozen config / 64 partitions / `shuffle_parts=512`) differing only in the clustering route:

| run | route | dedupe | driver peak RSS |
| --- | --- | ---: | ---: |
| 33074452121 | in-memory `scipy` | 3284.24s | 132.0 GB |
| 33087786765 | distributed WCC | 3686.03s | 50.9 GB |

The distributed route has no driver collect, so the **81.2 GB gap is the in-memory route's driver cost**. Run 33074452121 also carried `GOLDENMATCH_CLUSTER_DEBUG=1`, so its pair count comes from the same execution: **609,398,412**. That is **143 B/pair**.

### The denominator is the trap

The tempting number is the artifact's `tp + fp` = 226,579,648. That is the **predicted-pair count used for quality scoring**, 2.7x smaller than the edge set that reaches the router -- `build_clusters_distributed` routes on `pairs_ds.count()`.

Calibrating on `tp + fp` gives **385 B/pair**: wrong by exactly the ratio of the denominators, and entirely plausible-looking while being so. I know because that is what I wrote first. A test now pins both the constant *and* rejects 385 by name.

## 2. The bench pinned the decision it was supposed to measure

`quality_invariant_scale.py` set `CLUSTERING_THRESHOLD=2e9` -- "never distribute". A reasonable workaround for the distributed WCC's checkpoint tail when it was written, back when the alternative was a fixed 50M-pair threshold that distributed far below where it was needed.

Then #956 made the unset default memory-aware -- the same judgement the pin was making by hand, but sized against the actual head. **An explicit threshold wins over the memory-aware route**, so the pin outlived its cause *and* suppressed its replacement. Every at-scale run since has measured a route the product would not choose.

Unpinned. Behaviour-preserving on the cluster these runs use (609.4M x 143 B = 81 GB against ~241 GB available -> in-memory, the same route the pin forced) and differs exactly where it should: a smaller head, or a larger rung. `--clustering-threshold` still forces either route for a deliberate A/B.

## Does the new constant change any decision?

At 100M, on the 256 GB head: no -- 81 GB fits either way. It changes the **64 GB** case, where 96 B/pair estimated 54.5 GB, kept clustering on the driver, and would have met 81 GB of real allocation. That is an OOM, not a slow run, and it is what the second test encodes.

## Docs swept

The same wrong figures had spread. Corrected in `tuning.mdx` (x4), `ray-optimal-setup.md`, `quality-invariant-scale.md`, and three comments in `clustering.py` -- including a "CC costs ~70s at 226M edges" estimate that `GOLDENMATCH_CLUSTER_DEBUG` had already measured at **315.9s of a 707.3s stage**, still sitting in the docstring of the flag that refuted it.

Historical specs and plans under `docs/superpowers/` are left as written -- they are records of what was decided at the time.

## Verification

Output is unchanged across all four 100M runs: pairwise F1 `0.9265507059539793` identical to 16 digits, cluster F1 and `multi_member_clusters` (18,880,989) byte-identical.

Ran locally (22 passed): the four `_route_distributed` tests and the full `test_qis_harness.py`. All monkeypatch `psutil` or spawn a subprocess -- **no Ray**.

**Not run locally:** the Ray-dependent tests in `test_distributed_clustering.py`. Those start a local Ray cluster and belong in CI, which is where they run here.

Mutation-checked: with the constant at `96` both new tests fail; at `385` the calibration test fails while the routing test passes, since over-estimating is the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaapLLjB7dFxQMnWPqsZE5
