### PR TITLE
docs: 86 duplicate tests, not 106 - and the fix is confirmed on main

### DIFF
--- a/docs/superpowers/specs/2026-08-28-ray-production-readiness-design.md
+++ b/docs/superpowers/specs/2026-08-28-ray-production-readiness-design.md
@@ -54,19 +54,25 @@ The shell expands the glob to explicit file paths. `--ignore` filters directory
 traversal during collection; it does not filter paths named explicitly on the
 command line. Both flags are no-ops.
 
-Measured on run `33176961803`, job `98868039914`:
-
-| file | tests collected | should be in this job |
-|---|---:|---|
-| `test_distributed_randomized_contraction_wcc.py` | 55 | no — `distributed_wcc` gates it |
-| `test_distributed_clustering.py` | 51 | no — `distributed` gates it |
-| everything else | 75 | yes |
-
-So 106 of 181 tests (59%) are a second run of the two blocking gates. The job
-takes 669–929s, and roughly 430s of the top-20 durations belong to the two files
-it believes it excluded.
+Measured on run `33176961803`, job `98868039914`: the job collected **181**
+tests, of which **86** belong to `test_distributed_clustering.py` and
+`test_distributed_randomized_contraction_wcc.py` — a second run of the two jobs
+that already block the merge queue. It took 669–929s, and roughly 430s of its
+top-20 durations belonged to the two files it believed it excluded.
 
 This is why G2 looks expensive. It is not.
+
+**Confirmed after the fix** (run `33197155069`, job `98937164988`): 95 tests
+collected, exactly 181 − 86, none from either gate file, and **69.5s wall against
+669s** — 9.6x, and well under the ~3-4 min this section originally predicted. The
+promotion in G2 therefore costs about a minute of merge-queue time, not eleven.
+
+> An earlier revision of this section said "106 of 181 (59%)". That came from
+> counting nodeid *occurrences* in the job log — each test appears on its PASSED
+> line and again in the durations list — rather than distinct tests. The correct
+> figure is 86 of 181 (48%), and it is now confirmed by arithmetic that closes:
+> the post-fix job collects exactly 181 − 86. Count distinct nodeids, not log
+> lines.
 
 ### G2 — the ray-executing pipeline cannot fail a merge
 

--- a/scripts/distributed_test_files.py
+++ b/scripts/distributed_test_files.py
@@ -4,9 +4,12 @@ distributed CI jobs.
 `.github/workflows/ci.yml` used to express the split as a shell glob plus two
 `--ignore` flags. The glob expands to explicit paths and `--ignore` only filters
 directory traversal, so both flags were no-ops: on run 33176961803 the
-`distributed_broad` job collected 51 tests from test_distributed_clustering.py
-and 55 from test_distributed_randomized_contraction_wcc.py -- 106 of its 181
-tests were a second run of the two jobs that already block the merge queue.
+`distributed_broad` job collected 181 tests, of which 86 came from
+test_distributed_clustering.py and test_distributed_randomized_contraction_wcc.py
+-- a second run of the two jobs that already block the merge queue.
+
+Confirmed by the fix: the same job on run 33197155069 collected 95 (181 - 86) and
+went from 669s to 69.5s wall.
 
 Each job now asks this module for its file list, so the partition is executed
 rather than asserted.


### PR DESCRIPTION
## What and why

Two corrections to figures introduced in #2799, plus the post-merge confirmation that the fix works.

**The count was inflated.** `106 of 181` came from counting nodeid *occurrences* in the CI job log - each test appears on its PASSED line and again in the slowest-durations list - rather than distinct tests. The correct figure is **86 of 181** (48%, not 59%).

**The fix is confirmed on main.** Run `33197155069`, job `98937164988`:

| | before (33176961803) | after (33197155069) |
|---|---:|---:|
| collected | 181 | 95 |
| from the two gate files | 86 | **0** |
| wall | 669s | **69.5s** |

95 = 181 - 86 exactly, so the arithmetic closes both ways and the corrected count is the one the evidence supports.

**Consequence worth noting:** 69.5s is far better than the ~3-4 min this work predicted. Promoting `distributed_broad` into `ci-required` therefore costs about a minute of merge-queue time, not eleven - a stronger argument for doing it than the original estimate made.

## Changes

- `scripts/distributed_test_files.py` module docstring: corrected count, plus the confirmed before/after.
- The spec's G1: corrected count, the post-fix confirmation, and a note recording how the miscount happened (count distinct nodeids, not log lines).

## Testing

```
python3 -m pytest scripts/test_distributed_test_files.py -q   # 9 passed
uv run ruff check scripts/distributed_test_files.py           # All checks passed
python3 scripts/check_docs_links.py                           # PASS
python3 scripts/check_docs_consistency.py                     # PASS
```

Comment and documentation text only - no logic change.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean - not installed on this machine; ran its ruff hook directly
- [x] Package `CHANGELOG.md` updated if behavior changed - no behavior change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed