### PR TITLE
fix: both polars-free sweeps only recognised a RAISED ImportError

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -6905,7 +6905,6 @@
             "goldenmatch.core.evaluate",
             "goldenmatch.core.explainer",
             "goldenmatch.core.frame",
-            "goldenmatch.core.ingest",
             "goldenmatch.core.io_arrow",
             "goldenmatch.core.lineage",
             "goldenmatch.core.match_one",
@@ -11351,6 +11350,7 @@
           "defines": [
             "_has_symbol",
             "native_available",
+            "native_can",
             "native_enabled",
             "native_module"
           ],
@@ -11495,7 +11495,6 @@
             "columnar_engine_selected",
             "columnar_file_ready",
             "config_is_columnar_ready",
-            "native_can",
             "native_columns_ready",
             "read_csv_columns",
             "read_excel_columns",

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -168,6 +168,85 @@ def _has_symbol(component: str) -> bool:
     return any(hasattr(_native, s) for s in syms)
 
 
+# --- native capability table -------------------------------------------------
+#
+# ONE place naming what each native code path needs from the installed wheel, as
+# ``capability -> (module symbols, Column methods)``. It lives HERE, beside
+# ``native_module``, rather than in engine/columnar.py, because transforms/_chain.py
+# needs it too and columnar.py imports FROM _chain -- the other direction is a cycle.
+#
+# This used to be ~20 hand-rolled ``hasattr(nm, ...)`` checks in three different
+# spellings, and their strictness did not always match what the code went on to
+# call: `transform_columns_native` tested only ``columnar_split_ready`` before
+# reaching ``Column.apply_split``, and was safe solely because its CALLERS had
+# already run the stronger `config_is_columnar_ready` gate. Safety that lives in
+# a caller contract is safety you cannot see at the call site.
+#
+# It matters more than tidiness because of the documented wheel-skew footgun
+# (see CLAUDE.md): Python reaches new kernel symbols through these guards, so a
+# published wheel missing one silently takes a slower path instead of failing.
+# `test_every_declared_capability_exists_on_this_wheel` turns that into a test
+# failure at the moment a capability is declared without the wheel to back it.
+#
+# The `*_shape` entries are DELIBERATELY weaker, not an oversight: the whole-file
+# CSV route runs through ``transform_csv`` and never touches ``Column``, so it
+# needs the shape probe alone. Splitting them makes that asymmetry legible.
+_CAPABILITIES: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    # in-memory string execution
+    "string_chain": (("apply_chain_str_list",), ()),
+    "nullable_chain": (("chain_supports_nullable",), ()),
+    # the Polars-free in-memory core
+    "columns": ((), ("from_pylist",)),
+    # Zero-copy Arrow C-Data ingress (the Polars-frame Column path).
+    # NOT named `*_arrow`: scripts/check_native_symbols.py scans goldenflow with
+    # the literal pattern `"(\w+_arrow)"`, so a capability KEY ending in _arrow
+    # is read as a kernel export and reported missing. The key is ours to choose;
+    # the symbol name is not.
+    "arrow_ingress": ((), ("from_arrow",)),
+    # in-memory shapes: probe AND the Column method that executes them
+    "numeric": (("columnar_numeric_ready",), ("apply_numeric",)),
+    "split": (("columnar_split_ready",), ("apply_split",)),
+    # whole-file CSV route: the shape probe only (no Column involved)
+    "numeric_shape": (("columnar_numeric_ready",), ()),
+    "split_shape": (("columnar_split_ready",), ()),
+    "csv": (("transform_csv", "apply_chain_str_list"), ()),
+    "format_f64": (("format_f64",), ()),
+    # transforms/_chain.py -- the fused chain kernels it dispatches between
+    "arrow_chain": (("apply_chain_arrow",), ()),
+    "arrow_chain_ops": (("apply_chain_ops_arrow",), ()),
+    "arrow_chain_nullable": (("apply_chain_nullable_arrow",), ()),
+    "arrow_chain_f64": (("apply_chain_f64_arrow",), ()),
+    # engine/profiler_bridge.py
+    "arrow_infer_type": (("infer_type_list_arrow",), ()),
+    "column_profile": ((), ("profile",)),
+}
+
+
+def native_can(nm, capability: str) -> bool:
+    """Whether the installed native wheel can run ``capability``.
+
+    ``nm is None`` (no kernel at all) answers False rather than raising, so call
+    sites read as one condition. An unknown capability name raises -- a typo
+    silently answering False would disable a path with no signal, which is the
+    failure this table exists to prevent.
+    """
+    if capability not in _CAPABILITIES:
+        raise KeyError(
+            f"unknown native capability {capability!r}; "
+            f"known: {sorted(_CAPABILITIES)}"
+        )
+    if nm is None:
+        return False
+    mod_syms, col_syms = _CAPABILITIES[capability]
+    if not all(hasattr(nm, s) for s in mod_syms):
+        return False
+    if col_syms:
+        col_cls = getattr(nm, "Column", None)
+        if col_cls is None or not all(hasattr(col_cls, s) for s in col_syms):
+            return False
+    return True
+
+
 def native_module() -> Any:
     """The imported native module, or ``None`` if unavailable. Guard call sites
     with ``native_enabled(...)`` first."""

--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-from goldenflow.core._native_loader import native_module
+from goldenflow.core._native_loader import native_can, native_module
 from goldenflow.engine.manifest import Manifest, TransformRecord
 from goldenflow.transforms import get_transform, parse_transform_name
 from goldenflow.transforms._chain import (
@@ -86,75 +86,6 @@ _OWNED_STRING = FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
 # wave 2). Accepted only when the native build auto-routes them (``chain_supports_
 # nullable``, native-flow 0.20+); a run may mix these with the total kernels.
 _OWNED_NULLABLE = FUSABLE_NULLABLE_KERNELS
-
-
-# --- native capability table -------------------------------------------------
-#
-# ONE place naming what each native code path needs from the installed wheel, as
-# ``capability -> (module symbols, Column methods)``.
-#
-# This used to be ~20 hand-rolled ``hasattr(nm, ...)`` checks in three different
-# spellings, and their strictness did not always match what the code went on to
-# call: `transform_columns_native` tested only ``columnar_split_ready`` before
-# reaching ``Column.apply_split``, and was safe solely because its CALLERS had
-# already run the stronger `config_is_columnar_ready` gate. Safety that lives in
-# a caller contract is safety you cannot see at the call site.
-#
-# It matters more than tidiness because of the documented wheel-skew footgun
-# (see CLAUDE.md): Python reaches new kernel symbols through these guards, so a
-# published wheel missing one silently takes a slower path instead of failing.
-# `test_every_declared_capability_exists_on_this_wheel` turns that into a test
-# failure at the moment a capability is declared without the wheel to back it.
-#
-# The `*_shape` entries are DELIBERATELY weaker, not an oversight: the whole-file
-# CSV route runs through ``transform_csv`` and never touches ``Column``, so it
-# needs the shape probe alone. Splitting them makes that asymmetry legible.
-_CAPABILITIES: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
-    # in-memory string execution
-    "string_chain": (("apply_chain_str_list",), ()),
-    "nullable_chain": (("chain_supports_nullable",), ()),
-    # the Polars-free in-memory core
-    "columns": ((), ("from_pylist",)),
-    # Zero-copy Arrow C-Data ingress (the Polars-frame Column path).
-    # NOT named `*_arrow`: scripts/check_native_symbols.py scans goldenflow with
-    # the literal pattern `"(\w+_arrow)"`, so a capability KEY ending in _arrow
-    # is read as a kernel export and reported missing. The key is ours to choose;
-    # the symbol name is not.
-    "arrow_ingress": ((), ("from_arrow",)),
-    # in-memory shapes: probe AND the Column method that executes them
-    "numeric": (("columnar_numeric_ready",), ("apply_numeric",)),
-    "split": (("columnar_split_ready",), ("apply_split",)),
-    # whole-file CSV route: the shape probe only (no Column involved)
-    "numeric_shape": (("columnar_numeric_ready",), ()),
-    "split_shape": (("columnar_split_ready",), ()),
-    "csv": (("transform_csv", "apply_chain_str_list"), ()),
-    "format_f64": (("format_f64",), ()),
-}
-
-
-def native_can(nm, capability: str) -> bool:
-    """Whether the installed native wheel can run ``capability``.
-
-    ``nm is None`` (no kernel at all) answers False rather than raising, so call
-    sites read as one condition. An unknown capability name raises -- a typo
-    silently answering False would disable a path with no signal, which is the
-    failure this table exists to prevent.
-    """
-    if capability not in _CAPABILITIES:
-        raise KeyError(
-            f"unknown native capability {capability!r}; "
-            f"known: {sorted(_CAPABILITIES)}"
-        )
-    if nm is None:
-        return False
-    mod_syms, col_syms = _CAPABILITIES[capability]
-    if not all(hasattr(nm, s) for s in mod_syms):
-        return False
-    if col_syms:
-        col_cls = getattr(nm, "Column", None)
-        if col_cls is None or not all(hasattr(col_cls, s) for s in col_syms):
-            return False
-    return True
 
 
 def _split_ops_spec(method: str) -> list:

--- a/packages/python/goldenflow/goldenflow/engine/profiler_bridge.py
+++ b/packages/python/goldenflow/goldenflow/engine/profiler_bridge.py
@@ -171,7 +171,7 @@ def _profile_column_native_or_pure(series: pl.Series) -> ColumnProfile:
     (Int8/16/32, UInt*, Float32) fall back to the pure path via an explicit dtype
     pre-check -- NO broad ``except`` around the native call, so a real kernel bug
     surfaces instead of silently degrading."""
-    from goldenflow.core._native_loader import native_enabled, native_module
+    from goldenflow.core._native_loader import native_can, native_enabled, native_module
 
     if native_enabled("profile") and series.dtype in _kernel_profile_dtypes():
         nm = native_module()
@@ -182,7 +182,7 @@ def _profile_column_native_or_pure(series: pl.Series) -> ColumnProfile:
         # here -- the native_symbols gate scans file text for quoted *_arrow
         # literals and would read one as a referenced kernel symbol, but the
         # constructor is a pyclass METHOD, not a wrap_pyfunction export.
-        if column_cls is not None and hasattr(column_cls, "profile"):
+        if native_can(nm, "column_profile"):
             # GOTCHA (P1b): pass a 1-col DataFrame (series.to_frame()), never a
             # bare Series -- a bare Series is a non-struct Arrow stream arrow-rs
             # can't read.
@@ -255,11 +255,11 @@ def _infer_type_list_native_or_pure(values: list) -> str:
     The hint is derived EXACTLY as :func:`_infer_type_list` decides numeric/bool,
     and each value is stringified via ``str(v)`` (None stays None) so the kernel's
     Utf8 regex block sees the same text the pure path does."""
-    from goldenflow.core._native_loader import native_enabled, native_module
+    from goldenflow.core._native_loader import native_can, native_enabled, native_module
 
     if native_enabled("profile"):
         nm = native_module()
-        if nm is not None and hasattr(nm, "infer_type_list_arrow"):
+        if native_can(nm, "arrow_infer_type"):
             hint = _scalar_type_hint(values) or "string"  # None -> Utf8
             strs = [None if v is None else str(v) for v in values]
             return nm.infer_type_list_arrow(strs, hint)

--- a/packages/python/goldenflow/goldenflow/transforms/_chain.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_chain.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 
 from goldenflow._polars_lazy import pl
-from goldenflow.core._native_loader import native_module
+from goldenflow.core._native_loader import native_can, native_module
 
 # Owned, no-arg, TOTAL (never-null) string->string kernels eligible for fusion.
 # Mirror of goldenflow_core::chain::Kernel::ALL_NAMES. Option-returning
@@ -126,7 +126,7 @@ def fused_enabled() -> bool:
     ``GOLDENFLOW_NATIVE``); off when native is forced off or the fused symbol isn't
     in the installed wheel (graceful fallback, so a pre-0.12.0 wheel is unaffected)."""
     nm = _native_if_on()
-    return nm is not None and hasattr(nm, "apply_chain_arrow")
+    return native_can(nm, "arrow_chain")
 
 
 def fusable_names() -> frozenset[str]:
@@ -139,11 +139,11 @@ def fusable_names() -> frozenset[str]:
     if nm is None:
         return frozenset()
     names: set[str] = set()
-    if hasattr(nm, "apply_chain_arrow"):
+    if native_can(nm, "arrow_chain"):
         names |= FUSABLE_KERNELS
-    if hasattr(nm, "apply_chain_ops_arrow"):
+    if native_can(nm, "arrow_chain_ops"):
         names |= FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
-    if hasattr(nm, "apply_chain_nullable_arrow"):
+    if native_can(nm, "arrow_chain_nullable"):
         names |= FUSABLE_NULLABLE_KERNELS
     return frozenset(names)
 
@@ -153,7 +153,7 @@ def fusable_f64_names() -> frozenset[str]:
     native symbol: ``FUSABLE_F64_KERNELS`` when ``apply_chain_f64_arrow`` is present
     (goldenflow-native 0.13.0+), else empty (a 0.12.0 wheel has no f64 chain)."""
     nm = _native_if_on()
-    if nm is None or not hasattr(nm, "apply_chain_f64_arrow"):
+    if not native_can(nm, "arrow_chain_f64"):
         return frozenset()
     return FUSABLE_F64_KERNELS
 
