### PR TITLE
docs: the single-box edge is a memory bound, not a row count

### DIFF
--- a/docs/superpowers/specs/2026-08-28-ray-production-readiness-design.md
+++ b/docs/superpowers/specs/2026-08-28-ray-production-readiness-design.md
@@ -212,8 +212,13 @@ this document is otherwise about — the figure was read out of
 `docs/distributed/ray-optimal-setup.md` §1 and propagated without checking what
 produced it. `docs/quality-invariant-scale.md` is the source: the measured ladder
 is 25M/69 GB, 50M/138 GB, 100M/276 GB on a 503 GB box, and it names 200M as
-projected, not measured. The correction **widens** Ray's window rather than
-narrowing it: it opens around 100M on commodity hardware, not 200M.
+projected, not measured. The correction does not simply move the window's edge —
+it shows the edge is **not a row count at all**. `bucket` runs out of *box*, so
+the boundary tracks memory: ~10M on a 64 GB runner, and ~180M projected on the
+503 GB box (100M measured, 276 GB, ~2.76 GB per million rows — and
+`quality-invariant-scale.md` notes RSS is "~sublinear-to-linear", so treat that
+as an extrapolation like any other). Ray's window opens wherever your box ends,
+which on anything short of a high-memory instance is far below 200M.
 
 **D2 — Settle G7 before funding anything architectural.**
 If scoring saturates the cluster, the 3.0x Spark gap may substantially close, and


### PR DESCRIPTION
## What and why

Follow-up to #2799. That PR corrected the false "`bucket` is validated
single-box through 200M" claim, but the correction note I added alongside it
introduced its own imprecision:

> The correction **widens** Ray's window rather than narrowing it: it opens
> around 100M on commodity hardware, not 200M.

100M was measured on a single `n2-highmem-64` with **503 GB** of RAM. That is
not commodity hardware, and on a 64 GB runner the same shape caps near 10M. So
the sentence replaced a wrong number with a right number attached to the wrong
machine.

The commit landed one merge-queue cycle too late to ride along with #2799.

## Changes

Replaces that sentence with the point the evidence actually supports: the
single-box edge is **not a row count at all**, it is a memory bound, so it moves
with the box.

- ~10M on a 64 GB runner
- ~180M projected on the 503 GB box (100M measured at 276 GB, so ~2.76 GB per
  million rows)

and labels the 180M as an extrapolation, since `quality-invariant-scale.md`
records peak RSS as "~sublinear-to-linear" rather than strictly linear.

## Testing

```
python3 scripts/check_docs_links.py         # PASS
python3 scripts/check_docs_consistency.py   # PASS
```

Documentation only, one file, one paragraph. No code, no CI wiring.

## Checklist

- [x] Tests added/updated and passing locally for the changed package - n/a, docs only; both docs gates pass
- [ ] `pre-commit run --all-files` is clean - `pre-commit` is not installed on this machine
- [x] Package `CHANGELOG.md` updated if behavior changed - no behavior change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed
