### PR TITLE
Close out phase A: honest Rust/TS signals, and arm the dead-code ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,10 +681,14 @@ jobs:
       # scripts/dead_code/other_langs.py's docstring for why a tool-absent
       # result must never look like a clean one.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-      - name: Install cargo-machete (cargo-binstall, prebuilt)
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall cargo-machete --no-confirm
+      - name: Install cargo-machete
+        # `cargo install --locked`, matching the five other cargo-tool installs
+        # in this file (cargo-llvm-cov, cargo-pgrx, wasm-bindgen-cli, inferno).
+        # Deliberately NOT the cargo-binstall bootstrap, which is a `curl | bash`
+        # of an unpinned script from a moving branch -- every action here is
+        # SHA-pinned precisely to avoid that, and a dead-code gate is not worth
+        # a new supply-chain surface to save a minute of build time.
+        run: cargo install cargo-machete --locked
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         # Reads version from root package.json `packageManager` field.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,22 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      # Provisions cargo-machete and ts-prune (via `pnpm dlx`, so no lockfile/
+      # devDependency change needed) so the other_langs signals below actually
+      # measure something instead of reading NOT MEASURED on every run. See
+      # scripts/dead_code/other_langs.py's docstring for why a tool-absent
+      # result must never look like a clean one.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - name: Install cargo-machete (cargo-binstall, prebuilt)
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall cargo-machete --no-confirm
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        # Reads version from root package.json `packageManager` field.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: gm-cov-*
@@ -782,10 +798,12 @@ jobs:
         run: uv run python -m dead_code.report --coverage-xml packages/python/goldenmatch/coverage.xml
       - name: Ratchet
         if: steps.combine.outputs.full_union == 'true'
-        # A0 (docs/superpowers/specs/2026-09-01-dead-code-audit-design.md, Delivery
-        # stages) lands this job report-only: it must not gate. Flipping the ratchet
-        # to gating is A3, a later phase -- until then a candidate must not fail CI.
-        continue-on-error: true
+        # A3 (docs/superpowers/specs/2026-09-01-dead-code-audit-design.md, Delivery
+        # stages): the gate is now armed. A0 landed this job report-only
+        # (continue-on-error: true) so the first real CI report could be triaged
+        # without blocking merges; that report came back 790 modules known, 0
+        # candidates, KNOWN_DEAD is empty, and the ratchet passes -- so a new dead
+        # module now fails this job for real, same as any other required check.
         run: uv run pytest scripts/test_no_new_dead_code.py -q
       - name: Report + ratchet skipped (partial coverage union)
         if: steps.combine.outputs.full_union != 'true'

--- a/scripts/dead_code/other_langs.py
+++ b/scripts/dead_code/other_langs.py
@@ -3,23 +3,42 @@
 Rust symbol removal is bounded to exports that check_native_symbols already
 flags as unwired: cargo-machete reasons about DEPENDENCIES, not functions, so
 Rust internals stay out of scope for phase A.
+
+Every public function here returns `list[str] | None`: `None` means NOT
+MEASURED (the tool could not be run, or its invocation itself failed), a list
+-- possibly empty -- means the tool ran and that is what it found. Collapsing
+those two into the same `[]` is the exact defect class this whole detector
+exists to catch, and it shipped inside the detector itself: with
+cargo-machete and ts-prune absent from the CI runner, "unused rust deps: 0"
+and "unused ts exports: 0" read as clean results when nothing had actually
+been measured. See report.py's other_langs_report() for how the distinction
+surfaces in the report.
 """
 
 from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import NamedTuple
 
 REPO = Path(__file__).resolve().parent.parent.parent
 
 
-def _run(cmd: list[str], cwd: Path | None = None) -> str | None:
-    """Run a tool, returning None when it is absent or fails."""
+class ToolRun(NamedTuple):
+    stdout: str
+    returncode: int
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> ToolRun | None:
+    """Run a tool, returning None when the executable itself is absent, cannot
+    be launched, or times out. A `ToolRun` otherwise -- even a nonzero return
+    code is a real, measured result: cargo-machete in particular exits 1 to
+    signal "found unused dependencies", not "failed to run"."""
     try:
         proc = subprocess.run(cmd, cwd=cwd or REPO, capture_output=True, text=True, timeout=600)
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
-    return proc.stdout
+    return ToolRun(proc.stdout, proc.returncode)
 
 
 def _parse_machete(output: str) -> list[str]:
@@ -39,28 +58,50 @@ def _parse_machete(output: str) -> list[str]:
     return sorted(set(found))
 
 
-def unused_rust_deps() -> list[str]:
-    """Crate dependencies nothing uses, per cargo-machete."""
-    out = _run(["cargo", "machete", "--with-metadata"])
-    if not out:
-        return []
-    return _parse_machete(out)
+def unused_rust_deps() -> list[str] | None:
+    """Crate dependencies nothing uses, per cargo-machete.
+
+    None means NOT MEASURED. A successful cargo-machete run always emits
+    explanatory text on stdout, whether it found something (the per-crate
+    dependency listing) or not ("found no unused dependencies") -- so blank
+    stdout only happens when the invocation itself failed: `cargo` absent
+    entirely (`_run` returns None), or `cargo` present without the `machete`
+    subcommand installed (cargo exits nonzero with nothing on stdout). Blank
+    stdout is therefore the tell used here, not the return code -- cargo-
+    machete repurposes that to mean "found something" (1) vs "clean" (0),
+    the opposite of the usual "nonzero means broken" convention.
+    """
+    result = _run(["cargo", "machete", "--with-metadata"])
+    if result is None or not result.stdout.strip():
+        return None
+    return _parse_machete(result.stdout)
 
 
-def unwired_rust_exports() -> list[str]:
+def unwired_rust_exports() -> list[str] | None:
     """Kernel exports with no host reference, per check_native_symbols.