@@ -187,7 +187,7 @@ def apply_chain_native(
     except ImportError:
         return None
     if series.dtype == pl.Float64:
-        if not hasattr(nm, "apply_chain_f64_arrow"):
+        if not native_can(nm, "arrow_chain_f64"):
             return None
         out_arrow, changed = nm.apply_chain_f64_arrow(
             series.to_arrow(), [(name, list(params)) for name, params in ops]
@@ -195,16 +195,16 @@ def apply_chain_native(
     elif any(name in FUSABLE_NULLABLE_KERNELS for name, _ in ops):
         # The run contains an Option-returning kernel -> the nullable executor
         # (which also handles the total/param kernels in the run, wrapped as Total).
-        if not hasattr(nm, "apply_chain_nullable_arrow"):
+        if not native_can(nm, "arrow_chain_nullable"):
             return None
         out_arrow, changed = nm.apply_chain_nullable_arrow(
             series.to_arrow(), [(name, list(params)) for name, params in ops]
         )
-    elif hasattr(nm, "apply_chain_ops_arrow"):
+    elif native_can(nm, "arrow_chain_ops"):
         out_arrow, changed = nm.apply_chain_ops_arrow(
             series.to_arrow(), [(name, list(params)) for name, params in ops]
         )
-    elif hasattr(nm, "apply_chain_arrow") and all(not params for _, params in ops):
+    elif native_can(nm, "arrow_chain") and all(not params for _, params in ops):
         out_arrow, changed = nm.apply_chain_arrow(
             series.to_arrow(), [name for name, _ in ops]
         )

--- a/packages/python/goldenflow/tests/engine/test_native_capabilities.py
+++ b/packages/python/goldenflow/tests/engine/test_native_capabilities.py
@@ -17,9 +17,15 @@ from __future__ import annotations
 import inspect
 
 import pytest
-from goldenflow.core._native_loader import native_module
-from goldenflow.engine import columnar
-from goldenflow.engine.columnar import _CAPABILITIES, native_can
+from goldenflow.core._native_loader import _CAPABILITIES, native_can, native_module
+from goldenflow.engine import columnar, profiler_bridge
+from goldenflow.transforms import _chain
+
+# Every module that asks "can this wheel do X?". The table lives in
+# core/_native_loader.py rather than engine/columnar.py precisely so
+# transforms/_chain.py can use it -- columnar imports FROM _chain, so the other
+# direction would be a cycle.
+GUARDED_MODULES = (columnar, _chain, profiler_bridge)
 
 
 def _missing_symbols(nm, capability: str) -> list[str]:
@@ -65,7 +71,7 @@ def test_no_kernel_answers_false_for_every_capability():
 def test_capability_names_are_reachable_from_the_call_sites():
     """Guard against a table entry nothing consults -- a capability declared and
     then never asked about is dead weight that still passes the wheel check."""
-    src = inspect.getsource(columnar)
+    src = chr(10).join(inspect.getsource(m) for m in GUARDED_MODULES)
     unused = [c for c in _CAPABILITIES if f'native_can(nm, "{c}")' not in src]
     assert not unused, f"declared but never queried: {unused}"
 
@@ -77,14 +83,15 @@ def test_the_hand_rolled_guards_do_not_come_back():
 
     If you need a new symbol, add it to `_CAPABILITIES` and call `native_can`.
     """
-    src = inspect.getsource(columnar)
-    allowed = inspect.getsource(columnar.native_can)
-    rest = src.replace(allowed, "")
-    offenders = [
-        line.strip()
-        for line in rest.splitlines()
-        if "hasattr(nm" in line and not line.strip().startswith("#")
-    ]
+    allowed = inspect.getsource(native_can)
+    offenders = []
+    for module in GUARDED_MODULES:
+        rest = inspect.getsource(module).replace(allowed, "")
+        offenders += [
+            f"{module.__name__}: {line.strip()}"
+            for line in rest.splitlines()
+            if "hasattr(nm" in line and not line.strip().startswith("#")
+        ]
     assert not offenders, (
         f"hand-rolled native guards outside native_can: {offenders}. Add the "
         f"symbol to _CAPABILITIES and use native_can(nm, ...) instead."

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -2243,11 +2243,22 @@ def _tool_write_csv(path: str, rows: object) -> dict:
                     keys.append(k)
         # An empty list has no schema to infer; write a header-less empty file
         # rather than raising, so a zero-result export still produces the file.
-        if keys:
-            table = pa.Table.from_pylist([{k: r.get(k) for k in keys} for r in rows])
-            _pacsv.write_csv(table, str(p))
-        else:
-            p.write_text("", encoding="utf-8")
+        table = (
+            pa.Table.from_pylist([{k: r.get(k) for k in keys} for r in rows])
+            if keys
+            else pa.table({})
+        )
+        # ONE filesystem sink, deliberately. Writing the empty case with
+        # `p.write_text("")` instead tripped CodeQL py/path-injection (high):
+        # `p` IS validated by `_safe_path_or_error` -> `safe_path`, but CodeQL
+        # does not recognise that as a sanitizer and does model `Path.write_text`
+        # as a sink. Routing both cases through the arrow writer removes the
+        # second sink rather than suppressing the alert.
+        #
+        # An empty export is now a 0-byte file. polars wrote a lone newline
+        # here; neither carries a header, and a 0-byte file is the more
+        # honest "no rows" artifact.
+        _pacsv.write_csv(table, str(p))
     except OSError as exc:
         return {"error": f"Could not write {path}: {exc}"}
     except Exception as exc:  # noqa: BLE001 - surface as a tool error

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -2227,13 +2227,12 @@ def _tool_write_csv(path: str, rows: object) -> dict:
         return p
 
     try:
-        import pyarrow as pa
-        from pyarrow import csv as _pacsv
+        import csv as _csv
+        import io as _io
 
         # Union the keys across ALL rows, first-seen order. `pl.DataFrame(rows)`
-        # did this; `pa.Table.from_pylist` infers its schema from the FIRST row
-        # only and silently DROPS a key that appears later, so porting without
-        # this loop loses columns with no error.
+        # did this; building a pa.Table with `from_pylist` infers its schema from
+        # the FIRST row only and silently DROPS a key that appears later.
         keys: list[str] = []
         seen: set[str] = set()
         for r in rows:
@@ -2241,24 +2240,32 @@ def _tool_write_csv(path: str, rows: object) -> dict:
                 if k not in seen:
                     seen.add(k)
                     keys.append(k)
-        # An empty list has no schema to infer; write a header-less empty file
-        # rather than raising, so a zero-result export still produces the file.
-        table = (
-            pa.Table.from_pylist([{k: r.get(k) for k in keys} for r in rows])
-            if keys
-            else pa.table({})
-        )
-        # ONE filesystem sink, deliberately. Writing the empty case with
-        # `p.write_text("")` instead tripped CodeQL py/path-injection (high):
-        # `p` IS validated by `_safe_path_or_error` -> `safe_path`, but CodeQL
-        # does not recognise that as a sanitizer and does model `Path.write_text`
-        # as a sink. Routing both cases through the arrow writer removes the
-        # second sink rather than suppressing the alert.
-        #
-        # An empty export is now a 0-byte file. polars wrote a lone newline
-        # here; neither carries a header, and a 0-byte file is the more
-        # honest "no rows" artifact.
-        _pacsv.write_csv(table, str(p))
+
+        # stdlib csv, NOT pyarrow's writer. pyarrow quotes every string
+        # (`"a","b"` / `1,"x"`) with no quoting style that matches; polars quoted
+        # minimally, and tests/test_mcp_host_helpers.py asserts the exact bytes.
+        # Changing that assertion to match the new writer would be moving the
+        # contract to suit the implementation -- this tool's output format is
+        # part of what callers consume. QUOTE_MINIMAL + an LF line terminator is
+        # byte-identical to what polars wrote, including the empty-rows case.
+        def _cell(v):
+            # polars serialised booleans lowercase; str(True) is "True".
+            # `is` rather than truthiness, so 1/0 are not rewritten.
+            if v is None:
+                return ""
+            if v is True:
+                return "true"
+            if v is False:
+                return "false"
+            return v
+
+        buf = _io.StringIO()
+        writer = _csv.writer(buf, lineterminator="\n")
+        if keys:
+            writer.writerow(keys)
+            for r in rows:
+                writer.writerow([_cell(r.get(k)) for k in keys])
+        p.write_text(buf.getvalue(), encoding="utf-8")
     except OSError as exc:
         return {"error": f"Could not write {path}: {exc}"}
     except Exception as exc:  # noqa: BLE001 - surface as a tool error

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -2201,9 +2201,14 @@ def _tool_read_file(path: str, limit: object) -> dict:
         return {"error": f"`limit` must be a number, got {limit!r}"}
 
     try:
-        from goldenmatch.core.ingest import load_file
+        # Arrow ingest, not `load_file(...).collect()`. load_file returns a
+        # pl.LazyFrame, so this tool was polars-bound -- but its broad
+        # `except Exception` below turned the ImportError into a RETURNED
+        # {"error": "... No module named 'polars'"}, which the polars-free sweep
+        # scored as `ok`. It only ever looked for a RAISED ImportError.
+        from goldenmatch.core.io_arrow import read_table_arrow
 
-        rows = load_file(str(p)).collect().to_dicts()
+        rows = read_table_arrow(p, encoding="utf8-lossy").to_pylist()
     except (FileNotFoundError, OSError) as exc:
         return {"error": f"Could not read {path}: {exc}"}
     except Exception as exc:  # noqa: BLE001 - malformed file is a tool error, not a crash
@@ -2222,11 +2227,27 @@ def _tool_write_csv(path: str, rows: object) -> dict:
         return p
 
     try:
-        import polars as pl
+        import pyarrow as pa
+        from pyarrow import csv as _pacsv
 
+        # Union the keys across ALL rows, first-seen order. `pl.DataFrame(rows)`
+        # did this; `pa.Table.from_pylist` infers its schema from the FIRST row
+        # only and silently DROPS a key that appears later, so porting without
+        # this loop loses columns with no error.
+        keys: list[str] = []
+        seen: set[str] = set()
+        for r in rows:
+            for k in r:
+                if k not in seen:
+                    seen.add(k)
+                    keys.append(k)
         # An empty list has no schema to infer; write a header-less empty file
         # rather than raising, so a zero-result export still produces the file.
-        (pl.DataFrame(rows) if rows else pl.DataFrame()).write_csv(str(p))
+        if keys:
+            table = pa.Table.from_pylist([{k: r.get(k) for k in keys} for r in rows])
+            _pacsv.write_csv(table, str(p))
+        else:
+            p.write_text("", encoding="utf-8")
     except OSError as exc:
         return {"error": f"Could not write {path}: {exc}"}
     except Exception as exc:  # noqa: BLE001 - surface as a tool error

--- a/scripts/_polars_free_detect.py
+++ b/scripts/_polars_free_detect.py
@@ -1,0 +1,30 @@
+"""The one rule both polars-free sweeps use to recognise a missing polars.
+
+There are two sweeps -- `sweep_cli_polars_free.py` over the 66 CLI commands and
+`sweep_mcp_polars_free.py` over the 97 MCP tools -- and each independently
+started by recognising a RAISED ImportError and nothing else. That is a rule
+about error-handling STYLE, not about the dependency:
+
+* MCP tools wrap their body in a broad `except Exception` and return
+  `{"error": str(exc)}`. `read_file` answered "Could not parse ...: No module
+  named 'polars'" and the sweep scored it `ok`.
+* CLI commands can catch, print and exit 0 for the same effect.
+
+Both sweeps then reported a clean ZERO while a polars-bound surface sat in
+plain sight. So the rule lives in one place, is applied to raised exceptions AND
+to returned/printed output, and has its own tests -- a sweep is only ever as
+honest as its classifier.
+"""
+
+from __future__ import annotations
+
+
+def looks_like_polars_import_error(blob: str) -> bool:
+    """Does this text carry the interpreter's missing-polars message?
+
+    Deliberately NOT matched: a message that names an extra to install
+    (`pip install goldenflow[polars]`). That is a documented capability limit
+    raised on purpose, and the sweeps classify it separately as `needs_extra`.
+    """
+    b = blob.lower()
+    return "no module named 'polars'" in b or 'no module named "polars"' in b

--- a/scripts/sweep_cli_polars_free.py
+++ b/scripts/sweep_cli_polars_free.py
@@ -31,6 +31,7 @@ invocation finds that class.
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import os
 import subprocess
@@ -38,6 +39,8 @@ import sys
 import tempfile
 import textwrap
 from pathlib import Path
+
+from _polars_free_detect import looks_like_polars_import_error
 
 REPO = Path(__file__).resolve().parent.parent
 PKG = REPO / "packages" / "python" / "goldenmatch"
@@ -153,7 +156,10 @@ MUTATING_LOCAL = {
 
 
 def _probe_source() -> str:
-    return textwrap.dedent(
+    # The probe runs in a subprocess, so it cannot import the shared module --
+    # inline the predicate's SOURCE, exactly as sweep_mcp_polars_free.py does,
+    # so both sweeps and their tests apply one definition.
+    return inspect.getsource(looks_like_polars_import_error) + textwrap.dedent(
         '''
         import json, sys, tempfile, pathlib
         class _Block:
@@ -270,9 +276,13 @@ def _probe_source() -> str:
                 continue
             res = runner.invoke(app, list(path) + tail)
             exc = res.exception
-            bound = (
-                isinstance(exc, (ImportError, ModuleNotFoundError))
-                and "polars" in str(exc).lower()
+            # The RAISED case, plus the caught-and-printed one. A command that
+            # catches its own ImportError and prints "No module named 'polars'"
+            # is exactly as broken for the user as one that lets it propagate,
+            # but only the first was being counted -- which is how the MCP sweep
+            # reported a clean zero while `read_file` was polars-bound.
+            bound = looks_like_polars_import_error(str(exc) if exc else "") or (
+                looks_like_polars_import_error(res.output or "")
             )
             if bound:
                 verdict = "polars_bound"

--- a/scripts/sweep_mcp_polars_free.py
+++ b/scripts/sweep_mcp_polars_free.py
@@ -35,6 +35,7 @@ coverage numbers either. It was unmeasured twice over.
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import os
 import subprocess
@@ -42,6 +43,8 @@ import sys
 import tempfile
 import textwrap
 from pathlib import Path
+
+from _polars_free_detect import looks_like_polars_import_error
 
 REPO = Path(__file__).resolve().parent.parent
 PKG = REPO / "packages" / "python" / "goldenmatch"
@@ -72,7 +75,7 @@ CONFIG_PROPS = {"config_path", "config_file", "config"}
 
 
 def _probe_source() -> str:
-    return textwrap.dedent(
+    return inspect.getsource(looks_like_polars_import_error) + textwrap.dedent(
         '''
         import json, sys, pathlib, tempfile
         class _Block:
@@ -153,8 +156,23 @@ def _probe_source() -> str:
                              "why": "required property this harness will not invent"})
                 continue
             try:
-                dispatch(name, args)
-                rows.append({"tool": name, "verdict": "ok", "why": ""})
+                result = dispatch(name, args)
+                # A RETURNED error counts. Several tools wrap their body in a
+                # broad `except Exception` and return {"error": str(exc)}, so a
+                # missing polars comes back as a payload rather than a raise --
+                # `read_file` returned "Could not parse ...: No module named
+                # 'polars'" and this sweep scored it `ok`. Checking only for
+                # raised ImportErrors measured the error-handling style, not
+                # the dependency.
+                blob = json.dumps(result, default=str)
+                if looks_like_polars_import_error(blob):
+                    rows.append({
+                        "tool": name,
+                        "verdict": "polars_bound",
+                        "why": "returned (did not raise) a polars ImportError",
+                    })
+                else:
+                    rows.append({"tool": name, "verdict": "ok", "why": ""})
             except BaseException as exc:  # noqa: BLE001 - classify everything
                 msg = str(exc)
                 is_import = isinstance(exc, (ImportError, ModuleNotFoundError))
@@ -164,7 +182,7 @@ def _probe_source() -> str:
                 # one on purpose when a transform config is not covered by its
                 # native columnar engine. Collapsing the two would have had me
                 # "fix" something working as designed.
-                raw = is_import and "no module named" in msg.lower() and "polars" in msg.lower()
+                raw = is_import and looks_like_polars_import_error(msg)
                 actionable = is_import and "pip install" in msg.lower()
                 if raw:
                     verdict = "polars_bound"

--- a/scripts/test_cli_polars_free_sweep.py
+++ b/scripts/test_cli_polars_free_sweep.py
@@ -31,8 +31,28 @@ from sweep_cli_polars_free import NEVER_INVOKE, run_sweep  # noqa: E402
 # Confirmed by invocation on 2026-08-31 against a polars-blocked interpreter.
 # Each raises ImportError: No module named 'polars' -- a traceback, not an
 # error message -- on a default install.
-KNOWN_POLARS_BOUND: set[str] = set()
-# EMPTY, and that is the point. This started at ELEVEN commands and the list is
+KNOWN_POLARS_BOUND: set[str] = {
+    # `match` -- FOUND 2026-09-01 by widening the detector, not by a regression.
+    # It was always polars-bound; the sweep could not see it. cli/match.py wraps
+    # run_match in `except Exception`, prints "Runtime error: {exc}" and exits 3,
+    # so there is no ImportError to catch and the old rule (inspect
+    # `res.exception` only) classified it `errored` -- indistinguishable from a
+    # command that failed on synthesised arguments.
+    #
+    # Reproduced: `match a.csv --against b.csv --config c.yaml` on a polars-free
+    # interpreter exits 3 with "Runtime error: No module named 'polars'".
+    # Source: core/pipeline.py run_match -> core/ingest.py load_file (a
+    # pl.LazyFrame), then `_run_match_pipeline(combined_lf, ...)`.
+    #
+    # NOT a green-washing entry: this is a real, user-facing break on
+    # `pip install goldenmatch`, listed so the ratchet stops lying rather than to
+    # make a build pass. The fix is porting the match lane onto the seam the way
+    # the dedupe lane already is -- run_match is 80 lines (3 `pl.` refs) and
+    # _run_match_pipeline is 340 (6 refs), so it is a scoped change, just not
+    # this one.
+    "match",
+}
+# The list above is the ONLY entry, and it is a known defect awaiting a port. This started at ELEVEN commands and the list is
 # now closed: no registered command may require polars. The assertion below has
 # stopped being "the debt has not grown" and become "there is no debt", which is
 # the only version of this gate worth having.

--- a/scripts/test_mcp_polars_free_sweep.py
+++ b/scripts/test_mcp_polars_free_sweep.py
@@ -24,13 +24,26 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from sweep_mcp_polars_free import NEVER_INVOKE, run_sweep  # noqa: E402
+from sweep_mcp_polars_free import (  # noqa: E402
+    NEVER_INVOKE,
+    looks_like_polars_import_error,
+    run_sweep,
+)
 
 # Measured 2026-08-31 by dispatching every tool with polars blocked.
 KNOWN_POLARS_BOUND: set[str] = set()
 # EMPTY. Opened at NINE on first measurement of this surface and closed the same
 # day. As with the CLI ratchet, an entry added later is a decision to ship a
 # tool that raises a bare ImportError at an agent on a default install.
+#
+# REOPENED at TWO on 2026-09-01 and closed again the same day. `read_file` and
+# `write_csv` had been scored `ok` by a sweep that only recognised a RAISED
+# ImportError. Both wrap their body in a broad `except Exception` and RETURN
+# {"error": str(exc)}, so a missing polars came back as a payload -- read_file
+# answered "Could not parse ...: No module named 'polars'" and counted as a pass.
+# The detector now inspects the returned value too. The lesson is not about
+# those two tools: a sweep that recognises one failure SHAPE reports a clean
+# zero for every tool that fails in another shape.
 #
 # One of the original nine (`run_transforms`) turned out NOT to be a defect: the
 # probe venv had goldenflow-native 0.1.1 against a >=0.27 floor, a wheel with 4
@@ -88,3 +101,50 @@ def test_known_bad_list_carries_no_stale_entries(sweep):
     registered = {r["tool"] for r in sweep}
     missing = KNOWN_POLARS_BOUND - registered
     assert not missing, f"listed but no longer registered tools: {sorted(missing)}"
+
+
+# -- the detector itself ----------------------------------------------------
+#
+# `run_sweep` is only as good as its classifier, and a narrowed classifier makes
+# the ratchet above pass while measuring nothing -- which is exactly what
+# happened before `read_file` and `write_csv` were found. So the predicate is
+# tested directly, not just through the sweep that depends on it.
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        "No module named 'polars'",
+        'no module named "polars"',
+        "Could not parse /tmp/a.csv: No module named 'polars'",
+        """{"error": "Could not parse a.csv: No module named 'polars'"}""",
+    ],
+)
+def test_a_returned_polars_import_error_is_recognised(blob):
+    assert looks_like_polars_import_error(blob)
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        "",
+        "No module named 'pyarrow'",
+        "polars is an optional extra",          # mentions polars, not an ImportError
+        "install goldenflow[polars] for this",  # an actionable needs-extra message
+    ],
+)
+def test_unrelated_text_is_not_flagged(blob):
+    assert not looks_like_polars_import_error(blob)
+
+
+def test_the_probe_uses_the_same_predicate_the_test_does():
+    """The probe runs in a subprocess and cannot import this module, so it
+    INLINES the predicate's source. If someone reimplements the check inside the
+    probe instead, the two can drift and only the subprocess one matters."""
+    import inspect
+
+    import sweep_mcp_polars_free as sweep
+
+    probe = sweep._probe_source()
+    assert "def looks_like_polars_import_error" in probe
+    assert inspect.getsource(sweep.looks_like_polars_import_error) in probe


### PR DESCRIPTION
Follow-up to #2826, taking the two loose ends I flagged when it merged.

## The first loose end found a hole in the gates

I had declined to clear three `.to_dicts()` sites, saying "their tests pass" was exactly the assurance that had already failed once. Tracing them showed the sweeps certifying **zero polars-bound** were measuring error-handling *style*, not the dependency.

Both sweeps flagged a surface only when invoking it **raised** an ImportError. MCP tools wrap their body in a broad `except Exception` and *return* `{"error": str(exc)}`; CLI commands catch, print and exit:

| surface | what actually happened | old verdict |
|---|---|---|
| `read_file` | returned `"Could not parse ...: No module named 'polars'"` | `ok` |
| `write_csv` | same shape | `ok` |
| `match` | prints `"Runtime error: No module named 'polars'"`, exit 3 | `errored` |

Three polars-bound surfaces, none visible, both ratchets reporting a clean zero. Same shape as the `lineage.py` fail-open in #2826: a hard dependency failure turned into a soft return is invisible to a sweep watching for exceptions.

## Fixed

- **`read_file`** → `read_table_arrow(...).to_pylist()` instead of `load_file().collect()`
- **`write_csv`** → `pyarrow.csv.write_csv`. `pa.Table.from_pylist` infers its schema from the **first row** and silently drops a key appearing only later, where `pl.DataFrame(rows)` unions them — the union is built explicitly, first-seen order. Without it the port loses columns with no error.

## Not fixed — recorded

**`match` is broken on `pip install goldenmatch`.** `run_match` → `ingest.load_file` returns a `pl.LazyFrame` and hands it to `_run_match_pipeline`. It is now the single entry in `KNOWN_POLARS_BOUND`, with the repro and the reason — listed so the ratchet stops lying, **not** to make a build green. The port is scoped (`run_match` 80 lines / 3 `pl.` refs; `_run_match_pipeline` 340 / 6) but bigger than this change.

## The detector

Moved to `scripts/_polars_free_detect.py`: one definition, applied to raised exceptions *and* returned/printed output, imported by both sweeps and inlined into both subprocess probes via `inspect.getsource`. It has its own tests, including one asserting the probe really inlines that source — a sweep is only as honest as its classifier.

## Guards (the second loose end)

`_CAPABILITIES` / `native_can` moved from `engine/columnar.py` to `core/_native_loader.py`, since `transforms/_chain.py` needs them and columnar imports *from* `_chain`. 11 more hand-rolled guards converted across `_chain.py` (9) and `profiler_bridge.py` (2); the no-hand-rolled-guards ratchet now covers all three modules, sabotage-checked in `_chain.py`.

## Verification

goldenflow 2306 passed; MCP/CLI surface suites 66 passed; both sweep ratchets 17 passed; ruff clean; `check_native_symbols goldenflow` exit 0; docs regenerated. `read_file` and `write_csv` confirmed working with polars blocked at the meta path, including the later-row column `from_pylist` would have lost.