### PR TITLE
fix: both suggest-quality regressions — bucket dropped blocking keys, postflight undid threshold suggestions

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1484,7 +1484,23 @@ def score_buckets(
     # worked -- issue #1048. `passes` is None for static/single-key configs, so
     # fall back to `keys`; only a config with NEITHER (nothing to block on)
     # returns empty, matching the no-candidate-pairs semantics.
-    pass_keys = blocking_config.passes or blocking_config.keys
+    # Mirror blocker.py's dispatch EXACTLY. `passes or keys` was wrong for one
+    # shape: a `static` config carrying BOTH. Legacy blocks a static config on
+    # `keys` and never looks at `passes` (blocker.py: the static branch iterates
+    # `config.keys`); `passes or keys` took `passes` instead, so the two
+    # backends blocked on DIFFERENT fields and bucket scored a candidate set the
+    # plan never described -- zero pairs, no error.
+    #
+    # Every parity test in tests/test_score_buckets_multipass.py sets
+    # `keys=[zip]` alongside `passes=[zip, ssn]`, i.e. keys is a SUBSET of
+    # passes, so dropping keys lost nothing and none of them could see this.
+    # Auto-config emits keys=[org_name] with passes=[postcode, record_id],
+    # where the dropped key is the only one that pairs the duplicates: on the
+    # suggest_quality orgs_hard corpus that was 0 pairs vs legacy's 242.
+    if blocking_config.strategy == "multi_pass":
+        pass_keys = blocking_config.passes or blocking_config.keys
+    else:
+        pass_keys = blocking_config.keys or blocking_config.passes
     if not pass_keys:
         return []
 

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/apply.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/apply.py
@@ -75,6 +75,27 @@ def apply_suggestion(
 
     if op == "set_threshold":
         _apply_set_threshold(new_config, patch)
+        # An explicitly applied threshold must SURVIVE the pipeline.
+        #
+        # `_apply_postflight` re-cuts pair scores to its own recomputed
+        # threshold whenever the config came from `auto_configure_df`, unless
+        # `_strict_autoconfig` is set. Applying a raise here truncates the score
+        # distribution, postflight then recomputes a cut FROM that truncated
+        # distribution, and the raise is undone -- the known
+        # postflight-on-a-truncated-distribution failure.
+        #
+        # It made threshold suggestions unverifiable: `review_config`'s verify
+        # gate scored `thr:raise:fuzzy_match` at 0.8200 against a 0.6467
+        # baseline when postflight was suppressed, and 0.3913 -> DROP when it
+        # was not. The suggester was correctly refusing to recommend a change
+        # the pipeline would immediately revert. Measured on the
+        # suggest_quality dblp_acm corpus, which is why its convergence F1 sat
+        # at base (0.5645) instead of 0.7296.
+        #
+        # Only for set_threshold: the other ops do not fight postflight, and
+        # pinning strict for them would suppress adjustments nobody asked to
+        # keep.
+        new_config._strict_autoconfig = True
     elif op == "set_scorer":
         _apply_set_scorer(new_config, patch)
     elif op == "add_negative_evidence":

--- a/packages/python/goldenmatch/tests/test_bucket_blocking_keys_dropped.py
+++ b/packages/python/goldenmatch/tests/test_bucket_blocking_keys_dropped.py
@@ -1,0 +1,155 @@
+"""The bucket scorer blocked a `static` config on the WRONG field list.
+
+`backends/score_buckets.py` resolved its block keys as::
+
+    pass_keys = blocking_config.passes or blocking_config.keys
+
+which inverts `blocker.py` for one shape: a `strategy="static"` config carrying
+BOTH `keys` and `passes`. Legacy blocks a static config on `keys` and never
+looks at `passes`; `passes or keys` took `passes` instead. The two backends then
+blocked on different fields, and bucket scored a candidate set the plan never
+described -- zero pairs, no error, no warning.
+
+Why no existing test caught it: every parity case in
+`test_score_buckets_multipass.py` sets `keys=[zip]` alongside
+`passes=[zip, ssn]`, i.e. `keys` is a SUBSET of `passes`, so taking `passes`
+lost nothing. Auto-config emits `keys=[org_name]` with
+`passes=[postcode, record_id]`, where the dropped key is the only one that pairs
+the duplicates.
+
+Measured on the suggest_quality `orgs_hard` corpus (845 rows, that exact
+auto-config): bucket 0 pairs / 0 dupes vs legacy 242 pairs / 313 dupes, moving
+the dataset's convergence F1 from 0.2939 to 0.0000. With the fix it is 0.4108.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+
+# `grp` pairs the records; `city` and `id` deliberately do not.
+#
+# The names must be dissimilar ACROSS groups. An earlier draft used
+# "Acme Holdings {i}", where every record scored > 0.8 against every other -- so
+# blocking on the WRONG field still produced (wrong) clusters and the test passed
+# with the fix reverted. Distinct words make the wrong blocking produce a
+# different answer, which is what the assertions need in order to mean anything.
+_WORDS = [
+    "Quorvex", "Blimtal", "Zandric", "Purnoss", "Ferrigo",
+    "Wystrim", "Kalbonn", "Tovanti", "Grexil", "Marnoth",
+    "Sylvorn", "Dranmix", "Ulbreth", "Cintaro", "Hexavil",
+    "Jorlund", "Nepthal", "Ravonix", "Torbeck", "Yalmire",
+]
+
+
+def _key(field: str) -> BlockingKeyConfig:
+    return BlockingKeyConfig(fields=[field], transforms=["lowercase"])
+
+
+def _frame(pl):
+    rows = []
+    for i, w in enumerate(_WORDS):
+        rows.append(
+            {"id": f"a{i}", "grp": f"g{i}", "name": f"{w} Holdings", "city": "leeds"}
+        )
+        rows.append(
+            {"id": f"b{i}", "grp": f"g{i}", "name": f"{w} Holdngs", "city": "york"}
+        )
+    return pl.DataFrame(rows)
+
+
+def _config(strategy: str) -> GoldenMatchConfig:
+    """A WEIGHTED matchkey on purpose: bucket routing governs the FUZZY scoring
+    stage only, and exact matchkeys take a different path. A first draft of this
+    test used an exact matchkey and passed with the fix reverted."""
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_name",
+                type="weighted",
+                threshold=0.8,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            )
+        ],
+        blocking=BlockingConfig(
+            strategy=strategy,
+            keys=[_key("grp")],
+            passes=[_key("city"), _key("id")],
+            union_mode=True,
+        ),
+    )
+
+
+def _multi_clusters(df, cfg) -> list:
+    from goldenmatch.core.pipeline import run_dedupe_df
+
+    res = run_dedupe_df(df, cfg, output_clusters=True, output_dupes=True)
+    clusters = res.get("clusters") or {}
+    return [c for c in clusters.values() if len(c.get("members", [])) > 1]
+
+
+def test_static_keys_and_passes_finds_its_duplicates():
+    """The regression, asserted on the OUTCOME rather than on routing."""
+    pl = pytest.importorskip("polars")
+
+    multi = _multi_clusters(_frame(pl), _config("static"))
+
+    # EXACT, not "some": with the wrong field list, blocking can still emit
+    # spurious clusters, so a non-empty check would not distinguish the two.
+    assert len(multi) == len(_WORDS), (
+        f"expected {len(_WORDS)} two-member clusters, got {len(multi)} -- bucket "
+        f"blocked on `passes` instead of `keys` again"
+    )
+    assert all(len(c["members"]) == 2 for c in multi)
+
+
+def test_bucket_and_legacy_agree_on_a_static_keys_plus_passes_config():
+    """Parity for the shape no existing parity test covered.
+
+    The two backends must select the same block-key list, so forcing the legacy
+    route has to produce the same clusters.
+    """
+    pl = pytest.importorskip("polars")
+    from goldenmatch.core import pipeline
+
+    df, cfg = _frame(pl), _config("static")
+
+    bucket = {frozenset(c["members"]) for c in _multi_clusters(df, cfg)}
+
+    original = pipeline._use_bucket_scorer
+    pipeline._use_bucket_scorer = lambda *a, **k: False
+    try:
+        legacy = {frozenset(c["members"]) for c in _multi_clusters(df, cfg)}
+    finally:
+        pipeline._use_bucket_scorer = original
+
+    assert bucket == legacy
+    assert bucket, "both backends found nothing -- the fixture stopped matching"
+
+
+def test_multi_pass_still_blocks_on_passes():
+    """Guard against 'fixing' this by inverting it. A `multi_pass` config carries
+    its keys in `.passes`, and `blocker.py` iterates `.passes` for that strategy
+    -- so bucket must keep preferring `passes` there.
+
+    Asserted as a DIFFERENCE rather than as emptiness: blocking on `city` still
+    lets some cross-group pairs clear 0.8 (the names share " Holdings"), so
+    "finds nothing" was the wrong expectation. What must hold is that the two
+    strategies select different block keys and therefore different clusters.
+    """
+    pl = pytest.importorskip("polars")
+    df = _frame(pl)
+
+    static = {frozenset(c["members"]) for c in _multi_clusters(df, _config("static"))}
+    multi = {frozenset(c["members"]) for c in _multi_clusters(df, _config("multi_pass"))}
+
+    assert static != multi, (
+        "static and multi_pass produced identical clusters -- bucket is no "
+        "longer distinguishing `keys` from `passes` by strategy"
+    )
+    assert len(static) == len(_WORDS)

--- a/packages/python/goldenmatch/tests/test_threshold_suggestion_survives_postflight.py
+++ b/packages/python/goldenmatch/tests/test_threshold_suggestion_survives_postflight.py
@@ -1,0 +1,128 @@
+"""An applied threshold suggestion must survive `_apply_postflight`.
+
+`_apply_postflight` re-cuts the scored pairs to its OWN recomputed threshold
+whenever the config came from `auto_configure_df` (it carries a
+`_preflight_report`), unless `_strict_autoconfig` is set. Applying a
+`set_threshold` suggestion truncates the score distribution; postflight then
+recomputes a cut FROM that truncated distribution and the raise is undone --
+the postflight-on-a-truncated-distribution failure this codebase has hit before.
+
+The visible symptom was that threshold suggestions became unverifiable.
+`review_config`'s verify gate scored `thr:raise:fuzzy_match` at cand_health
+0.8200 against a 0.6467 baseline with postflight suppressed, and 0.3913 -> DROP
+with it active. The suggester was correctly refusing to recommend a change the
+pipeline would immediately revert -- so `suggest_quality`'s dblp_acm convergence
+sat at base (0.5645) instead of 0.7296.
+
+It surfaced when the TUI's MatchEngine stopped running its own parallel pipeline
+and delegated to `run_dedupe_df` (#2826): the old copy never called postflight,
+so verification had been measuring a pipeline that did not re-cut. The delegation
+was right -- verification should measure the shipped path -- which is what made
+the underlying conflict visible.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.suggest.apply import apply_suggestion
+from goldenmatch.core.suggest.types import Suggestion
+
+
+def _config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_match",
+                type="weighted",
+                threshold=0.65,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            )
+        ],
+        # A weighted matchkey requires a blocking config; irrelevant to what is
+        # asserted here, but the schema refuses to build without it.
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["name"], transforms=["lowercase"])],
+        ),
+    )
+
+
+def _suggestion(**patch) -> Suggestion:
+    kind = patch.pop("kind", "raise_threshold")
+    return Suggestion(
+        id=f"test:{kind}",
+        kind=kind,
+        target="fuzzy_match",
+        rationale="test",
+        current_value=0.65,
+        proposed_value=patch.get("value", 0.82),
+        predicted_effect="test",
+        confidence=1.0,
+        patch=patch,
+    )
+
+
+def test_a_threshold_patch_pins_strict_autoconfig():
+    cfg = apply_suggestion(
+        _config(),
+        _suggestion(op="set_threshold", matchkey="fuzzy_match", value=0.82),
+    )
+    assert cfg._strict_autoconfig is True
+    assert cfg.get_matchkeys()[0].threshold == pytest.approx(0.82)
+
+
+def test_other_patches_do_not_pin_strict():
+    """Only `set_threshold` fights postflight. Pinning strict for the rest would
+    suppress adjustments nobody asked to keep."""
+    cfg = apply_suggestion(
+        _config(),
+        _suggestion(
+            kind="set_scorer",
+            op="set_scorer",
+            matchkey="fuzzy_match",
+            field="name",
+            scorer="levenshtein",
+        ),
+    )
+    assert not getattr(cfg, "_strict_autoconfig", False)
+
+
+def test_the_original_config_is_still_not_mutated():
+    original = _config()
+    apply_suggestion(
+        original,
+        _suggestion(op="set_threshold", matchkey="fuzzy_match", value=0.82),
+    )
+    assert not getattr(original, "_strict_autoconfig", False)
+    assert original.get_matchkeys()[0].threshold == pytest.approx(0.65)
+
+
+def test_postflight_does_not_recut_a_strict_config():
+    """The other half of the guarantee: strict must actually suppress the re-cut.
+
+    Without it, postflight filters the pair list to its own `adj.to_value` and
+    the applied threshold is gone.
+    """
+    pl = pytest.importorskip("polars")
+    from goldenmatch.core.autoconfig_verify import PreflightReport
+    from goldenmatch.core.pipeline import _apply_postflight
+
+    df = pl.DataFrame(
+        {"__row_id__": list(range(6)), "name": [f"n{i}" for i in range(6)]}
+    )
+    pairs = [(0, 1, 0.95), (2, 3, 0.85), (4, 5, 0.70)]
+
+    cfg = apply_suggestion(
+        _config(),
+        _suggestion(op="set_threshold", matchkey="fuzzy_match", value=0.82),
+    )
+    cfg._preflight_report = PreflightReport()
+
+    out, _report = _apply_postflight(df, cfg, list(pairs))
+    assert out == pairs, "postflight re-cut a config that pinned its threshold"


### PR DESCRIPTION
Two independent bugs, both surfaced (not caused) by #2826, both root-caused by bisect and fixed.

Local measurements, against the recorded baselines:

| dataset | baseline | before | after |
|---|---|---|---|
| `orgs_hard` | 0.2939 | **0.0000** | **0.4164** |
| `dblp_acm` | 0.7296 | **0.5645** | **0.7296** |

---

## 1. The bucket scorer blocked on the wrong field list

`score_buckets.py` resolved block keys as `pass_keys = blocking_config.passes or blocking_config.keys`. That **inverts `blocker.py`** for a `strategy="static"` config carrying *both*: legacy blocks on `keys` and never reads `passes`. The two backends blocked on different fields, so bucket scored a candidate set the plan never described — **zero pairs, no error**.

On `orgs_hard` (auto-config: `keys=[org_name]`, `passes=[postcode, record_id]`): bucket 0 pairs / 0 dupes vs legacy 242 / 313.

**Why no test caught it:** every parity case in `test_score_buckets_multipass.py` uses `keys=[zip]` with `passes=[zip, ssn]` — `keys` is a *subset*, so dropping it lost nothing. It only bites when `keys` holds a field `passes` doesn't, which is exactly what auto-config emits.

Fixed by mirroring `blocker.py`'s dispatch, so bucket keeps its performance.

## 2. Postflight undid the threshold suggestion being verified

`_apply_postflight` re-cuts pairs to its own recomputed threshold whenever the config came from `auto_configure_df`, unless `_strict_autoconfig`. Applying a `set_threshold` suggestion truncates the score distribution; postflight recomputes a cut **from that truncated distribution** and the raise is undone — a failure shape this codebase has hit before.

From `review_config`'s own verify log on `dblp_acm` (baseline health 0.6467):

```
thr:dip:fuzzy_match    0.4214 -> DROP   (identical before/after)
ne:id                  0.3504 -> DROP   (identical before/after)
thr:raise:fuzzy_match  0.8200 -> KEEP   postflight suppressed
                       0.3913 -> DROP   postflight active
```

One candidate, one divergence. The suggester was correctly refusing to recommend a change the pipeline would immediately revert.

`apply_suggestion` now pins `_strict_autoconfig` for `set_threshold` patches only. That fixes it **for users too**: before this, applying a threshold suggestion to an auto-config was silently reverted at run time.

---

## Why #2826 surfaced both

It deleted the TUI `MatchEngine`'s parallel pipeline in favour of delegating to `run_dedupe_df`. That copy used the legacy scorer and never called postflight, and `scripts/suggest_quality/oracle.py` runs through `MatchEngine` — so the harness had been measuring a **lookalike**, not the shipped path. Both bugs were already shipping to users; the delegation removed the masking. Restoring the parallel pipeline would have re-hidden them.

## Tests

Bucket: three tests, each earned. The first draft used an **exact** matchkey (bucket routing governs the *fuzzy* stage only) and passed with the fix reverted; the second used names all scoring > 0.8 against each other, so wrong blocking still produced clusters and it passed again. All three now fail when the fix is reverted.

Postflight: four tests; the two asserting the guarantee fail when reverted.

## Verification

623 passed (bucket/blocking/pipeline/dedupe) + 305 passed (suggest/postflight/autoconfig-verify); ruff clean; docs current.

Pre-existing and unrelated, confirmed by running them at `origin/main`: 3 `test_pipeline_fused_fs_match` failures.

**The full scorecard is CI's verdict** — `historical_50k` OOMs on the dev box at 50,578 rows, so only the two affected datasets were measured locally.