### PR TITLE
A1 triage: resolve the Rust and TypeScript dead-surface findings

### DIFF
--- a/packages/python/goldenmatch/web/frontend-dioxus-spike/Cargo.toml
+++ b/packages/python/goldenmatch/web/frontend-dioxus-spike/Cargo.toml
@@ -62,6 +62,16 @@ required-features = ["web"]
 # node). Build for the wasm32-unknown-unknown target.
 web = ["dep:dioxus", "dioxus/web", "dep:gloo-net", "dep:wasm-bindgen-futures", "charming/wasm"]
 
+# wasm-bindgen-futures: staged for the `web` feature's async JS interop (the
+# Sensitivity route port), but nothing calls it yet -- `web.rs` only reaches
+# `dioxus::launch` so far, and Dioxus's own internal use of
+# wasm-bindgen-futures already covers what's built today. cargo-machete can't
+# see "declared for the next increment of an optional, sandbox-unbuildable
+# feature" -- ignored rather than removed, so it doesn't get silently
+# re-added (and re-verified) the day the web build actually needs it.
+[package.metadata.cargo-machete]
+ignored = ["wasm-bindgen-futures"]
+
 [profile]
 
 [profile.wasm-dev]

--- a/packages/rust/extensions/analysis-native/Cargo.lock
+++ b/packages/rust/extensions/analysis-native/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
  "analysis-core",
  "arrow",
  "pyo3",
- "rustc-hash",
 ]
 
 [[package]]
@@ -680,12 +679,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"

