### PR TITLE
build(deps): port blake2 0.10 -> 0.11 (supersedes #2816-#2818)

### DIFF
--- a/packages/rust/extensions/datafusion-udf/Cargo.lock
+++ b/packages/rust/extensions/datafusion-udf/Cargo.lock
@@ -557,11 +557,11 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -659,6 +659,12 @@ dependencies = [
  "chrono",
  "phf",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "comfy-table"
@@ -812,6 +818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1377,7 +1392,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1389,6 +1403,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2729,12 +2744,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/packages/rust/extensions/goldenembed-core/Cargo.toml
+++ b/packages/rust/extensions/goldenembed-core/Cargo.toml
@@ -20,7 +20,7 @@ name = "goldenembed_core"
 
 [dependencies]
 # BLAKE2b feature hashing (byte-parity with the Python featurizer). wasm-friendly.
-blake2 = "0.10"
+blake2 = "0.11"
 # Deserialize FeaturizerConfig from the model config.json (in the native runtime).
 serde = { version = "1", features = ["derive"] }
 

--- a/packages/rust/extensions/goldenembed-core/src/featurizer.rs
+++ b/packages/rust/extensions/goldenembed-core/src/featurizer.rs
@@ -8,8 +8,8 @@
 //! truncated to 8 bytes little-endian; index = h % n_features, sign = +1 if
 //! bit63 else -1; L2-normalize with f32 sum-of-squares + f32 sqrt. The nonzero
 //! counts are small exact integers, so the result matches numpy bit-for-bit.
-use blake2::digest::{Update, VariableOutput};
-use blake2::Blake2bVar;
+use blake2::digest::consts::U8;
+use blake2::{Blake2b, Digest};
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -36,13 +36,10 @@ fn prepare(text: &str, lowercase: bool, boundary: &str) -> String {
 }
 
 fn hash_gram(seed_le: &[u8; 8], gram: &str, n_features: u64) -> (usize, f32) {
-    let mut hasher = Blake2bVar::new(8).expect("blake2b-8 is valid");
+    let mut hasher = Blake2b::<U8>::new();
     hasher.update(seed_le);
     hasher.update(gram.as_bytes());
-    let mut buf = [0u8; 8];
-    hasher
-        .finalize_variable(&mut buf)
-        .expect("8-byte output fits");
+    let buf: [u8; 8] = hasher.finalize().into();
     let h = u64::from_le_bytes(buf);
     let idx = (h % n_features) as usize;
     let sign = if (h >> 63) & 1 == 1 {
@@ -93,6 +90,28 @@ impl FeaturizerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the blake2b-8 digest against CPython's `hashlib` -- see the twin test
+    /// in `goldenmatch-native`'s `featurize.rs`. `hash_gram` sets the feature
+    /// index and sign, so a drifted digest silently changes every embedding, and
+    /// the committed wasm parity fixtures would be regenerated around the drift
+    /// rather than catching it.
+    ///
+    /// Regenerate with:
+    ///   python -c "import hashlib; h=hashlib.blake2b(digest_size=8);     ///     h.update((0).to_bytes(8,'little')); h.update(b'ab'); print(h.hexdigest())"
+    #[test]
+    fn blake2b8_digest_matches_cpython_hashlib() {
+        let mut hasher = Blake2b::<U8>::new();
+        hasher.update(0u64.to_le_bytes());
+        hasher.update(b"ab");
+        let buf: [u8; 8] = hasher.finalize().into();
+        let hex: String = buf.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            hex, "1c477b7b71d464b0",
+            "blake2b-8 digest drifted from CPython hashlib"
+        );
+        assert_eq!(u64::from_le_bytes(buf), 12710517632214451996);
+    }
 
     fn cfg() -> FeaturizerConfig {
         FeaturizerConfig {

--- a/packages/rust/extensions/goldenembed/Cargo.lock
+++ b/packages/rust/extensions/goldenembed/Cargo.lock
@@ -40,11 +40,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -89,6 +98,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "core-foundation"
@@ -135,6 +150,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,9 +183,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -302,6 +345,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "id-arena"
@@ -717,7 +769,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -748,12 +800,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/packages/rust/extensions/goldenembed/Cargo.toml
+++ b/packages/rust/extensions/goldenembed/Cargo.toml
@@ -31,7 +31,7 @@ goldenembed-core = { path = "../goldenembed-core" }
 # ONNX Runtime backend — optional (behind the `onnx` feature). Not built by
 # default; the native weights.npz matmul path replaces it.
 ort = { version = "2.0.0-rc.10", optional = true }
-blake2 = "0.10"
+blake2 = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"

--- a/packages/rust/extensions/goldenembed/src/lib.rs
+++ b/packages/rust/extensions/goldenembed/src/lib.rs
@@ -48,11 +48,11 @@ enum Backend {
 
 /// blake2b-8 hex digest of `data` — the cache-namespace fallback ingredient.
 fn digest8(data: &[u8]) -> String {
-    use blake2::digest::{Update, VariableOutput};
-    let mut h = blake2::Blake2bVar::new(8).expect("blake2b-8 is valid");
+    use blake2::digest::consts::U8;
+    use blake2::{Blake2b, Digest};
+    let mut h = Blake2b::<U8>::new();
     h.update(data);
-    let mut out = [0u8; 8];
-    h.finalize_variable(&mut out).expect("8-byte output fits");
+    let out: [u8; 8] = h.finalize().into();
     crate::model_id::hex(&out)
 }
 

--- a/packages/rust/extensions/goldenembed/src/model_id.rs
+++ b/packages/rust/extensions/goldenembed/src/model_id.rs
@@ -6,8 +6,8 @@ use std::io::Read;
 use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
-use blake2::digest::{Update, VariableOutput};
-use blake2::Blake2bVar;
+use blake2::digest::consts::U8;
+use blake2::{Blake2b, Digest};
 
 /// Lowercase hex of a byte slice (matches Python `hexdigest()`).
 pub(crate) fn hex(bytes: &[u8]) -> String {
@@ -58,15 +58,12 @@ pub fn compute_model_id(dir: &Path, dim: usize) -> Result<String> {
     let zip_path = dir.join("weights.npz");
     let weights = read_zip_entry(&zip_path, "weights.npy")?
         .ok_or_else(|| anyhow!("weights.npy missing from {}", zip_path.display()))?;
-    let mut hasher = Blake2bVar::new(8).expect("blake2b-8 is valid");
+    let mut hasher = Blake2b::<U8>::new();
     hasher.update(npy_data(&weights)?);
     if let Some(bias) = read_zip_entry(&zip_path, "bias.npy")? {
         hasher.update(npy_data(&bias)?);
     }
-    let mut out = [0u8; 8];
-    hasher
-        .finalize_variable(&mut out)
-        .expect("8-byte output fits");
+    let out: [u8; 8] = hasher.finalize().into();
     Ok(format!("inhouse:d{dim}:{}", hex(&out)))
 }
 

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -258,20 +258,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
+ "digest",
 ]
 
 [[package]]
@@ -402,16 +393,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -430,24 +411,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -496,16 +466,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -673,7 +633,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1118,7 +1078,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1132,12 +1092,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -32,7 +32,7 @@ extension-module = ["pyo3/extension-module"]
 pyo3 = { version = ">=0.29, <0.30", features = ["abi3-py311"] }
 # BLAKE2b for the char-n-gram feature hashing kernel — must match Python
 # hashlib.blake2b(digest_size=8) byte-for-byte (see featurize.rs).
-blake2 = "0.10"
+blake2 = "0.11"
 # Canonical record fingerprint canonicalizer (sha256 + JSON parsing live here),
 # shared pyo3-free with the pgrx `postgres` crate so both compute the same id.
 goldenmatch-fingerprint-core = { path = "../fingerprint-core" }

--- a/packages/rust/extensions/native/src/featurize.rs
+++ b/packages/rust/extensions/native/src/featurize.rs
@@ -17,8 +17,8 @@
 //! - L2 normalize with a float32 sum-of-squares + float32 sqrt, then divide in
 //!   f64 and round to f32. The nonzero counts are small exact integers, so the
 //!   sum carries no rounding and the result matches numpy bit-for-bit.
-use blake2::digest::{Update, VariableOutput};
-use blake2::Blake2bVar;
+use blake2::digest::consts::U8;
+use blake2::{Blake2b, Digest};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use rayon::prelude::*;
@@ -38,13 +38,10 @@ fn prepare(text: &str, lowercase: bool, boundary: &str) -> String {
 
 /// `(index, sign)` for one n-gram. Matches the Python `_hash`.
 fn hash_gram(seed_le: &[u8; 8], gram: &str, n_features: u64) -> (usize, f32) {
-    let mut hasher = Blake2bVar::new(8).expect("blake2b-8 is valid");
+    let mut hasher = Blake2b::<U8>::new();
     hasher.update(seed_le);
     hasher.update(gram.as_bytes());
-    let mut buf = [0u8; 8];
-    hasher
-        .finalize_variable(&mut buf)
-        .expect("8-byte output fits");
+    let buf: [u8; 8] = hasher.finalize().into();
     let h = u64::from_le_bytes(buf);
     let idx = (h % n_features) as usize;
     let sign = if (h >> 63) & 1 == 1 {
@@ -225,6 +222,31 @@ mod tests {
     use super::*;
 
     const SEED: [u8; 8] = 42u64.to_le_bytes();
+
+    /// Pins the blake2b-8 digest itself against CPython's `hashlib`, so a future
+    /// blake2 bump cannot silently move the feature-hash space.
+    ///
+    /// `hash_gram` decides both the feature INDEX and its SIGN, so a changed
+    /// digest changes every embedding this crate produces -- silently, and in a
+    /// way that only shows up as drifted vectors. The blake2 0.10 -> 0.11 port
+    /// swapped `Blake2bVar::new(8)` for `Blake2b::<U8>` (0.11 removed the former);
+    /// the two are byte-identical, and this test is what says so out loud.
+    ///
+    /// Regenerate with:
+    ///   python -c "import hashlib; h=hashlib.blake2b(digest_size=8);     ///     h.update((42).to_bytes(8,'little')); h.update(b'smith'); print(h.hexdigest())"
+    #[test]
+    fn blake2b8_digest_matches_cpython_hashlib() {
+        let mut hasher = Blake2b::<U8>::new();
+        hasher.update(SEED);
+        hasher.update(b"smith");
+        let buf: [u8; 8] = hasher.finalize().into();
+        let hex: String = buf.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            hex, "1f56c4814a193598",
+            "blake2b-8 digest drifted from CPython hashlib"
+        );
+        assert_eq!(u64::from_le_bytes(buf), 10967700275326113311);
+    }
 
     #[test]
     fn prepare_lowercases_collapses_and_wraps() {


### PR DESCRIPTION
## What

Ports **blake2 0.10 → 0.11** across all three manifests and all four call sites, and proves the digest does not move.

Supersedes **#2816, #2817, #2818** — Dependabot opened one PR per manifest, and each failed the entire Rust lane (`rust`, `rust_pgrx` ×3, `goldenembed`, `embed_wheel`, `fixture_drift`, `typescript`/wasm):

```
error[E0432]: unresolved import `blake2::digest::VariableOutput`
error[E0432]: unresolved import `blake2::Blake2bVar`
```

0.11 removes `Blake2bVar` and `digest::VariableOutput`. No single-manifest bump can pass, because the crates share cores.

## Why this needed care rather than a version bump

blake2b-8 is not an implementation detail here:

- `hash_gram` derives the feature **index** and its **sign** from the digest — a changed digest silently changes **every embedding** the suite produces.
- `model_id` derives the published `inhouse:d{dim}:{…}` identifier from it.

Both are pinned byte-for-byte to CPython's `hashlib.blake2b(digest_size=8)`. A drifted digest would not fail loudly — the committed wasm parity fixtures would simply be regenerated *around* the drift.

So byte-identity was established **before** the port rather than assumed. A scratch crate on blake2 0.11 confirmed `Blake2b::<U8>` reproduces the CPython digest exactly, including the multi-update + `[u8; 8]`-via-`.into()` shape all four sites need:

```
blake2 0.11 Blake2b<U8> = 6b8b93739e28ed78
python  hashlib blake2b8 = 6b8b93739e28ed78
```

## The port

`Blake2bVar::new(8)` → `Blake2b::<U8>::new()`; `finalize_variable(&mut buf)` → `finalize().into()`. No behaviour change, and the two `.expect()` calls the old variable-output API forced are now gone.

## Tests added

Two tests pin the **digest itself** — in `native/src/featurize.rs` and `goldenembed-core/src/featurizer.rs` — each carrying the `python -c` line to regenerate the expected value.

The existing suites already covered the *consumers* (`model_id_matches_python_no_bias`, `model_id_matches_python_with_bias`, `native_load_embeds_match_numpy_reference`, `native_project_matches_numpy_reference`, all green here). But nothing asserted the digest, so a future bump could move it with only fixtures standing in the way — and fixtures regenerate.

## Verification

| Check | goldenembed-core | goldenembed | native |
|---|---|---|---|
| `cargo check --all-targets` | 0 | 0 | 0 |
| `cargo test` | 5 passed | 7 + 1 passed | 8 passed (featurize) |
| `cargo clippy --all-targets -- -D warnings` | — | — | 0 |

`rustfmt` applied to the four touched files.

## Lockfiles

`datafusion-udf/Cargo.lock` is updated too — it takes `goldenembed` by path, so a `--locked` build there would otherwise fail. That crate never appeared in Dependabot's three PRs. `goldenembed-core/Cargo.lock` is gitignored (library crate), unlike the three tracked ones.

The native lock also **shrinks**: `generic-array` and `subtle` drop out of the tree entirely, replaced by `hybrid-array`.

## Not security updates

No advisory, no `security` label — these are plain cargo version-requirement bumps. Worth stating, because it means there was no deadline forcing a rushed port of a byte-exact hash.