+
+    None means NOT MEASURED for every package (check_native_symbols could not
+    be run at all -- effectively unreachable since it's a bundled script
+    invoked with the same Python interpreter running this code, but handled
+    for honesty rather than assumed). A single package's own failure (no
+    native-symbol registry entry, or zero scanned references -- both written
+    to stderr with blank stdout) does not sink the whole signal: the other
+    packages still measure and report, matching the tolerance the original
+    per-package loop already had.
 
     Note: The parser is spot-checked, not fixture-tested — verified against real
     check_native_symbols output (5 goldencheck entries matched exactly, 39 items
     total), unlike `_parse_machete`, which has a committed fixture test.
     """
     found: list[str] = []
+    measured_any = False
     for pkg in ("goldenmatch", "goldenflow", "goldencheck", "infermap", "goldenanalysis"):
-        out = _run(["python", "scripts/check_native_symbols.py", pkg])
-        if not out:
+        result = _run(["python", "scripts/check_native_symbols.py", pkg])
+        if result is None or not result.stdout.strip():
             continue
+        measured_any = True
         in_block = False
-        for line in out.splitlines():
+        for line in result.stdout.splitlines():
             if line.startswith("unwired"):
                 in_block = True
                 continue
@@ -69,21 +110,39 @@ def unwired_rust_exports() -> list[str]:
                     found.append(f"{pkg}:{line[4:].strip()}")
                 else:
                     in_block = False
+    if not measured_any:
+        return None
     return sorted(set(found))
 
 
-def unused_ts_exports() -> list[str]:
+def unused_ts_exports() -> list[str] | None:
     """Exported TypeScript symbols with no importer, per ts-prune.
 
-    Note: The parser is UNVERIFIED — ts-prune is not installed in this environment,
-    so an empty result may indicate no findings or that the parser has never run.
+    Invoked via `pnpm dlx ts-prune` rather than `pnpm exec ts-prune`: ts-prune
+    is not a declared devDependency of the TS package, so `pnpm exec` (which
+    only resolves locally-installed binaries) always failed with "command not
+    found" -- silently, because that failure surfaced as ordinary nonzero-exit,
+    empty-stdout output, indistinguishable downstream from a genuinely clean
+    run. `pnpm dlx` fetches the package on demand instead, so the invocation
+    itself succeeds whether or not ts-prune has ever been installed.
+
+    None means NOT MEASURED. Unlike cargo-machete and check_native_symbols, a
+    genuinely clean ts-prune run ALSO produces empty stdout (it prints one
+    line per unused export and nothing at all when there are none), with exit
+    code 0 -- so blank stdout cannot be the failure signal here without
+    misreporting every real "zero findings" run as NOT MEASURED. The exit
+    code is used instead: `pnpm dlx` exits 0 whenever ts-prune itself ran,
+    regardless of what it found; a nonzero exit means the invocation failed
+    (package fetch/network failure, or no runnable ts-prune at all).
     """
     ts_root = REPO / "packages" / "typescript" / "goldenmatch"
     if not ts_root.exists():
-        return []
-    out = _run(["pnpm", "exec", "ts-prune"], cwd=ts_root)
-    if not out:
-        return []
+        return None
+    result = _run(["pnpm", "dlx", "ts-prune"], cwd=ts_root)
+    if result is None or result.returncode != 0:
+        return None
     return sorted(
-        line.strip() for line in out.splitlines() if line.strip() and "(used in module)" not in line
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip() and "(used in module)" not in line
     )

--- a/scripts/dead_code/report.py
+++ b/scripts/dead_code/report.py
@@ -151,6 +151,38 @@ def candidates(coverage_xml: Path | None) -> list[dict]:
     return [{"module": m, "static": True, "runtime": True} for m in sorted(eligible & uncovered)]
 
 
+# Human-readable reasons a signal reads NOT MEASURED, keyed by the same label
+# main() prints it under. Kept beside the presentation code that uses them,
+# not in other_langs.py -- the "why" here is about this CI run's environment,
+# not a property of the tool functions themselves.
+_OTHER_LANGS_NOT_MEASURED_REASON = {
+    "unused rust deps": "cargo-machete not installed",
+    "unwired rust exports": "check_native_symbols could not run for any package",
+    "unused ts exports": "ts-prune not installed",
+}
+
+
+def other_langs_report() -> dict[str, list[str] | None]:
+    """The three other_langs signals, keyed by their report label.
+
+    Each value is exactly what its function returned: None means NOT
+    MEASURED, a list (possibly empty) means measured. Both main()'s text and
+    --json branches read this so the two presentations can never disagree
+    about which signals were actually measured.
+    """
+    from dead_code.other_langs import (
+        unused_rust_deps,
+        unused_ts_exports,
+        unwired_rust_exports,
+    )
+
+    return {
+        "unused rust deps": unused_rust_deps(),
+        "unwired rust exports": unwired_rust_exports(),
+        "unused ts exports": unused_ts_exports(),
+    }
+
+
 def public_export_inventory() -> list[str]:
     """Modules that are unimported internally but MAY be public API.
 
