### PR TITLE
chore(pypi): fill the two discovery-metadata gaps in the suite's listings

### DIFF
--- a/packages/python/goldensuite-mcp/CHANGELOG.md
+++ b/packages/python/goldensuite-mcp/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## [0.6.1] - 2026-08-30
+
+### Changed
+
+- **PyPI discovery metadata.** Keywords 5 -> 15 and package URLs 4 -> 7. This
+  package is the suite's MCP entry point but carried its thinnest listing, and
+  the terms it did carry were all data-domain ones: someone looking for an MCP
+  server searches for the protocol and the client (`mcp-server`,
+  `model-context-protocol`, `claude-desktop`) at least as often. `Documentation`
+  now points at the docs site rather than the GitHub README, and the
+  `AI agents (llms.txt)`, `Changelog` and `Author` URLs match the sibling
+  packages.
+
 ## [0.6.0] - 2026-08-15
 
 ### Changed

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
@@ -12,5 +12,5 @@ are logged at startup so deployers know which tool was shadowed.
 """
 from goldensuite_mcp.server import create_server
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = ["create_server", "__version__"]

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -4,13 +4,22 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldensuite-mcp"
-version = "0.6.0"
+version = "0.6.1"
 description = "One MCP server exposing every Golden Suite tool — goldenmatch, goldencheck, goldenflow, goldenpipe, infermap"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 license = { text = "MIT" }
 authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
-keywords = ["mcp", "data-quality", "entity-resolution", "golden-suite", "claude"]
+# The suite's MCP entry point, and the thinnest metadata in it until now (5
+# keywords, 4 URLs). Someone looking for this searches for the PROTOCOL and
+# the client ("mcp server", "model context protocol", "claude desktop") at
+# least as often as for the data terms, so both vocabularies are carried.
+keywords = [
+    "mcp", "mcp-server", "model-context-protocol", "claude", "claude-desktop",
+    "ai-agents", "llm-tools", "agent-tools",
+    "entity-resolution", "deduplication", "record-linkage", "data-quality",
+    "data-cleaning", "schema-inference", "golden-suite",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -44,8 +53,14 @@ goldensuite-mcp = "goldensuite_mcp.cli:main"
 [project.urls]
 Homepage = "https://github.com/benseverndev-oss/goldenmatch"
 Repository = "https://github.com/benseverndev-oss/goldenmatch"
-Documentation = "https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/python/goldensuite-mcp#readme"
+Documentation = "https://docs.bensevern.dev/docs/goldensuite-mcp/overview"
+# Agent-facing entry point, matching the sibling packages. PyPI renders these
+# URLs and they are scraped, so this is the discovery path for a tool that
+# never clones the repo.
+"AI agents (llms.txt)" = "https://docs.bensevern.dev/docs/llms.txt"
 Issues = "https://github.com/benseverndev-oss/goldenmatch/issues"
+Changelog = "https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldensuite-mcp/CHANGELOG.md"
+Author = "https://bensevern.dev"
 
 [tool.uv.sources]
 goldenmatch = { workspace = true }

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,18 +13,33 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.2.0"
+version = "0.2.1"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+# Shipped 16 releases with NO keywords at all, so it was reachable only by
+# exact name. It is an optional accelerator rather than a thing to adopt on its
+# own, so the terms lead with what it accelerates (and with `goldenmatch`
+# itself, which is how someone who already has the base package looks for it).
+keywords = [
+    "goldenmatch", "golden-suite", "entity-resolution", "deduplication",
+    "record-linkage", "fuzzy-matching", "jaro-winkler", "levenshtein",
+    "rust", "pyo3", "native-extension", "performance",
+]
 classifiers = [
+    "Development Status :: 4 - Beta",
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
+    "Topic :: Database",
     "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 
 [project.urls]

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -35,4 +35,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.2.0"
+    __version__ = "0.2.1"


### PR DESCRIPTION
## Problem

Every other package in the suite carries 9–16 keywords and the full URL set. These two did not — and both are entry points rather than leaf packages.

| Package | Keywords | URLs |
|---|---|---|
| `goldensuite-mcp` 0.6.0 | 5 | 4 |
| `goldenmatch-native` 0.2.0 | **0** (16 releases) | 5 |

## Change

**`goldensuite-mcp` → 0.6.1** — keywords 5 → 15, URLs 4 → 7. It is the suite's MCP entry point but had the thinnest listing in the repo, and every term it carried was a data-domain one. Someone hunting for an MCP server searches for the protocol and the client (`mcp-server`, `model-context-protocol`, `claude-desktop`) at least as often as for `entity-resolution`. `Documentation` now points at the docs-site page rather than a GitHub README anchor; `AI agents (llms.txt)`, `Changelog` and `Author` match the siblings.

**`goldenmatch-native` → 0.2.1** — no keywords at all across 16 releases, so it was reachable only by exact name. Adds 12, leading with what it accelerates and with `goldenmatch` itself, since the realistic search is by someone who already has the base package. Classifiers gain the Python versions, `Development Status` and the `Topic :: Database` / `Information Analysis` pair the base package carries.

## Why the version bumps

Metadata-only changes otherwise ship nothing: the publish workflows run with `skip-existing: true`, so re-publishing at the same version silently no-ops (the trap already recorded in `CLAUDE.md`). `goldenmatch-native`'s bump is applied in lockstep across `pyproject.toml`, `Cargo.toml`, `Cargo.lock` and the `__init__` fallback.

## Verification

- `scripts/check_version_consistency.py` — **49 packages, all files in lockstep**.
- Both `pyproject.toml` files re-parsed with `tomllib`; metadata renders as intended.
- All three new URLs return **200** (`docs.bensevern.dev/docs/goldensuite-mcp/overview`, `/docs/llms.txt`, and the changelog path).
- `ruff check packages/python/goldensuite-mcp` passes.
- `scripts/regen_docs.py --check` — docs current, nothing to regenerate.

No code paths change; this is listing metadata plus the version bumps needed to publish it.