### PR TITLE
fix(ttfs): record WHY the first-run probe failed, not pip's upgrade notice

### DIFF
--- a/scripts/test_ttfs_probe.py
+++ b/scripts/test_ttfs_probe.py
@@ -196,3 +196,80 @@ def test_every_row_shape_carries_the_same_keys():
     bad = mod.build_row(install_s=1.0, run_s=None, f1=None, floor=0.9, fail="install")
     none = mod.unavailable_row("no docker")
     assert set(ok) == set(bad) == set(none) == set(mod.ROW_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# diagnostic_note -- the probe's only window into WHY a first run failed
+# ---------------------------------------------------------------------------
+
+
+def test_note_takes_the_run_log_for_a_run_failure():
+    """The regression this function exists for.
+
+    The 2026-08-29 nightly recorded `ttfs_fail: "run"` with a note containing
+    only pip's "A new release of pip is available" notice -- the real cause
+    ("Auto-config error: No module named 'polars'") never reached the board,
+    because the note was the tail of stdout+stderr and pip's stderr came last.
+    """
+    note = mod.diagnostic_note(
+        phase="run",
+        install_log="Successfully installed goldenmatch-3.16.0\n"
+        "[notice] A new release of pip is available: 25.0.1 -> 26.2.1",
+        run_log="No config file - auto-detecting column types...\n"
+        "Auto-config error: No module named 'polars'",
+        run_rc=1,
+    )
+    assert "No module named 'polars'" in note
+    assert "new release of pip" not in note
+
+
+def test_note_takes_the_install_log_for_an_install_failure():
+    note = mod.diagnostic_note(
+        phase="install",
+        install_log="ERROR: Could not find a version that satisfies goldenmatch",
+        run_log="",
+    )
+    assert "Could not find a version" in note
+
+
+def test_note_carries_the_exit_code_for_a_run_failure():
+    """"Exited 1 and said nothing" is itself the finding, so the code is kept
+    even when the log is empty."""
+    note = mod.diagnostic_note(phase="run", install_log="", run_log="", run_rc=1)
+    assert note.startswith("[exit 1]")
+
+
+def test_note_on_an_empty_run_log_says_so_rather_than_recording_nothing():
+    note = mod.diagnostic_note(phase="run", install_log="x", run_log="", run_rc=1)
+    assert note is not None
+    assert "no output" in note
+
+
+def test_note_falls_back_to_the_docker_stream_when_no_container_log_exists():
+    """A daemon-level failure writes neither in-container log; the docker
+    client's own output is then the only evidence there is."""
+    note = mod.diagnostic_note(
+        phase="install",
+        install_log="",
+        run_log="",
+        fallback="docker: Error response from daemon: no such image",
+    )
+    assert "no such image" in note
+
+
+def test_note_is_tail_truncated_to_the_budget():
+    note = mod.diagnostic_note(
+        phase="run", install_log="", run_log="A" * 5000 + "THE_ACTUAL_ERROR", run_rc=2
+    )
+    assert len(note) <= mod._NOTE_CHARS
+    # Truncation keeps the END, where the error is.
+    assert note.endswith("THE_ACTUAL_ERROR")
+
+
+def test_note_install_phase_omits_the_run_exit_code():
+    """An install failure never reached the run, so there is no run status to
+    report -- labelling one would be inventing a fact."""
+    note = mod.diagnostic_note(
+        phase="install", install_log="pip exploded", run_log="", run_rc=None
+    )
+    assert not note.startswith("[exit")

--- a/scripts/ttfs_probe.py
+++ b/scripts/ttfs_probe.py
@@ -51,6 +51,10 @@ _FLOOR = 0.90
 # workflow that burns its whole budget and lands no data at all.
 _INSTALL_TIMEOUT_S = 900
 _RUN_TIMEOUT_S = 600
+# A traceback tail has to fit. The old 400 was set when the note was a
+# curiosity; it is the only diagnostic the nightly keeps, so size it for the
+# job -- an unreadable note is why a FAILED row sat unexplained.
+_NOTE_CHARS = 1500
 
 # Every row shape carries every key -- the scoreboard renders them positionally,
 # so a missing key would KeyError the nightly rather than degrade to "—".
@@ -159,6 +163,40 @@ def prf1(predicted: set[tuple[int, int]], truth: set[tuple[int, int]]) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def diagnostic_note(
+    *,
+    phase: str | None,
+    install_log: str,
+    run_log: str,
+    run_rc: int | None = None,
+    fallback: str = "",
+) -> str | None:
+    """Pick the log that explains THIS failure and return its tail.
+
+    The probe used to record ``(stdout + stderr)[-400:]`` of the whole
+    container. Two things made that useless. The halves are concatenated, not
+    interleaved, so the tail was always the END OF STDERR -- and pip writes its
+    "a new release of pip is available" notice there, after everything. And the
+    dedupe ran under ``--quiet``, which suppressed the error message entirely.
+    So a real failure ("Auto-config error: No module named 'polars'") was
+    recorded as a pip upgrade notice, and the scoreboard could report THAT the
+    first run broke but never WHY.
+
+    Now each phase writes its own log inside the container and this picks the
+    one that failed: install failures explain themselves from pip's log, run
+    failures from the CLI's. Prefixed with the exit code when there is one,
+    because "exited 1 silently" is itself the finding.
+    """
+    chosen = install_log if phase == "install" else run_log
+    text = (chosen or "").strip()
+    if not text:
+        # An empty log IS informative -- say so rather than recording nothing.
+        text = fallback.strip() or f"{phase or 'run'} produced no output"
+    if run_rc is not None and phase != "install":
+        text = f"[exit {run_rc}] {text}"
+    return text[-_NOTE_CHARS:] or None
+
+
 def build_row(
     *,
     install_s: float | None,
@@ -256,15 +294,27 @@ def probe(*, image: str = _IMAGE, floor: float = _FLOOR, keep: bool = False) -> 
         # exercised without a Docker daemon. Fewer unverifiable dependencies on
         # the branch that is hardest to test.
         now = "python -c 'import time; print(time.time())'"
+        # Each phase writes its OWN log. Without that split the host can only
+        # see one concatenated blob whose tail is pip's stderr, which is how a
+        # broken first run got recorded as a pip upgrade notice.
+        #
+        # The dedupe deliberately does NOT pass --quiet: this probe exists to
+        # find out why the first run fails, and --quiet suppresses the very
+        # message that says so. Its output goes to a file, so the extra
+        # verbosity costs nothing.
         script = (
             "set -e; "
             f"S=$({now}); "
-            "pip install --quiet --no-cache-dir goldenmatch; "
+            "pip install --quiet --no-cache-dir goldenmatch > /work/install_log 2>&1; "
             'python -c "import time,sys; '
             "open('/work/install_s','w').write('%.3f' % (time.time()-float(sys.argv[1])))\" \"$S\"; "
-            "cd /work && "
+            "cd /work; "
+            "set +e; "
             "goldenmatch dedupe customers.csv --output-clusters "
-            "--output-dir /work/out --run-name ttfs --quiet"
+            "--output-dir /work/out --run-name ttfs > /work/run_log 2>&1; "
+            # Keep the run's own status as the container's status -- writing
+            # run_rc must not turn a failed dedupe into a successful script.
+            "RC=$?; echo $RC > /work/run_rc; exit $RC"
         )
         cmd = [
             "docker",
@@ -283,6 +333,13 @@ def probe(*, image: str = _IMAGE, floor: float = _FLOOR, keep: bool = False) -> 
         ]
         elapsed, code, output = _timed(cmd, _INSTALL_TIMEOUT_S + _RUN_TIMEOUT_S)
 
+        def _read(name: str) -> str:
+            f = workdir / name
+            try:
+                return f.read_text(encoding="utf-8", errors="replace") if f.exists() else ""
+            except OSError:
+                return ""
+
         install_file = workdir / "install_s"
         install_s = None
         if install_file.exists():
@@ -290,6 +347,16 @@ def probe(*, image: str = _IMAGE, floor: float = _FLOOR, keep: bool = False) -> 
                 install_s = round(float(install_file.read_text().strip()), 3)
             except ValueError:
                 install_s = None
+
+        install_log = _read("install_log")
+        run_log = _read("run_log")
+        run_rc = None
+        rc_text = _read("run_rc").strip()
+        if rc_text:
+            try:
+                run_rc = int(rc_text)
+            except ValueError:
+                run_rc = None
 
         if code != 0:
             # If the install duration never landed, pip is what failed.
@@ -305,7 +372,15 @@ def probe(*, image: str = _IMAGE, floor: float = _FLOOR, keep: bool = False) -> 
                 f1=None,
                 floor=floor,
                 fail=phase,
-                note=output.strip()[-400:] or None,
+                note=diagnostic_note(
+                    phase=phase,
+                    install_log=install_log,
+                    run_log=run_log,
+                    run_rc=run_rc if phase == "run" else None,
+                    # `output` is the docker client's own stream: it explains a
+                    # daemon-level failure, where neither in-container log exists.
+                    fallback=output,
+                ),
             )
 
         run_s = round(elapsed - install_s, 3) if install_s is not None else None
@@ -318,7 +393,13 @@ def probe(*, image: str = _IMAGE, floor: float = _FLOOR, keep: bool = False) -> 
                 f1=None,
                 floor=floor,
                 fail="run",
-                note="run exited 0 but wrote no clusters file",
+                note=diagnostic_note(
+                    phase="run",
+                    install_log=install_log,
+                    run_log=run_log,
+                    run_rc=run_rc,
+                    fallback="run exited 0 but wrote no clusters file",
+                ),
             )
 
         rows = parse_clusters_csv(clusters.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Problem

The 2026-08-29 nightly recorded `ttfs_fail: "run"` with this note:

> ` conflicting behaviour with the system package manager, ... [notice] A new release of pip is available: 25.0.1 -> 26.2.1 ...`

The actual cause — `Auto-config error: No module named 'polars'` — never reached the scoreboard. The board could report **that** a stranger's first run broke, but never **why**, which is a plausible reason the row sat at FAILED without being chased.

## Two independent defects

1. The note was `(stdout + stderr)[-400:]` of the whole container. `_timed` concatenates the halves rather than interleaving them, so the tail was always the *end of stderr* — where pip writes its upgrade notice, after everything else.
2. The dedupe ran under `--quiet`, which suppressed the error message outright. The probe exists to find out why the first run fails; the flag hid exactly that.

## Change

- Each phase writes its own log inside the container (`/work/install_log`, `/work/run_log`), so the host can read the one that belongs to the failure.
- The dedupe drops `--quiet` — its output goes to a file, so the verbosity is free.
- The run's exit code is propagated as the container's, rather than being swallowed by the `echo $? > run_rc` that records it (`RC=$?; echo $RC > ...; exit $RC`).
- `diagnostic_note()` picks the failing phase's log and tails it, prefixed with the exit code — "exited 1 and said nothing" is itself a finding. Falls back to the docker client's own stream for a daemon-level failure where neither in-container log exists.
- Note budget 400 → 1500 chars so a traceback tail fits.

## Verification

- 7 new unit tests on `diagnostic_note`, including the exact pip-notice regression (asserts the polars error is kept **and** the pip notice is not). Full file: **27 passed**.
- Container script verified `sh -n` clean.
- `ruff check scripts/` passes.

The container path itself needs Docker and is exercised by the nightly, not here — which is why the note-selection logic was extracted as a pure function rather than left inline.