### PR TITLE
fix(bench): default the ray cluster to us-east1-b, and alert on failure

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -109,10 +109,10 @@ on:
         description: "Ray version for BOTH launcher and cluster image. Default 2.56.0 = goldenmatch's own declared [ray] floor, one minor above the 2.55.1 that produced the June baseline. Pinned so a sweep varies the knob and not Ray. Empty = float to latest."
         required: false
         default: "2.56.0"
-      zone: 
-        description: "GCE zone. Capacity is per-zone and independent of quota -- on ZONE_RESOURCE_POOL_EXHAUSTED, retry in another zone rather than waiting. n2-highmem-32/-64 and n2-standard-16 are offered in us-central1-{a,b,c,f}."
+      zone:
+        description: "GCE zone. Capacity is per-zone and independent of quota -- on ZONE_RESOURCE_POOL_EXHAUSTED, or on `0/N workers` at Verify workers joined, re-dispatch in another zone rather than waiting. Default us-east1-b: every green run to date used it (33087786765, 33074452121, 33006980567, 32992647463), while us-central1-a returned 0/3 on-demand n2-standard-16 workers in run 33174606401 and .ray/cluster-gce.yaml already records its spot capacity as intermittent. n2-highmem-32/-64 and n2-standard-16 are also offered in us-central1-{a,b,c,f}."
         required: false
-        default: "us-central1-a"
+        default: "us-east1-b"
       head_machine:
         description: "Head node machine type (the driver generates the full frame in memory; highmem for distributed runs). 100M: n2-highmem-32 (256 GB); 200M: n2-highmem-64 (512 GB)."
         required: false
@@ -120,6 +120,8 @@ on:
 
 permissions:
   contents: read
+  issues: write # the alert step files/updates the bench-infra failure issue
+  actions: read # the alert step reads its own run's jobs to name the failed step
 
 jobs:
   ray-cluster-bench:
@@ -513,6 +515,28 @@ jobs:
                   --quiet || true
               fi
             done
+
+      # Dispatch-only workflows get no scheduled-failure email and never reach
+      # main-health, so a failure is visible only to whoever rereads the Actions
+      # tab. Run 33174606401 failed and sat unnoticed. Runs LAST so every prior
+      # step has a conclusion to report.
+      - name: File / update the bench-infra alert issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZONE: ${{ inputs.zone }}
+          HEAD_MACHINE: ${{ inputs.head_machine }}
+          MAX_WORKERS: ${{ inputs.max_workers }}
+        run: |
+          # Name the first failed step so the issue can say capacity vs code
+          # without the reader opening the run.
+          # Non-fatal: the step runs under `bash -e`, so a 403 or a transient
+          # API error here would abort before the issue is filed -- the alert
+          # failing silently is the exact failure it exists to prevent.
+          FAILED="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+            --jq '[.jobs[].steps[] | select(.conclusion=="failure") | .name] | .[0] // "unknown"' \
+            2>/dev/null || echo "unknown")"
+          bash scripts/ray_bench_alert.sh "${GITHUB_RUN_ID}" "$FAILED"
 
       - name: Post headline to step summary
         if: always()

--- a/scripts/ray_bench_alert.sh
+++ b/scripts/ray_bench_alert.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ray_bench_alert.sh RUN_ID FAILED_STEP
+# Files (or updates) a single dedicated GitHub issue when a bench-ray-cluster run
+# fails. Idempotent: one open issue is reused (commented + reopened), never
+# re-spammed. Mirrors scripts/qis_alert.sh.
+#
+# WHY a dispatch-only workflow needs this. bench-ray-cluster has no schedule, so
+# it gets none of GitHub's automatic scheduled-failure email and never reaches
+# main-health. A failure was therefore visible only to whoever happened to reread
+# the Actions tab -- run 33174606401 sat failed and unnoticed. The failure is
+# also expensive to leave unread: the head node bills for the ~15 min before the
+# worker check gives up, and the most common causes (zone capacity, quota) are
+# transient and zone-specific, so the fix is usually a re-dispatch elsewhere
+# rather than a code change.
+set -euo pipefail
+
+RUN_ID="${1:?usage: ray_bench_alert.sh RUN_ID FAILED_STEP}"
+FAILED_STEP="${2:-unknown}"
+REPO="${GITHUB_REPOSITORY:-benseverndev-oss/goldenmatch}"
+ASSIGNEE="benzsevern"
+LABEL="bench-infra"
+MARKER="<!-- ray-bench-alert -->"
+RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+TITLE="bench-ray-cluster run failed"
+
+gh label create "$LABEL" --repo "$REPO" --color 1D76DB \
+  --description "Bench harness / cluster provisioning failures" --force >/dev/null 2>&1 || true
+
+BODY="$(cat <<EOF
+${MARKER}
+
+**A \`bench-ray-cluster\` run failed.** This workflow is dispatch-only, so nothing
+else surfaces the failure.
+
+- Failing run: ${RUN_URL}
+- Failed step: \`${FAILED_STEP}\`
+- Zone: \`${ZONE:-unset}\` / head \`${HEAD_MACHINE:-unset}\` / workers \`${MAX_WORKERS:-unset}\`
+
+**First thing to check: was it capacity, or was it us?**
+
+\`Verify workers joined\` failing with \`0/N workers\` is almost always GCE
+capacity in that zone, not a code change -- capacity is per-zone and independent
+of quota. Re-dispatch in another zone before debugging anything. Every green run
+to date used \`us-east1-b\`; \`us-central1-a\` has now produced \`0/3\` on
+on-demand \`n2-standard-16\` (run 33174606401), and \`.ray/cluster-gce.yaml\`
+already records its spot capacity there as intermittent.
+
+A failure at \`Submit bench\` or later IS worth reading as a real signal.
+
+Teardown runs under \`if: always()\`, so a failed run should not leak instances --
+confirm \`Ray down\` and \`Defensive cleanup\` both succeeded on the run above.
+
+This issue auto-updates on each failing run; close it once a run is green.
+EOF
+)"
+
+EXISTING="$(gh issue list --repo "$REPO" --state open --label "$LABEL" --json number,body \
+  --jq "map(select(.body | contains(\"${MARKER}\"))) | .[0].number // empty" 2>/dev/null || true)"
+
+if [ -n "$EXISTING" ]; then
+  gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
+  echo "updated existing alert issue #${EXISTING}"
+else
+  gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" \
+    --label "$LABEL" --assignee "$ASSIGNEE"
+  echo "filed a new alert issue"
+fi


### PR DESCRIPTION
## What happened

Run [33174606401](https://github.com/benseverndev-oss/goldenmatch/actions/runs/33174606401) failed at `Verify workers joined`:

```
workers RUNNING: 0/3     (x20, every 31s)
Only 0/3 workers launched within 10 min.
```

The head provisioned cleanly (SSH and rsync both working in later steps) and `ray up` succeeded with no quota or `ZONE_RESOURCE_POOL_EXHAUSTED` error. `Ray down` and `Defensive cleanup` both succeeded, so **nothing leaked**.

It sat on the #2796 merge commit, but nothing in that change is implicated: the failure is two steps before `Submit bench`, so no goldenmatch code ran.

## Cause: the default zone is the one the evidence says not to use

| | zone | outcome |
| --- | --- | --- |
| 33087786765 | us-east1-b | success |
| 33074452121 | us-east1-b | success |
| 33006980567 | us-east1-b | success |
| 32992647463 | us-east1-b | success |
| **33174606401** | **us-central1-a** | **0/3 workers** |

Every green run used `us-east1-b` — their artifacts are even named `qis-957-east1-v3/v4`. The workflow's `zone` input defaulted to `us-central1-a`, so a dispatch that did not override it landed on the bad zone.

`.ray/cluster-gce.yaml` already records the problem:

> On-demand workers. We started on preemptible (60-80% cheaper) but n2-standard-16 spot capacity in us-central1-a was intermittent — v44l / v45 saw workers either fail to launch or get preempted within seconds

Moving to on-demand fixed the preemption; it did not fix capacity. This run shows on-demand `n2-standard-16` unavailable there too.

**Fix:** default `zone` to `us-east1-b`, with the run ids in the input description so the next reader can check the claim rather than trust it.

## Second problem: nobody was told

`bench-ray-cluster` is dispatch-only. It gets none of GitHub's automatic scheduled-failure email and never reaches `main-health`, so a failure is visible only to whoever rereads the Actions tab. This one was not read for a day.

That is not free to miss — the head node bills for the ~15 minutes before the worker check gives up.

**Fix:** on failure, file/update a single `bench-infra` issue via `scripts/ray_bench_alert.sh`, mirroring the existing `scripts/qis_alert.sh` pattern. Idempotent: one open issue is reused and commented, never re-spammed. It names the failed step so the reader can tell capacity from code without opening the run, and says plainly that `0/N workers` means re-dispatch elsewhere before debugging anything.

## Checks

- `scripts/test_workflow_yaml.py` — 10 passed
- `zizmor --offline` — actionable findings identical to main (4 low / 1 medium / 13 high); the added step appears in none of them
- Granted `actions: read` alongside `issues: write`. Without it the step's own jobs-API call 403s; the lookup is also `|| echo unknown` so a transient error cannot abort the step before the issue is filed — an alert that fails silently is the exact failure it exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaapLLjB7dFxQMnWPqsZE5