@@ -175,11 +207,29 @@ def main() -> int:
     found = candidates(args.coverage_xml)
     inventory = public_export_inventory()
     scope = candidacy_scope(args.coverage_xml)
+    other_langs = other_langs_report()
 
     if args.json:
+        other_langs_json = {
+            label: (
+                {"measured": True, "items": items}
+                if items is not None
+                else {
+                    "measured": False,
+                    "items": None,
+                    "reason": _OTHER_LANGS_NOT_MEASURED_REASON[label],
+                }
+            )
+            for label, items in other_langs.items()
+        }
         print(
             json.dumps(
-                {"candidates": found, "public_inventory": inventory, "candidacy_scope": scope},
+                {
+                    "candidates": found,
+                    "public_inventory": inventory,
+                    "candidacy_scope": scope,
+                    "other_langs": other_langs_json,
+                },
                 indent=2,
             )
         )
@@ -210,17 +260,10 @@ def main() -> int:
         print("  no --coverage-xml given: runtime signal unknown, reporting nothing")
     print(f"\npublic-export inventory (reported only): {len(inventory)}")
 
-    from dead_code.other_langs import (
-        unused_rust_deps,
-        unused_ts_exports,
-        unwired_rust_exports,
-    )
-
-    for label, items in (
-        ("unused rust deps", unused_rust_deps()),
-        ("unwired rust exports", unwired_rust_exports()),
-        ("unused ts exports", unused_ts_exports()),
-    ):
+    for label, items in other_langs.items():
+        if items is None:
+            print(f"\n{label}: NOT MEASURED ({_OTHER_LANGS_NOT_MEASURED_REASON[label]})")
+            continue
         print(f"\n{label}: {len(items)}")
         for item in items[:40]:
             print(f"  - {item}")

--- a/scripts/test_dead_code_other_langs.py
+++ b/scripts/test_dead_code_other_langs.py
@@ -1,8 +1,12 @@
 """TypeScript and Rust candidacy.
 
-Each returns [] when its tool is missing rather than raising, so a machine
-without cargo-machete reports "nothing found" instead of failing the run -- but
-the CI job installs the tools, so [] there means genuinely none.
+Each returns None -- NOT MEASURED -- when its tool is missing rather than
+raising or silently reporting an empty list, so a machine without
+cargo-machete distinguishes "never looked" from "looked, found nothing"
+instead of collapsing both into `0`. That collapse was itself the exact
+defect class this detector exists to catch: it shipped inside the detector,
+where the CI runner's missing cargo-machete/ts-prune made "unused rust deps: 0"
+and "unused ts exports: 0" indistinguishable from a genuine clean result.
 """
 
 from __future__ import annotations
@@ -27,13 +31,20 @@ def test_the_machete_invocation_actually_returns_output():
     """A wrong flag or cwd makes _run return None, which every other test would read as 'no findings'."""
     if shutil.which("cargo") is None:
         pytest.skip("cargo not on PATH")
-    assert _run(["cargo", "machete", "--with-metadata"]) is not None
+    result = _run(["cargo", "machete", "--with-metadata"])
+    assert result is not None
+    assert result.stdout
 
 
-def test_a_missing_tool_is_empty_not_an_exception(monkeypatch):
+def test_a_missing_tool_is_not_measured_not_an_empty_list(monkeypatch):
+    """With no PATH at all, `cargo` and `pnpm` can't be found -- _run returns
+    None -- and the public functions must surface that as None (NOT
+    MEASURED), not as [] (measured, clean). [] would be indistinguishable
+    from a genuine zero-findings run, which is the whole bug this test
+    guards against."""
     monkeypatch.setenv("PATH", "")
