### PR TITLE
release: goldenmatch 3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Zero-config matching that **beats expert-tuned Splink head-to-head on messy cust
 <p align="center"><sub><em>Pair drilldown in the web workbench: cluster members, field-level diff, and a one-line NL explanation per pair. <code>pip install goldenmatch[web]</code> then <code>goldenmatch serve-ui &lt;project&gt;</code>. <a href="https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI">More screenshots →</a></em></sub></p>
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->
+> **v3.17.0: The documented first run works on a default install.** `pip install goldenmatch`
+followed by `goldenmatch dedupe customers.csv` -- the quickstart on every doc
+surface -- exited 3 on a polars-free install, which is what a plain install has
+produced since polars became an optional extra. Three separate polars imports on
+the zero-config path (auto-config ingest, the Arrow lane's preflight decline, and
+the csv writer) are gone, with polars' exact csv bytes reproduced and
+parity-pinned.
+>
 > **v3.13.0: Fellegi-Sunter training runs distributed on Spark.** The E-step reads only the
 comparison vector, so identical vectors collapse to one counted row and the whole
 step becomes a Spark `GROUP BY` over agreement patterns -- the cluster counts, the
@@ -61,13 +69,6 @@ off `information_schema` instead of a sampled frame, plus catalog reconciliation
 and a real-LLM namer validation harness -- so a warehouse's existing model can be
 discovered, reconciled against what is really there, and named without hand
 curation.
->
-> **v3.11.0: Customer 360 serving surface, and a fused FS kernel that covers the
-reference-data name scorers.** `customer_360` composes the golden record,
-per-field provenance, linked source records, the event timeline and the
-relationship neighborhood into one read, with semantic-layer drill-through; the
-fused Fellegi-Sunter kernel now covers the reference-data name scorers and an
-in-RAM sequential Arrow-native batch scorer with end-WCC.
 <!-- README-callouts:end -->
 
 ---

