### PR TITLE
fix(zero-config): make the documented first run work without the polars extra

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -4,7 +4,7 @@
   "packages": {
     "goldenmatch": {
       "root": "packages/python/goldenmatch/goldenmatch",
-      "module_count": 481,
+      "module_count": 482,
       "modules": [
         {
           "module": "goldenmatch",
@@ -162,7 +162,8 @@
           "file": "packages/python/goldenmatch/goldenmatch/_polars_lazy.py",
           "purpose": "Lazy Polars proxy -- W0 of the Polars eviction (spec:",
           "defines": [
-            "_LazyPolars"
+            "_LazyPolars",
+            "polars_available"
           ]
         },
         {
@@ -1952,6 +1953,7 @@
             "_project_pass_pairs",
             "_promote_facility_fullname_ne",
             "_quality_aware_blocking_enabled",
+            "_read_autoconfig_input",
             "_rebuild_from_decisions",
             "_require_sketch_column",
             "_resolve_effective_exclusion_overrides",
@@ -2009,6 +2011,7 @@
             "goldenmatch.core.embedder",
             "goldenmatch.core.execution_plan",
             "goldenmatch.core.frame",
+            "goldenmatch.core.io_arrow",
             "goldenmatch.core.perceptual_autoconfig",
             "goldenmatch.core.probabilistic",
             "goldenmatch.core.profile_emitter",
@@ -6924,6 +6927,16 @@
           "file": "packages/python/goldenmatch/goldenmatch/output/__init__.py"
         },
         {
+          "module": "goldenmatch.output._csv_arrow",
+          "file": "packages/python/goldenmatch/goldenmatch/output/_csv_arrow.py",
+          "purpose": "Polars-parity CSV writer for a ``pyarrow.Table`` -- the polars-free fallback.",
+          "defines": [
+            "_quote",
+            "_render",
+            "write_csv_polars_parity"
+          ]
+        },
+        {
           "module": "goldenmatch.output.report",
           "file": "packages/python/goldenmatch/goldenmatch/output/report.py",
           "purpose": "Report generators for GoldenMatch runs.",
@@ -6940,7 +6953,8 @@
             "write_output"
           ],
           "imports": [
-            "goldenmatch._polars_lazy"
+            "goldenmatch._polars_lazy",
+            "goldenmatch.output._csv_arrow"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
+++ b/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
@@ -25,9 +25,11 @@ the goldenflow/goldencheck template, which exposes ``Any``).
 """
 from __future__ import annotations
 
+import sys
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
-__all__ = ["pl"]
+__all__ = ["pl", "polars_available"]
 
 
 class _LazyPolars:
@@ -53,3 +55,27 @@ if TYPE_CHECKING:
     import polars as pl
 else:
     pl = _LazyPolars()
+
+
+@lru_cache(maxsize=1)
+def polars_available() -> bool:
+    """Whether ``import polars`` would succeed -- WITHOUT importing it.
+
+    Polars is an optional extra (``pip install goldenmatch[polars]``), so a
+    plain ``pip install goldenmatch`` has none. Any site that HAS a working
+    arrow path and only reaches for polars to preserve a formatting contract
+    needs to branch on availability up front: touching ``pl.anything`` to find
+    out is what turned "no polars installed" into a crash on the zero-config
+    CLI path.
+
+    Cached -- the answer cannot change within a process.
+    """
+    mod = sys.modules.get("polars")
+    if mod is not None:
+        return True
+    try:
+        from importlib.util import find_spec
+
+        return find_spec("polars") is not None
+    except Exception:  # noqa: BLE001 -- a blocked/broken polars is an absent one
+        return False

--- a/packages/python/goldenmatch/goldenmatch/cli/dedupe.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/dedupe.py
@@ -176,8 +176,10 @@ def dedupe_cmd(
         try:
             cfg = load_config(config)
         except (FileNotFoundError, ValueError) as exc:
-            if not quiet:
-                console.print(f"[red]Config error:[/red] {exc}")
+            # Fatal errors go to stderr REGARDLESS of --quiet: the flag hides
+            # progress, and a command that exits non-zero in silence cannot be
+            # diagnosed by whoever ran it.
+            err_console.print(f"[red]Config error:[/red] {exc}")
             raise typer.Exit(code=1)
     else:
         # Try project settings first
@@ -208,8 +210,7 @@ def dedupe_cmd(
                 if not quiet:
                     console.print("[green]Auto-config complete. Launching TUI for review...[/green]")
             except Exception as exc:
-                if not quiet:
-                    console.print(f"[red]Auto-config error:[/red] {exc}")
+                err_console.print(f"[red]Auto-config error:[/red] {exc}")
                 raise typer.Exit(code=1)
 
             # Override model if specified
@@ -387,8 +388,7 @@ def dedupe_cmd(
     except Exception as exc:
         if _excl_token is not None:
             _RUNTIME_EXCLUDE_COLUMNS.reset(_excl_token)
-        if not quiet:
-            console.print(f"[red]Runtime error:[/red] {exc}")
+        err_console.print(f"[red]Runtime error:[/red] {exc}")
         raise typer.Exit(code=3)
     if _excl_token is not None:
         _RUNTIME_EXCLUDE_COLUMNS.reset(_excl_token)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -5925,6 +5925,59 @@ def _rebuild_from_decisions(
     )
 
 
+def _read_autoconfig_input(path: Path):
+    """Read one auto-config input file into a ``pyarrow.Table``, polars-free.
+
+    This is the zero-config FILE front door -- ``goldenmatch dedupe data.csv``
+    lands here before anything else runs. It used to read via ``pl.read_csv`` /
+    ``pl.read_excel`` / ``pl.read_parquet``, which made a plain
+    ``pip install goldenmatch`` (polars is an optional extra, and the rest of
+    the autoconfig stack has been arrow-native since #1754) fail 100% of the
+    time with "Auto-config error: No module named 'polars'".
+
+    Reads through ``read_table_arrow``, whose polars-parity is pinned by
+    ``tests/test_io_arrow_ingest_parity.py``. The legacy polars call passed
+    ``ignore_errors=True`` (null out cells that do not parse to the inferred
+    dtype) and accepted ``.xls``, neither of which the stricter arrow reader
+    does, so a reader failure falls back to polars WHERE IT IS INSTALLED rather
+    than turning a file that used to load into a hard error. With polars absent
+    there is nothing to fall back to and the arrow error is re-raised -- a real
+    reader diagnostic, not a bare ImportError.
+    """
+    from goldenmatch.core.io_arrow import read_table_arrow
+
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".parquet" or suffix == ".xlsx":
+            return read_table_arrow(path)
+        if suffix == ".xls":
+            raise ValueError("Unsupported file format: '.xls'")
+        return read_table_arrow(path, encoding="utf8-lossy")
+    except Exception as arrow_exc:  # noqa: BLE001 -- any reader failure retries on polars
+        try:
+            if suffix in (".xlsx", ".xls"):
+                fallback = pl.read_excel(path, engine="openpyxl")
+            elif suffix == ".parquet":
+                fallback = pl.read_parquet(path)
+            else:
+                fallback = pl.read_csv(
+                    path, encoding="utf8-lossy", infer_schema_length=10000, ignore_errors=True
+                )
+        except ImportError:
+            # No polars to fall back to: surface the arrow reader's own error.
+            raise arrow_exc from None
+        logger.warning(
+            "arrow ingest failed for %s (%s); fell back to the polars reader. "
+            "Auto-config still ran, but this file will NOT load on a "
+            "polars-free install.",
+            path,
+            arrow_exc,
+        )
+        # Downstream is arrow-native; hand it a table so the fallback does not
+        # drag a polars frame through the rest of auto-config.
+        return fallback.to_arrow()
+
+
 def auto_configure(files: list[tuple[str, str]]) -> GoldenMatchConfig:
     """Auto-generate a GoldenMatchConfig from input files.
 
@@ -5934,19 +5987,18 @@ def auto_configure(files: list[tuple[str, str]]) -> GoldenMatchConfig:
     Returns:
         A fully populated GoldenMatchConfig ready for pipeline execution.
     """
-    # Load and combine files
-    dfs = []
-    for path, _source_name in files:
-        p = Path(path)
-        if p.suffix.lower() in (".xlsx", ".xls"):
-            df = pl.read_excel(p, engine="openpyxl")
-        elif p.suffix.lower() == ".parquet":
-            df = pl.read_parquet(p)
-        else:
-            df = pl.read_csv(p, encoding="utf8-lossy", infer_schema_length=10000, ignore_errors=True)
-        dfs.append(df)
+    import pyarrow as pa
 
-    combined = pl.concat(dfs, how="diagonal") if len(dfs) > 1 else dfs[0]
+    tables = [_read_autoconfig_input(Path(path)) for path, _source_name in files]
+
+    # polars' ``how="diagonal"`` unions the column sets and null-fills what a
+    # given file lacks; ``promote_options="permissive"`` is arrow's equivalent
+    # (and the spelling already used for the same job at pipeline.py:6108).
+    combined = (
+        pa.concat_tables(tables, promote_options="permissive")
+        if len(tables) > 1
+        else tables[0]
+    )
     return auto_configure_df(combined)
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from goldenmatch.distributed.record_store import PreparedRecordStore
 
 from goldenmatch._polars_lazy import pl
+from goldenmatch._polars_lazy import polars_available as _polars_available
 from goldenmatch.config.schemas import GoldenMatchConfig, GoldenRulesConfig
 from goldenmatch.core.autofix import auto_fix_dataframe
 from goldenmatch.core.bench import record_metric, record_metrics, stage
@@ -5080,10 +5081,17 @@ def _run_dedupe_pipeline(
                     "__oversized__": cinfo["oversized"],
                 })
         if cluster_rows:
-            # Built from Python rows -- lane-free; polars construction keeps
-            # the writer's csv/xlsx formatting contract identical either way.
-            clusters_df = pl.DataFrame(cluster_rows)
-            write_output(clusters_df, directory, run_name, "clusters", fmt)
+            # Built from Python rows -- lane-free. Polars construction keeps the
+            # writer's csv/xlsx formatting contract identical when polars is
+            # there; without it (the optional-extra install) build the same rows
+            # as a pa.Table so `--output-clusters` still writes.
+            if _polars_available():
+                clusters_out: Any = pl.DataFrame(cluster_rows)
+            else:
+                import pyarrow as _pa_cl
+
+                clusters_out = _pa_cl.Table.from_pylist(cluster_rows)
+            write_output(clusters_out, directory, run_name, "clusters", fmt)
 
     if output_dupes and len(dupes_df) > 0:
         write_output(dupes_df, directory, run_name, "dupes", fmt)
@@ -6372,8 +6380,21 @@ def _frame_lane_eligible(
     """
     # W-7: throughput sketch tier no longer declines -- its polars-local
     # block bridges the table once at entry (TRANSITIONAL).
-    if getattr(config, "_preflight_report", None) is not None:
-        return False
+    #
+    # `_preflight_report` USED to decline here. `auto_configure_df` always sets
+    # it, so that single line pinned every ZERO-CONFIG run to the classic polars
+    # lane -- the one path that, on a plain `pip install goldenmatch`, has no
+    # polars to be pinned to. The decline dated from when postflight's signals
+    # read a polars frame directly; `_signal_blocking_recall` and
+    # `_signal_block_size_percentiles` both route through `to_frame` now, so it
+    # outlived its cause. Removed after measuring both lanes output-identical
+    # (clusters/golden/dupes/unique byte-for-byte, lineage identical up to pair
+    # order) across five dataset shapes: `scripts/diff_zeroconfig_lanes.py`.
+    #
+    # NOTE the separate `_preflight_report` decline on the FUSED match route
+    # (`_try_match_fused`) is unrelated and still stands: postflight can raise
+    # the effective threshold from a histogram the fused kernel never
+    # materializes.
     # W-4: memory + identity no longer decline -- both bridge (pa->pl) at
     # their entries (TRANSITIONAL; deep ports are D6 prerequisites).
     # W-5: blocking auto-suggest no longer declines -- _run_auto_suggest

--- a/packages/python/goldenmatch/goldenmatch/output/_csv_arrow.py
+++ b/packages/python/goldenmatch/goldenmatch/output/_csv_arrow.py
@@ -1,0 +1,91 @@
+"""Polars-parity CSV writer for a ``pyarrow.Table`` -- the polars-free fallback.
+
+``output/writer.py`` pins csv/xlsx byte formatting to the polars writers: that
+is the published output contract, and changing it is a major-version decision
+(see the note in ``write_output``). But polars is an OPTIONAL extra, so on a
+plain ``pip install goldenmatch`` there is no polars writer to bridge to and
+``goldenmatch dedupe data.csv --output-clusters`` could not write its output at
+all.
+
+This module writes the bytes polars writes. An install WITH polars still takes
+the polars writer and is untouched; a polars-free install now gets the same
+file instead of an error.
+
+pyarrow's own ``write_csv`` cannot do this job: ``quoting_style="needed"``
+still quotes every string value AND the entire header row, while ``"none"``
+never quotes, which would corrupt any value containing the delimiter.
+
+Formatting rules, each pinned against the real polars writer by
+``tests/test_csv_arrow_polars_parity.py``:
+
+  * a field is quoted only when it contains the delimiter, a double quote, CR
+    or LF -- quotes inside are doubled;
+  * a null writes as an EMPTY field while an empty string writes as ``""``;
+    keeping those two distinguishable is why this is hand-rolled;
+  * booleans write bare lowercase ``true`` / ``false``;
+  * floats use ``repr`` (so ``2.0`` stays ``2.0``; pyarrow's writer emits
+    ``2``), with bare ``NaN`` / ``inf`` / ``-inf``;
+  * temporal values write ISO-8601 via ``isoformat()``.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+
+def _render(value: Any) -> str | None:
+    """Cell text, or ``None`` for a SQL null (an empty, unquoted field)."""
+    if value is None:
+        return None
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "inf" if value > 0 else "-inf"
+        return repr(value)
+    if isinstance(value, str):
+        return value
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        return iso()
+    return str(value)
+
+
+def _quote(text: str | None, delimiter: str) -> str:
+    if text is None:
+        return ""  # null -> empty field, never quoted
+    if text == "":
+        return '""'  # empty string -> quoted, so it is not read back as null
+    if (
+        delimiter in text
+        or '"' in text
+        or "\n" in text
+        or "\r" in text
+    ):
+        return '"' + text.replace('"', '""') + '"'
+    return text
+
+
+def write_csv_polars_parity(
+    table: Any, path: str | Path, *, delimiter: str = ","
+) -> Path:
+    """Write ``table`` (a ``pyarrow.Table``) to ``path`` the way polars would."""
+    path = Path(path)
+    names = list(table.column_names)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        fh.write(delimiter.join(_quote(n, delimiter) for n in names))
+        fh.write("\n")
+        for batch in table.to_batches():
+            for row in batch.to_pylist():
+                fh.write(
+                    delimiter.join(
+                        _quote(_render(row[n]), delimiter) for n in names
+                    )
+                )
+                fh.write("\n")
+    return path

--- a/packages/python/goldenmatch/goldenmatch/output/writer.py
+++ b/packages/python/goldenmatch/goldenmatch/output/writer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from goldenmatch._polars_lazy import pl
+from goldenmatch._polars_lazy import pl, polars_available
 
 
 def write_output(
@@ -29,14 +29,32 @@ def write_output(
     filename = f"{run_name}_{output_type}.{fmt}"
     path = directory / filename
 
-    is_pl = isinstance(df, pl.DataFrame)
-    if fmt == "parquet" and not is_pl:
-        import pyarrow.parquet as pq
+    # Availability is checked BEFORE any `pl.` access: polars is an optional
+    # extra, and `isinstance(df, pl.DataFrame)` would itself import it (and
+    # raise on a polars-free install) just to ask the question.
+    have_polars = polars_available()
+    is_pl = have_polars and isinstance(df, pl.DataFrame)
 
-        pq.write_table(df, path)
-        return path
     if not is_pl:
-        df = pl.from_arrow(df)  # polars-lane: csv/xlsx byte-formatting (quoting, null spelling, xlsx engine) is the PINNED output contract; parquet already returned arrow-native above
+        if fmt == "parquet":
+            import pyarrow.parquet as pq
+
+            pq.write_table(df, path)
+            return path
+        if not have_polars:
+            if fmt == "csv":
+                # Polars-free install: write the bytes polars would have
+                # written (parity pinned by tests/test_csv_arrow_polars_parity.py)
+                # rather than failing on the missing optional extra.
+                from goldenmatch.output._csv_arrow import write_csv_polars_parity
+
+                return write_csv_polars_parity(df, path)
+            raise RuntimeError(
+                f"{fmt!r} output requires the optional polars extra "
+                f"(pip install 'goldenmatch[polars]'). 'csv' and 'parquet' "
+                f"write without it."
+            )
+        df = pl.from_arrow(df)  # polars-lane: xlsx byte-formatting (engine) is the PINNED output contract; csv/parquet already returned above
 
     if fmt == "csv":
         df.write_csv(path)

--- a/packages/python/goldenmatch/tests/test_cli_dedupe.py
+++ b/packages/python/goldenmatch/tests/test_cli_dedupe.py
@@ -230,3 +230,23 @@ class TestMatchCmd:
         result = runner.invoke(app, ["match", "--help"])
         assert result.exit_code == 0
         assert "match" in result.output.lower()
+
+
+def test_quiet_still_reports_a_fatal_error():
+    """`--quiet` hides progress, never diagnostics.
+
+    A fatal error used to be printed only `if not quiet`, so
+    `goldenmatch dedupe data.csv --quiet` exited 1 having printed NOTHING. That
+    is how the zero-config polars failure stayed invisible: the nightly
+    time-to-first-success probe ran with `--quiet`, so it recorded that the
+    first run broke without ever capturing why.
+    """
+    from goldenmatch.cli.main import app
+    from typer.testing import CliRunner
+
+    result = CliRunner().invoke(
+        app, ["dedupe", "definitely_not_a_real_file_xyz.csv", "--quiet"]
+    )
+    assert result.exit_code != 0
+    assert result.output.strip(), "a failing --quiet run printed nothing at all"
+    assert "error" in result.output.lower()

--- a/packages/python/goldenmatch/tests/test_csv_arrow_polars_parity.py
+++ b/packages/python/goldenmatch/tests/test_csv_arrow_polars_parity.py
@@ -1,0 +1,85 @@
+"""`write_csv_polars_parity` must produce the bytes polars' `write_csv` does.
+
+The csv output contract is pinned to polars (see `output/writer.write_output`).
+The arrow writer only ever runs on a polars-FREE install, where there is nothing
+to compare against at runtime -- so the comparison has to happen here, in a test
+environment that has both.
+
+Any divergence found by this test is a bug in `_csv_arrow`, not a tolerated
+delta: a user who later installs the `polars` extra must not see their output
+files change spelling.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+import pyarrow as pa
+import pytest
+from goldenmatch.output._csv_arrow import write_csv_polars_parity
+
+pl = pytest.importorskip("polars", reason="parity is measured AGAINST polars")
+
+
+CASES: dict[str, dict] = {
+    "plain": {"a": [1, 2, 3], "b": ["x", "y", "z"]},
+    "nulls_and_empty": {"a": [1, None, 3], "b": ["x", None, ""]},
+    "delimiter_in_value": {"a": ["he, said", "plain", "x"], "b": ["1", "2", "3"]},
+    "quotes_in_value": {"a": ['she "said"', 'a"b', "c"], "b": ["1", "2", "3"]},
+    "newline_in_value": {"a": ["li\nne", "b", "c"], "b": ["1", "2", "3"]},
+    "carriage_return": {"a": ["li\r\nne", "b", "c"], "b": ["1", "2", "3"]},
+    "floats": {"a": [1.5, 2.0, None, 0.1], "b": ["w", "x", "y", "z"]},
+    "negative_and_big": {"a": [-1.25, 1e16, -0.0, 3.0], "b": ["w", "x", "y", "z"]},
+    "bools": {"a": [True, False, None], "b": ["x", "y", "z"]},
+    "ints_and_nulls": {"a": [1, None, -3], "b": [0, 5, None]},
+    "unicode": {"a": ["ünïcøde", "日本語", "emoji"], "b": ["1", "2", "3"]},
+    "cluster_output_shape": {
+        "__cluster_id__": [1, 2, 3],
+        "__row_id__": [10, 11, 12],
+        "__cluster_size__": [2, 3, 2],
+        "__oversized__": [False, True, False],
+    },
+    "header_needing_quotes": {'we,ird': [1, 2], 'with"quote': ["a", "b"]},
+    "all_null_column": {"a": [None, None], "b": ["x", "y"]},
+    "single_row": {"a": [1], "b": ["only"]},
+}
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_arrow_csv_matches_polars_bytes(name, tmp_path):
+    table = pa.table(CASES[name])
+
+    arrow_path = tmp_path / "arrow.csv"
+    write_csv_polars_parity(table, arrow_path)
+
+    polars_path = tmp_path / "polars.csv"
+    pl.from_arrow(table).write_csv(polars_path)
+
+    assert arrow_path.read_bytes() == polars_path.read_bytes(), (
+        f"{name}\n arrow ={arrow_path.read_bytes()!r}\n polars={polars_path.read_bytes()!r}"
+    )
+
+
+def test_temporal_matches_polars(tmp_path):
+    """Dates/datetimes render ISO-8601 the way polars spells them."""
+    table = pa.table(
+        {
+            "d": pa.array([dt.date(2026, 1, 2), dt.date(1999, 12, 31), None]),
+            "s": ["a", "b", "c"],
+        }
+    )
+    arrow_path = tmp_path / "a.csv"
+    polars_path = tmp_path / "p.csv"
+    write_csv_polars_parity(table, arrow_path)
+    pl.from_arrow(table).write_csv(polars_path)
+    assert arrow_path.read_bytes() == polars_path.read_bytes()
+
+
+def test_null_and_empty_string_stay_distinguishable(tmp_path):
+    """The distinction the hand-rolled writer exists for: a null is an empty
+    field, an empty string is ``""``. Reading back must recover both."""
+    table = pa.table({"a": [None, ""], "b": ["x", "y"]})
+    path = tmp_path / "a.csv"
+    write_csv_polars_parity(table, path)
+    assert path.read_text(encoding="utf-8") == 'a,b\n,x\n"",y\n'
+    back = pl.read_csv(path)
+    assert back["a"].to_list() == [None, ""]

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -194,10 +194,27 @@ def test_frame_lane_allows_throughput_plan():
     assert _eligible(cfg) is True
 
 
-def test_frame_lane_declines_preflight():
+def test_frame_lane_allows_preflight():
+    """`_preflight_report` no longer declines the lane.
+
+    `auto_configure_df` always sets it, so this decline pinned every ZERO-CONFIG
+    run to the classic polars lane -- the one path that, on a plain
+    `pip install goldenmatch`, has no polars to be pinned to. It dated from when
+    postflight's signals read a polars frame directly; `_signal_blocking_recall`
+    and `_signal_block_size_percentiles` both route through `to_frame` now.
+
+    Removed after measuring both lanes output-identical across five dataset
+    shapes (`scripts/diff_zeroconfig_lanes.py`): clusters/golden/dupes/unique
+    byte-for-byte, lineage identical up to pair order.
+
+    The separate `_preflight_report` decline on the FUSED match route is
+    unrelated and still stands (`pipeline._try_match_fused`): postflight can
+    raise the effective threshold from a score histogram the fused kernel never
+    materializes.
+    """
     cfg = _base_cfg()
     object.__setattr__(cfg, "_preflight_report", {"x": 1})
-    assert _eligible(cfg) is False
+    assert _eligible(cfg) is True
 
 
 def test_frame_lane_allows_probabilistic_mk():

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -275,3 +275,149 @@ def test_zero_config_dedupe_df_is_polars_free():
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
     assert "ZERO-CONFIG POLARS-FREE OK" in proc.stdout
+
+
+# -- Tier 4: the FILE front-door (what `pip install goldenmatch` actually runs) --
+
+
+def test_auto_configure_files_is_polars_free(tmp_path):
+    """SUBPROCESS, polars import BLOCKED: `auto_configure([(csv, name)])` runs to
+    completion WITHOUT importing polars.
+
+    Tier 3 above proves the *DataFrame* front-door, and only when the native
+    kernel is built. Neither holds for a plain ``pip install goldenmatch``: there
+    is no native wheel and no polars (it is an optional extra), and the first
+    thing the CLI does with a file is ``auto_configure(files)``. That ingest was
+    the last polars island on the zero-config path -- ``pl.read_csv`` /
+    ``pl.read_excel`` / ``pl.read_parquet`` + ``pl.concat`` -- so
+    ``goldenmatch dedupe customers.csv`` exited 1 with "Auto-config error: No
+    module named 'polars'" for every user who installed the documented way.
+
+    Deliberately runs ``GOLDENMATCH_NATIVE=0``: the pure-Python backend is what a
+    wheel-only install gets, so the gate has to hold without the kernel.
+    """
+    csv = tmp_path / "customers.csv"
+    rows = ["first,last,email,zip"]
+    for i in range(120):
+        f = ["ann", "ann", "bob", "bobby", "cara", "dan"][i % 6]
+        last = ["smith", "smith", "jones", "jones", "lee", "poe"][i % 6]
+        rows.append(f"{f},{last},{f}.{last}@x.com,{10000 + (i % 30)}")
+    csv.write_text("\n".join(rows), encoding="utf-8")
+
+    body = f"""
+        import sys
+        from goldenmatch.core.autoconfig import auto_configure
+        cfg = auto_configure([({str(csv)!r}, "customers")])
+        assert cfg is not None
+        assert cfg.get_matchkeys(), "auto_configure produced no matchkeys"
+        assert "polars" not in sys.modules, "polars leaked on the file front-door"
+        print("FILE FRONT-DOOR POLARS-FREE OK")
+    """
+    proc = _run_subprocess(
+        body,
+        {
+            "GOLDENMATCH_FRAME": "arrow",
+            "GOLDENMATCH_NATIVE": "0",
+            "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE": "1",
+            "POLARS_SKIP_CPU_CHECK": "1",
+            "GOLDENMATCH_AUTOCONFIG_MEMORY": "0",
+        },
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert "FILE FRONT-DOOR POLARS-FREE OK" in proc.stdout
+
+
+def test_auto_configure_files_matches_polars_ingest(tmp_path):
+    """The Arrow ingest must not change what auto-config DECIDES.
+
+    Config-equivalence (matchkeys + blocking), not row-identity: the same CSV
+    read through the arrow reader and through the legacy polars reader must
+    produce the same auto-config decisions. Guards the swap in
+    ``_read_autoconfig_input``.
+    """
+    import polars as pl
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.io_arrow import read_table_arrow
+
+    csv = tmp_path / "c.csv"
+    rows = ["first,last,email,zip"]
+    for i in range(200):
+        f = ["ann", "bob", "cara", "dan", "eve"][i % 5]
+        last = ["smith", "jones", "lee", "poe", "ray"][(i // 5) % 5]
+        rows.append(f"{f},{last},{f}.{last}@x.com,{10000 + (i % 40)}")
+    csv.write_text("\n".join(rows), encoding="utf-8")
+
+    def _summary(cfg):
+        mks = sorted(
+            (mk.type, tuple(sorted(fl.field for fl in (mk.fields or []) if fl.field)))
+            for mk in cfg.get_matchkeys()
+        )
+        blk = None
+        if cfg.blocking:
+            blk = (
+                cfg.blocking.strategy,
+                tuple(sorted(k.fields[0] if k.fields else "?" for k in (cfg.blocking.keys or []))),
+            )
+        return (mks, blk)
+
+    cfg_arrow = auto_configure_df(read_table_arrow(csv, encoding="utf8-lossy"), _skip_finalize=True)
+    cfg_polars = auto_configure_df(
+        pl.read_csv(csv, encoding="utf8-lossy", infer_schema_length=10000, ignore_errors=True),
+        _skip_finalize=True,
+    )
+    assert _summary(cfg_arrow) == _summary(cfg_polars)
+
+
+# -- Tier 5: the whole CLI, polars-free (what the README tells people to run) --
+
+
+def test_cli_zero_config_dedupe_is_polars_free(tmp_path):
+    """SUBPROCESS, polars import BLOCKED: the documented first command --
+    ``goldenmatch dedupe <csv> --output-clusters`` -- runs to completion,
+    exits 0 and WRITES its output, with no polars and no native kernel.
+
+    This is the end-to-end version of the tiers above and the one that matches
+    what a reader of the README actually types after ``pip install goldenmatch``.
+    Three separate leaks sat on it: the ``auto_configure`` file ingest, the
+    ``_preflight_report`` decline that pinned every zero-config run to the
+    classic polars lane, and the csv writer.
+    """
+    csv = tmp_path / "customers.csv"
+    rows = ["first,last,email,zip"]
+    for i in range(150):
+        f = ["ann", "ann", "bob", "bobby", "cara", "dan"][i % 6]
+        last = ["smith", "smith", "jones", "jones", "lee", "poe"][i % 6]
+        rows.append(f"{f},{last},{f}.{last}@x.com,{10000 + (i % 30)}")
+    csv.write_text("\n".join(rows), encoding="utf-8")
+    outdir = tmp_path / "out"
+
+    body = f"""
+        import sys
+        from typer.testing import CliRunner
+        from goldenmatch.cli.main import app
+
+        result = CliRunner().invoke(
+            app,
+            ["dedupe", {str(csv)!r}, "--output-clusters",
+             "--output-dir", {str(outdir)!r}, "--run-name", "tw"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output[-3000:]
+        assert "polars" not in sys.modules, "polars leaked on the CLI zero-config path"
+        import os
+        written = sorted(os.listdir({str(outdir)!r}))
+        assert any(f.endswith("_clusters.csv") for f in written), written
+        print("CLI ZERO-CONFIG POLARS-FREE OK")
+    """
+    proc = _run_subprocess(
+        body,
+        {
+            "GOLDENMATCH_FRAME": "arrow",
+            "GOLDENMATCH_NATIVE": "0",
+            "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE": "1",
+            "POLARS_SKIP_CPU_CHECK": "1",
+            "GOLDENMATCH_AUTOCONFIG_MEMORY": "0",
+        },
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-3000:]}"
+    assert "CLI ZERO-CONFIG POLARS-FREE OK" in proc.stdout

--- a/scripts/diff_zeroconfig_lanes.py
+++ b/scripts/diff_zeroconfig_lanes.py
@@ -1,0 +1,170 @@
+"""Arrow-lane vs classic-polars-lane equivalence for ZERO-CONFIG runs.
+
+`_frame_lane_eligible` declined the arrow lane whenever `config._preflight_report`
+was set -- which auto_configure_df ALWAYS sets. Zero-config, the one path with no
+polars to fall back on, was therefore the one path pinned to the polars lane.
+
+The decline dated from when postflight's signals read a polars frame directly;
+they route through `to_frame` now (`autoconfig_verify._signal_blocking_recall`,
+`_signal_block_size_percentiles`), so the decline outlived its cause. This script
+is the evidence for removing it: run each fixture shape ZERO-CONFIG down both
+lanes and compare the written outputs byte-for-byte.
+
+    python scripts/diff_zeroconfig_lanes.py
+
+Exits non-zero on any divergence. Requires polars (it compares AGAINST the polars
+lane); the point of the change is that the arrow lane no longer needs it.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _fixtures(root: Path) -> dict[str, list[tuple[str, str]]]:
+    """Dataset shapes that exercise different auto-config decisions."""
+    out: dict[str, list[tuple[str, str]]] = {}
+
+    def _w(name: str, header: str, rows: list[str]) -> Path:
+        p = root / name
+        p.write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+        return p
+
+    # 1. fuzzy-only: no exact-eligible identifier survives the guards
+    rows = []
+    for i in range(240):
+        f = ["ann", "ann", "bob", "bobby", "cara", "dan"][i % 6]
+        last = ["smith", "smith", "jones", "jones", "lee", "poe"][i % 6]
+        rows.append(f"{f},{last},{f}.{last}@x.com,{10000 + (i % 30)}")
+    out["fuzzy_only"] = [(str(_w("fuzzy.csv", "first,last,email,zip", rows)), "a")]
+
+    # 2. exact-eligible identifier present (drives a different matchkey set)
+    rows = []
+    for i in range(300):
+        f = ["ann", "bob", "cara", "dan", "eve"][i % 5]
+        last = ["smith", "jones", "lee", "poe", "ray"][(i // 5) % 5]
+        rows.append(f"ACC{i % 150:04d},{f},{last},{10000 + (i % 40)}")
+    out["exact_ident"] = [(str(_w("exact.csv", "account_no,first,last,zip", rows)), "a")]
+
+    # 3. nulls + empty strings (reader null-spelling divergence bait)
+    rows = []
+    for i in range(200):
+        f = ["ann", "bob", "cara", ""][i % 4]
+        last = ["smith", "", "lee", "poe"][i % 4]
+        mid = "" if i % 3 else "q"
+        rows.append(f"{f},{last},{mid},{10000 + (i % 25)}")
+    out["sparse_nulls"] = [(str(_w("sparse.csv", "first,last,middle,zip", rows)), "a")]
+
+    # 4. dates + numerics (dtype-spelling contract at the classify boundary)
+    rows = []
+    for i in range(200):
+        f = ["ann", "ann", "bob", "bobby"][i % 4]
+        last = ["smith", "smith", "jones", "jones"][i % 4]
+        rows.append(f"{f},{last},19{60 + (i % 40)}-0{1 + (i % 9)}-1{i % 9},{i % 97}")
+    out["dates_numeric"] = [(str(_w("dates.csv", "first,last,dob,score", rows)), "a")]
+
+    # 5. two files, shared schema (the multi-file concat + __source__ path).
+    #    NOTE disjoint column sets across files are NOT covered: run_dedupe's
+    #    arrow ingest calls concat_frames() without relaxed=True, so a schema
+    #    mismatch raises ArrowInvalid before the lane choice is even made. That
+    #    is a pre-existing bug on BOTH lanes, independent of this comparison.
+    rows_a = [f"{['ann','bob','cara'][i%3]},{['smith','jones','lee'][i%3]},{10000+i%20}"
+              for i in range(150)]
+    rows_b = [f"{['ann','bob','dan'][i%3]},{['smith','jones','poe'][i%3]},{10000+i%35}"
+              for i in range(150)]
+    out["two_files"] = [
+        (str(_w("m_a.csv", "first,last,zip", rows_a)), "a"),
+        (str(_w("m_b.csv", "first,last,zip", rows_b)), "b"),
+    ]
+    return out
+
+
+def _canonical_lineage(raw: bytes) -> bytes:
+    """Lineage normalised for comparison.
+
+    Two fields are expected to differ and are NOT part of the equivalence
+    contract:
+
+      * ``generated_at`` -- wall-clock, different on any two runs.
+      * the ORDER of ``pairs`` -- the two lanes emit the same pair set in a
+        different sequence (measured: same length, same members, same
+        per-pair content on all fixtures below). Cluster membership, which is
+        what the pairs feed, is byte-identical in ``*_clusters.csv``.
+
+    Everything else -- pair contents, counts, and all lineage metadata -- must
+    match exactly, so sorting rather than dropping keeps them under test.
+    """
+    doc = json.loads(raw)
+    doc.pop("generated_at", None)
+    if isinstance(doc.get("pairs"), list):
+        doc["pairs"] = sorted(
+            doc["pairs"], key=lambda p: json.dumps(p, sort_keys=True)
+        )
+    return json.dumps(doc, sort_keys=True).encode()
+
+
+def _hash_outputs(directory: Path) -> dict[str, str]:
+    got: dict[str, str] = {}
+    for f in sorted(os.listdir(directory)):
+        p = directory / f
+        if not p.is_file():
+            continue
+        raw = p.read_bytes()
+        if p.name.endswith("_lineage.json"):
+            raw = _canonical_lineage(raw)
+        got[f] = hashlib.sha256(raw).hexdigest()[:16]
+    return got
+
+
+def _run(files, force_arrow: bool, outdir: Path) -> dict[str, str]:
+    import goldenmatch.core.pipeline as pipeline
+    from goldenmatch.core.autoconfig import auto_configure
+
+    shutil.rmtree(outdir, ignore_errors=True)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    original = pipeline.__dict__.setdefault("_orig_fle", pipeline._frame_lane_eligible)
+    pipeline._frame_lane_eligible = (
+        (lambda config, matchkeys, *, writes_outputs: True) if force_arrow else original
+    )
+    try:
+        cfg = auto_configure(files)
+        cfg.output.directory = str(outdir)
+        cfg.output.run_name = "r"
+        cfg.output.format = "csv"
+        pipeline.run_dedupe(
+            files=files, config=cfg,
+            output_clusters=True, output_golden=True, output_dupes=True,
+            output_unique=True, output_report=False,
+        )
+    finally:
+        pipeline._frame_lane_eligible = original
+    return _hash_outputs(outdir)
+
+
+def main() -> int:
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    failures = 0
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for name, files in _fixtures(root).items():
+            arrow = _run(files, True, root / f"{name}_arrow")
+            classic = _run(files, False, root / f"{name}_classic")
+            same = arrow == classic
+            print(f"{'OK  ' if same else 'DIFF'}  {name:20s} files={len(arrow)}")
+            if not same:
+                failures += 1
+                for k in sorted(set(arrow) | set(classic)):
+                    if arrow.get(k) != classic.get(k):
+                        print(f"        {k}: arrow={arrow.get(k)} classic={classic.get(k)}")
+    print("\nRESULT:", "ALL EQUIVALENT" if not failures else f"{failures} DIVERGENT")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The bug

`pip install goldenmatch && goldenmatch dedupe customers.csv` — the command the README leads with — **fails 100% of the time**, and silently under `--quiet`:

```
$ goldenmatch dedupe customers.csv --output-clusters --output-dir out --run-name ttfs --quiet
$ echo $?
1                        # no output, no clusters file
```

Without `--quiet`: `Auto-config error: No module named 'polars'`.

Polars has been an optional extra since the eviction, but the zero-config path still had three hard requirements on it. This is why `context-network/planning/scoreboard.md` has been recording **`Time-to-first-success: FAILED (run)`** — against a board whose own gate reads *"a stranger's first run has to work before anything else on this board can matter."*

Reproduced on `origin/main`, not just on the 3.16.0 wheel.

## Three leaks, all fixed on the arrow lane

Per the standing rule, none of this re-adds polars — each consumer moves to pyarrow.

**1. `auto_configure`'s FILE ingest** still read via `pl.read_csv` / `read_excel` / `read_parquet` + `pl.concat`. `auto_configure_df` has been arrow-native since #1754; the file front door was the last island (and the one item plan PR-3 listed but left). Now reads through `read_table_arrow`, whose polars parity is already pinned by `test_io_arrow_ingest_parity`, and concatenates with `promote_options="permissive"` — polars' `how="diagonal"` equivalent, the spelling already used at `pipeline.py:6108`.

A reader failure falls back to polars **where it is installed**, so the `ignore_errors=True` tolerance and `.xls` support the old call had are not silently withdrawn. With polars absent the arrow error is re-raised — a real reader diagnostic instead of a bare `ImportError`.

**2. `_frame_lane_eligible` declined the arrow lane whenever `_preflight_report` was set.** `auto_configure_df` *always* sets it, so that single line pinned **every zero-config run** to the classic polars lane — precisely the path that has no polars to be pinned to.

The decline dated from when postflight's signals read a polars frame directly. `_signal_blocking_recall` and `_signal_block_size_percentiles` both route through `to_frame` now, so it had outlived its cause. (The separate `_preflight_report` decline on the *fused* match route is unrelated and still stands — postflight can raise the threshold from a histogram the fused kernel never materializes.)

**3. The csv writer.** Output formatting is deliberately pinned to polars' writers, and changing those bytes is a major-version decision — so this **does not change them**. `write_output` keeps the polars path whenever polars is installed, and falls back to a hand-rolled writer only when it is not, so no existing user's output changes spelling.

pyarrow's own `write_csv` cannot stand in: `quoting_style="needed"` quotes every string value *and* the whole header row, `"none"` never quotes at all, and floats render `2` where polars writes `2.0`.

**Also:** `--quiet` no longer suppresses fatal errors. It hides progress; a command that exits non-zero in silence cannot be diagnosed by whoever ran it — and that is exactly what kept this bug invisible (the nightly probe runs with `--quiet`).

## Evidence

The lane change in (2) touches every zero-config run, so it is measured rather than asserted. `scripts/diff_zeroconfig_lanes.py` is committed as the harness:

```
OK    fuzzy_only           files=4
OK    exact_ident          files=4
OK    sparse_nulls         files=4
OK    dates_numeric        files=4
OK    two_files            files=5
RESULT: ALL EQUIVALENT
```

Five dataset shapes, zero-config down both lanes: **byte-identical** clusters / golden / dupes / unique, and lineage identical up to pair *ordering* (same pairs, same count, same metadata). The ordering delta is documented in the harness rather than hidden. Separately, the polars-free CLI run's output is byte-identical to the polars-installed one.

## New gates

- **Tiers 4 and 5** of `test_zero_config_no_polars`: the file front door, and the whole CLI, with polars blocked. Both run `GOLDENMATCH_NATIVE=0` on purpose — a wheel-only install has no native kernel, and the existing tier-3 gate *skips* without one, which is how this path stayed uncovered.
- **17 byte-parity cases** pinning the arrow csv writer against the real polars writer (floats, quoting, unicode, dates, and the null-vs-empty-string distinction the hand-rolled writer exists for).

## Regression surface

The `-k "pipeline or writer or output or lineage or io_arrow or frame or dedupe or cli"` selection fails **16 tests on clean `origin/main`** and the **same 16** here. The only delta is `test_frame_lane_declines_preflight` → `test_frame_lane_allows_preflight`, updated because it asserted the behaviour (2) deliberately changes.

`-k autoconfig`: 961 passed, 1 failed — `test_build_blocking_id_union_arrow_parity`, confirmed failing identically on clean `origin/main`.

`ruff check packages/python/goldenmatch scripts/` clean; `regen_docs.py --check` current (codemap regenerated); flag-staleness OK.

## Noted, not fixed here

Multi-file input with **disjoint schemas** raises `ArrowInvalid` in `run_dedupe` — `concat_frames(frames)` is called without `relaxed=True` at `pipeline.py:2099`. That happens before the lane choice, so it affects both lanes and predates this PR. Out of scope; the harness documents why its two-file fixture shares a schema.