-    assert unused_rust_deps() == []
-    assert unused_ts_exports() == []
+    assert unused_rust_deps() is None
+    assert unused_ts_exports() is None
 
 
 def test_parse_machete_real_output():
@@ -100,3 +111,15 @@ def test_parse_machete_no_unused_deps():
     """Test parser when cargo-machete reports no unused dependencies."""
     no_findings = "cargo-machete found no unused dependencies.\n"
     assert _parse_machete(no_findings) == []
+
+
+def test_machete_present_reports_a_real_nonzero_count():
+    """SABOTAGE CHECK for the honest/real split: with cargo-machete actually
+    on PATH, unused_rust_deps() must report a real non-empty finding (this
+    repo genuinely has unused Cargo dependencies right now), not an empty
+    list masquerading as clean and not None masquerading as absent."""
+    if shutil.which("cargo") is None or shutil.which("cargo-machete") is None:
+        pytest.skip("cargo-machete not on PATH")
+    result = unused_rust_deps()
+    assert result is not None
+    assert len(result) > 0


### PR DESCRIPTION
## What and why

Closes out phase A of the dead-code audit (`docs/superpowers/specs/2026-09-01-dead-code-audit-design.md`): makes two signals honest and real, then arms the ratchet (stage A3).

The detector's first full-union report on main reads `790 modules known, 0 candidates` with a passing ratchet. Two things stood between that and a gate worth trusting.

## Changes

**1. Two signals said "nothing found" when they meant "never looked".**

The merge-queue report printed `unused rust deps: 0` while the same code run locally finds ELEVEN, and `unused ts exports: 0` always. `_run()` returned `None` when a tool was absent and the callers turned that into `[]`, so a missing tool was indistinguishable from a clean result. That is the exact defect class this detector exists to eliminate, sitting inside the detector.

Fixed both ways:

- *Honest*: the three `other_langs` functions now return `list[str] | None`, where `None` means NOT MEASURED. The report prints `unused ts exports: NOT MEASURED (ts-prune not installed)` instead of `0`, and `--json` carries `{"measured": false, "items": null, "reason": ...}` rather than collapsing it. The per-tool tell differs by necessity: cargo-machete and check_native_symbols always emit stdout on a real run, but a genuinely clean ts-prune run IS empty stdout, so that one keys off the return code.
- *Real*: the `dead_code` job now installs cargo-machete and ts-prune, so both actually measure. `unused_ts_exports()` also moved from `pnpm exec ts-prune` to `pnpm dlx ts-prune` -- ts-prune was never a devDependency, so that invocation could never have worked. That signal has been broken since it was written, not merely uninstalled.

**2. The ratchet now gates (A3).**

`continue-on-error: true` is removed from the Ratchet step. A0 deliberately landed the job report-only so the first real report could be read without blocking merges; that report came back clean, `KNOWN_DEAD` is empty, and the ratchet was verified against a real-CI-shaped `coverage.xml` with both a positive and a negative control before the flip. A new dead module now fails this job like any other check.

**3. cargo-machete installs the way this repo installs cargo tools.**

`cargo install cargo-machete --locked`, matching the five existing cargo-tool installs here. The first draft bootstrapped cargo-binstall by piping an unpinned script from a moving branch into bash; every action in this workflow is SHA-pinned to avoid precisely that, and a dead-code gate is not worth a new supply-chain surface to save a minute of build time.

## Testing

```
pytest scripts/test_dead_code_other_langs.py scripts/test_dead_code_report.py \
  scripts/test_no_new_dead_code.py scripts/test_workflow_yaml.py
-> 27 passed, 1 skipped
```

The skip is the ratchet, which needs the combined `coverage.xml` only CI builds. `ruff check` clean on every touched file.

Sabotage-checked in both directions: with cargo-machete present, `unused_rust_deps()` returns 11 real dependencies; with `PATH=""` it returns `None`, never `0` or `[]`.

Local report output, showing the distinction working:

```
unused rust deps: 11
unwired rust exports: 39
unused ts exports: NOT MEASURED (ts-prune not installed)
```

(The ts-prune line is a Windows subprocess/PATHEXT quirk on the dev box, not a CI condition - it is installed in the job.)

## What this PR cannot verify

The ratchet only runs against a FULL coverage union, which at PR time requires a change under `packages/python/goldenmatch/`. This PR touches `scripts/` and `ci.yml`, so the union will be partial, the report suppressed, and the ratchet skipped - by design, since a partial union manufactures false candidates. The armed gate is therefore first exercised in the merge queue, where `force_all` produces the full matrix.

`KNOWN_DEAD` is empty and the last full-union report was 0 candidates, so the expected outcome is a pass. If it does fail there, that is the gate working.