--- a/docs-site/goldenmatch/installation.mdx
+++ b/docs-site/goldenmatch/installation.mdx
@@ -10,13 +10,13 @@ keywords: ["installation", "pip", "docker", "postgresql", "duckdb", "dbt", "extr
 pip install goldenmatch
 ```
 
-Requires Python 3.11 or later. Core dependencies: Polars, RapidFuzz, Typer, Pydantic, Textual.
+Requires Python 3.11 or later. Core dependencies: PyArrow, DuckDB, NumPy, Typer, Rich, Pydantic, Textual. Polars is **not** among them -- it has been an optional compatibility extra since v3.1.0, and the polars-free install is the faster configuration. Neither is RapidFuzz: GoldenMatch owns its scorer math (a vendored Rust `score-core::strsim` plus a byte-identical pure-Python path), and RapidFuzz remains only as a dev-time parity oracle.
 
 ### Native acceleration (default on common platforms)
 
 `pip install goldenmatch` now pulls the compiled `goldenmatch-native` kernel automatically on macOS (x86_64 + arm64), Linux (x86_64 + aarch64), and Windows (amd64). No `[native]` extra is needed; the `[native]` extra still works as a back-compat alias. The kernel accelerates the hot paths (block scoring, record fingerprints, cluster build, dedup-pairs) and lets the v3 planner pick the bucket+native backend as the suggested path up to 750k rows on common boxes.
 
-The pure-Python + Polars pipeline is the byte-for-byte reference and the automatic fallback on any platform without a prebuilt wheel. Alpine/musl users may not get a prebuilt wheel yet (a `musllinux` wheel is a separate follow-up) and degrade gracefully to pure-Python.
+**Rust is the reference implementation** (the 2026-07 reference-mode change); the pure-Python + Arrow pipeline is the lossy fallback, byte-identical on the parity-gated hot paths and used automatically on any platform without a prebuilt wheel. Alpine/musl users may not get a prebuilt wheel yet (a `musllinux` wheel is a separate follow-up) and degrade gracefully to pure-Python.
 
 Opt out with environment variables:
 

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.16.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.17.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs/.docs-sweep.json
+++ b/docs/.docs-sweep.json
@@ -1,8 +1,9 @@
 {
-  "version": "3.16.0",
-  "commit": "e8dea428d",
-  "date": "2026-08-24",
-  "previous_swept_version": "3.3.1",
+  "version": "3.17.0",
+  "commit": "824502d94",
+  "date": "2026-08-30",
+  "previous_swept_version": "3.16.0",
   "note": "Set by the rollout-docs-sweep skill when a docs sweep completes for a release. The check_docs_sweep.py gate asserts version == current packages/python/goldenmatch version; bump this marker at the END of a docs sweep.",
-  "backlog_note": "NO PROSE SWEEP WAS PERFORMED FOR 3.4.0..3.16.0. The gate script existed but was wired into no workflow, so the marker sat at 3.3.1 across 13 minor releases while nothing enforced it. It is now wired into cut-goldenmatch-release.yml. This marker was advanced to 3.16.0 to arm the gate from here forward rather than to claim those releases were swept -- the 3.4.0..3.16.0 prose backlog is UNSWEPT and tracked separately. Delete this key at the first real sweep."
+  "sweep_scope": "3.17.0 sweep was SCOPED to what this release changes (the polars-free zero-config path, #2810) plus anything the grep for that surface turned up. It found and fixed two live errors on docs-site/goldenmatch/installation.mdx -- Polars and RapidFuzz were both listed as core dependencies when neither has been one since v3.1.0 and the rapidfuzz eviction respectively, and the 'pure-Python + Polars pipeline is the byte-for-byte reference' line predates the 2026-07 reference-mode change that made Rust the reference. It was NOT a full-surface sweep of every page in .claude/doc-surfaces.md.",
+  "backlog_note": "NO FULL PROSE SWEEP HAS BEEN PERFORMED FOR 3.4.0..3.16.0. The gate script existed but was wired into no workflow, so the marker sat at 3.3.1 across 13 minor releases while nothing enforced it. It is now wired into cut-goldenmatch-release.yml. The marker was advanced to 3.16.0 to arm the gate rather than to claim those releases were swept, and 3.17.0's scoped sweep (above) does not discharge that backlog either. Delete this key at the first full sweep."
 }

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,51 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.17.0] - 2026-08-30
+
+<!-- README-callout
+**The documented first run works on a default install.** `pip install goldenmatch`
+followed by `goldenmatch dedupe customers.csv` -- the quickstart on every doc
+surface -- exited 3 on a polars-free install, which is what a plain install has
+produced since polars became an optional extra. Three separate polars imports on
+the zero-config path (auto-config ingest, the Arrow lane's preflight decline, and
+the csv writer) are gone, with polars' exact csv bytes reproduced and
+parity-pinned.
+--> - 2026-08-30
+
+### Fixed
+
+- **The documented first run works on a default install (#2810).**
+  `pip install goldenmatch` then `goldenmatch dedupe customers.csv` -- the
+  quickstart on the README, the docs site and the PyPI page -- exited 3 on a
+  polars-free install, which is exactly what a plain `pip install` produces since
+  v3.1.0 made polars an optional extra. Three independent polars imports sat on
+  that path, each reachable only once the previous was fixed:
+  `auto_configure(files)` ingested csv/parquet/xlsx through `pl.read_*` and
+  `pl.concat`; `_frame_lane_eligible` declined the Arrow lane whenever a preflight
+  report was attached, which `auto_configure_df` *always* attaches, so every
+  zero-config run routed into the classic polars lane; and `write_output` bridged
+  csv through polars because the polars writer's byte formatting is the pinned
+  output contract.
+
+  Ingest now runs through the existing `read_table_arrow` parity reader (polars is
+  kept as a fallback when it is installed and Arrow rejects a file). The preflight
+  decline is removed because both signals it guarded now route through `to_frame`;
+  equivalence of the two lanes is committed as `scripts/diff_zeroconfig_lanes.py`
+  (5 fixtures, hashed outputs, `RESULT: ALL EQUIVALENT`) rather than left in a
+  scratch directory. csv writes through a new `output/_csv_arrow.py` that
+  reproduces polars' bytes -- quoting, null vs. empty string, float spelling,
+  temporal `isoformat` -- pinned by 17 cases in
+  `tests/test_csv_arrow_polars_parity.py`; pyarrow's own `write_csv` cannot match
+  it (`quoting_style="needed"` still quotes every string and the header, `"none"`
+  never quotes, and floats render `2` where polars writes `2.0`).
+
+  `xlsx` output still needs the extra and now names it instead of raising
+  `ModuleNotFoundError`. A fatal CLI error is printed to stderr unconditionally
+  rather than suppressed by `--quiet`, which is why this failed silently in the
+  time-to-first-success probe. Verified end-to-end with polars blocked at the
+  import hook: exit 0, 64 clusters, `polars` never imported.
+
 ### Added
 - **`scripts/controller_budget_cost.py` -- what auto-config's wall-clock budget costs in quality, and why the obvious repair is not shippable.** #2756 reported that `ControllerBudget.for_dataset` predicts iteration cost from row count and is wrong by 16x, so wide-text lanes commit v0 by construction. Both halves were measured. The proxy is genuinely poor (~4.5x today; the 16x collapsed once #2747 capped an unbounded bridge measurement) but it is not the mechanism: iteration 0 is the mandatory MEASUREMENT pass, and charging it against the budget that caps optional adaptation is what starves the search. Restarting the clock after it is worth **F1 0.1097 -> 0.1490** on Amazon-Google dedupe. **It was built, measured, and abandoned** -- on a host slow enough for the budget to bind, that cut is precisely what makes the controller cheap, so restarting it makes the machine least able to afford the work do the most of it. Measured on the arrow-parity `shared-email-switchboard` shape: 2 pipeline passes and 6.1s became 4 and 15.8s once the budget bound, and under `-n auto` that killed a CI worker on five consecutive runs, without reproducing once on an idle box. An absolute `2x` ceiling did not save it. Frugality-under-load and adaptation-under-load are the same knob pointed opposite ways, so the harness ships and the change does not. (#2756)
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -57,6 +57,14 @@ npm install goldenmatch
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->
+> **v3.17.0: The documented first run works on a default install.** `pip install goldenmatch`
+followed by `goldenmatch dedupe customers.csv` -- the quickstart on every doc
+surface -- exited 3 on a polars-free install, which is what a plain install has
+produced since polars became an optional extra. Three separate polars imports on
+the zero-config path (auto-config ingest, the Arrow lane's preflight decline, and
+the csv writer) are gone, with polars' exact csv bytes reproduced and
+parity-pinned.
+>
 > **v3.13.0: Fellegi-Sunter training runs distributed on Spark.** The E-step reads only the
 comparison vector, so identical vectors collapse to one counted row and the whole
 step becomes a Spark `GROUP BY` over agreement patterns -- the cluster counts, the
@@ -71,13 +79,6 @@ off `information_schema` instead of a sampled frame, plus catalog reconciliation
 and a real-LLM namer validation harness -- so a warehouse's existing model can be
 discovered, reconciled against what is really there, and named without hand
 curation.
->
-> **v3.11.0: Customer 360 serving surface, and a fused FS kernel that covers the
-reference-data name scorers.** `customer_360` composes the golden record,
-per-field provenance, linked source records, the event timeline and the
-relationship neighborhood into one read, with semantic-layer drill-through; the
-fused Fellegi-Sunter kernel now covers the reference-data name scorers and an
-in-RAM sequential Arrow-native batch scorer with end-WCC.
 <!-- README-callouts:end -->
 
 ---

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -47,7 +47,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/goldenmatch/output/writer.py
+++ b/packages/python/goldenmatch/goldenmatch/output/writer.py
@@ -17,10 +17,14 @@ def write_output(
     """Write a frame to the specified format (csv, parquet, xlsx).
 
     W-2 widening: dual-rep. A ``pa.Table`` writes parquet NATIVELY
-    (pyarrow.parquet); csv/xlsx BRIDGE through polars because the polars
-    writers' formatting (csv quoting/null spelling, xlsx engine) is the
-    pinned output contract -- an arrow-native csv writer would change
-    bytes on disk. Revisit at D6 (format change allowed at a major).
+    (pyarrow.parquet). Since #2810 csv is native too on a polars-free
+    install, via ``output/_csv_arrow.py`` -- which REPRODUCES the polars
+    writer's bytes rather than changing them (quoting, null vs. empty
+    string, float spelling, temporal isoformat), parity pinned by
+    tests/test_csv_arrow_polars_parity.py. When polars IS installed csv
+    still bridges through it, so that install has a single author for the
+    pinned contract. xlsx always bridges through polars (its engine is the
+    contract) and names the extra in a clear error when polars is absent.
     Returns the Path of the written file.
     """
     directory = Path(directory)

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.16.0"
+version = "3.17.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## What

Cuts **goldenmatch 3.17.0** so that #2810 — *the documented first run works on a default install* — actually reaches users. That fix merged on 2026-08-30 but `main` and PyPI were both still `3.16.0`, so `pip install goldenmatch` continued to serve the broken build and the TTFS scoreboard row stayed `FAILED (run)` (the probe installs from PyPI by design).

## Why 3.17.0 and not 3.16.1

`main` has carried 19 commits touching the package since `v3.16.0`, and several add public API — `MatchkeyConfig.link_threshold_observed` (#2637) and `segments.infer_kinds` (#2758). The CHANGELOG declares strict SemVer, so a release cutting all of `main` is a **minor**, not a patch. The `[Unreleased]` section becomes `[3.17.0]`.

## Changes

- **Version bumped in lockstep** across `pyproject.toml`, `goldenmatch/__init__.py`, and `server.json` (both `.version` and `packages[].version`) — what the `cut-goldenmatch-release.yml` guard and the `version_consistency` gate require.
- **CHANGELOG `## [3.17.0]`** section with the #2810 entry plus a `README-callout` marker.
- **Regenerated, not hand-edited:** README callout blocks (root + package) and `docs-site/reference/api-surface.mdx`.

## Docs sweep

The release cutter runs a Tier-3 prose-sweep gate that fails unless `docs/.docs-sweep.json` matches the package version, so this is a precondition rather than a formality. The sweep was **scoped to what this release changes** and turned up two live errors on the installation page — the first page a new user reads:

- `Core dependencies: Polars, RapidFuzz, Typer, Pydantic, Textual.` Neither Polars nor RapidFuzz has been a core dependency for some time (polars became an optional extra in v3.1.0; rapidfuzz was evicted to a dev-only parity oracle). This page was recommending precisely the belief that kept #2810 invisible.
- `The pure-Python + Polars pipeline is the byte-for-byte reference` predates the 2026-07 reference-mode change that made **Rust** the reference and the Python path the lossy fallback.

Also corrected the `write_output` docstring, which still claimed an arrow-native csv writer "would change bytes on disk" — #2810 wrote one that reproduces them, parity-pinned by `tests/test_csv_arrow_polars_parity.py`.

`docs/.docs-sweep.json` records the sweep as **scoped**. The 3.4.0..3.16.0 prose backlog remains unswept and its note is kept rather than deleted — this does not discharge it.

## Verification

All run against the committed tree, reading each script's own exit code:

| Gate | Result |
|---|---|
| `check_version_consistency.py` | 0 — 49 packages in lockstep |
| `check_docs_sweep.py` | 0 — marker 3.17.0 == goldenmatch 3.17.0 |
| `check_docs_consistency.py` | 0 — 13/13 PASS |
| `check_docs_staleness.py` | 0 |
| `regen_docs.py --check` | 0 — "Docs are current" |

Import smoke: `__version__ == 3.17.0`, `server.json` and `packages[]` agree, `output/_csv_arrow` imports.

## After merge

Dispatch `cut-goldenmatch-release.yml` with `version = 3.17.0`. It pushes the `v3.17.0` tag and calls `publish-goldenmatch.yml` in the same run (a `GITHUB_TOKEN` tag push does not re-trigger it). Not doing that by hand: `gh release create` publishes an immutable release immediately and **permanently tombstones the tag name**.
