### PR TITLE
fix(zero-config): NE on an exact matchkey no longer needs polars (3.17.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Zero-config matching that **beats expert-tuned Splink head-to-head on messy cust
 <p align="center"><sub><em>Pair drilldown in the web workbench: cluster members, field-level diff, and a one-line NL explanation per pair. <code>pip install goldenmatch[web]</code> then <code>goldenmatch serve-ui &lt;project&gt;</code>. <a href="https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI">More screenshots →</a></em></sub></p>
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->
+> **v3.17.1: The polars-free first run actually works now.** 3.17.0 claimed this and did not
+deliver it: auto-config puts negative evidence on the exact matchkey by default,
+and that path still bridged to polars, so `goldenmatch dedupe customers.csv`
+exited 3 on a default install. Verified the way it should have been the first
+time -- `pip install` into a clean polars-free venv, then the documented command.
+>
 > **v3.17.0: The documented first run works on a default install.** `pip install goldenmatch`
 followed by `goldenmatch dedupe customers.csv` -- the quickstart on every doc
 surface -- exited 3 on a polars-free install, which is what a plain install has
@@ -63,12 +69,6 @@ driver only fits. Training cost tracks DISTINCT vectors (bounded by
 distributed counting stage 5.25x, while distinct patterns grew 3.0% (433 -> 446)
 and driver-side EM stayed at 0.01s. Runs on jar-only executors via
 `goldenmatch-spark`, off the same Rust kernel every other surface uses.
->
-> **v3.12.0: Semantic-model discovery reaches warehouse scale.** Model derivation now runs
-off `information_schema` instead of a sampled frame, plus catalog reconciliation
-and a real-LLM namer validation harness -- so a warehouse's existing model can be
-discovered, reconciled against what is really there, and named without hand
-curation.
 <!-- README-callouts:end -->
 
 ---

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.17.0` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.17.1` | `1.29.0` | `goldenmatch` | 97 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.5.0` | `0.9.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.2.0` | `0.20.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.5.0` | `0.5.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs/.docs-sweep.json
+++ b/docs/.docs-sweep.json
@@ -1,9 +1,9 @@
 {
-  "version": "3.17.0",
+  "version": "3.17.1",
   "commit": "824502d94",
-  "date": "2026-08-30",
-  "previous_swept_version": "3.16.0",
+  "date": "2026-08-31",
+  "previous_swept_version": "3.17.0",
   "note": "Set by the rollout-docs-sweep skill when a docs sweep completes for a release. The check_docs_sweep.py gate asserts version == current packages/python/goldenmatch version; bump this marker at the END of a docs sweep.",
-  "sweep_scope": "3.17.0 sweep was SCOPED to what this release changes (the polars-free zero-config path, #2810) plus anything the grep for that surface turned up. It found and fixed two live errors on docs-site/goldenmatch/installation.mdx -- Polars and RapidFuzz were both listed as core dependencies when neither has been one since v3.1.0 and the rapidfuzz eviction respectively, and the 'pure-Python + Polars pipeline is the byte-for-byte reference' line predates the 2026-07 reference-mode change that made Rust the reference. It was NOT a full-surface sweep of every page in .claude/doc-surfaces.md.",
+  "sweep_scope": "3.17.1 is a bugfix-only cut for the leak 3.17.0 shipped (negative evidence on an exact matchkey still bridged to polars). No prose surface makes a claim that this changes -- installation.mdx was already corrected in the 3.17.0 sweep, and it is now simply TRUE where it was aspirational. Marker advanced to keep the release gate armed; no new sweep was performed and none was owed.",
   "backlog_note": "NO FULL PROSE SWEEP HAS BEEN PERFORMED FOR 3.4.0..3.16.0. The gate script existed but was wired into no workflow, so the marker sat at 3.3.1 across 13 minor releases while nothing enforced it. It is now wired into cut-goldenmatch-release.yml. The marker was advanced to 3.16.0 to arm the gate rather than to claim those releases were swept, and 3.17.0's scoped sweep (above) does not discharge that backlog either. Delete this key at the first full sweep."
 }

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,56 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.17.1] - 2026-08-31
+
+<!-- README-callout
+**The polars-free first run actually works now.** 3.17.0 claimed this and did not
+deliver it: auto-config puts negative evidence on the exact matchkey by default,
+and that path still bridged to polars, so `goldenmatch dedupe customers.csv`
+exited 3 on a default install. Verified the way it should have been the first
+time -- `pip install` into a clean polars-free venv, then the documented command.
+--> - 2026-08-31
+
+### Fixed
+
+- **Negative evidence on an exact matchkey no longer requires polars -- the leak
+  3.17.0 shipped while claiming the opposite (#2810 follow-up).**
+  `_apply_negative_evidence_to_exact_pairs` took a `pl.DataFrame` and read it
+  with polars-only indexing (`full_df[col][idx]`, `.height`, `.columns`), so its
+  caller in `_run_dedupe_pipeline` bridged through `_as_polars_df`. Auto-config's
+  `promote_negative_evidence` step puts NE on the exact matchkey by default, so
+  that bridge sat on the zero-config path: on a polars-free install every
+  auto-config controller iteration errored, the run fell back to a v0 RED
+  sentinel, and the final pipeline raised `ModuleNotFoundError: No module named
+  'polars'` -- exit 3, on the exact command the README, the docs site and the
+  PyPI page all tell people to run.
+
+  It now reads through the Frame seam and works on a `pa.Table` unchanged. This
+  is also strictly less work than before: each NE column is materialized once
+  instead of two scalar frame lookups per pair per field. The sibling
+  `_apply_guard_to_exact_pairs` had already been given a bridge-free shape for
+  the same reason; NE is now in line with it. The remaining `_as_polars_df`
+  callers are the golden-record builders, which are a separate documented
+  removal point and are not on this path.
+
+  **Why 3.17.0 missed it.** The fix was verified against `run_dedupe`, the entry
+  point that had been changed -- not `run_dedupe_df`, which is what the CLI's
+  auto-config controller actually calls. A tier-5 test did run the whole CLI with
+  polars blocked and passed, because its fixture (`first,last,email,zip`) has no
+  `id` column and so never causes NE to be promoted: the code path was covered,
+  the config shape that path generates on ordinary data was not.
+
+  Both gaps are now gated. `tests/test_ne_exact_pairs_backend_parity.py` pins
+  arrow/polars equivalence of the function and asserts the arrow call imports no
+  polars. A new tier-6 test in `tests/test_zero_config_no_polars.py` runs the
+  documented CLI command on a csv **with** an id column and asserts negative
+  evidence is actually present in the committed config, so the gate cannot go
+  quietly vacuous again. Both fail on 3.17.0 and pass here. The tier-6 env pins
+  `GOLDENMATCH_AUTOCONFIG_MEMORY=1` explicitly rather than inheriting it: a
+  sibling test in the same file sets it to `0` in the parent pytest process, and
+  `0` drops the exact matchkey -- which made whether the gate tested anything
+  depend on test order alone.
+
 ## [3.17.0] - 2026-08-30
 
 <!-- README-callout

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -57,6 +57,12 @@ npm install goldenmatch
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py; edit the CHANGELOG, not this block) -->
+> **v3.17.1: The polars-free first run actually works now.** 3.17.0 claimed this and did not
+deliver it: auto-config puts negative evidence on the exact matchkey by default,
+and that path still bridged to polars, so `goldenmatch dedupe customers.csv`
+exited 3 on a default install. Verified the way it should have been the first
+time -- `pip install` into a clean polars-free venv, then the documented command.
+>
 > **v3.17.0: The documented first run works on a default install.** `pip install goldenmatch`
 followed by `goldenmatch dedupe customers.csv` -- the quickstart on every doc
 surface -- exited 3 on a polars-free install, which is what a plain install has
@@ -73,12 +79,6 @@ driver only fits. Training cost tracks DISTINCT vectors (bounded by
 distributed counting stage 5.25x, while distinct patterns grew 3.0% (433 -> 446)
 and driver-side EM stayed at 0.01s. Runs on jar-only executors via
 `goldenmatch-spark`, off the same Rust kernel every other surface uses.
->
-> **v3.12.0: Semantic-model discovery reaches warehouse scale.** Model derivation now runs
-off `information_schema` instead of a sampled frame, plus catalog reconciliation
-and a real-LLM namer validation harness -- so a warehouse's existing model can be
-discovered, reconciled against what is really there, and named without hand
-curation.
 <!-- README-callouts:end -->
 
 ---

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -47,7 +47,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.17.0"
+__version__ = "3.17.1"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3803,8 +3803,14 @@ def _run_dedupe_pipeline(
                         from goldenmatch.core.scorer import (
                             _apply_negative_evidence_to_exact_pairs,
                         )
+                        # No _as_polars_df bridge: NE reads through the Frame
+                        # seam now. That bridge was the last polars import on
+                        # the zero-config CLI path (auto-config puts NE on an
+                        # exact matchkey by default), so it raised on a
+                        # polars-free install -- see the note on
+                        # _apply_negative_evidence_to_exact_pairs.
                         pairs = _apply_negative_evidence_to_exact_pairs(
-                            pairs, mk, _as_polars_df(collected_df)
+                            pairs, mk, collected_df
                         )
                     if mk.guard:
                         # Guarded matchkey: drop pairs failing the pair predicate.

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -861,7 +861,7 @@ def _apply_negative_evidence_batch(
 def _apply_negative_evidence_to_exact_pairs(  # pyright: ignore[reportUnusedFunction]  # called from core/pipeline.py (outside slice)
     pairs: list[tuple[int, int, float]],
     matchkey: MatchkeyConfig,
-    full_df: pl.DataFrame,
+    full_df: Any,
 ) -> list[tuple[int, int, float]]:
     """v1.12 Path Y: filter pairs from find_exact_matches by NE penalty.
 
@@ -871,6 +871,17 @@ def _apply_negative_evidence_to_exact_pairs(  # pyright: ignore[reportUnusedFunc
 
     When matchkey.negative_evidence is None or empty: returns pairs unchanged
     (today's binary behavior preserved).
+
+    ``full_df`` is a polars DataFrame OR a ``pa.Table``: it is read through the
+    Frame seam, never with polars-only indexing. It USED to be typed
+    ``pl.DataFrame``, and the caller bridged with ``_as_polars_df`` -- which made
+    this the last polars import on the zero-config CLI path, because
+    auto-config's ``promote_negative_evidence`` step puts NE on an exact matchkey
+    by default. A polars-free install therefore died here on the documented first
+    run (every controller iteration errored, then the final pipeline raised),
+    which is what #2810 missed and 3.17.0 shipped. The sibling
+    ``_apply_guard_to_exact_pairs`` had already been given a bridge-free shape for
+    the same reason; this brings NE into line.
     """
     if not matchkey.negative_evidence:
         return pairs
@@ -882,10 +893,22 @@ def _apply_negative_evidence_to_exact_pairs(  # pyright: ignore[reportUnusedFunc
             matchkey.name,
         )
 
-    # Build a lookup of (row_id → row_index_in_full_df) for fast NE column access
+    # Read through the Frame seam so this works on both backends. Materializing
+    # each NE column ONCE (rather than indexing the frame per pair, as the
+    # polars-only version did) is also strictly less work: the old shape did two
+    # scalar frame lookups per pair per NE field.
+    from goldenmatch.core.frame import to_frame  # noqa: PLC0415
+
+    _frame = to_frame(full_df)
+    _cols = set(_frame.columns)
     row_id_to_idx: dict[int, int] = dict(
-        zip(full_df["__row_id__"].to_list(), range(full_df.height))
+        zip(_frame.column("__row_id__").to_list(), range(_frame.height))
     )
+    _ne_values: dict[str, list] = {
+        ne.field: _frame.column(ne.field).to_list()
+        for ne in matchkey.negative_evidence
+        if ne.field in _cols
+    }
 
     # Materialize the per-pair NE value dicts, then score them all in one
     # vectorized pass (_apply_negative_evidence_batch -> native pairwise). The
@@ -901,12 +924,11 @@ def _apply_negative_evidence_to_exact_pairs(  # pyright: ignore[reportUnusedFunc
             continue
         pair_dict: dict = {}
         for ne in matchkey.negative_evidence:
-            if ne.field not in full_df.columns:
+            values = _ne_values.get(ne.field)
+            if values is None:
                 continue
             try:
-                val_a = full_df[ne.field][idx_a]
-                val_b = full_df[ne.field][idx_b]
-                pair_dict[ne.field] = (val_a, val_b)
+                pair_dict[ne.field] = (values[idx_a], values[idx_b])
             except Exception:
                 pair_dict[ne.field] = (None, None)
         valid_pairs.append((row_a, row_b))

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.17.0"
+version = "3.17.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/docs/",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.17.0",
+      "version": "3.17.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,11 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 5,  # A1-A8 + A9-slice-1 retired; rebase onto deep-D2b removed the 2 frames-path sites; golden_quality_scores retired (cell_quality is arrow-native)
+    # NOTE: update DOWNWARD only. 5 -> 4: the NE-on-exact-matchkey bridge is
+    # retired -- _apply_negative_evidence_to_exact_pairs reads through the Frame
+    # seam now, so the caller no longer wraps collected_df in _as_polars_df.
+    # That bridge was the last polars import on the zero-config CLI path.
+    "core/pipeline.py": 4,  # A1-A8 + A9-slice-1 retired; rebase onto deep-D2b removed the 2 frames-path sites; golden_quality_scores retired (cell_quality is arrow-native); NE-on-exact retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_ne_exact_pairs_backend_parity.py
+++ b/packages/python/goldenmatch/tests/test_ne_exact_pairs_backend_parity.py
@@ -1,0 +1,123 @@
+"""``_apply_negative_evidence_to_exact_pairs`` is backend-neutral.
+
+The function used to be typed ``pl.DataFrame`` and read with polars-only
+indexing (``full_df[col][idx]``, ``.height``, ``.columns``), so its one caller in
+``core/pipeline.py`` bridged with ``_as_polars_df``. That bridge was the last
+polars import on the zero-config CLI path -- auto-config's
+``promote_negative_evidence`` step puts NE on an exact matchkey by default -- and
+it made ``goldenmatch dedupe <csv>`` exit 3 on a polars-free install.
+
+It now reads through the Frame seam. These tests pin BOTH halves of that:
+
+* it produces identical results on a ``pa.Table`` and a ``pl.DataFrame``, so the
+  change is behaviour-neutral for anyone who has polars installed; and
+* the arrow call never imports polars, so the seam is real rather than an
+  ``isinstance`` check with a bridge behind it.
+"""
+from __future__ import annotations
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+
+def _matchkey():
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField, NegativeEvidenceField
+
+    return MatchkeyConfig(
+        name="exact_email",
+        type="exact",
+        fields=[MatchkeyField(field="email")],
+        threshold=0.5,
+        negative_evidence=[
+            NegativeEvidenceField(
+                field="dob", scorer="exact", threshold=0.4, penalty=0.6,
+            ),
+            NegativeEvidenceField(
+                field="city", scorer="token_sort", threshold=0.4, penalty=0.3,
+            ),
+        ],
+    )
+
+
+def _columns() -> dict[str, list]:
+    """Rows 1-6 pair up on email; dob/city agreement varies so some pairs are
+    penalized past the threshold and some are not (a test where every pair
+    survives would not distinguish the backends)."""
+    return {
+        "__row_id__": [1, 2, 3, 4, 5, 6],
+        "email": ["a@x.com", "a@x.com", "b@x.com", "b@x.com", "c@x.com", "c@x.com"],
+        "dob": ["1990-01-01", "1990-01-01", "1975-06-30", "1988-02-11", None, "2001-09-09"],
+        "city": ["Leeds", "Leeds", "Bristol", "Cardiff", "Dundee", None],
+    }
+
+
+_PAIRS = [(1, 2, 1.0), (3, 4, 1.0), (5, 6, 1.0)]
+
+
+def test_arrow_and_polars_give_identical_results():
+    from goldenmatch.core.scorer import _apply_negative_evidence_to_exact_pairs
+
+    pl = pytest.importorskip("polars")
+    cols = _columns()
+    mk = _matchkey()
+
+    arrow_out = _apply_negative_evidence_to_exact_pairs(_PAIRS, mk, pa.table(cols))
+    polars_out = _apply_negative_evidence_to_exact_pairs(_PAIRS, mk, pl.DataFrame(cols))
+
+    assert arrow_out == polars_out, f"arrow={arrow_out} polars={polars_out}"
+    # Guard against the vacuous case: if NE filtered nothing, the two backends
+    # would agree trivially and this test would prove nothing.
+    assert len(arrow_out) < len(_PAIRS), (
+        "NE penalized no pair -- fixture no longer exercises the filter"
+    )
+
+
+def test_arrow_path_does_not_import_polars():
+    """The arrow call must not touch polars even when polars is installed."""
+    import subprocess
+    import sys
+    import textwrap
+    from pathlib import Path
+
+    body = textwrap.dedent(
+        """
+        import sys
+        class _Block:
+            def find_spec(self, name, path=None, target=None):
+                if name == 'polars' or name.startswith('polars.'):
+                    raise ImportError('polars blocked')
+                return None
+        sys.meta_path.insert(0, _Block())
+
+        import pyarrow as pa
+        from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField, NegativeEvidenceField
+        from goldenmatch.core.scorer import _apply_negative_evidence_to_exact_pairs
+
+        mk = MatchkeyConfig(
+            name="exact_email", type="exact", fields=[MatchkeyField(field="email")], threshold=0.5,
+            negative_evidence=[
+                NegativeEvidenceField(field="dob", scorer="exact", threshold=0.4, penalty=0.6),
+            ],
+        )
+        tbl = pa.table({
+            "__row_id__": [1, 2, 3, 4],
+            "email": ["a@x.com", "a@x.com", "b@x.com", "b@x.com"],
+            "dob": ["1990-01-01", "1990-01-01", "1975-06-30", "1988-02-11"],
+        })
+        out = _apply_negative_evidence_to_exact_pairs([(1, 2, 1.0), (3, 4, 1.0)], mk, tbl)
+        assert "polars" not in sys.modules, "polars imported on the arrow NE path"
+        print("NE ARROW POLARS-FREE OK", len(out))
+        """
+    )
+    env_path = str(Path(__file__).parent.parent)
+    import os
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = env_path
+    env["GOLDENMATCH_NATIVE"] = "0"
+    proc = subprocess.run(
+        [sys.executable, "-c", body], capture_output=True, text=True, env=env, timeout=300,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-3000:]}"
+    assert "NE ARROW POLARS-FREE OK" in proc.stdout

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -421,3 +421,113 @@ def test_cli_zero_config_dedupe_is_polars_free(tmp_path):
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-3000:]}"
     assert "CLI ZERO-CONFIG POLARS-FREE OK" in proc.stdout
+
+
+# -- Tier 6: NE on an exact matchkey, polars-free ---------------------------
+
+
+def _customers_csv_with_id(path, n: int = 90) -> None:
+    """A csv shaped like the one a reader actually has: an ``id`` column plus
+    near-duplicate rows.
+
+    The ``id`` column is the point. Tier 5's fixture has none, and without it
+    auto-config never promotes NEGATIVE EVIDENCE onto the exact matchkey -- so
+    Tier 5 ran the whole CLI polars-free and still missed the leak that
+    ``_apply_negative_evidence_to_exact_pairs`` carried (it took a
+    ``pl.DataFrame`` via an ``_as_polars_df`` bridge). The path was covered; the
+    CONFIG SHAPE that path generates on ordinary data was not.
+    """
+    firsts = ["Jonathan", "Jon", "Katherine", "Kate", "Michael", "Mike"]
+    lasts = ["Okafor", "Nakamura", "Silva", "Petrov", "Andersen", "Rahman"]
+    rows = ["id,first_name,last_name,email,city"]
+    rid = 0
+    for i in range(n):
+        f, l = firsts[i % len(firsts)], lasts[i % len(lasts)]
+        email = f"{f.lower()}.{l.lower()}@example.com"
+        city = ["Leeds", "Bristol", "Cardiff"][i % 3]
+        rid += 1
+        rows.append(f"{rid},{f},{l},{email},{city}")
+        if i % 2 == 0:  # near-duplicate: same identity, noisier spelling
+            rid += 1
+            rows.append(f"{rid},{f},{l},{email.replace('example.com', 'Example.COM')},{city.upper()}")
+    path.write_text("\n".join(rows), encoding="utf-8")
+
+
+def test_cli_zero_config_with_negative_evidence_is_polars_free(tmp_path):
+    """SUBPROCESS, polars BLOCKED: the documented first command on a csv that
+    HAS an id column -- so auto-config promotes negative evidence onto the exact
+    matchkey -- runs to completion and writes its clusters.
+
+    Regression gate for the leak 3.17.0 shipped: NE on an exact matchkey went
+    through ``_as_polars_df``, so on a polars-free install every auto-config
+    controller iteration errored and the final pipeline raised
+    ``ModuleNotFoundError: No module named 'polars'`` (exit 3) -- on the exact
+    command the README, the docs site and the PyPI page all tell people to run.
+
+    The test asserts NE is ACTUALLY ACTIVE in the committed config, not just
+    that the run exits 0. Without that assertion the fixture could drift back to
+    a shape that never promotes NE and the gate would silently stop testing
+    anything -- which is precisely how this escaped the first time.
+    """
+    csv = tmp_path / "customers.csv"
+    _customers_csv_with_id(csv)
+    outdir = tmp_path / "out"
+
+    csv_repr = repr(str(csv))
+    body = f"""
+        import os, sys
+        from typer.testing import CliRunner
+        from goldenmatch.cli.main import app
+
+        # PRECONDITION, checked BEFORE the run: this fixture must still produce
+        # a config with negative evidence on the exact matchkey, or the gate
+        # below proves nothing. Checked first because the CLI run leaves
+        # process state behind that changes what a later auto_configure returns.
+        from goldenmatch.core.autoconfig import auto_configure
+        _cfg = auto_configure([({csv_repr}, "customers")])
+        assert any(
+            getattr(mk, "negative_evidence", None) for mk in _cfg.matchkeys
+        ), (
+            "fixture no longer promotes negative evidence -- gate is now vacuous. "
+            f"matchkeys={{[(m.name, len(m.negative_evidence or [])) for m in _cfg.matchkeys]}}"
+        )
+        assert "polars" not in sys.modules, "polars leaked in auto_configure"
+
+        result = CliRunner().invoke(
+            app,
+            ["dedupe", {str(csv)!r}, "--output-clusters",
+             "--output-dir", {str(outdir)!r}, "--run-name", "ne"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output[-4000:]
+        assert "polars" not in sys.modules, "polars leaked on the NE exact-matchkey path"
+
+        written = sorted(os.listdir({str(outdir)!r}))
+        assert any(f.endswith("_clusters.csv") for f in written), written
+
+        print("CLI ZERO-CONFIG NE POLARS-FREE OK")
+    """
+    # Deliberately NOT the tier-5 env. GOLDENMATCH_AUTOCONFIG_MEMORY=0 and
+    # GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1 make auto-config drop the
+    # `exact_email` matchkey entirely, and with it the negative evidence this
+    # gate exists to exercise (measured on this fixture: matchkeys go from
+    # [exact_email (1 NE), fuzzy_match] to just [fuzzy_match]). Setting them
+    # here would leave the test green against the very bug it is written for.
+    proc = _run_subprocess(
+        body,
+        {
+            "GOLDENMATCH_FRAME": "arrow",
+            "GOLDENMATCH_NATIVE": "0",
+            "POLARS_SKIP_CPU_CHECK": "1",
+            # Set EXPLICITLY, never left to inherit. `_run_subprocess` copies
+            # `os.environ`, and `test_zero_config_dedupe_df_arrow_functional`
+            # earlier in this file does
+            # `os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")` in
+            # the PARENT pytest process -- so running this test after that one
+            # silently handed it the one value that drops the exact matchkey,
+            # and whether this gate tested anything came down to test ORDER.
+            "GOLDENMATCH_AUTOCONFIG_MEMORY": "1",
+        },
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-4000:]}"
+    assert "CLI ZERO-CONFIG NE POLARS-FREE OK" in proc.stdout

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -426,31 +426,54 @@ def test_cli_zero_config_dedupe_is_polars_free(tmp_path):
 # -- Tier 6: NE on an exact matchkey, polars-free ---------------------------
 
 
-def _customers_csv_with_id(path, n: int = 90) -> None:
-    """A csv shaped like the one a reader actually has: an ``id`` column plus
-    near-duplicate rows.
+def _customers_csv_with_id(path, n_identities: int = 60) -> None:
+    """A csv shaped like the one a reader actually has: a unique ``id``, an
+    ``email`` that IS an identifier, and near-duplicate rows.
 
-    The ``id`` column is the point. Tier 5's fixture has none, and without it
-    auto-config never promotes NEGATIVE EVIDENCE onto the exact matchkey -- so
-    Tier 5 ran the whole CLI polars-free and still missed the leak that
-    ``_apply_negative_evidence_to_exact_pairs`` carried (it took a
-    ``pl.DataFrame`` via an ``_as_polars_df`` bridge). The path was covered; the
-    CONFIG SHAPE that path generates on ordinary data was not.
+    Two properties are load-bearing, and both were learned the hard way:
+
+    * **Emails must be mostly distinct.** Auto-config only builds an exact
+      matchkey on a column that clears an identifier-uniqueness guard
+      (``cardinality_ratio >= 0.50`` for ``col_type=email``), and it only
+      promotes NEGATIVE EVIDENCE onto a matchkey that exists. An earlier
+      version of this fixture cycled first and last names in lockstep, which
+      produced ~9 distinct emails over 135 rows (ratio 0.0667); auto-config
+      excluded every exact-eligible column and fell back to fuzzy-only, so the
+      gate went vacuous. Here each identity gets its own email and only some are
+      duplicated, giving ratio ~0.67 -- the guard wants >= 0.50, and 1.0 fails
+      too (a perfectly-unique column is a surrogate key, not shared identity).
+    * **``id`` stays perfectly unique.** It is excluded as an exact matchkey
+      (a surrogate key has no shared identity to match on) but it is exactly
+      what NE gets promoted ON.
+
+    Tier 5's fixture has no id column at all, which is why tier 5 ran the whole
+    CLI polars-free and still missed the leak in
+    ``_apply_negative_evidence_to_exact_pairs``: the code path was covered, the
+    config shape that path generates on ordinary data was not.
     """
-    firsts = ["Jonathan", "Jon", "Katherine", "Kate", "Michael", "Mike"]
-    lasts = ["Okafor", "Nakamura", "Silva", "Petrov", "Andersen", "Rahman"]
+    firsts = ["Jonathan", "Katherine", "Michael", "Elizabeth", "Robert", "Amara",
+              "Priya", "Tomasz", "Yusuf", "Ingrid"]
+    lasts = ["Okafor", "Nakamura", "Silva", "Petrov", "Andersen", "Rahman",
+             "Dubois", "Kowalski", "Mbeki", "Lindqvist"]
+    cities = ["Leeds", "Bristol", "Cardiff", "Dundee"]
     rows = ["id,first_name,last_name,email,city"]
     rid = 0
-    for i in range(n):
-        f, l = firsts[i % len(firsts)], lasts[i % len(lasts)]
-        email = f"{f.lower()}.{l.lower()}@example.com"
-        city = ["Leeds", "Bristol", "Cardiff"][i % 3]
+    for i in range(n_identities):
+        f = firsts[i % len(firsts)]
+        l = lasts[(i // len(firsts)) % len(lasts)]
+        email = f"{f.lower()}.{l.lower()}{i}@example.com"
+        city = cities[i % len(cities)]
         rid += 1
         rows.append(f"{rid},{f},{l},{email},{city}")
         if i % 2 == 0:  # near-duplicate: same identity, noisier spelling
             rid += 1
-            rows.append(f"{rid},{f},{l},{email.replace('example.com', 'Example.COM')},{city.upper()}")
-    path.write_text("\n".join(rows), encoding="utf-8")
+            # The email is repeated VERBATIM: it is the identity the exact
+            # matchkey joins on, and case-mangling it would make every address
+            # distinct -- which pushes cardinality_ratio to 1.0 and gets the
+            # column excluded as a perfectly-unique surrogate key, the same
+            # guard that excludes `id`. The noise belongs in the other columns.
+            rows.append(f"{rid},{f.upper()},{l},{email},{city.upper()}")
+    path.write_text(chr(10).join(rows), encoding="utf-8")
 
 
 def test_cli_zero_config_with_negative_evidence_is_polars_free(tmp_path):
@@ -519,6 +542,16 @@ def test_cli_zero_config_with_negative_evidence_is_polars_free(tmp_path):
             "GOLDENMATCH_FRAME": "arrow",
             "GOLDENMATCH_NATIVE": "0",
             "POLARS_SKIP_CPU_CHECK": "1",
+            # Isolate the CROSS-RUN auto-config memory
+            # (`~/.goldenmatch/autoconfig_memory.db`, keyed by data shape, with
+            # no env override -- so redirecting home is the only lever). Without
+            # this the gate reads a config REMEMBERED from an earlier run on a
+            # similarly-shaped csv instead of deriving one from this fixture:
+            # it passed on a developer box with a warm store and failed in CI
+            # with a cold one, which is a false green in the direction that
+            # matters.
+            "HOME": str(tmp_path / "home"),
+            "USERPROFILE": str(tmp_path / "home"),
             # Set EXPLICITLY, never left to inherit. `_run_subprocess` copies
             # `os.environ`, and `test_zero_config_dedupe_df_arrow_functional`
             # earlier in this file does


### PR DESCRIPTION
## What

**3.17.0 shipped a fix that does not work.** This is the real one, plus the gates that should have caught it.

I verified 3.17.0 the way it should have been verified the first time — `pip install goldenmatch` from PyPI into a clean venv with no polars, then the documented command:

```
$ goldenmatch dedupe customers.csv --output-clusters --output-dir out --run-name ttfs
auto-config controller: every iteration errored (n_errored=4, n_red=0, ...)
Runtime error: No module named 'polars'
EXIT=3
```

Identical to the pre-#2810 behaviour.

## Root cause

`_apply_negative_evidence_to_exact_pairs` took a `pl.DataFrame` and read it with polars-only indexing (`full_df[col][idx]`, `.height`, `.columns`), so its caller in `_run_dedupe_pipeline` bridged through `_as_polars_df`. Auto-config's `promote_negative_evidence` step puts NE on the exact matchkey **by default**, which puts that bridge squarely on the zero-config path.

It now reads through the Frame seam, so a `pa.Table` works unchanged. It is also strictly less work than before: each NE column is materialized once rather than two scalar frame lookups per pair per field. Its sibling `_apply_guard_to_exact_pairs` already carried a bridge-free shape *and a docstring explaining why* — NE simply never got the same treatment.

The remaining `_as_polars_df` callers are the golden-record builders, a separate documented removal point, not on this path.

## Why 3.17.0 missed it

Worth stating plainly, because both failure modes are general:

1. **I verified the entry point I had changed, not the one the CLI calls.** The fix was checked against `run_dedupe`. The CLI's zero-config route goes through the auto-config controller, which calls `run_dedupe_df`.
2. **A test did run the whole CLI polars-free, and passed.** Its fixture is `first,last,email,zip` — no `id` column, so auto-config never promotes NE. The code path was covered; the *config shape that path generates on ordinary data* was not.

## Gates added

Both were confirmed to **fail against `origin/main`** before being kept — a test that has never been seen red is not evidence:

- `tests/test_ne_exact_pairs_backend_parity.py` — arrow/polars equivalence of the function, plus a subprocess assertion that the arrow call imports no polars. Carries an anti-vacuity assertion that NE actually filtered something, since two backends agreeing on "nothing happened" proves nothing.
- **Tier 6** in `tests/test_zero_config_no_polars.py` — the documented CLI command on a csv **with** an id column, asserting NE is genuinely present in the committed config so the gate cannot go quietly vacuous the way tier 5 did.

One thing that surfaced while writing it, worth its own note: tier 6 pins `GOLDENMATCH_AUTOCONFIG_MEMORY=1` **explicitly** rather than inheriting. A sibling test in the same file does `os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")` in the *parent* pytest process, and `_run_subprocess` copies `os.environ` — so `0` leaked in, and `0` drops the exact matchkey entirely (measured: `[exact_email (1 NE), fuzzy_match]` → `[fuzzy_match]`). Whether the gate tested anything came down to test **order**.

## Verification

| Check | Result |
|---|---|
| New tests vs `origin/main` | 3 failed (correct — they catch the bug) |
| New tests vs this branch | 11 passed |
| NE / exact / csv-parity suites | 90 passed |
| `ruff check` (changed files) | 0 |
| `version_consistency` / `docs_sweep` / `docs_consistency` / `docs_staleness` / `regen_docs --check` | all 0 |

End-to-end, clean venv, **no polars installed**, this branch installed from source:

```
$ goldenmatch dedupe customers.csv --output-clusters --output-dir out --run-name ttfs
Dedupe complete. 40 clusters found.
EXIT=0
out/ttfs_clusters.csv  out/ttfs_lineage.json
```

The auto-config panel in that run shows `exact_email | id | ensemble | 0.40 | -0.30` — NE is active, so the previously-leaking path is genuinely exercised rather than skipped.

## After merge

Dispatch `cut-goldenmatch-release.yml` with `3.17.1`. The golden-suite floor bump is prepared on a separate branch and deliberately **not** opened yet — it should point at `>=3.17.1`, not at the broken `3.17.0`.
