### PR TITLE
fix(distributed): the Ray lane's golden_rules fallback could not construct

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -278,7 +278,13 @@ def _run_phase5_pipeline(
 
     # 5. Distributed golden (groupby __cluster_id__ via repartition + map_batches)
     #    -> a Ray Dataset. Stays distributed; NOT collected to the driver.
-    rules = cfg.golden_rules or GoldenRulesConfig()
+    # `GoldenRulesConfig()` does not construct -- `_validate_default` raises
+    # unless `default_strategy` or `default` is set -- so an unset
+    # `cfg.golden_rules` (it is Optional) killed this lane HERE, after phase-4
+    # matching and phase-5 clustering had already run. `most_complete` is what
+    # core/pipeline.py, backends/datafusion_spine.py and spark/config_pipeline.py
+    # all fall back to; this lane was the only one out of step.
+    rules = cfg.golden_rules or GoldenRulesConfig(default_strategy="most_complete")
     user_columns = [c for c in _row_columns(ds) if not c.startswith("__")]
     golden_ds = build_golden_records_distributed(
         multi_ds, rules, user_columns=user_columns,

--- a/packages/python/goldenmatch/tests/test_golden_rules_fallback_lanes.py
+++ b/packages/python/goldenmatch/tests/test_golden_rules_fallback_lanes.py
@@ -1,0 +1,111 @@
+"""Every execution lane's `golden_rules` fallback must construct, and agree.
+
+`GoldenMatchConfig.golden_rules` is optional, so each lane supplies its own
+default when a run does not configure survivorship. Four lanes do this
+independently -- single-box, DataFusion spine, Spark, and Ray -- and nothing
+compared them, so one of them fell out of step: `distributed/pipeline.py` built
+a bare `GoldenRulesConfig()`, which does not construct at all
+(`_validate_default` requires `default_strategy` or `default`). The Ray lane
+therefore died at the golden step AFTER matching and clustering had completed.
+
+WHY THIS TEST IS AST-BASED. Reaching `distributed/pipeline.py` at runtime needs
+Ray, which is not installed for the unit suite, and importing the module is
+enough to require it. Reading the fallback expressions statically checks every
+lane -- including ones this suite cannot execute -- which is exactly the set the
+defect lived in. It also generalises: a fifth lane added tomorrow is checked the
+day it is written, with no runtime harness.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from goldenmatch.config.schemas import GoldenRulesConfig
+
+PACKAGE = Path(__file__).resolve().parent.parent / "goldenmatch"
+
+
+def _golden_rules_fallbacks() -> list[tuple[str, int, ast.Call]]:
+    """Every `<expr>.golden_rules or GoldenRulesConfig(...)` in the package."""
+    found: list[tuple[str, int, ast.Call]] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(PACKAGE).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.Or):
+                continue
+            for left, right in zip(node.values, node.values[1:]):
+                if not (isinstance(left, ast.Attribute) and left.attr == "golden_rules"):
+                    continue
+                if not isinstance(right, ast.Call):
+                    continue
+                name = getattr(right.func, "id", getattr(right.func, "attr", ""))
+                if name == "GoldenRulesConfig":
+                    found.append((rel, right.lineno, right))
+    return found
+
+
+def test_the_scan_finds_every_lane():
+    """Guard the guard: a scan that finds nothing would pass vacuously."""
+    sites = _golden_rules_fallbacks()
+    modules = {module for module, _, _ in sites}
+    assert modules >= {
+        "core/pipeline.py",
+        "backends/datafusion_spine.py",
+        "spark/config_pipeline.py",
+        "distributed/pipeline.py",
+    }, f"a known lane fell out of the scan: {sorted(modules)}"
+
+
+@pytest.mark.parametrize(
+    "module,line,call",
+    _golden_rules_fallbacks(),
+    # Default ids stringify the ast.Call as `<ast.Call object at 0x...>`, so a
+    # failure names a memory address instead of the lane that failed.
+    ids=[f"{module}:{line}" for module, line, _ in _golden_rules_fallbacks()],
+)
+def test_each_lane_fallback_constructs(module: str, line: int, call: ast.Call):
+    """A fallback that raises turns an unset optional into a late crash.
+
+    `GoldenRulesConfig()` is not a valid config: `_validate_default` raises
+    `GoldenRulesConfig requires 'default_strategy' or 'default'.`
+    """
+    kwargs = {}
+    for keyword in call.keywords:
+        if keyword.arg is None:
+            pytest.skip(f"{module}:{line} splats kwargs; not statically evaluable")
+        try:
+            kwargs[keyword.arg] = ast.literal_eval(keyword.value)
+        except ValueError:
+            pytest.skip(f"{module}:{line} passes a non-literal {keyword.arg}")
+
+    GoldenRulesConfig(**kwargs)  # must not raise
+
+
+def test_the_lanes_agree_on_the_default_strategy():
+    """Four lanes defaulting differently is a silent behaviour fork.
+
+    This is the shared-decision shape from the phase-B audit: the fallback is a
+    value the FIELD does not carry, so each reader invents one, and nothing
+    makes them agree.
+    """
+    chosen: dict[str, object] = {}
+    for module, line, call in _golden_rules_fallbacks():
+        strategy = next(
+            (
+                ast.literal_eval(kw.value)
+                for kw in call.keywords
+                if kw.arg == "default_strategy"
+            ),
+            None,
+        )
+        chosen[f"{module}:{line}"] = strategy
+
+    assert len(set(chosen.values())) == 1, (
+        f"lanes disagree on the fallback survivorship strategy: {chosen}"
+    )

--- a/packages/python/goldenmatch/tests/test_phase5_explicit_config_739.py
+++ b/packages/python/goldenmatch/tests/test_phase5_explicit_config_739.py
@@ -29,9 +29,19 @@ def _no_survivorship_rules():
       ``golden_rules.field_groups`` / ``.field_rules``; a bare MagicMock exposes
       truthy auto-attributes there and trips the guard. Empty list/dict make it a
       no-op (these tests configure no field-group/conditional survivorship).
-    - The golden tail does ``rules = cfg.golden_rules or GoldenRulesConfig()``;
-      the mock must stay TRUTHY so it short-circuits -- a bare GoldenRulesConfig()
-      raises (it requires a ``default_strategy``/``default``).
+    - The golden tail does ``rules = cfg.golden_rules or <fallback>``; the mock
+      must stay TRUTHY so these tests exercise the CONFIGURED rules rather than
+      the lane's default.
+
+      This bullet used to read "a bare GoldenRulesConfig() raises (it requires a
+      ``default_strategy``/``default``)" -- which was true, and was the actual
+      bug: the Ray lane's fallback could not construct, so any run that left
+      ``golden_rules`` unset died at the golden step. Fixed in
+      distributed/pipeline.py by falling back to
+      ``GoldenRulesConfig(default_strategy="most_complete")``, matching the
+      other three lanes. A falsy mock no longer raises here -- it would quietly
+      test the default instead of the explicit config, which is why the mock
+      stays truthy.
     """
     return MagicMock(field_groups=[], field_rules={})
 


### PR DESCRIPTION
## What and why

The Ray distributed lane crashes at the golden step on any run that does not configure survivorship.

`_run_phase5_pipeline` did:

```python
rules = cfg.golden_rules or GoldenRulesConfig()   # distributed/pipeline.py:281
```

A bare `GoldenRulesConfig()` does not construct. `_validate_default` raises `GoldenRulesConfig requires 'default_strategy' or 'default'.`

`GoldenMatchConfig.golden_rules` is `GoldenRulesConfig | None` (`config/schemas.py:2444`), so it is None whenever a run leaves survivorship unset, and that line sits on the main path of `_run_phase5_pipeline` - not behind `_skip_golden`. The lane therefore dies **after** phase-4 matching and phase-5 clustering have already completed. At 100M rows that is hours of work discarded on a config default.

Three other lanes all fall back to `GoldenRulesConfig(default_strategy="most_complete")`:

| lane | fallback |
| --- | --- |
| `core/pipeline.py:4631` | `GoldenRulesConfig(default_strategy="most_complete")` |
| `backends/datafusion_spine.py:134` | `GoldenRulesConfig(default_strategy="most_complete")` |
| `spark/config_pipeline.py:1486` | `GoldenRulesConfig(default_strategy="most_complete")` |
| `distributed/pipeline.py:281` | `GoldenRulesConfig()` |

This lane was the only one out of step, which is what made it invisible: four modules independently inventing the same default, with nothing comparing them. The fix matches the other three.

**The defect was already known.** `test_phase5_explicit_config_739.py`'s `_no_survivorship_rules` helper documents it in its docstring - "the mock must stay TRUTHY so it short-circuits -- a bare `GoldenRulesConfig()` raises (it requires a `default_strategy`/`default`)" - and works around it rather than fixing it. That comment is updated here: it now describes a hazard that no longer exists, and leaving it would preserve a workaround for a fixed bug.

Found by the phase-B shared-decision inventory (#2843) as finding F1. That detector exists to catch exactly this shape - a decision duplicated across modules rather than shared code - and F1 is the first thing it produced.

## Changes

One line in `distributed/pipeline.py`, plus a comment recording why the value is what it is.

New `tests/test_golden_rules_fallback_lanes.py` scans the package for every `<expr>.golden_rules or GoldenRulesConfig(...)` and asserts (a) each one constructs and (b) the lanes agree on `default_strategy`.

**Why the test is AST-based rather than runtime.** Reaching `distributed/pipeline.py` needs Ray, which the unit suite does not have - importing the module is enough to require it. A runtime test therefore could not cover the lane the defect actually lived in. Reading the fallback expressions statically checks every lane including the ones this suite cannot execute, and it generalises: a fifth lane added later is checked the day it is written, with no harness.

## Testing

Red before, green after. On the pre-fix tree both assertions fail naming `distributed/pipeline.py:281`:

```
FAILED test_each_lane_fallback_constructs[distributed/pipeline.py-281-...]
FAILED test_the_lanes_agree_on_the_default_strategy
  AssertionError: lanes disagree on the fallback survivorship strategy:
    {'backends/datafusion_spine.py:134': 'most_complete',
     'core/pipeline.py:4631': 'most_complete',
     'distributed/pipeline.py:281': None,
     'spark/config_pipeline.py:1486': 'most_complete'}
```

After: 6 passed.

Sabotage-checked, because a scan that finds nothing would make the parametrized test vacuous rather than failing. With the scan's match predicate broken, `test_the_scan_finds_every_lane` fires and the parametrized test collapses to `1 skipped` - the guard is load-bearing.

Neighbours and the wider golden/survivorship area:

```
test_golden_rules_fallback_lanes.py + test_phase5_explicit_config_739.py
  + test_config.py + test_distributed_golden.py + test_distributed_phase5_e2e.py
-> 73 passed, 2 skipped

tests/survivorship/ + test_golden.py + the new file
-> 366 passed, 1 failed
```

The single failure is `survivorship/test_groups.py::test_infermap_smoke_real`, an `ImportError: cannot import name 'FieldGroupSpec' from 'goldencheck_types'` resolving out of the **main** checkout rather than this worktree - the known worktree/PYTHONPATH skew on this box, not a regression. It does not touch `golden_rules`.

`ruff check` clean on all three files. Derived-doc gates run against this branch: `regen_docs.py --check` -> "Docs are current", `check_docs_staleness.py --base origin/main` -> OK.

`test_config.py::test_default_strategy_required` (which asserts `GoldenRulesConfig()` raises) is untouched and still passes - that behaviour is correct and is what makes the old fallback a bug.

## Scope

One remediation, per the phase-B spec's "one per PR" rule, so a wrong fix reverts cleanly. Findings F2 (`distributed/scoring.py:535` blocks on `passes` where `blocker.py` blocks on `keys`) and F3 (`core/blocker.py` reports a key set it did not block on) are separate and not addressed here.

This branch is off `main` and does not depend on #2843.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on touched files
- [ ] Package `CHANGELOG.md` - not updated; no public API change
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` - no workflow or gotcha changed