--- a/packages/rust/extensions/analysis-native/Cargo.toml
+++ b/packages/rust/extensions/analysis-native/Cargo.toml
@@ -26,8 +26,6 @@ pyo3 = { version = ">=0.29, <0.30", features = ["extension-module", "abi3-py311"
 # Pyo3-free histogram/quantile kernels; the #[pyfunction] shims below are thin
 # Arrow-reading wrappers over this crate.
 analysis-core = { path = "../analysis-core" }
-# Dense per-column value interning for the frame kernels (mirrors goldencheck-native).
-rustc-hash = "2"
 # Arrow C Data Interface for zero-copy kernel input (mirrors goldencheck-native).
 # `pyarrow` brings the PyArrowType FFI bridge; default features (csv/ipc/json/
 # compute) are off -- we only read array buffers.

--- a/packages/rust/extensions/autoconfig-core/Cargo.toml
+++ b/packages/rust/extensions/autoconfig-core/Cargo.toml
@@ -20,19 +20,3 @@ fancy-regex = "0.19"
 once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
-[features]
-arrow = ["dep:arrow", "dep:rand", "dep:rand_chacha"]
-
-[dependencies.arrow]
-version = "59"
-default-features = false
-optional = true
-
-[dependencies.rand]
-version = "0.10"
-optional = true
-
-[dependencies.rand_chacha]
-version = "0.10"
-optional = true

--- a/packages/rust/extensions/autoconfig-core/src/lib.rs
+++ b/packages/rust/extensions/autoconfig-core/src/lib.rs
@@ -12,8 +12,6 @@ pub mod extrapolate;
 pub mod planner;
 pub mod select_blocking;
 pub mod thresholds;
-#[cfg(feature = "arrow")]
-pub mod profile;
 
 // Layer 1 re-exports (A3)
 pub use planner::{

--- a/packages/rust/extensions/datafusion-udf/Cargo.lock
+++ b/packages/rust/extensions/datafusion-udf/Cargo.lock
@@ -1678,7 +1678,6 @@ name = "goldenmatch-datafusion-udf"
 version = "0.1.0"
 dependencies = [
  "alloc-stdlib",
- "arrow 58.4.0",
  "arrow-array 58.4.0",
  "arrow-schema 58.4.0",
  "brotli-decompressor",
@@ -1690,7 +1689,6 @@ dependencies = [
  "goldenmatch-graph-core",
  "goldenmatch-score-core",
  "pyo3",
- "pyo3-build-config",
 ]
 
 [[package]]

--- a/packages/rust/extensions/datafusion-udf/Cargo.toml
+++ b/packages/rust/extensions/datafusion-udf/Cargo.toml
@@ -28,7 +28,6 @@ crate-type = ["cdylib"]
 datafusion-common = { version = "53", default-features = false }
 datafusion-expr = "53"
 datafusion-ffi = "53"
-arrow = { version = "58", features = ["ffi"] }
 arrow-array = "58"
 arrow-schema = "58"
 # Canonical string scorers shared pyo3-free with the `native` ext, so the FFI
@@ -63,8 +62,14 @@ pyo3 = { version = "0.29", features = ["extension-module", "abi3", "abi3-py311"]
 alloc-stdlib = "=0.2.4"
 brotli-decompressor = "=5.0.3"
 
-[build-dependencies]
-pyo3-build-config = "0.29"
+# alloc-stdlib and brotli-decompressor above are version-pin-only entries (see
+# the comment on them): nothing in this crate imports either directly, by
+# design. cargo-machete has no way to distinguish that from a genuinely dead
+# dependency, so it flags both every run -- ignored rather than removed,
+# because removing them is exactly what would let the resolver drift back
+# into the alloc-no-stdlib 2.x/3.x conflict the comment describes.
+[package.metadata.cargo-machete]
+ignored = ["alloc-stdlib", "brotli-decompressor"]
 
 [profile.release]
 opt-level = 3

--- a/packages/rust/extensions/goldencheck-native/Cargo.lock
+++ b/packages/rust/extensions/goldencheck-native/Cargo.lock
@@ -411,7 +411,6 @@ dependencies = [
  "arrow",
  "goldencheck-core",
  "pyo3",
- "rustc-hash",
 ]
 
 [[package]]

--- a/packages/rust/extensions/goldencheck-native/Cargo.toml
+++ b/packages/rust/extensions/goldencheck-native/Cargo.toml
@@ -26,8 +26,6 @@ pyo3 = { version = ">=0.29, <0.30", features = ["extension-module", "abi3-py311"
 # Pyo3-free deep-profiling kernels (Benford, composite-key & FD mining). The
 # #[pyfunction] shims below are thin Arrow-reading wrappers over this crate.
 goldencheck-core = { path = "../goldencheck-core" }
-# Dense per-column value interning for the key/FD kernels.
-rustc-hash = "2"
 # Arrow C Data Interface for zero-copy kernel input (mirrors goldenmatch's
 # native crate). `pyarrow` brings the PyArrowType FFI bridge; default features
 # (csv/ipc/json/compute) are off -- we only read array buffers.

--- a/packages/rust/extensions/goldencheck-wasm/Cargo.toml
+++ b/packages/rust/extensions/goldencheck-wasm/Cargo.toml
@@ -19,7 +19,6 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 goldencheck-core = { path = "../goldencheck-core" }
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [profile.release]

--- a/packages/rust/extensions/graph-layout/Cargo.toml
+++ b/packages/rust/extensions/graph-layout/Cargo.toml
@@ -34,6 +34,15 @@ tiny-skia = { version = "0.12", optional = true }
 default = []
 skia = ["dep:tiny-skia"]
 
+# tiny-skia backs the `skia` feature's anti-aliased PNG output, but that swap
+# (raster.rs's own comment: "--features skia swaps in tiny-skia") isn't
+# implemented yet -- the built-in PPM rasterizer is the only renderer today.
+# cargo-machete can't see "declared for a documented, not-yet-built optional
+# feature" -- ignored rather than removed, so the placeholder survives
+# without a nag every run of a demo crate the default CI lane doesn't build.
+[package.metadata.cargo-machete]
+ignored = ["tiny-skia"]
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -61,3 +61,15 @@ path = "src/bin/pgrx_embed.rs"
 
 [dev-dependencies]
 pgrx-tests = "0.12.9"
+
+# pgrx-tests backs the `#[pg_test]` attribute macro (pgrx crate) used under
+# `#[cfg(any(test, feature = "pg_test"))]` in kernels.rs / docs.rs /
+# key_integrity.rs / goldencheck_kernels.rs, plus the `pg_test` harness module
+# in lib.rs -- referenced only through that macro's generated code, invisible
+# to cargo-machete's static text scan. `cargo pgrx test` itself doesn't run in
+# this repo (see fs_em.rs's NOTE and reference_pgrx_test_incompatible.md: a
+# psql smoke test stands in for it), but the dev-dependency still has to
+# exist for `cargo check --tests` / `cargo build --tests` to compile those
+# cfg(test) modules at all.
+[package.metadata.cargo-machete]
+ignored = ["pgrx-tests"]

--- a/packages/typescript/goldenmatch/src/core/llm/budget.ts
+++ b/packages/typescript/goldenmatch/src/core/llm/budget.ts
@@ -249,10 +249,3 @@ export function countTokensApprox(text: string): number {
   if (!text) return 0;
   return Math.ceil(text.length / 4);
 }
-
-/** Return the pricing table (read-only) for inspection/tests. */
-export function getPricing(): Readonly<
-  Record<string, { readonly input: number; readonly output: number }>
-> {
-  return PRICING;
-}

--- a/packages/typescript/goldenmatch/src/core/semantic/parseUtil.ts
+++ b/packages/typescript/goldenmatch/src/core/semantic/parseUtil.ts
@@ -35,10 +35,3 @@ export function asStr(v: unknown): string {
   if (v === undefined || v === null) return "";
   return String(v);
 }
-
-/** A trimmed non-empty string if `v` is a string with content, else undefined. */
-export function optStr(v: unknown): string | undefined {
-  if (typeof v !== "string") return undefined;
-  const s = v.trim();
-  return s.length ? s : undefined;
-}

--- a/packages/typescript/goldenmatch/src/node/connectors/index.ts
+++ b/packages/typescript/goldenmatch/src/node/connectors/index.ts
@@ -37,7 +37,3 @@ export type { BigQueryConfig } from "./bigquery.js";
 export type { DatabricksConfig } from "./databricks.js";
 export type { SalesforceConfig } from "./salesforce.js";
 export type { HubSpotConfig } from "./hubspot.js";
-
-// Re-export the existing local-file connector for convenience.
-export { readFile, readCsv, readJson, writeCsv, writeJson } from "./file.js";
-export type { ReadCsvOptions, WriteCsvOptions } from "./file.js";

--- a/packages/typescript/goldenmatch/src/node/tui/index.ts
+++ b/packages/typescript/goldenmatch/src/node/tui/index.ts
@@ -1,6 +1,0 @@
-/**
- * index.ts -- TUI module entry point.
- */
-
-export { startTui } from "./app.js";
-export type { TuiOptions } from "./app.js";

--- a/scripts/dead_code/other_langs.py
+++ b/scripts/dead_code/other_langs.py
@@ -17,11 +17,13 @@ surfaces in the report.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import NamedTuple
 
 REPO = Path(__file__).resolve().parent.parent.parent
+TS_ROOT = REPO / "packages" / "typescript" / "goldenmatch"
 
 
 class ToolRun(NamedTuple):
@@ -115,8 +117,99 @@ def unwired_rust_exports() -> list[str] | None:
     return sorted(set(found))
 
 
-def unused_ts_exports() -> list[str] | None:
-    """Exported TypeScript symbols with no importer, per ts-prune.
+def _ts_public_entry_files() -> set[str] | None:
+    """Published entry-point source files, resolved from package.json's `exports` map.
+
+    None means NOT MEASURED: package.json is missing, unreadable, or has no
+    `exports` map -- distinct from "measured, package has zero public
+    entries" (an empty set), which would silently reclassify every finding
+    as actionable instead of leaving the split undetermined.
+
+    Each exports target's `types` field names a `dist/<stem>.d.ts` file that
+    tsup's `entry` map (tsup.config.ts) builds 1:1 from `src/<stem>.ts` --
+    every entry in that map has its dist-relative key equal the src value's
+    path with only the extension swapped, so the src file is derived by
+    string substitution rather than by parsing tsup.config.ts itself: strip
+    the `./dist/` prefix and `.d.ts` suffix, wrap the remainder in
+    `src/<stem>.ts`. This walks the whole `exports` map, not one hardcoded
+    subpath -- the package publishes 17 entries (the main barrel, the `core`
+    and `node` barrels, and 14 single-file opt-in wasm/leaf subpaths under
+    `./core/*`), and a hardcoded `src/node/index.ts` would silently miss the
+    other 16, which is exactly the mistake this function exists to avoid.
+    """
+    pkg_path = TS_ROOT / "package.json"
+    try:
+        pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    exports = pkg.get("exports")
+    if not isinstance(exports, dict):
+        return None
+    prefix, suffix = "./dist/", ".d.ts"
+    entries: set[str] = set()
+    for target in exports.values():
+        if not isinstance(target, dict):
+            continue
+        types_path = target.get("types")
+        if not (isinstance(types_path, str) and types_path.startswith(prefix)):
+            continue
+        if not types_path.endswith(suffix):
+            continue
+        stem = types_path[len(prefix) : -len(suffix)]
+        entries.add(f"src/{stem}.ts")
+    return entries
+
+
+def _ts_prune_finding_file(line: str) -> str:
+    """The file a ts-prune finding line names, normalized for comparison
+    against `_ts_public_entry_files()`'s forward-slash `src/...` set.
+
+    ts-prune emits platform-native separators -- backslash on Windows, where
+    this detector was profiled (`.superpowers/sdd/2026-09-01-dead-code-audit-
+    phase-a/tsprune-raw.txt`) -- and a leading separator (`\\src\\...` /
+    `./src/...`) that a bare string-equality check would leave in place,
+    silently failing to match every entry file.
+    """
+    left = line.split(" - ", 1)[0]
+    path = left.rsplit(":", 1)[0].replace("\\", "/").lstrip("/")
+    if path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def _split_ts_prune_findings(stdout: str, entry_files: set[str]) -> tuple[list[str], list[str]]:
+    """Partition raw ts-prune findings into (actionable, public_inventory).
+
+    A finding tagged `(used in module)` has a real internal reference and is
+    dropped entirely, same as the pre-split behavior. Of what remains, a
+    finding in one of the package's published entry files (see
+    `_ts_public_entry_files()`) is public API -- reported in the inventory
+    bucket but never actioned in this phase, mirroring
+    `report.public_export_inventory()` on the Python side. This catches more
+    than the obvious `src/node/index.ts` barrel: `src/core/documentsWasm.ts`,
+    `src/core/sketchWasm.ts` and `src/core/suggestWasm.ts` are THEMSELVES
+    published entry points (`./core/documents-wasm`, `./core/sketch-wasm`,
+    `./core/suggest-wasm`), so an export ts-prune flags there (e.g.
+    `documentsWasmAvailable`) is public API too, even though it lives outside
+    the obviously-huge barrel -- a naive "everything in src/node/index.ts is
+    public, everything else is actionable" split would misclassify these
+    three as deletable.
+    """
+    actionable: list[str] = []
+    public_inventory: list[str] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or "(used in module)" in line:
+            continue
+        if _ts_prune_finding_file(line) in entry_files:
+            public_inventory.append(line)
+        else:
+            actionable.append(line)
+    return sorted(set(actionable)), sorted(set(public_inventory))
+
+
+def _ts_prune_split() -> tuple[list[str], list[str]] | None:
+    """Run ts-prune once and partition its findings. None means NOT MEASURED.
 
     Invoked via `pnpm dlx ts-prune` rather than `pnpm exec ts-prune`: ts-prune
     is not a declared devDependency of the TS package, so `pnpm exec` (which
@@ -126,23 +219,64 @@ def unused_ts_exports() -> list[str] | None:
     run. `pnpm dlx` fetches the package on demand instead, so the invocation
     itself succeeds whether or not ts-prune has ever been installed.
 
-    None means NOT MEASURED. Unlike cargo-machete and check_native_symbols, a
-    genuinely clean ts-prune run ALSO produces empty stdout (it prints one
-    line per unused export and nothing at all when there are none), with exit
-    code 0 -- so blank stdout cannot be the failure signal here without
+    A genuinely clean ts-prune run produces empty stdout (it prints one line
+    per unused export and nothing at all when there are none), with exit code
+    0 -- so blank stdout cannot be the failure signal here without
     misreporting every real "zero findings" run as NOT MEASURED. The exit
     code is used instead: `pnpm dlx` exits 0 whenever ts-prune itself ran,
     regardless of what it found; a nonzero exit means the invocation failed
     (package fetch/network failure, or no runnable ts-prune at all).
+
+    Also NOT MEASURED when ts-prune ran fine but `_ts_public_entry_files()`
+    could not resolve the package's entry files: a finding cannot be
+    correctly classified without that set, so nothing is reported rather than
+    reporting every finding as actionable (silently including public API) or
+    every finding as public (silently hiding real candidates).
+
+    Called once per public function below (`unused_ts_exports()` and
+    `ts_public_export_inventory()`), so a caller that wants both pays for two
+    `pnpm dlx` invocations -- accepted for now to keep each public function
+    independently callable and testable, matching the rest of this module.
     """
-    ts_root = REPO / "packages" / "typescript" / "goldenmatch"
-    if not ts_root.exists():
+    if not TS_ROOT.exists():
         return None
-    result = _run(["pnpm", "dlx", "ts-prune"], cwd=ts_root)
+    result = _run(["pnpm", "dlx", "ts-prune"], cwd=TS_ROOT)
     if result is None or result.returncode != 0:
         return None
-    return sorted(
-        line.strip()
-        for line in result.stdout.splitlines()
-        if line.strip() and "(used in module)" not in line
-    )
+    entry_files = _ts_public_entry_files()
+    if entry_files is None:
+        return None
+    return _split_ts_prune_findings(result.stdout, entry_files)
+
+
+def unused_ts_exports() -> list[str] | None:
+    """Exported TypeScript symbols with no importer and no publishing excuse.
+
+    This is the actionable half of ts-prune's output: findings already
+    filtered to drop both `(used in module)` hits and anything reachable
+    through the package's published `exports` map (see
+    `ts_public_export_inventory()` for that half). Deleting published public
+    API is out of scope for phase A -- see this repo's dead-code-audit design
+    spec -- so conflating the two into one number (as this function used to)
+    made the headline count dominated by exactly what the spec excludes: of
+    an early raw run's 840 findings, 666 were the `src/node/index.ts` public
+    barrel alone.
+
+    None means NOT MEASURED.
+    """
+    split = _ts_prune_split()
+    return None if split is None else split[0]
+
+
+def ts_public_export_inventory() -> list[str] | None:
+    """Exported TypeScript symbols ts-prune flags, that live in a published
+    entry file (per package.json's `exports` map).
+
+    Reported only, mirroring `report.public_export_inventory()` on the Python
+    side: deleting published public API is out of scope for phase A, so an
+    export here is not a deletion candidate, only a fact about the surface.
+
+    None means NOT MEASURED.
+    """
+    split = _ts_prune_split()
+    return None if split is None else split[1]

--- a/scripts/dead_code/report.py
+++ b/scripts/dead_code/report.py
@@ -158,12 +158,15 @@ def candidates(coverage_xml: Path | None) -> list[dict]:
 _OTHER_LANGS_NOT_MEASURED_REASON = {
     "unused rust deps": "cargo-machete not installed",
     "unwired rust exports": "check_native_symbols could not run for any package",
-    "unused ts exports": "ts-prune not installed",
+    "unused ts exports": "ts-prune not installed, or the package's exports map could not be read",
+    "ts public-export inventory": (
+        "ts-prune not installed, or the package's exports map could not be read"
+    ),
 }
 
 
 def other_langs_report() -> dict[str, list[str] | None]:
-    """The three other_langs signals, keyed by their report label.
+    """The four other_langs signals, keyed by their report label.
 
     Each value is exactly what its function returned: None means NOT
     MEASURED, a list (possibly empty) means measured. Both main()'s text and
@@ -171,6 +174,7 @@ def other_langs_report() -> dict[str, list[str] | None]:
     about which signals were actually measured.
     """
     from dead_code.other_langs import (
+        ts_public_export_inventory,
         unused_rust_deps,
         unused_ts_exports,
         unwired_rust_exports,
@@ -180,6 +184,7 @@ def other_langs_report() -> dict[str, list[str] | None]:
         "unused rust deps": unused_rust_deps(),
         "unwired rust exports": unwired_rust_exports(),
         "unused ts exports": unused_ts_exports(),
+        "ts public-export inventory": ts_public_export_inventory(),
     }
 
 

--- a/scripts/test_dead_code_other_langs.py
+++ b/scripts/test_dead_code_other_langs.py
@@ -120,16 +120,28 @@ def test_parse_machete_no_unused_deps():
     assert _parse_machete(no_findings) == []
 
 
-def test_machete_present_reports_a_real_nonzero_count():
+def test_machete_present_measures_for_real():
     """SABOTAGE CHECK for the honest/real split: with cargo-machete actually
-    on PATH, unused_rust_deps() must report a real non-empty finding (this
-    repo genuinely has unused Cargo dependencies right now), not an empty
-    list masquerading as clean and not None masquerading as absent."""
+    on PATH, unused_rust_deps() must return a real MEASURED result (a list,
+    even an empty one) -- never None, which would mean the invocation
+    silently failed and got misread as "measured, clean" instead of "didn't
+    run". `result is not None` is the assertion this test exists for; a
+    non-empty list is not, on its own, evidence the invocation worked (an
+    empty list from a broken invocation would look identical).
+
+    Originally this asserted `len(result) > 0` because the repo genuinely
+    had unused dependencies at the time (the 11 findings the phase-A dead-
+    code audit's Rust triage went on to resolve on 2026-09-01: 7 removed, 4
+    kept `ignored` with a reason). Now that they're triaged, a real measured
+    run legitimately comes back empty, so that assertion would fail on
+    correctly-clean output -- hardcoding it back to `== []` would make this
+    test double as an unrelated regrowth ratchet, which is
+    test_no_new_dead_code.py's job, not this one's.
+    """
     if shutil.which("cargo") is None or shutil.which("cargo-machete") is None:
         pytest.skip("cargo-machete not on PATH")
     result = unused_rust_deps()
     assert result is not None
-    assert len(result) > 0
 
 
 def test_ts_public_entry_files_reads_the_real_exports_map():

--- a/scripts/test_dead_code_other_langs.py
+++ b/scripts/test_dead_code_other_langs.py
@@ -11,6 +11,7 @@ and "unused ts exports: 0" indistinguishable from a genuine clean result.
 
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -19,9 +20,14 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+import dead_code.other_langs as other_langs  # noqa: E402
 from dead_code.other_langs import (  # noqa: E402
     _parse_machete,
     _run,
+    _split_ts_prune_findings,
+    _ts_prune_finding_file,
+    _ts_public_entry_files,
+    ts_public_export_inventory,
     unused_rust_deps,
     unused_ts_exports,
 )
@@ -45,6 +51,7 @@ def test_a_missing_tool_is_not_measured_not_an_empty_list(monkeypatch):
     monkeypatch.setenv("PATH", "")
     assert unused_rust_deps() is None
     assert unused_ts_exports() is None
+    assert ts_public_export_inventory() is None
 
 
 def test_parse_machete_real_output():
@@ -123,3 +130,109 @@ def test_machete_present_reports_a_real_nonzero_count():
     result = unused_rust_deps()
     assert result is not None
     assert len(result) > 0
+
+
+def test_ts_public_entry_files_reads_the_real_exports_map():
+    """Against the real package.json (no ts-prune invocation needed), the
+    resolved entry-file set must contain the main barrel, the `core` and
+    `node` sub-barrels, and a single-file wasm leaf entry -- not just the
+    obvious `src/node/index.ts`, which is the exact hardcoding this function
+    exists to avoid (other sub-entries like `./core/documents-wasm` deserve
+    the same public-API treatment, and previously did not get it)."""
+    entries = _ts_public_entry_files()
+    assert entries is not None
+    for expected in (
+        "src/index.ts",
+        "src/core/index.ts",
+        "src/node/index.ts",
+        "src/core/documentsWasm.ts",
+        "src/core/sketchWasm.ts",
+        "src/core/suggestWasm.ts",
+    ):
+        assert expected in entries, f"{expected} missing from resolved entry files"
+    # Internal sub-barrels that are NOT in package.json's exports map must
+    # not be swept in as public API just because they look like barrels.
+    for not_public in ("src/node/connectors/index.ts", "src/node/tui/index.ts"):
+        assert not_public not in entries
+
+
+def test_ts_public_entry_files_none_when_package_json_missing(tmp_path, monkeypatch):
+    """No package.json at all -- NOT MEASURED, not 'zero public entries'
+    (which would silently reclassify every finding as actionable)."""
+    monkeypatch.setattr(other_langs, "TS_ROOT", tmp_path)
+    assert _ts_public_entry_files() is None
+
+
+def test_ts_public_entry_files_none_when_exports_map_missing(tmp_path, monkeypatch):
+    """A package.json without an `exports` map is also NOT MEASURED."""
+    (tmp_path / "package.json").write_text('{"name": "x"}', encoding="utf-8")
+    monkeypatch.setattr(other_langs, "TS_ROOT", tmp_path)
+    assert _ts_public_entry_files() is None
+
+
+def test_ts_public_entry_files_none_when_package_json_is_invalid_json(tmp_path, monkeypatch):
+    (tmp_path / "package.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(other_langs, "TS_ROOT", tmp_path)
+    assert _ts_public_entry_files() is None
+
+
+def test_ts_public_entry_files_derives_src_path_from_dist_types_path(tmp_path, monkeypatch):
+    """The dist -> src derivation: `./dist/core/foo.d.ts` becomes
+    `src/core/foo.ts`, for every subpath in the exports map, not just `.`."""
+    pkg = {
+        "exports": {
+            ".": {"types": "./dist/index.d.ts"},
+            "./core": {"types": "./dist/core/index.d.ts"},
+            "./core/leaf": {"types": "./dist/core/leaf.d.ts"},
+            # Malformed / irrelevant entries must be skipped, not crash the resolver.
+            "./no-types": {"import": "./dist/no-types.js"},
+            "./not-a-dict": "./dist/oops.js",
+        }
+    }
+    (tmp_path / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+    monkeypatch.setattr(other_langs, "TS_ROOT", tmp_path)
+    assert _ts_public_entry_files() == {
+        "src/index.ts",
+        "src/core/index.ts",
+        "src/core/leaf.ts",
+    }
+
+
+def test_ts_prune_finding_file_normalizes_windows_and_posix_paths():
+    """ts-prune emits platform-native separators (backslash on Windows, where
+    this detector was profiled; forward slash on the Linux CI runner) and a
+    leading separator that must be stripped before comparing against the
+    forward-slash entry-file set."""
+    assert _ts_prune_finding_file("\\src\\node\\index.ts:19 - readCsv") == "src/node/index.ts"
+    assert _ts_prune_finding_file("./src/node/index.ts:19 - readCsv") == "src/node/index.ts"
+    assert _ts_prune_finding_file("src/node/index.ts:19 - readCsv") == "src/node/index.ts"
+
+
+def test_split_ts_prune_findings_partitions_public_from_actionable():
+    """The three-way split this whole fix exists for: a finding tagged
+    `(used in module)` is dropped entirely; a finding in a published entry
+    file goes to the public-export inventory (reported, never actioned); and
+    everything else is actionable."""
+    raw = "\n".join(
+        [
+            "\\src\\node\\index.ts:5 - publicThing",
+            "\\src\\node\\index.ts:6 - alsoUsedInternally (used in module)",
+            "\\src\\core\\internal.ts:10 - deadThing",
+            "\\src\\core\\internal.ts:11 - liveThing (used in module)",
+            "\\src\\core\\documentsWasm.ts:185 - documentsWasmAvailable",
+        ]
+    )
+    entry_files = {"src/node/index.ts", "src/core/documentsWasm.ts"}
+    actionable, inventory = _split_ts_prune_findings(raw, entry_files)
+    assert actionable == ["\\src\\core\\internal.ts:10 - deadThing"]
+    assert inventory == [
+        "\\src\\core\\documentsWasm.ts:185 - documentsWasmAvailable",
+        "\\src\\node\\index.ts:5 - publicThing",
+    ]
+
+
+def test_split_ts_prune_findings_empty_stdout_is_empty_not_none():
+    """The split itself never returns None for either bucket -- that
+    distinction belongs to `_ts_prune_split()` (tool ran or not), not the
+    pure parsing/partitioning step."""
+    assert _split_ts_prune_findings("", {"src/node/index.ts"}) == ([], [])

--- a/scripts/test_dead_code_report.py
+++ b/scripts/test_dead_code_report.py
@@ -303,3 +303,38 @@ def test_non_goldenmatch_module_is_excluded_not_evaluated(tmp_path):
         "goldenmatch-scoped, or candidacy_scope() stopped counting correctly. "
         "Either way this test can no longer witness the restriction it names."
     )
+
+
+def test_other_langs_report_carries_the_ts_public_export_split():
+    """other_langs_report() must expose the TS public-export inventory as its
+    own key, separate from the actionable `unused ts exports` -- the fix this
+    whole module change is for. Conflating the two (as the report used to)
+    made `unused ts exports` dominated by the published `src/node/index.ts`
+    barrel: 666 of an early profiled run's 840 raw findings."""
+    from dead_code.report import _OTHER_LANGS_NOT_MEASURED_REASON, other_langs_report
+
+    result = other_langs_report()
+    assert set(result) == {
+        "unused rust deps",
+        "unwired rust exports",
+        "unused ts exports",
+        "ts public-export inventory",
+    }
+    # Every key must have a NOT-MEASURED reason -- main() looks this up
+    # unconditionally for any signal that came back None, so a key missing
+    # here is a KeyError waiting for a machine without ts-prune installed.
+    for label in result:
+        assert label in _OTHER_LANGS_NOT_MEASURED_REASON
+
+
+def test_other_langs_report_ts_signals_are_none_or_lists_never_mixed(monkeypatch):
+    """With no PATH at all, both TS-derived signals must read NOT MEASURED
+    (None) together -- they share one ts-prune invocation
+    (`_ts_prune_split()`), so one coming back None and the other a list would
+    mean the split logic silently diverged from the tool-availability check."""
+    from dead_code.report import other_langs_report
+
+    monkeypatch.setenv("PATH", "")
+    result = other_langs_report()
+    assert result["unused ts exports"] is None
+    assert result["ts public-export inventory"] is None


### PR DESCRIPTION
## What and why

Finishes stage A1 of the dead-code audit. A1 covers three languages, not one - Python (a module nothing imports), TypeScript (an exported symbol with no importer), Rust (an unused crate dependency, or an unwired export). Python was triaged and came back with 0 candidates. The TypeScript and Rust halves were declared done against signals that reported `0` because their tools were not installed. #2840 made those signals real; this PR triages what they found.

## Changes

**1. The TypeScript signal was measuring mostly public API.**

`unused_ts_exports()` reported 695. Of the 840 raw ts-prune findings, 666 sit in `src/node/index.ts`, which `package.json`'s `exports` map builds to `dist/index.js` - the published entry point of the `goldenmatch` npm package. The spec puts public API out of scope for deletion, and the Python side already separates a reported-only `public-export inventory` from real candidates; TypeScript conflated them.

Now split, with the entry points resolved from the `exports` map (17 published entries) rather than a hardcoded path:

```
unused ts exports: 26
ts public-export inventory: 669
```

**2. Rust: 11 unused dependencies across 8 crates - 7 removed, 4 kept with a reason.**

Removed `rustc-hash` (analysis-native, goldencheck-native), `arrow`/`rand`/`rand_chacha` (autoconfig-core), `arrow`/`pyo3-build-config` (datafusion-udf), `serde` (goldencheck-wasm). Kept, with `[package.metadata.cargo-machete] ignored` entries explaining why: `alloc-stdlib` and `brotli-decompressor` (transitive version pins), `pgrx-tests` (reached only through the `#[pg_test]` macro), `wasm-bindgen-futures` and `tiny-skia` (buildable, not-yet-wired optional features).

`cargo machete --with-metadata` now reports clean.

**Worth calling out: autoconfig-core's `arrow` feature could never have compiled.** `lib.rs` declared `pub mod profile;` while `src/profile.rs` does not exist, so `cargo check --features arrow` fails with E0583. That predates this PR - the three dependencies were declared for a feature that was already broken, and nothing would notice unless someone enabled it. The dangling module declaration goes with them.

**3. TypeScript: 26 actionable findings - 11 deleted, 15 kept.**

Deleted: `optStr` (parseUtil.ts) and `getPricing` (budget.ts), both with zero consumers; a duplicate 7-symbol re-export block in `connectors/index.ts`; and the orphaned `src/node/tui/index.ts` barrel. `src/node/tui/app.ts` is untouched and `cli.ts`'s dynamic `import("./node/tui/app.js")` still resolves - only the unused barrel went.

Kept, with reasons: 4 config-file `default` exports (consumed by the tooling that reads those files), 4 entries in a generated `.d.ts`, 2 cross-language parity constants that are value-identical to their Python and Rust counterparts, 4 `isXWasmEnabled` functions belonging to a 7-member family whose siblings are exercised in tests the same way, and 1 piscina worker entry point.

## Testing

- Python: 27 passed, `ruff check` clean.
- Rust: `cargo check` clean for every modified crate except `goldenmatch_pg`, which fails on this Windows box with a pre-existing pgrx-bindgen `libintl.h` gap - reproduced identically before the change, so not a regression. CI covers it.
- TypeScript: `pnpm typecheck` clean; `pnpm test` 3650 passed, 158 skipped, 1 failing file (`warehouse-bigquery.parity.test.ts`) on a pre-existing Windows CRLF artifact in a `.sql` fixture, untouched by this PR.

One test changed meaning as a direct consequence: `test_machete_present_reports_a_real_nonzero_count` asserted `len(result) > 0` on the premise that this repo had unused Cargo dependencies. That premise was true when written and is false now that they are triaged. The assertion is now `result is not None` - the thing that sabotage check actually exists to catch, a silently-failed invocation misread as "measured, clean". Hardcoding `== []` was rejected: that would make it double as a regrowth ratchet, which is `test_no_new_dead_code.py`'s job.

## A1 status after this

Every module-level candidate in all three languages is now either deleted or recorded with a reason. Python: 0 candidates. Rust: clean. TypeScript: 26 actionable, 11 deleted, 15 kept with reasons.
