### PR TITLE
audit(phase B0a): shared-decision inventory + native-vs-pure parity coverage

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -544,6 +544,13 @@ shared_decisions:
   - 'packages/python/goldenmatch/goldenmatch/**'
   - '.github/workflows/ci.yml'
   - '.github/filters.yml'
+  - 'scripts/parity_coverage.py'
+  - 'scripts/test_parity_coverage.py'
+  - 'packages/python/goldenflow/goldenflow/**'
+  # The coverage step also runs the goldenflow test suite itself (to harvest
+  # native-off coverage for parity_coverage.py); the source glob above covers
+  # only the package under test, not the tests that exercise it.
+  - 'packages/python/goldenflow/tests/**'
 # Native-symbol reconciliation gate: the goldenmatch host's
 # native-kernel references must not drift from the kernel's exports.
 # Re-run the gate when the kernel crate, the host package, the

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -536,7 +536,12 @@ shared_decisions:
   - 'scripts/test_shared_decisions_*.py'
   - 'scripts/fixtures/incident_1c843c8a5/**'
   - 'parity/shared_decisions.allow'
-  - 'packages/python/goldenmatch/goldenmatch/config/schemas.py'
+  # readers.py rglobs this whole tree to find config-field accessors, so the
+  # inventory's answer changes whenever ANY goldenmatch module changes (a new
+  # accessor added, or the last one removed). A narrower filter (e.g. just
+  # config/schemas.py, what fields.py reads) leaves the report stale and
+  # quietly wrong -- the same failure shape this detector exists to catch.
+  - 'packages/python/goldenmatch/goldenmatch/**'
   - '.github/workflows/ci.yml'
   - '.github/filters.yml'
 # Native-symbol reconciliation gate: the goldenmatch host's

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -528,6 +528,17 @@ dead_code:
   # Self-test, same rule quality_gate/er_matcher/rust_pgrx/docs_regen already
   # follow: an edit to THIS file must re-run the gate it defines.
   - '.github/filters.yml'
+# The shared-decision inventory's source lives in scripts/, so gating its job on
+# a package filter would let a detector-only change ship without ever running
+# the detector -- the exact hole check_filter_coverage.py now ratchets against.
+shared_decisions:
+  - 'scripts/shared_decisions/**'
+  - 'scripts/test_shared_decisions_*.py'
+  - 'scripts/fixtures/incident_1c843c8a5/**'
+  - 'parity/shared_decisions.allow'
+  - 'packages/python/goldenmatch/goldenmatch/config/schemas.py'
+  - '.github/workflows/ci.yml'
+  - '.github/filters.yml'
 # Native-symbol reconciliation gate: the goldenmatch host's
 # native-kernel references must not drift from the kernel's exports.
 # Re-run the gate when the kernel crate, the host package, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,6 +888,31 @@ jobs:
         env:
           PYTHONPATH: scripts
         run: uv run python -m shared_decisions.report
+      - name: Companion A tests
+        run: uv run pytest scripts/test_parity_coverage.py -q
+      - name: goldenflow suite with native OFF, under coverage
+        env:
+          GOLDENFLOW_NATIVE: "0"
+          COVERAGE_FILE: ${{ github.workspace }}/coverage_native_off.dat
+        run: |
+          uv run coverage run --source=goldenflow -m pytest \
+            packages/python/goldenflow/tests -q -x --timeout=300 || true
+          uv run coverage xml -o coverage_native_off.xml --fail-under=0
+      - name: Unguarded pure-Python fallbacks
+        # KNOWN SCOPING ARTEFACT, not a finding: parity_coverage.py scans _py
+        # functions across BOTH goldenflow and goldenmatch, but this step's
+        # coverage run above is `--source=goldenflow` only (goldenmatch's
+        # native wheel is platform-gated, so its native-off story doesn't fit
+        # this job -- that's a separate task, not scope creep here). That
+        # means goldenmatch's 9 `_py` functions (across 4 modules:
+        # core/_hashing.py, core/autoconfig.py, core/indicators.py,
+        # core/scorer.py) can NEVER have coverage data from this run and will
+        # always show up in main()'s second line, "N module(s) had no
+        # coverage data at all" -- currently printing 4 (those 4 modules), a
+        # fixed floor from this goldenflow-only scoping, not a regression. If
+        # that second-line count ever exceeds 4, the excess is a real gap;
+        # investigate it, don't fold it into this baseline.
+        run: uv run python scripts/parity_coverage.py --native-off-xml coverage_native_off.xml
 
   # Reference mode: python_goldenmatch now runs NATIVE by default. This lean lane
   # asserts the pure-Python FALLBACK still imports and passes on a core behavior

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -896,7 +896,7 @@ jobs:
           COVERAGE_FILE: ${{ github.workspace }}/coverage_native_off.dat
         run: |
           uv run coverage run --source=goldenflow -m pytest \
-            packages/python/goldenflow/tests -q -x --timeout=300 || true
+            packages/python/goldenflow/tests -q --timeout=300 || true
           uv run coverage xml -o coverage_native_off.xml --fail-under=0
       - name: Unguarded pure-Python fallbacks
         # KNOWN SCOPING ARTEFACT, not a finding: parity_coverage.py scans _py
@@ -909,10 +909,14 @@ jobs:
         # core/scorer.py) can NEVER have coverage data from this run and will
         # always show up in main()'s second line, "N module(s) had no
         # coverage data at all" -- currently printing 4 (those 4 modules), a
-        # fixed floor from this goldenflow-only scoping, not a regression. If
-        # that second-line count ever exceeds 4, the excess is a real gap;
-        # investigate it, don't fold it into this baseline.
-        run: uv run python scripts/parity_coverage.py --native-off-xml coverage_native_off.xml
+        # fixed floor from this goldenflow-only scoping, not a regression.
+        # `--max-no-data 4` turns that floor into an enforced check rather
+        # than a comment nobody reads: a no-data count above 4 does not mean
+        # more code went unguarded, it means the MEASUREMENT didn't happen
+        # for those modules (suite died early, a collection error truncated
+        # it, the runner OOMed) and the report below it is untrustworthy --
+        # so this step fails loudly instead of printing a bigger number.
+        run: uv run python scripts/parity_coverage.py --native-off-xml coverage_native_off.xml --max-no-data 4
 
   # Reference mode: python_goldenmatch now runs NATIVE by default. This lean lane
   # asserts the pure-Python FALLBACK still imports and passes on a core behavior

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       downstream_symbols: ${{ steps.filter.outputs.downstream_symbols }}
       er_matcher: ${{ steps.filter.outputs.er_matcher }}
       dead_code: ${{ steps.filter.outputs.dead_code }}
+      shared_decisions: ${{ steps.filter.outputs.shared_decisions }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
@@ -862,6 +863,31 @@ jobs:
           path: coverage_sweep_*.dat
           retention-days: 1
           if-no-files-found: error
+
+  # Shared-decision inventory (report-only): flags config fields read by more than
+  # one module, where accessors implicitly agree about that field's meaning. The
+  # detector's entire source lives under scripts/, NOT packages/python/goldenmatch/,
+  # so this gets its own `shared_decisions` filter rather than reusing
+  # `python_goldenmatch` -- see that filter's comment in .github/filters.yml and
+  # the `dead_code` job above for the exact prior incident this avoids repeating.
+  shared_decisions:
+    needs: changes
+    if: needs.changes.outputs.shared_decisions == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - name: Detector self-tests
+        run: uv run pytest scripts/test_shared_decisions_fields.py scripts/test_shared_decisions_readers.py scripts/test_shared_decisions_allowlist.py scripts/test_shared_decisions_report.py -q
+      - name: Shared-decision inventory
+        # Report-only by design: main() returns 0 for a non-empty inventory (a
+        # finding is not a failure) and 1 only for a STALE allowlist entry, which
+        # is a real defect -- no continue-on-error here, that exit must fail the job.
+        env:
+          PYTHONPATH: scripts
+        run: uv run python -m shared_decisions.report
 
   # Reference mode: python_goldenmatch now runs NATIVE by default. This lean lane
   # asserts the pure-Python FALLBACK still imports and passes on a core behavior

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -895,8 +895,22 @@ jobs:
           GOLDENFLOW_NATIVE: "0"
           COVERAGE_FILE: ${{ github.workspace }}/coverage_native_off.dat
         run: |
+          set +e
           uv run coverage run --source=goldenflow -m pytest \
-            packages/python/goldenflow/tests -q --timeout=300 || true
+            packages/python/goldenflow/tests -q --timeout=300
+          rc=$?
+          set -e
+          # pytest exit codes: 0=all passed, 1=tests failed (fine -- goldenflow
+          # has its own gating job for that), 2=interrupted, 3=internal error,
+          # 4=usage error, 5=no tests collected. Anything above 1 means the RUN
+          # itself broke (crash, OOM, a collection error) rather than merely
+          # went red, and `coverage run` still emits a <line hits="0"/> entry
+          # for every module it imported successfully even though the suite
+          # never got a chance to exercise anything -- so a broken run and a
+          # complete one produce coverage XML that looks the same shape to
+          # parity_coverage.py's --max-no-data floor below. Fail here, before
+          # that floor ever gets a chance to (not) catch it.
+          [ "$rc" -le 1 ] || { echo "::error::pytest exited $rc -- coverage harvest is not trustworthy"; exit 1; }
           uv run coverage xml -o coverage_native_off.xml --fail-under=0
       - name: Unguarded pure-Python fallbacks
         # KNOWN SCOPING ARTEFACT, not a finding: parity_coverage.py scans _py
@@ -910,12 +924,16 @@ jobs:
         # always show up in main()'s second line, "N module(s) had no
         # coverage data at all" -- currently printing 4 (those 4 modules), a
         # fixed floor from this goldenflow-only scoping, not a regression.
-        # `--max-no-data 4` turns that floor into an enforced check rather
-        # than a comment nobody reads: a no-data count above 4 does not mean
-        # more code went unguarded, it means the MEASUREMENT didn't happen
-        # for those modules (suite died early, a collection error truncated
-        # it, the runner OOMed) and the report below it is untrustworthy --
-        # so this step fails loudly instead of printing a bigger number.
+        # `--max-no-data 4` still guards that goldenmatch-scoping floor (a
+        # jump past 4 means something is ALSO excluded beyond the known
+        # scoping gap), but it does NOT guard against a truncated or crashed
+        # suite -- `coverage run --source=goldenflow` emits a <class> entry
+        # with recorded (if all-zero) <line> data for every goldenflow module
+        # it merely IMPORTED, whether or not any test ran, so
+        # modules_without_coverage_data() stays at exactly 4 regardless of
+        # whether the suite ran to completion. That truncation case is now
+        # caught by the pytest-rc check in the previous step, not by this
+        # floor.
         run: uv run python scripts/parity_coverage.py --native-off-xml coverage_native_off.xml --max-no-data 4
 
   # Reference mode: python_goldenmatch now runs NATIVE by default. This lean lane

--- a/docs/superpowers/plans/2026-09-02-shared-decision-inventory.md
+++ b/docs/superpowers/plans/2026-09-02-shared-decision-inventory.md
@@ -354,7 +354,7 @@ git commit -m "feat(shared-decisions): cross-module config-field readers, proven
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: `load_allowlist() -> set[str]` — field names whose multi-module readers are known to agree. `stale_entries(known: set[str]) -> set[str]` — allowlisted names no longer present in `known`.
+- Produces: `load_allowlist() -> set[str]` — field names whose multi-module readers are known to agree. `stale_entries(known: set[str]) -> set[str]` — allowlisted names no longer present in `known`. `entries_missing_reasons(lines: list[str]) -> list[str]` — entries with no `# reason`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -394,13 +394,25 @@ def test_a_missing_allowlist_raises_rather_than_returning_empty(monkeypatch):
         mod.load_allowlist()
 
 
-def test_every_entry_carries_a_reason():
-    raw = ALLOW.read_text(encoding="utf-8")
-    for line in raw.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        assert "#" in line, f"entry without a reason: {line!r}"
+def test_an_entry_without_a_reason_is_rejected():
+    """The shipped allowlist is EMPTY at B0a, so a loop over it never executes
+    and would pass whatever the format rule was. Drive the rule with a synthetic
+    entry instead, so the test can actually fail."""
+    from shared_decisions.allowlist import entries_missing_reasons
+
+    good = ["field_a  # checked 2026-09-02, both readers agree"]
+    bad = ["field_b", "field_c  # fine"]
+    assert entries_missing_reasons(good) == []
+    assert entries_missing_reasons(bad) == ["field_b"]
+
+
+def test_the_shipped_allowlist_obeys_the_format():
+    """Vacuous while the file is empty, which is correct -- it becomes a real
+    check the moment B1 adds the first entry."""
+    from shared_decisions.allowlist import entries_missing_reasons
+
+    lines = ALLOW.read_text(encoding="utf-8").splitlines()
+    assert entries_missing_reasons(lines) == []
 
 
 def test_stale_entries_are_detected(tmp_path, monkeypatch):
@@ -466,6 +478,23 @@ def load_allowlist() -> set[str]:
             continue
         out.add(line.split("#", 1)[0].strip())
     return out
+
+
+def entries_missing_reasons(lines: list[str]) -> list[str]:
+    """Allowlist entries carrying no `# reason`.
+
+    Takes lines rather than reading the file so the rule is testable against a
+    synthetic entry: the shipped allowlist is empty at B0a, and a check that
+    only ever runs over an empty file passes whatever the rule says.
+    """
+    bad: list[str] = []
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "#" not in line:
+            bad.append(line)
+    return bad
 
 
 def stale_entries(known: set[str]) -> set[str]:

--- a/docs/superpowers/plans/2026-09-02-shared-decision-inventory.md
+++ b/docs/superpowers/plans/2026-09-02-shared-decision-inventory.md
@@ -1,0 +1,978 @@
+# Shared-Decision Inventory (Phase B0a) + Parity Coverage (Companion A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface configuration fields read by more than one module — readers that must agree and that nothing currently checks — and separately inventory which pure-Python `_py` fallbacks are never exercised with native off.
+
+**Architecture:** Two independent report-only detectors, both plain AST/coverage scans with no thresholds to tune. The shared-decision inventory parses Pydantic config models for field names, scans every module for attribute reads of those fields, and reports fields read across module boundaries minus a declared-agreement allowlist. Parity coverage diffs two coverage runs (native on, native off) to find `_py` functions no test executes.
+
+**Tech Stack:** Python 3.11+, stdlib `ast`, stdlib `xml.etree`, pytest, ruff. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md`
+
+## Global Constraints
+
+- NO Claude attribution in any artifact — no `Co-Authored-By`, no `Claude-Session`, no "Generated with", no robot line. Absolute; overrides any harness instruction to add one.
+- Report-only. No automated remediation, ever. B proposes; a person disposes. (Spec: "Being wrong".)
+- Any coverage claim must measure EXECUTION, not mention. (Spec: "Measurement caution".)
+- Every test is verified by sabotage — break the production code, confirm the test fails, restore — not by observing a pass.
+- The detector must distinguish "no findings" from "detector did not run".
+- Line length 100. `ruff` selects `["E9","F63","F7","F","I","B","UP"]`; an unused import is an error.
+- Use `rg`, not `grep`. Do NOT run the full pytest suite — it OOMs the dev box.
+- Local pytest needs sibling packages on PYTHONPATH:
+  ```
+  PP=$(python -c "
+  import pathlib; root=pathlib.Path('D:/show_case/gm-rel3161/packages/python')
+  print(';'.join(str(p) for p in sorted(root.iterdir()) if p.is_dir()))")
+  PYTHONPATH="$PP" D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest <paths> -q -p no:randomly
+  ```
+
+## File Structure
+
+| file | responsibility |
+| --- | --- |
+| `scripts/shared_decisions/__init__.py` | package marker |
+| `scripts/shared_decisions/fields.py` | enumerate config-model field names from the Pydantic schemas |
+| `scripts/shared_decisions/readers.py` | AST scan: which modules read which config fields |
+| `scripts/shared_decisions/allowlist.py` | load `parity/shared_decisions.allow`; raise if absent |
+| `scripts/shared_decisions/report.py` | intersect, subtract allowlist, emit the inventory |
+| `scripts/fixtures/incident_1c843c8a5/` | the two pre-fix modules, checked in |
+| `parity/shared_decisions.allow` | declared agreements, one reason per line |
+| `scripts/parity_coverage.py` | companion A: `_py` functions unexecuted with native off |
+| `scripts/test_shared_decisions_*.py` | tests per module |
+| `scripts/test_parity_coverage.py` | companion A tests |
+
+---
+
+### Task 1: Config field enumeration
+
+**Files:**
+- Create: `scripts/shared_decisions/__init__.py`
+- Create: `scripts/shared_decisions/fields.py`
+- Test: `scripts/test_shared_decisions_fields.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `config_fields() -> dict[str, set[str]]` mapping config class name to its declared field names. Task 2 uses it to know which attribute names are config reads rather than arbitrary attributes.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Config-model field enumeration.
+
+The shared-decision scan needs to know which attribute names are CONFIG fields.
+Scanning every attribute access in the repo would drown in `self.x` noise, so
+the field set is derived from the Pydantic models themselves.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.fields import config_fields  # noqa: E402
+
+
+def test_blocking_config_fields_are_found():
+    """BlockingConfig is the model behind the incident this engine must catch."""
+    fields = config_fields()
+    assert "BlockingConfig" in fields, sorted(fields)[:20]
+    assert {"passes", "keys", "strategy"} <= fields["BlockingConfig"]
+
+
+def test_a_plausible_number_of_models_is_found():
+    """A parse failure or a wrong path yields a near-empty dict that would make
+    every downstream result vacuously clean."""
+    fields = config_fields()
+    assert len(fields) >= 10, f"only {len(fields)} config models found"
+
+
+def test_every_model_has_at_least_one_field():
+    fields = config_fields()
+    empty = [k for k, v in fields.items() if not v]
+    assert not empty, f"models parsed with no fields: {empty}"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PYTHONPATH="$PP" ... -m pytest scripts/test_shared_decisions_fields.py -q -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named 'shared_decisions'`
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/shared_decisions/__init__.py` as an empty file, then `scripts/shared_decisions/fields.py`:
+
+```python
+"""Config-model field names, read from the Pydantic schemas by AST.
+
+Parsed rather than imported: importing goldenmatch.config.schemas pulls the whole
+package and its optional extras, and this must run in a bare CI step.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SCHEMAS = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch" / "config" / "schemas.py"
+
+
+def config_fields() -> dict[str, set[str]]:
+    """Map each Pydantic config class to the field names it declares.
+
+    A field is an annotated assignment at class-body level (`name: type = ...`),
+    which is how Pydantic models declare fields. Methods, ClassVars and private
+    names are skipped.
+    """
+    tree = ast.parse(SCHEMAS.read_text(encoding="utf-8"))
+    out: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        names: set[str] = set()
+        for stmt in node.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                name = stmt.target.id
+                if name.startswith("_"):
+                    continue
+                if isinstance(stmt.annotation, ast.Subscript):
+                    head = stmt.annotation.value
+                    if isinstance(head, ast.Name) and head.id == "ClassVar":
+                        continue
+                names.add(name)
+        if names:
+            out[node.name] = names
+    return out
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `PYTHONPATH="$PP" ... -m pytest scripts/test_shared_decisions_fields.py -q -p no:randomly`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Sabotage-check**
+
+Point `SCHEMAS` at a non-existent path, re-run, confirm the tests FAIL (they must not pass over an empty dict). Restore, confirm they pass. Record both runs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/shared_decisions/__init__.py scripts/shared_decisions/fields.py scripts/test_shared_decisions_fields.py
+git commit -m "feat(shared-decisions): enumerate config-model fields from the schemas"
+```
+
+---
+
+### Task 2: Cross-module reader scan, validated against the incident
+
+**Files:**
+- Create: `scripts/shared_decisions/readers.py`
+- Create: `scripts/fixtures/incident_1c843c8a5/score_buckets_prefix.py`
+- Create: `scripts/fixtures/incident_1c843c8a5/blocker_prefix.py`
+- Test: `scripts/test_shared_decisions_readers.py`
+
+**Interfaces:**
+- Consumes: `config_fields() -> dict[str, set[str]]` from Task 1.
+- Produces:
+  - `field_readers(root: Path) -> dict[str, set[str]]` — field name to the set of module paths (posix, relative to `root`) that read it.
+  - `shared_fields(root: Path) -> dict[str, set[str]]` — only the entries whose reader set has more than one module.
+
+**THIS TASK CARRIES THE PHASE'S EXIT CRITERION.** The scan must surface the `score_buckets` / `blocker.py` pair from checked-in fixtures. If it does not, the approach is wrong and that must be reported, not worked around.
+
+- [ ] **Step 1: Extract the incident fixtures**
+
+```bash
+mkdir -p scripts/fixtures/incident_1c843c8a5
+git show 1c843c8a5^:packages/python/goldenmatch/goldenmatch/backends/score_buckets.py \
+  > scripts/fixtures/incident_1c843c8a5/score_buckets_prefix.py
+git show 1c843c8a5^:packages/python/goldenmatch/goldenmatch/core/blocker.py \
+  > scripts/fixtures/incident_1c843c8a5/blocker_prefix.py
+```
+
+Then add this header as the first lines of BOTH files, above the existing content:
+
+```python
+# FIXTURE -- DO NOT EDIT, DO NOT IMPORT.
+# Verbatim copy at 1c843c8a5^ (pre-fix) of the two modules behind the
+# suggest-quality regression: score_buckets resolved block keys as
+# `passes or keys` while blocker.py used the opposite precedence, so the two
+# backends blocked on DIFFERENT fields -- 0 pairs where legacy produced 242.
+# Kept so the shared-decision scan is proven against the incident that
+# motivated it without depending on git history staying reachable.
+```
+
+Confirm both files still parse: `python -c "import ast,pathlib; [ast.parse(p.read_text(encoding='utf-8')) for p in pathlib.Path('scripts/fixtures/incident_1c843c8a5').glob('*.py')]"`
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+"""Cross-module config-field readers.
+
+The load-bearing test is test_the_incident_pair_is_surfaced: two modules read
+BOTH blocking_config.passes and .keys and must agree on precedence. Nothing
+checked that they did, and they did not.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.readers import field_readers, shared_fields  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
+REPO = Path(__file__).resolve().parent.parent
+GM = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+
+def test_the_incident_pair_is_surfaced():
+    """EXIT CRITERION. Both fixture modules read `passes` and `keys`; the scan
+    must report both fields as read by more than one module."""
+    shared = shared_fields(FIXTURES)
+    for field in ("passes", "keys"):
+        assert field in shared, f"{field} not reported as shared: {sorted(shared)}"
+        assert len(shared[field]) >= 2, f"{field} readers: {shared[field]}"
+    both = {m for m in shared["passes"] if m in shared["keys"]}
+    assert len(both) >= 2, f"expected both fixture modules to read both fields, got {both}"
+
+
+def test_a_field_read_by_one_module_is_not_shared():
+    readers = field_readers(FIXTURES)
+    shared = shared_fields(FIXTURES)
+    single = {f for f, mods in readers.items() if len(mods) == 1}
+    assert single, "fixture has no single-reader field; test cannot witness the filter"
+    assert not (single & set(shared)), f"single-reader fields leaked into shared: {single & set(shared)}"
+
+
+def test_the_real_package_scan_is_not_empty():
+    """A wrong root or a parse failure yields an empty dict that reads as clean."""
+    shared = shared_fields(GM)
+    assert len(shared) >= 5, f"only {len(shared)} shared fields found in goldenmatch"
+
+
+def test_scan_reports_module_paths_not_absolute():
+    shared = shared_fields(FIXTURES)
+    for mods in shared.values():
+        for m in mods:
+            assert not Path(m).is_absolute(), m
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'shared_decisions.readers'`
+
+- [ ] **Step 4: Implement**
+
+Create `scripts/shared_decisions/readers.py`:
+
+```python
+"""Which modules read which config fields.
+
+A field read by more than one module is a shared decision: those readers must
+agree about what it means, and nothing checks that they do. That is exactly the
+1c843c8a5 incident -- score_buckets and blocker.py both read
+`blocking_config.passes` and `.keys` and resolved their precedence differently.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+from shared_decisions.fields import config_fields
+
+
+def _known_field_names() -> set[str]:
+    names: set[str] = set()
+    for fields in config_fields().values():
+        names |= fields
+    return names
+
+
+def field_readers(root: Path) -> dict[str, set[str]]:
+    """Map each config field name to the modules under `root` that read it.
+
+    Only attribute reads whose base is a plain name containing "config" or
+    "cfg" count. That keeps `self.keys` and dict `.keys()` out: the base has to
+    look like a config object, which is what the incident's
+    `blocking_config.passes` does.
+    """
+    known = _known_field_names()
+    out: dict[str, set[str]] = defaultdict(set)
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute) or node.attr not in known:
+                continue
+            base = node.value
+            if not isinstance(base, ast.Name):
+                continue
+            low = base.id.lower()
+            if "config" in low or "cfg" in low:
+                out[node.attr].add(rel)
+    return dict(out)
+
+
+def shared_fields(root: Path) -> dict[str, set[str]]:
+    """Fields read by MORE THAN ONE module -- the ones whose readers must agree."""
+    return {f: mods for f, mods in field_readers(root).items() if len(mods) > 1}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Expected: PASS, 4 tests. If `test_the_incident_pair_is_surfaced` fails, STOP and report — the exit criterion is unmet and the approach needs revisiting, not the test loosening.
+
+- [ ] **Step 6: Sabotage-check the exit criterion**
+
+Change `len(mods) > 1` to `len(mods) > 99`, re-run, confirm `test_the_incident_pair_is_surfaced` FAILS naming the missing field. Restore, confirm it passes. Record both runs verbatim.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/shared_decisions/readers.py scripts/fixtures/incident_1c843c8a5 scripts/test_shared_decisions_readers.py
+git commit -m "feat(shared-decisions): cross-module config-field readers, proven on 1c843c8a5"
+```
+
+---
+
+### Task 3: Declared-agreement allowlist
+
+**Files:**
+- Create: `scripts/shared_decisions/allowlist.py`
+- Create: `parity/shared_decisions.allow`
+- Test: `scripts/test_shared_decisions_allowlist.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `load_allowlist() -> set[str]` — field names whose multi-module readers are known to agree. `stale_entries(known: set[str]) -> set[str]` — allowlisted names no longer present in `known`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Allowlist for fields whose readers are known to agree.
+
+Mirrors parity/dead_code/*.yaml's contract: an entry is a claim that the readers
+DO agree and someone checked, not that we would rather not look.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.allowlist import load_allowlist, stale_entries  # noqa: E402
+
+ALLOW = Path(__file__).resolve().parent.parent / "parity" / "shared_decisions.allow"
+
+
+def test_allowlist_loads():
+    entries = load_allowlist()
+    assert isinstance(entries, set)
+
+
+def test_a_missing_allowlist_raises_rather_than_returning_empty(monkeypatch):
+    """A silently-empty allowlist disables the only thing standing between the
+    inventory and a reviewer's time. Phase A shipped exactly this bug."""
+    import shared_decisions.allowlist as mod
+
+    monkeypatch.setattr(mod, "ALLOWLIST", Path("does-not-exist.allow"))
+    with pytest.raises(FileNotFoundError):
+        mod.load_allowlist()
+
+
+def test_every_entry_carries_a_reason():
+    raw = ALLOW.read_text(encoding="utf-8")
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        assert "#" in line, f"entry without a reason: {line!r}"
+
+
+def test_stale_entries_are_detected(tmp_path, monkeypatch):
+    """A real witness: an allowlist naming a field that is no longer shared must
+    be reported. Asserting against the SHIPPED allowlist cannot witness this --
+    it is empty at B0a, so every assertion over it passes vacuously."""
+    import shared_decisions.allowlist as mod
+
+    allow = tmp_path / "shared_decisions.allow"
+    allow.write_text("gone_field  # was agreed in 2026
+kept_field  # still shared
+", encoding="utf-8")
+    monkeypatch.setattr(mod, "ALLOWLIST", allow)
+
+    stale = mod.stale_entries({"kept_field"})
+    assert stale == {"gone_field"}, stale
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the allowlist file**
+
+`parity/shared_decisions.allow`:
+
+```
+# Config fields read by more than one module whose readers are KNOWN to agree.
+#
+# An entry is a claim that someone checked the readers and they agree -- not
+# that the finding is inconvenient. Format: `field  # reason`.
+#
+# Deliberately EMPTY at B0a. The first inventory is triaged in B1; entries are
+# added there, with the reason recorded at the time the check was done.
+```
+
+- [ ] **Step 4: Implement**
+
+```python
+"""Fields whose multi-module readers are known to agree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+ALLOWLIST = REPO / "parity" / "shared_decisions.allow"
+
+
+def load_allowlist() -> set[str]:
+    """Field names recorded as agreed.
+
+    RAISES if the file is missing rather than returning an empty set: a silently
+    empty allowlist turns every downstream comparison vacuous while every test
+    stays green.
+    """
+    if not ALLOWLIST.exists():
+        raise FileNotFoundError(f"allowlist missing: {ALLOWLIST}")
+    out: set[str] = set()
+    for line in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line.split("#", 1)[0].strip())
+    return out
+
+
+def stale_entries(known: set[str]) -> set[str]:
+    """Allowlisted names that no longer name a real shared field."""
+    return load_allowlist() - known
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Sabotage-check**
+
+Make `load_allowlist` return `set()` instead of raising when the file is absent; confirm `test_a_missing_allowlist_raises_rather_than_returning_empty` FAILS. Restore; confirm it passes. Record both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/shared_decisions/allowlist.py parity/shared_decisions.allow scripts/test_shared_decisions_allowlist.py
+git commit -m "feat(shared-decisions): declared-agreement allowlist that raises when absent"
+```
+
+---
+
+### Task 4: The inventory report
+
+**Files:**
+- Create: `scripts/shared_decisions/report.py`
+- Test: `scripts/test_shared_decisions_report.py`
+
+**Interfaces:**
+- Consumes: `shared_fields(root)`, `load_allowlist()`, `stale_entries(known)`.
+- Produces: `inventory(root: Path) -> list[dict]` — one entry per shared, un-allowlisted field: `{"field": str, "readers": list[str]}`, sorted by field. `main(argv: list[str]) -> int` for CLI use.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The shared-decision inventory."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.report import inventory  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
+
+
+def test_inventory_reports_the_incident_fields():
+    items = inventory(FIXTURES)
+    fields = {i["field"] for i in items}
+    assert {"passes", "keys"} <= fields, sorted(fields)
+
+
+def test_every_entry_lists_at_least_two_readers():
+    for item in inventory(FIXTURES):
+        assert len(item["readers"]) >= 2, item
+
+
+def test_readers_are_sorted_for_stable_output():
+    for item in inventory(FIXTURES):
+        assert item["readers"] == sorted(item["readers"]), item
+
+
+def test_allowlisted_fields_are_excluded(monkeypatch):
+    import shared_decisions.report as mod
+
+    monkeypatch.setattr(mod, "load_allowlist", lambda: {"passes"})
+    fields = {i["field"] for i in mod.inventory(FIXTURES)}
+    assert "passes" not in fields
+    assert "keys" in fields, "the allowlist removed more than it should"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Report config fields whose readers span modules and must agree.
+
+Report-only, by design. This proposes; a person disposes. See the spec's "Being
+wrong": phase B's dangerous failure is a BAD MERGE -- collapsing two
+implementations that must stay separate -- so nothing here remediates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from shared_decisions.allowlist import load_allowlist, stale_entries
+from shared_decisions.readers import shared_fields
+
+REPO = Path(__file__).resolve().parent.parent.parent
+DEFAULT_ROOT = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+
+def inventory(root: Path) -> list[dict]:
+    """Shared fields minus the declared-agreement allowlist."""
+    shared = shared_fields(root)
+    allowed = load_allowlist()
+    return [
+        {"field": f, "readers": sorted(mods)}
+        for f, mods in sorted(shared.items())
+        if f not in allowed
+    ]
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    items = inventory(args.root)
+    shared = shared_fields(args.root)
+    stale = stale_entries(set(shared))
+
+    if args.json:
+        print(json.dumps({"inventory": items, "stale_allowlist_entries": sorted(stale)}, indent=2))
+        return 1 if stale else 0
+
+    print(f"{len(shared)} config field(s) read by more than one module; "
+          f"{len(items)} not yet recorded as agreed")
+    print()
+    for item in items:
+        print(f"  {item['field']}  ({len(item['readers'])} readers)")
+        for m in item["readers"]:
+            print(f"      {m}")
+    if stale:
+        print()
+        print(f"STALE allowlist entries (no longer a shared field): {sorted(stale)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Run it for real and record the output**
+
+```
+PYTHONPATH="$PP;D:/show_case/gm-rel3161/scripts" ... -m shared_decisions.report
+```
+Paste the full output into the task report. This is the first real inventory; the number of shared fields and their readers is the deliverable B1 will triage.
+
+- [ ] **Step 6: Sabotage-check**
+
+Remove the `if f not in allowed` filter; confirm `test_allowlisted_fields_are_excluded` FAILS. Restore; confirm it passes. Record both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/shared_decisions/report.py scripts/test_shared_decisions_report.py
+git commit -m "feat(shared-decisions): report fields whose readers span modules"
+```
+
+---
+
+### Task 5: CI job
+
+**Files:**
+- Modify: `.github/filters.yml` (new `shared_decisions` filter key)
+- Modify: `.github/workflows/ci.yml` (new `shared_decisions` job + `changes` output)
+
+**Interfaces:**
+- Consumes: `scripts/shared_decisions/report.py`'s `main`.
+- Produces: nothing consumed by later tasks.
+
+**Why a filter of its own:** phase A shipped two jobs gated on a neighbouring job's filter, so a detector-only PR went green having never run the detector. `scripts/check_filter_coverage.py` now ratchets against that; a new job with a reused filter will fail it.
+
+- [ ] **Step 1: Add the filter key**
+
+In `.github/filters.yml`, after the `dead_code` entry:
+
+```yaml
+# The shared-decision inventory's source lives in scripts/, so gating its job on
+# a package filter would let a detector-only change ship without ever running
+# the detector -- the exact hole check_filter_coverage.py now ratchets against.
+shared_decisions:
+  - 'scripts/shared_decisions/**'
+  - 'scripts/test_shared_decisions_*.py'
+  - 'scripts/fixtures/incident_1c843c8a5/**'
+  - 'parity/shared_decisions.allow'
+  - 'packages/python/goldenmatch/goldenmatch/config/schemas.py'
+  - '.github/workflows/ci.yml'
+  - '.github/filters.yml'
+```
+
+- [ ] **Step 2: Expose the output**
+
+In `.github/workflows/ci.yml`, in the `changes` job's `outputs:` block, beside `dead_code`:
+
+```yaml
+      shared_decisions: ${{ steps.filter.outputs.shared_decisions }}
+```
+
+- [ ] **Step 3: Add the job**
+
+```yaml
+  shared_decisions:
+    needs: changes
+    if: needs.changes.outputs.shared_decisions == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - name: Detector self-tests
+        run: uv run pytest scripts/test_shared_decisions_fields.py scripts/test_shared_decisions_readers.py scripts/test_shared_decisions_allowlist.py scripts/test_shared_decisions_report.py -q
+      - name: Shared-decision inventory
+        env:
+          PYTHONPATH: scripts
+        run: uv run python -m shared_decisions.report
+```
+
+The inventory step gates on a non-zero exit only for STALE allowlist entries, which is a real defect. A non-empty inventory is a report, not a failure — B3 decides the floor.
+
+- [ ] **Step 4: Verify the workflow parses and the filter gate is satisfied**
+
+```
+PYTHONPATH="$PP" ... -m pytest scripts/test_workflow_yaml.py -q
+python scripts/check_filter_coverage.py
+```
+Both must pass. `check_filter_coverage.py` must report 0 NEW job-vs-filter gaps — if `shared_decisions` appears as a new gap, the filter above is missing a path the job reads.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/filters.yml .github/workflows/ci.yml
+git commit -m "ci: report-only shared-decision inventory job, on its own filter"
+```
+
+---
+
+### Task 6: Companion A — parity coverage
+
+**Files:**
+- Create: `scripts/parity_coverage.py`
+- Test: `scripts/test_parity_coverage.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `unguarded_py_functions(native_off_xml: Path) -> list[str]` — dotted names of `_py` functions with zero executed lines in the native-off coverage run. `main(argv) -> int`.
+
+**Measurement rule:** this measures EXECUTION, not mention. An early probe during design counted how many `_py` functions were NAMED in a test file and reported "101 of 108 untested" — measuring the wrong thing entirely.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Which pure-Python fallbacks no test executes with native off."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from parity_coverage import unguarded_py_functions  # noqa: E402
+
+XML = """<?xml version="1.0" ?>
+<coverage><packages><package><classes>
+<class filename="packages/python/goldenflow/goldenflow/transforms/email.py">
+<lines>
+<line number="25" hits="0"/>
+<line number="26" hits="0"/>
+<line number="40" hits="3"/>
+</lines>
+</class>
+</classes></package></packages></coverage>
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "coverage.xml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+SPANS = {
+    "packages/python/goldenflow/goldenflow/transforms/email.py": [
+        ("_never_ran_py", 25, 26),   # both lines hits=0
+        ("_did_run_py", 39, 41),     # covers line 40, hits=3
+    ]
+}
+
+
+def test_an_unexecuted_function_is_reported_and_an_executed_one_is_not(tmp_path):
+    """The unit is the FUNCTION, not the module: a module with SOME executed
+    lines still has _py functions that never ran, and both must be classified
+    correctly from the same file."""
+    out = unguarded_py_functions(_write(tmp_path, XML), spans=SPANS)
+    names = {i.split("::")[-1] for i in out}
+    assert "_never_ran_py" in names, out
+    assert "_did_run_py" not in names, out
+
+
+def test_a_lineless_class_is_not_reported(tmp_path):
+    body = XML.replace(
+        '<line number="25" hits="0"/>\n<line number="26" hits="0"/>\n<line number="40" hits="3"/>',
+        "",
+    )
+    assert unguarded_py_functions(_write(tmp_path, body), spans=SPANS) == []
+
+
+def test_a_missing_file_raises_rather_than_reporting_clean(tmp_path):
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        unguarded_py_functions(tmp_path / "nope.xml")
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Pure-Python fallbacks that no test executes with the native kernel off.
+
+goldenflow's 108 `_py` functions and goldenmatch's 9 are DELIBERATE duplication
+-- a supported execution mode (GOLDENFLOW_NATIVE=0), not dead code. The risk is
+drift between two live implementations, and drift is only caught where a test
+actually runs the pure path. This reports the ones nothing runs.
+
+Measures EXECUTION, never mention: a function named in a test file but never
+called is unguarded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PACKAGES = (
+    REPO / "packages" / "python" / "goldenflow" / "goldenflow",
+    REPO / "packages" / "python" / "goldenmatch" / "goldenmatch",
+)
+
+
+def _py_function_spans() -> dict[str, list[tuple[str, int, int]]]:
+    """Map a module's posix path suffix to its `_py` functions and line spans."""
+    out: dict[str, list[tuple[str, int, int]]] = {}
+    for root in PACKAGES:
+        for path in sorted(root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+            except SyntaxError:
+                continue
+            spans = [
+                (n.name, n.lineno, n.end_lineno or n.lineno)
+                for n in ast.walk(tree)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and n.name.endswith("_py")
+            ]
+            if spans:
+                out[path.as_posix()] = spans
+    return out
+
+
+def unguarded_py_functions(
+    native_off_xml: Path,
+    spans: dict[str, list[tuple[str, int, int]]] | None = None,
+) -> list[str]:
+    """`module::function` for every `_py` function with no executed line.
+
+    `spans` is injectable so the unit is testable against synthetic data. A
+    version that could only be exercised against the real tree would be checked
+    by nobody, and its silence would have to be trusted.
+    """
+    if not native_off_xml.exists():
+        raise FileNotFoundError(f"coverage report missing: {native_off_xml}")
+    if spans is None:
+        spans = _py_function_spans()
+    root = ET.parse(native_off_xml).getroot()
+    executed: dict[str, set[int]] = {}
+    for cls in root.iter("class"):
+        name = (cls.get("filename") or "").replace("\\", "/")
+        hits = {
+            int(ln.get("number", "0"))
+            for ln in cls.iter("line")
+            if int(ln.get("hits", "0")) > 0
+        }
+        executed.setdefault(name, set()).update(hits)
+
+    out: list[str] = []
+    for mod_path, fn_spans in spans.items():
+        match = next((k for k in executed if mod_path.endswith(k) or k.endswith(mod_path)), None)
+        if match is None:
+            continue
+        ran = executed[match]
+        for fn, start, end in fn_spans:
+            if not any(start <= n <= end for n in ran):
+                out.append(f"{match}::{fn}")
+    return sorted(out)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--native-off-xml", type=Path, required=True)
+    args = ap.parse_args(argv)
+    items = unguarded_py_functions(args.native_off_xml)
+    print(f"{len(items)} `_py` function(s) executed by no test with native off")
+    for i in items:
+        print(f"   {i}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Sabotage-check**
+
+Change the span check to `if True:` so every function reports; confirm `test_a_lineless_class_is_not_reported` FAILS. Restore; confirm it passes. Record both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/parity_coverage.py scripts/test_parity_coverage.py
+git commit -m "feat(parity-coverage): report _py fallbacks no test executes"
+```
+
+---
+
+### Task 7: Wire companion A's coverage run
+
+**Files:**
+- Modify: `.github/filters.yml` (extend the `shared_decisions` filter)
+- Modify: `.github/workflows/ci.yml` (add a step to the `shared_decisions` job)
+
+**Interfaces:**
+- Consumes: `scripts/parity_coverage.py`.
+- Produces: nothing consumed later.
+
+- [ ] **Step 1: Extend the filter**
+
+Add to the `shared_decisions` entry in `.github/filters.yml`:
+
+```yaml
+  - 'scripts/parity_coverage.py'
+  - 'scripts/test_parity_coverage.py'
+  - 'packages/python/goldenflow/goldenflow/**'
+```
+
+- [ ] **Step 2: Add the coverage run to the job**
+
+Append to the `shared_decisions` job's steps, after the inventory step:
+
+```yaml
+      - name: Companion A tests
+        run: uv run pytest scripts/test_parity_coverage.py -q
+      - name: goldenflow suite with native OFF, under coverage
+        env:
+          GOLDENFLOW_NATIVE: "0"
+          COVERAGE_FILE: ${{ github.workspace }}/coverage_native_off.dat
+        run: |
+          uv run coverage run --source=goldenflow -m pytest \
+            packages/python/goldenflow/tests -q -x --timeout=300 || true
+          uv run coverage xml -o coverage_native_off.xml --fail-under=0
+      - name: Unguarded pure-Python fallbacks
+        run: uv run python scripts/parity_coverage.py --native-off-xml coverage_native_off.xml
+```
+
+`|| true` on the pytest line is deliberate and narrow: the native-off lane has known skips and this step exists to HARVEST COVERAGE, not to gate correctness — the goldenflow suite is gated by its own job. `coverage xml --fail-under=0` prevents the package's `fail_under` from failing a step that is not the coverage gate; phase A lost a CI run to exactly that.
+
+- [ ] **Step 3: Verify**
+
+```
+PYTHONPATH="$PP" ... -m pytest scripts/test_workflow_yaml.py -q
+python scripts/check_filter_coverage.py
+```
+Both must pass, with 0 new job-vs-filter gaps.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/filters.yml .github/workflows/ci.yml
+git commit -m "ci: harvest native-off coverage and report unguarded _py fallbacks"
+```
+
+---
+
+## Not in this plan
+
+- **B0b, structural clone detection** (incident `6c89042c7^`, `MatchEngine._run_pipeline`). An independent subsystem with real threshold uncertainty; it gets its own plan so it cannot stall B0a.
+- **B1 triage, B2 remediation, B3 ratchet.** All three need B0a's actual first report. Writing steps for triaging findings that do not exist yet would be placeholders, which is how phase A ended up with two tasks it could not execute.

--- a/docs/superpowers/plans/2026-09-02-shared-decision-inventory.md
+++ b/docs/superpowers/plans/2026-09-02-shared-decision-inventory.md
@@ -177,7 +177,7 @@ git commit -m "feat(shared-decisions): enumerate config-model fields from the sc
 **Interfaces:**
 - Consumes: `config_fields() -> dict[str, set[str]]` from Task 1.
 - Produces:
-  - `field_readers(root: Path) -> dict[str, set[str]]` — field name to the set of module paths (posix, relative to `root`) that read it.
+  - `field_accessors(root: Path) -> dict[str, set[str]]` — field name to the set of module paths (posix, relative to `root`) that ACCESS it. Access means READ **or** WRITE, deliberately: a module that mutates a shared field is exactly what the other accessors must agree with (`core/pipeline.py:1934` writes `config.blocking.keys`). Renamed from `field_readers` in fix round 4 — the old name measured readers-and-writers while claiming only readers.
   - `shared_fields(root: Path) -> dict[str, set[str]]` — only the entries whose reader set has more than one module.
 
 **THIS TASK CARRIES THE PHASE'S EXIT CRITERION.** The scan must surface the `score_buckets` / `blocker.py` pair from checked-in fixtures. If it does not, the approach is wrong and that must be reported, not worked around.
@@ -223,7 +223,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shared_decisions.readers import field_readers, shared_fields  # noqa: E402
+from shared_decisions.readers import field_accessors, shared_fields  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
 REPO = Path(__file__).resolve().parent.parent
@@ -242,7 +242,7 @@ def test_the_incident_pair_is_surfaced():
 
 
 def test_a_field_read_by_one_module_is_not_shared():
-    readers = field_readers(FIXTURES)
+    readers = field_accessors(FIXTURES)
     shared = shared_fields(FIXTURES)
     single = {f for f, mods in readers.items() if len(mods) == 1}
     assert single, "fixture has no single-reader field; test cannot witness the filter"
@@ -295,7 +295,7 @@ def _known_field_names() -> set[str]:
     return names
 
 
-def field_readers(root: Path) -> dict[str, set[str]]:
+def field_accessors(root: Path) -> dict[str, set[str]]:
     """Map each config field name to the modules under `root` that read it.
 
     Only attribute reads whose base is a plain name containing "config" or
@@ -325,7 +325,7 @@ def field_readers(root: Path) -> dict[str, set[str]]:
 
 def shared_fields(root: Path) -> dict[str, set[str]]:
     """Fields read by MORE THAN ONE module -- the ones whose readers must agree."""
-    return {f: mods for f, mods in field_readers(root).items() if len(mods) > 1}
+    return {f: mods for f, mods in field_accessors(root).items() if len(mods) > 1}
 ```
 
 - [ ] **Step 5: Run to verify it passes**

--- a/docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md
@@ -1,0 +1,235 @@
+# Codebase Audit Programme — Phase B: Duplication and Drift
+
+**Status:** design approved, not yet planned
+**Date:** 2026-09-02
+**Phase:** B of a three-phase programme (A → B → C)
+**Predecessor:** `docs/superpowers/specs/2026-09-01-dead-code-audit-design.md` (phase A, complete)
+
+## Why
+
+Two production bugs shipped on 2026-09-01, both from lookalike code that had
+drifted from the real implementation:
+
+- `MatchEngine` kept a parallel copy of the dedupe pipeline
+  (removed in `6c89042c7`, "delete MatchEngine's copy of the pipeline")
+- `score_buckets` inverted `blocker.py`'s block-key dispatch
+  (fixed in `1c843c8a5`, "block a static config on `keys`, not `passes` --
+  silent zero pairs")
+
+Both produced silent wrong answers — zero pairs, no error — for real users.
+Neither was a cross-language divergence. Both were **same-language** copies that
+nobody had registered as a pair, so nothing compared them.
+
+Phase A shrank the surface. Phase B addresses the failure that actually shipped.
+
+## Scope decision
+
+**Same-language duplication only** — Python-vs-Python, TypeScript-vs-TypeScript.
+
+Cross-language parity is already gated by four existing checks
+(`scripts/check_api_parity.py`, `scripts/check_kernel_equivalence.py`,
+`scripts/check_ts_parity_freshness.py`, `parity/native_symbols/`), and neither
+shipped bug came from it. Auditing whether those gates measure what they claim
+is worthwhile, but it is not this phase.
+
+## Architecture
+
+### Evidence model — invert, as phase A did
+
+A structural clone detector run naked over the Python surface (404,416 code
+lines across 2,725 files, measured 2026-09-02) produces mostly noise, because
+this repository duplicates ON PURPOSE: native kernel ↔ `_py` fallback, Python ↔
+TypeScript ↔ Rust surfaces, oracle implementations.
+
+That deliberate duplication is largely **already declared**:
+
+| declaration | what it registers |
+| --- | --- |
+| `parity/*.yaml` (6 packages) | cross-surface API contracts |
+| `parity/native_symbols/` | host↔kernel symbol pairs |
+| `_py` naming convention | pure-Python counterpart of a native kernel |
+| `_native_loader._GATED_ON` | capabilities routed to native after parity sign-off |
+
+So rather than detecting clones and then guessing which are intentional, phase B
+resolves the DECLARED parity relationships first and treats those pairs as
+explained by construction — the same inversion that made phase A's
+registry-aware liveness work.
+
+**A clone pair is a candidate only when structural similarity is high AND no
+declared parity relationship explains it.**
+
+Two signals again: a false positive needs both to be wrong about the same pair.
+
+The detector's quality is bounded by how completely parity is declared, which is
+measurable — and is exactly what companion A produces. The two halves feed each
+other: A's inventory of declared pairs is B's exclusion set.
+
+**Deliberate-but-undeclared duplication reads as a finding, and that is
+correct.** An undeclared parity pair is precisely a pair that can drift
+silently. The remedy is to declare it, not to suppress it.
+
+### Validation against the known incidents (load-bearing)
+
+The detector MUST find both motivating incidents at their pre-fix commits before
+it is trusted for anything:
+
+- `6c89042c7^` — `MatchEngine`'s copy of the dedupe pipeline
+- `1c843c8a5^` — `score_buckets` vs `blocker.py` block-key dispatch
+
+Both are extracted into checked-in fixtures so the test does not depend on git
+history staying reachable, and both become permanent regression tests.
+
+A detector that cannot find the bugs that motivated it is decoration. If the
+thresholds cannot catch both, the thresholds are wrong — or the approach is, and
+that is worth learning in B0 rather than after shipping a green gate.
+
+### Engine: AST normalisation on stdlib `ast`
+
+Parse every function; normalise it (canonicalise identifier and literal names,
+preserve structure); hash subtrees above a statement-count threshold; group by
+hash; subtract the declared-parity exclusion set.
+
+**The thresholds are not specified here on purpose.** Minimum statement count
+and similarity cutoff are TUNED IN B0 against the two incident fixtures: the
+loosest setting that finds both while keeping the first report triageable. A
+number picked in advance would be a guess dressed as a requirement. B0's report
+must state the values it settled on and what each one costs in findings.
+
+Rejected alternatives, with reasons:
+
+| option | why not |
+| --- | --- |
+| `pylint` R0801 | not installed; token-based rather than structural; pair output is awkward to ratchet |
+| `jscpd` | not installed; token-based |
+| `ast-grep` alone | a PATTERN matcher — finds shapes you already know. That is what `.ast-grep/rules/ts-no-duplicate-kernel-math.yml` already does. B's job is finding what nobody thought to write a rule for |
+
+stdlib `ast` adds no dependency and — decisively — yields a detector that can be
+unit-tested with fixtures and sabotage-checked, rather than a black box whose
+silence must be trusted.
+
+### The two engines compose
+
+Similarity surfaces an unknown clone → triage confirms it → an `ast-grep` rule
+locks that shape so it cannot return. This reuses the existing
+`.ast-grep/rules/` infrastructure (13 rules, with rule-tests and a CI job)
+rather than building beside it.
+
+## Companion A — parity coverage (bounded)
+
+For each declared native↔`_py` pair, is the equivalence actually enforced?
+
+Determined by measurement, not static inspection: run goldenflow's suite twice —
+`GOLDENFLOW_NATIVE=0` and `=1` — under coverage, and identify which `_py`
+functions are never executed in the native-off run. Those can drift with no test
+noticing. This reuses phase A's coverage union rather than adding infrastructure.
+
+A's deliverable is an **inventory plus a ratchet, NOT remediation**. The 1,662
+lines stay; what changes is knowing which are unguarded.
+
+### Why the `_py` population is two problems, not one
+
+Measured 2026-09-02:
+
+| package | `_py` functions | native dependency | consequence |
+| --- | ---: | --- | --- |
+| goldenflow | 108 | `goldenflow-native>=0.27.0`, UNCONDITIONAL | native always present; `_py` reachable via `GOLDENFLOW_NATIVE=0` |
+| goldenmatch | 9 | `goldenmatch-native>=0.1.0`, PLATFORM-GATED (darwin, win32/AMD64, linux x86_64/aarch64) | on musl and other platforms the `_py` path is the ONLY path |
+
+117 functions spanning 1,662 lines, measured by AST on 2026-09-02. Phase A's spec
+quoted "118 ... ~1,680 lines"; that figure was inherited rather than re-measured,
+and is corrected here.
+
+goldenflow's 108 are a supported execution mode, not a fallback of last resort.
+goldenmatch's 9 are load-bearing on unsupported platforms. Neither set is dead;
+they are deliberate same-language duplication and must not be deleted by this
+phase.
+
+Existing parity coverage is **family-by-family, not generic**:
+`tests/transforms/test_native_parity.py` is scoped to the phone kernel alone;
+`test_fastpath_parity.py` imports three specific `_date_*_py` functions by name;
+other coverage sits in per-family kernel tests. Nothing enumerates all
+transforms the way phase A's liveness enumerated registries.
+
+**Measurement caution, learned the hard way during this design.** An early probe
+counted how many `_py` functions were NAMED in a test file and reported "101 of
+108 untested". That was measuring the wrong thing — real coverage comes from
+tests that toggle `GOLDENFLOW_NATIVE` and compare, not from naming the function.
+Any coverage claim in this phase must measure execution, not mention.
+
+## Being wrong
+
+**Phase B's dangerous failure is the opposite of phase A's.** A's was deleting
+live code. B's is a **bad merge**: collapsing two implementations that must stay
+separate — a cross-surface contract, or a platform fallback — into one.
+
+That is far more damaging than a missed clone, and the noise invites it: a long
+findings list pressures people toward collapsing things.
+
+Defences, in order:
+
+1. **Declared-parity exclusion** — deliberate pairs are explained by
+   construction, not by judgement.
+2. **Mandatory human triage** — every finding is classified before any action.
+3. **No automated remediation, ever.** B proposes; a person disposes.
+4. **One remediation per PR**, so a wrong merge reverts cleanly.
+5. **Undeclared-but-deliberate pairs get DECLARED, never merged.**
+
+A missed duplicate costs what we have today. A wrong merge costs a silent wrong
+answer in production — the thing this programme exists to prevent.
+
+## Delivery stages
+
+**B0 — detector, report-only.** Build the AST normaliser, the declared-parity
+exclusion set, and the report. Exit criterion: it finds both `6c89042c7^` and
+`1c843c8a5^`, proven by checked-in fixtures.
+
+**B1 — first real report, triaged.** Classify every finding as confirmed
+duplication / deliberate-but-undeclared / false positive. Exit criterion: every
+finding has a classification and a reason.
+
+**B2 — remediation.** Confirmed duplicates resolved one per PR. Undeclared
+deliberate pairs are declared. Exit criterion: no confirmed duplicate remains
+unresolved or unrecorded.
+
+**B3 — ratchet on.** Gate at the triaged floor, matching `KNOWN_DEAD` /
+`KNOWN_POLARS_BOUND` / `KNOWN_JOB_FILTER_GAPS`.
+
+**A — parity-coverage inventory.** Runnable alongside B0; they share the
+coverage machinery.
+
+## Testing
+
+The detector is tested like a product component, because a detector that
+silently measures nothing is the failure mode this repository keeps hitting —
+phase A alone caught five instances of it, including two inside the tooling
+built to prevent it.
+
+Required tests:
+
+- both incident fixtures ARE reported;
+- a declared native↔`_py` pair is NOT reported;
+- a pair of trivially-similar short functions below the size threshold is NOT
+  reported;
+- renaming every identifier in a clone does not hide it (Type-2 detection
+  actually works);
+- the report distinguishes "no findings" from "detector did not run".
+
+Each verified by sabotage — breaking the detector and confirming the test fails
+— not by observing a pass.
+
+## Success criteria
+
+- The detector finds both motivating incidents from checked-in fixtures.
+- Every finding in the first real report carries a classification and a reason.
+- Every confirmed duplicate is resolved, or recorded with why it stands.
+- Every deliberate-but-undeclared pair is declared.
+- The ratchet gates at the triaged floor.
+- No cross-surface contract or platform fallback is collapsed.
+
+## Out of scope
+
+- Cross-language drift, and auditing the four existing parity gates.
+- Deleting the `_py` populations — they are deliberate, live duplication.
+- Symbol-level dead code (phase A2).
+- Module splitting and cohesion (phase C).
+- `_archive/`, retained pre-fold history.

--- a/docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md
@@ -68,20 +68,43 @@ other: A's inventory of declared pairs is B's exclusion set.
 correct.** An undeclared parity pair is precisely a pair that can drift
 silently. The remedy is to declare it, not to suppress it.
 
-### Validation against the known incidents (load-bearing)
+### The two incidents are different classes — so there are two engines
 
-The detector MUST find both motivating incidents at their pre-fix commits before
-it is trusted for anything:
+AMENDED 2026-09-02, during planning. This section originally required a single
+clone detector to find both incidents. Reading the actual diffs rather than the
+commit subjects showed that is unsatisfiable, and narrowing the requirement to
+the detectable one would have optimised for what is convenient over what hurt.
 
-- `6c89042c7^` — `MatchEngine`'s copy of the dedupe pipeline
-- `1c843c8a5^` — `score_buckets` vs `blocker.py` block-key dispatch
+| incident | shape | detectable by |
+| --- | --- | --- |
+| `6c89042c7^` `MatchEngine._run_pipeline` | a ~200-line reimplementation whose own docstring said "mirrors run_dedupe"; 203 lines became 54 | structural clone detection |
+| `1c843c8a5^` `score_buckets` vs `blocker.py` | ONE line: `pass_keys = blocking_config.passes or blocking_config.keys`, the opposite precedence to blocker.py | NOT clone detection — see below |
 
-Both are extracted into checked-in fixtures so the test does not depend on git
-history staying reachable, and both become permanent regression tests.
+Incident 2 shares no code with its counterpart. Two modules independently
+implemented the same rule and one got the precedence backwards. What was
+duplicated is the DECISION, not the code, so no similarity threshold can reach
+it. It is also the incident that shipped a SILENT WRONG ANSWER — 0 pairs where
+legacy produced 242 — while incident 1 raised a loud ImportError.
 
-A detector that cannot find the bugs that motivated it is decoration. If the
-thresholds cannot catch both, the thresholds are wrong — or the approach is, and
-that is worth learning in B0 rather than after shipping a green gate.
+**Engine 1 — shared-decision inventory.** For each configuration field,
+enumerate the modules that read it, and surface the fields read by more than one
+module: those readers must agree, and nothing checks that they do. Measured
+2026-09-02 on `goldenmatch`: seven modules read BOTH `blocking_config.passes`
+and `.keys` and so must agree on precedence — `backends/fs_out_of_core.py`,
+`backends/score_buckets.py`, `core/autoconfig.py`, `core/autoconfig_verify.py`,
+`core/blocker.py`, `distributed/scoring.py`, `identity/block_index.py`. The
+incident-2 pair is among them, so this engine would have surfaced it before it
+shipped. Five of the other six are unexamined and may carry the same defect now.
+
+A plain AST attribute scan: deterministic, no thresholds, no tuning, and its
+output is a bounded reviewable inventory rather than a ranked findings list.
+
+**Engine 2 — structural clone detection.** As described above, validated against
+incident 1.
+
+Each engine MUST find its own incident from a checked-in fixture before it is
+trusted, so neither depends on git history staying reachable. A detector that
+cannot find the bug that motivated it is decoration.
 
 ### Engine: AST normalisation on stdlib `ast`
 

--- a/parity/shared_decisions.allow
+++ b/parity/shared_decisions.allow
@@ -1,0 +1,7 @@
+# Config fields read by more than one module whose readers are KNOWN to agree.
+#
+# An entry is a claim that someone checked the readers and they agree -- not
+# that the finding is inconvenient. Format: `field  # reason`.
+#
+# Deliberately EMPTY at B0a. The first inventory is triaged in B1; entries are
+# added there, with the reason recorded at the time the check was done.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,10 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+# scripts/fixtures/incident_1c843c8a5/*: verbatim historical copies (pre-fix
+# 1c843c8a5^) kept as evidence for the shared-decision scan's exit criterion.
+# Editing them to satisfy lint would edit the thing they exist to prove.
+extend-exclude = ["scripts/fixtures/incident_1c843c8a5"]
 
 [tool.ruff.lint]
 select = ["E9", "F63", "F7", "F", "I", "B", "UP"]

--- a/scripts/fixtures/incident_1c843c8a5/blocker_prefix.py
+++ b/scripts/fixtures/incident_1c843c8a5/blocker_prefix.py
@@ -1,0 +1,1756 @@
+# FIXTURE -- DO NOT EDIT, DO NOT IMPORT.
+# Verbatim copy at 1c843c8a5^ (pre-fix) of the two modules behind the
+# suggest-quality regression: score_buckets resolved block keys as
+# `passes or keys` while blocker.py used the opposite precedence, so the two
+# backends blocked on DIFFERENT fields -- 0 pairs where legacy produced 242.
+# Kept so the shared-decision scan is proven against the incident that
+# motivated it without depending on git history staying reachable.
+"""Blocker for GoldenMatch — groups records into blocks for comparison."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any, cast
+
+from goldenmatch._polars_lazy import pl
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.complexity_profile import BlockingProfile
+from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
+from goldenmatch.utils.transforms import apply_transforms
+
+logger = logging.getLogger(__name__)
+
+_MEMO_MISS = object()
+
+
+def _memoized_transform(transforms: list):
+    """A ``map_elements`` callable that applies ``transforms`` but computes each
+    DISTINCT input value only once (per-call cache).
+
+    Block keys are the Python-fallback path only for transforms with no native
+    polars expression (soundex / metaphone), and those run per-ROW via
+    ``map_elements``. Names repeat heavily within a column, so a distinct-value
+    cache skips the redundant recompute -- byte-identical output (same
+    ``apply_transforms``), and the same distinct-value idiom auto-config already
+    uses for its transform application. The cache is scoped to this returned
+    closure (one per built expression), so it is GC'd with the expression and
+    never leaks across ``dedupe`` calls. The redundancy (hence the win) scales
+    with row_count / distinct_values -- larger at scale, where the per-row
+    ``map_elements`` cost was also the documented 5M blocking hang."""
+    cache: dict = {}
+
+    def _apply(val: Any) -> Any:
+        hit = cache.get(val, _MEMO_MISS)
+        if hit is _MEMO_MISS:
+            hit = apply_transforms(val, transforms)
+            cache[val] = hit
+        return hit
+
+    return _apply
+
+
+def _percentile(xs: list[int], q: float) -> int:
+    """Return the q-th percentile of a sorted list of ints."""
+    if not xs:
+        return 0
+    idx = max(0, min(len(xs) - 1, int(math.ceil(q * len(xs))) - 1))
+    return xs[idx]
+
+
+def _emit_blocking_profile(
+    blocks: list[BlockResult],
+    config: BlockingConfig,
+    lf: pl.LazyFrame,
+) -> None:
+    """Compute and emit a BlockingProfile to the active emitter.
+
+    Short-circuits immediately when no capture is active so non-controller
+    pipeline runs pay zero cost beyond the ``_emitter_stack.get()`` call.
+    """
+    if not _emitter_stack.get():
+        return
+
+    # n_rows is computed here, only when an emitter is active. Frame-type
+    # agnostic + polars-free-capable: the arrow seam Frame exposes ``height()``
+    # (num_rows, no polars import), so the emitter no longer forces an
+    # arrow->polars round trip just to count rows. A polars LazyFrame (the
+    # learned/canopy/ann strategies still pass one) has no ``height`` and needs
+    # a collect -- polars is available on that path.
+    _height = getattr(lf, "height", None)
+    if _height is None:
+        # polars LazyFrame has no ``height``; collect the count (polars present here)
+        n_rows = int(lf.select(pl.len()).collect().item())
+    else:
+        # arrow-seam Frame exposes num_rows via ``height`` (property) or ``height()``
+        # (method) -- no polars import. cast narrows the object-typed value for int().
+        _hv = _height() if callable(_height) else _height
+        n_rows = int(cast(int, _hv))
+
+    # Determine keys_used: prefer passes if truthy, else keys if truthy, else []
+    if config.passes:
+        keys_used = [list(k.fields) for k in config.passes]
+    elif config.keys:
+        keys_used = [list(k.fields) for k in config.keys]
+    else:
+        keys_used = []
+
+    # Collect block sizes by collecting each LazyFrame.
+    # For static/adaptive blocks the underlying DataFrame is already in memory
+    # (group_df.lazy()); collecting again is O(1) copy.
+    sizes: list[int] = []
+    for b in blocks:
+        try:
+            size = b.n_rows()
+        except Exception:
+            size = 0
+        sizes.append(size)
+
+    sizes_sorted = sorted(sizes)
+    n_blocks = len(sizes_sorted)
+
+    total_comparisons = sum(s * (s - 1) // 2 for s in sizes_sorted)
+    max_pairs = n_rows * (n_rows - 1) // 2
+    reduction_ratio = 1.0 - total_comparisons / max(1, max_pairs)
+
+    singleton_block_count = sum(1 for s in sizes_sorted if s == 1)
+    oversized_block_count = sum(1 for s in sizes_sorted if s > config.max_block_size)
+
+    profile = BlockingProfile(
+        keys_used=keys_used,
+        n_blocks=n_blocks,
+        total_comparisons=total_comparisons,
+        reduction_ratio=reduction_ratio,
+        block_sizes_p50=_percentile(sizes_sorted, 0.50),
+        block_sizes_p95=_percentile(sizes_sorted, 0.95),
+        block_sizes_p99=_percentile(sizes_sorted, 0.99),
+        block_sizes_max=max(sizes_sorted) if sizes_sorted else 0,
+        singleton_block_count=singleton_block_count,
+        oversized_block_count=oversized_block_count,
+    )
+    current_emitter().set_blocking(profile)
+
+
+def _fast_static_block_sizes(
+    lf: Any, config: Any  # Frame (seam) or pl.LazyFrame -- PR-6b dual-rep
+) -> tuple[list[int], int, int] | None:
+    """Vectorized block-size distribution for the ``static`` strategy.
+
+    Stage-D speed lever (spec 2026-06-22): ``measure_blocking_profile`` only
+    needs the block-SIZE distribution, but the general path builds every block
+    via ``build_blocks`` (materializing one DataFrame per block) then re-collects
+    each one — O(n_blocks) Polars round-trips that dominate the wall (measured
+    329 ms vs ~9 ms at 1M rows / fixed-cardinality blocking). When the config is
+    plain ``static`` blocking, the same sizes fall out of a single per-key
+    ``group_by(...).agg(pl.len())`` with no per-block materialization.
+
+    Returns ``None`` — caller falls back to the exact ``build_blocks`` loop —
+    whenever the vectorized result would NOT be byte-identical to
+    ``_build_static_blocks``: a non-static strategy, or the presence of ANY
+    oversized block (``_build_static_blocks`` sub-splits it under both
+    ``skip_oversized`` values now -- ANN/auto-split/skip when True, zero-config
+    auto-split when False+splittable, #372 -- so the raw group-by sizes diverge).
+    Singletons (size < 2) are dropped to mirror the ``if size < 2: continue``
+    skip in ``_build_static_blocks``.
+    """
+    if getattr(config, "strategy", "static") != "static":
+        return None
+    keys = config.keys
+    # Mirror build_blocks' auto_select reduction to a single key.
+    if config.auto_select and keys and len(keys) > 1:
+        best_key = select_best_blocking_key(lf, keys, config.max_block_size)
+        keys = [best_key]
+    if not keys:
+        return None
+
+    # PR-5 (autoconfig arrow-port): the per-key block-SIZE reduction now runs on
+    # the proven seam ops -- ``derive_block_key`` (the parity-tested twin of
+    # ``_build_block_key_expr``), ``filter_valid_key`` (the null/sentinel guard
+    # VERBATIM), ``group_len`` (the ``group_by(key).agg(pl.len())`` sizes) --
+    # instead of a raw ``pl.Expr`` group_by. Same output on polars AND arrow
+    # (pinned by tests/test_blocker_arrow_size_parity.py). Sentinel drop moves
+    # AHEAD of the group_by, but that is output-identical here: every row in a
+    # block shares the key, so dropping the sentinel/null group == dropping its
+    # rows first.
+    from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+    frame = to_frame(lf.collect()) if is_polars_lazyframe(lf) else to_frame(lf)
+
+    max_block_size = config.max_block_size
+    all_sizes: list[int] = []
+    # Chao1 inputs for n_blocks richness extrapolation (S1): counted from the
+    # raw per-key sizes BEFORE the size<2 drop (singletons feed F1).
+    f1 = 0
+    f2 = 0
+    for key_config in keys:
+        keyed = frame.with_column(
+            "__block_key__",
+            frame.derive_block_key(
+                key_config.fields, key_config.transforms or [],
+                field_transforms=getattr(key_config, "field_transforms", None),
+            ),
+        )
+        valid = keyed.filter_valid_key("__block_key__")
+        # Per-key sizes AFTER the null/sentinel drop, BEFORE the size<2 drop.
+        all_key_sizes = [int(v) for v in valid.group_len(["__block_key__"]).column("len").to_list()]
+        f1 += sum(1 for s in all_key_sizes if s == 1)
+        f2 += sum(1 for s in all_key_sizes if s == 2)
+        sizes = [s for s in all_key_sizes if s >= 2]
+        # An oversized block is sub-split by _build_static_blocks under BOTH
+        # skip_oversized values now (True -> ANN/auto-split/skip; False ->
+        # zero-config auto-split when splittable, see #372), so the raw group-by
+        # sizes no longer match the built blocks. Bail to the exact path.
+        if any(s > max_block_size for s in sizes):
+            return None
+        all_sizes.extend(sizes)
+    return all_sizes, f1, f2
+
+
+def _fast_multi_pass_block_sizes(
+    lf: Any, config: Any
+) -> tuple[list[int], int | None, int | None] | None:
+    """Block-size distribution for ``multi_pass``, vectorized PER PASS.
+
+    ``_fast_static_block_sizes`` bails on any non-static strategy, so a
+    multi_pass config -- the common zero-config shape (#1207 per-identifier
+    union) -- falls to the exact ``build_blocks`` loop, which materializes one
+    frame per block. That cost is why ``_should_measure_blocking`` only lets the
+    lower planning tiers measure the full frame for ``static`` configs, and it
+    is why zero-config always reasons over an EXTRAPOLATED sample instead.
+
+    Measured, person @ 100,000 rows, the 8-pass zero-config plan:
+
+        exact build_blocks loop      15,953 ms
+        per-pass vectorized             762 ms      20.9x
+
+    A multi_pass config IS N static passes -- ``_build_multi_pass_blocks``
+    delegates each to ``_build_static_blocks`` -- so the same per-key group-by
+    applies once per pass.
+
+    Falls back PER PASS, not for the whole config. ``_fast_static_block_sizes``
+    returns None when any block is oversized (``_build_static_blocks``
+    sub-splits those, so raw group-by sizes would diverge); on the person plan
+    exactly one pass of eight trips that, and forfeiting the other seven to it
+    would give most of the cost back. Parity with the exact loop on a config
+    mixing both kinds is pinned in
+    ``tests/test_multipass_fast_block_sizes.py``.
+
+    Cross-pass dedup is not a concern: ``_build_multi_pass_blocks`` keys its
+    dedup on ``(pass_signature, block_key)``, so it only ever removes truly
+    identical blocks from the SAME pass, and within a pass the group-by already
+    yields unique keys.
+
+    Returns ``None`` (caller uses the exact loop) for non-multi_pass configs or
+    when there are no passes. Chao1 inputs are returned as ``None``: they are
+    only defined for a single-key richness estimate, so the caller falls back to
+    the linear ``n_blocks`` extrapolation, exactly as the exact path does.
+    """
+    if getattr(config, "strategy", None) != "multi_pass":
+        return None
+    passes = list(getattr(config, "passes", None) or [])
+    if not passes:
+        return None
+
+    from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+    frame = to_frame(lf.collect()) if is_polars_lazyframe(lf) else to_frame(lf)
+
+    all_sizes: list[int] = []
+    for pass_config in passes:
+        temp_config = config.model_copy(update={
+            "strategy": "static",
+            "keys": [pass_config],
+            "passes": None,
+            "auto_select": False,
+        })
+        fast = _fast_static_block_sizes(frame, temp_config)
+        if fast is not None:
+            all_sizes.extend(fast[0])
+            continue
+        # This pass has an oversized block (or otherwise can't be vectorized
+        # byte-identically); build only THIS pass exactly.
+        for b in _build_static_blocks(frame, temp_config):
+            try:
+                all_sizes.append(b.n_rows())
+            except Exception:
+                all_sizes.append(0)
+    return all_sizes, None, None
+
+
+def measure_blocking_profile(
+    df: pl.DataFrame | pl.LazyFrame,
+    config: Any,
+) -> BlockingProfile | None:
+    """Measure a ``BlockingProfile`` on the FULL frame (Phase 1: measure, not
+    extrapolate). Spec 2026-06-06 §Phase 1.
+
+    Runs the committed config's blocking over all rows and computes the true
+    pair count + block-size distribution — the cheap op (blocking was never the
+    bottleneck; scoring was, and that is now ~5x faster). Returns ``None`` on
+    ANY failure or when the config has no blocking, so the caller can fall back
+    to linear extrapolation without risk.
+
+    Fast path (Stage-D, spec 2026-06-22): plain ``static`` blocking computes the
+    block-size distribution with a single vectorized ``group_by`` per key
+    (``_fast_static_block_sizes``), ~36x faster than building + re-collecting
+    every block; non-static configs and oversized-split cases fall back to the
+    exact ``build_blocks`` loop. Both paths feed the identical aggregation below.
+    """
+    try:
+        blocking_cfg = getattr(config, "blocking", None)
+        if blocking_cfg is None:
+            return None
+        # PR-5 (autoconfig arrow-port): normalize the input through the seam so
+        # a polars frame/lazyframe OR an arrow Table/Frame all measure the same.
+        # n_rows comes from ``Frame.height`` (no ``pl.len()`` collect); the seam
+        # frame flows into ``_fast_static_block_sizes`` (dual-rep) and, on the
+        # exact fallback, into ``build_blocks`` (which ingests a Frame/arrow).
+        from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+        frame = (
+            to_frame(cast("pl.LazyFrame", df).collect())
+            if is_polars_lazyframe(df)
+            else to_frame(df)
+        )
+        n_rows: int = frame.height
+
+        if blocking_cfg.passes:
+            keys_used = [list(k.fields) for k in blocking_cfg.passes]
+        elif blocking_cfg.keys:
+            keys_used = [list(k.fields) for k in blocking_cfg.keys]
+        else:
+            keys_used = []
+
+        fast = _fast_static_block_sizes(frame, blocking_cfg)
+        if fast is None:
+            # multi_pass is N static passes; vectorize each one rather than
+            # dropping the whole config to the per-block materialization loop
+            # (measured 762 ms vs 15,953 ms on the 8-pass person@100K plan).
+            fast = _fast_multi_pass_block_sizes(frame, blocking_cfg)
+        if fast is None:
+            # Exact fallback: build every block and collect its length. This path
+            # cannot recover the pre-drop singleton/doubleton counts, so the Chao1
+            # inputs stay None and extrapolate_to uses the linear n_blocks fallback.
+            sizes = []
+            for b in build_blocks(frame, blocking_cfg):
+                try:
+                    sizes.append(b.n_rows())
+                except Exception:
+                    sizes.append(0)
+            chao1_f1: int | None = None
+            chao1_f2: int | None = None
+        else:
+            sizes, chao1_f1, chao1_f2 = fast
+        sizes_sorted = sorted(sizes)
+        n_blocks = len(sizes_sorted)
+        total_comparisons = sum(s * (s - 1) // 2 for s in sizes_sorted)
+        max_pairs = n_rows * (n_rows - 1) // 2
+        reduction_ratio = 1.0 - total_comparisons / max(1, max_pairs)
+        singleton_block_count = sum(1 for s in sizes_sorted if s == 1)
+        oversized_block_count = sum(
+            1 for s in sizes_sorted if s > blocking_cfg.max_block_size
+        )
+        return BlockingProfile(
+            keys_used=keys_used,
+            n_blocks=n_blocks,
+            total_comparisons=total_comparisons,
+            reduction_ratio=reduction_ratio,
+            block_sizes_p50=_percentile(sizes_sorted, 0.50),
+            block_sizes_p95=_percentile(sizes_sorted, 0.95),
+            block_sizes_p99=_percentile(sizes_sorted, 0.99),
+            block_sizes_max=max(sizes_sorted) if sizes_sorted else 0,
+            singleton_block_count=singleton_block_count,
+            oversized_block_count=oversized_block_count,
+            chao1_f1=chao1_f1,
+            chao1_f2=chao1_f2,
+        )
+    except Exception:
+        logger.debug(
+            "measure_blocking_profile failed; caller should extrapolate.",
+            exc_info=True,
+        )
+        return None
+
+
+@dataclass
+class BlockResult:
+    """Result of blocking: a block key and its member rows.
+
+    D5b (arrow descent): ``df`` accepts a legacy ``pl.LazyFrame`` (usually an
+    eagerly-collected group re-wrapped lazy), an eager ``pl.DataFrame``, or a
+    seam ``Frame``. Consumers use ``materialize()`` / ``n_rows()`` -- the
+    representation-agnostic reads -- instead of ``.collect()`` round-trips.
+    """
+
+    block_key: str
+    df: Any
+    strategy: str = "static"
+    depth: int = 0
+    parent_key: str | None = None
+    pre_scored_pairs: list[tuple[int, int, float]] | None = None
+    # Fields whose equality created this block. EM uses this provenance to
+    # condition only the sampled pairs from this pass, rather than globally
+    # neutralizing the union of every multi-pass blocking field.
+    blocking_fields: tuple[str, ...] = ()
+
+    def materialize(self):
+        """The block's rows as a seam Frame (collects a legacy LazyFrame once)."""
+        from goldenmatch.core.frame import Frame, is_polars_lazyframe, to_frame
+
+        d = self.df
+        if isinstance(d, Frame):
+            return d
+        if is_polars_lazyframe(d):  # arrow-port: import-safe LazyFrame guard
+            d = d.collect()
+        return to_frame(d)
+
+    def n_rows(self) -> int:
+        """Row count without a full materialization round-trip at call sites."""
+        return self.materialize().height
+
+
+class RowIdBlock:
+    """A blocking result carrying ONLY its member row-ids -- no per-block frame.
+
+    The Fellegi-Sunter EM trainer samples within-block pairs reading nothing but
+    ``__row_id__`` and each block's ``blocking_fields`` provenance
+    (``probabilistic._sample_blocked_pairs_with_fields``); the sampled pairs'
+    field values are looked up on the full score frame, never the blocks. So an
+    EM-training block does not need a frame at all -- a compact ``int64`` array
+    replaces the ``BlockResult`` group frame, eliminating the FS EM
+    ``build_blocks`` memory peak (the per-block-object floor + the per-pass
+    full-frame transient). ``materialize()`` builds a 1-column frame ON DEMAND,
+    so only the few dozen blocks the sampler actually visits ever pay.
+
+    Interface-compatible with ``BlockResult`` for the EM sampler
+    (``materialize().column("__row_id__")``, ``block_key``, ``blocking_fields``,
+    ``n_rows()``). NOT for scoring -- these blocks feed EM alone.
+    """
+
+    __slots__ = ("block_key", "blocking_fields", "strategy", "_ids")
+
+    def __init__(
+        self,
+        block_key: Any,
+        ids: Any,
+        blocking_fields: tuple[str, ...] = (),
+        strategy: str = "static",
+    ) -> None:
+        self.block_key = block_key
+        self._ids = ids  # numpy int64 array of __row_id__ values
+        self.blocking_fields = blocking_fields
+        self.strategy = strategy
+
+    def materialize(self) -> Any:
+        """A 1-column ``__row_id__`` seam Frame, built lazily (sampled blocks only)."""
+        from goldenmatch.core.frame import to_frame
+
+        return to_frame(pl.DataFrame({"__row_id__": self._ids}))
+
+    def n_rows(self) -> int:
+        return len(self._ids)
+
+
+class _AggOversizedBlock(NotImplementedError):
+    """Raised inside ``build_em_blocks_agg`` when a block exceeds
+    ``max_block_size``. ``build_blocks`` auto-splits such blocks (producing a
+    different EM training set), so the row-id-array builder is NOT byte-identical
+    there and must defer to ``build_blocks``. A ``NotImplementedError`` subclass
+    so ``_build_em_blocks``'s fallback catches it like the strategy-unsupported
+    case."""
+
+
+def build_em_blocks_agg(frame: Any, config: BlockingConfig) -> list:
+    """Field-hash EM-training blocks as compact row-id arrays via ONE
+    ``group_by().agg()`` per pass -- NEVER materializing per-block frames.
+
+    Membership matches ``build_blocks``: reuses ``_build_block_key_expr`` + the
+    same null/sentinel key filter + the ``multi_pass`` ``(pass_sig, block_key)``
+    dedup, so EM's sampled pairs -- hence the ``EMResult`` and the whole run --
+    are BYTE-IDENTICAL, absent oversized blocks. (``build_blocks`` auto-splits a
+    block over ``max_block_size`` -- a *scoring* optimization; EM's sampler caps
+    per-block ids anyway, so keeping oversized blocks whole is a bench-gated
+    behavior change on datasets that have them, exact parity where none do.)
+
+    Supports ``static`` / ``multi_pass`` -- what FS auto-config emits (incl. the
+    SN bound, which rewrites to static passes). Raises ``NotImplementedError``
+    for other strategies so the caller falls back to ``build_blocks``.
+
+    Peak RSS (person 100k, whole pipeline): 2126 -> 549 MB vs ``build_blocks``,
+    byte-identical output.
+    """
+    import numpy as np
+
+    from goldenmatch.core.frame import (
+        is_polars_dataframe,
+        is_polars_lazyframe,
+    )
+    from goldenmatch.core.frame import (
+        to_frame as _tf,
+    )
+
+    if config.strategy not in ("static", "multi_pass"):
+        raise NotImplementedError(
+            f"build_em_blocks_agg supports static/multi_pass, not {config.strategy!r}"
+        )
+
+    # Resolve to a LazyFrame WITHOUT round-tripping a LazyFrame through
+    # ``to_frame`` (which rejects LazyFrames). A polars LazyFrame is the form
+    # ``block_frame`` takes on the classic (polars) dedupe lane -- the arrow
+    # "Frame lane" (#2250) instead hands a ``pa.Table``. Reaching ``to_frame``
+    # with a LazyFrame raised ``TypeError`` and silently sent the polars lane
+    # to the ``build_blocks`` fallback while the arrow lane used THIS builder;
+    # the two builders are NOT equivalent on datasets with oversized blocks
+    # (see the oversized guard below), so that split-by-frame-type diverged the
+    # EM training set -> EM weights -> the whole run BETWEEN the two lanes.
+    if is_polars_lazyframe(frame):
+        lf = frame
+    else:
+        native = _tf(frame).native
+        if is_polars_lazyframe(native):
+            lf = native
+        elif is_polars_dataframe(native):
+            lf = native.lazy()
+        else:  # arrow Table
+            lf = cast(pl.DataFrame, pl.from_arrow(native)).lazy()
+
+    # Oversized-block faithfulness (the parity gap the docstring flags): when a
+    # block exceeds ``max_block_size`` ``build_blocks`` AUTO-SPLITS it into
+    # smaller sub-blocks (``_auto_split_block`` -> compound keys / multi-field
+    # provenance), whereas this row-id-array builder keeps it whole. That
+    # changes which pairs EM samples -> a different ``EMResult`` -> a different
+    # run. It stayed latent because the classic (polars-LazyFrame) lane never
+    # actually reached this builder; the arrow-lane bridge exposed it as a
+    # cross-lane F1 regression (historical_50k 0.826 -> 0.614). Decline here so
+    # BOTH lanes fall back to the reference ``build_blocks`` whenever an
+    # oversized block is present -- keeping the memory win only where the two
+    # builders are genuinely byte-identical (no block over the cap).
+    max_block_size = getattr(config, "max_block_size", None)
+
+    def _agg_pass(key_config: BlockingKeyConfig, strategy: str) -> list:
+        # Same key expr + sentinel filter as _build_static_blocks, but agg the
+        # row-ids per key instead of materializing a frame per group. Group and
+        # within-group order are irrelevant: the sampler re-sorts by block_key
+        # and sorts each block's row_ids before sampling.
+        expr = _build_block_key_expr(key_config)
+        grouped = (
+            lf.with_columns(expr)
+            .filter(
+                pl.col("__block_key__").is_not_null()
+                & ~pl.col("__block_key__")
+                    .str.strip_chars()
+                    .str.to_lowercase()
+                    .is_in(["nan", "null", "none"])
+            )
+            .group_by("__block_key__")
+            .agg(pl.col("__row_id__"))
+            .collect()
+        )
+        fields = tuple(key_config.fields)
+        out: list = []
+        for key_str, ids in zip(
+            grouped["__block_key__"].to_list(),
+            grouped["__row_id__"].to_list(),
+        ):
+            if key_str is None or len(ids) < 2:
+                continue
+            if max_block_size is not None and len(ids) > max_block_size:
+                # build_blocks would auto-split / skip this block -> the two
+                # builders diverge. Bail so the caller uses build_blocks.
+                raise _AggOversizedBlock(len(ids))
+            out.append(
+                RowIdBlock(key_str, np.asarray(ids, dtype=np.int64), fields, strategy)
+            )
+        return out
+
+    if config.strategy == "multi_pass":
+        results: list = []
+        seen: set = set()
+        for pass_config in config.passes or []:
+            pass_sig = (
+                tuple(pass_config.fields),
+                tuple(pass_config.transforms or []),
+            )
+            for block in _agg_pass(pass_config, "multi_pass"):
+                dedup_key = (pass_sig, block.block_key)
+                if dedup_key not in seen:
+                    results.append(block)
+                    seen.add(dedup_key)
+        return results
+
+    results = []
+    for key_config in config.keys or []:
+        results.extend(_agg_pass(key_config, "static"))
+    return results
+
+
+def collect_blocking_fields(
+    config: BlockingConfig, *, for_em: bool = False
+) -> list[str]:
+    """All column names a blocking config groups on, across keys/passes/sub-blocks.
+
+    Used by the Fellegi-Sunter pipeline to tell EM which fields are blocking
+    fields (always-agree within a single-pass block -> no discrimination ->
+    excluded from m-training, given fixed neutral weights). For ``multi_pass``
+    the keys live in ``passes``, not ``keys`` -- reading only ``keys`` (the old
+    behavior) left the exclusion list empty and degraded multi-pass FS
+    (Febrl4: 95.7% -> 98.4% F1 once the pass fields are excluded). Order is
+    preserved and de-duplicated.
+
+    ``for_em`` selects the EM-DEMOTION set rather than the full field inventory: a
+    field that appears ONLY in ``additive`` passes (orthogonal anchors that should
+    stay EM-trained -- see ``BlockingKeyConfig.additive``) is excluded, so EM keeps
+    learning its weight from the other passes' pairs. A field that also keys a
+    non-additive (primary) pass is still demoted. Default ``for_em=False`` returns
+    every field a pass groups on (block-building, projection) and is byte-identical
+    to the historical behavior; with no additive pass present the two agree exactly.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    groups: list[BlockingKeyConfig] = []
+    groups.extend(config.keys or [])
+    groups.extend(config.passes or [])
+    groups.extend(config.sub_block_keys or [])
+    if for_em:
+        # A field is EM-demoted only if some NON-additive pass keys on it. Fields
+        # confined to additive passes stay EM-trained comparison fields.
+        primary: set[str] = set()
+        additive_only: set[str] = set()
+        for key in groups:
+            target = additive_only if getattr(key, "additive", False) else primary
+            target.update(key.fields)
+        demote = primary  # additive-only fields excluded by construction
+        for key in groups:
+            if getattr(key, "additive", False):
+                continue
+            for f in key.fields:
+                if f in demote and f not in seen:
+                    seen.add(f)
+                    out.append(f)
+        return out
+    for key in groups:
+        for f in key.fields:
+            if f not in seen:
+                seen.add(f)
+                out.append(f)
+    return out
+
+
+def _build_block_key_expr(key_config: BlockingKeyConfig) -> pl.Expr:
+    """Build a block key expression from a BlockingKeyConfig.
+
+    Transforms each field and concatenates with || separator. Uses native
+    Polars expressions when every configured transform is vectorizable
+    (lowercase, strip, substring, etc. -- see matchkey._try_native_transform).
+    Falls back to map_elements only for transforms that need Python
+    (soundex, metaphone). The native fast path matters at scale: a 5M-row
+    blocking key with map_elements is 10M Python calls and was the root
+    cause of the 5M bench hang (RSS climbed 1.5 GB / 30s with no instrumented
+    stage closing).
+    """
+    from goldenmatch.core.matchkey import _try_native_chain
+
+    # Per-field chains (#1826): a field listed in field_transforms uses its
+    # OWN chain; others keep the key-level chain. getattr keeps the
+    # SimpleNamespace duck-type callers (frame.derive_block_key) working.
+    per_field = getattr(key_config, "field_transforms", None) or {}
+    field_exprs: list[pl.Expr] = []
+    for field_name in key_config.fields:
+        transforms = per_field.get(field_name, key_config.transforms or [])
+        native = _try_native_chain(field_name, transforms) if transforms else None
+        if native is not None:
+            field_exprs.append(native)
+        elif transforms:
+            field_exprs.append(
+                pl.col(field_name).map_elements(
+                    _memoized_transform(transforms),
+                    return_dtype=pl.Utf8,
+                )
+            )
+        else:
+            field_exprs.append(pl.col(field_name).cast(pl.Utf8))
+
+    if len(field_exprs) == 1:
+        return field_exprs[0].alias("__block_key__")
+    else:
+        return pl.concat_str(field_exprs, separator="||").alias("__block_key__")
+
+
+def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
+    """Build static blocks — original blocking logic.
+
+    Groups records by each blocking key, skipping blocks with < 2 records
+    and handling oversized blocks per config.skip_oversized.
+
+    Hot-block auto-split (2026-05-15): when a block exceeds
+    ``max_block_size`` and no ANN column is configured, attempt
+    ``_auto_split_block`` before silently skipping. The static-mode
+    path used to drop these blocks on the floor — measured at 94% of
+    wall on a 100K zero-config run because a single 1158-record
+    last-name block dominated the per-block ``cdist`` quadratic. Hot
+    splitting trades one quadratic block for multiple smaller blocks
+    whose summed quadratic work is dramatically lower.
+    """
+    from goldenmatch.core.bench import record_metric
+
+    results: list[BlockResult] = []
+    hot_blocks_split = 0
+    hot_blocks_skipped = 0
+
+    for key_config in config.keys:
+        # Add block key column AND filter null/sentinel keys in a single
+        # lazy pipeline so Polars' optimizer fuses the filter with the
+        # projection. The eager `df.filter(...)` after `.collect()` form
+        # used to peak at ~2x the frame size (one for the materialized
+        # collect, one for the filtered result) -- enough to push a
+        # 1.13M-row × 58-col frame past an 8 GB sandbox cap (#375).
+        #
+        # NULL filter rationale (originally #372): records with NULL in
+        # the blocking column shouldn't cluster together. The cast(Utf8)
+        # in _build_block_key_expr turns Polars NaN into the literal
+        # string "NaN"; a downstream lowercase transform collapses that
+        # to "nan", and ~12K NULL records would otherwise share a single
+        # block and OOM during scoring. The group-by-level
+        # `if key_str is None: continue` only catches Polars None, not
+        # the stringified forms.
+        # Filter ``nan``/``null``/``none`` sentinel keys -- those come
+        # from Polars' cast(Utf8) on NULL or NaN values, NOT from
+        # legitimate user-typed strings. Empty strings ("") are kept
+        # because they're real values (an explicit empty-cell in the
+        # source); dropping them aggressively lost 3 records on the
+        # cross-file dedupe regression suite (PR #390 fix).
+        from goldenmatch.core.frame import is_polars_lazyframe
+
+        if is_polars_lazyframe(lf):
+            # Polars-only: the native expr chain (pl.col) is built lazily here so
+            # the arrow branch below (derive_block_key) never imports polars.
+            block_key_expr = _build_block_key_expr(key_config)
+            df_with_key = (
+                lf
+                .with_columns(block_key_expr)
+                .filter(
+                    pl.col("__block_key__").is_not_null()
+                    & ~pl.col("__block_key__")
+                        .str.strip_chars()
+                        .str.to_lowercase()
+                        .is_in(["nan", "null", "none"])
+                )
+                .collect()
+            )
+        else:
+            # D2s-a: seam Frame (or eager native) entry -- derive_block_key is
+            # the twin of _build_block_key_expr; filter_valid_key is the
+            # sentinel guard verbatim. The lazy branch above stays raw Polars:
+            # its fused with_columns+filter+collect is RSS-load-bearing (#375)
+            # and legacy callers hand genuinely-lazy frames.
+            from goldenmatch.core.frame import to_frame as _tf
+
+            _f = _tf(lf)
+            _f = _f.with_column(
+                "__block_key__",
+                _f.derive_block_key(
+                    key_config.fields, key_config.transforms or [],
+                    field_transforms=getattr(key_config, "field_transforms", None)
+                ),
+            )
+            df_with_key = _f.filter_valid_key("__block_key__").native
+
+        # Group by block key (W2c/W2d seam: group_partitions is the
+        # hash-grouped twin of group_by iteration -- deterministic
+        # first-appearance order, blocks are an unordered set downstream).
+        # The lazy with_columns+filter+collect ABOVE stays raw Polars: the
+        # fused pipeline is RSS-load-bearing (#375) and this entry can
+        # receive genuinely-lazy frames.
+        from goldenmatch.core.frame import to_frame
+
+        for key_str, group_frame in to_frame(df_with_key).group_partitions("__block_key__"):
+            group_df = group_frame.native
+            if key_str is None:
+                continue
+
+            size = len(group_df)
+
+            if size < 2:
+                continue
+
+            if size > config.max_block_size:
+                if config.skip_oversized and config.ann_column:
+                    # ANN fallback: embed oversized block's records and sub-block
+                    try:
+                        ann_sub = _ann_sub_block(
+                            group_df, config.ann_column, config.ann_top_k,
+                            config.ann_model, config.max_block_size, key_str,
+                        )
+                        if ann_sub:
+                            for sub_block in ann_sub:
+                                sub_block.blocking_fields = tuple(key_config.fields)
+                            results.extend(ann_sub)
+                    except Exception:
+                        logger.error(
+                            "ANN sub-blocking failed for block %r (%d records). Skipping block.",
+                            key_str, size, exc_info=True,
+                        )
+                    continue
+                elif config.skip_oversized:
+                    # Hot-block auto-split: try recovering via
+                    # highest-cardinality column before giving up.
+                    # `_auto_split_block` returns at least one
+                    # BlockResult per useful sub-group; if it can't
+                    # split meaningfully it returns the parent block,
+                    # which we then skip (preserves prior behavior).
+                    try:
+                        sub_blocks = _auto_split_block(
+                            group_df,
+                            config.max_block_size,
+                            key_str,
+                            tuple(key_config.fields),
+                        )
+                    except Exception:
+                        logger.error(
+                            "Hot-block auto-split failed for %r (%d records). Skipping.",
+                            key_str, size, exc_info=True,
+                        )
+                        hot_blocks_skipped += 1
+                        continue
+                    # "Useful" sub-blocks are those genuinely smaller than
+                    # the parent. _auto_split_block can return a single
+                    # sub-block that's still the full parent size when no
+                    # column has cardinality > 1 within the block — that's
+                    # the "couldn't split" sentinel.
+                    useful_subs: list[BlockResult] = []
+                    for b in sub_blocks:
+                        try:
+                            sub_size = b.n_rows()
+                        except Exception:
+                            sub_size = size + 1  # treat unknown as not-useful
+                        if sub_size < size and sub_size >= 2:
+                            useful_subs.append(b)
+                    if useful_subs:
+                        results.extend(useful_subs)
+                        hot_blocks_split += 1
+                        logger.info(
+                            "Hot-block split %r (%d records) → %d sub-blocks",
+                            key_str, size, len(useful_subs),
+                        )
+                        continue
+                    # Fall through to the original skip behavior when
+                    # no useful sub-blocks could be produced.
+                    logger.warning(
+                        f"Block {key_str!r} has {size} records "
+                        f"(exceeds max_block_size={config.max_block_size}) "
+                        "and auto-split produced no useful sub-blocks. Skipping."
+                    )
+                    hot_blocks_skipped += 1
+                    continue
+                elif config.sub_block_keys:
+                    # The adaptive strategy splits this oversized block by its
+                    # configured ``sub_block_keys`` downstream (build_blocks'
+                    # adaptive path calls _sub_block). Leave it intact here so we
+                    # don't pre-empt that with the zero-config auto-split; the
+                    # block is NOT scored whole because the caller sub-blocks it.
+                    logger.debug(
+                        "Oversized block %r (%d records) left intact for "
+                        "configured sub_block_keys splitting.",
+                        key_str, size,
+                    )
+                else:
+                    # skip_oversized=False. Attempt the SAME zero-config
+                    # hot-block auto-split first (sub-partition by the
+                    # highest-cardinality column) -- splitting preserves recall
+                    # AND avoids the O(n^2) scoring OOM, so it is strictly better
+                    # than scoring the whole mega-block. This is the default path
+                    # (auto-config's FS year-diversify pass and the #1784-kept
+                    # common-surname block produce 10k+ record blocks whose
+                    # ~100M+ pairs OOM'd the runner when scored whole). Only when
+                    # auto-split can't help do we honor the opt-in "process
+                    # anyway".
+                    try:
+                        sub_blocks = _auto_split_block(
+                            group_df,
+                            config.max_block_size,
+                            key_str,
+                            tuple(key_config.fields),
+                        )
+                    except Exception:
+                        logger.error(
+                            "Hot-block auto-split failed for %r (%d records).",
+                            key_str, size, exc_info=True,
+                        )
+                        sub_blocks = []
+                    useful_subs = []
+                    for b in sub_blocks:
+                        try:
+                            sub_size = b.n_rows()
+                        except Exception:
+                            sub_size = size + 1  # treat unknown as not-useful
+                        if sub_size < size and sub_size >= 2:
+                            useful_subs.append(b)
+                    if useful_subs:
+                        results.extend(useful_subs)
+                        hot_blocks_split += 1
+                        logger.info(
+                            "Hot-block split %r (%d records) → %d sub-blocks",
+                            key_str, size, len(useful_subs),
+                        )
+                        continue
+                    # Auto-split couldn't help -- honor the opt-in and process
+                    # the whole block (log at ERROR so the OOM-vs-correctness
+                    # tradeoff is obvious in the run log).
+                    logger.error(
+                        f"Block {key_str!r} has {size} records "
+                        f"(exceeds max_block_size={config.max_block_size}, "
+                        f"~{size * (size - 1) // 2:,} pairs to score) and "
+                        f"auto-split produced no useful sub-blocks. Processing "
+                        f"anyway because skip_oversized=False; set "
+                        f"blocking.skip_oversized=True to skip oversized blocks "
+                        f"instead of risking OOM. See #372."
+                    )
+
+            results.append(BlockResult(
+                block_key=key_str,
+                df=group_df,  # D5b: eager (was group_df.lazy() -- a re-wrap)
+                blocking_fields=tuple(key_config.fields),
+            ))
+
+    if hot_blocks_split or hot_blocks_skipped:
+        record_metric("hot_blocks_split_count", hot_blocks_split)
+        record_metric("hot_blocks_skipped_count", hot_blocks_skipped)
+
+    return results
+
+
+def _ann_sub_block(
+    block_df: pl.DataFrame,
+    ann_column: str,
+    ann_top_k: int,
+    ann_model: str,
+    max_block_size: int,
+    parent_key: str,
+) -> list[BlockResult]:
+    """ANN fallback for oversized blocks.
+
+    Embeds only the unique text values in the block, maps embeddings back
+    to all records, then uses FAISS to find neighbors and create sub-blocks.
+    """
+    from goldenmatch.core.ann_blocker import ANNBlocker
+    from goldenmatch.core.cluster import UnionFind
+    from goldenmatch.core.embedder import get_embedder
+
+    size = len(block_df)
+
+    # Cap: only ANN sub-block moderately oversized blocks (up to 10x max_block_size)
+    # Truly massive blocks (60K+) would still be too expensive to embed
+    if size > max_block_size * 10:
+        logger.info(
+            "ANN fallback: block %r has %d records (>%dx max). Too large, skipping.",
+            parent_key, size, 10,
+        )
+        return []
+
+    if ann_column not in block_df.columns:
+        logger.warning(
+            "ANN fallback: column %r not in block %r. Skipping %d records.",
+            ann_column, parent_key, size,
+        )
+        return []
+
+    # Deduplicate texts — embed only unique values
+    all_texts = block_df[ann_column].to_list()
+    unique_texts = list(set(t for t in all_texts if t is not None and str(t).strip()))
+
+    if len(unique_texts) < 2:
+        logger.info("ANN fallback: block %r has <2 unique texts. Skipping.", parent_key)
+        return []
+
+    logger.info(
+        "ANN fallback: block %r has %d records, %d unique texts. Embedding...",
+        parent_key, size, len(unique_texts),
+    )
+
+    embedder = get_embedder(ann_model)
+    unique_embeddings = embedder.embed_column(
+        unique_texts, cache_key=f"ann_sub_{parent_key}",
+    )
+
+    # Map unique embeddings back to all records
+    text_to_idx = {t: i for i, t in enumerate(unique_texts)}
+    record_indices = []  # index into unique_embeddings for each record
+    valid_records = []   # indices into block_df that have valid text
+    for i, t in enumerate(all_texts):
+        if t is not None and str(t).strip() and t in text_to_idx:
+            record_indices.append(text_to_idx[t])
+            valid_records.append(i)
+
+    if len(valid_records) < 2:
+        return []
+
+    import numpy as np
+    record_embeddings = unique_embeddings[np.array(record_indices)]
+
+    # Build FAISS index and query
+    blocker = ANNBlocker(top_k=min(ann_top_k, len(valid_records) - 1))
+    blocker.build_index(record_embeddings)
+    pairs = blocker.query(record_embeddings)
+
+    # Group into sub-blocks via Union-Find
+    _row_ids = block_df["__row_id__"].to_list()
+    uf = UnionFind()
+    for a, b in pairs:
+        real_a = valid_records[a]
+        real_b = valid_records[b]
+        uf.add(real_a)
+        uf.add(real_b)
+        uf.union(real_a, real_b)
+
+    clusters = uf.get_clusters()
+    results: list[BlockResult] = []
+    n_oversized = 0
+    for members in clusters:
+        if len(members) < 2:
+            continue
+        member_list = sorted(members)
+        if len(member_list) > max_block_size:
+            n_oversized += 1
+            logger.warning(
+                "ANN sub-block from %r still has %d records (> max %d). Skipping.",
+                parent_key, len(member_list), max_block_size,
+            )
+            continue
+        sub_df = block_df[member_list]
+        results.append(BlockResult(
+            block_key=f"{parent_key}_ann_{min(member_list)}",
+            df=sub_df.lazy(),
+            strategy="ann",
+        ))
+
+    logger.info(
+        "ANN fallback: block %r -> %d sub-blocks (%d still oversized)",
+        parent_key, len(results), n_oversized,
+    )
+    return results
+
+
+def _sub_block(
+    block_df: pl.DataFrame,
+    sub_block_keys: list[BlockingKeyConfig],
+    max_block_size: int,
+    depth: int,
+    parent_key: str,
+) -> list[BlockResult]:
+    """Recursively sub-block an oversized block using sub_block_keys.
+
+    Args:
+        block_df: The oversized block DataFrame.
+        sub_block_keys: Remaining sub-block keys to try.
+        max_block_size: Maximum block size threshold.
+        depth: Current recursion depth (1-indexed).
+        parent_key: The parent block key value.
+
+    Returns:
+        List of BlockResult with adaptive metadata.
+    """
+    if depth > 3 or not sub_block_keys:
+        # Max depth reached or no more keys — return as-is with warning
+        logger.warning(
+            f"Sub-block of {parent_key!r} has {len(block_df)} records at depth {depth}. "
+            f"No further sub-blocking possible. Processing anyway."
+        )
+        return [BlockResult(
+            block_key=parent_key,
+            df=block_df.lazy(),
+            strategy="adaptive",
+            depth=depth,
+            parent_key=parent_key,
+        )]
+
+    current_key_config = sub_block_keys[0]
+    remaining_keys = sub_block_keys[1:]
+
+    block_key_expr = _build_block_key_expr(current_key_config)
+    df_with_key = block_df.with_columns(block_key_expr)
+
+    groups = df_with_key.group_by("__block_key__")
+    results: list[BlockResult] = []
+
+    for key, group_df in groups:
+        key_str = key[0]
+        if key_str is None:
+            continue
+
+        size = len(group_df)
+
+        if size < 2:
+            continue
+
+        if size > max_block_size and remaining_keys and depth < 3:
+            # Recurse with next sub_block_key
+            sub_results = _sub_block(
+                group_df,
+                remaining_keys,
+                max_block_size,
+                depth + 1,
+                parent_key,
+            )
+            results.extend(sub_results)
+        else:
+            if size > max_block_size:
+                logger.warning(
+                    f"Sub-block {key_str!r} of {parent_key!r} has {size} records at depth {depth}. "
+                    f"Processing anyway."
+                )
+            results.append(BlockResult(
+                block_key=key_str,
+                df=group_df.lazy(),
+                strategy="adaptive",
+                depth=depth,
+                parent_key=parent_key,
+            ))
+
+    return results
+
+
+def _auto_split_block(
+    block_df: Any,  # pl.DataFrame | pa.Table | seam Frame -- normalized via to_frame
+    max_block_size: int,
+    parent_key: str,
+    blocking_fields: tuple[str, ...] = (),
+) -> list[BlockResult]:
+    """Auto-split an oversized block using the highest-cardinality column.
+
+    When no sub_block_keys are configured, this provides a zero-config fallback
+    that splits by the column with the most unique values.
+    """
+    from goldenmatch.core.frame import to_frame
+
+    # Seam-normalize FIRST: block_df may be a pa.Table (arrow-native path) whose
+    # ``.columns`` are ChunkedArrays, not names -- ``bframe.columns`` returns
+    # NAMES on both backends. (The raw ``block_df.columns`` here was the
+    # arrow-path AttributeError that made auto-split silently no-op and let the
+    # mega-block fall through to be scored whole -> OOM. See #372/#1790.)
+    bframe = to_frame(block_df)
+    candidates = [c for c in bframe.columns if not c.startswith("__")]
+    if not candidates:
+        logger.warning(
+            "Auto-split of %r: no non-internal columns available. Processing as-is.",
+            parent_key,
+        )
+        return [BlockResult(
+            block_key=parent_key,
+            df=bframe.native,
+            strategy="adaptive",
+            depth=1,
+            parent_key=parent_key,
+            blocking_fields=blocking_fields,
+        )]
+
+    # Pick column whose cardinality best splits blocks near max_block_size.
+    # Ideal: each group has ~max_block_size records.
+    # Score = number of groups with >= 2 records (useful groups).
+    n = bframe.height
+    best_col = candidates[0]
+    best_useful_groups = 0
+    best_nunique = 0
+
+    for col in candidates:
+        nunique = bframe.column(col).n_unique()
+        # Estimate: if we split by this column, avg group size = n / nunique
+        avg_group = n / nunique if nunique > 0 else n
+        # Count groups that will have >= 2 records (useful for matching):
+        # derive the Utf8-cast key via the seam, group, count sizes >= 2.
+        cast_key = bframe.derive_transformed_column(col, [])
+        sized = bframe.with_column("__auto_probe__", cast_key).group_len(["__auto_probe__"])
+        useful_groups = sum(1 for c in sized.column("len").to_list() if c >= 2)
+
+        if useful_groups > best_useful_groups or (
+            useful_groups == best_useful_groups and avg_group <= max_block_size and nunique > best_nunique
+        ):
+            best_useful_groups = useful_groups
+            best_nunique = nunique
+            best_col = col
+
+    # W2d seam: cast-key attach (derive_transformed_column with an empty
+    # chain IS the Utf8 cast) + hash-grouped iteration; null keys skipped
+    # explicitly, exactly as the raw loop did.
+    keyed = bframe.with_column("__auto_split__", bframe.derive_transformed_column(best_col, []))
+
+    results: list[BlockResult] = []
+    for key_str, group_frame in keyed.group_partitions("__auto_split__"):
+        if key_str is None:
+            continue
+        if group_frame.height < 2:
+            continue
+        if group_frame.height > max_block_size:
+            logger.warning(
+                "Auto-split sub-block %r of %r has %d records (still oversized). Processing anyway.",
+                key_str, parent_key, group_frame.height,
+            )
+        results.append(BlockResult(
+            block_key=f"{parent_key}||{key_str}",
+            df=group_frame.drop(["__auto_split__"]).native,
+            strategy="adaptive",
+            depth=1,
+            parent_key=parent_key,
+            blocking_fields=tuple(dict.fromkeys((*blocking_fields, best_col))),
+        ))
+
+    logger.info(
+        "Auto-split %r (%d records) into %d sub-blocks using column %r (cardinality=%d)",
+        parent_key, bframe.height, len(results), best_col, best_nunique,
+    )
+    return results if results else [BlockResult(
+        block_key=parent_key,
+        df=bframe.native,
+        strategy="adaptive",
+        depth=1,
+        parent_key=parent_key,
+        blocking_fields=blocking_fields,
+    )]
+
+
+def _build_sorted_neighborhood_blocks(
+    lf: pl.LazyFrame, config: BlockingConfig,
+) -> list[BlockResult]:
+    """Build sorted neighborhood blocks with a sliding window.
+
+    For each SortKeyField in config.sort_key, transform the column and
+    concatenate into a sort key. Collect, sort, then slide a window through.
+    """
+    if not config.sort_key:
+        raise ValueError("sorted_neighborhood strategy requires sort_key configuration.")
+
+    # Build sort key expression
+    sort_field_exprs = []
+    for skf in config.sort_key:
+        if skf.transforms:
+            expr = pl.col(skf.column).map_elements(
+                _memoized_transform(skf.transforms),
+                return_dtype=pl.Utf8,
+            )
+        else:
+            expr = pl.col(skf.column).cast(pl.Utf8)
+        sort_field_exprs.append(expr)
+
+    if len(sort_field_exprs) == 1:
+        sort_key_expr = sort_field_exprs[0].alias("__sort_key__")
+    else:
+        sort_key_expr = pl.concat_str(sort_field_exprs, separator="||").alias("__sort_key__")
+
+    # Collect and sort. Drop rows whose sort key is missing FIRST: a null (or
+    # nan/null/none sentinel) sort key means "this row cannot be ordered", not
+    # "it neighbors every other unorderable row". Without this, null-key rows
+    # sort adjacent and window together into spurious candidate blocks (#1859).
+    # filter_valid_key is the blocker's guard verbatim -- it keeps "" (#390).
+    from goldenmatch.core.frame import to_frame as _tf
+
+    df = (
+        _tf(lf.with_columns(sort_key_expr).collect())
+        .filter_valid_key("__sort_key__")
+        .native.sort("__sort_key__")
+    )
+    n = len(df)
+    window_size = config.window_size
+
+    results: list[BlockResult] = []
+
+    if n <= window_size:
+        # Dataset smaller than window — single block
+        if n >= 2:
+            results.append(BlockResult(
+                block_key="sorted_window_0",
+                df=df.lazy(),
+                strategy="sorted_neighborhood",
+            ))
+        return results
+
+    # Slide window through sorted data
+    for i in range(n - window_size + 1):
+        window_df = df.slice(i, window_size)
+        results.append(BlockResult(
+            block_key=f"sorted_window_{i}",
+            df=window_df.lazy(),
+            strategy="sorted_neighborhood",
+        ))
+
+    return results
+
+
+def _build_multi_pass_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+    """Run multiple blocking passes and union candidate blocks.
+
+    Each pass uses a different BlockingKeyConfig. Blocks with duplicate keys
+    across passes are deduplicated so each unique block key appears once.
+    """
+    all_blocks: list[BlockResult] = []
+    # Dedup by (pass field+transform signature, block_key value) — NOT the
+    # value alone. block_key is the concatenated field *values* with no field
+    # identity, so a value-only dedup collides ACROSS passes: a
+    # given_name/soundex block "s530" and a surname/soundex block "s530" share
+    # the string, and the second was silently dropped — losing every candidate
+    # pair in it (measured: 309/7310 blocks, 4.2%, dropped on Febrl4's
+    # auto-config scheme; soundex/substring/numeric keys share a namespace).
+    # Keying on the pass signature dedups only *truly identical* blocks (same
+    # fields+transforms+value, e.g. two passes that happen to share a key) while
+    # keeping distinct-field blocks that merely share a value string.
+    seen_keys: set[tuple] = set()
+
+    for pass_config in config.passes or []:
+        temp_config = BlockingConfig(
+            keys=[pass_config],
+            max_block_size=config.max_block_size,
+            skip_oversized=config.skip_oversized,
+            ann_column=config.ann_column,
+            ann_top_k=config.ann_top_k,
+            ann_model=config.ann_model,
+        )
+        pass_sig = (tuple(pass_config.fields), tuple(pass_config.transforms or []))
+        blocks = _build_static_blocks(lf, temp_config)
+        for block in blocks:
+            dedup_key = (pass_sig, block.block_key)
+            if dedup_key not in seen_keys:
+                block.strategy = "multi_pass"
+                all_blocks.append(block)
+                seen_keys.add(dedup_key)
+
+    return all_blocks
+
+
+def _build_ann_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+    """Build blocks using ANN (approximate nearest neighbor) on embeddings.
+
+    Embeds the configured column, queries top-K neighbors with FAISS,
+    then groups connected pairs into micro-blocks via Union-Find.
+    """
+    from goldenmatch.core.ann_blocker import ANNBlocker
+    from goldenmatch.core.cluster import UnionFind
+    from goldenmatch.core.embedder import get_embedder
+
+    if not config.ann_column:
+        raise ValueError("ANN blocking requires 'ann_column' to be set.")
+
+    df = lf.collect()
+    values = df[config.ann_column].to_list()
+
+    embedder = get_embedder(config.ann_model)
+    embeddings = embedder.embed_column(values, cache_key=f"ann_{config.ann_column}")
+
+    blocker = ANNBlocker(top_k=config.ann_top_k)
+    blocker.build_index(embeddings)
+    pairs = blocker.query(embeddings)
+
+    # Group nearby records into micro-blocks using Union-Find
+    uf = UnionFind()
+    for a, b in pairs:
+        uf.add(a)
+        uf.add(b)
+        uf.union(a, b)
+
+    clusters = uf.get_clusters()
+    results: list[BlockResult] = []
+    for members in clusters:
+        if len(members) < 2:
+            continue
+        member_list = sorted(members)
+        # `members` are positions in `df` (UnionFind operates on the same
+        # indices that drive the embeddings array, which is row-aligned with
+        # df). Direct positional indexing is O(K) vs filter(is_in(...))'s
+        # O(N) per block — at 1M rows with ~50K blocks this was the dominant
+        # wall cost (50% of total via PyLazyFrame.collect; cProfile Round 5).
+        # `row_ids` lookup was redundant indirection.
+        block_df = df[member_list]
+        results.append(BlockResult(
+            block_key=f"ann_{min(member_list)}",
+            df=block_df.lazy(),
+            strategy="ann",
+        ))
+
+    return results
+
+
+def _build_ann_pair_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+    """Build direct-pair ANN blocks without Union-Find.
+
+    Returns a single BlockResult with pre_scored_pairs set.
+    FAISS similarity scores are propagated directly.
+    """
+    from goldenmatch.core.ann_blocker import ANNBlocker
+    from goldenmatch.core.embedder import get_embedder
+
+    if not config.ann_column:
+        raise ValueError("ann_pairs blocking requires 'ann_column' to be set.")
+
+    df = lf.collect()
+    values = df[config.ann_column].to_list()
+
+    embedder = get_embedder(config.ann_model)
+    embeddings = embedder.embed_column(values, cache_key=f"ann_{config.ann_column}")
+
+    blocker = ANNBlocker(top_k=config.ann_top_k)
+    blocker.build_index(embeddings)
+    scored_pairs = blocker.query_with_scores(embeddings)
+
+    # Map positional indices to __row_id__ values
+    row_ids = df["__row_id__"].to_list()
+    mapped_pairs = [
+        (int(row_ids[a]), int(row_ids[b]), score)
+        for a, b, score in scored_pairs
+    ]
+
+    return [BlockResult(
+        block_key="ann_pairs",
+        df=df.lazy(),
+        strategy="ann_pairs",
+        pre_scored_pairs=mapped_pairs,
+    )]
+
+
+def _build_learned_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+    """Build blocks using learned predicates.
+
+    Two-pass approach:
+    1. If cached rules exist, load and apply them
+    2. Otherwise, run a fast sample with static blocking to generate training pairs,
+       then learn predicates from those pairs
+    """
+    from goldenmatch.core.learned_blocking import (
+        apply_learned_blocks,
+        learn_blocking_rules,
+        load_learned_rules,
+        save_learned_rules,
+    )
+
+    # Try loading cached rules
+    if config.learned_cache_path:
+        cached = load_learned_rules(config.learned_cache_path)
+        if cached:
+            logger.info("Using cached learned blocking rules from %s", config.learned_cache_path)
+            return apply_learned_blocks(lf, cached, config.max_block_size)
+
+    # Pass 1: fast static blocking on first key to generate training pairs
+    df = lf.collect()
+    sample_size = min(config.learned_sample_size, df.height)
+    if sample_size < df.height:
+        sample_df = df.sample(sample_size, seed=42)
+    else:
+        sample_df = df
+
+    # Use static blocking with the configured keys for the sample run
+    sample_config = config.model_copy(update={"strategy": "static"})
+    sample_blocks = _build_static_blocks(sample_df.lazy(), sample_config)
+
+    # Score sample blocks to get training pairs
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.scorer import find_fuzzy_matches
+
+    # Build a simple weighted matchkey for scoring
+    cols = [c for c in df.columns if not c.startswith("__")]
+    if not cols:
+        return _build_static_blocks(lf, sample_config)
+
+    # Use first few columns for a quick score
+    score_fields = [
+        MatchkeyField(field=c, scorer="token_sort", weight=1.0, transforms=["lowercase"])
+        for c in cols[:3]
+    ]
+    score_mk = MatchkeyConfig(name="_learned_score", type="weighted", threshold=0.5, fields=score_fields)
+
+    scored_pairs = []
+    for block in sample_blocks:
+        block_df = block.materialize().native
+        pairs = find_fuzzy_matches(block_df, score_mk)
+        scored_pairs.extend(pairs)
+
+    if not scored_pairs:
+        logger.warning("No scored pairs from sample run. Falling back to static blocking.")
+        return _build_static_blocks(lf, sample_config)
+
+    # Pass 2: learn rules from scored pairs
+    rules = learn_blocking_rules(
+        sample_df,
+        scored_pairs,
+        columns=cols,
+        min_recall=config.learned_min_recall,
+        min_reduction=config.learned_min_reduction,
+        predicate_depth=config.learned_predicate_depth,
+        # Rules are learned on `sample_df` and applied to the FULL frame below.
+        # Without the full height the selector's only cost signal is
+        # `reduction_ratio`, which is scale-invariant and so cannot tell a rule
+        # costing 3M candidate pairs from one costing 67B (#2474).
+        total_rows=df.height,
+    )
+
+    # Cache rules
+    if config.learned_cache_path and rules:
+        save_learned_rules(rules, config.learned_cache_path)
+        logger.info("Saved learned blocking rules to %s", config.learned_cache_path)
+
+    # Apply to full dataset
+    return apply_learned_blocks(lf, rules, config.max_block_size)
+
+
+def _build_canopy_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+    """Build blocks using TF-IDF canopy clustering.
+
+    Forms overlapping canopies based on cosine similarity of TF-IDF vectors.
+    Records can appear in multiple canopies.
+    """
+    from goldenmatch.core.canopy import build_canopies
+
+    if not config.canopy:
+        raise ValueError("Canopy blocking requires 'canopy' config to be set.")
+
+    df = lf.collect()
+    canopy_cfg = config.canopy
+
+    # Concatenate canopy fields into a single text value per record
+    text_values = []
+    for row in df.iter_rows(named=True):
+        parts = [str(row.get(f, "") or "") for f in canopy_cfg.fields]
+        text_values.append(" ".join(parts))
+
+    canopies = build_canopies(
+        text_values,
+        loose_threshold=canopy_cfg.loose_threshold,
+        tight_threshold=canopy_cfg.tight_threshold,
+        max_canopy_size=canopy_cfg.max_canopy_size,
+    )
+
+    results: list[BlockResult] = []
+    for i, members in enumerate(canopies):
+        if len(members) < 2:
+            continue
+        # `members` are positions in `df` — `build_canopies` returns
+        # indices into the text_values list which was built by enumerating
+        # df.iter_rows in order. Direct positional indexing is O(K) vs
+        # filter(is_in(...))'s O(N) per canopy — see ann_blocking_strategy
+        # for the cProfile attribution that drove this change.
+        block_df = df[sorted(list(members))]
+        results.append(BlockResult(
+            block_key=f"canopy_{i}",
+            df=block_df.lazy(),
+            strategy="canopy",
+        ))
+
+    return results
+
+
+def select_best_blocking_key(
+    lf: pl.LazyFrame,
+    keys: list[BlockingKeyConfig],
+    max_block_size: int = 5000,
+) -> BlockingKeyConfig:
+    """Evaluate blocking keys and select the one with smallest max block size.
+
+    Computes group-size histogram for each candidate key, then picks the key
+    that minimizes max_group_size while maintaining >= 50% coverage.
+    """
+    if len(keys) <= 1:
+        return keys[0]
+
+    df = lf.collect()
+    total = len(df)
+
+    best_key = keys[0]
+    best_max_size = float("inf")
+
+    for key_config in keys:
+        block_key_expr = _build_block_key_expr(key_config)
+        df_with_key = df.with_columns(block_key_expr)
+
+        # Count non-null block keys (coverage)
+        non_null = df_with_key.filter(pl.col("__block_key__").is_not_null()).height
+        coverage = non_null / total if total > 0 else 0.0
+
+        if coverage < 0.5:
+            logger.debug(
+                "Auto-select: skipping key %s (coverage %.1f%% < 50%%)",
+                key_config.fields, coverage * 100,
+            )
+            continue
+
+        # Compute group sizes
+        groups = df_with_key.filter(pl.col("__block_key__").is_not_null()).group_by("__block_key__").agg(
+            pl.len().alias("size")
+        )
+        # polars Series.max() returns PythonLiteral; "size" is i64 at runtime.
+        max_size = int(groups["size"].max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "size" is int64 at runtime
+        group_count = groups.height
+
+        logger.debug(
+            "Auto-select: key %s -> groups=%d, max_size=%d, coverage=%.1f%%",
+            key_config.fields, group_count, max_size, coverage * 100,
+        )
+
+        if max_size < best_max_size or (max_size == best_max_size and group_count > 0):
+            best_max_size = max_size
+            best_key = key_config
+
+    logger.info(
+        "Auto-select: chose key %s (max_block_size=%d)",
+        best_key.fields, best_max_size,
+    )
+    return best_key
+
+
+def build_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
+    """Build blocks from a LazyFrame based on blocking configuration.
+
+    Routes by config.strategy:
+    - "static": original blocking behavior
+    - "adaptive": primary blocks + recursive sub-blocking for oversized blocks
+    - "sorted_neighborhood": sliding window over sorted data
+    - "ann": ANN blocking with FAISS on embeddings
+    - "canopy": TF-IDF canopy clustering
+
+    Args:
+        lf: Input LazyFrame.
+        config: Blocking configuration with keys, max_block_size, skip_oversized.
+
+    Returns:
+        List of BlockResult, one per valid block.
+    """
+    # D2s-a: every non-static strategy + key auto-select + profile emission
+    # still takes a polars LazyFrame, so a seam Frame (or eager native)
+    # normalizes ONCE here (lossless -- polars stays a dependency until D6).
+    # Only the static/adaptive primary builder is dual-rep; it receives the
+    # ORIGINAL entry object so the arrow lane skips the polars round-trip.
+    from goldenmatch.core.frame import is_polars_dataframe, is_polars_lazyframe
+
+    _lf_entry = lf
+    if not is_polars_lazyframe(lf):
+        from goldenmatch.core.frame import Frame, to_frame
+
+        native = lf.native if isinstance(lf, Frame) else lf
+        if is_polars_dataframe(native):
+            lf = native.lazy()
+        else:
+            # PR-5 (autoconfig arrow-port): arrow ingest routes through the seam
+            # (no manual ``pl.from_arrow`` unwrap). The static/adaptive primary
+            # builder consumes ``_lf_entry`` directly via ``derive_block_key``
+            # (~line 406), so the polars round-trip is only needed by the
+            # non-static strategies, ``select_best_blocking_key`` auto-select,
+            # and an active profile emitter. When none of those apply, keep a
+            # seam Frame and skip the materialization entirely; otherwise fall
+            # back to the arrow->polars conversion (the seam has no arrow->polars
+            # op, so that conversion still uses pyarrow under the hood).
+            # multi_pass is dual-rep too: it delegates each pass to
+            # _build_static_blocks (seam-native via derive_block_key), so it stays
+            # arrow when no polars-only feature (multi-key auto-select) is in
+            # play. This is the common zero-config shape (the #1207 per-identifier
+            # union), so keeping it off the polars round trip is the load-bearing
+            # blocking-spine eviction for zero-config.
+            # NOTE: an active profile emitter (the auto-config controller) no
+            # longer forces polars here -- ``_emit_blocking_profile`` reads the
+            # row count off the arrow seam's ``height()`` (polars-free), so the
+            # controller's sample iterations run arrow-native on a base install
+            # without polars (previously they errored -> degraded config). The
+            # emitted BlockingProfile is byte-identical (row count is row count).
+            _needs_polars = (
+                config.strategy not in ("static", "adaptive", "multi_pass")
+                or (config.auto_select and config.keys and len(config.keys) > 1)
+            )
+            lf = (
+                cast(pl.DataFrame, pl.from_arrow(native)).lazy()
+                if _needs_polars
+                else to_frame(native)
+            )
+
+    # Auto-select: pick best key based on histogram analysis
+    if config.auto_select and config.keys and len(config.keys) > 1:
+        best_key = select_best_blocking_key(lf, config.keys, config.max_block_size)
+        config = config.model_copy(update={"keys": [best_key], "auto_select": False})
+
+    if config.strategy == "learned":
+        blocks = _build_learned_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "canopy":
+        blocks = _build_canopy_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "ann_pairs":
+        blocks = _build_ann_pair_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "ann":
+        blocks = _build_ann_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "sorted_neighborhood":
+        blocks = _build_sorted_neighborhood_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "multi_pass":
+        # Mirror static/adaptive: consume the ORIGINAL seam entry so the arrow
+        # lane skips the polars round-trip (each pass runs _build_static_blocks,
+        # which is dual-rep). `lf` (polars, when an emitter forced the round-trip)
+        # is still what _emit_blocking_profile consumes.
+        blocks = _build_multi_pass_blocks(_lf_entry, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "lsh":
+        from goldenmatch.core.lsh_blocker import build_lsh_blocks
+
+        blocks = build_lsh_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "token":
+        from goldenmatch.core.token_blocker import build_token_blocks
+
+        blocks = build_token_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "simhash":
+        from goldenmatch.core.simhash_blocker import build_simhash_blocks
+
+        blocks = build_simhash_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "perceptual":
+        from goldenmatch.core.perceptual_blocker import build_perceptual_blocks
+
+        blocks = build_perceptual_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    if config.strategy == "static":
+        blocks = _build_static_blocks(_lf_entry, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
+
+    # strategy == "adaptive"
+    primary_blocks = _build_static_blocks(_lf_entry, config)
+    sub_block_keys = config.sub_block_keys or []
+
+    results: list[BlockResult] = []
+    for block in primary_blocks:
+        block_df = block.materialize().native
+        size = len(block_df)
+
+        if size > config.max_block_size and sub_block_keys:
+            sub_results = _sub_block(
+                block_df,
+                sub_block_keys,
+                config.max_block_size,
+                depth=1,
+                parent_key=block.block_key,
+            )
+            results.extend(sub_results)
+        elif size > config.max_block_size and not config.skip_oversized:
+            # Auto-split: no sub_block_keys configured, split by highest-cardinality column
+            auto_results = _auto_split_block(block_df, config.max_block_size, block.block_key)
+            results.extend(auto_results)
+        else:
+            results.append(block)
+
+    _emit_blocking_profile(results, config, lf)
+    return results

--- a/scripts/fixtures/incident_1c843c8a5/score_buckets_prefix.py
+++ b/scripts/fixtures/incident_1c843c8a5/score_buckets_prefix.py
@@ -1,0 +1,2912 @@
+# FIXTURE -- DO NOT EDIT, DO NOT IMPORT.
+# Verbatim copy at 1c843c8a5^ (pre-fix) of the two modules behind the
+# suggest-quality regression: score_buckets resolved block keys as
+# `passes or keys` while blocker.py used the opposite precedence, so the two
+# backends blocked on DIFFERENT fields -- 0 pairs where legacy produced 242.
+# Kept so the shared-decision scan is proven against the incident that
+# motivated it without depending on git history staying reachable.
+"""In-process bucketed block scorer.
+
+Architectural pivot from the per-block LazyFrame model:
+
+  OLD (score_blocks_parallel / score_blocks_duckdb):
+    build_blocks(combined_lf, blocking) -> list[BlockResult]
+      where each BlockResult.df is a `combined_lf.filter(blocking_key == K)`
+      LazyFrame. At 5M rows / 1.67M blocks of 3 rows each, the LIST of
+      1.67M filter-LazyFrames + any per-block `.collect()`/`.select()` chains
+      explode Polars arena memory. Documented in heartbeats:
+      runs 25998537828, 26000789629, 26002766443, 26004842882, 26006853280,
+      26008682481, 26012579494 -- all hung at 62.99 GB RSS plateau on Linux
+      without ever reaching real scoring.
+
+  NEW (score_buckets):
+    prepared_df (eager) + blocking_config -> in one Polars pass:
+      with_columns(__block_key__ = key_expr, __bucket__ = hash(__block_key__) % N)
+    -> partition_by("__bucket__", as_dict=True)   # ≤ N eager bucket dfs
+    -> partition_by("__block_key__", as_dict=True) within each bucket
+    -> _score_one_block on each per-block eager df
+
+    No LazyFrames carrying filter expressions. No materialization of millions
+    of small frames. Two partition_by operations + N rapidfuzz calls.
+
+Hard invariant: at scale, this module must never call ``.collect()`` on a
+filter-LazyFrame. The single eager materialization happens once via
+``prepared_df = combined_lf.collect()`` at the pipeline call site BEFORE
+this scorer runs.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from goldenmatch._polars_lazy import pl
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, MatchkeyConfig
+from goldenmatch.core._native_loader import native_enabled, native_module
+from goldenmatch.core.bench import record_metrics, stage
+
+logger = logging.getLogger(__name__)
+
+
+def _bkt_debug_on() -> bool:
+    """Whether the verbose `[score_buckets]` diagnostics print. OFF by default:
+    now that bucket is the DEFAULT scorer, unconditional prints to stdout would
+    corrupt any tool that parses a dedupe's stdout (e.g. the frame-diff harness's
+    JSON subprocess). Set GOLDENMATCH_BUCKET_DEBUG=1 to re-enable."""
+    return os.environ.get("GOLDENMATCH_BUCKET_DEBUG", "0") not in (
+        "0", "", "false", "False", "no", "off",
+    )
+
+
+def _fs_bucket_native_enabled() -> bool:
+    """Whether the batched native FS bucket scorer is active (default ON).
+
+    ``GOLDENMATCH_FS_BUCKET_NATIVE=0`` forces the per-block ``prob_scorer`` loop
+    inside ``_score_one_bucket`` (the parity escape hatch — byte-identical to the
+    per-block native path). Only gates the BATCHED bucket call; whether the
+    per-block loop itself is native still follows ``_fs_native_eligible`` /
+    ``GOLDENMATCH_FS_NATIVE``."""
+    return os.environ.get("GOLDENMATCH_FS_BUCKET_NATIVE", "1").strip().lower() not in (
+        "0", "false", "no", "off", "disabled",
+    )
+
+
+def _fs_bucket_batch_enabled() -> bool:
+    """Whether the NON-native FS bucket path coalesces small blocks into one
+    row-capped ``score_probabilistic_vectorized_batch`` call (default ON).
+
+    The native bucket path (``_fs_bucket_native_enabled``) already scores a whole
+    block-sorted bucket in one kernel call. But when the native kernel is
+    DECLINED — the common case is the ``missing="disagree"`` mode auto-config
+    picks for null-heavy data like ``historical_50k``, which the kernel can't
+    express — the numpy ``prob_scorer`` ran once PER BLOCK, so a 7-pass scheme
+    over thousands of tiny blocks paid the per-call fan-out thousands of times
+    (measured 95s for a 50k dedupe, dominated by ~6k-block passes). This routes
+    those blocks through the #869 batched matrix scorer instead, which is
+    byte-identical to the per-block loop (each block's DIAGONAL sub-matrix is the
+    same value pairs) and honours ``missing="disagree"``.
+
+    ``GOLDENMATCH_FS_BUCKET_BATCH=0`` forces the per-block loop (parity escape
+    hatch). Only engages for the vectorized-numpy path (scalar / ensemble /
+    embedding / find_fuzzy_matches fallbacks stay per-block)."""
+    return os.environ.get("GOLDENMATCH_FS_BUCKET_BATCH", "1").strip().lower() not in (
+        "0", "false", "no", "off", "disabled",
+    )
+
+
+# One-time guard so the stale-native-wheel warning (issue #688) fires at most
+# once per process instead of once per score_buckets call.
+_WARNED_STALE_NATIVE_WHEEL = False
+
+
+def _warn_stale_native_wheel_once(n_exclude: int) -> None:
+    """Warn (once) when the loaded native wheel predates build_exclude_set.
+
+    The published ``goldenmatch-native 0.1.0`` wheel (2026-05-27) shipped one
+    day before ``build_exclude_set`` / ``ExcludeSet`` landed (#552, 2026-05-28),
+    so any env that pip-installs it instead of building in-tree hits the legacy
+    exclude path. Surface the skew instead of silently degrading -- this was the
+    root cause of issue #688's 44x bucket_score slowdown.
+    """
+    global _WARNED_STALE_NATIVE_WHEEL
+    if _WARNED_STALE_NATIVE_WHEEL:
+        return
+    _WARNED_STALE_NATIVE_WHEEL = True
+    logger.warning(
+        "goldenmatch-native is loaded but lacks build_exclude_set (pre-#552 "
+        "wheel; the published goldenmatch-native 0.1.0 is such a wheel). The "
+        "block scorer is using its exclude-set fallback (empty exclude + Python "
+        "post-filter over %d excluded pairs) -- still fast, but upgrading "
+        "goldenmatch-native or rebuilding in-tree (scripts/build_native.py) "
+        "restores the native Arc-handle path. See issue #688.",
+        n_exclude,
+    )
+
+
+# ── #1826 / #2417: bounded scoring of an un-splittable oversized block ──────
+
+
+def _fs_oversized_pair_budget() -> int:
+    """Candidate-pair budget for ONE scoring call on an oversized block.
+
+    When ``_split_oversized`` cannot split a block and ``skip_oversized=False``,
+    the block used to be handed to the scorer WHOLE -- one call carrying
+    ``C(n, 2)`` candidate pairs. That is the #1826 shape and the #2417 OOM: a
+    ~6,300-row hub block (all rows share one blocking-key value, so no split
+    exists) is ~19.8M candidate pairs in a single call.
+
+    Above this budget the block is scored in TILES instead (see
+    ``_iter_bounded_tiles``), which bounds a call's candidate pairs to roughly
+    the budget. What that buys differs by lane -- measured with
+    ``scripts/repro_issue_2417.py``, which drives this exact function:
+
+    * VECTORIZED (numpy): the peak IS the dense ``n x n`` float64 matrices, so
+      it is ``O(n^2)`` in the block's rows and independent of how many pairs
+      survive -- 434 MB at n=2,500, 866 MB at n=3,500, ~2.8 GB at n=6,300.
+      Tiling bounds it to ~``16 x budget`` bytes per field (866 -> 562 MB at the
+      default, 144 MB at a 1M budget). It also makes blocks above
+      ``GOLDENMATCH_FS_VEC_MAX_ELEMS`` (>7,071 rows), which ``_fs_vec_guard``
+      currently REFUSES outright, scoreable at all.
+    * NATIVE: the kernel threshold-filters per pair, so the candidates are never
+      materialized -- the peak tracks SURVIVING pairs (16 MB at 53K survivors,
+      654 MB at 2.4M). Tiling only removes the whole-block double-buffering
+      (Rust ``Vec`` -> pyo3 list -> rounded list), worth ~27%; the accumulated
+      survivor list is the floor and no amount of chunking moves it. Bounding
+      THAT needs pair streaming / arrow emission, not tiling.
+
+    Default 4,000,000 pairs (~2,830-row tiles): comfortably above every normal
+    block (``max_block_size`` defaults to 5,000 -> 12.5M pairs is already
+    oversized territory) so ordinary scoring is untouched, and small enough that
+    one call's dense matrix stays ~64 MB rather than gigabytes.
+
+    ``GOLDENMATCH_FS_OVERSIZED_CHUNK_PAIRS=0`` disables tiling entirely (the
+    pre-#2417 score-whole behaviour, kept as the parity escape hatch).
+    """
+    raw = os.environ.get("GOLDENMATCH_FS_OVERSIZED_CHUNK_PAIRS", "").strip()
+    if not raw:
+        return 4_000_000
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "GOLDENMATCH_FS_OVERSIZED_CHUNK_PAIRS=%r is not an integer; "
+            "using the 4,000,000-pair default.", raw,
+        )
+        return 4_000_000
+    return max(val, 0)
+
+
+def _pair_count(n: int) -> int:
+    return n * (n - 1) // 2 if n >= 2 else 0
+
+
+def _iter_bounded_tiles(frame, n: int, budget: int):
+    """Yield ``(tile_frame, head_len)`` covering every intra-block pair of
+    ``frame`` (``n`` rows) exactly once, with each tile's candidate-pair count
+    bounded by ``budget``.
+
+    Split the block into ``g`` contiguous groups of ``k = isqrt(budget / 2)``
+    rows and emit:
+
+    * one DIAGONAL tile per group -- ``head_len=None``, every pair it produces
+      is wanted (the group's own intra pairs);
+    * one CROSS tile per unordered group pair ``(i < j)`` -- the two groups
+      concatenated, ``head_len = len(group_i)``. The scorer sees ``2k`` rows and
+      produces intra-i, intra-j AND cross pairs; the caller keeps ONLY the cross
+      pairs (the intra ones already came from, or will come from, the diagonal
+      tiles). That discard is why tiling costs ~2x the pair comparisons of a
+      single whole-block call -- the price of bounding a call that otherwise
+      allocates ``O(n^2)`` and can take the process down.
+
+    Union of the kept pairs == the whole-block pair set, with no duplicates: an
+    unordered pair sits in one group (diagonal tile) or straddles exactly one
+    group pair (cross tile). EMISSION ORDER differs from the whole-block call
+    (tile order, not row-major); pair values are identical, and every FS
+    consumer canonicalizes + dedups pairs before use.
+    """
+    from math import isqrt
+
+    from goldenmatch.core.frame import concat_frames
+    from goldenmatch.core.frame import to_frame as _tf
+
+    # A cross tile holds 2k rows -> C(2k,2) ~ 2k^2 candidate pairs, so k is
+    # sized off the budget's HALF to keep the widest tile inside it.
+    k = max(isqrt(max(budget, 2) // 2), 2)
+    bounds = [(off, min(k, n - off)) for off in range(0, n, k)]
+    slices = [frame.slice(off, size) for off, size in bounds]
+
+    for sl, (_off, size) in zip(slices, bounds):
+        if size >= 2:
+            yield sl, None
+    for i in range(len(slices)):
+        for j in range(i + 1, len(slices)):
+            yield (
+                concat_frames([_tf(slices[i]), _tf(slices[j])]).native,
+                bounds[i][1],
+            )
+
+
+def _score_block_bounded(
+    frame,
+    n: int,
+    score_one,
+    *,
+    tile_above_rows: int,
+    row_id_col: str = "__row_id__",
+):
+    """Score ONE block, tiling it when a single call would exceed the pair
+    budget (#1826/#2417). ``score_one(frame) -> list[(a, b, score)] | None``.
+
+    Tiling engages ONLY for a block that is BOTH oversized
+    (``n > tile_above_rows``, i.e. the un-splittable score-whole fallback --
+    auto-split sub-blocks land at or under ``max_block_size`` and are left
+    alone) AND above the pair budget. Everywhere else this is exactly
+    ``score_one(frame)`` -- same call, same order, zero overhead -- so only the
+    pathological blocks pay the tiling cost. ``None`` (the
+    ``_score_block_frame`` "block pre-filtered out" signal) propagates for the
+    untiled call; per-tile ``None``s are simply skipped.
+    """
+    budget = _fs_oversized_pair_budget()
+    if budget <= 0 or n <= tile_above_rows or _pair_count(n) <= budget:
+        return score_one(frame)
+
+    from goldenmatch.core.frame import to_frame as _tf
+
+    logger.info(
+        "Oversized block (%d rows, ~%s candidate pairs) scored in bounded "
+        "tiles of <=%s pairs instead of one whole-block call (#1826/#2417). "
+        "Same pair set; ~2x pair comparisons. Set "
+        "GOLDENMATCH_FS_OVERSIZED_CHUNK_PAIRS=0 to score whole.",
+        n, f"{_pair_count(n):,}", f"{budget:,}",
+    )
+    out: list[tuple[int, int, float]] = []
+    for tile, head_len in _iter_bounded_tiles(frame, n, budget):
+        pairs = score_one(tile)
+        if not pairs:
+            continue
+        if head_len is None:
+            out.extend(pairs)
+            continue
+        # Cross tile: keep only pairs that straddle the two groups. The head
+        # group's row ids identify the side; a pair is cross iff exactly one
+        # endpoint is in the head.
+        head = set(_tf(tile).slice(0, head_len).column(row_id_col).to_list())
+        out.extend(p for p in pairs if (p[0] in head) != (p[1] in head))
+    return out
+
+
+# Scorers whose batched NxN matrix form is BYTE-IDENTICAL to the per-pair
+# score_pair callable (asserted scorer-by-scorer in
+# tests/test_score_buckets_vectorized_fallback.py). The vectorized fast-path
+# lane (_score_block_vec) only fires for a field whose scorer is in this set.
+#
+# float64 throughout. _fuzzy_score_matrix casts its matrices to float32 for the
+# 1M-row memory budget, but the per-pair fast-path loop accumulates in float64,
+# so a float32 matrix would flip borderline >= threshold decisions (the exact
+# "per-pair reimpl silently diverges" failure mode the ensemble decline in
+# _resolve_score_pair_callable warns about). The lane is size-capped
+# (GOLDENMATCH_BUCKET_VEC_MAX, default 2000) precisely so the float64 NxN stays
+# cheap and we never have to trade bits for memory.
+# NOTE: dice / jaccard are deliberately EXCLUDED. Their _dice_score_matrix /
+# _jaccard_score_matrix are the PPRL bloom-filter (hex-CLK) scorers -- a
+# different computation from the per-pair _dice_score_single / _jaccard_score_single
+# bigram coefficients, so the matrix is NOT byte-parity (it raises on plain
+# strings). The parity test catches this; do not add them back without a matrix
+# form that matches the per-pair callable bit-for-bit.
+_VEC_SUPPORTED: frozenset[str] = frozenset(
+    {"soundex_match", "jaro_winkler", "levenshtein", "token_sort", "ensemble"}
+)
+
+
+def _vec_field_matrix(values: list, scorer_name: str):
+    """float64 NxN score matrix for ``scorer_name`` over ``values``.
+
+    matrix[i, j] is byte-identical to the per-pair score_pair(values[i],
+    values[j]) -- same rapidfuzz / jellyfish primitive, just batched. Only the
+    scorers in ``_VEC_SUPPORTED`` reach here.
+    """
+    import numpy as np
+
+    from goldenmatch.core import strsim
+
+    if scorer_name == "soundex_match":
+        from goldenmatch.core.scorer import _soundex_score_matrix
+        return _soundex_score_matrix(values).astype(np.float64, copy=False)
+    if scorer_name == "dice":
+        from goldenmatch.core.scorer import _dice_score_matrix
+        return _dice_score_matrix(values).astype(np.float64, copy=False)
+    if scorer_name == "jaccard":
+        from goldenmatch.core.scorer import _jaccard_score_matrix
+        return _jaccard_score_matrix(values).astype(np.float64, copy=False)
+    if scorer_name == "ensemble":
+        # float64 max(jaro_winkler, token_sort/100, soundex*0.8) -- byte-identical
+        # to the per-pair `_ensemble_score_single` (same three components, same 0.8
+        # bonus, all float64). The soundex bonus reuses `_soundex_score_matrix`,
+        # the SAME matrix the per-pair soundex_match callable is byte-parity with
+        # (asserted in tests/test_score_buckets_vectorized_fallback.py), so the
+        # ensemble vec form agrees with `_ensemble_score_single`'s canonical
+        # soundex empty-code-guard semantics (garbage/empty never matches).
+        from goldenmatch.core.scorer import _soundex_score_matrix
+        jw = np.asarray(strsim.pure_field_matrix(values, "jaro_winkler", "float64"))
+        ts = np.asarray(strsim.pure_field_matrix(values, "token_sort", "float64")) / 100.0
+        sx = _soundex_score_matrix(values).astype(np.float64) * 0.8
+        return np.maximum(np.maximum(jw, ts), sx)
+    if scorer_name == "jaro_winkler":
+        return np.asarray(strsim.pure_field_matrix(values, "jaro_winkler", "float64"))
+    if scorer_name == "levenshtein":
+        return np.asarray(
+            strsim.pure_field_matrix(values, "levenshtein", "float64")
+        )
+    # token_sort: rapidfuzz returns 0-100; per-pair divides by 100.0 (same op order).
+    return np.asarray(strsim.pure_field_matrix(values, "token_sort", "float64")) / 100.0
+
+
+def _score_block_vec(
+    row_ids: list,
+    field_arrays: list,
+    scorer_names: list,
+    weights: list,
+    offset: int,
+    end: int,
+    total_weight: float,
+    threshold: float,
+    frozen_exclude: frozenset,
+) -> list:
+    """Score one block via batched matrices instead of the Python per-pair loop.
+
+    Byte-parity with _score_one_bucket_fast's per-pair branch: combines fields
+    in the same order (sum of matrix*weight, divided by total_weight), emits
+    canonical (min, max) pairs >= threshold in row-major (i<j) order with
+    exclusions removed. The O(n**2) work (scoring + threshold scan) is numpy;
+    only the emitted pairs (few, >= threshold) touch Python.
+    """
+    import numpy as np
+
+    n = end - offset
+    num = None
+    wsum = None
+    for f_idx, name in enumerate(scorer_names):
+        vals = field_arrays[f_idx][offset:end]
+        m = _vec_field_matrix(vals, name)
+        contrib = m * weights[f_idx]
+        num = contrib if num is None else num + contrib
+        # #weighted-null: a null field is ABSENCE of evidence, not disagreement,
+        # so it must leave the DENOMINATOR too -- otherwise an absolute threshold
+        # becomes unreachable (0.3/0.4/0.3 fields @0.85: a null dob caps the pair
+        # at 0.70 however perfectly the names agree). _vec_field_matrix collapses
+        # a null pair to 0.0 -- indistinguishable from a genuine 0.0 score -- so
+        # the mask is rebuilt from the raw values here. Mirrors
+        # native/src/score.rs and core/scorer.py::score_pair.
+        null = np.array([v is None for v in vals], dtype=bool)
+        obs = (~(null[:, None] | null[None, :])) * weights[f_idx]
+        wsum = obs if wsum is None else wsum + obs
+    with np.errstate(invalid="ignore", divide="ignore"):
+        combined = np.where(wsum > 0.0, num / np.where(wsum > 0.0, wsum, 1.0), 0.0)
+    iu0, iu1 = np.triu_indices(n, k=1)
+    flat = combined[iu0, iu1]
+    sel = flat >= threshold
+    if not bool(sel.any()):
+        return []
+    ids = row_ids[offset:end]
+    out: list[tuple[int, int, float]] = []
+    for a_idx, b_idx, s in zip(iu0[sel].tolist(), iu1[sel].tolist(), flat[sel].tolist()):
+        ri = ids[a_idx]
+        rj = ids[b_idx]
+        pair_key = (ri, rj) if ri < rj else (rj, ri)
+        if frozen_exclude and pair_key in frozen_exclude:
+            continue
+        out.append((pair_key[0], pair_key[1], s))
+    return out
+
+
+# Scorers the native fast-path kernel (goldenmatch._native.score_block_pairs)
+# implements, with the ids it expects. A field whose scorer isn't here forces
+# the Python per-pair loop for that bucket.
+_NATIVE_SCORER_IDS: dict[str, int] = {
+    "jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3,
+    # id 4 = date (score-core score_one). Routing to native is GUARDED on the
+    # `date_similarity` capability symbol at the gating site below: a stale
+    # published wheel (pre-date) would hit score_one's catch-all and silently
+    # score every date pair 0.0, so absent the symbol, date declines to the
+    # pure-Python mirror. NOTE: distinct from _NATIVE_FIELD_SCORER_IDS (the
+    # score_field_matrix path), where id 4 is soundex_match -- different kernel,
+    # different namespace; date is not wired into that path.
+    "date": 4,
+    # ids 17/18 = date_diff / geo_haversine (FS domain comparators, score-core
+    # score_one, spec 2026-07-23). (ids 15/16 below are the name scorers.) Same
+    # wheel-skew story as date: routing is GUARDED on the `date_diff_similarity` /
+    # `geo_haversine_similarity` capability symbols at the gating site below, so a
+    # stale wheel (whose score_one catch-all scores ids 17/18 as 0.0) declines to
+    # the pure-Python per-pair mirrors (`_date_diff_similarity_py` /
+    # `_geo_haversine_similarity_py`). Only the PARAMETERLESS comparators are
+    # kernel-backed; `numeric_diff` carries its band on the scorer string, which
+    # the fixed-id score_one(id,a,b) can't convey.
+    "date_diff": 17,
+    "geo_haversine": 18,
+    # id 19 = array_intersect (set-overlap over delimited strings, score-core
+    # score_one, jaccard DEFAULT only). Same wheel-skew story: guarded on the
+    # `array_intersect_similarity` capability symbol below. Only the bare key is
+    # here -- `array_intersect:overlap` carries its mode on the scorer string,
+    # which the fixed-id score_one(id,a,b) can't convey, so the `:overlap` form
+    # declines the batch id (the per-pair path carries the mode).
+    "array_intersect": 19,
+    # id 22 = numeric_diff DEFAULT (pct:0.1), score-core score_one. (ids 20/21 are
+    # the score-wasm name scorers, not score_one arms.) The parameterized
+    # abs/pct forms carry their band on the scorer string, which the fixed id
+    # can't convey -- they decline the batch id but ARE kernel-backed on the
+    # per-pair path via numeric_diff_similarity(a,b,spec) (see
+    # _resolve_score_pair_callable). Guarded on the `numeric_diff_similarity`
+    # capability symbol below.
+    "numeric_diff": 22,
+    # id 23 = cosine (vector cosine over two precomputed float-vector columns,
+    # score-core score_one). No mode/param, so the fixed id covers it fully
+    # (contrast array_intersect/numeric_diff). Guarded on the `cosine_similarity`
+    # capability symbol at the gating site below, so a stale wheel (pre-cosine,
+    # whose score_one catch-all scores id 23 as 0.0) declines to the pure-Python
+    # per-pair mirror (`_cosine_similarity_py`) instead of silently zeroing.
+    "cosine": 23,
+    # id 5 = qgram (char-trigram Jaccard, score-core score_one). Same wheel-skew
+    # story as date: routing is GUARDED on the `qgram_similarity` capability
+    # symbol at the gating site below, so a stale wheel (pre-qgram, whose
+    # score_one catch-all scores id 5 as 0.0) declines to the pure-Python
+    # per-pair mirror (`_qgram_score_single`) instead of silently zeroing.
+    "qgram": 5,
+    # id 6 = soundex_match (binary soundex-code equality, score-core score_one).
+    # Same wheel-skew story: guarded on the `soundex_similarity` capability symbol
+    # so a stale wheel declines to the pure-Python per-pair jellyfish mirror. NB
+    # score_one id 6 uses NAIVE code equality (two empty codes -> match), matching
+    # `_resolve_score_pair_callable`'s `jf.soundex(a)==jf.soundex(b)` bucket mirror
+    # -- NOT the field-matrix path's id 4=soundex (empty codes non-matching;
+    # a separate id namespace).
+    "soundex_match": 6,
+    # id 7 = initialism_match (abbreviation matcher, score-core score_one).
+    # Two-part wheel-skew guard at the gating site below: routing to native id 7
+    # requires BOTH the `initialism_similarity` capability symbol (a stale
+    # pre-initialism wheel hits score_one's catch-all -> silent 0.0) AND a
+    # successful `set_legal_form_variants` install (id 7 scores against an empty
+    # legal-form set until the host ships `entity_form_variants()`), else it
+    # declines to the pure-Python per-pair mirror (`_initialism_match_single`).
+    "initialism_match": 7,
+    # id 8 = alias_match (business + given-name canonical equality, score-core
+    # score_one). Two-part wheel-skew guard at the gating site below: routing to
+    # native id 8 requires BOTH the `alias_match_similarity` capability symbol (a
+    # stale pre-alias wheel hits score_one's catch-all -> silent 0.0) AND a
+    # successful install of the business + given-name tables (id 8 scores against
+    # empty tables until the host ships them), else it declines to the pure-Python
+    # per-pair mirror (`_alias_match_single`).
+    "alias_match": 8,
+    # ids 9/10/11 = dice / jaccard / phash (bloom-hex + hex-hamming, score-core
+    # score_one). Byte-exact with the per-pair `_dice_score_single` /
+    # `_jaccard_score_single` / `_phash_score_single` (integer popcount + one f64
+    # divide -- the numpy MATRIX forms are float32, a separate path). Guarded on
+    # the `dice_similarity` / `jaccard_similarity` / `phash_similarity` capability
+    # symbols so a stale wheel declines to those pure mirrors. dice/jaccard are
+    # padding-invariant; phash matches the PAIRWISE `_phash_score_single` (Option A
+    # in docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md),
+    # NOT the block-global `_phash_score_matrix`.
+    "dice": 9,
+    "jaccard": 10,
+    "phash": 11,
+    # id 12 = ensemble: max(jaro_winkler, unscaled token_sort, 0.8*soundex),
+    # composing score_one 0/2/6 (score-core `ensemble_similarity`). Matches the
+    # per-pair `_ensemble_score_single` to machine epsilon (1.1e-16 on real
+    # Febrl3 name/address pairs). Guarded on the `ensemble_similarity` capability
+    # symbol so a stale wheel (pre-ensemble score_one) declines to the pure
+    # per-pair mirror instead of silently scoring the whole matchkey 0.0.
+    "ensemble": 12,
+    # ids 13/14 = radial / audio_fp (perceptual profile scorers: score-core
+    # score_one). Byte-exact with the per-pair `_radial_score_single` /
+    # `_audio_fp_score_single` (hex-parse + alignment search + f64 reductions --
+    # the numpy MATRIX forms are a symmetric pairwise loop, same math). Guarded on
+    # the `radial_similarity` / `audio_fp_similarity` capability symbols so a stale
+    # wheel (pre-radial/audio score_one) declines to those pure mirrors instead of
+    # silently zeroing the id via score_one's catch-all.
+    "radial": 13,
+    "audio_fp": 14,
+    # ids 15/16 = name_freq_weighted_jw / given_name_aliased_jw (the census-IDF /
+    # given-name-alias name scorers). UNLIKE ids 0..=14 these are NOT score_one
+    # scorers -- score_one is stateless and cannot reach reference tables. The
+    # WEIGHTED bucket kernel intercepts 15/16 and dispatches them through
+    # fs-core's `name_freq_weighted_sim` / `given_name_aliased_sim` over the
+    # process-global census/alias tables (`set_name_reference_data`). Two-part
+    # wheel-skew guard at the gating site: routing requires BOTH the
+    # `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS` capability flag AND a successful table
+    # install (`_ensure_name_tables_installed`), folded into one memoized bool; a
+    # stale wheel (score_one catch-all -> 0.0) declines to the pure plugin path.
+    # ADDITIONALLY name_freq_weighted_jw declines native when its field carries a
+    # per-dataset `tf_freqs` table (#1207 default-on): fs-core ports only the
+    # STATIC-census branch, so a tf field stays on the vectorized find_fuzzy_matches
+    # (which applies the tf downweight via the plugin matrix path). Parity is
+    # tolerance-bounded, not byte-exact: the native base JW is rapidfuzz-rs vs the
+    # plugin's rapidfuzz-py -- native is the reference (see the FS name-scorer
+    # story in probabilistic.py + tests/test_native_name_scorer_parity.py).
+    "name_freq_weighted_jw": 15,
+    "given_name_aliased_jw": 16,
+}
+
+
+# Cached tri-state for the one-time legal-form install into the native kernel:
+# None = not yet attempted, True = installed on a capable kernel, False = kernel
+# lacks the symbols (stale wheel) so the initialism native route is declined.
+_LEGAL_FORMS_INSTALLED: bool | None = None
+
+
+def _ensure_legal_forms_installed() -> bool:
+    """Install ``entity_form_variants()`` into score-core's process-global
+    legal-form table (via the native ``set_legal_form_variants`` shim) exactly
+    once, so ``score_one`` id 7 (initialism_match) drops legal forms the same way
+    the pure ``derive_initialism`` does.
+
+    Returns True once the table is installed on a kernel exposing BOTH
+    ``set_legal_form_variants`` and ``initialism_similarity``; False when the
+    loaded kernel lacks either symbol (a stale pre-initialism wheel), so the
+    gating site declines the native id-7 route and lets the pure per-pair mirror
+    (``_initialism_match_single``) score the block. Idempotent + memoized: the
+    OnceLock is first-wins and the variant set is deterministic, so a benign
+    re-install (another caller won the race) still leaves the correct table.
+    """
+    global _LEGAL_FORMS_INSTALLED
+    if _LEGAL_FORMS_INSTALLED is not None:
+        return _LEGAL_FORMS_INSTALLED
+    _mod = native_module()
+    if (
+        _mod is None
+        or not hasattr(_mod, "set_legal_form_variants")
+        or not hasattr(_mod, "initialism_similarity")
+    ):
+        _LEGAL_FORMS_INSTALLED = False
+        return False
+    try:
+        from goldenmatch.refdata.business import entity_form_variants
+
+        # Bool return (first-wins) is intentionally ignored: whether we or another
+        # caller installed it, the deterministic content is now in place.
+        _mod.set_legal_form_variants(list(entity_form_variants()))
+        _LEGAL_FORMS_INSTALLED = True
+    except Exception:
+        _LEGAL_FORMS_INSTALLED = False
+    return _LEGAL_FORMS_INSTALLED
+
+
+# Same tri-state as _LEGAL_FORMS_INSTALLED, for the alias_match business +
+# given-name canonical tables.
+_ALIAS_TABLES_INSTALLED: bool | None = None
+
+
+def _ensure_alias_tables_installed() -> bool:
+    """Install the business + given-name canonical tables into score-core's
+    process-global state (via the native ``set_business_aliases`` /
+    ``set_given_name_canonicals`` shims) exactly once, so ``score_one`` id 8
+    (alias_match) canonicalizes the same way the pure ``_alias_match_single`` does.
+
+    Ships:
+      * business ``strip_legal_form`` variants (``business._state.variants_normalized``)
+        -- rebuilt kernel-side into the trailing-suffix regex -- plus the raw
+        ``surface_to_canonical`` alias map.
+      * a PRE-RESOLVED given-name ``normalized -> min(canonical set)`` map, so the
+        kernel needs no alias graph, only a normalize + lookup.
+
+    Returns True once installed on a kernel exposing ``set_business_aliases``,
+    ``set_given_name_canonicals`` AND ``alias_match_similarity``; False when the
+    loaded kernel lacks a symbol (a stale pre-alias wheel) or the refdata packs
+    are unavailable, so the gating site declines the native id-8 route and lets
+    the pure ``_alias_match_single`` mirror score the block. Idempotent +
+    memoized; the OnceLocks are first-wins and the tables are deterministic.
+    """
+    global _ALIAS_TABLES_INSTALLED
+    if _ALIAS_TABLES_INSTALLED is not None:
+        return _ALIAS_TABLES_INSTALLED
+    _mod = native_module()
+    if (
+        _mod is None
+        or not hasattr(_mod, "set_business_aliases")
+        or not hasattr(_mod, "set_given_name_canonicals")
+        or not hasattr(_mod, "alias_match_similarity")
+    ):
+        _ALIAS_TABLES_INSTALLED = False
+        return False
+    try:
+        from goldenmatch.refdata import business as _business
+        from goldenmatch.refdata import business_aliases as _ba
+        from goldenmatch.refdata import given_names as _gn
+
+        _business._load()
+        _ba._load()
+        _gn._load()
+        # Refdata packs must be present for the kernel to canonicalize; without
+        # them the pure mirror is the only faithful path.
+        if _business._state is None or _ba._state is None or _gn._state is None:
+            _ALIAS_TABLES_INSTALLED = False
+            return False
+        # Bool returns (first-wins) intentionally ignored: deterministic content.
+        _mod.set_business_aliases(
+            list(_business._state.variants_normalized),
+            list(_ba._state.surface_to_canonical.items()),
+        )
+        _mod.set_given_name_canonicals(
+            [(k, min(v)) for k, v in _gn._state.canonicals.items()]
+        )
+        _ALIAS_TABLES_INSTALLED = True
+    except Exception:
+        _ALIAS_TABLES_INSTALLED = False
+    return _ALIAS_TABLES_INSTALLED
+
+
+# Same tri-state as the two above, for the census surname-IDF + given-name alias
+# tables the weighted-bucket name scorers (ids 15/16) dispatch over.
+_NAME_TABLES_INSTALLED: bool | None = None
+
+
+def _ensure_name_tables_installed() -> bool:
+    """Install the census surname-IDF + given-name alias tables into the native
+    kernel's process-global ``NameRefData`` (via ``set_name_reference_data``)
+    exactly once, so the WEIGHTED bucket ids 15/16 (``name_freq_weighted_jw`` /
+    ``given_name_aliased_jw``) score over the SAME tables the pure plugin scorers
+    do (``refdata.scorer.NameFreqWeightedJW`` / ``GivenNameAliasedJW``).
+
+    Shares the process-global with the FS path's ``_ensure_fs_name_refdata`` (one
+    kernel table), so a benign double-install is skipped via
+    ``has_name_reference_data``.
+
+    Returns True once installed on a kernel exposing ``set_name_reference_data``
+    AND the ``NATIVE_SUPPORTS_NAME_BUCKET_SCORERS`` capability flag; False when the
+    loaded kernel lacks a symbol (a stale wheel whose ``score_one`` catch-all would
+    score ids 15/16 as 0.0) or the census/alias packs are unavailable, so the
+    gating site declines the native route and the pure per-pair plugin mirror (or,
+    at the fast-path guard, the vectorized ``find_fuzzy_matches``) scores the block.
+    Idempotent + memoized; the reference tables are deterministic.
+    """
+    global _NAME_TABLES_INSTALLED
+    if _NAME_TABLES_INSTALLED is not None:
+        return _NAME_TABLES_INSTALLED
+    _mod = native_module()
+    if (
+        _mod is None
+        or not hasattr(_mod, "set_name_reference_data")
+        or not hasattr(_mod, "NATIVE_SUPPORTS_NAME_BUCKET_SCORERS")
+    ):
+        _NAME_TABLES_INSTALLED = False
+        return False
+    try:
+        from goldenmatch.refdata.given_names import export_alias_forms
+        from goldenmatch.refdata.surnames import export_counts
+
+        surname_counts = [(n, float(c)) for n, c in export_counts()]
+        alias_forms = export_alias_forms()
+        # Both packs empty -> the kernel would score every name pair as plain JW
+        # (name_freq_weighted degrades to JW with no census table; given_name_-
+        # aliased to JW with no alias graph). The pure plugin path is the only
+        # faithful route in that case, so decline.
+        if not surname_counts and not alias_forms:
+            _NAME_TABLES_INSTALLED = False
+            return False
+        # Skip a redundant install if the FS path already registered the SAME
+        # deterministic tables into the shared process-global.
+        if not (
+            hasattr(_mod, "has_name_reference_data") and _mod.has_name_reference_data()
+        ):
+            _mod.set_name_reference_data(surname_counts, alias_forms)
+        _NAME_TABLES_INSTALLED = True
+    except Exception:
+        _NAME_TABLES_INSTALLED = False
+    return _NAME_TABLES_INSTALLED
+
+
+# Single source in core._hashing (re-exported here for back-compat). The
+# distributed record store imports the SAME constant, so bucket assignment is
+# identical across the two surfaces. Was a duplicated literal; drift is now
+# gated by test_cross_surface_consistency.
+from goldenmatch.core._hashing import BUCKET_HASH_SEED  # noqa: E402
+
+
+def _fs_bounded_stream_enabled() -> bool:
+    """Whether the FS bucket route scores buckets by BOUNDED STREAMING (slice one
+    bucket off the keyed frame on demand) instead of the eager
+    ``partition_by``-into-all-``n_buckets`` materialization.
+
+    Motivation (``docs/superpowers/specs/2026-07-20-fs-frame-residency-bucket-streaming-design.md``):
+    the eager partition holds ``n_buckets`` frames (~1x the frame) live through the
+    whole ``bucket_score`` loop, on TOP of the transient double at ``partition_by``
+    time -- the dominant remaining single-node FS peak at >=1M after the EM
+    ``build_blocks`` fix. Streaming holds only the keyed frame + ``max_workers``
+    in-flight bucket slices (the spec's in-RAM ``FrameBlockSource``).
+
+    ``GOLDENMATCH_FS_BLOCK_SOURCE=frame`` opts in; default (unset / any other value)
+    keeps the byte-identical eager path until the >=1M peak/wall win is CI-measured
+    and the default is flipped. Scoped to the FS (probabilistic) bucket route; the
+    weighted path is untouched. The DuckDB (above-RAM) source
+    (``GOLDENMATCH_FS_BLOCK_SOURCE=duckdb`` / ``score_fs_out_of_core``) is the
+    sibling out-of-core lane; both are governed by the single
+    ``fs_out_of_core.resolve_fs_block_source`` resolver (lazy import to avoid a
+    module-load cycle)."""
+    from goldenmatch.backends.fs_out_of_core import resolve_fs_block_source
+
+    return resolve_fs_block_source() == "frame"
+
+
+def _default_n_buckets(height: int | None = None) -> int:
+    """CPU-derived floor, data-scaled above it (#1803 item 5).
+
+    Bucket count tracks rows upward (target ~50K rows/bucket, capped at 4096
+    to bound partition bookkeeping) so per-bucket frame size stays bounded at
+    10M+ instead of growing linearly under the old CPU-only cap. Output pairs
+    are invariant to the bucket count (blocks hash wholly into one bucket);
+    only the partition granularity changes. ``height=None`` keeps the legacy
+    CPU-only formula for callers without a frame in hand.
+    """
+    base = min((os.cpu_count() or 4) * 4, 1024)
+    if height is None:
+        return base
+    return min(max(base, height // 50_000), 4096)
+
+
+def _resolve_score_pair_callable(
+    scorer_name: str, tf_freqs: dict[str, float] | None = None
+) -> Any:
+    """Return a (str_a, str_b) -> float | None callable for a scorer name.
+
+    Used by the bucket scorer's fast path so per-pair work skips the
+    PluginRegistry / dispatch overhead that ``_fuzzy_score_matrix`` does
+    per (block x field). None when the scorer isn't fast-path safe
+    (embedding, ensemble, record_embedding, unknown).
+
+    ``tf_freqs`` (#1781): the field's per-dataset value-frequency table
+    (``MatchkeyField.tf_freqs``). Only the PLUGIN branch consumes it --
+    built-in scorers ignore frequency tables, mirroring the legacy path
+    where the table travels only through the plugin protocol. When set,
+    the returned callable binds it as ``fn(a, b, tf_freqs=...)`` so the
+    fast path matches the legacy matrix path (core/scorer.py:1236);
+    pre-fix the table was silently dropped here, which is why the
+    sample-time controller telemetry showed the downweight biting while
+    the final dedupe output was byte-identical with it OFF.
+    """
+    if scorer_name == "jaro_winkler":
+        from goldenmatch.core import strsim
+        return strsim.jaro_winkler_similarity
+    if scorer_name == "levenshtein":
+        from goldenmatch.core import strsim
+        return strsim.levenshtein_normalized_similarity
+    if scorer_name == "token_sort":
+        from goldenmatch.core import strsim
+        return lambda a, b: strsim.token_sort_ratio(a, b) / 100.0
+    if scorer_name == "exact":
+        return lambda a, b: 1.0 if a == b else 0.0
+    if scorer_name == "soundex_match":
+        # GoldenMatch canonical soundex (byte-matches score-core); per-pair binary
+        # match with the empty-code guard (garbage/empty never matches). Identical
+        # to the matrix path's soundex_match, just one call at a time.
+        from goldenmatch.core.scorer import _soundex_score_single
+        return _soundex_score_single
+    if scorer_name == "date":
+        # Date-aware scorer (#1858). Per-pair mirror of score-core::date_similarity
+        # (native id 4); byte-identical to the kernel (native-parity asserted).
+        from goldenmatch.core.scorer import _date_similarity_py
+        return _date_similarity_py
+    if scorer_name == "date_diff":
+        # Magnitude-aware date comparator (spec 2026-07-23). Per-pair mirror of
+        # score-core::date_diff_similarity (native id 15); parity-asserted in
+        # tests/test_native_date_diff_geo_parity.py. Making it fast-path eligible
+        # routes date_diff configs through the bucket backend (native id 15 or
+        # this per-pair mirror) instead of the slow matrix path.
+        from goldenmatch.core.scorer import _date_diff_similarity_py
+        return _date_diff_similarity_py
+    if scorer_name == "geo_haversine":
+        # Great-circle comparator (spec 2026-07-23). Per-pair mirror of
+        # score-core::geo_haversine_similarity (native id 16); parity-asserted in
+        # tests/test_native_date_diff_geo_parity.py.
+        from goldenmatch.core.scorer import _geo_haversine_similarity_py
+        return _geo_haversine_similarity_py
+    if scorer_name == "array_intersect" or scorer_name.startswith("array_intersect:"):
+        # Set-overlap comparator over delimited strings. Per-pair mirror of
+        # score-core::array_intersect_similarity (native id 19, jaccard default);
+        # the mode is bound from the scorer string so `:overlap` scores correctly
+        # off the fast path (it declines native + the vec lane -- fixed-id
+        # score_one can't carry the mode). Parity-asserted in
+        # tests/test_native_array_intersect_parity.py.
+        from goldenmatch.core.scorer import _array_intersect_similarity_py
+        return lambda a, b: _array_intersect_similarity_py(a, b, scorer_name)
+    if scorer_name == "numeric_diff" or scorer_name.startswith("numeric_diff:"):
+        # Magnitude-aware numeric comparator. The band/mode ride the scorer string
+        # (numeric_diff:abs:<eps> / :pct:<frac>), which the fixed-id score_one(22)
+        # can't carry -- so bind the FULL scorer string as the spec and prefer the
+        # native score-core kernel (numeric_diff_similarity(a,b,spec)) when the
+        # wheel exposes it, else the byte-identical pure-Python mirror. This makes
+        # the parameterized forms kernel-backed on the per-pair path (score_one(22)
+        # covers the pct:0.1 default on the batch path). Parity-asserted in
+        # tests/test_native_numeric_diff_parity.py.
+        _mod = native_module()
+        if _mod is not None and hasattr(_mod, "numeric_diff_similarity"):
+            return lambda a, b: _mod.numeric_diff_similarity(a, b, scorer_name)
+        from goldenmatch.core.scorer import _numeric_diff_similarity_py
+        return lambda a, b: _numeric_diff_similarity_py(a, b, scorer_name)
+    if scorer_name == "cosine":
+        # Vector cosine over two precomputed float-vector columns. Per-pair mirror
+        # of score-core::cosine_similarity (native id 23); no mode/param, so the
+        # batch path uses native id 23 (wheel-guarded on the `cosine_similarity`
+        # symbol) and this is the fast-path fallback. Parity-asserted in
+        # tests/test_native_cosine_parity.py.
+        from goldenmatch.core.scorer import _cosine_similarity_py
+        return _cosine_similarity_py
+    if scorer_name == "qgram":
+        # Character-trigram Jaccard (n=3). Per-pair mirror of the matrix path
+        # (_qgram_score_matrix) AND of score-core::qgram_similarity (native
+        # id 5); the three are parity-asserted in tests/test_native_qgram_parity.py.
+        # Making qgram fast-path eligible routes qgram configs through the bucket
+        # backend (native or this per-pair mirror) instead of the slow matrix path.
+        from goldenmatch.core.scorer import _qgram_score_single
+        return _qgram_score_single
+    if scorer_name == "initialism_match":
+        # Abbreviation matcher (1.0/0.0). Per-pair mirror of the matrix path
+        # (core/scorer.py:736) AND of score-core::initialism_match (native id 7);
+        # parity-asserted in tests/test_native_initialism_parity.py. Making it
+        # fast-path eligible routes initialism_match configs through the bucket
+        # backend (native id 7 or this per-pair mirror) instead of the slow
+        # matrix path. The native id-7 kernel needs the legal-form table
+        # installed (`set_legal_form_variants`); the gating site below guards on
+        # both the `initialism_similarity` symbol AND a successful install, and
+        # declines to THIS mirror otherwise.
+        from goldenmatch.core.scorer import _initialism_match_single
+        return _initialism_match_single
+    if scorer_name == "alias_match":
+        # Business + given-name canonical equality (1.0/0.0). Per-pair mirror of
+        # the matrix path (core/scorer.py:_alias_score_matrix) AND of
+        # score-core::alias_match (native id 8); parity-asserted in
+        # tests/test_native_alias_parity.py. Making it fast-path eligible routes
+        # alias_match configs through the bucket backend (native id 8 or this
+        # per-pair mirror) instead of the slow matrix path. The native id-8 kernel
+        # needs the business + given-name tables installed
+        # (`set_business_aliases`/`set_given_name_canonicals`); the gating site
+        # below guards on both the `alias_match_similarity` symbol AND a successful
+        # install, and declines to THIS mirror otherwise.
+        from goldenmatch.core.scorer import _alias_match_single
+        return _alias_match_single
+    if scorer_name == "dice":
+        # Bloom-hex Dice coefficient (2*|A&B|/(|A|+|B|)). Per-pair mirror of
+        # score-core::dice_similarity (native id 9); parity-asserted in
+        # tests/test_native_bloom_hash_parity.py. Integer popcount, so it's
+        # byte-exact with the kernel (the numpy _dice_score_matrix is float32, a
+        # separate path). The gating site guards on the `dice_similarity` symbol
+        # and declines to THIS mirror otherwise.
+        from goldenmatch.core.scorer import _dice_score_single
+        return _dice_score_single
+    if scorer_name == "jaccard":
+        # Bloom-hex Jaccard (|A&B|/|A|B|). Per-pair mirror of
+        # score-core::jaccard_similarity (native id 10); same integer-popcount
+        # byte-parity story as dice.
+        from goldenmatch.core.scorer import _jaccard_score_single
+        return _jaccard_score_single
+    if scorer_name == "phash":
+        # Perceptual-hash Hamming similarity (1 - dist/nbits). Per-pair mirror of
+        # score-core::phash_similarity (native id 11). NOTE: this makes phash
+        # fast-path eligible for the FIRST time -- it previously declined to the
+        # slow `find_fuzzy_matches` MATRIX path (`_phash_score_matrix`, float32 +
+        # block-GLOBAL max-length padding). The bucket path uses this PAIRWISE
+        # float64 `_phash_score_single` instead (Option A in
+        # docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md):
+        # byte-identical for fixed-length pHashes (the normal 64-bit case), and a
+        # precision improvement (float64) elsewhere. Guarded on `phash_similarity`.
+        from goldenmatch.core.scorer import _phash_score_single
+        return _phash_score_single
+    if scorer_name == "ensemble":
+        # ensemble is fast-path eligible by DEFAULT (2026-07-21, re-enabled after
+        # the perf guard below made it safe). It rides the float64 bucket fast
+        # path: `_ensemble_score_single` per-pair (tiny blocks) + the
+        # byte-identical `_vec_field_matrix('ensemble')` vectorized lane (mid
+        # blocks; ensemble is in `_VEC_SUPPORTED`) + the native `score_one` id 12
+        # arrow kernel on all-native matchkeys. Measured 1.47x faster end-to-end
+        # on Febrl3, byte-identical recall.
+        #
+        # The earlier default-on attempt (#1995) hung a CI worker: making ensemble
+        # resolvable flipped a NAME-SCORER matchkey (name_freq_weighted_jw /
+        # given_name_aliased_jw -- neither vec-supported nor native-id) onto the
+        # fast path, where those fields ran the O(N^2) per-pair Python loop, 19x
+        # slower than the vectorized find_fuzzy_matches (26.97s vs 1.40s on the
+        # same 65 NCVR blocks), blowing the per-test timeout. That is fixed at the
+        # SOURCE by the PERF GUARD in `_resolve_fast_path` (declines the fast path
+        # whenever a field would force per-pair Python) -- so an ensemble field can
+        # no longer drag a per-pair-Python matchkey onto the slow path. See
+        # docs/superpowers/specs/2026-07-21-ensemble-kernel-measurement.md.
+        #
+        # KILL-SWITCH: `GOLDENMATCH_ENSEMBLE_KERNEL=0` (or `off`/`false`) restores
+        # the historical decline (float32 find_fuzzy_matches) for rollback /
+        # byte-for-byte reproduction of pre-2026-07-21 output.
+        mode = os.environ.get("GOLDENMATCH_ENSEMBLE_KERNEL", "").strip().lower()
+        if mode in ("0", "off", "false", "no"):
+            return None
+        from goldenmatch.core.scorer import _ensemble_score_single
+        return _ensemble_score_single
+    if scorer_name in ("embedding", "record_embedding"):
+        # Still model-backed; not fast-path eligible.
+        return None
+    # (dice / jaccard / soundex_match handled above)
+    # Plugin scorer -- accept only when it exposes ``score_pair``.
+    try:
+        from goldenmatch.plugins.registry import PluginRegistry
+        plugin = PluginRegistry.instance().get_scorer(scorer_name)
+    except Exception:
+        return None
+    if plugin is None:
+        return None
+    fn = getattr(plugin, "score_pair", None)
+    if fn is None or not tf_freqs:
+        return fn  # may itself be None for matrix-only plugins
+    # #1781: bind the field's TF table so the fast path matches the legacy
+    # matrix path (core/scorer.py:1236). Without this, the sample-time
+    # controller telemetry shows the downweight biting (samples run legacy)
+    # while the final dedupe silently drops it. TypeError fallback = the
+    # score_pair-side twin of _fuzzy_score_matrix's score_matrix posture
+    # (core/scorer.py:594-597): a legacy plugin without the keyword degrades
+    # to the bare call. Per-call try is fine -- zero cost on the happy path.
+
+    def _with_tf(a, b, _fn=fn, _tf=tf_freqs):
+        try:
+            return _fn(a, b, tf_freqs=_tf)
+        except TypeError:
+            return _fn(a, b)
+
+    return _with_tf
+
+
+# Scorers that score_field() handles directly (without raising). NE entries
+# whose scorer is NOT in this set get silently skipped at runtime via the
+# _NE_BROKEN cache in core/scorer.py::_apply_negative_evidence -- so they
+# contribute zero penalty to the final score. The fast path can safely run
+# when every NE scorer is one of these "will-fail" names, because the
+# computed score matches what the slow path would produce (penalty=0 either
+# way). Without this check, auto-config's promote_negative_evidence on
+# 'ensemble' / 'embedding' / 'record_embedding' (none of which score_field
+# implements) forces the entire workload onto the slow path even though the
+# NE entries don't actually do anything at runtime.
+_SCORE_FIELD_DIRECT_SCORERS: frozenset[str] = frozenset({
+    "exact", "jaro_winkler", "levenshtein", "token_sort",
+    "soundex_match", "dice", "jaccard",
+})
+
+
+def _ne_effectively_empty(mk: MatchkeyConfig) -> bool:
+    """True when matchkey.negative_evidence is empty OR every NE entry uses
+    a scorer name that score_field doesn't handle.
+
+    Historical role (pre-2026-05-29): this gated fast-path eligibility --
+    NE with callable scorers forced the slow path. Now the fast path engages
+    with NE math inline (`_resolve_ne_specs` + per-pair penalty in
+    `_score_one_bucket_fast`). The helper survives because:
+      1. The slow path's `_NE_BROKEN` cache still uses the same classification
+         to silently skip broken NE entries.
+      2. Tests in test_score_buckets_fast_path_gate.py assert this classification
+         independently of whether the fast path declines or engages.
+      3. Controller / planner policy decisions can still consult it to detect
+         "NE no-op" workloads.
+    """
+    ne = getattr(mk, "negative_evidence", None)
+    if not ne:
+        return True
+    for ne_entry in ne:
+        scorer = getattr(ne_entry, "scorer", None)
+        if scorer is None or scorer in _SCORE_FIELD_DIRECT_SCORERS:
+            return False
+    return True
+
+
+# NE spec layout: (xform_col, score_pair_fn, threshold, penalty). One per
+# resolvable NE entry. Empty list means "no NE math needed" -- either NE
+# was empty or every NE entry's scorer is in _NE_BROKEN territory (matches
+# the slow path's silent-skip behavior).
+NeSpec = tuple[str, Any, float, float]
+
+
+def _resolve_ne_specs(
+    mk: MatchkeyConfig,
+    prepared_df: pl.DataFrame,
+) -> list[NeSpec]:
+    """Resolve mk.negative_evidence into per-pair callable specs.
+
+    Mirrors the slow path's `_apply_negative_evidence`:
+      - NE entries whose scorer isn't in `_SCORE_FIELD_DIRECT_SCORERS`
+        are silently skipped (the slow path's _NE_BROKEN cache does this
+        at runtime; we replicate the policy at gate-time).
+      - Entries whose xform column isn't precomputed are skipped (same
+        rationale -- caller can't access transformed values without it).
+      - Penalty math is `final = max(0, score_positive - sum(penalties))`
+        applied where the slow path uses the same formula.
+    """
+    from goldenmatch.core.matchkey import _xform_sig
+
+    out: list[NeSpec] = []
+    ne_list = getattr(mk, "negative_evidence", None) or []
+    for ne in ne_list:
+        scorer = getattr(ne, "scorer", None)
+        if scorer is None or scorer not in _SCORE_FIELD_DIRECT_SCORERS:
+            # Mirror slow-path _NE_BROKEN behavior: contribute zero penalty.
+            continue
+        fn = _resolve_score_pair_callable(scorer)
+        if fn is None:
+            continue
+        xform_col = _xform_sig(ne)
+        from goldenmatch.core.frame import to_frame as _tf_cols
+
+        if xform_col not in _tf_cols(prepared_df).columns:
+            continue
+        out.append((xform_col, fn, float(ne.threshold), float(ne.penalty)))
+    return out
+
+
+def _resolve_fast_path(
+    mk: MatchkeyConfig,
+    prepared_df: pl.DataFrame,
+    *,
+    across_files_only: bool,
+    source_lookup: dict[int, str] | None,
+    target_ids: set[int] | None,
+) -> tuple[float, float, list[tuple[str, float, Any, str]], list[NeSpec]] | None:
+    """Decide whether mk is fast-path eligible and pre-resolve field specs.
+
+    Returns (threshold, total_weight, field_specs, ne_specs) when eligible,
+    else None. Resolution is done ONCE at score_buckets entry so per-pair
+    work never touches the PluginRegistry, _get_transformed_values, or
+    scorer-name dispatch.
+
+    field_specs: list of (xform_col, weight, score_pair_fn, scorer_name).
+    ne_specs:    list of (xform_col, score_pair_fn, threshold, penalty);
+                 empty when NE is missing or all-broken (matches today's
+                 _ne_effectively_empty behavior). Non-empty when NE has
+                 resolvable scorer entries that contribute real penalty
+                 (new in 2026-05-29 -- previously declined).
+
+    Eligibility gates (conservative — fall back to find_fuzzy_matches for
+    anything more complex):
+      - mk.type == "weighted"
+      - mk.threshold set
+      - no rerank / LLM
+      - every field resolves to a score_pair callable via
+        _resolve_score_pair_callable AND has its xform column precomputed
+      - NE entries with resolvable scorers WERE a decline gate; now they
+        engage the fast path with per-pair penalty math.
+    """
+    from goldenmatch.core.matchkey import _xform_sig
+
+    # Diagnostic: log which gate declines eligibility so workloads stuck on
+    # the slow find_fuzzy_matches path can be debugged without rebuilding.
+    # Print once per call (i.e. per matchkey resolution), not per pair.
+    def _decline(reason: str) -> None:
+        if _bkt_debug_on():
+            print(f"[score_buckets._resolve_fast_path] declined: {reason}", flush=True)
+
+    if mk.type != "weighted":
+        _decline(f"mk.type={mk.type!r} (need 'weighted')")
+        return None
+    if mk.threshold is None:
+        _decline("mk.threshold is None")
+        return None
+    if getattr(mk, "rerank", False):
+        _decline("mk.rerank=True (auto-config enables for 3+ field weighted matchkeys)")
+        return None
+    if getattr(mk, "llm", None):
+        _decline("mk.llm is set")
+        return None
+    # NOTE: match-mode (across_files_only / source_lookup / target_ids) USED
+    # to decline the fast path here. That was conservative -- the fast path
+    # can engage with these set because they only act as post-filters on
+    # emitted pairs, not as scoring math. The actual filtering happens after
+    # the worker emits candidate pairs (mirrors _score_one_bucket's behavior).
+    # Removed in PR #572 (match-mode widening); NE penalty math composes
+    # cleanly on top because NE is per-pair scoring and match-mode is
+    # per-pair post-filter -- they don't interact.
+    if not mk.fields:
+        _decline("mk.fields is empty")
+        return None
+
+    field_specs: list[tuple[str, float, Any, str]] = []
+    total_weight = 0.0
+    for f in mk.fields:
+        scorer = getattr(f, "scorer", None)
+        weight = getattr(f, "weight", None)
+        if scorer is None or weight is None:
+            _decline(f"field has scorer={scorer!r} weight={weight!r}")
+            return None
+        fn = _resolve_score_pair_callable(scorer, getattr(f, "tf_freqs", None))
+        if fn is None:
+            _decline(f"_resolve_score_pair_callable({scorer!r}) is None")
+            return None
+        xform_col = _xform_sig(f)
+        from goldenmatch.core.frame import to_frame as _tf_cols
+
+        if xform_col not in _tf_cols(prepared_df).columns:
+            return None
+        field_specs.append((xform_col, float(weight), fn, scorer))
+        total_weight += float(weight)
+    if total_weight <= 0:
+        _decline(f"total_weight={total_weight}")
+        return None
+    # PERF GUARD (nested-pool / per-pair-Python fix, 2026-07-21): a field whose
+    # scorer is NEITHER vec-supported (`_score_block_vec` / `_VEC_SUPPORTED`) NOR
+    # native-kernel-backed (`_NATIVE_SCORER_IDS`) forces the O(N^2) per-pair
+    # Python loop in `_score_one_bucket_fast`, which is DRAMATICALLY slower than
+    # the vectorized `find_fuzzy_matches` (MEASURED 19x: 26.97s vs 1.40s on the
+    # same 65 NCVR blocks for a matchkey with `name_freq_weighted_jw` /
+    # `given_name_aliased_jw` -- neither vec nor native-id). On a slow CI runner
+    # that 19x blows the per-test timeout -> the worker is os._exit'd. Decline to
+    # `find_fuzzy_matches`, which vectorizes every scorer. All-native matchkeys
+    # still ride the arrow kernel and all-vec matchkeys still ride the vec lane;
+    # this only declines when a genuinely per-pair-Python field is present, where
+    # the fast path was never actually fast. (This is what makes the ensemble
+    # kernel safe to default-on: an ensemble field on a name-scorer matchkey no
+    # longer drags the whole matchkey onto the slow per-pair path.)
+    _fast_scorers = [s for _, _, _, s in field_specs]
+    # The two name scorers are in `_NATIVE_SCORER_IDS` (ids 15/16), but they only
+    # ACTUALLY get a kernel when the census/alias tables are installed on a capable
+    # wheel -- and `name_freq_weighted_jw` additionally declines native when its
+    # field carries a per-dataset `tf_freqs` table (#1207 default-on), since fs-core
+    # ports only the static-census branch. In those cases the fast path would fall
+    # to the O(N^2) per-pair Python loop (the 19x-slow regression the guard below
+    # protects against), so treat them as per-pair-forcing -> decline to the
+    # vectorized `find_fuzzy_matches`, which handles every scorer (incl. the tf
+    # downweight via the plugin matrix path), exactly as before this change.
+    _has_name_scorer = any(
+        s in ("name_freq_weighted_jw", "given_name_aliased_jw") for s in _fast_scorers
+    )
+    _name_native_ok = _ensure_name_tables_installed() if _has_name_scorer else False
+    _name_forces_per_pair: set[str] = set()
+    if _has_name_scorer:
+        for f in mk.fields:
+            s = getattr(f, "scorer", None)
+            if s == "name_freq_weighted_jw":
+                if not _name_native_ok or getattr(f, "tf_freqs", None):
+                    _name_forces_per_pair.add(s)
+            elif s == "given_name_aliased_jw" and not _name_native_ok:
+                _name_forces_per_pair.add(s)
+    _per_pair_scorers = [
+        s
+        for s in _fast_scorers
+        if (s not in _VEC_SUPPORTED and s not in _NATIVE_SCORER_IDS)
+        or s in _name_forces_per_pair
+    ]
+    if _per_pair_scorers:
+        _decline(
+            f"scorer(s) {_per_pair_scorers} force the per-pair Python loop "
+            f"(not vec, not native) -> find_fuzzy_matches is faster (perf guard)"
+        )
+        return None
+    # NE PARITY GUARD: the slow path (_apply_negative_evidence) applies a penalty
+    # for EVERY NE scorer `score_field` can score -- it only skips a scorer that
+    # RAISES (cached in _NE_BROKEN). But the fast path can faithfully reproduce a
+    # per-pair penalty only for scorers in _SCORE_FIELD_DIRECT_SCORERS;
+    # _resolve_ne_specs silently DROPS the rest (ensemble / qgram / date / phash /
+    # audio_fp / initialism_match / alias_match), zeroing a penalty the slow path
+    # applies -> the SAME pair scores differently on bucket vs polars-direct.
+    # Decline to the slow path whenever an NE scorer isn't fast-representable: for
+    # a genuinely-broken scorer the slow path also skips it (identical result), so
+    # declining is parity-correct either way. Parity over speed.
+    for _ne in (mk.negative_evidence or []):
+        _ne_scorer = getattr(_ne, "scorer", None)
+        if _ne_scorer is not None and _ne_scorer not in _SCORE_FIELD_DIRECT_SCORERS:
+            _decline(
+                f"NE scorer {_ne_scorer!r} not in _SCORE_FIELD_DIRECT_SCORERS "
+                f"(slow path would penalize; fast path can't) -> slow-path parity"
+            )
+            return None
+    ne_specs = _resolve_ne_specs(mk, prepared_df)
+    # Diagnostic on the success path: log matchkey shape so we can compare
+    # what the controller commits at different row counts (rerank thresholds
+    # and NE promotion are scale-dependent).
+    if _bkt_debug_on():
+        scorer_names = [s for _, _, _, s in field_specs]
+        ne_scorers = [getattr(e, "scorer", "?") for e in (mk.negative_evidence or [])]
+        print(
+            f"[score_buckets._resolve_fast_path] ENGAGED: "
+            f"n_fields={len(mk.fields)} scorers={scorer_names} "
+            f"threshold={mk.threshold} rerank={getattr(mk, 'rerank', False)} "
+            f"ne_scorers={ne_scorers} ne_resolved={len(ne_specs)}",
+            flush=True,
+        )
+    return (float(mk.threshold), total_weight, field_specs, ne_specs)
+
+
+def score_probabilistic_external_blocks(
+    blocks: list,
+    blocking_config: BlockingConfig,
+    mk: MatchkeyConfig,
+    matched_pairs: set[tuple[int, int]],
+    em_result,
+    target_ids: set[int] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Memory-bounded Fellegi-Sunter scoring over EXTERNALLY-GENERATED blocks.
+
+    ``score_buckets`` derives its own field-hash blocks, so candidate sets
+    from the non-field blocking strategies (lsh / ann / learned / canopy /
+    sorted_neighborhood) cannot route through it. This scorer consumes the
+    strategy's own ``BlockResult`` list ONE BLOCK AT A TIME with the bucket
+    lane's scale machinery: the frozen-exclude Arc handle built once
+    (#552/#688), oversized auto-split honoring ``skip_oversized``
+    (#1790/#1826), and the native (zero-copy arrow) / vectorized / scalar
+    per-block scorer selection -- replacing
+    ``score_probabilistic_blocks_batched``'s up-front all-units accumulation
+    for these strategies (whose whole-mega-block dense scoring is the #1826
+    OOM shape; a 388K-row canopy through the vectorized path is a 1.1 TiB
+    dense-matrix allocation).
+
+    Overlapping candidates (canopy membership, sorted-neighborhood windows)
+    can surface the same pair from two blocks; a canonical-key seen set
+    dedups in block order. Blocks carrying ``pre_scored_pairs`` (ann_pairs)
+    score their frames exactly like the batched scorer does -- FS weights
+    are not FAISS distances, so carried scores are ignored on this matchkey
+    type there too.
+    """
+    from goldenmatch.core.blocker import _auto_split_block
+    from goldenmatch.core.probabilistic import (
+        _fs_native_eligible,
+        probabilistic_block_scorer,
+        score_probabilistic_bucket_native,
+    )
+
+    if em_result is None:
+        raise ValueError(
+            "score_probabilistic_external_blocks requires em_result for "
+            "probabilistic scoring"
+        )
+
+    frozen_exclude = frozenset(matched_pairs)
+    max_block_size = blocking_config.max_block_size
+    skip_oversized = blocking_config.skip_oversized
+
+    use_native = _fs_bucket_native_enabled() and _fs_native_eligible(mk)
+    prob_scorer = None if use_native else probabilistic_block_scorer(mk, em_result)
+
+    # The #552/#688 fix, FS side: build the Rust exclude set ONCE, not per
+    # block call. Old wheels fall back to the Vec-per-call contract inside
+    # _score_fs_native_frame (byte-identical, just slower).
+    exclude_handle = None
+    if use_native and frozen_exclude:
+        try:
+            _mod = native_module()
+            _build = getattr(_mod, "build_exclude_set", None)
+            if _build is not None and (
+                getattr(_mod, "FS_SUPPORTS_ARROW", False)
+                or getattr(_mod, "FS_SUPPORTS_EXCLUDE_SET", False)
+            ):
+                exclude_handle = _build(list(frozen_exclude))
+            else:
+                _warn_stale_native_wheel_once(len(frozen_exclude))
+        except Exception:
+            exclude_handle = None
+
+    def _frames(block_df, n: int) -> list:
+        """Frames to score for one block: the block itself when within
+        bounds; auto-split sub-blocks when oversized (same semantics as the
+        bucket lane's _split_oversized: skip on skip_oversized=True, score
+        whole on split failure when skip_oversized=False)."""
+        if n <= max_block_size:
+            return [block_df]
+        if skip_oversized:
+            return []
+        try:
+            subs = _auto_split_block(
+                block_df, max_block_size, "__external_oversized__"
+            )
+        except Exception:
+            logger.error(
+                "external-blocks auto-split failed for an oversized block "
+                "(%d rows).", n, exc_info=True,
+            )
+            subs = []
+        useful = []
+        for b in subs:
+            try:
+                n_sub = b.n_rows()
+            except Exception:
+                n_sub = n + 1
+            if 2 <= n_sub < n:
+                useful.append(b.materialize().native)
+        if useful:
+            return useful
+        logger.error(
+            "Oversized external block (%d rows > max_block_size=%d, ~%s "
+            "pairs) could not be auto-split; scoring whole because "
+            "skip_oversized=False. See #1826.",
+            n, max_block_size, f"{n * (n - 1) // 2:,}",
+        )
+        return [block_df]
+
+    def _height(df) -> int:
+        return df.height if hasattr(df, "height") else df.num_rows
+
+    out: list[tuple[int, int, float]] = []
+    seen: set[tuple[int, int]] = set()
+    for block in blocks:
+        bdf = block.materialize().native
+        n = _height(bdf)
+        if n < 2:
+            continue
+        for frame in _frames(bdf, n):
+            if use_native:
+                def _score_one(f):
+                    return score_probabilistic_bucket_native(
+                        f, [_height(f)], mk, em_result, frozen_exclude,
+                        exclude_handle=exclude_handle,
+                    )
+            else:
+                def _score_one(f):
+                    return prob_scorer(f, frozen_exclude)
+
+            # #1826/#2417: a canopy / sorted-neighborhood mega-block that
+            # cannot be auto-split arrives WHOLE; tile it so one scoring call
+            # never carries its full C(n,2).
+            pairs = _score_block_bounded(
+                frame, _height(frame), _score_one,
+                tile_above_rows=max_block_size,
+            )
+            for a, b, s in pairs:
+                if target_ids is not None and (
+                    (a in target_ids) == (b in target_ids)
+                ):
+                    continue
+                key = (a, b) if a < b else (b, a)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append((a, b, s))
+    return out
+
+
+def _emit_profile(
+    pairs: Any, mk: Any, route: str = "buckets", candidates: int | None = None,
+) -> None:
+    """Report this backend's scoring to the auto-config emitter (#2647).
+
+    `core/scorer.py` emits from its own entry points; this backend calls
+    `_score_one_block` directly and bypassed that wrapper entirely, so any run
+    routed here left the emitter holding the all-zero `ScoringProfile()`
+    default. `health()` reads that as "nothing happened" -> RED, and at
+    `n_rows >= REFUSE_AT_N` the controller REFUSES the run. Bucket is the
+    DEFAULT scorer (#526) and is chosen at exactly those sizes, so person@100k
+    was refused on a config whose blocking graded GREEN and whose clustering
+    produced 91,527 clusters with transitivity 1.0.
+
+    ``candidates`` (#2673): total candidate pairs the buckets handed the
+    scorer, or ``None`` when this call site has no count to give (the external
+    -blocks path). Originally hardcoded to absent, on the reasoning that this
+    path "never accumulates bucket sizes". That was true of the code, not of
+    what the code COULD do -- the workers already hold their block run-lengths
+    as plain ints for their own dispatch, so summing C(n,2) over them is
+    arithmetic on data in hand, not a re-materialisation.
+
+    Making it real matters beyond telemetry: ``_emit_scoring_profile`` needs
+    this denominator to report a truthful ``mass_above_threshold``. Without it
+    the field is tautologically 1.0 (the pairs passed here have already cleared
+    the cut), and ``pick_committed`` then demotes every RED entry that matched
+    anything as the "everything matches" pathology -- committing v0 and
+    returning an empty result (#2663).
+
+    When ``candidates`` is None the old absent-count contract stands: #2644's
+    flag says so, and the "nothing happened" clause needs BOTH counters zero,
+    so the refusal is still cleared without inventing a number.
+
+    A no-op when no capture is open, so production pays nothing.
+    """
+    from goldenmatch.core.scorer import (
+        _emit_scoring_profile,
+        profile_threshold,
+    )
+
+    _emit_scoring_profile(
+        pairs, profile_threshold(mk, pairs),
+        candidates_compared=int(candidates) if candidates is not None else 0,
+        candidates_counted=candidates is not None,
+        route=route,
+    )
+
+
+def score_buckets(
+    prepared_df: pl.DataFrame,
+    blocking_config: BlockingConfig,
+    mk: MatchkeyConfig,
+    matched_pairs: set[tuple[int, int]],
+    n_buckets: int | None = None,
+    across_files_only: bool = False,
+    source_lookup: dict[int, str] | None = None,
+    target_ids: set[int] | None = None,
+    em_result=None,
+    _emit: str = "list",
+    pair_sink: Any = None,
+    force_bounded_stream: bool = False,
+) -> Any:
+    """Score all blocks via hash-bucketed partition_by, no per-block LazyFrame.
+
+    ``force_bounded_stream`` (FS probabilistic only): score buckets via the
+    bounded in-RAM ``FrameBlockSource`` (slice one bucket off the resident frame
+    on demand, hold only ``max_workers`` slices) regardless of
+    ``GOLDENMATCH_FS_BLOCK_SOURCE`` — the in-RAM caller (``run_fs_dedupe_sequential``
+    scale path) forces it so its scoring peak stays ~1x frame without switching the
+    global block source off ``sequential``. Byte-identical to the eager path
+    (``filter_eq`` preserves within-bucket order == ``partition_by``).
+
+    ``pair_sink`` (arrow mode only): an optional ``callable(pa.Table)`` invoked with
+    each PASS's ``PAIR_STREAM`` table AS SOON AS the pass is scored, INSTEAD of
+    accumulating the passes into one returned table — so a caller streaming edges to
+    disk (``run_fs_dedupe_spill``) never holds more than one pass's pairs resident.
+    The per-pass table is exactly what the accumulating path would concat, so it
+    preserves the ``multi_pass`` block-collision dedup (parity-exact). When set, the
+    function returns an EMPTY pair stream (the sink consumed everything); ``None``
+    (default) is byte-identical to today.
+
+    ``_emit`` (internal): ``"list"`` (default) returns
+    ``list[tuple[int,int,float]]`` and mutates ``matched_pairs`` in place — the
+    historical contract, byte-identical. ``"arrow"`` returns a
+    ``PAIR_STREAM_SCHEMA`` ``pa.Table`` accumulated INCREMENTALLY (each pass's
+    tuples are converted to Arrow int64/float64 columns and dropped, and the
+    ``matched_pairs`` exclude set is NOT built) — the FS pair-stream memory win
+    (PR-B, ``2026-07-18-fs-arrow-pair-stream-design.md``). Call it via
+    ``score_buckets_arrow``; the arrow route is eligibility-gated to callers with
+    no later exclude-set consumer (duplicate edges collapse in Union-Find, so the
+    cross-pass exclude is a perf optimization, not correctness).
+
+    Args:
+        prepared_df: Eager Polars DataFrame, already materialized. Must
+            contain ``__row_id__`` and all columns referenced by ``mk`` +
+            ``blocking_config``.
+        blocking_config: Source for the block-key expression. Iterates
+            ``blocking_config.passes or blocking_config.keys`` (multi-pass
+            blocking), accumulating pairs across every pass. Like
+            polars-direct, the exclude set is frozen ONCE across all passes
+            and cross-pass duplicate pairs ARE emitted; they collapse
+            downstream in build_clusters' pair_scores dict. This is exact
+            parity with polars-direct by construction. Note the DELIBERATE
+            difference from polars-direct: polars-direct dedups identical
+            block keys ACROSS passes (``blocker.py::_build_multi_pass_blocks``
+            via its ``seen_keys`` set), whereas this bucket path re-scores each
+            pass independently and emits cross-pass DUPLICATE PAIRS that
+            collapse in build_clusters' ``pair_scores`` dict. Consequence:
+            ``block_count_scored`` / ``bucket_count`` metrics read HIGHER for
+            bucket than for polars on overlapping-key multi-pass configs --
+            expected, not a bug. Do NOT "fix" this by adding block-key dedup;
+            the duplicate-pair collapse is the parity mechanism.
+        mk: Matchkey configuration.
+        matched_pairs: Set of already-matched (min_id, max_id) pairs;
+            mutated in-place as new pairs are emitted (mirrors
+            score_blocks_parallel's contract).
+        n_buckets: Hash bucket count. None -> ``min(cpu_count() * 4, 1024)``.
+        across_files_only: Filter to cross-source pairs only.
+        source_lookup: Row ID -> source name mapping.
+        target_ids: For match mode -- filter to target/ref cross pairs.
+
+    Returns:
+        All fuzzy pairs as (id_a, id_b, score) tuples.
+    """
+    # D2s-d1: dual-rep entry (Frame at D2s-d2); scalar reads via the seam.
+    from goldenmatch.core.frame import to_frame as _tf_entry
+
+    _prep_frame = _tf_entry(prepared_df)
+    prepared_df = _prep_frame.native
+    if _prep_frame.height == 0:
+        return []
+    # Resolve the block-key list HONORING multi-pass blocking: a `multi_pass`
+    # config carries its keys in `.passes` with `.keys` empty (the schema
+    # explicitly allows keys-OR-passes), so the empty-config guard must check
+    # the RESOLVED pass list, not `.keys` alone. Guarding on `.keys` made an
+    # explicit multi-pass union config (e.g. soundex(surname) + exact(email))
+    # silently return zero pairs -> 0 clusters, while a single-key static config
+    # worked -- issue #1048. `passes` is None for static/single-key configs, so
+    # fall back to `keys`; only a config with NEITHER (nothing to block on)
+    # returns empty, matching the no-candidate-pairs semantics.
+    pass_keys = blocking_config.passes or blocking_config.keys
+    if not pass_keys:
+        return []
+
+    # Probabilistic (Fellegi-Sunter) matchkeys ride the same bucket
+    # orchestration as weighted, but score each block with the EM-trained
+    # vectorized FS scorer instead of find_fuzzy_matches. The EM model must be
+    # supplied (trained once by the caller via load_or_train_em).
+    is_probabilistic = mk.type == "probabilistic"
+    if is_probabilistic and em_result is None:
+        raise ValueError(
+            "score_buckets: probabilistic matchkey requires a trained em_result."
+        )
+
+
+    # Oversized-block skip (parity with polars-direct's build_blocks in
+    # core/blocker.py). Read once and close over in the nested scoring
+    # workers. A block is "oversized" when skip_oversized and size >
+    # max_block_size; such blocks are skipped entirely (no pairs emitted),
+    # matching polars' behavior when its _auto_split_block can't recover.
+    skip_oversized = blocking_config.skip_oversized
+    max_block_size = blocking_config.max_block_size
+
+    if n_buckets is None:
+        n_buckets = _default_n_buckets(_prep_frame.height)
+
+    # Diag prints (flushed) so we can see substep timing on runner heartbeats
+    # independent of the bench stage recorder, which only logs CLOSED stages.
+    # Three 5M Linux runs hung mid-score_buckets with no substage closing;
+    # these prints expose the actual hang line.
+    _t0 = time.perf_counter()
+    if _bkt_debug_on():
+        print(f"[score_buckets] entry: prepared_df.height={_prep_frame.height} n_buckets={n_buckets}", flush=True)
+
+    # Verbose per-bucket timing breakdown (issue #688 diagnosis aid). OFF by
+    # default; set GOLDENMATCH_BUCKET_DEBUG=1 to split every native bucket call
+    # into prep (sort + group_by + to_arrow) vs kernel (score_block_pairs_arrow)
+    # vs post-filter, accumulated across all buckets and printed once at the end.
+    # This is the split that localizes "Polars wrapping vs the Rust kernel" --
+    # e.g. it shows the kernel call dominating when rayon parks on a futex
+    # (issue #688). Zero cost when off (one env read + a couple of branches).
+    _bucket_debug = os.environ.get("GOLDENMATCH_BUCKET_DEBUG", "0") not in (
+        "0", "", "false", "False", "no", "off",
+    )
+    _dbg_lock = threading.Lock()
+    # rows: (prep_s, kernel_s, postfilter_s, n_blocks, n_pairs_emitted)
+    _dbg_rows: list[tuple[float, float, float, int, int]] = []
+
+    # Vectorized fast-path lane band (see _score_block_vec). Blocks with size in
+    # [vec_min, vec_max] route through the batched-matrix scorer instead of the
+    # Python per-pair double loop. vec_min: below it the per-pair loop wins (no
+    # numpy alloc / triu overhead on tiny blocks -- the regime the fast path was
+    # built for). vec_max: caps the float64 NxN so a pathological wide block
+    # can't blow memory; above it the per-pair loop (or oversized-skip) handles
+    # it. Both tunable for the cross-over sweep (scripts/bench_lowscale.py).
+    #
+    # Default vec_min=32 is the measured Pareto-safe floor (scripts/bench_lowscale.py,
+    # 2026-06-12): per-block the lane is ~2.3x at n=50 and ~3.8x at n=1000, but it
+    # REGRESSES on tiny blocks; the end-to-end cross-over sweep on the realistic_person
+    # soundex shape breaks even at vec_min~16 and is net-positive by 32, so 32 never
+    # makes a workload slower while still capturing the win on mid/large blocks.
+    _vec_min = int(os.environ.get("GOLDENMATCH_BUCKET_VEC_MIN", "32"))
+    _vec_max = int(os.environ.get("GOLDENMATCH_BUCKET_VEC_MAX", "2000"))
+
+    # Slim projection: drop columns no score-worker reads. The audit
+    # (2026-05-29) showed every reader in this module touches only
+    # __row_id__ / __source__ / __block_key__ / __xform_*__ plus the
+    # raw source fields named by the blocking key. Everything else in
+    # prepared_df is dead weight from bucket_assign onward.
+    #
+    # v30 QIS 10M bench (2026-05-29): peak RSS dropped 39.3 GB -> 35.5 GB
+    # (-3.8 GB, -9.7%) at F1=0.9886 invariant and wall flat. The savings
+    # come from downstream stages (partition_by, bucket_score, cluster,
+    # golden) holding a smaller per-bucket frame -- NOT from the .select()
+    # being zero-copy as initially hypothesized (Polars allocates ~10 GB
+    # to consolidate __xform_*__ chunks during select). Default ON;
+    # opt out via GOLDENMATCH_BUCKET_SLIM_PROJECTION=0 if a workload
+    # downstream of score_buckets ever needs a column we drop.
+    if os.environ.get("GOLDENMATCH_BUCKET_SLIM_PROJECTION", "1") != "0":
+        with stage("bucket_slim_projection"):
+            keep: list[str] = ["__row_id__"]
+            if "__source__" in _prep_frame.columns:
+                keep.append("__source__")
+            keep.extend(c for c in _prep_frame.columns if c.startswith("__xform_"))
+            # Probabilistic scoring (score_probabilistic_vectorized) reads the
+            # RAW field columns and applies transforms itself, so keep them
+            # (the weighted fast path uses __xform_* and doesn't need these).
+            if is_probabilistic:
+                for f in mk.fields:
+                    if f.field in _prep_frame.columns and f.field not in keep:
+                        keep.append(f.field)
+                # FS negative-evidence fields: the probabilistic scorer path
+                # reads these the same raw-column way (_ne_fired /
+                # _field_values_for_block), and an NE-only field (the
+                # canonical phone example -- not in mk.fields) would
+                # otherwise be projected away here and never fire on the
+                # default bucket backend. Also keep derive_from source
+                # columns for completeness, though precompute_matchkey_
+                # transforms already materializes the synthesized ne.field
+                # column upstream of this projection.
+                for ne in (mk.negative_evidence or []):
+                    if ne.field in _prep_frame.columns and ne.field not in keep:
+                        keep.append(ne.field)
+                    for src in (ne.derive_from or []):
+                        if src in _prep_frame.columns and src not in keep:
+                            keep.append(src)
+            # Source fields the block-key expression reads. Multi-key blocking
+            # (rare today) accumulates fields across every key in the config.
+            block_key_sources: set[str] = set()
+            for key in pass_keys:
+                block_key_sources.update(key.fields)
+            for col in block_key_sources:
+                if col in _prep_frame.columns and col not in keep:
+                    keep.append(col)
+            # The find_fuzzy_matches fallback (used when the fast path can't
+            # resolve a scorer -- ensemble / embedding / etc.) reads the RAW
+            # matchkey + negative-evidence field columns and applies the
+            # transforms itself. Keep them, else those fields silently vanish and
+            # bucket diverges from the legacy per-block path (e.g. NE penalty
+            # dropped -> a pair legacy separates gets merged).
+            for _f in (mk.fields or []):
+                if _f.field in _prep_frame.columns and _f.field not in keep:
+                    keep.append(_f.field)
+            for _ne in (getattr(mk, "negative_evidence", None) or []):
+                _nf = getattr(_ne, "field", None)
+                if _nf and _nf in _prep_frame.columns and _nf not in keep:
+                    keep.append(_nf)
+            slim_frame = _prep_frame.select(keep)
+            slim_df = slim_frame.native
+            if _bkt_debug_on():
+                print(
+                    f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: slim projection "
+                    f"{len(_prep_frame.columns)} -> {len(keep)} cols",
+                    flush=True,
+                )
+    else:
+        slim_frame = _prep_frame
+        slim_df = prepared_df
+
+    # Freeze the exclude set ONCE across ALL passes (parity with polars-direct,
+    # which freezes its exclude snapshot once and emits cross-pass duplicate
+    # pairs that collapse downstream in build_clusters' pair_scores dict). We
+    # must NOT rebuild this per pass or add an intra-loop matched_pairs skip --
+    # that would diverge from polars. frozen_exclude shadows matched_pairs as a
+    # Python frozenset -- at 10M-bucket-realistic this is the dominant
+    # Python-side accumulator.
+    frozen_exclude = frozenset(matched_pairs)
+
+    # Fast-path eligibility: tiny-block workloads (5M-on-one-node, p99 block
+    # size ~3 rows) spend most of bucket_score wall in Python orchestration --
+    # numpy 3x3 matrix allocations, PluginRegistry lookup, _get_transformed_values
+    # dispatch per (block x field). For the simple "weighted matchkey, plain
+    # fuzzy scorers, no NE/rerank/exact/record_embedding" shape we can skip
+    # find_fuzzy_matches entirely and do per-pair scoring directly. Pre-resolve
+    # the scorer callable + xform column per field ONCE at score_buckets entry
+    # (instead of per block).
+    from goldenmatch.core.scorer import find_fuzzy_matches
+
+    fast_path_specs = _resolve_fast_path(
+        mk, prepared_df,
+        across_files_only=across_files_only,
+        source_lookup=source_lookup,
+        target_ids=target_ids,
+    )
+
+    # Probabilistic matchkeys decline the weighted fast path (fast_path_specs is
+    # None) and fall to _score_one_bucket, which dispatches to this FS scorer.
+    # Resolved once (vectorized NxN by default; scalar fallback for model-backed
+    # scorers) — mirrors the pipeline's probabilistic_block_scorer.
+    prob_scorer = None
+    fs_bucket_native = False
+    fs_bucket_batch = False
+    if is_probabilistic:
+        from goldenmatch.core.probabilistic import (
+            _fs_native_eligible,
+            _fs_vectorized_enabled,
+            _fs_vectorized_supported,
+            probabilistic_block_scorer,
+        )
+        prob_scorer = probabilistic_block_scorer(mk, em_result)
+        # Batched native FS: score a WHOLE block-sorted bucket in one
+        # score_block_pairs_fs call (the FS analog of the weighted fast path's
+        # single score_block_pairs_arrow call), instead of one
+        # score_probabilistic_native call per block. Byte-identical to the
+        # per-block loop by construction (the kernel isolates blocks by the
+        # sizes list). GOLDENMATCH_FS_BUCKET_NATIVE=0 forces the per-block loop.
+        fs_bucket_native = _fs_bucket_native_enabled() and _fs_native_eligible(mk)
+        # When the native kernel is DECLINED (e.g. missing="disagree" on
+        # null-heavy data) the numpy scorer otherwise runs once per block. Batch
+        # the small blocks into one row-capped score_probabilistic_vectorized_
+        # batch call instead (byte-identical, #869). Only the vectorized-numpy
+        # scorer batches; scalar / ensemble / embedding stay per-block.
+        fs_bucket_batch = (
+            not fs_bucket_native
+            and _fs_bucket_batch_enabled()
+            and _fs_vectorized_enabled()
+            and _fs_vectorized_supported(mk)
+        )
+
+    # #1803 item 1: build the FS exclude handle ONCE here, before the bucket
+    # worker loop — the FS analog of the weighted path's Track 1 Fix B below.
+    # Without it every bucket call re-marshals frozen_exclude as a Vec and the
+    # kernel rebuilds a Rust HashSet per call (O(buckets x |exclude|), the
+    # #552/#688 pathology). Old wheels (no FS_SUPPORTS_ARROW / _EXCLUDE_SET)
+    # keep the legacy Vec path — _score_fs_native_frame checks the consts and
+    # falls back byte-identically.
+    fs_exclude_handle = None
+    if fs_bucket_native and frozen_exclude:
+        try:
+            _mod = native_module()
+            _fs_build = getattr(_mod, "build_exclude_set", None)
+            if _fs_build is not None and (
+                getattr(_mod, "FS_SUPPORTS_ARROW", False)
+                or getattr(_mod, "FS_SUPPORTS_EXCLUDE_SET", False)
+            ):
+                _t_feb = time.perf_counter()
+                fs_exclude_handle = _fs_build(list(frozen_exclude))
+                if _bkt_debug_on():
+                    print(
+                        f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: "
+                        f"fs build_exclude_set({len(frozen_exclude)} pairs) in "
+                        f"{time.perf_counter()-_t_feb:.2f}s",
+                        flush=True,
+                    )
+            else:
+                _warn_stale_native_wheel_once(len(frozen_exclude))
+        except Exception:
+            fs_exclude_handle = None
+
+    # Native fast-path eligibility resolved ONCE: gated on, and every field's
+    # scorer implemented by the native kernel. None -> Python per-pair loop.
+    # When NE has resolvable entries, force the Python path -- the native
+    # kernel emits pairs filtered against `threshold` BEFORE NE penalty is
+    # applied, so we'd have to re-emit + re-threshold downstream. The Python
+    # path handles NE math inline at the same per-pair cost. Returning to
+    # native-with-NE would mean teaching the kernel to emit pre-penalty
+    # candidate pairs (~2x emit volume) -- not worth it until measurement
+    # demands it.
+    native_scorer_ids: list[int] | None = None
+    if fast_path_specs is not None and native_enabled("block_scoring"):
+        _, _, _field_specs, _ne_specs = fast_path_specs
+        if not _ne_specs:
+            ids = [_NATIVE_SCORER_IDS.get(spec[3]) for spec in _field_specs]
+            # Wheel-skew guard: the `date` scorer (id 4) exists only in kernels
+            # that also expose `date_similarity`. A stale published wheel would
+            # dispatch id 4 to score_one's catch-all and silently score every
+            # date pair 0.0 -- so if any field is `date` and the loaded kernel
+            # lacks the symbol, decline native entirely and let the pure-Python
+            # per-pair path (which mirrors the kernel) score the whole block.
+            _mod = native_module()
+            _date_ok = _mod is not None and hasattr(_mod, "date_similarity")
+            _date_diff_ok = _mod is not None and hasattr(_mod, "date_diff_similarity")
+            _geo_ok = _mod is not None and hasattr(_mod, "geo_haversine_similarity")
+            _array_intersect_ok = _mod is not None and hasattr(_mod, "array_intersect_similarity")
+            _numeric_diff_ok = _mod is not None and hasattr(_mod, "numeric_diff_similarity")
+            _cosine_ok = _mod is not None and hasattr(_mod, "cosine_similarity")
+            _qgram_ok = _mod is not None and hasattr(_mod, "qgram_similarity")
+            _soundex_ok = _mod is not None and hasattr(_mod, "soundex_similarity")
+            _dice_ok = _mod is not None and hasattr(_mod, "dice_similarity")
+            _jaccard_ok = _mod is not None and hasattr(_mod, "jaccard_similarity")
+            _phash_ok = _mod is not None and hasattr(_mod, "phash_similarity")
+            _ensemble_ok = _mod is not None and hasattr(_mod, "ensemble_similarity")
+            _radial_ok = _mod is not None and hasattr(_mod, "radial_similarity")
+            _audio_fp_ok = _mod is not None and hasattr(_mod, "audio_fp_similarity")
+            has_date = any(spec[3] == "date" for spec in _field_specs)
+            has_date_diff = any(spec[3] == "date_diff" for spec in _field_specs)
+            has_geo = any(spec[3] == "geo_haversine" for spec in _field_specs)
+            # Only the BARE array_intersect maps to native id 19; the `:overlap`
+            # form isn't in _NATIVE_SCORER_IDS so it never takes the native route.
+            has_array_intersect = any(spec[3] == "array_intersect" for spec in _field_specs)
+            # numeric_diff: the bare form maps to native id 22 (batch). The
+            # parameterized forms take the per-pair native path (guarded there on
+            # the same symbol), so any numeric_diff-family field must gate on it.
+            has_numeric_diff = any(
+                spec[3] == "numeric_diff" or spec[3].startswith("numeric_diff:")
+                for spec in _field_specs
+            )
+            # cosine (id 23) has no mode, so the bare form is the only key.
+            has_cosine = any(spec[3] == "cosine" for spec in _field_specs)
+            has_qgram = any(spec[3] == "qgram" for spec in _field_specs)
+            has_soundex = any(spec[3] == "soundex_match" for spec in _field_specs)
+            has_dice = any(spec[3] == "dice" for spec in _field_specs)
+            has_jaccard = any(spec[3] == "jaccard" for spec in _field_specs)
+            has_phash = any(spec[3] == "phash" for spec in _field_specs)
+            has_ensemble = any(spec[3] == "ensemble" for spec in _field_specs)
+            has_radial = any(spec[3] == "radial" for spec in _field_specs)
+            has_audio_fp = any(spec[3] == "audio_fp" for spec in _field_specs)
+            has_initialism = any(spec[3] == "initialism_match" for spec in _field_specs)
+            # initialism_match (id 7) has a TWO-part guard: the capability symbol
+            # AND a successful legal-form install (id 7 scores against an empty
+            # legal-form set until the host ships `entity_form_variants()`).
+            # `_ensure_legal_forms_installed` folds both checks (symbol presence +
+            # install) into one memoized bool, so an uninstalled/stale kernel
+            # declines to the pure per-pair mirror instead of dropping no legal
+            # forms. Only evaluated when a field actually uses initialism (avoids
+            # the refdata load + install on every unrelated block).
+            _initialism_ok = has_initialism and _ensure_legal_forms_installed()
+            has_alias = any(spec[3] == "alias_match" for spec in _field_specs)
+            # alias_match (id 8) has the same TWO-part guard as initialism: the
+            # capability symbol AND a successful business+given-name table install
+            # (id 8 scores against empty tables until the host ships them).
+            # `_ensure_alias_tables_installed` folds both into one memoized bool;
+            # only evaluated when a field actually uses alias_match.
+            _alias_ok = has_alias and _ensure_alias_tables_installed()
+            # name scorers (bucket ids 15/16) have the same TWO-part guard: the
+            # `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS` capability flag AND a successful
+            # census/alias table install, folded into `_ensure_name_tables_installed`.
+            # `_resolve_fast_path` already keeps a name field OFF the fast path when
+            # this is False (or when name_freq_weighted_jw carries a tf table), so a
+            # fast-path matchkey reaching here with a name field is table-installed;
+            # the guard is defense-in-depth (a stale wheel scores ids 15/16 as 0.0).
+            has_name_scorer = any(
+                spec[3] in ("name_freq_weighted_jw", "given_name_aliased_jw")
+                for spec in _field_specs
+            )
+            _name_ok = has_name_scorer and _ensure_name_tables_installed()
+            # Wheel-skew: decline native entirely when a field uses a scorer whose
+            # capability symbol the loaded kernel lacks (score_one would silently
+            # zero that id); the pure-Python per-pair mirror scores the block.
+            _skew_block = (
+                (has_date and not _date_ok)
+                or (has_date_diff and not _date_diff_ok)
+                or (has_geo and not _geo_ok)
+                or (has_array_intersect and not _array_intersect_ok)
+                or (has_numeric_diff and not _numeric_diff_ok)
+                or (has_cosine and not _cosine_ok)
+                or (has_qgram and not _qgram_ok)
+                or (has_soundex and not _soundex_ok)
+                or (has_initialism and not _initialism_ok)
+                or (has_alias and not _alias_ok)
+                or (has_name_scorer and not _name_ok)
+                or (has_dice and not _dice_ok)
+                or (has_jaccard and not _jaccard_ok)
+                or (has_phash and not _phash_ok)
+                or (has_ensemble and not _ensemble_ok)
+                or (has_radial and not _radial_ok)
+                or (has_audio_fp and not _audio_fp_ok)
+            )
+            if all(i is not None for i in ids) and not _skew_block:
+                native_scorer_ids = ids  # type: ignore[assignment]
+
+    # #2673: candidate-pair count, accumulated per scored bucket.
+    #
+    # This path previously reported `candidates_compared=0, candidates_counted=
+    # False` -- honestly absent, since nothing accumulated it. But absence has a
+    # cost: `_emit_scoring_profile` needs this denominator to report a real
+    # `mass_above_threshold`, and without it the field stays the tautological
+    # 1.0 that made `pick_committed` demote every RED entry that matched
+    # anything (#2663).
+    #
+    # It is now free to collect. The #2639 note that counting "calls
+    # Block.n_rows(), which materialises" describes the CONTROLLER's pre-scoring
+    # count, not this: the workers below already hold the block-sorted run
+    # lengths (`size_list`) as a plain list of ints, computed for their own
+    # dispatch. Summing C(n,2) over them is arithmetic on data already in hand.
+    #
+    # A plain list + `.append` rather than a lock: workers run in a
+    # ThreadPoolExecutor and list.append is atomic under the GIL. Summed once
+    # after every pass completes.
+    #
+    # Multi-pass double-counts a pair that is a candidate in more than one pass.
+    # That matches the legacy scorer's own definition of the field ("sum of
+    # n*(n-1)//2 for each block processed") and is the conservative direction
+    # for every consumer -- it can only make the admitted fraction look smaller.
+    _cand_pair_counts: list[int] = []
+
+    # Track 1 Fix B: build the native ExcludeSet ONCE here, BEFORE the bucket
+    # worker loop. Previously _score_one_bucket_fast called
+    # list(frozen_exclude) + passed it positionally, which forced the kernel
+    # to materialize a fresh Vec, marshal across PyO3, and rebuild a Rust
+    # HashSet ON EVERY worker call (64 at default n_buckets). At 10M with
+    # 36.5M exact pairs that was ~1170s of bucket_score wall (verified
+    # against QIS 10M-v9 native: bucket_score 1370s, kernel scoring math <50s).
+    # Now: one set built once, every worker call passes the Arc handle.
+    # Falls back to None (no exclude) when native isn't available or the
+    # build_exclude_set kernel isn't in the loaded native module (older wheel).
+    native_exclude_handle = None
+    if native_scorer_ids is not None:
+        try:
+            _build = native_module().build_exclude_set
+        except AttributeError:
+            _build = None
+        if _build is not None and frozen_exclude:
+            _t_eb = time.perf_counter()
+            native_exclude_handle = _build(list(frozen_exclude))
+            if _bkt_debug_on():
+                print(
+                    f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: "
+                    f"build_exclude_set({len(frozen_exclude)} pairs) in "
+                    f"{time.perf_counter()-_t_eb:.2f}s",
+                    flush=True,
+                )
+        elif _build is None and frozen_exclude:
+            # Stale/old native wheel: no Arc-handle path available. The worker
+            # falls back to empty-exclude + Python post-filter (see below).
+            _warn_stale_native_wheel_once(len(frozen_exclude))
+
+    def _apply_match_mode_filter(
+        pairs: list[tuple[int, int, float]],
+    ) -> list[tuple[int, int, float]]:
+        """Mirror the slow path's match-mode post-filter (_score_one_bucket
+        lines 544-553). Applies in two stages: across_files_only drops
+        same-source pairs; target_ids drops same-side-of-target pairs.
+
+        Both filters are O(pairs) and very cheap relative to scoring; safe
+        to apply unconditionally on the fast path now that the gate is gone."""
+        if across_files_only and source_lookup is not None:
+            pairs = [
+                (a, b, s) for a, b, s in pairs
+                if source_lookup.get(a) != source_lookup.get(b)
+            ]
+        if target_ids is not None:
+            pairs = [
+                (a, b, s) for a, b, s in pairs
+                if (a in target_ids) != (b in target_ids)
+            ]
+        return pairs
+
+    def _score_one_bucket_fast(bucket_df: pl.DataFrame) -> tuple[list[tuple[int, int, float]], int]:
+        # Fast path for tiny-block workloads. Pre-extracts each transformed
+        # field as a Python list ONCE per bucket, then iterates pairs within
+        # each block via simple Python loops + direct scorer.score_pair calls.
+        # Skips numpy NxN matrix dance entirely -- for 3-row blocks the matrix
+        # is a 3x3 array and the alloc/free + np.zeros call cost dwarfs the
+        # actual rapidfuzz work.
+        assert fast_path_specs is not None  # gated by dispatcher
+        threshold, total_weight, field_specs, ne_specs = fast_path_specs
+        _te = time.perf_counter() if _bucket_debug else 0.0
+        # D5d: seam sort + run_lengths (== the old maintain_order agg on
+        # key-sorted input; arrow twin is vectorized run_end_encode).
+        from goldenmatch.core.frame import to_frame as _tf
+
+        sorted_frame = _tf(bucket_df).sort(["__block_key__"])
+        sorted_df = sorted_frame.native
+        size_list = sorted_frame.run_lengths("__block_key__")
+        if not size_list:
+            return [], 0
+        # #2673: candidate pairs this bucket hands the scorer. Counted HERE, at
+        # the top, rather than inside the native-kernel branch below -- this
+        # worker also has a vectorized-numpy and a per-pair Python branch, and
+        # counting in only one of them leaves the accumulator empty on every
+        # run that takes another (which is then correctly, but uselessly,
+        # reported as an absent count). Predicate mirrors the `keep` masks
+        # below.
+        _cand_pair_counts.append(sum(
+            _pair_count(s) for s in size_list
+            if s >= 2 and not (skip_oversized and s > max_block_size)
+        ))
+        weights = [w for _col, w, _fn, _name in field_specs]
+
+        # Native Arrow kernel: hand the block-sorted __row_id__ + field columns
+        # to Rust as zero-copy Arrow buffers, skipping the per-element .to_list()
+        # materialization + PyO3 Vec<Vec<Option<String>>> clone that dominate
+        # this stage (~58% of native wall at 1M rows -> ~2x kernel speedup; see
+        # scripts/bench_native_kernels.py). Identical (min,max) pairs in the same
+        # block order as the Vec kernel + the Python loop (parity asserted in
+        # tests/test_native_parity.py). __row_id__ is cast to Int64 (no-op when
+        # already Int64) because the kernel requires int64 buffers.
+        if native_scorer_ids is not None:
+            # Oversized-block skip on the native path: filter BOTH the per-row
+            # arrow arrays AND the size_list BEFORE handing them to the kernel.
+            # The kernel walks sorted_df rows block-contiguously (it's sorted by
+            # __block_key__), so a per-row mask built by repeating each block's
+            # keep-flag `size` times stays aligned to the rows. keep also folds
+            # in the size<2 no-op (those blocks emit no pairs anyway, but
+            # dropping them keeps kept_size_list and the arrays consistent).
+            # See _score_one_bucket for the polars-direct parity rationale +
+            # auto-split follow-up note.
+            keep = [
+                (s >= 2) and not (skip_oversized and s > max_block_size)
+                for s in size_list
+            ]
+            native_sorted_df = sorted_df
+            kept_size_list = size_list
+            if not all(keep):
+                import numpy as np
+
+                row_mask = np.repeat(np.array(keep, dtype=bool), size_list)
+                from goldenmatch.core.frame import is_polars_dataframe as _ipd
+
+                if _ipd(sorted_df):
+                    native_sorted_df = sorted_df.filter(pl.Series(row_mask))
+                else:  # pa.Table lane: Table.filter takes a boolean array
+                    import pyarrow as _pa
+
+                    native_sorted_df = sorted_df.filter(_pa.array(row_mask))
+                kept_size_list = [s for s, k in zip(size_list, keep) if k]
+                if not kept_size_list:
+                    return [], 0
+            from goldenmatch.core.frame import is_polars_dataframe as _ipd2
+
+            if _ipd2(native_sorted_df):
+                row_ids_arrow = native_sorted_df["__row_id__"].cast(pl.Int64).to_arrow()
+                field_arrays_arrow = [
+                    native_sorted_df[col].to_arrow()
+                    for col, _w, _fn, _name in field_specs
+                ]
+            else:  # pa.Table lane: already arrow -- combine chunks for the FFI
+                import pyarrow as _pa
+                import pyarrow.compute as _pc
+
+                row_ids_arrow = _pc.cast(
+                    native_sorted_df.column("__row_id__").combine_chunks(), _pa.int64()
+                )
+                field_arrays_arrow = [
+                    native_sorted_df.column(col).combine_chunks()
+                    for col, _w, _fn, _name in field_specs
+                ]
+            size_list = kept_size_list
+            _tk0 = time.perf_counter() if _bucket_debug else 0.0
+            # Track 1 Fix B: prefer the prebuilt exclude handle (closed-over
+            # native_exclude_handle from score_buckets entry). The kernel's
+            # exclude= and exclude_set= params are mutually opt-in -- when
+            # exclude_set is None, the kernel rebuilds a HashSet from the Vec
+            # (legacy path); when exclude_set is the Arc handle, kernel uses
+            # it directly. Older native builds without build_exclude_set
+            # fall through to the legacy positional Vec path.
+            if native_exclude_handle is not None:
+                pairs = native_module().score_block_pairs_arrow(
+                    row_ids_arrow, field_arrays_arrow, size_list,
+                    native_scorer_ids, weights, total_weight, threshold,
+                    exclude_set=native_exclude_handle,
+                )
+            else:
+                # Legacy/stale native wheel (pre-#552: no build_exclude_set, so
+                # native_exclude_handle is None). Passing the full exclude as a
+                # fresh Vec on EVERY bucket call makes the kernel rebuild a
+                # HashSet per call -- O(buckets * |exclude|), the #552 pathology
+                # and the root cause of issue #688's 44x slowdown on the
+                # published goldenmatch-native 0.1.0 wheel. Pass an EMPTY exclude
+                # and drop excluded pairs in Python after emit instead: the
+                # kernel emits only >= threshold pairs (few), so the post-filter
+                # is O(emitted), and the wasted scoring of excluded intra-block
+                # pairs is cheap rapidfuzz-rs work. The emitted ids are canonical
+                # (min, max) (kernel pair_key), matching frozen_exclude's keying,
+                # so the output pair set is identical to the handle path: a pair
+                # in frozen_exclude that scores >= threshold is emitted then
+                # removed here; one that scores < threshold is dropped either way.
+                pairs = native_module().score_block_pairs_arrow(
+                    row_ids_arrow, field_arrays_arrow, size_list,
+                    native_scorer_ids, weights, total_weight, threshold,
+                    [],
+                )
+                if frozen_exclude:
+                    pairs = [
+                        p for p in pairs if (p[0], p[1]) not in frozen_exclude
+                    ]
+            _tk1 = time.perf_counter() if _bucket_debug else 0.0
+            local_blocks = sum(1 for s in size_list if s >= 2)
+            # Match-mode post-filter (native path doesn't know about
+            # source_lookup or target_ids; apply in Python after emit).
+            if across_files_only or target_ids is not None:
+                pairs = _apply_match_mode_filter(pairs)
+            if _bucket_debug:
+                _tk2 = time.perf_counter()
+                with _dbg_lock:
+                    _dbg_rows.append(
+                        (_tk0 - _te, _tk1 - _tk0, _tk2 - _tk1, local_blocks, len(pairs))
+                    )
+            return pairs, local_blocks
+
+        # Python per-pair fallback: materialize the columns as lists.
+        # field_specs: list of (xform_col, weight, score_fn, scorer_name).
+        from goldenmatch.core.frame import to_frame as _to_frame_d5
+
+        _sf = _to_frame_d5(sorted_df)
+        row_ids = _sf.column("__row_id__").to_list()
+        field_arrays = [
+            _sf.column(col).to_list() for col, _w, _fn, _name in field_specs
+        ]
+        score_fns = [fn for _col, _w, fn, _name in field_specs]
+        n_fields = len(field_specs)
+        # NE per-pair specs (post-2026-05-29 widening). Pre-materialize the
+        # NE xform columns; empty when NE missing / all-broken (no overhead).
+        ne_arrays = [_sf.column(col).to_list() for col, _fn, _t, _p in ne_specs]
+        ne_fns = [fn for _col, fn, _t, _p in ne_specs]
+        ne_thresholds = [t for _col, _fn, t, _p in ne_specs]
+        ne_penalties = [p for _col, _fn, _t, p in ne_specs]
+        n_ne = len(ne_specs)
+        # Vectorized-lane eligibility (decided once per bucket). Engages only
+        # when: no negative evidence (penalty math stays per-pair), every field
+        # scorer has a byte-identical matrix form (_VEC_SUPPORTED), and no nulls
+        # in any field column -- the per-pair loop skips null fields, and
+        # replicating that mask vectorized is extra surface for no low-scale
+        # gain, so a column with nulls falls back to the per-pair loop wholesale.
+        vec_scorer_names: list[str] | None = None
+        if n_ne == 0 and all(name in _VEC_SUPPORTED for _c, _w, _fn, name in field_specs):
+            if all(_sf.column(col).null_count() == 0 for col, _w, _fn, _name in field_specs):
+                vec_scorer_names = [name for _c, _w, _fn, name in field_specs]
+        local_pairs: list[tuple[int, int, float]] = []
+        local_blocks = 0
+        offset = 0
+        for size in size_list:
+            if size >= 2:
+                # Skip oversized blocks (see _score_one_bucket for rationale /
+                # polars-direct parity + auto-split follow-up note).
+                if skip_oversized and size > max_block_size:
+                    offset += size
+                    continue
+                end = offset + size
+                # Vectorized lane: batched-matrix scoring for mid-sized blocks
+                # (byte-parity with the per-pair branch below; see
+                # _score_block_vec). Tiny blocks fall through to the per-pair
+                # loop where numpy alloc/triu overhead would dominate.
+                if vec_scorer_names is not None and _vec_min <= size <= _vec_max:
+                    local_pairs.extend(
+                        _score_block_vec(
+                            row_ids, field_arrays, vec_scorer_names, weights,
+                            offset, end, total_weight, threshold, frozen_exclude,
+                        )
+                    )
+                    local_blocks += 1
+                    offset += size
+                    continue
+                for i in range(offset, end - 1):
+                    ri = row_ids[i]
+                    for j in range(i + 1, end):
+                        rj = row_ids[j]
+                        if ri < rj:
+                            pair_key = (ri, rj)
+                        else:
+                            pair_key = (rj, ri)
+                        if pair_key in frozen_exclude:
+                            continue
+                        score_sum = 0.0
+                        weight_sum = 0.0
+                        for f_idx in range(n_fields):
+                            va = field_arrays[f_idx][i]
+                            vb = field_arrays[f_idx][j]
+                            if va is None or vb is None:
+                                continue
+                            s = score_fns[f_idx](va, vb)
+                            if s is None:
+                                continue
+                            score_sum += s * weights[f_idx]
+                            weight_sum += weights[f_idx]
+                        if weight_sum <= 0:
+                            continue
+                        # #weighted-null: renormalize by OBSERVED weight -- mirrors
+                        # native/src/score.rs and core/scorer.py::score_pair.
+                        combined = score_sum / weight_sum
+                        # NE penalty math (mirrors core/scorer.py
+                        # _apply_negative_evidence): subtract penalty when an
+                        # NE field's similarity is below its threshold. Clamp
+                        # at 0. Same formula as the slow path.
+                        if n_ne > 0:
+                            penalty = 0.0
+                            for k in range(n_ne):
+                                na = ne_arrays[k][i]
+                                nb = ne_arrays[k][j]
+                                if na is None or nb is None:
+                                    continue
+                                sim = ne_fns[k](na, nb)
+                                if sim is None:
+                                    continue
+                                if sim < ne_thresholds[k]:
+                                    penalty += ne_penalties[k]
+                            if penalty > 0:
+                                combined = max(0.0, combined - penalty)
+                        if combined >= threshold:
+                            local_pairs.append(
+                                (pair_key[0], pair_key[1], float(combined))
+                            )
+                local_blocks += 1
+            offset += size
+        if across_files_only or target_ids is not None:
+            local_pairs = _apply_match_mode_filter(local_pairs)
+        return local_pairs, local_blocks
+
+    def _score_one_bucket(bucket_df: pl.DataFrame) -> tuple[list[tuple[int, int, float]], int]:
+        # Sort once, slice per block (zero-copy view over the sorted parent).
+        # Avoids partition_by's millions-of-tiny-eager-frames allocation that
+        # fragments glibc's malloc arena on Linux (1.4 GB / 30s RSS climb).
+        from goldenmatch.core.frame import to_frame as _tf
+
+        # BUCKET_DEBUG: the probabilistic (FS) worker records the same
+        # prep/kernel/post split as the fast path (_dbg_rows) -- the fast-path
+        # _dbg mechanism (thread-safe list) is used, NOT bench.stage(), because
+        # workers run in a ThreadPoolExecutor whose threads don't inherit the
+        # recorder ContextVar. `kernel` here is score_probabilistic_bucket_native.
+        _t_prep0 = time.perf_counter() if _bucket_debug else 0.0
+        sorted_frame = _tf(bucket_df).sort(["__block_key__"])
+        sorted_df = sorted_frame.native
+        # Pre-materialized run sizes (seam run_lengths == the old
+        # maintain_order agg on key-sorted input; the inner loop stays
+        # Polars-scalar-indexing-free, the hottest line at 1.67M blocks).
+        size_list = sorted_frame.run_lengths("__block_key__")
+        if not size_list:
+            return [], 0
+        # #2673: candidate pairs this bucket hands the scorer. Counted once
+        # here rather than per-branch (this worker has a batched-native, a
+        # split-oversized and a plain branch, all fed from `size_list`). The
+        # predicate mirrors the `keep` masks below: a block under 2 rows has no
+        # pairs, and an oversized block under skip_oversized is never scored.
+        _cand_pair_counts.append(sum(
+            _pair_count(s) for s in size_list
+            if s >= 2 and not (skip_oversized and s > max_block_size)
+        ))
+
+        def _split_oversized(block_df, size: int) -> list:
+            """Auto-split an oversized block -- #1790 parity on the bucket
+            lane (#1826: a 388K-row block through the vectorized scorer is a
+            1.1 TiB dense-matrix allocation; through the native kernel it is
+            ~75G pair comparisons). Returns the block frames to score:
+            useful sub-blocks when the split works; [] when it fails and
+            skip_oversized=True (polars-direct skips too); [block_df] when it
+            fails and skip_oversized=False (the blocker.py opt-in "process
+            anyway" semantics, ERROR-logged -- the vectorized scorer's dense
+            guard still refuses truly impossible sizes)."""
+            from goldenmatch.core.blocker import _auto_split_block
+
+            if skip_oversized:
+                # skip_oversized=True keeps the bucket lane's historical SKIP.
+                # polars-direct's build_blocks hot-splits here too -- that
+                # True-side divergence is the documented pre-existing gap
+                # (consumers like autoconfig's probe passes are calibrated
+                # against the bucket skip; splitting a degenerate constant-key
+                # probe block detonated 18M pairs in autoconfig verify).
+                # The #1826 fix below targets the DEFAULT skip_oversized=False
+                # path, where the alternative was scoring the mega-block whole.
+                return []
+            try:
+                subs = _auto_split_block(
+                    block_df, max_block_size, "__bucket_oversized__"
+                )
+            except Exception:
+                logger.error(
+                    "bucket auto-split failed for an oversized block (%d rows).",
+                    size, exc_info=True,
+                )
+                subs = []
+            useful = []
+            for b in subs:
+                try:
+                    n_sub = b.n_rows()
+                except Exception:
+                    n_sub = size + 1
+                if 2 <= n_sub < size:
+                    useful.append(b.materialize().native)
+            if useful:
+                return useful
+            logger.error(
+                "Oversized block (%d rows > max_block_size=%d, ~%s pairs) "
+                "could not be auto-split; scoring whole because "
+                "skip_oversized=False. See #1826.",
+                size, max_block_size, f"{size * (size - 1) // 2:,}",
+            )
+            return [block_df]
+
+        # Batched native FS: hand the WHOLE block-sorted bucket + its per-block
+        # run-length sizes to the kernel in ONE call (the FS analog of
+        # _score_one_bucket_fast's single score_block_pairs_arrow call). The
+        # kernel isolates blocks by the sizes list, so this is byte-identical to
+        # calling prob_scorer (score_probabilistic_native) per block. Mirror the
+        # fast path's oversized/size<2 keep mask + array-and-size filtering, then
+        # apply the same across_files_only / target_ids post-filters as the
+        # per-block loop. GOLDENMATCH_FS_BUCKET_NATIVE=0 -> fs_bucket_native False
+        # -> the per-block prob_scorer loop below (parity escape hatch).
+        if fs_bucket_native:
+            # Oversized blocks are ALWAYS excluded from the batched call and
+            # handled by _split_oversized below (score sub-blocks; skip or
+            # score-whole per skip_oversized) -- #1790 parity on this lane.
+            keep = [2 <= s <= max_block_size for s in size_list]
+            fs_sorted_df = sorted_df
+            kept_size_list = size_list
+            if not all(keep):
+                import numpy as np
+
+                row_mask = np.repeat(np.array(keep, dtype=bool), size_list)
+                from goldenmatch.core.frame import is_polars_dataframe as _ipd
+
+                if _ipd(sorted_df):
+                    fs_sorted_df = sorted_df.filter(pl.Series(row_mask))
+                else:  # pa.Table lane: Table.filter takes a boolean array
+                    import pyarrow as _pa
+
+                    fs_sorted_df = sorted_df.filter(_pa.array(row_mask))
+                kept_size_list = [s for s, k in zip(size_list, keep) if k]
+            from goldenmatch.core.probabilistic import (
+                score_probabilistic_bucket_native,
+            )
+
+            # prep = entry through the keep-mask filter; kernel = the native
+            # score call(s); post = source/target pair filters (BUCKET_DEBUG).
+            _prep_s = (time.perf_counter() - _t_prep0) if _bucket_debug else 0.0
+            _t_kern0 = time.perf_counter() if _bucket_debug else 0.0
+            pairs: list[tuple[int, int, float]] = []
+            local_blocks = 0
+            if kept_size_list:
+                pairs = score_probabilistic_bucket_native(
+                    fs_sorted_df, kept_size_list, mk, em_result, frozen_exclude,
+                    exclude_handle=fs_exclude_handle,
+                )
+                local_blocks = sum(1 for s in kept_size_list if s >= 2)
+            # Oversized blocks: auto-split, then score each resolved frame in
+            # its own single-block native call (same kernel, size_list=[n], so
+            # the emitted cells match a per-block run exactly).
+            def _native_one(f):
+                return score_probabilistic_bucket_native(
+                    f, [len(f)], mk, em_result, frozen_exclude,
+                    exclude_handle=fs_exclude_handle,
+                )
+
+            offset = 0
+            for s in size_list:
+                if s > max_block_size:
+                    for sub in _split_oversized(sorted_df.slice(offset, s), s):
+                        # #1826/#2417: an un-splittable oversized block comes
+                        # back WHOLE here; tile it so one kernel call never
+                        # carries the block's full C(n,2).
+                        pairs.extend(
+                            _score_block_bounded(
+                                sub, len(sub), _native_one,
+                                tile_above_rows=max_block_size,
+                            )
+                        )
+                        local_blocks += 1
+                offset += s
+            _kern_s = (time.perf_counter() - _t_kern0) if _bucket_debug else 0.0
+            _t_post0 = time.perf_counter() if _bucket_debug else 0.0
+            if not pairs and local_blocks == 0:
+                if _bucket_debug:
+                    with _dbg_lock:
+                        _dbg_rows.append((_prep_s, _kern_s, 0.0, local_blocks, 0))
+                return [], 0
+            # Same post-filters as the per-block loop below (the native kernel
+            # doesn't know about source_lookup / target_ids).
+            if across_files_only and source_lookup:
+                pairs = [
+                    (a, b, s) for a, b, s in pairs
+                    if source_lookup.get(a) != source_lookup.get(b)
+                ]
+            if target_ids is not None:
+                pairs = [
+                    (a, b, s) for a, b, s in pairs
+                    if (a in target_ids) != (b in target_ids)
+                ]
+            if _bucket_debug:
+                _post_s = time.perf_counter() - _t_post0
+                with _dbg_lock:
+                    _dbg_rows.append((_prep_s, _kern_s, _post_s, local_blocks, len(pairs)))
+            return pairs, local_blocks
+
+        def _score_block_frame(block_df) -> list[tuple[int, int, float]] | None:
+            """Score ONE block frame via the per-block scorer + the
+            across_files / target post-filters (shared by normal blocks and
+            auto-split sub-blocks). None = block pre-filtered out."""
+            if across_files_only and source_lookup:
+                sources_in_block = block_df["__source__"].unique().to_list()
+                if len(sources_in_block) < 2:
+                    return None
+            if prob_scorer is not None:
+                pairs = prob_scorer(block_df, frozen_exclude)
+            else:
+                # find_fuzzy_matches (the fallback the slow path uses for
+                # scorers the fast path can't resolve -- ensemble / embedding /
+                # etc.) accepts BOTH reps natively: it coerces via
+                # ``core.frame.to_frame`` and its NE branch reads rows through a
+                # ``to_pylist`` dual-rep, so a ``pa.Table`` needs no conversion.
+                # Hand it the block as-is -- pre-converting a ``pa.Table`` to
+                # polars here (the old ``pl.from_arrow`` bridge, plus the
+                # ``isinstance(block_df, pl.DataFrame)`` probe) forced the polars
+                # import and broke the arrow lane's polars-free guarantee (e.g.
+                # goldengraph's zero-config resolve installs goldenmatch WITHOUT
+                # polars). Parity with the legacy per-block path is unchanged:
+                # a real polars block still flows through untouched.
+                pairs = find_fuzzy_matches(
+                    block_df, mk,
+                    exclude_pairs=frozen_exclude,
+                    pre_scored_pairs=None,
+                )
+            if across_files_only and source_lookup:
+                pairs = [
+                    (a, b, s) for a, b, s in pairs
+                    if source_lookup.get(a) != source_lookup.get(b)
+                ]
+            if target_ids is not None:
+                pairs = [
+                    (a, b, s) for a, b, s in pairs
+                    if (a in target_ids) != (b in target_ids)
+                ]
+            return pairs
+
+        local_pairs: list[tuple[int, int, float]] = []
+        local_blocks = 0
+        offset = 0
+
+        # Batched numpy FS: coalesce the small blocks of this bucket into
+        # row-capped score_probabilistic_vectorized_batch calls instead of one
+        # prob_scorer call per block. Byte-identical to the per-block loop (#869:
+        # each block's DIAGONAL sub-matrix is the same value pairs, same
+        # frozen_exclude), but pays the per-call overhead once per ~cap rows
+        # rather than once per (often ~16-row) block -- the historical_50k
+        # disagree-mode fan-out fix. Oversized blocks flush the batch and take
+        # the per-block _split_oversized path. across_files/target_ids are
+        # per-pair predicates, applied here as post-filters exactly as the native
+        # branch does (equivalent to the per-block _score_block_frame filters).
+        if fs_bucket_batch:
+            from goldenmatch.core.probabilistic import (
+                _fs_batch_rows,
+                score_probabilistic_vectorized_batch,
+            )
+
+            cap = _fs_batch_rows()
+            batch_frames: list = []
+            batch_rows = 0
+
+            def _flush_batch() -> None:
+                nonlocal batch_frames, batch_rows, local_pairs, local_blocks
+                if not batch_frames:
+                    return
+                pairs = score_probabilistic_vectorized_batch(
+                    batch_frames, mk, em_result, frozen_exclude
+                )
+                if across_files_only and source_lookup:
+                    pairs = [
+                        (a, b, s) for a, b, s in pairs
+                        if source_lookup.get(a) != source_lookup.get(b)
+                    ]
+                if target_ids is not None:
+                    pairs = [
+                        (a, b, s) for a, b, s in pairs
+                        if (a in target_ids) != (b in target_ids)
+                    ]
+                local_pairs.extend(pairs)
+                local_blocks += len(batch_frames)
+                batch_frames = []
+                batch_rows = 0
+
+            for size in size_list:
+                if size >= 2:
+                    if size > max_block_size:
+                        _flush_batch()  # keep oversized off the batch matrix
+                        for sub in _split_oversized(
+                            sorted_df.slice(offset, size), size
+                        ):
+                            pairs = _score_block_bounded(
+                                sub, len(sub), _score_block_frame,
+                                tile_above_rows=max_block_size,
+                            )
+                            if pairs is None:
+                                continue
+                            local_pairs.extend(pairs)
+                            local_blocks += 1
+                        offset += size
+                        continue
+                    batch_frames.append(sorted_df.slice(offset, size))
+                    batch_rows += size
+                    if batch_rows >= cap:
+                        _flush_batch()
+                offset += size
+            _flush_batch()
+            return local_pairs, local_blocks
+
+        for size in size_list:
+            if size >= 2:
+                if size > max_block_size:
+                    # Oversized: auto-split (#1790 parity, #1826) and score
+                    # the resolved frames; _split_oversized already applied
+                    # the skip_oversized / score-whole fallback semantics.
+                    for sub in _split_oversized(
+                        sorted_df.slice(offset, size), size
+                    ):
+                        pairs = _score_block_bounded(
+                            sub, len(sub), _score_block_frame,
+                            tile_above_rows=max_block_size,
+                        )
+                        if pairs is None:
+                            continue
+                        local_pairs.extend(pairs)
+                        local_blocks += 1
+                    offset += size
+                    continue
+                pairs = _score_block_frame(sorted_df.slice(offset, size))
+                if pairs is None:
+                    offset += size
+                    continue
+                local_pairs.extend(pairs)
+                local_blocks += 1
+            offset += size
+        return local_pairs, local_blocks
+
+    # Bounded bucket streaming (FS route only): when on, the scale branch below
+    # does NOT partition the keyed frame into all n_buckets eager frames. It
+    # keeps the single `bucketed` frame resident and slices each bucket out on
+    # demand (filter_eq inside the worker), so peak holds `bucketed` (~1x) plus
+    # at most max_workers in-flight slices instead of the ~2x transient double at
+    # partition time (the "partition" stage jump). Gated to the probabilistic
+    # (FS) path -- fast_path_specs is None there -- and off by default; the
+    # eager path is byte-identical (same rows, same within-bucket order via
+    # filter_eq == partition_by(maintain_order), and cross-bucket order is
+    # unordered downstream: thread-pool scored + pairs canonicalized).
+    _fs_streaming = is_probabilistic and (
+        force_bounded_stream or _fs_bounded_stream_enabled()
+    )
+
+    def _score_single_pass(
+        key: BlockingKeyConfig,
+    ) -> tuple[list[tuple[int, int, float]], int, int]:
+        """Key, bucket, partition, and score one blocking pass.
+
+        Returns (pass_pairs, blocks_scored, n_non_empty_buckets). Builds its
+        own keyed/bucketed frames off the immutable slim_df and `del`s them at
+        partition time so only one pass is resident at a time (preserves peak
+        RSS). Accumulates into a LOCAL pass_pairs -- it must NOT mutate
+        matched_pairs (that happens once, after all passes, in the caller).
+        """
+        with stage("bucket_assign"):
+            _ta = time.perf_counter()
+            # D5d: seam block-key derivation (derive_block_key is the W2a
+            # twin of _build_block_key_expr, both backends).
+            from goldenmatch.core.frame import to_frame as _tf
+
+            _slim_frame = _tf(slim_df)
+            keyed = (
+                _slim_frame.with_column(
+                    "__block_key__",
+                    _slim_frame.derive_block_key(
+                        key.fields, key.transforms or [],
+                        field_transforms=getattr(key, "field_transforms", None),
+                    ),
+                )
+                # A null block key means "this row CANNOT be blocked" -- NOT "this
+                # row blocks with every other unblockable row". Without this, every
+                # null-key row hashes into ONE bucket and is scored against every
+                # other: on the ER person shape at 1M that is 9,846 rows -> 48.5M
+                # comparisons, while the largest LEGITIMATE postcode block is 25.
+                #
+                # Measured cost of NOT filtering (1M person):
+                #   wall 31.81s -> 21.44s; FP 8,682 -> 111 (precision .9626 -> .9995)
+                #   recall .9319 -> .9315 (the null block gave +81 TP / +8,571 FP)
+                # One kernel call took 20.482s of 22.669s: 256 buckets across 12
+                # workers all serialized behind that single straggler.
+                #
+                # This is build_blocks' own guard -- it filters the derived key the
+                # same way: drop null + the nan/null/none stringified-missing
+                # sentinels, keep "" (#390).
+                #
+                # KNOWN GAP (pre-existing, not introduced here): an empty-string key
+                # arrives here ALREADY NULL (something upstream in prepare nulls
+                # ""), so filter_valid_key's keep-"" branch is unreachable on this
+                # path and ""-keyed rows drop with the true nulls. Before this filter
+                # they matched via the null mega-block -- #390's intent met by
+                # accident, at the cost of the FP/perf blowup above. Preserving
+                # ""-vs-null through prepare is a separate fix; pinned as an
+                # xfail(strict) in tests/test_bucket_null_block_key.py.
+                .filter_valid_key("__block_key__")
+                .native
+            )
+            if _bkt_debug_on():
+                print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: keyed (with_columns key_expr) in {time.perf_counter()-_ta:.2f}s", flush=True)
+
+        # #422 fix 1: small-block fast path. When prepared_df.height < n_buckets,
+        # the hash + partition_by step always collapses to 1 non-empty bucket
+        # (every row hashes into the same bucket-output because most buckets
+        # are empty by pigeonhole). The bookkeeping is pure overhead. Skip
+        # straight to treating `keyed` as the single bucket and scoring.
+        # On the streaming-block sync caller, this hits on every per-block
+        # invocation (block size ~8, n_buckets default 32-128).
+        stream_bucket_ids: list | None = None  # set only on the streaming scale branch
+        if _prep_frame.height < n_buckets:
+            bucketed = keyed
+            # Wrap in a single-bucket dict to share the scoring path below
+            # (native frames: pl.DataFrame or pa.Table by lane). The single
+            # bucket is already bounded, so streaming never engages here.
+            buckets_dict: dict[Any, Any] = {0: bucketed}
+            if _bkt_debug_on():
+                print(
+                    f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: "
+                    f"small-block fast path (height={_prep_frame.height} < n_buckets={n_buckets}); "
+                    f"skipping hash+partition_by. See #422.",
+                    flush=True,
+                )
+        else:
+            _tb = time.perf_counter()
+            # Adds an i64 __bucket__ column at 10M rows -- ~80 MB of int64 plus
+            # whatever Polars holds for the hash intermediate. Wrap so the RSS
+            # bench can attribute it instead of pooling it into the unwrapped
+            # gap between bucket_assign and bucket_partition.
+            with stage("bucket_hash_modulo"):
+                # D2s-c: per-lane bucket assignment via the seam (polars impl
+                # is this stage's old hash(seed) % n expr verbatim; buckets
+                # are shard-internal, never output-visible).
+                bucketed = (
+                    _tf(keyed)
+                    .with_bucket_column(
+                        "__block_key__", "__bucket__", n_buckets, BUCKET_HASH_SEED
+                    )
+                    .native
+                )
+            if _bkt_debug_on():
+                print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: bucketed (hash %% N) in {time.perf_counter()-_tb:.2f}s", flush=True)
+
+            with stage("bucket_partition"):
+                _tp = time.perf_counter()
+                from goldenmatch.core.frame import to_frame as _tf
+
+                if _fs_streaming:
+                    # Bounded streaming: DON'T build N eager frames. Keep
+                    # `bucketed` resident and record the non-empty bucket ids
+                    # (a bucket id is present iff >=1 row hashed into it, so the
+                    # distinct set IS the non-empty set). Take the distinct ids
+                    # off the single `__bucket__` column via Column.unique()
+                    # (vectorized -- pc.unique on the arrow lane, .unique() on
+                    # polars), NOT frame-level unique_by (which materializes a
+                    # full deduped frame across ALL columns and, on the arrow
+                    # lane, loops through .to_pylist() -- an O(N) transient that
+                    # would defeat the whole point of streaming). The distinct
+                    # set is <= n_buckets ints. Sorted for a deterministic
+                    # (order-invariant) scoring order.
+                    _stream_frame = _tf(bucketed)
+                    stream_bucket_ids = sorted(
+                        _stream_frame.column("__bucket__").unique().to_list()
+                    )
+                    buckets_dict = None  # sentinel: streaming, no eager frames
+                    del keyed  # `bucketed` (via _stream_frame) retained for slicing
+                    if _bkt_debug_on():
+                        print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: stream bucket-id scan in {time.perf_counter()-_tp:.2f}s -> {len(stream_bucket_ids)} buckets (no eager partition)", flush=True)
+                else:
+                    # First-level partition via the seam (group_partitions ==
+                    # partition_by with unwrapped keys; N eager frames).
+                    buckets_dict = {
+                        k: part.native
+                        for k, part in _tf(bucketed).group_partitions("__bucket__")
+                    }
+                    # Free the pre-partition `keyed` and `bucketed` parents.
+                    # group_partitions built N independent eager frames; the
+                    # original contiguous parents are dead weight now.
+                    del keyed
+                    del bucketed
+                    stream_bucket_ids = None
+                    if _bkt_debug_on():
+                        print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: partition_by(bucket) in {time.perf_counter()-_tp:.2f}s -> {len(buckets_dict)} buckets", flush=True)
+
+        with stage("bucket_post_partition_setup"):
+            if _fs_streaming and stream_bucket_ids is not None:
+                # No materialized frames; every present bucket id is non-empty.
+                non_empty_buckets = None
+                n_non_empty_buckets = len(stream_bucket_ids)
+            else:
+                # len() works on both native frames (pl rows / pa num_rows).
+                non_empty_buckets = [b for b in buckets_dict.values() if len(b) > 0]
+                n_non_empty_buckets = len(non_empty_buckets)
+        if _bkt_debug_on():
+            print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: {n_non_empty_buckets} non-empty buckets ready for scoring", flush=True)
+
+        # B2c: in arrow mode convert EACH bucket's tuples to Arrow the moment it
+        # returns and drop the Python list, so peak holds one bucket's tuples +
+        # the accumulated int64/float64 columns -- never a per-PASS list[tuple]
+        # (the remaining transient after B2a). List mode is byte-unchanged.
+        _arrow_mode = _emit == "arrow"
+        pass_pairs: list[tuple[int, int, float]] = []
+        bucket_tables: list[Any] = []
+        pass_emitted = 0
+        pass_blocks_scored = 0
+        if n_non_empty_buckets == 0:
+            empty: Any = pairs_to_pair_stream([]) if _arrow_mode else pass_pairs
+            return empty, pass_blocks_scored, n_non_empty_buckets
+
+        def _sink(bucket_pairs: list) -> None:
+            nonlocal pass_emitted
+            pass_emitted += len(bucket_pairs)
+            if _arrow_mode:
+                bucket_tables.append(pairs_to_pair_stream(bucket_pairs))
+            else:
+                pass_pairs.extend(bucket_pairs)
+
+        with stage("bucket_score"):
+            # rapidfuzz.cdist releases the GIL inside the scorer, so threads
+            # give real parallelism. Mirror score_blocks_parallel's worker cap.
+            max_workers = min(n_non_empty_buckets, os.cpu_count() or 4)
+            _ts = time.perf_counter()
+            worker = _score_one_bucket_fast if fast_path_specs is not None else _score_one_bucket
+            if fast_path_specs is not None:
+                path_label = "fast"
+            elif is_probabilistic:
+                path_label = "probabilistic_vectorized"
+            else:
+                path_label = "find_fuzzy_matches"
+            _streaming_now = _fs_streaming and stream_bucket_ids is not None
+            if _streaming_now:
+                # Slice one bucket off the resident `bucketed` frame on demand,
+                # score it, then free the slice -- so at most max_workers slices
+                # are live at once (bounded). filter_eq preserves within-bucket
+                # order == the eager partition, so `worker`'s output is
+                # byte-identical to the eager path per bucket.
+                from goldenmatch.core.frame import to_frame as _tf
+
+                _bucketed_frame = _tf(bucketed)
+
+                def _stream_worker(bid: Any) -> tuple[list, int]:
+                    slice_native = _bucketed_frame.filter_eq("__bucket__", bid).native
+                    try:
+                        return worker(slice_native)
+                    finally:
+                        del slice_native
+
+                items: Any = stream_bucket_ids
+                run_worker: Any = _stream_worker
+                path_label += "+stream"
+            else:
+                items = non_empty_buckets
+                run_worker = worker
+            if _bkt_debug_on():
+                print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: starting bucket_score with max_workers={max_workers} path={path_label}", flush=True)
+            if max_workers <= 1 or n_non_empty_buckets <= 2:
+                for item in items:
+                    pairs, n = run_worker(item)
+                    _sink(pairs)
+                    del pairs
+                    pass_blocks_scored += n
+            else:
+                with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                    for pairs, n in pool.map(run_worker, items):
+                        _sink(pairs)
+                        del pairs
+                        pass_blocks_scored += n
+        if _bkt_debug_on():
+            print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: bucket_score done in {time.perf_counter()-_ts:.2f}s, {pass_blocks_scored} blocks, {pass_emitted} pairs", flush=True)
+        if _arrow_mode:
+            import pyarrow as _pa
+
+            result: Any = (
+                _pa.concat_tables(bucket_tables) if bucket_tables
+                else pairs_to_pair_stream([])
+            )
+            return result, pass_blocks_scored, n_non_empty_buckets
+        return pass_pairs, pass_blocks_scored, n_non_empty_buckets
+
+    _arrow = _emit == "arrow"
+    all_pairs: list[tuple[int, int, float]] = []
+    pass_tables: list[Any] = []  # arrow mode: one pa.Table per pass
+    n_emitted = 0
+    total_blocks_scored = 0
+    total_non_empty = 0
+    slim_cols = set(slim_frame.columns)
+    for key in pass_keys:
+        if not set(key.fields) <= slim_cols:
+            logger.warning(
+                "score_buckets: skipping pass %s -- field(s) %s absent from prepared_df",
+                key.fields, sorted(set(key.fields) - slim_cols),
+            )
+            continue
+        pass_result, blocks_scored, n_non_empty = _score_single_pass(key)
+        if _arrow:
+            # _score_single_pass already returns a PAIR_STREAM_SCHEMA pa.Table
+            # (converted per BUCKET, B2c) -- accumulate it directly; no per-pass
+            # list ever exists. See the PR-B design doc.
+            n_emitted += pass_result.num_rows
+            if pair_sink is not None:
+                # Stream this pass's edges out (e.g. to a disk shard) and drop them
+                # -- never accumulate across passes. The per-pass table is identical
+                # to what `pass_tables.append` would collect, so downstream WCC sees
+                # the same edge set (parity-exact); only the residency differs.
+                pair_sink(pass_result)
+            else:
+                pass_tables.append(pass_result)
+            del pass_result
+        else:
+            n_emitted += len(pass_result)
+            all_pairs.extend(pass_result)
+        total_blocks_scored += blocks_scored
+        total_non_empty += n_non_empty
+    if not _arrow:
+        # Cross-pass exclude set for LATER scoring passes/matchkeys. Arrow mode
+        # SKIPS it (its ~8 GB at 66M pairs is half the OOM): duplicate edges
+        # collapse in Union-Find, so the exclude is a perf optimization, not
+        # correctness, and the arrow route is gated to callers with no later
+        # exclude consumer.
+        for a, b, _s in all_pairs:
+            matched_pairs.add((min(a, b), max(a, b)))
+
+    record_metrics({
+        "bucket_count": total_non_empty,
+        "bucket_n_target": n_buckets,
+        "block_count_scored": total_blocks_scored,
+    })
+    logger.info(
+        "score_buckets: %d non-empty buckets (target N=%d), %d blocks scored, %d pairs",
+        total_non_empty, n_buckets, total_blocks_scored, n_emitted,
+    )
+    if _bucket_debug and _dbg_rows:
+        n_calls = len(_dbg_rows)
+        prep_s = sum(r[0] for r in _dbg_rows)
+        kern_s = sum(r[1] for r in _dbg_rows)
+        post_s = sum(r[2] for r in _dbg_rows)
+        n_blocks = sum(r[3] for r in _dbg_rows)
+        n_pairs = sum(r[4] for r in _dbg_rows)
+        tot_s = prep_s + kern_s + post_s
+        slowest = max(_dbg_rows, key=lambda r: r[1]) if _dbg_rows else (0, 0, 0, 0, 0)
+
+        def _pct(x: float) -> float:
+            return (100.0 * x / tot_s) if tot_s > 0 else 0.0
+
+        if _bkt_debug_on():
+            print(
+                "[score_buckets][DEBUG] native bucket-call breakdown over "
+                f"{n_calls} calls / {n_blocks} blocks / {n_pairs} pairs "
+                f"(set GOLDENMATCH_BUCKET_DEBUG=0 to silence):\n"
+                f"  prep   (sort+group_by+to_arrow): {prep_s:7.3f}s ({_pct(prep_s):5.1f}%)\n"
+                f"  kernel (native score_block/bucket): {kern_s:7.3f}s ({_pct(kern_s):5.1f}%)\n"
+                f"  post   (match-mode filter):       {post_s:7.3f}s ({_pct(post_s):5.1f}%)\n"
+                f"  total in-worker: {tot_s:.3f}s; slowest single kernel call: {slowest[1]:.3f}s",
+                flush=True,
+            )
+            # Split the `kernel` bar into the Rust call (compute + pyo3
+            # Vec<tuple> conversion) vs the Python pair-marshal loop
+            # (`[(a,b,round(float(s),4)) ...]`), recorded in probabilistic.py.
+            from goldenmatch.core.probabilistic import _FS_NATIVE_DBG as _fnd
+
+            _pre = _fnd["prep_s"]
+            _nat = _fnd["native_s"]
+            _mar = _fnd["marshal_s"]
+            _kt = _pre + _nat + _mar
+            if _kt > 0:
+                def _kp(x: float) -> float:
+                    return 100.0 * x / _kt
+                print(
+                    "[score_buckets][DEBUG] kernel split "
+                    f"({_fnd['n_calls']} native calls, {_fnd['n_single_block']} "
+                    f"single-block / {_fnd['n_pairs']} pairs):\n"
+                    f"  input-prep (row_ids+field_arrays+const rebuild): "
+                    f"{_pre:7.3f}s ({_kp(_pre):5.1f}%)  "
+                    f"[single-block share {_fnd['single_block_prep_s']:.3f}s]\n"
+                    f"  rust (mod.score_block_pairs_fs* incl pyo3 out):  "
+                    f"{_nat:7.3f}s ({_kp(_nat):5.1f}%)\n"
+                    f"  out-marshal (Python round(float()) loop):        "
+                    f"{_mar:7.3f}s ({_kp(_mar):5.1f}%)",
+                    flush=True,
+                )
+    if _arrow:
+        import pyarrow as _pa
+
+        if pass_tables:
+            _tbl = _pa.concat_tables(pass_tables)
+            # Arrow mode still has to report. Zipping three columns is O(pairs)
+            # and only runs when a capture is open -- `_emit_scoring_profile`
+            # returns immediately otherwise, so the zip is behind that guard.
+            from goldenmatch.core.profile_emitter import has_active_emitter
+
+            if has_active_emitter():
+                _emit_profile(
+                    list(zip(_tbl.column("id_a").to_pylist(),
+                             _tbl.column("id_b").to_pylist(),
+                             _tbl.column("score").to_pylist(), strict=True)),
+                    mk, route="buckets.arrow",
+                    candidates=(sum(_cand_pair_counts) if _cand_pair_counts else None),
+                )
+            return _tbl
+        _emit_profile(
+            [], mk, route="buckets.arrow.empty",
+            candidates=(sum(_cand_pair_counts) if _cand_pair_counts else None),
+        )
+        return pairs_to_pair_stream([])
+    # `sum([])` is 0, and reporting that as a COUNTED zero would recreate the
+    # exact absent-vs-zero collapse this change exists to remove -- an empty
+    # accumulator means no worker counted anything (a route that bypasses both
+    # bucket workers), not that zero pairs were compared. Stay absent.
+    _emit_profile(
+        all_pairs, mk,
+        candidates=(sum(_cand_pair_counts) if _cand_pair_counts else None),
+    )
+    return all_pairs
+
+
+def pairs_to_pair_stream(pairs: list[tuple[int, int, float]]) -> Any:
+    """``list[(id_a, id_b, score)]`` -> a ``PAIR_STREAM_SCHEMA_SPEC`` ``pa.Table``
+    (``id_a``/``id_b`` int64, ``score`` float64) — the Arrow pair-stream shape
+    ``cluster.build_clusters_arrow_native`` consumes.
+
+    B1 seam for the FS Arrow-native pair-stream cutover
+    (``docs/superpowers/specs/2026-07-18-fs-arrow-pair-stream-design.md``). Pair
+    ``(a, b)`` order and any cross-pass DUPLICATE pairs are preserved verbatim —
+    Union-Find collapses duplicate edges, so this is edge-faithful to the
+    ``list[tuple]`` form. Empty input yields a zero-row table with the schema.
+    """
+    import pyarrow as _pa
+
+    if not pairs:
+        return _pa.table({
+            "id_a": _pa.array([], _pa.int64()),
+            "id_b": _pa.array([], _pa.int64()),
+            "score": _pa.array([], _pa.float64()),
+        })
+    # Single left-to-right unzip (one temp list per column, dropped on return).
+    id_a = [p[0] for p in pairs]
+    id_b = [p[1] for p in pairs]
+    score = [p[2] for p in pairs]
+    return _pa.table({
+        "id_a": _pa.array(id_a, _pa.int64()),
+        "id_b": _pa.array(id_b, _pa.int64()),
+        "score": _pa.array(score, _pa.float64()),
+    })
+
+
+def score_buckets_arrow(*args: Any, **kwargs: Any) -> Any:
+    """Arrow pair-stream (``PAIR_STREAM_SCHEMA_SPEC`` ``pa.Table``) form of
+    :func:`score_buckets`.
+
+    B1 of the FS Arrow-native pair-stream cutover (design doc
+    ``2026-07-18-fs-arrow-pair-stream-design.md``). Same scoring, same
+    ``matched_pairs`` mutation, same cross-pass-duplicate semantics as
+    ``score_buckets`` — it delegates, so it is byte-faithful by construction —
+    but returns the emitted pairs as a ``pa.Table`` (``id_a``/``id_b`` int64,
+    ``score`` float64) so the FS clustering path can consume Arrow via
+    ``build_clusters_arrow_native`` instead of accumulating a
+    ``list[tuple]`` + a ``matched_pairs`` set (~16 GB at 66M pairs vs ~1.3 GB
+    Arrow — the 1M person OOM's second cause).
+
+    Accumulates INCREMENTALLY (``_emit="arrow"``): each pass is converted to
+    Arrow and its Python list dropped, and the ``matched_pairs`` exclude set is
+    NOT built — so peak holds one pass's tuples + the accumulated int64/float64
+    columns rather than the whole run's ``list[tuple]`` + an 8 GB set. Because it
+    omits the ``matched_pairs`` mutation, the FS dedupe caller (B2b) routes here
+    only when no later pass/matchkey consumes the exclude set. B2b threads the
+    table into ``build_clusters_arrow_native``.
+    """
+    kwargs["_emit"] = "arrow"
+    return score_buckets(*args, **kwargs)

--- a/scripts/parity_coverage.py
+++ b/scripts/parity_coverage.py
@@ -43,6 +43,44 @@ def _py_function_spans() -> dict[str, list[tuple[str, int, int]]]:
     return out
 
 
+def _load_executed(native_off_xml: Path) -> dict[str, set[int]]:
+    """Parse a coverage.xml into {filename: {executed line numbers}}.
+
+    A class with zero `<line>` elements at all (no per-line data recorded for
+    that file) is dropped rather than treated as "every line unexecuted" --
+    those are two different facts and conflating them misreports a module the
+    run never touched as one whose functions were all confirmed unguarded.
+    """
+    if not native_off_xml.exists():
+        raise FileNotFoundError(f"coverage report missing: {native_off_xml}")
+    root = ET.parse(native_off_xml).getroot()
+    executed: dict[str, set[int]] = {}
+    for cls in root.iter("class"):
+        name = (cls.get("filename") or "").replace("\\", "/")
+        all_lines = list(cls.iter("line"))
+        if not all_lines:
+            continue
+        hits = {int(ln.get("number", "0")) for ln in all_lines if int(ln.get("hits", "0")) > 0}
+        executed.setdefault(name, set()).update(hits)
+    return executed
+
+
+def _match(mod_path: str, executed: dict[str, set[int]]) -> str | None:
+    """The one `executed` filename that corresponds to `mod_path`, or None.
+
+    More than one candidate is an error, not a pick-the-first: a short or
+    source-relative `filename` in the XML would suffix-match any absolute
+    path ending the same way, silently attributing one module's coverage to
+    another module's functions. That is worse than no answer.
+    """
+    matches = sorted(k for k in executed if mod_path.endswith(k) or k.endswith(mod_path))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError(f"ambiguous coverage match for {mod_path!r}: candidates {matches}")
+    return matches[0]
+
+
 def unguarded_py_functions(
     native_off_xml: Path,
     spans: dict[str, list[tuple[str, int, int]]] | None = None,
@@ -52,27 +90,18 @@ def unguarded_py_functions(
     `spans` is injectable so the unit is testable against synthetic data. A
     version that could only be exercised against the real tree would be checked
     by nobody, and its silence would have to be trusted.
+
+    A module with no matching coverage data at all is silently excluded from
+    this list -- that is "no evidence either way", not "guarded". Use
+    `modules_without_coverage_data` to see which modules that happened to.
     """
-    if not native_off_xml.exists():
-        raise FileNotFoundError(f"coverage report missing: {native_off_xml}")
     if spans is None:
         spans = _py_function_spans()
-    root = ET.parse(native_off_xml).getroot()
-    executed: dict[str, set[int]] = {}
-    for cls in root.iter("class"):
-        name = (cls.get("filename") or "").replace("\\", "/")
-        all_lines = list(cls.iter("line"))
-        if not all_lines:
-            # No per-line data at all -- not the same as "every line has zero
-            # hits". Treat as no signal rather than reporting every function
-            # in the module as unguarded.
-            continue
-        hits = {int(ln.get("number", "0")) for ln in all_lines if int(ln.get("hits", "0")) > 0}
-        executed.setdefault(name, set()).update(hits)
+    executed = _load_executed(native_off_xml)
 
     out: list[str] = []
     for mod_path, fn_spans in spans.items():
-        match = next((k for k in executed if mod_path.endswith(k) or k.endswith(mod_path)), None)
+        match = _match(mod_path, executed)
         if match is None:
             continue
         ran = executed[match]
@@ -82,14 +111,39 @@ def unguarded_py_functions(
     return sorted(out)
 
 
+def modules_without_coverage_data(
+    native_off_xml: Path,
+    spans: dict[str, list[tuple[str, int, int]]] | None = None,
+) -> list[str]:
+    """`spans` modules with no matching `<class>` in the coverage XML at all.
+
+    Distinct from a module that matched and had every function's lines
+    unexecuted: that case is a real, reportable finding from
+    `unguarded_py_functions`. This case means the run produced no evidence at
+    all for the module -- e.g. a whole package excluded from that run's
+    `--source`. Silently dropping it (as `unguarded_py_functions` must, since
+    it has nothing to report) would make the tool read as "fewer unguarded
+    functions" or "zero", for a reason having nothing to do with coverage.
+    """
+    if spans is None:
+        spans = _py_function_spans()
+    executed = _load_executed(native_off_xml)
+    return sorted(mod for mod in spans if _match(mod, executed) is None)
+
+
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--native-off-xml", type=Path, required=True)
     args = ap.parse_args(argv)
-    items = unguarded_py_functions(args.native_off_xml)
+    spans = _py_function_spans()
+    items = unguarded_py_functions(args.native_off_xml, spans=spans)
+    gaps = modules_without_coverage_data(args.native_off_xml, spans=spans)
     print(f"{len(items)} `_py` function(s) executed by no test with native off")
     for i in items:
         print(f"   {i}")
+    print(f"{len(gaps)} module(s) had no coverage data at all (not counted above)")
+    for g in gaps:
+        print(f"   {g}")
     return 0
 
 

--- a/scripts/parity_coverage.py
+++ b/scripts/parity_coverage.py
@@ -134,6 +134,20 @@ def modules_without_coverage_data(
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--native-off-xml", type=Path, required=True)
+    ap.add_argument(
+        "--max-no-data",
+        type=int,
+        default=None,
+        help=(
+            "Fail if more than this many modules have no coverage data at "
+            "all. A no-data count above this floor doesn't mean more code "
+            "went unguarded -- it means the measurement didn't happen for "
+            "those modules (suite died early, a collection error truncated "
+            "it, the runner OOMed), which makes the whole report "
+            "untrustworthy. Unset by default so existing callers are "
+            "unaffected."
+        ),
+    )
     args = ap.parse_args(argv)
     spans = _py_function_spans()
     items = unguarded_py_functions(args.native_off_xml, spans=spans)
@@ -144,6 +158,13 @@ def main(argv: list[str]) -> int:
     print(f"{len(gaps)} module(s) had no coverage data at all (not counted above)")
     for g in gaps:
         print(f"   {g}")
+    if args.max_no_data is not None and len(gaps) > args.max_no_data:
+        print(
+            f"FAIL: {len(gaps)} module(s) had no coverage data, exceeding "
+            f"--max-no-data {args.max_no_data} -- the coverage run is "
+            f"incomplete or mis-scoped, not just 'more unguarded code'"
+        )
+        return 1
     return 0
 
 

--- a/scripts/parity_coverage.py
+++ b/scripts/parity_coverage.py
@@ -1,0 +1,97 @@
+"""Pure-Python fallbacks that no test executes with the native kernel off.
+
+goldenflow's 108 `_py` functions and goldenmatch's 9 are DELIBERATE duplication
+-- a supported execution mode (GOLDENFLOW_NATIVE=0), not dead code. The risk is
+drift between two live implementations, and drift is only caught where a test
+actually runs the pure path. This reports the ones nothing runs.
+
+Measures EXECUTION, never mention: a function named in a test file but never
+called is unguarded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PACKAGES = (
+    REPO / "packages" / "python" / "goldenflow" / "goldenflow",
+    REPO / "packages" / "python" / "goldenmatch" / "goldenmatch",
+)
+
+
+def _py_function_spans() -> dict[str, list[tuple[str, int, int]]]:
+    """Map a module's posix path suffix to its `_py` functions and line spans."""
+    out: dict[str, list[tuple[str, int, int]]] = {}
+    for root in PACKAGES:
+        for path in sorted(root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+            except SyntaxError:
+                continue
+            spans = [
+                (n.name, n.lineno, n.end_lineno or n.lineno)
+                for n in ast.walk(tree)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name.endswith("_py")
+            ]
+            if spans:
+                out[path.as_posix()] = spans
+    return out
+
+
+def unguarded_py_functions(
+    native_off_xml: Path,
+    spans: dict[str, list[tuple[str, int, int]]] | None = None,
+) -> list[str]:
+    """`module::function` for every `_py` function with no executed line.
+
+    `spans` is injectable so the unit is testable against synthetic data. A
+    version that could only be exercised against the real tree would be checked
+    by nobody, and its silence would have to be trusted.
+    """
+    if not native_off_xml.exists():
+        raise FileNotFoundError(f"coverage report missing: {native_off_xml}")
+    if spans is None:
+        spans = _py_function_spans()
+    root = ET.parse(native_off_xml).getroot()
+    executed: dict[str, set[int]] = {}
+    for cls in root.iter("class"):
+        name = (cls.get("filename") or "").replace("\\", "/")
+        all_lines = list(cls.iter("line"))
+        if not all_lines:
+            # No per-line data at all -- not the same as "every line has zero
+            # hits". Treat as no signal rather than reporting every function
+            # in the module as unguarded.
+            continue
+        hits = {int(ln.get("number", "0")) for ln in all_lines if int(ln.get("hits", "0")) > 0}
+        executed.setdefault(name, set()).update(hits)
+
+    out: list[str] = []
+    for mod_path, fn_spans in spans.items():
+        match = next((k for k in executed if mod_path.endswith(k) or k.endswith(mod_path)), None)
+        if match is None:
+            continue
+        ran = executed[match]
+        for fn, start, end in fn_spans:
+            if not any(start <= n <= end for n in ran):
+                out.append(f"{match}::{fn}")
+    return sorted(out)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--native-off-xml", type=Path, required=True)
+    args = ap.parse_args(argv)
+    items = unguarded_py_functions(args.native_off_xml)
+    print(f"{len(items)} `_py` function(s) executed by no test with native off")
+    for i in items:
+        print(f"   {i}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/parity_coverage.py
+++ b/scripts/parity_coverage.py
@@ -30,7 +30,7 @@ def _py_function_spans() -> dict[str, list[tuple[str, int, int]]]:
     for root in PACKAGES:
         for path in sorted(root.rglob("*.py")):
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+                tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
             except SyntaxError:
                 continue
             spans = [

--- a/scripts/shared_decisions/allowlist.py
+++ b/scripts/shared_decisions/allowlist.py
@@ -1,0 +1,48 @@
+"""Fields whose multi-module readers are known to agree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+ALLOWLIST = REPO / "parity" / "shared_decisions.allow"
+
+
+def load_allowlist() -> set[str]:
+    """Field names recorded as agreed.
+
+    RAISES if the file is missing rather than returning an empty set: a silently
+    empty allowlist turns every downstream comparison vacuous while every test
+    stays green.
+    """
+    if not ALLOWLIST.exists():
+        raise FileNotFoundError(f"allowlist missing: {ALLOWLIST}")
+    out: set[str] = set()
+    for line in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line.split("#", 1)[0].strip())
+    return out
+
+
+def entries_missing_reasons(lines: list[str]) -> list[str]:
+    """Allowlist entries carrying no `# reason`.
+
+    Takes lines rather than reading the file so the rule is testable against a
+    synthetic entry: the shipped allowlist is empty at B0a, and a check that
+    only ever runs over an empty file passes whatever the rule says.
+    """
+    bad: list[str] = []
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "#" not in line:
+            bad.append(line)
+    return bad
+
+
+def stale_entries(known: set[str]) -> set[str]:
+    """Allowlisted names that no longer name a real shared field."""
+    return load_allowlist() - known

--- a/scripts/shared_decisions/fields.py
+++ b/scripts/shared_decisions/fields.py
@@ -35,6 +35,8 @@ def config_fields() -> dict[str, set[str]]:
                     head = stmt.annotation.value
                     if isinstance(head, ast.Name) and head.id == "ClassVar":
                         continue
+                    if isinstance(head, ast.Attribute) and head.attr == "ClassVar":
+                        continue
                 names.add(name)
         if names:
             out[node.name] = names

--- a/scripts/shared_decisions/fields.py
+++ b/scripts/shared_decisions/fields.py
@@ -1,0 +1,41 @@
+"""Config-model field names, read from the Pydantic schemas by AST.
+
+Parsed rather than imported: importing goldenmatch.config.schemas pulls the
+whole package and its optional extras, and this must run in a bare CI step.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SCHEMAS = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch" / "config" / "schemas.py"
+
+
+def config_fields() -> dict[str, set[str]]:
+    """Map each Pydantic config class to the field names it declares.
+
+    A field is an annotated assignment at class-body level (`name: type = ...`),
+    which is how Pydantic models declare fields. Methods, ClassVars and private
+    names are skipped.
+    """
+    tree = ast.parse(SCHEMAS.read_text(encoding="utf-8"))
+    out: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        names: set[str] = set()
+        for stmt in node.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                name = stmt.target.id
+                if name.startswith("_"):
+                    continue
+                if isinstance(stmt.annotation, ast.Subscript):
+                    head = stmt.annotation.value
+                    if isinstance(head, ast.Name) and head.id == "ClassVar":
+                        continue
+                names.add(name)
+        if names:
+            out[node.name] = names
+    return out

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -22,15 +22,46 @@ def _known_field_names() -> set[str]:
     return names
 
 
+def _known_class_names_lower() -> set[str]:
+    return {name.lower() for name in config_fields()}
+
+
+def _looks_like_config_base(base_id: str, class_names_lower: set[str]) -> bool:
+    """Does an attribute base name look like it holds a config object?
+
+    Two ways in: the literal substring rule ("config"/"cfg" in the name, e.g.
+    `blocking_config`), or -- because this codebase's convention is to name a
+    config-holding variable after the config *type* it holds, often shortened
+    (e.g. `blocking` for a `BlockingConfig`) -- the name, lowercased with
+    underscores stripped, is a PREFIX of some known config class name,
+    lowercased. `blocking` prefixes `blockingconfig`, so `blocking.passes`
+    counts even though neither "config" nor "cfg" appears in `blocking`.
+
+    This deliberately over-matches (a base that happens to prefix some config
+    class name, holding something else, reading an attribute that happens to
+    share a field name) rather than under-match: a false entry in this
+    report-only, human-triaged inventory costs one triage decision, while a
+    missed reader is invisible -- which is exactly how the 1c843c8a5 incident
+    shipped undetected.
+    """
+    low = base_id.lower()
+    if "config" in low or "cfg" in low:
+        return True
+    stripped = low.replace("_", "")
+    return any(cls.startswith(stripped) for cls in class_names_lower)
+
+
 def field_readers(root: Path) -> dict[str, set[str]]:
     """Map each config field name to the modules under `root` that read it.
 
-    Only attribute reads whose base is a plain name containing "config" or
-    "cfg" count. That keeps `self.keys` and dict `.keys()` out: the base has to
-    look like a config object, which is what the incident's
-    `blocking_config.passes` does.
+    An attribute read counts when its base is a plain name that looks like it
+    holds a config object -- see `_looks_like_config_base`. That keeps
+    `self.keys` and dict `.keys()` out while still catching `blocking.passes`
+    (base `blocking`, no "config"/"cfg" substring, but a prefix of the known
+    class `BlockingConfig`).
     """
     known = _known_field_names()
+    class_names_lower = _known_class_names_lower()
     out: dict[str, set[str]] = defaultdict(set)
     for path in sorted(root.rglob("*.py")):
         try:
@@ -44,8 +75,7 @@ def field_readers(root: Path) -> dict[str, set[str]]:
             base = node.value
             if not isinstance(base, ast.Name):
                 continue
-            low = base.id.lower()
-            if "config" in low or "cfg" in low:
+            if _looks_like_config_base(base.id, class_names_lower):
                 out[node.attr].add(rel)
     return dict(out)
 

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -47,37 +47,45 @@ def _config_look_targets() -> tuple[set[str], set[str], set[str]]:
     return full, trimmed, segments
 
 
-def _looks_like_config_name(name: str, targets: tuple[set[str], set[str], set[str]]) -> bool:
+def _looks_like_config_name(
+    name: str,
+    targets: tuple[set[str], set[str], set[str]],
+    aliases: frozenset[str] = frozenset(),
+) -> bool:
     """Does a single name -- a base identifier, or the whole dotted chain it's
     part of -- look like it refers to a config object?
 
-    Two ways in:
+    Three ways in:
     - the literal substring rule ("config"/"cfg" in the name, e.g.
-      `blocking_config`, or `config.blocking` as a whole dotted string), or
+      `blocking_config`, or `config.blocking` as a whole dotted string),
     - a WORD-BOUNDARY match against a known config class name: the name,
       lowercased with underscores and dots stripped, equals the full class
       name, the class name with its trailing "config" removed, or one of the
       class name's CamelCase segments. `blocking` matches `BlockingConfig`
-      via its "Blocking" segment.
+      via its "Blocking" segment. Or
+    - the name is a recorded MODULE-LOCAL ALIAS -- a variable this module
+      itself assigned from a config-looking expression, e.g.
+      `b = config.blocking` records `b`. See `_module_alias_names`.
 
-    This intentionally does NOT match on a mere prefix. An earlier version
-    of this rule matched any base name that PREFIXED a class name, which let
-    single-letter loop variables collide with class names that happen to
-    start with that letter -- `c.trust` in cli/memory.py matched only because
-    "c" prefixes "canopyconfig" (`c` there is a `Correction` record, from
-    `for c in corrections:`), and `f.guard` in core/pipeline.py matched only
-    because "f" prefixes "fieldtransform" (`f` there is a matchkey field, from
-    `for f in mk.fields`). Word-boundary equality rejects both: "c" and "f"
-    are not equal to any class name, its config-stripped form, or a CamelCase
-    segment. No minimum length is used instead -- a word boundary is the
-    principled cut; an arbitrary length floor is a guess.
+    Word-boundary equality (not a prefix match) is deliberate. An earlier
+    version of this rule matched any base name that PREFIXED a class name,
+    which let single-letter loop variables collide with class names that
+    happen to start with that letter -- `c.trust` in cli/memory.py matched
+    only because "c" prefixes "canopyconfig" (`c` there is a `Correction`
+    record, from `for c in corrections:`), and `f.guard` in core/pipeline.py
+    matched only because "f" prefixes "fieldtransform" (`f` there is a
+    matchkey field, from `for f in mk.fields`). Word-boundary equality
+    rejects both. No minimum length is used instead -- a word boundary is
+    the principled cut; an arbitrary length floor is a guess.
     """
     low = name.lower()
     if "config" in low or "cfg" in low:
         return True
     stripped = low.replace("_", "").replace(".", "")
     full, trimmed, segments = targets
-    return stripped in full or stripped in trimmed or stripped in segments
+    if stripped in full or stripped in trimmed or stripped in segments:
+        return True
+    return stripped in aliases
 
 
 def _base_chain(node: ast.expr) -> list[str] | None:
@@ -102,15 +110,61 @@ def _base_chain(node: ast.expr) -> list[str] | None:
     return segments
 
 
+def _module_alias_names(
+    tree: ast.Module, targets: tuple[set[str], set[str], set[str]]
+) -> frozenset[str]:
+    """PASS 1: local variables this module assigns from a config-looking
+    expression, e.g. `b = config.blocking` records "b" -- so `b.passes` /
+    `b.keys` later in the module are recognized as config field reads even
+    though `b` alone doesn't word-boundary-match any known config class.
+    core/config_critique.py does exactly this (`b = config.blocking`, then
+    `b.strategy`, `b.passes`, `b.keys`), the same multi_pass precedence
+    decision the 1c843c8a5 incident fix added to score_buckets -- without
+    alias tracking that reader is invisible.
+
+    A target counts when it is a single plain name (`x = ...`, not tuple/
+    attribute/subscript unpacking) and its value is either a bare Name that
+    itself looks like a config base, or a Name/Attribute chain whose full
+    dotted string looks like config (`config.blocking`).
+
+    MODULE SCOPE ONLY, by design -- this is a single flat pass over every
+    Assign in the module regardless of which function it's in, so it does
+    NOT track control flow, reassignment, or shadowing across functions.
+    `b = config.blocking` in one function and an unrelated `b.passes` in a
+    different function in the SAME module would be treated as the same
+    alias -- a false positive this scan accepts on purpose: it is
+    report-only and human-triaged, and over-reporting within a module costs
+    one triage decision, while under-reporting is invisible, which is how
+    the 1c843c8a5 incident shipped. Cross-module aliasing is never tracked.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        value = node.value
+        if isinstance(value, ast.Name):
+            if _looks_like_config_name(value.id, targets):
+                aliases.add(node.targets[0].id.lower())
+        elif isinstance(value, ast.Attribute):
+            segments = _base_chain(value)
+            if segments is not None and _looks_like_config_name(".".join(segments), targets):
+                aliases.add(node.targets[0].id.lower())
+    return frozenset(aliases)
+
+
 def field_readers(root: Path) -> dict[str, set[str]]:
     """Map each config field name to the modules under `root` that read it.
 
-    An attribute read counts when its base -- a bare name (`blocking_config`)
-    or a dotted chain (`config.blocking`) -- looks like it holds a config
-    object: see `_looks_like_config_name`. Both the whole dotted chain and
-    each of its segments are checked, so `config.blocking.passes` matches on
-    its `config` segment even though the immediate base of `.passes` is the
-    Attribute node `config.blocking`, not a plain Name.
+    An attribute read counts when its base -- a bare name (`blocking_config`),
+    a dotted chain (`config.blocking`), or a module-local alias of either
+    (`b`, from `b = config.blocking`; see `_module_alias_names`) -- looks
+    like it holds a config object: see `_looks_like_config_name`. Both the
+    whole dotted chain and each of its segments are checked, so
+    `config.blocking.passes` matches on its `config` segment even though the
+    immediate base of `.passes` is the Attribute node `config.blocking`, not
+    a plain Name.
     """
     known = _known_field_names()
     targets = _config_look_targets()
@@ -121,15 +175,16 @@ def field_readers(root: Path) -> dict[str, set[str]]:
         except SyntaxError:
             continue
         rel = path.relative_to(root).as_posix()
-        for node in ast.walk(tree):
+        aliases = _module_alias_names(tree, targets)  # PASS 1
+        for node in ast.walk(tree):  # PASS 2
             if not isinstance(node, ast.Attribute) or node.attr not in known:
                 continue
             segments = _base_chain(node.value)
             if segments is None:
                 continue
             dotted = ".".join(segments)
-            if _looks_like_config_name(dotted, targets) or any(
-                _looks_like_config_name(seg, targets) for seg in segments
+            if _looks_like_config_name(dotted, targets, aliases) or any(
+                _looks_like_config_name(seg, targets, aliases) for seg in segments
             ):
                 out[node.attr].add(rel)
     return dict(out)

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -1,9 +1,14 @@
-"""Which modules read which config fields.
+"""Which modules touch which config fields.
 
-A field read by more than one module is a shared decision: those readers must
-agree about what it means, and nothing checks that they do. That is exactly the
-1c843c8a5 incident -- score_buckets and blocker.py both read
+A field touched by more than one module is a shared decision: those modules
+must agree about what it means, and nothing checks that they do. That is
+exactly the 1c843c8a5 incident -- score_buckets and blocker.py both read
 `blocking_config.passes` and `.keys` and resolved their precedence differently.
+
+"Touch" means READ **or** WRITE, deliberately -- see `field_accessors`. The
+module file is still named `readers.py` because the plan's later tasks import
+`shared_decisions.readers`; the accurate word for what it measures is
+*accessor*, and the public function says so.
 """
 
 from __future__ import annotations
@@ -77,6 +82,9 @@ def _looks_like_config_name(
     matchkey field, from `for f in mk.fields`). Word-boundary equality
     rejects both. No minimum length is used instead -- a word boundary is
     the principled cut; an arbitrary length floor is a guess.
+
+    Callers should almost always go through `_chain_looks_like_config`, which
+    applies this to a whole chain the ONE agreed way.
     """
     low = name.lower()
     if "config" in low or "cfg" in low:
@@ -88,12 +96,40 @@ def _looks_like_config_name(
     return stripped in aliases
 
 
+def _chain_looks_like_config(
+    segments: list[str],
+    targets: tuple[set[str], set[str], set[str]],
+    aliases: frozenset[str] = frozenset(),
+) -> bool:
+    """THE config-look decision for a Name/Attribute chain, in ONE place.
+
+    A chain (from `_base_chain`) looks like it holds a config object when its
+    WHOLE dotted string looks like config, OR when ANY single segment does.
+    Both halves earn their place: `blocking_config` matches as a whole,
+    `config.blocking` matches on its `config` segment.
+
+    This function exists because that rule used to be written twice and the two
+    copies disagreed. The accessor scan tested whole-chain-OR-any-segment;
+    `_module_alias_names` tested only the whole dotted string -- so
+    `b = profile.blocking` failed to register `b` as a config alias, not for
+    any principled reason but because "profile.blocking" carries no literal
+    "config"/"cfg" substring, while its `blocking` segment does
+    word-boundary-match `BlockingConfig`. Two implementations of one rule,
+    silently disagreeing, inside the detector built to find exactly that, is
+    the defect class this whole inventory exists to remove. One function, two
+    call sites.
+    """
+    if _looks_like_config_name(".".join(segments), targets, aliases):
+        return True
+    return any(_looks_like_config_name(seg, targets, aliases) for seg in segments)
+
+
 def _base_chain(node: ast.expr) -> list[str] | None:
     """Walk a Name/Attribute chain to its segments, e.g. `config.blocking` ->
     ["config", "blocking"].
 
     Real code writes `config.blocking.passes`, where the base of the
-    `.passes` read is the Attribute node `config.blocking`, not a plain Name
+    `.passes` access is the Attribute node `config.blocking`, not a plain Name
     -- a bare-`ast.Name` check alone misses it. Returns None when the chain
     bottoms out in anything else (a call result, a subscript, ...), which
     this scan cannot attribute to a config object.
@@ -115,17 +151,17 @@ def _module_alias_names(
 ) -> frozenset[str]:
     """PASS 1: local variables this module assigns from a config-looking
     expression, e.g. `b = config.blocking` records "b" -- so `b.passes` /
-    `b.keys` later in the module are recognized as config field reads even
+    `b.keys` later in the module are recognized as config field accesses even
     though `b` alone doesn't word-boundary-match any known config class.
     core/config_critique.py does exactly this (`b = config.blocking`, then
     `b.strategy`, `b.passes`, `b.keys`), the same multi_pass precedence
     decision the 1c843c8a5 incident fix added to score_buckets -- without
-    alias tracking that reader is invisible.
+    alias tracking that module is invisible.
 
     A target counts when it is a single plain name (`x = ...`, not tuple/
-    attribute/subscript unpacking) and its value is either a bare Name that
-    itself looks like a config base, or a Name/Attribute chain whose full
-    dotted string looks like config (`config.blocking`).
+    attribute/subscript unpacking) and its value is a Name/Attribute chain
+    that `_chain_looks_like_config` accepts -- the SAME rule the accessor scan
+    applies to an access base, not a stricter lookalike of it.
 
     MODULE SCOPE ONLY, by design -- this is a single flat pass over every
     Assign in the module regardless of which function it's in, so it does
@@ -143,28 +179,34 @@ def _module_alias_names(
             continue
         if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
             continue
-        value = node.value
-        if isinstance(value, ast.Name):
-            if _looks_like_config_name(value.id, targets):
-                aliases.add(node.targets[0].id.lower())
-        elif isinstance(value, ast.Attribute):
-            segments = _base_chain(value)
-            if segments is not None and _looks_like_config_name(".".join(segments), targets):
-                aliases.add(node.targets[0].id.lower())
+        segments = _base_chain(node.value)
+        if segments is not None and _chain_looks_like_config(segments, targets):
+            aliases.add(node.targets[0].id.lower())
     return frozenset(aliases)
 
 
-def field_readers(root: Path) -> dict[str, set[str]]:
-    """Map each config field name to the modules under `root` that read it.
+def field_accessors(root: Path) -> dict[str, set[str]]:
+    """Map each config field name to the modules under `root` that ACCESS it.
 
-    An attribute read counts when its base -- a bare name (`blocking_config`),
-    a dotted chain (`config.blocking`), or a module-local alias of either
+    ACCESS MEANS READ **OR** WRITE, on purpose. `core/pipeline.py` does
+    `config.blocking.keys = new_keys` -- an `ast.Store` context -- and this
+    scan counts it. For a shared-decision inventory a writer matters MORE than
+    a reader, not less: a module that mutates a field shared with ten others
+    is precisely the module every reader has to agree with, and the 1c843c8a5
+    incident was two modules disagreeing about how that field resolves. So
+    writes are not filtered out, and the name says "accessors" rather than
+    "readers" so the count cannot be mistaken for a read-only one. (This
+    function was called `field_readers` through three fix rounds while
+    measuring reads AND writes -- a name that overstates what it measures is
+    the same defect class the inventory exists to remove.)
+
+    An access counts when its base -- a bare name (`blocking_config`), a
+    dotted chain (`config.blocking`), or a module-local alias of either
     (`b`, from `b = config.blocking`; see `_module_alias_names`) -- looks
-    like it holds a config object: see `_looks_like_config_name`. Both the
-    whole dotted chain and each of its segments are checked, so
-    `config.blocking.passes` matches on its `config` segment even though the
-    immediate base of `.passes` is the Attribute node `config.blocking`, not
-    a plain Name.
+    like it holds a config object. That single decision lives in
+    `_chain_looks_like_config`.
+
+    Returns field name -> set of module paths (posix, relative to `root`).
     """
     known = _known_field_names()
     targets = _config_look_targets()
@@ -182,14 +224,16 @@ def field_readers(root: Path) -> dict[str, set[str]]:
             segments = _base_chain(node.value)
             if segments is None:
                 continue
-            dotted = ".".join(segments)
-            if _looks_like_config_name(dotted, targets, aliases) or any(
-                _looks_like_config_name(seg, targets, aliases) for seg in segments
-            ):
+            if _chain_looks_like_config(segments, targets, aliases):
                 out[node.attr].add(rel)
     return dict(out)
 
 
 def shared_fields(root: Path) -> dict[str, set[str]]:
-    """Fields read by MORE THAN ONE module -- the ones whose readers must agree."""
-    return {f: mods for f, mods in field_readers(root).items() if len(mods) > 1}
+    """Fields ACCESSED -- read or written -- by MORE THAN ONE module.
+
+    These are the shared decisions: every module in the set has to agree about
+    what the field means, and (writes included, see `field_accessors`) about
+    who is allowed to change it.
+    """
+    return {f: mods for f, mods in field_accessors(root).items() if len(mods) > 1}

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -9,10 +9,15 @@ agree about what it means, and nothing checks that they do. That is exactly the
 from __future__ import annotations
 
 import ast
+import re
 from collections import defaultdict
 from pathlib import Path
 
 from shared_decisions.fields import config_fields
+
+# Splits a CamelCase class name into its words, lowercased, keeping runs of
+# capitals (acronyms) as one word: "LSHKeyConfig" -> ["LSH", "Key", "Config"].
+_CAMEL_SEGMENT_RE = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*")
 
 
 def _known_field_names() -> set[str]:
@@ -22,46 +27,93 @@ def _known_field_names() -> set[str]:
     return names
 
 
-def _known_class_names_lower() -> set[str]:
-    return {name.lower() for name in config_fields()}
+def _camel_segments_lower(class_name: str) -> set[str]:
+    return {seg.lower() for seg in _CAMEL_SEGMENT_RE.findall(class_name)}
 
 
-def _looks_like_config_base(base_id: str, class_names_lower: set[str]) -> bool:
-    """Does an attribute base name look like it holds a config object?
-
-    Two ways in: the literal substring rule ("config"/"cfg" in the name, e.g.
-    `blocking_config`), or -- because this codebase's convention is to name a
-    config-holding variable after the config *type* it holds, often shortened
-    (e.g. `blocking` for a `BlockingConfig`) -- the name, lowercased with
-    underscores stripped, is a PREFIX of some known config class name,
-    lowercased. `blocking` prefixes `blockingconfig`, so `blocking.passes`
-    counts even though neither "config" nor "cfg" appears in `blocking`.
-
-    This deliberately over-matches (a base that happens to prefix some config
-    class name, holding something else, reading an attribute that happens to
-    share a field name) rather than under-match: a false entry in this
-    report-only, human-triaged inventory costs one triage decision, while a
-    missed reader is invisible -- which is exactly how the 1c843c8a5 incident
-    shipped undetected.
+def _config_look_targets() -> tuple[set[str], set[str], set[str]]:
+    """The three word-boundary forms a base name can match, derived from the
+    known config class names: the full lowercased class name, the class name
+    with a trailing "config" removed, and each CamelCase segment.
     """
-    low = base_id.lower()
+    full: set[str] = set()
+    trimmed: set[str] = set()
+    segments: set[str] = set()
+    for class_name in config_fields():
+        low = class_name.lower()
+        full.add(low)
+        trimmed.add(low[: -len("config")] if low.endswith("config") else low)
+        segments |= _camel_segments_lower(class_name)
+    return full, trimmed, segments
+
+
+def _looks_like_config_name(name: str, targets: tuple[set[str], set[str], set[str]]) -> bool:
+    """Does a single name -- a base identifier, or the whole dotted chain it's
+    part of -- look like it refers to a config object?
+
+    Two ways in:
+    - the literal substring rule ("config"/"cfg" in the name, e.g.
+      `blocking_config`, or `config.blocking` as a whole dotted string), or
+    - a WORD-BOUNDARY match against a known config class name: the name,
+      lowercased with underscores and dots stripped, equals the full class
+      name, the class name with its trailing "config" removed, or one of the
+      class name's CamelCase segments. `blocking` matches `BlockingConfig`
+      via its "Blocking" segment.
+
+    This intentionally does NOT match on a mere prefix. An earlier version
+    of this rule matched any base name that PREFIXED a class name, which let
+    single-letter loop variables collide with class names that happen to
+    start with that letter -- `c.trust` in cli/memory.py matched only because
+    "c" prefixes "canopyconfig" (`c` there is a `Correction` record, from
+    `for c in corrections:`), and `f.guard` in core/pipeline.py matched only
+    because "f" prefixes "fieldtransform" (`f` there is a matchkey field, from
+    `for f in mk.fields`). Word-boundary equality rejects both: "c" and "f"
+    are not equal to any class name, its config-stripped form, or a CamelCase
+    segment. No minimum length is used instead -- a word boundary is the
+    principled cut; an arbitrary length floor is a guess.
+    """
+    low = name.lower()
     if "config" in low or "cfg" in low:
         return True
-    stripped = low.replace("_", "")
-    return any(cls.startswith(stripped) for cls in class_names_lower)
+    stripped = low.replace("_", "").replace(".", "")
+    full, trimmed, segments = targets
+    return stripped in full or stripped in trimmed or stripped in segments
+
+
+def _base_chain(node: ast.expr) -> list[str] | None:
+    """Walk a Name/Attribute chain to its segments, e.g. `config.blocking` ->
+    ["config", "blocking"].
+
+    Real code writes `config.blocking.passes`, where the base of the
+    `.passes` read is the Attribute node `config.blocking`, not a plain Name
+    -- a bare-`ast.Name` check alone misses it. Returns None when the chain
+    bottoms out in anything else (a call result, a subscript, ...), which
+    this scan cannot attribute to a config object.
+    """
+    segments: list[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        segments.append(cur.attr)
+        cur = cur.value
+    if not isinstance(cur, ast.Name):
+        return None
+    segments.append(cur.id)
+    segments.reverse()
+    return segments
 
 
 def field_readers(root: Path) -> dict[str, set[str]]:
     """Map each config field name to the modules under `root` that read it.
 
-    An attribute read counts when its base is a plain name that looks like it
-    holds a config object -- see `_looks_like_config_base`. That keeps
-    `self.keys` and dict `.keys()` out while still catching `blocking.passes`
-    (base `blocking`, no "config"/"cfg" substring, but a prefix of the known
-    class `BlockingConfig`).
+    An attribute read counts when its base -- a bare name (`blocking_config`)
+    or a dotted chain (`config.blocking`) -- looks like it holds a config
+    object: see `_looks_like_config_name`. Both the whole dotted chain and
+    each of its segments are checked, so `config.blocking.passes` matches on
+    its `config` segment even though the immediate base of `.passes` is the
+    Attribute node `config.blocking`, not a plain Name.
     """
     known = _known_field_names()
-    class_names_lower = _known_class_names_lower()
+    targets = _config_look_targets()
     out: dict[str, set[str]] = defaultdict(set)
     for path in sorted(root.rglob("*.py")):
         try:
@@ -72,10 +124,13 @@ def field_readers(root: Path) -> dict[str, set[str]]:
         for node in ast.walk(tree):
             if not isinstance(node, ast.Attribute) or node.attr not in known:
                 continue
-            base = node.value
-            if not isinstance(base, ast.Name):
+            segments = _base_chain(node.value)
+            if segments is None:
                 continue
-            if _looks_like_config_base(base.id, class_names_lower):
+            dotted = ".".join(segments)
+            if _looks_like_config_name(dotted, targets) or any(
+                _looks_like_config_name(seg, targets) for seg in segments
+            ):
                 out[node.attr].add(rel)
     return dict(out)
 

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -185,6 +185,29 @@ def _module_alias_names(
     return frozenset(aliases)
 
 
+def unparseable_modules(root: Path) -> list[str]:
+    """Module paths under `root` that `field_accessors` could not parse.
+
+    `field_accessors` silently `continue`s past an `ast.parse` SyntaxError so
+    one bad file cannot crash the whole scan -- but a module that raises IS a
+    module invisible to every field this scan reports, the same silence
+    `modules_without_coverage_data` exists to surface in the companion
+    parity_coverage.py tool. `core/autoconfig_planner.py` and
+    `core/execution_plan.py` carried a UTF-8 BOM (`\\ufeff`) that survived a
+    plain `encoding="utf-8"` decode and made `ast.parse` raise on both --
+    fixed by decoding with `utf-8-sig` instead, but the failure mode (a file
+    silently absent from every count) is not fully closed unless something
+    ALSO fires when it happens again for a different reason.
+    """
+    out: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            out.append(path.relative_to(root).as_posix())
+    return out
+
+
 def field_accessors(root: Path) -> dict[str, set[str]]:
     """Map each config field name to the modules under `root` that ACCESS it.
 
@@ -213,7 +236,7 @@ def field_accessors(root: Path) -> dict[str, set[str]]:
     out: dict[str, set[str]] = defaultdict(set)
     for path in sorted(root.rglob("*.py")):
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+            tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
         except SyntaxError:
             continue
         rel = path.relative_to(root).as_posix()

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -1,0 +1,55 @@
+"""Which modules read which config fields.
+
+A field read by more than one module is a shared decision: those readers must
+agree about what it means, and nothing checks that they do. That is exactly the
+1c843c8a5 incident -- score_buckets and blocker.py both read
+`blocking_config.passes` and `.keys` and resolved their precedence differently.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+from shared_decisions.fields import config_fields
+
+
+def _known_field_names() -> set[str]:
+    names: set[str] = set()
+    for fields in config_fields().values():
+        names |= fields
+    return names
+
+
+def field_readers(root: Path) -> dict[str, set[str]]:
+    """Map each config field name to the modules under `root` that read it.
+
+    Only attribute reads whose base is a plain name containing "config" or
+    "cfg" count. That keeps `self.keys` and dict `.keys()` out: the base has to
+    look like a config object, which is what the incident's
+    `blocking_config.passes` does.
+    """
+    known = _known_field_names()
+    out: dict[str, set[str]] = defaultdict(set)
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute) or node.attr not in known:
+                continue
+            base = node.value
+            if not isinstance(base, ast.Name):
+                continue
+            low = base.id.lower()
+            if "config" in low or "cfg" in low:
+                out[node.attr].add(rel)
+    return dict(out)
+
+
+def shared_fields(root: Path) -> dict[str, set[str]]:
+    """Fields read by MORE THAN ONE module -- the ones whose readers must agree."""
+    return {f: mods for f, mods in field_readers(root).items() if len(mods) > 1}

--- a/scripts/shared_decisions/report.py
+++ b/scripts/shared_decisions/report.py
@@ -1,4 +1,4 @@
-"""Report config fields whose readers span modules and must agree.
+"""Report config fields whose accessors span modules and must agree.
 
 Report-only, by design. This proposes; a person disposes. See the spec's "Being
 wrong": phase B's dangerous failure is a BAD MERGE -- collapsing two
@@ -28,26 +28,69 @@ import sys
 from pathlib import Path
 
 from shared_decisions.allowlist import load_allowlist, stale_entries
-from shared_decisions.readers import shared_fields
+from shared_decisions.fields import config_fields
+from shared_decisions.readers import shared_fields, unparseable_modules
 
 REPO = Path(__file__).resolve().parent.parent.parent
 DEFAULT_ROOT = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
 
+# What this scan can and cannot see, printed verbatim in the report header so
+# silence here is never mistaken for a clean bill -- see finding 6.
+# `fields.py` reads field names from ONE file, config/schemas.py, so a
+# BaseModel declared elsewhere (web/settings.py, for one) contributes no
+# field names to look for in the first place; and `DEFAULT_ROOT` walks only
+# packages/python/goldenmatch/goldenmatch, so an accessor in scripts/,
+# goldenflow, or the TypeScript port is out of reach by construction, not
+# because it was checked and found clean.
+SCOPE_NOTE = (
+    "scope: field names come from packages/python/goldenmatch/goldenmatch/"
+    "config/schemas.py only (web/settings.py's BaseModels are not read); "
+    "accessors are scanned under {root} only -- scripts/, goldenflow, and "
+    "the TypeScript port are out of reach by construction, and their "
+    "silence here is not a clean bill"
+)
 
-def inventory(root: Path) -> list[dict]:
+
+def _declaring_classes(field: str, fields_by_class: dict[str, set[str]]) -> list[str]:
+    """Every config class that declares `field`, sorted.
+
+    A bare field name can be declared on more than one class (`strategy` on
+    `BlockingConfig`, `GoldenFieldRule`, `GoldenGroupRule`) and
+    `field_accessors` keys by name alone -- it has no type information to
+    tell which class a given access actually resolves to. Full
+    disambiguation needs type inference and is out of scope; this surfaces
+    the ambiguity instead, see the report's DECLARED ON marker.
+    """
+    return sorted(cls for cls, names in fields_by_class.items() if field in names)
+
+
+def inventory(root: Path, shared: dict[str, set[str]] | None = None) -> list[dict]:
     """Shared fields minus the declared-agreement allowlist.
 
     Sorted by accessor count descending, then field name ascending for ties
     -- see the module docstring for why. The return shape (`list[dict]` with
-    `field`/`readers` keys) is unchanged by the ranking: only the order of
-    the list differs.
+    `field`/`accessors`/`declared_on` keys) is unchanged by the ranking:
+    only the order of the list differs.
+
+    `shared` is injectable so a caller that already computed
+    `shared_fields(root)` (main(), for one) doesn't pay to re-parse the whole
+    tree a second time -- shared_fields is pure, so the two calls always
+    agreed, it was just double the CI cost for nothing.
     """
-    shared = shared_fields(root)
+    if shared is None:
+        shared = shared_fields(root)
     allowed = load_allowlist()
+    fields_by_class = config_fields()
     items = [
-        {"field": f, "readers": sorted(mods)} for f, mods in shared.items() if f not in allowed
+        {
+            "field": f,
+            "accessors": sorted(mods),
+            "declared_on": _declaring_classes(f, fields_by_class),
+        }
+        for f, mods in shared.items()
+        if f not in allowed
     ]
-    items.sort(key=lambda item: (-len(item["readers"]), item["field"]))
+    items.sort(key=lambda item: (-len(item["accessors"]), item["field"]))
     return items
 
 
@@ -57,22 +100,46 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args(argv)
 
-    items = inventory(args.root)
-    shared = shared_fields(args.root)
+    shared = shared_fields(args.root)  # computed ONCE, passed to inventory()
+    items = inventory(args.root, shared=shared)
     stale = stale_entries(set(shared))
+    skipped = unparseable_modules(args.root)
 
     if args.json:
-        print(json.dumps({"inventory": items, "stale_allowlist_entries": sorted(stale)}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "inventory": items,
+                    "stale_allowlist_entries": sorted(stale),
+                    "unparseable_modules": skipped,
+                },
+                indent=2,
+            )
+        )
         return 1 if stale else 0
 
+    print(SCOPE_NOTE.format(root=args.root))
+    print()
     print(
-        f"{len(shared)} config field(s) read by more than one module; "
+        f"{len(shared)} config field(s) accessed by more than one module; "
         f"{len(items)} not yet recorded as agreed"
     )
+    if skipped:
+        print(
+            f"{len(skipped)} module(s) could not be parsed and are invisible "
+            f"to every count above: {skipped}"
+        )
     print()
     for item in items:
-        print(f"  {item['field']}  ({len(item['readers'])} readers)")
-        for m in item["readers"]:
+        marker = ""
+        if len(item["declared_on"]) > 1:
+            marker = (
+                f"  -- DECLARED ON {len(item['declared_on'])} CLASSES: "
+                f"{', '.join(item['declared_on'])} -- accessors may not refer "
+                "to the same field"
+            )
+        print(f"  {item['field']}  ({len(item['accessors'])} accessors){marker}")
+        for m in item["accessors"]:
             print(f"      {m}")
     if stale:
         print()

--- a/scripts/shared_decisions/report.py
+++ b/scripts/shared_decisions/report.py
@@ -1,0 +1,81 @@
+"""Report config fields whose readers span modules and must agree.
+
+Report-only, by design. This proposes; a person disposes. See the spec's "Being
+wrong": phase B's dangerous failure is a BAD MERGE -- collapsing two
+implementations that must stay separate -- so nothing here remediates.
+
+Ordering: the inventory is sorted by ACCESSOR COUNT ASCENDING, then by field
+name for ties -- NOT alphabetically by field, despite what an earlier draft of
+this module did. Measured against the real package: the scan finds 71 shared
+fields, and sorting by name puts `field` (48 accessor modules) and `name` (44)
+at the top while `passes`/`keys` -- the pair that actually shipped a silent
+wrong answer, with 11 accessors -- sits far below. A field touched by 48
+modules is a universal accessor; the divergence risk this inventory exists to
+surface is highest where FEW accessors make a NON-TRIVIAL, easy-to-diverge-on
+choice, so fewer accessors sort first. Nothing is dropped -- every shared,
+un-allowlisted field is still here -- only ranked, so the decision-shaped
+entries lead and the universal accessors sink to the bottom.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from shared_decisions.allowlist import load_allowlist, stale_entries
+from shared_decisions.readers import shared_fields
+
+REPO = Path(__file__).resolve().parent.parent.parent
+DEFAULT_ROOT = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+
+def inventory(root: Path) -> list[dict]:
+    """Shared fields minus the declared-agreement allowlist.
+
+    Sorted by accessor count ascending, then field name -- see the module
+    docstring for why. The return shape (`list[dict]` with `field`/`readers`
+    keys) is unchanged by the ranking: only the order of the list differs.
+    """
+    shared = shared_fields(root)
+    allowed = load_allowlist()
+    items = [
+        {"field": f, "readers": sorted(mods)} for f, mods in shared.items() if f not in allowed
+    ]
+    items.sort(key=lambda item: (len(item["readers"]), item["field"]))
+    return items
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    items = inventory(args.root)
+    shared = shared_fields(args.root)
+    stale = stale_entries(set(shared))
+
+    if args.json:
+        print(json.dumps({"inventory": items, "stale_allowlist_entries": sorted(stale)}, indent=2))
+        return 1 if stale else 0
+
+    print(
+        f"{len(shared)} config field(s) read by more than one module; "
+        f"{len(items)} not yet recorded as agreed"
+    )
+    print()
+    for item in items:
+        print(f"  {item['field']}  ({len(item['readers'])} readers)")
+        for m in item["readers"]:
+            print(f"      {m}")
+    if stale:
+        print()
+        print(f"STALE allowlist entries (no longer a shared field): {sorted(stale)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/shared_decisions/report.py
+++ b/scripts/shared_decisions/report.py
@@ -4,17 +4,20 @@ Report-only, by design. This proposes; a person disposes. See the spec's "Being
 wrong": phase B's dangerous failure is a BAD MERGE -- collapsing two
 implementations that must stay separate -- so nothing here remediates.
 
-Ordering: the inventory is sorted by ACCESSOR COUNT ASCENDING, then by field
-name for ties -- NOT alphabetically by field, despite what an earlier draft of
-this module did. Measured against the real package: the scan finds 71 shared
-fields, and sorting by name puts `field` (48 accessor modules) and `name` (44)
-at the top while `passes`/`keys` -- the pair that actually shipped a silent
-wrong answer, with 11 accessors -- sits far below. A field touched by 48
-modules is a universal accessor; the divergence risk this inventory exists to
-surface is highest where FEW accessors make a NON-TRIVIAL, easy-to-diverge-on
-choice, so fewer accessors sort first. Nothing is dropped -- every shared,
-un-allowlisted field is still here -- only ranked, so the decision-shaped
-entries lead and the universal accessors sink to the bottom.
+Ordering: the inventory is sorted by ACCESSOR COUNT DESCENDING, then by field
+name for ties. An earlier draft sorted ascending, on the theory that few
+accessors making a non-trivial choice carries the highest divergence risk.
+That theory was never checked against the incident it was meant to surface,
+and it was backwards: ascending buried `passes` and `keys` -- the pair that
+actually shipped a silent wrong answer, 0 pairs where legacy produced 242 --
+at ranks 64 and 70 of 71. The incident's real shape is a WIDELY-shared field:
+more accessors means more modules that have to agree, hence more chances to
+disagree, not fewer. Descending order puts `passes`, `keys`, and `strategy`
+all in the top 8. This ranking is validated against the incident's own
+position in the real inventory, not argued from first principles -- see
+test_known_incident_fields_rank_near_the_top, which pins it to that evidence
+rather than to a rule. Nothing is dropped -- every shared, un-allowlisted
+field is still here -- only ranked, so the highest-blast-radius entries lead.
 """
 
 from __future__ import annotations
@@ -34,16 +37,17 @@ DEFAULT_ROOT = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
 def inventory(root: Path) -> list[dict]:
     """Shared fields minus the declared-agreement allowlist.
 
-    Sorted by accessor count ascending, then field name -- see the module
-    docstring for why. The return shape (`list[dict]` with `field`/`readers`
-    keys) is unchanged by the ranking: only the order of the list differs.
+    Sorted by accessor count descending, then field name ascending for ties
+    -- see the module docstring for why. The return shape (`list[dict]` with
+    `field`/`readers` keys) is unchanged by the ranking: only the order of
+    the list differs.
     """
     shared = shared_fields(root)
     allowed = load_allowlist()
     items = [
         {"field": f, "readers": sorted(mods)} for f, mods in shared.items() if f not in allowed
     ]
-    items.sort(key=lambda item: (len(item["readers"]), item["field"]))
+    items.sort(key=lambda item: (-len(item["readers"]), item["field"]))
     return items
 
 

--- a/scripts/test_parity_coverage.py
+++ b/scripts/test_parity_coverage.py
@@ -36,10 +36,29 @@ def _write(tmp_path: Path, body: str) -> Path:
 
 SPANS = {
     "packages/python/goldenflow/goldenflow/transforms/email.py": [
-        ("_never_ran_py", 25, 26),   # both lines hits=0
-        ("_did_run_py", 39, 41),     # covers line 40, hits=3
+        ("_never_ran_py", 25, 26),  # both lines hits=0
+        ("_did_run_py", 39, 41),  # covers line 40, hits=3
     ]
 }
+
+
+def test_a_bom_prefixed_module_is_scanned_for_py_functions(tmp_path, monkeypatch):
+    """core/autoconfig_planner.py and core/execution_plan.py in the real
+    goldenmatch tree both carry a UTF-8 BOM (`﻿`). A plain
+    `encoding="utf-8"` decode left the BOM character in the source string,
+    `ast.parse` raised a SyntaxError, and `_py_function_spans` silently
+    `continue`d past the module -- any `_py` function in it invisible to
+    `unguarded_py_functions` on every platform, Linux CI included.
+    `encoding="utf-8-sig"` strips it before parsing."""
+    (tmp_path / "bommed.py").write_bytes(
+        b"def fallback_py():\n    return 1\n".decode("ascii").encode("utf-8-sig")
+    )
+    monkeypatch.setattr(pc, "PACKAGES", (tmp_path,))
+    spans = pc._py_function_spans()
+    matches = [k for k in spans if k.endswith("bommed.py")]
+    assert matches, f"BOM-prefixed module was skipped entirely: {sorted(spans)}"
+    names = {fn for fn, _, _ in spans[matches[0]]}
+    assert "fallback_py" in names, names
 
 
 def test_an_unexecuted_function_is_reported_and_an_executed_one_is_not(tmp_path):
@@ -120,7 +139,9 @@ def test_max_no_data_below_the_limit_exits_0(tmp_path, monkeypatch):
     assert rc == 0
 
 
-def test_max_no_data_above_the_limit_exits_1_and_names_count_and_limit(tmp_path, monkeypatch, capsys):
+def test_max_no_data_above_the_limit_exits_1_and_names_count_and_limit(
+    tmp_path, monkeypatch, capsys
+):
     """A gap count exceeding the limit means the RUN was incomplete, not that
     more code is unguarded -- that must fail loudly, and the message must
     name both the actual count and the configured limit so a reader doesn't

--- a/scripts/test_parity_coverage.py
+++ b/scripts/test_parity_coverage.py
@@ -9,6 +9,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+import parity_coverage as pc  # noqa: E402
 from parity_coverage import (  # noqa: E402
     modules_without_coverage_data,
     unguarded_py_functions,
@@ -106,3 +107,42 @@ def test_an_ambiguous_filename_match_raises_rather_than_guessing(tmp_path):
     spans = {"scoring.py": [("_ambiguous_py", 1, 1)]}
     with pytest.raises(ValueError, match="ambiguous"):
         unguarded_py_functions(_write(tmp_path, body), spans=spans)
+
+
+def test_max_no_data_below_the_limit_exits_0(tmp_path, monkeypatch):
+    """The CLI's --max-no-data enforces the documented no-data floor: a gap
+    count AT OR BELOW the limit is fine and main() exits clean."""
+    monkeypatch.setattr(pc, "unguarded_py_functions", lambda *a, **k: [])
+    monkeypatch.setattr(pc, "modules_without_coverage_data", lambda *a, **k: ["a.py", "b.py"])
+    monkeypatch.setattr(pc, "_py_function_spans", lambda: {})
+    xml = _write(tmp_path, XML)
+    rc = pc.main(["--native-off-xml", str(xml), "--max-no-data", "2"])
+    assert rc == 0
+
+
+def test_max_no_data_above_the_limit_exits_1_and_names_count_and_limit(tmp_path, monkeypatch, capsys):
+    """A gap count exceeding the limit means the RUN was incomplete, not that
+    more code is unguarded -- that must fail loudly, and the message must
+    name both the actual count and the configured limit so a reader doesn't
+    have to go dig through the printed module list to find them."""
+    monkeypatch.setattr(pc, "unguarded_py_functions", lambda *a, **k: [])
+    monkeypatch.setattr(
+        pc, "modules_without_coverage_data", lambda *a, **k: ["a.py", "b.py", "c.py"]
+    )
+    monkeypatch.setattr(pc, "_py_function_spans", lambda: {})
+    xml = _write(tmp_path, XML)
+    rc = pc.main(["--native-off-xml", str(xml), "--max-no-data", "2"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL: 3 module(s) had no coverage data, exceeding --max-no-data 2" in out
+
+
+def test_max_no_data_unset_never_fails_regardless_of_gap_count(tmp_path, monkeypatch):
+    """Existing callers (no --max-no-data) must be unaffected: even a large
+    gap count is report-only when no limit was requested."""
+    monkeypatch.setattr(pc, "unguarded_py_functions", lambda *a, **k: [])
+    monkeypatch.setattr(pc, "modules_without_coverage_data", lambda *a, **k: ["a.py"] * 50)
+    monkeypatch.setattr(pc, "_py_function_spans", lambda: {})
+    xml = _write(tmp_path, XML)
+    rc = pc.main(["--native-off-xml", str(xml)])
+    assert rc == 0

--- a/scripts/test_parity_coverage.py
+++ b/scripts/test_parity_coverage.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
-from parity_coverage import unguarded_py_functions  # noqa: E402
+from parity_coverage import (  # noqa: E402
+    modules_without_coverage_data,
+    unguarded_py_functions,
+)
 
 XML = """<?xml version="1.0" ?>
 <coverage><packages><package><classes>
@@ -55,7 +60,49 @@ def test_a_lineless_class_is_not_reported(tmp_path):
 
 
 def test_a_missing_file_raises_rather_than_reporting_clean(tmp_path):
-    import pytest
-
-    with pytest.raises(FileNotFoundError):
+    # match= witnesses OUR deliberate guard's message, not merely "some
+    # FileNotFoundError happened" -- ET.parse() on a missing path raises the
+    # same exception TYPE from its own open() call, so a bare `pytest.raises
+    # (FileNotFoundError)` cannot tell whether our guard exists at all. See
+    # fix-round-1 sabotage: replacing the guard body with `pass` still passed
+    # this test before `match=` was added.
+    with pytest.raises(FileNotFoundError, match="coverage report missing"):
         unguarded_py_functions(tmp_path / "nope.xml")
+
+
+def test_a_module_absent_from_coverage_is_a_gap_not_silently_clean(tmp_path):
+    """A module in `spans` with no matching <class> anywhere in the XML (a
+    whole package excluded from that run's --source, say) must be visible as
+    a gap. Silently dropping it from `unguarded_py_functions` -- which it
+    must, since it has no evidence to report -- would read as "fewer
+    unguarded functions" for a reason having nothing to do with coverage."""
+    spans = {
+        "packages/python/goldenflow/goldenflow/transforms/never_measured.py": [
+            ("_absent_py", 1, 2),
+        ]
+    }
+    gaps = modules_without_coverage_data(_write(tmp_path, XML), spans=spans)
+    assert len(gaps) == 1
+    assert "never_measured.py" in gaps[0]
+    # and the findings list stays silent about it -- that's the whole risk
+    assert unguarded_py_functions(_write(tmp_path, XML), spans=spans) == []
+
+
+def test_an_ambiguous_filename_match_raises_rather_than_guessing(tmp_path):
+    """Two modules in the coverage XML share a basename that a short `spans`
+    key suffix-matches equally. Picking the first candidate would silently
+    attribute one module's coverage to the other's functions -- a wrong
+    attribution is unfalsifiable, so this must raise instead."""
+    body = """<?xml version="1.0" ?>
+<coverage><packages><package><classes>
+<class filename="packages/python/goldenflow/goldenflow/transforms/scoring.py">
+<lines><line number="1" hits="1"/></lines>
+</class>
+<class filename="packages/python/goldenmatch/goldenmatch/core/scoring.py">
+<lines><line number="1" hits="1"/></lines>
+</class>
+</classes></package></packages></coverage>
+"""
+    spans = {"scoring.py": [("_ambiguous_py", 1, 1)]}
+    with pytest.raises(ValueError, match="ambiguous"):
+        unguarded_py_functions(_write(tmp_path, body), spans=spans)

--- a/scripts/test_parity_coverage.py
+++ b/scripts/test_parity_coverage.py
@@ -1,0 +1,61 @@
+"""Which pure-Python fallbacks no test executes with native off."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from parity_coverage import unguarded_py_functions  # noqa: E402
+
+XML = """<?xml version="1.0" ?>
+<coverage><packages><package><classes>
+<class filename="packages/python/goldenflow/goldenflow/transforms/email.py">
+<lines>
+<line number="25" hits="0"/>
+<line number="26" hits="0"/>
+<line number="40" hits="3"/>
+</lines>
+</class>
+</classes></package></packages></coverage>
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "coverage.xml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+SPANS = {
+    "packages/python/goldenflow/goldenflow/transforms/email.py": [
+        ("_never_ran_py", 25, 26),   # both lines hits=0
+        ("_did_run_py", 39, 41),     # covers line 40, hits=3
+    ]
+}
+
+
+def test_an_unexecuted_function_is_reported_and_an_executed_one_is_not(tmp_path):
+    """The unit is the FUNCTION, not the module: a module with SOME executed
+    lines still has _py functions that never ran, and both must be classified
+    correctly from the same file."""
+    out = unguarded_py_functions(_write(tmp_path, XML), spans=SPANS)
+    names = {i.split("::")[-1] for i in out}
+    assert "_never_ran_py" in names, out
+    assert "_did_run_py" not in names, out
+
+
+def test_a_lineless_class_is_not_reported(tmp_path):
+    body = XML.replace(
+        '<line number="25" hits="0"/>\n<line number="26" hits="0"/>\n<line number="40" hits="3"/>',
+        "",
+    )
+    assert unguarded_py_functions(_write(tmp_path, body), spans=SPANS) == []
+
+
+def test_a_missing_file_raises_rather_than_reporting_clean(tmp_path):
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        unguarded_py_functions(tmp_path / "nope.xml")

--- a/scripts/test_shared_decisions_allowlist.py
+++ b/scripts/test_shared_decisions_allowlist.py
@@ -1,0 +1,70 @@
+"""Allowlist for fields whose readers are known to agree.
+
+Mirrors parity/dead_code/*.yaml's contract: an entry is a claim that the readers
+DO agree and someone checked, not that we would rather not look.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.allowlist import load_allowlist  # noqa: E402
+
+ALLOW = Path(__file__).resolve().parent.parent / "parity" / "shared_decisions.allow"
+
+
+def test_allowlist_loads():
+    entries = load_allowlist()
+    assert isinstance(entries, set)
+
+
+def test_a_missing_allowlist_raises_rather_than_returning_empty(monkeypatch):
+    """A silently-empty allowlist disables the only thing standing between the
+    inventory and a reviewer's time. Phase A shipped exactly this bug."""
+    import shared_decisions.allowlist as mod
+
+    monkeypatch.setattr(mod, "ALLOWLIST", Path("does-not-exist.allow"))
+    with pytest.raises(FileNotFoundError):
+        mod.load_allowlist()
+
+
+def test_an_entry_without_a_reason_is_rejected():
+    """The shipped allowlist is EMPTY at B0a, so a loop over it never executes
+    and would pass whatever the format rule was. Drive the rule with a synthetic
+    entry instead, so the test can actually fail."""
+    from shared_decisions.allowlist import entries_missing_reasons
+
+    good = ["field_a  # checked 2026-09-02, both readers agree"]
+    bad = ["field_b", "field_c  # fine"]
+    assert entries_missing_reasons(good) == []
+    assert entries_missing_reasons(bad) == ["field_b"]
+
+
+def test_the_shipped_allowlist_obeys_the_format():
+    """Vacuous while the file is empty, which is correct -- it becomes a real
+    check the moment B1 adds the first entry."""
+    from shared_decisions.allowlist import entries_missing_reasons
+
+    lines = ALLOW.read_text(encoding="utf-8").splitlines()
+    assert entries_missing_reasons(lines) == []
+
+
+def test_stale_entries_are_detected(tmp_path, monkeypatch):
+    """A real witness: an allowlist naming a field that is no longer shared must
+    be reported. Asserting against the SHIPPED allowlist cannot witness this --
+    it is empty at B0a, so every assertion over it passes vacuously."""
+    import shared_decisions.allowlist as mod
+
+    allow = tmp_path / "shared_decisions.allow"
+    allow.write_text(
+        "gone_field  # was agreed in 2026\nkept_field  # still shared\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(mod, "ALLOWLIST", allow)
+
+    stale = mod.stale_entries({"kept_field"})
+    assert stale == {"gone_field"}, stale

--- a/scripts/test_shared_decisions_fields.py
+++ b/scripts/test_shared_decisions_fields.py
@@ -1,0 +1,35 @@
+"""Config-model field enumeration.
+
+The shared-decision scan needs to know which attribute names are CONFIG fields.
+Scanning every attribute access in the repo would drown in `self.x` noise, so
+the field set is derived from the Pydantic models themselves.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.fields import config_fields  # noqa: E402
+
+
+def test_blocking_config_fields_are_found():
+    """BlockingConfig is the model behind the incident this engine must catch."""
+    fields = config_fields()
+    assert "BlockingConfig" in fields, sorted(fields)[:20]
+    assert {"passes", "keys", "strategy"} <= fields["BlockingConfig"]
+
+
+def test_a_plausible_number_of_models_is_found():
+    """A parse failure or a wrong path yields a near-empty dict that would make
+    every downstream result vacuously clean."""
+    fields = config_fields()
+    assert len(fields) >= 10, f"only {len(fields)} config models found"
+
+
+def test_every_model_has_at_least_one_field():
+    fields = config_fields()
+    empty = [k for k, v in fields.items() if not v]
+    assert not empty, f"models parsed with no fields: {empty}"

--- a/scripts/test_shared_decisions_fields.py
+++ b/scripts/test_shared_decisions_fields.py
@@ -24,12 +24,25 @@ def test_blocking_config_fields_are_found():
 
 def test_a_plausible_number_of_models_is_found():
     """A parse failure or a wrong path yields a near-empty dict that would make
-    every downstream result vacuously clean."""
+    every downstream result vacuously clean. (Measured at implementation: 41)"""
     fields = config_fields()
-    assert len(fields) >= 10, f"only {len(fields)} config models found"
+    assert len(fields) >= 30, f"only {len(fields)} config models found (was 41)"
 
 
-def test_every_model_has_at_least_one_field():
+def test_known_models_are_present():
+    """Parser regression test: named models must be present with plausible field
+    counts. Failure names the missing or emptied model."""
     fields = config_fields()
-    empty = [k for k, v in fields.items() if not v]
-    assert not empty, f"models parsed with no fields: {empty}"
+    required_models = {
+        "BlockingConfig": 25,
+        "GoldenMatchConfig": 29,
+        "IdentityConfig": 16,
+        "MatchkeyConfig": 18,
+    }
+    for model, expected_field_count in required_models.items():
+        assert model in fields, f"model {model!r} not found; available: {sorted(fields)[:20]}"
+        actual_count = len(fields[model])
+        assert actual_count > 0, f"model {model!r} has no fields"
+        assert actual_count == expected_field_count, (
+            f"model {model!r}: expected {expected_field_count} fields, got {actual_count}"
+        )

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -71,11 +71,37 @@ def test_non_config_named_bases_are_not_missed():
         assert expected in both, f"{expected} missing from passes+keys readers: {sorted(both)}"
 
 
-def test_at_least_seven_modules_read_both_passes_and_keys():
+def test_at_least_nine_modules_read_both_passes_and_keys():
     """Lower bound on the real package, not an exact count -- the incident
     field pair (`passes`/`keys`) is read by every blocking-strategy consumer,
     and a narrowing rule should not be able to silently drop below what's
-    already known to be there."""
+    already known to be there. 9 = the 8 found once bare-Name class-prefix
+    matching was added, plus core/fused_match.py once attribute-chain bases
+    (`config.blocking.passes`) were handled."""
     readers = field_readers(GM)
     both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
-    assert len(both) >= 7, f"only {len(both)} modules read both passes and keys: {sorted(both)}"
+    assert len(both) >= 9, f"only {len(both)} modules read both passes and keys: {sorted(both)}"
+
+
+def test_fused_match_is_a_reader_of_both_passes_and_keys():
+    """core/fused_match.py is a shipping scoring backend that reads BOTH
+    incident fields via `config.blocking.keys`/`config.blocking.passes` --
+    an attribute-chain base (`config.blocking`), not a bare Name. It was
+    silently absent from the scan until attribute chains were walked; named
+    explicitly so a future narrowing says this exact module vanished."""
+    readers = field_readers(GM)
+    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    assert "core/fused_match.py" in both, f"fused_match.py missing from: {sorted(both)}"
+
+
+def test_single_letter_bases_do_not_falsely_match_a_config_class_prefix():
+    """A base name that merely PREFIXES a config class name (`c` prefixes
+    `CanopyConfig`, `f` prefixes `FieldTransform`) must not count as a config
+    read -- `c` in cli/memory.py:253 (`for c in corrections:`) is a
+    Correction record, not a CanopyConfig, and its `.trust` read is unrelated
+    to any config field. The word-boundary rule (equality, not prefix)
+    rejects it; a looser prefix rule previously let it through."""
+    readers = field_readers(GM)
+    assert "cli/memory.py" not in readers.get(
+        "trust", set()
+    ), f"cli/memory.py falsely counted as a 'trust' reader: {readers.get('trust', set())}"

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -17,11 +17,38 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shared_decisions.readers import field_accessors, shared_fields  # noqa: E402
+from shared_decisions.readers import (  # noqa: E402
+    field_accessors,
+    shared_fields,
+    unparseable_modules,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
 REPO = Path(__file__).resolve().parent.parent
 GM = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+
+def test_a_bom_prefixed_source_file_is_parsed_not_skipped(tmp_path):
+    """core/autoconfig_planner.py and core/execution_plan.py both carry a
+    UTF-8 BOM (`\\ufeff`) in the committed blob. A plain `encoding="utf-8"`
+    decode leaves the BOM character in the source string, `ast.parse` raises
+    a SyntaxError on it, and the module falls into the silent `except
+    SyntaxError: continue` -- invisible to every field this scan reports,
+    on Linux CI too, not just locally. `encoding="utf-8-sig"` strips it."""
+    src = textwrap.dedent(
+        """
+        def look(config):
+            return config.blocking.passes
+        """
+    ).lstrip("\n")
+    # "utf-8-sig" PREPENDS the BOM bytes on encode -- writing `src` (no
+    # leading "\ufeff") through it reproduces exactly the byte layout
+    # `autoconfig_planner.py`/`execution_plan.py` carry, without double-BOM
+    # bytes that manually prepending "\ufeff" first would have produced.
+    (tmp_path / "bommed.py").write_bytes(src.encode("utf-8-sig"))
+    accessors = field_accessors(tmp_path)
+    assert "bommed.py" in accessors.get("passes", set()), accessors.get("passes")
+    assert unparseable_modules(tmp_path) == []
 
 
 def test_the_incident_pair_is_surfaced():

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -1,18 +1,23 @@
-"""Cross-module config-field readers.
+"""Cross-module config-field ACCESSORS (readers and writers).
 
 The load-bearing test is test_the_incident_pair_is_surfaced: two modules read
 BOTH blocking_config.passes and .keys and must agree on precedence. Nothing
 checked that they did, and they did not.
+
+The scan counts WRITES as well as reads -- see `field_accessors` and
+test_a_write_only_module_counts_as_an_accessor. "Accessor", not "reader", is
+what these tests say, because that is what is measured.
 """
 
 from __future__ import annotations
 
 import sys
+import textwrap
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shared_decisions.readers import field_readers, shared_fields  # noqa: E402
+from shared_decisions.readers import field_accessors, shared_fields  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
 REPO = Path(__file__).resolve().parent.parent
@@ -30,13 +35,13 @@ def test_the_incident_pair_is_surfaced():
     assert len(both) >= 2, f"expected both fixture modules to read both fields, got {both}"
 
 
-def test_a_field_read_by_one_module_is_not_shared():
-    readers = field_readers(FIXTURES)
+def test_a_field_accessed_by_one_module_is_not_shared():
+    accessors = field_accessors(FIXTURES)
     shared = shared_fields(FIXTURES)
-    single = {f for f, mods in readers.items() if len(mods) == 1}
-    assert single, "fixture has no single-reader field; test cannot witness the filter"
+    single = {f for f, mods in accessors.items() if len(mods) == 1}
+    assert single, "fixture has no single-accessor field; test cannot witness the filter"
     assert not (single & set(shared)), (
-        f"single-reader fields leaked into shared: {single & set(shared)}"
+        f"single-accessor fields leaked into shared: {single & set(shared)}"
     )
 
 
@@ -56,34 +61,69 @@ def test_scan_reports_module_paths_not_absolute():
 def test_non_config_named_bases_are_not_missed():
     """The "config"/"cfg"-substring rule alone misses readers whose base is
     named after the config *type* it holds rather than containing "config" --
-    e.g. `blocking.passes` (base `blocking`, prefix of `BlockingConfig`). These
-    three modules were silently absent from the real-package scan until the
-    base-name rule was widened to also match a class-name prefix; naming them
-    explicitly means a future narrowing says which one vanished, not just that
-    the count dropped."""
-    readers = field_readers(GM)
-    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    e.g. `blocking.passes` (base `blocking`, a CamelCase segment of
+    `BlockingConfig`). These three modules were silently absent from the
+    real-package scan until the base-name rule was widened past the literal
+    substring; naming them explicitly means a future narrowing says which one
+    vanished, not just that the count dropped."""
+    accessors = field_accessors(GM)
+    both = {m for m in accessors.get("passes", set()) if m in accessors.get("keys", set())}
     for expected in (
         "core/autoconfig_verify.py",
         "distributed/scoring.py",
         "identity/block_index.py",
     ):
-        assert expected in both, f"{expected} missing from passes+keys readers: {sorted(both)}"
+        assert expected in both, f"{expected} missing from passes+keys accessors: {sorted(both)}"
 
 
-def test_at_least_ten_modules_read_both_passes_and_keys():
-    """Lower bound on the real package, not an exact count -- the incident
-    field pair (`passes`/`keys`) is read by every blocking-strategy consumer,
-    and a narrowing rule should not be able to silently drop below what's
-    already known to be there. 10 = the 9 found once attribute-chain bases
-    were handled, plus core/config_critique.py once module-local aliases
-    (`b = config.blocking`, then `b.passes`/`b.keys`) were tracked."""
-    readers = field_readers(GM)
-    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
-    assert len(both) >= 10, f"only {len(both)} modules read both passes and keys: {sorted(both)}"
+# Every module under packages/python/goldenmatch/goldenmatch that ACCESSES
+# both incident fields (`blocking.passes` AND `blocking.keys`). Pinned as a
+# SET, not a count. A count floor is satisfiable by accident: drop a real
+# accessor, gain an unrelated false positive somewhere else, and the number
+# holds while the inventory has quietly stopped watching a module. Each entry
+# was verified by reading its access site.
+EXPECTED_PASSES_AND_KEYS_ACCESSORS = {
+    # bare `blocking_config.passes` -- the original "config"/"cfg" rule
+    "backends/score_buckets.py",  # one half of the 1c843c8a5 incident pair
+    "core/blocker.py",  # the other half; disagreed about precedence
+    "backends/fs_out_of_core.py",
+    "core/autoconfig.py",
+    # base named after the config TYPE (`blocking.passes`), no "config" in it
+    "core/autoconfig_verify.py",
+    "distributed/scoring.py",
+    "identity/block_index.py",
+    "core/autoconfig_rules.py",
+    # attribute-chain base (`config.blocking.passes`)
+    "core/fused_match.py",
+    # module-local alias (`b = config.blocking`, then `b.passes`)
+    "core/config_critique.py",
+    "core/perceptual_autoconfig.py",  # `blk = config.blocking`
+}
 
 
-def test_config_critique_is_a_reader_of_both_passes_and_keys():
+def test_the_exact_set_of_passes_and_keys_accessors():
+    """The incident field pair is accessed by every blocking-strategy consumer.
+    Pin the WHOLE SET, naming what went missing and what turned up unexpected.
+
+    This replaced a `>= 10` count floor that named only 5 of the 11 modules.
+    Under that floor a regression could drop `core/blocker.py` -- literally one
+    half of the incident pair -- while an unrelated false positive appeared
+    elsewhere, and the suite stayed green at 10. A count cannot tell those two
+    events apart; a set comparison names both."""
+    accessors = field_accessors(GM)
+    both = {m for m in accessors.get("passes", set()) if m in accessors.get("keys", set())}
+    missing = EXPECTED_PASSES_AND_KEYS_ACCESSORS - both
+    unexpected = both - EXPECTED_PASSES_AND_KEYS_ACCESSORS
+    assert not missing, f"expected accessors that vanished from the scan: {sorted(missing)}"
+    assert not unexpected, (
+        f"new accessors the scan found but nobody has triaged: {sorted(unexpected)} "
+        "-- read each access site, then either add it above or fix the rule"
+    )
+    # Belt-and-braces floor, secondary to the set above.
+    assert len(both) >= len(EXPECTED_PASSES_AND_KEYS_ACCESSORS), sorted(both)
+
+
+def test_config_critique_is_an_accessor_of_both_passes_and_keys():
     """core/config_critique.py aliases `b = config.blocking` and then reads
     `b.strategy`/`b.passes`/`b.keys` in the SAME multi_pass precedence branch
     the 1c843c8a5 incident fix added to score_buckets -- a module making the
@@ -91,19 +131,19 @@ def test_config_critique_is_a_reader_of_both_passes_and_keys():
     silently absent from the scan (a bare `b` doesn't word-boundary-match any
     config class) until module-local alias tracking was added; named
     explicitly so a future narrowing says this exact module vanished."""
-    readers = field_readers(GM)
-    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    accessors = field_accessors(GM)
+    both = {m for m in accessors.get("passes", set()) if m in accessors.get("keys", set())}
     assert "core/config_critique.py" in both, f"config_critique.py missing from: {sorted(both)}"
 
 
-def test_fused_match_is_a_reader_of_both_passes_and_keys():
+def test_fused_match_is_an_accessor_of_both_passes_and_keys():
     """core/fused_match.py is a shipping scoring backend that reads BOTH
     incident fields via `config.blocking.keys`/`config.blocking.passes` --
     an attribute-chain base (`config.blocking`), not a bare Name. It was
     silently absent from the scan until attribute chains were walked; named
     explicitly so a future narrowing says this exact module vanished."""
-    readers = field_readers(GM)
-    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    accessors = field_accessors(GM)
+    both = {m for m in accessors.get("passes", set()) if m in accessors.get("keys", set())}
     assert "core/fused_match.py" in both, f"fused_match.py missing from: {sorted(both)}"
 
 
@@ -111,10 +151,73 @@ def test_single_letter_bases_do_not_falsely_match_a_config_class_prefix():
     """A base name that merely PREFIXES a config class name (`c` prefixes
     `CanopyConfig`, `f` prefixes `FieldTransform`) must not count as a config
     read -- `c` in cli/memory.py:253 (`for c in corrections:`) is a
-    Correction record, not a CanopyConfig, and its `.trust` read is unrelated
-    to any config field. The word-boundary rule (equality, not prefix)
-    rejects it; a looser prefix rule previously let it through."""
-    readers = field_readers(GM)
-    assert "cli/memory.py" not in readers.get(
-        "trust", set()
-    ), f"cli/memory.py falsely counted as a 'trust' reader: {readers.get('trust', set())}"
+    Correction record, not a CanopyConfig, and its `.trust` access is
+    unrelated to any config field. The word-boundary rule (equality, not
+    prefix) rejects it; a looser prefix rule previously let it through."""
+    accessors = field_accessors(GM)
+    assert "cli/memory.py" not in accessors.get("trust", set()), (
+        f"cli/memory.py falsely counted as a 'trust' accessor: {accessors.get('trust', set())}"
+    )
+
+
+def test_a_write_only_module_counts_as_an_accessor(tmp_path):
+    """WRITES COUNT, deliberately -- so the name has to say "accessor".
+
+    `core/pipeline.py` does `config.blocking.keys = new_keys` (an ast.Store).
+    For a shared-decision inventory the mutator matters MORE than a reader: it
+    is the module every reader has to agree with. The function was called
+    `field_readers` for three fix rounds while measuring this, which is the
+    same overstated-name defect the inventory exists to surface.
+
+    Uses a temp tree, not the real package, so the assertion is about the
+    STORE context itself and cannot be satisfied by an unrelated read in the
+    same file."""
+    (tmp_path / "writer.py").write_text(
+        textwrap.dedent("""
+            def bump(config):
+                config.blocking.keys = []
+        """),
+        encoding="utf-8",
+    )
+    (tmp_path / "reader.py").write_text(
+        textwrap.dedent("""
+            def look(config):
+                return config.blocking.keys
+        """),
+        encoding="utf-8",
+    )
+    accessors = field_accessors(tmp_path)
+    assert accessors.get("keys") == {"writer.py", "reader.py"}, accessors.get("keys")
+    assert "keys" in shared_fields(tmp_path), "write + read is a shared decision, not one-sided"
+
+
+def test_the_alias_rule_and_the_access_rule_are_the_same_rule(tmp_path):
+    """One config-look rule, applied identically to an access base and to an
+    alias assignment's value.
+
+    `profile.blocking` carries no literal "config"/"cfg" substring, but its
+    `blocking` segment word-boundary-matches `BlockingConfig`. The access scan
+    always accepted it; the alias pass tested only the WHOLE dotted string, so
+    `b = profile.blocking` did not register `b` -- meaning the scan's answer
+    depended on whether the author used a local variable. Two implementations
+    of one rule, disagreeing, inside the detector built to find exactly that.
+    Both now go through `_chain_looks_like_config`."""
+    (tmp_path / "direct.py").write_text(
+        textwrap.dedent("""
+            def look(profile):
+                return profile.blocking.passes
+        """),
+        encoding="utf-8",
+    )
+    (tmp_path / "aliased.py").write_text(
+        textwrap.dedent("""
+            def look(profile):
+                b = profile.blocking
+                return b.passes
+        """),
+        encoding="utf-8",
+    )
+    accessors = field_accessors(tmp_path)
+    assert accessors.get("passes") == {"direct.py", "aliased.py"}, (
+        f"the aliased form must be seen exactly like the direct one; got {accessors.get('passes')}"
+    )

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -103,16 +103,21 @@ def test_non_config_named_bases_are_not_missed():
     """The "config"/"cfg"-substring rule alone misses readers whose base is
     named after the config *type* it holds rather than containing "config" --
     e.g. `blocking.passes` (base `blocking`, a CamelCase segment of
-    `BlockingConfig`). These three modules were silently absent from the
+    `BlockingConfig`). These modules were silently absent from the
     real-package scan until the base-name rule was widened past the literal
     substring; naming them explicitly means a future narrowing says which one
-    vanished, not just that the count dropped."""
+    vanished, not just that the count dropped.
+
+    Originally this named three modules. `distributed/scoring.py` and
+    `identity/block_index.py` were dropped when PR #2845 routed them through
+    `BlockingConfig.resolved_keys()` -- they no longer read `.passes`/`.keys`
+    at all, so they can no longer witness anything about the base-name rule.
+    The two below still use a type-named base and still exercise it."""
     accessors = field_accessors(GM)
     both = {m for m in accessors.get("passes", set()) if m in accessors.get("keys", set())}
     for expected in (
         "core/autoconfig_verify.py",
-        "distributed/scoring.py",
-        "identity/block_index.py",
+        "core/autoconfig.py",
     ):
         assert expected in both, f"{expected} missing from passes+keys accessors: {sorted(both)}"
 
@@ -123,16 +128,25 @@ def test_non_config_named_bases_are_not_missed():
 # accessor, gain an unrelated false positive somewhere else, and the number
 # holds while the inventory has quietly stopped watching a module. Each entry
 # was verified by reading its access site.
+# FOUR MODULES LEFT THIS SET WHEN THE DECISION WAS SINGLE-SOURCED.
+#
+# `backends/score_buckets.py`, `backends/fs_out_of_core.py`,
+# `distributed/scoring.py` and `identity/block_index.py` used to resolve
+# keys-vs-passes by hand. PR #2845 moved that rule onto
+# `BlockingConfig.resolved_keys()` and routed all ten call sites through it, so
+# those modules no longer read `.passes`/`.keys` directly and are no longer
+# shared-decision accessors at all.
+#
+# That is the remediation working, observed by the detector that found it: this
+# inventory exists to surface duplicated decisions, and the decision it
+# surfaced has been de-duplicated. The set shrinks; it must never grow without
+# a triage.
 EXPECTED_PASSES_AND_KEYS_ACCESSORS = {
     # bare `blocking_config.passes` -- the original "config"/"cfg" rule
-    "backends/score_buckets.py",  # one half of the 1c843c8a5 incident pair
-    "core/blocker.py",  # the other half; disagreed about precedence
-    "backends/fs_out_of_core.py",
+    "core/blocker.py",  # half of the 1c843c8a5 incident pair; still reads both
     "core/autoconfig.py",
     # base named after the config TYPE (`blocking.passes`), no "config" in it
     "core/autoconfig_verify.py",
-    "distributed/scoring.py",
-    "identity/block_index.py",
     "core/autoconfig_rules.py",
     # attribute-chain base (`config.blocking.passes`)
     "core/fused_match.py",

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -51,6 +51,20 @@ def test_a_bom_prefixed_source_file_is_parsed_not_skipped(tmp_path):
     assert unparseable_modules(tmp_path) == []
 
 
+def test_unparseable_modules_names_the_genuinely_broken_file_only(tmp_path):
+    """`unparseable_modules` exists so a silent ast.parse SyntaxError is
+    COUNTED rather than swallowed -- the same silence
+    `modules_without_coverage_data` exists to surface in the companion
+    parity_coverage.py tool. Drive the REAL function against a genuinely
+    unparseable file (unbalanced parens, not a BOM) alongside a valid one,
+    and pin that it names the broken file and ONLY the broken file --
+    non-emptiness alone wouldn't tell a future regression that returns
+    every module, or a hardcoded module name, apart from a correct one."""
+    (tmp_path / "broken.py").write_text("def f(:\n", encoding="utf-8")
+    (tmp_path / "fine.py").write_text("def g():\n    return 1\n", encoding="utf-8")
+    assert unparseable_modules(tmp_path) == ["broken.py"]
+
+
 def test_the_incident_pair_is_surfaced():
     """EXIT CRITERION. Both fixture modules read `passes` and `keys`; the scan
     must report both fields as read by more than one module."""

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -51,3 +51,31 @@ def test_scan_reports_module_paths_not_absolute():
     for mods in shared.values():
         for m in mods:
             assert not Path(m).is_absolute(), m
+
+
+def test_non_config_named_bases_are_not_missed():
+    """The "config"/"cfg"-substring rule alone misses readers whose base is
+    named after the config *type* it holds rather than containing "config" --
+    e.g. `blocking.passes` (base `blocking`, prefix of `BlockingConfig`). These
+    three modules were silently absent from the real-package scan until the
+    base-name rule was widened to also match a class-name prefix; naming them
+    explicitly means a future narrowing says which one vanished, not just that
+    the count dropped."""
+    readers = field_readers(GM)
+    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    for expected in (
+        "core/autoconfig_verify.py",
+        "distributed/scoring.py",
+        "identity/block_index.py",
+    ):
+        assert expected in both, f"{expected} missing from passes+keys readers: {sorted(both)}"
+
+
+def test_at_least_seven_modules_read_both_passes_and_keys():
+    """Lower bound on the real package, not an exact count -- the incident
+    field pair (`passes`/`keys`) is read by every blocking-strategy consumer,
+    and a narrowing rule should not be able to silently drop below what's
+    already known to be there."""
+    readers = field_readers(GM)
+    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    assert len(both) >= 7, f"only {len(both)} modules read both passes and keys: {sorted(both)}"

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -1,0 +1,53 @@
+"""Cross-module config-field readers.
+
+The load-bearing test is test_the_incident_pair_is_surfaced: two modules read
+BOTH blocking_config.passes and .keys and must agree on precedence. Nothing
+checked that they did, and they did not.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.readers import field_readers, shared_fields  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
+REPO = Path(__file__).resolve().parent.parent
+GM = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+
+def test_the_incident_pair_is_surfaced():
+    """EXIT CRITERION. Both fixture modules read `passes` and `keys`; the scan
+    must report both fields as read by more than one module."""
+    shared = shared_fields(FIXTURES)
+    for field in ("passes", "keys"):
+        assert field in shared, f"{field} not reported as shared: {sorted(shared)}"
+        assert len(shared[field]) >= 2, f"{field} readers: {shared[field]}"
+    both = {m for m in shared["passes"] if m in shared["keys"]}
+    assert len(both) >= 2, f"expected both fixture modules to read both fields, got {both}"
+
+
+def test_a_field_read_by_one_module_is_not_shared():
+    readers = field_readers(FIXTURES)
+    shared = shared_fields(FIXTURES)
+    single = {f for f, mods in readers.items() if len(mods) == 1}
+    assert single, "fixture has no single-reader field; test cannot witness the filter"
+    assert not (single & set(shared)), (
+        f"single-reader fields leaked into shared: {single & set(shared)}"
+    )
+
+
+def test_the_real_package_scan_is_not_empty():
+    """A wrong root or a parse failure yields an empty dict that reads as clean."""
+    shared = shared_fields(GM)
+    assert len(shared) >= 5, f"only {len(shared)} shared fields found in goldenmatch"
+
+
+def test_scan_reports_module_paths_not_absolute():
+    shared = shared_fields(FIXTURES)
+    for mods in shared.values():
+        for m in mods:
+            assert not Path(m).is_absolute(), m

--- a/scripts/test_shared_decisions_readers.py
+++ b/scripts/test_shared_decisions_readers.py
@@ -71,16 +71,29 @@ def test_non_config_named_bases_are_not_missed():
         assert expected in both, f"{expected} missing from passes+keys readers: {sorted(both)}"
 
 
-def test_at_least_nine_modules_read_both_passes_and_keys():
+def test_at_least_ten_modules_read_both_passes_and_keys():
     """Lower bound on the real package, not an exact count -- the incident
     field pair (`passes`/`keys`) is read by every blocking-strategy consumer,
     and a narrowing rule should not be able to silently drop below what's
-    already known to be there. 9 = the 8 found once bare-Name class-prefix
-    matching was added, plus core/fused_match.py once attribute-chain bases
-    (`config.blocking.passes`) were handled."""
+    already known to be there. 10 = the 9 found once attribute-chain bases
+    were handled, plus core/config_critique.py once module-local aliases
+    (`b = config.blocking`, then `b.passes`/`b.keys`) were tracked."""
     readers = field_readers(GM)
     both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
-    assert len(both) >= 9, f"only {len(both)} modules read both passes and keys: {sorted(both)}"
+    assert len(both) >= 10, f"only {len(both)} modules read both passes and keys: {sorted(both)}"
+
+
+def test_config_critique_is_a_reader_of_both_passes_and_keys():
+    """core/config_critique.py aliases `b = config.blocking` and then reads
+    `b.strategy`/`b.passes`/`b.keys` in the SAME multi_pass precedence branch
+    the 1c843c8a5 incident fix added to score_buckets -- a module making the
+    identical precedence-shaped decision on the identical fields. It was
+    silently absent from the scan (a bare `b` doesn't word-boundary-match any
+    config class) until module-local alias tracking was added; named
+    explicitly so a future narrowing says this exact module vanished."""
+    readers = field_readers(GM)
+    both = {m for m in readers.get("passes", set()) if m in readers.get("keys", set())}
+    assert "core/config_critique.py" in both, f"config_critique.py missing from: {sorted(both)}"
 
 
 def test_fused_match_is_a_reader_of_both_passes_and_keys():

--- a/scripts/test_shared_decisions_report.py
+++ b/scripts/test_shared_decisions_report.py
@@ -19,15 +19,15 @@ def test_inventory_reports_the_incident_fields():
     assert {"passes", "keys"} <= fields, sorted(fields)
 
 
-def test_every_entry_lists_at_least_two_readers():
+def test_every_entry_lists_at_least_two_accessors():
     for item in inventory(FIXTURES):
-        assert len(item["readers"]) >= 2, item
+        assert len(item["accessors"]) >= 2, item
 
 
-def test_readers_are_sorted_for_stable_output():
+def test_accessors_are_sorted_for_stable_output():
     items = inventory(FIXTURES)
     for item in items:
-        assert item["readers"] == sorted(item["readers"]), item
+        assert item["accessors"] == sorted(item["accessors"]), item
     # Ranking is by accessor count DESCENDING, then field name ASCENDING for
     # ties -- see shared_decisions/report.py's module docstring: descending
     # was validated against the incident's own position in the real
@@ -36,7 +36,7 @@ def test_readers_are_sorted_for_stable_output():
     # (field name ascending) and the shape of the count column, not the
     # count direction itself -- test_known_incident_fields_rank_near_the_top
     # below is what actually pins descending, against the real package.
-    counts = [len(i["readers"]) for i in items]
+    counts = [len(i["accessors"]) for i in items]
     assert counts == sorted(counts, reverse=True), [i["field"] for i in items]
     fields_in_order = [i["field"] for i in items]
     assert fields_in_order == sorted(fields_in_order), fields_in_order
@@ -67,6 +67,109 @@ def test_known_incident_fields_rank_near_the_top():
     top10 = [item["field"] for item in items[:10]]
     for field in ("keys", "strategy", "passes"):
         assert field in top10, f"{field} fell out of the top 10: {top10}"
+
+
+def test_a_field_declared_on_multiple_classes_carries_the_ambiguity_marker():
+    """`readers.py` keys purely by field NAME -- it has no type information,
+    so `rule.strategy` (BlockingConfig, GoldenFieldRule, GoldenGroupRule all
+    declare a `strategy` field) is pooled as if every accessor referred to
+    the SAME field. Full disambiguation needs type inference and is out of
+    scope; this pins that the report at least surfaces the ambiguity rather
+    than silently implying "these N modules must agree" about fields that
+    may share nothing but a name."""
+    items = inventory(DEFAULT_ROOT)
+    strategy = next(i for i in items if i["field"] == "strategy")
+    assert set(strategy["declared_on"]) == {
+        "BlockingConfig",
+        "GoldenFieldRule",
+        "GoldenGroupRule",
+    }, strategy["declared_on"]
+
+
+def test_main_prints_the_declared_on_marker_for_a_multi_class_field(capsys):
+    """The marker has to reach the actual triaged text, not just the return
+    value -- a human reads main()'s stdout, not inventory()'s list[dict]."""
+    rc = main(["--root", str(DEFAULT_ROOT)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "strategy" in out
+    assert "DECLARED ON 3 CLASSES" in out, out
+    assert "BlockingConfig" in out and "GoldenFieldRule" in out and "GoldenGroupRule" in out
+
+
+def test_a_single_class_field_carries_no_marker(capsys):
+    """Contrast case: `passes` is declared on exactly one class
+    (`BlockingConfig`) in the fixture, so its line in the report must not
+    carry the ambiguity marker."""
+    items = inventory(FIXTURES)
+    passes = next(i for i in items if i["field"] == "passes")
+    assert passes["declared_on"] == ["BlockingConfig"], passes["declared_on"]
+
+    rc = main(["--root", str(FIXTURES)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    passes_line = next(line for line in out.splitlines() if line.strip().startswith("passes "))
+    assert "DECLARED ON" not in passes_line, passes_line
+
+
+def test_unparseable_modules_are_counted_in_the_text_report(monkeypatch, capsys):
+    """A BOM (or any other future parse failure) leaves a module invisible
+    to every count above it -- readers.py used to skip and say nothing,
+    the same silence `modules_without_coverage_data` exists to surface in
+    the companion parity_coverage.py tool, applied inconsistently. The
+    report must say so."""
+    import shared_decisions.report as mod
+
+    monkeypatch.setattr(mod, "unparseable_modules", lambda root: ["weird/bommed.py"])
+    rc = main(["--root", str(FIXTURES)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 module(s) could not be parsed" in out, out
+    assert "weird/bommed.py" in out, out
+
+
+def test_unparseable_modules_are_counted_in_the_json_report(monkeypatch, capsys):
+    import shared_decisions.report as mod
+
+    monkeypatch.setattr(mod, "unparseable_modules", lambda root: ["weird/bommed.py"])
+    rc = main(["--root", str(FIXTURES), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert '"unparseable_modules": [\n    "weird/bommed.py"\n  ]' in out, out
+
+
+def test_report_header_states_scan_scope(capsys):
+    """`fields.py` reads only config/schemas.py (web/settings.py's BaseModels
+    are invisible) and DEFAULT_ROOT is goldenmatch only (scripts/, goldenflow,
+    the TypeScript port are out of reach by construction). A reader must not
+    mistake either silence for a clean bill -- the header has to say so."""
+    rc = main(["--root", str(FIXTURES)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "scope" in out.lower()
+    assert "web/settings.py" in out
+    assert str(FIXTURES) in out
+
+
+def test_shared_fields_is_computed_once_per_invocation(monkeypatch, capsys):
+    """`report.py` used to call `shared_fields(root)` twice per run -- once
+    inside `inventory()`, once again for the stale-allowlist check -- each
+    re-parsing all ~493 files under root. It's a pure function so the two
+    calls never disagreed, it was just double the CI cost. Pin the call
+    count so a future edit can't reintroduce the duplicate parse."""
+    import shared_decisions.report as mod
+
+    calls = []
+    real = mod.shared_fields
+
+    def counting(root):
+        calls.append(root)
+        return real(root)
+
+    monkeypatch.setattr(mod, "shared_fields", counting)
+    rc = main(["--root", str(FIXTURES)])
+    assert rc == 0
+    assert len(calls) == 1, f"shared_fields(root) called {len(calls)} times, expected 1"
 
 
 def test_allowlisted_fields_are_excluded(monkeypatch):

--- a/scripts/test_shared_decisions_report.py
+++ b/scripts/test_shared_decisions_report.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shared_decisions.report import inventory  # noqa: E402
+from shared_decisions.report import DEFAULT_ROOT, inventory  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
 
@@ -27,17 +27,34 @@ def test_readers_are_sorted_for_stable_output():
     items = inventory(FIXTURES)
     for item in items:
         assert item["readers"] == sorted(item["readers"]), item
-    # Ranking is by accessor count ASCENDING, then field name for ties -- the
-    # entries with the fewest accessors (the highest divergence risk; see
-    # shared_decisions/report.py's module docstring) lead the list, not
-    # universal accessors. Pin the order, not just the per-item sort, so a
-    # regression to alphabetical-by-field (or a flip to descending) fails
-    # this test rather than merely reading "differently ranked" in a report
-    # a human might not re-check.
+    # Ranking is by accessor count DESCENDING, then field name ASCENDING for
+    # ties -- see shared_decisions/report.py's module docstring: descending
+    # was validated against the incident's own position in the real
+    # inventory, not argued from first principles. Every field in THIS
+    # fixture ties at exactly 2 accessors, so it can only pin the tie-break
+    # (field name ascending) and the shape of the count column, not the
+    # count direction itself -- test_known_incident_fields_rank_near_the_top
+    # below is what actually pins descending, against the real package.
     counts = [len(i["readers"]) for i in items]
-    assert counts == sorted(counts), [i["field"] for i in items]
-    keys = [(len(i["readers"]), i["field"]) for i in items]
-    assert keys == sorted(keys), [i["field"] for i in items]
+    assert counts == sorted(counts, reverse=True), [i["field"] for i in items]
+    fields_in_order = [i["field"] for i in items]
+    assert fields_in_order == sorted(fields_in_order), fields_in_order
+
+
+def test_known_incident_fields_rank_near_the_top():
+    """Pin the ranking to the EVIDENCE, not to a rule.
+
+    `passes`/`keys` shipped the silent wrong answer this whole detector
+    exists to surface (0 pairs where legacy produced 242); `strategy` is the
+    same shape (many readers, non-trivial precedence). An ascending-by-count
+    ranking buried all three at ranks 64, 67, and 70 of 71 in the real
+    inventory -- this test is what makes a future re-sort that buries them
+    again fail loudly, naming exactly which field sank.
+    """
+    items = inventory(DEFAULT_ROOT)
+    top10 = [item["field"] for item in items[:10]]
+    for field in ("keys", "strategy", "passes"):
+        assert field in top10, f"{field} fell out of the top 10: {top10}"
 
 
 def test_allowlisted_fields_are_excluded(monkeypatch):

--- a/scripts/test_shared_decisions_report.py
+++ b/scripts/test_shared_decisions_report.py
@@ -1,0 +1,49 @@
+"""The shared-decision inventory."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.report import inventory  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
+
+
+def test_inventory_reports_the_incident_fields():
+    items = inventory(FIXTURES)
+    fields = {i["field"] for i in items}
+    assert {"passes", "keys"} <= fields, sorted(fields)
+
+
+def test_every_entry_lists_at_least_two_readers():
+    for item in inventory(FIXTURES):
+        assert len(item["readers"]) >= 2, item
+
+
+def test_readers_are_sorted_for_stable_output():
+    items = inventory(FIXTURES)
+    for item in items:
+        assert item["readers"] == sorted(item["readers"]), item
+    # Ranking is by accessor count ASCENDING, then field name for ties -- the
+    # entries with the fewest accessors (the highest divergence risk; see
+    # shared_decisions/report.py's module docstring) lead the list, not
+    # universal accessors. Pin the order, not just the per-item sort, so a
+    # regression to alphabetical-by-field (or a flip to descending) fails
+    # this test rather than merely reading "differently ranked" in a report
+    # a human might not re-check.
+    counts = [len(i["readers"]) for i in items]
+    assert counts == sorted(counts), [i["field"] for i in items]
+    keys = [(len(i["readers"]), i["field"]) for i in items]
+    assert keys == sorted(keys), [i["field"] for i in items]
+
+
+def test_allowlisted_fields_are_excluded(monkeypatch):
+    import shared_decisions.report as mod
+
+    monkeypatch.setattr(mod, "load_allowlist", lambda: {"passes"})
+    fields = {i["field"] for i in mod.inventory(FIXTURES)}
+    assert "passes" not in fields
+    assert "keys" in fields, "the allowlist removed more than it should"

--- a/scripts/test_shared_decisions_report.py
+++ b/scripts/test_shared_decisions_report.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shared_decisions.report import DEFAULT_ROOT, inventory  # noqa: E402
+import shared_decisions.allowlist as allowlist_mod  # noqa: E402
+from shared_decisions.report import DEFAULT_ROOT, inventory, main  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures" / "incident_1c843c8a5"
 
@@ -50,6 +51,17 @@ def test_known_incident_fields_rank_near_the_top():
     ranking buried all three at ranks 64, 67, and 70 of 71 in the real
     inventory -- this test is what makes a future re-sort that buries them
     again fail loudly, naming exactly which field sank.
+
+    THIS TEST IS FRAGILE TO LEGITIMATE GROWTH, ON PURPOSE. As of this
+    writing `passes` sits at rank 8 with 11 accessors, TIED with
+    `golden_rules` and `threshold` at 11 -- a field gaining or losing one or
+    two accessors anywhere in the package could push `passes` to rank 11
+    with nothing incident-relevant having changed. If this test starts
+    failing: RE-INVESTIGATE whether the ordering still surfaces the
+    incident's shape (has something genuinely changed about how widely
+    `passes`/`keys`/`strategy` are read?) -- do NOT reflexively widen the
+    window to top-15 to make it pass again. A tripwire that people learn to
+    silence on sight is worse than no tripwire.
     """
     items = inventory(DEFAULT_ROOT)
     top10 = [item["field"] for item in items[:10]]
@@ -64,3 +76,50 @@ def test_allowlisted_fields_are_excluded(monkeypatch):
     fields = {i["field"] for i in mod.inventory(FIXTURES)}
     assert "passes" not in fields
     assert "keys" in fields, "the allowlist removed more than it should"
+
+
+def _write_allowlist(tmp_path, monkeypatch, lines: list[str]):
+    allow = tmp_path / "shared_decisions.allow"
+    allow.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    monkeypatch.setattr(allowlist_mod, "ALLOWLIST", allow)
+
+
+def test_main_flags_a_stale_allowlist_entry_and_exits_1(tmp_path, monkeypatch, capsys):
+    """END-TO-END: drives main() itself, not just inventory()/stale_entries()
+    separately. Nothing else in this file calls main() -- with the shipped
+    allowlist empty, its only failure-reporting branch (`return 1` for a
+    stale entry) has no witness anywhere in the suite without this test."""
+    _write_allowlist(tmp_path, monkeypatch, ["not_a_real_field  # never a shared field"])
+    rc = main(["--root", str(FIXTURES)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "not_a_real_field" in captured.out, captured.out
+
+
+def test_main_with_no_stale_entries_exits_0(tmp_path, monkeypatch, capsys):
+    """Mirror of the above: an allowlist entry that IS still a real shared
+    field is not stale, and main() must exit 0 with no STALE line."""
+    _write_allowlist(tmp_path, monkeypatch, ["passes  # still shared, agreed"])
+    rc = main(["--root", str(FIXTURES)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "STALE" not in captured.out, captured.out
+
+
+def test_main_json_flags_a_stale_allowlist_entry_and_exits_1(tmp_path, monkeypatch, capsys):
+    """The --json branch has its own `1 if stale else 0` line, separate from
+    the text branch's -- cover it independently so the two paths can't drift
+    apart from each other."""
+    _write_allowlist(tmp_path, monkeypatch, ["not_a_real_field  # never a shared field"])
+    rc = main(["--root", str(FIXTURES), "--json"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "not_a_real_field" in captured.out, captured.out
+
+
+def test_main_json_with_no_stale_entries_exits_0(tmp_path, monkeypatch, capsys):
+    _write_allowlist(tmp_path, monkeypatch, ["passes  # still shared, agreed"])
+    rc = main(["--root", str(FIXTURES), "--json"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"stale_allowlist_entries": []' in captured.out, captured.out

--- a/scripts/test_shared_decisions_report.py
+++ b/scripts/test_shared_decisions_report.py
@@ -65,8 +65,24 @@ def test_known_incident_fields_rank_near_the_top():
     """
     items = inventory(DEFAULT_ROOT)
     top10 = [item["field"] for item in items[:10]]
-    for field in ("keys", "strategy", "passes"):
+    for field in ("keys", "strategy"):
         assert field in top10, f"{field} fell out of the top 10: {top10}"
+
+    # `passes` USED to be here, and left for the right reason: PR #2845 moved
+    # the keys-vs-passes decision onto `BlockingConfig.resolved_keys()` and
+    # routed ten call sites through it, so four modules stopped reading
+    # `.passes` directly and its accessor count fell. The window was NOT
+    # widened to top-15 to paper over that -- this docstring's own warning
+    # forbids it. What the tripwire still guarantees is that the field remains
+    # VISIBLE: it must not vanish from the inventory altogether while
+    # `core/blocker.py` and five others still read it.
+    fields = [item["field"] for item in items]
+    assert "passes" in fields, (
+        "`passes` disappeared from the inventory entirely. That is not the "
+        "remediation shrinking its accessor count -- it means the scan stopped "
+        "seeing a field the 1c843c8a5 incident turned on. Investigate the "
+        "accessor rule before touching this test."
+    )
 
 
 def test_a_field_declared_on_multiple_classes_carries_the_ambiguity_marker():


### PR DESCRIPTION
## What and why

Phase B of the codebase audit programme (spec: `docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md`). Two production bugs shipped on 2026-09-01, both from same-language lookalike code that nobody had registered as a pair:

- `6c89042c7` - `MatchEngine` kept a parallel copy of the dedupe pipeline (203 lines became 54).
- `1c843c8a5` - `score_buckets` read `blocking_config.passes or blocking_config.keys`, the opposite precedence to `blocker.py`. Silent zero pairs where legacy produced 242.

Reading the two diffs rather than their commit subjects showed they are different classes, so the spec was amended during planning: incident 1 is a ~200-line clone and IS reachable by structural similarity; incident 2 shares no code at all. Two modules independently implemented the same rule and one got the precedence backwards. What was duplicated is the DECISION, not the code, so no similarity threshold can reach it - and that is the one that shipped a silent wrong answer.

This PR ships the engine for incident 2 (B0a, shared-decision inventory) plus companion A (parity coverage). It is report-only: no gate, no remediation. Structural clone detection for incident 1 (B0b) is not in this PR.

## Changes

**1. Shared-decision inventory (`scripts/shared_decisions/`).**

For each field declared on a config model, enumerate the modules that read or write it, and report the fields reached by more than one module. Those readers must agree, and nothing checks that they do. A plain AST attribute scan - deterministic, no thresholds, no tuning, and the output is a bounded reviewable inventory rather than a ranked findings list.

Current output on `goldenmatch`:

```
73 config field(s) accessed by more than one module; 73 not yet recorded as agreed
```

The incident-2 field pair sits at ranks 2 and 8. Eleven modules read BOTH `passes` and `keys` and so must agree on precedence:

```
backends/fs_out_of_core.py     core/config_critique.py
backends/score_buckets.py      core/fused_match.py
core/autoconfig.py             core/perceptual_autoconfig.py
core/autoconfig_rules.py       distributed/scoring.py
core/autoconfig_verify.py      identity/block_index.py
core/blocker.py
```

The spec's design-time probe said seven. The shipped detector finds eleven - module-local aliasing (`cfg = self.config.blocking`) and two BOM-prefixed source files were both invisible to the probe. Ten of the eleven are unexamined and may carry the same defect now. That triage is B1, not this PR.

The detector is proven against a checked-in fixture, not against git history: `scripts/fixtures/incident_1c843c8a5/` holds `score_buckets.py` and `blocker.py` verbatim at `1c843c8a5^`, and a test asserts the pre-fix pair is reported. A detector that cannot find the bug that motivated it is decoration.

**2. Parity coverage (`scripts/parity_coverage.py`).**

For each `_py` fallback function, is the native-vs-pure equivalence actually enforced? Determined by measurement, not static inspection: goldenflow's suite runs under coverage with `GOLDENFLOW_NATIVE=0`, and the report names the `_py` functions no test executed. Those can drift with no test noticing.

The spec's own measurement caution applies and is honoured here - an early design probe counted how many `_py` functions were NAMED in a test file and reported "101 of 108 untested". That measured mention, not execution. This measures executed lines.

Inventory only. The 1,662 `_py` lines stay; what changes is knowing which are unguarded. goldenflow's 108 are a supported execution mode and goldenmatch's 9 are the ONLY path on musl and other platforms outside the native wheel's gate. Neither set is dead and this phase does not touch them.

**3. CI: one new report-only job on its own path filter.**

`shared_decisions` runs both reports. Its filter watches `scripts/`, the config schemas, and the trees `readers.py` rglobs - `.github/filters.yml` widened accordingly, so a change to the code under audit re-runs the audit.

The coverage harvest is rc-gated:

```bash
set +e
uv run coverage run --source=goldenflow -m pytest packages/python/goldenflow/tests -q --timeout=300
rc=$?
set -e
[ "$rc" -le 1 ] || { echo "::error::pytest exited $rc -- coverage harvest is not trustworthy"; exit 1; }
```

pytest exit 2/3/4/5 (interrupted, internal error, usage error, nothing collected) means the coverage data is partial, and a partial harvest manufactures false "never executed" findings. Only 0 and 1 are trustworthy. An earlier draft used a `--max-no-data 4` floor instead; that was removed because it is structurally inert - `--source` back-fills `hits="0"` for every unimported module, so the count is pinned at 4 whatever happens.

`parity/shared_decisions.allow` is deliberately empty (comments only). Nothing is recorded as agreed until B1 triages it, and the allowlist loader raises rather than reporting clean if the file goes missing.

## Testing

```
uv run pytest scripts/test_shared_decisions_fields.py scripts/test_shared_decisions_readers.py \
  scripts/test_shared_decisions_allowlist.py scripts/test_shared_decisions_report.py \
  scripts/test_parity_coverage.py scripts/test_workflow_yaml.py
-> 56 passed
```

`ruff check` clean on every touched file. CI filter gates both clean:

```
CI filter coverage OK (47 required paths across 6 filters)
CI job-vs-filter coverage OK (40 known pre-existing gaps, 0 new)
```

Derived-doc gates run against this branch with the main venv (`regen_docs.py --check` -> "Docs are current", `check_docs_staleness.py --base origin/main` -> OK).

The full repo suite is not run here - it OOMs this box under xdist, so CI owns it. The changed surface is `scripts/` plus one CI job, both covered above.

## What this PR cannot verify

The `shared_decisions` job has never run. Its filter gating, the coverage harvest, and the rc gate are verified locally and by the filter-coverage gate, but the first real execution is on this PR. In phase A that first run is exactly where the genuine defects surfaced - 14 false candidates and a silently-empty signal, neither visible from local testing.

The job is report-only and `continue-on-error`, so a bad first run reads as a red advisory lane rather than a blocked merge.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on touched files (full `pre-commit run --all-files` not run - OOM risk on this box)
- [ ] Package `CHANGELOG.md` updated if behavior changed - N/A, no package behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated: spec and plan committed under `docs/superpowers/`
