### PR TITLE
fix(blocking): single-source the keys-vs-passes decision

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -446,11 +446,7 @@ def score_fs_out_of_core(
         prob_scorer = None if use_native else probabilistic_block_scorer(mk, em_result)
         frozen_exclude = frozenset(matched_pairs)
 
-        passes = (
-            list(blocking_config.passes or [])
-            if blocking_config.strategy == "multi_pass"
-            else list(blocking_config.keys or [])
-        )
+        passes = blocking_config.resolved_keys()
 
         _arrow = emit == "arrow"
         out: list[tuple[int, int, float]] = []
@@ -1790,9 +1786,7 @@ def _bucketed_passes(blocking_config: BlockingConfig) -> list:
     ``__block_key__`` equivalence class); the ``_fs_streaming_dedupe_eligible`` gate
     already restricts the route to them (SN/adaptive/ann have no single block key —
     unsound to hash-partition, see the design spec)."""
-    if blocking_config.strategy == "multi_pass":
-        return list(blocking_config.passes or [])
-    return list(blocking_config.keys or [])
+    return blocking_config.resolved_keys()
 
 
 def bucket_frame_to_shards(

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1497,10 +1497,7 @@ def score_buckets(
     # Auto-config emits keys=[org_name] with passes=[postcode, record_id],
     # where the dropped key is the only one that pairs the duplicates: on the
     # suggest_quality orgs_hard corpus that was 0 pairs vs legacy's 242.
-    if blocking_config.strategy == "multi_pass":
-        pass_keys = blocking_config.passes or blocking_config.keys
-    else:
-        pass_keys = blocking_config.keys or blocking_config.passes
+    pass_keys = blocking_config.resolved_keys()
     if not pass_keys:
         return []
 

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -1330,6 +1330,40 @@ class BlockingConfig(BaseModel):
         description="Perceptual-hash LSH configuration used when the strategy is 'perceptual'.",
     )
 
+    def resolved_keys(self) -> list[BlockingKeyConfig]:
+        """The block-key configs to actually block on. ONE definition, here.
+
+        `keys` and `passes` are two places to put the same thing, and which one
+        wins depends on `strategy`. That rule was written out seven times
+        across the package -- core/blocker.py (three sites),
+        backends/score_buckets.py, backends/fs_out_of_core.py (two sites),
+        identity/block_index.py, distributed/scoring.py -- and the copies did
+        not agree:
+
+        - `distributed/scoring.py` read `passes or keys` with NO strategy
+          branch, so a `static` config carrying both blocked on `passes` where
+          `core/blocker.py` blocked on `keys`. Different backends, different
+          candidate sets, no error.
+        - `_build_multi_pass_blocks` iterated `passes or []` with no fallback,
+          so a `multi_pass` config carrying only `keys` -- a shape this class's
+          OWN validator accepts, and whose error message advertises as valid
+          ("requires 'keys' or 'passes'") -- produced ZERO blocks and zero
+          candidate pairs. Silently.
+        - `core/blocker.py`'s two profile sites labelled the emitted
+          `BlockingProfile` with `passes` while the build used `keys`.
+
+        The rule adopted here is the one `1c843c8a5` established when it fixed
+        `score_buckets`, and it is the only one of the variants that honours
+        the validator's promise: a strategy prefers its own field, and falls
+        back to the other rather than blocking on nothing.
+
+        This is a method, not a `@property`, so it cannot be mistaken for a
+        Pydantic field in serialisation or `model_dump`.
+        """
+        if self.strategy == "multi_pass":
+            return list(self.passes or self.keys or [])
+        return list(self.keys or self.passes or [])
+
     @model_validator(mode="after")
     def _validate_keys_or_passes(self) -> BlockingConfig:
         """Ensure at least keys or passes is provided for strategies that need them."""

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -82,12 +82,7 @@ def _emit_blocking_profile(
         n_rows = int(cast(int, _hv))
 
     # Determine keys_used: prefer passes if truthy, else keys if truthy, else []
-    if config.passes:
-        keys_used = [list(k.fields) for k in config.passes]
-    elif config.keys:
-        keys_used = [list(k.fields) for k in config.keys]
-    else:
-        keys_used = []
+    keys_used = [list(k.fields) for k in config.resolved_keys()]
 
     # Collect block sizes by collecting each LazyFrame.
     # For static/adaptive blocks the underlying DataFrame is already in memory
@@ -308,12 +303,7 @@ def measure_blocking_profile(
         )
         n_rows: int = frame.height
 
-        if blocking_cfg.passes:
-            keys_used = [list(k.fields) for k in blocking_cfg.passes]
-        elif blocking_cfg.keys:
-            keys_used = [list(k.fields) for k in blocking_cfg.keys]
-        else:
-            keys_used = []
+        keys_used = [list(k.fields) for k in blocking_cfg.resolved_keys()]
 
         fast = _fast_static_block_sizes(frame, blocking_cfg)
         if fast is None:
@@ -560,7 +550,7 @@ def build_em_blocks_agg(frame: Any, config: BlockingConfig) -> list:
     if config.strategy == "multi_pass":
         results: list = []
         seen: set = set()
-        for pass_config in config.passes or []:
+        for pass_config in config.resolved_keys():
             pass_sig = (
                 tuple(pass_config.fields),
                 tuple(pass_config.transforms or []),
@@ -572,8 +562,13 @@ def build_em_blocks_agg(frame: Any, config: BlockingConfig) -> list:
                     seen.add(dedup_key)
         return results
 
+    # `resolved_keys()` here too, not `config.keys` -- the branch above selects
+    # the DEDUP behaviour (multi_pass dedups by pass signature), not which keys
+    # to block on. Behaviour-identical today, since the validator requires
+    # `keys` for static/adaptive, but leaving one arm reading the field
+    # directly is how the copies drifted apart in the first place.
     results = []
-    for key_config in config.keys or []:
+    for key_config in config.resolved_keys():
         results.extend(_agg_pass(key_config, "static"))
     return results
 
@@ -1287,7 +1282,7 @@ def _build_multi_pass_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[B
     # keeping distinct-field blocks that merely share a value string.
     seen_keys: set[tuple] = set()
 
-    for pass_config in config.passes or []:
+    for pass_config in config.resolved_keys():
         temp_config = BlockingConfig(
             keys=[pass_config],
             max_block_size=config.max_block_size,

--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -295,7 +295,7 @@ def _has_colocation_plan(config: GoldenMatchConfig) -> bool:
     if any(getattr(mk, "type", None) == "exact" for mk in matchkeys):
         return True
     blocking = getattr(config, "blocking", None)
-    if blocking is not None and (blocking.passes or blocking.keys):
+    if blocking is not None and blocking.resolved_keys():
         return True
     return False
 
@@ -532,7 +532,7 @@ def _attach_colocation_keys(df: Any, config: GoldenMatchConfig) -> Any:
 
     blocking = getattr(config, "blocking", None)
     if blocking is not None:
-        passes = blocking.passes or blocking.keys or []
+        passes = blocking.resolved_keys()
         for i, key_cfg in enumerate(passes):
             try:
                 key_series = std_df.select(_build_block_key_expr(key_cfg))["__block_key__"]

--- a/packages/python/goldenmatch/goldenmatch/identity/block_index.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/block_index.py
@@ -44,9 +44,7 @@ def _pass_signature(key_config: BlockingKeyConfig) -> str:
 
 def _passes_of(blocking: BlockingConfig) -> list[BlockingKeyConfig]:
     """The blocking passes to index: ``passes`` for multi_pass, else ``keys``."""
-    if getattr(blocking, "strategy", None) == "multi_pass":
-        return list(blocking.passes or [])
-    return list(blocking.keys or [])
+    return blocking.resolved_keys()
 
 
 def compute_frame_block_keys(

--- a/packages/python/goldenmatch/tests/test_block_key_resolution.py
+++ b/packages/python/goldenmatch/tests/test_block_key_resolution.py
@@ -1,0 +1,125 @@
+"""`keys` vs `passes` is ONE decision, and every backend must make it the same.
+
+`BlockingConfig` accepts the block keys in either `keys` or `passes`, and which
+one wins depends on `strategy`. That rule was written out seven times across
+the package and the copies disagreed, twice, on configs the schema accepts:
+
+- `strategy="multi_pass"` carrying only `keys` -- valid, and the validator's
+  own message advertises it ("requires 'keys' or 'passes'") -- made
+  `_build_multi_pass_blocks` produce ZERO blocks and zero candidate pairs,
+  silently, on the MAIN blocking path.
+- `strategy="static"` carrying both made `distributed/scoring.py` shuffle on
+  `passes` while `core/blocker.py` blocked on `keys`.
+
+Both are the `1c843c8a5` shape: a silent wrong answer from two modules
+resolving the same field pair differently.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.blocker import build_blocks
+
+PACKAGE = Path(__file__).resolve().parent.parent / "goldenmatch"
+
+
+def _key(name: str) -> BlockingKeyConfig:
+    return BlockingKeyConfig(fields=[name])
+
+
+@pytest.mark.parametrize(
+    "strategy,keys,passes,expected",
+    [
+        ("multi_pass", None, ["a", "b"], ["a", "b"]),
+        # The shape that produced zero pairs.
+        ("multi_pass", ["a"], None, ["a"]),
+        ("multi_pass", ["a"], ["b"], ["b"]),
+        ("static", ["a"], None, ["a"]),
+        # The shape distributed/scoring.py got backwards.
+        ("static", ["a"], ["b"], ["a"]),
+    ],
+)
+def test_resolved_keys_covers_every_schema_valid_shape(strategy, keys, passes, expected):
+    config = BlockingConfig(
+        strategy=strategy,
+        keys=[_key(k) for k in keys] if keys else [],
+        passes=[_key(p) for p in passes] if passes else None,
+    )
+    assert [k.fields[0] for k in config.resolved_keys()] == expected
+
+
+def test_resolved_keys_is_not_a_serialised_field():
+    """A `@property` would land in `model_dump` and change the config wire form."""
+    config = BlockingConfig(strategy="static", keys=[_key("a")])
+    assert "resolved_keys" not in config.model_dump()
+
+
+def test_multi_pass_with_only_keys_produces_blocks():
+    """END TO END. The regression: this returned zero blocks, silently.
+
+    Not a unit test of the resolver -- it drives `build_blocks`, the main
+    path, because the defect was that the main path never consulted `keys`.
+    """
+    table = pa.table(
+        {
+            "id": ["1", "2", "3", "4"],
+            "surname": ["smith", "smith", "jones", "jones"],
+        }
+    )
+    key = _key("surname")
+
+    def pairs(config: BlockingConfig) -> int:
+        blocks = build_blocks(table, config)
+        return sum(b.n_rows() * (b.n_rows() - 1) // 2 for b in blocks)
+
+    baseline = pairs(BlockingConfig(strategy="static", keys=[key]))
+    assert baseline == 2, "fixture no longer produces the pairs this test compares against"
+
+    assert pairs(BlockingConfig(strategy="multi_pass", passes=[key])) == baseline
+    assert pairs(BlockingConfig(strategy="multi_pass", keys=[key])) == baseline
+
+
+def test_the_validator_still_accepts_multi_pass_with_only_keys():
+    """Pin the premise. If this shape were rejected, the bug above could not
+    occur -- and the fix would be dead code guarding an impossible config."""
+    config = BlockingConfig(strategy="multi_pass", keys=[_key("a")])
+    assert config.passes is None
+
+
+def test_no_module_resolves_keys_versus_passes_by_hand():
+    """The decision has ONE home. A new copy is how the last two drifted.
+
+    Scans for `X.passes or X.keys` (and the reverse) outside schemas.py.
+    Deliberately narrow: it catches the two shapes that actually shipped
+    defects, not every mention of both fields -- unions
+    (`list(keys or []) + list(passes or [])`) and existence checks
+    (`if keys or passes`) are precedence-free and legitimate.
+    """
+    offenders: list[str] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        if path.name == "schemas.py":
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.Or):
+                continue
+            attrs = [v.attr for v in node.values if isinstance(v, ast.Attribute)]
+            if len(attrs) < 2:
+                continue
+            for left, right in zip(attrs, attrs[1:]):
+                if {left, right} == {"passes", "keys"}:
+                    rel = path.relative_to(PACKAGE).as_posix()
+                    offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, (
+        f"{offenders} resolve keys-vs-passes by hand. Call "
+        f"`config.resolved_keys()` instead -- that rule lives on BlockingConfig "
+        f"so the backends cannot disagree about it."
+    )


### PR DESCRIPTION
## What and why

`BlockingConfig` accepts the block keys in either `keys` or `passes`, and which one wins depends on `strategy`. That rule was written out **ten times across five modules**, and the copies did not agree. Two of the disagreements produce silent wrong answers on configs the schema accepts.

**1. `multi_pass` carrying only `keys` blocked on nothing.** This is the more serious of the two and it is on the main path.

`_validate_keys_or_passes` only raises when BOTH are empty - its message says "requires 'keys' or 'passes'" - so `strategy="multi_pass"` with `keys` and no `passes` is a valid config. `_build_multi_pass_blocks` iterated `config.passes or []` with no fallback, so it returned zero blocks. Zero candidate pairs, zero clusters, no error.

Measured on a 4-row fixture (two `smith`, two `jones`, blocking on surname):

```
static,     keys=[surname]                 blocks=2  candidate pairs=2
multi_pass, passes=[surname]               blocks=2  candidate pairs=2
multi_pass, KEYS=[surname], passes unset   blocks=0  candidate pairs=0   <-- silent
```

It needs no unusual config shape - just a `multi_pass` strategy with the keys in the field the schema says is fine.

**2. `static` carrying both split the backends.** `distributed/scoring.py:535` read `passes or keys` with no strategy branch:

| module | blocks on |
| --- | --- |
| `core/blocker.py` | `[org_name]` |
| `backends/score_buckets.py` | `[org_name]` |
| `distributed/scoring.py` | `[postcode, record_id]` |

Different backends, different candidate sets, no error. `core/blocker.py`'s two `BlockingProfile` sites had a third variant, labelling the emitted profile with `passes` while the build used `keys` - wrong telemetry into auto-config's controller.

All three are the `1c843c8a5` shape: two modules resolving the same field pair differently, and nothing comparing them.

## Changes

`BlockingConfig.resolved_keys()` is now the one definition:

```python
if self.strategy == "multi_pass":
    return list(self.passes or self.keys or [])
return list(self.keys or self.passes or [])
```

That is the rule `1c843c8a5` established when it fixed `score_buckets`, and it is the only one of the observed variants that honours what the validator promises: prefer the strategy's own field, fall back to the other rather than blocking on nothing. A method rather than a `@property`, so it cannot be mistaken for a Pydantic field in `model_dump`.

Ten call sites routed through it: `core/blocker.py` (5), `backends/fs_out_of_core.py` (2), `backends/score_buckets.py`, `identity/block_index.py`, `distributed/scoring.py` (2).

**Why one PR rather than three.** The phase-B spec puts remediation one-per-PR so a wrong merge reverts cleanly, and this is one remediation: the decision gets one home. Fixing the three wrong copies inline would have left seven more of the identical rule in place and the lanes inconsistent - two backends fixed for `multi_pass`-with-keys and three not. The revert is still a single revert.

## Testing

```
tests/test_block_key_resolution.py                          9 passed
tests/test_block*.py + test_bucket*.py       292 passed, 1 skipped, 2 xfailed
tests/test_fs_out_of_core.py + identity/ + test_config.py  484 passed, 7 skipped
```

`ruff check` clean on all seven files. Derived-doc gates run against this branch: `regen_docs.py --check` -> "Docs are current"; `check_docs_staleness.py --base origin/main` -> OK.

Three things about the tests worth flagging:

- `test_no_module_resolves_keys_versus_passes_by_hand` scans the package for a hand-rolled `X.passes or X.keys` and fails naming file and line. **It caught a tenth site while being written** (`distributed/scoring.py:298`, an existence check I had classified as precedence-free). Sabotage-verified: reverting `distributed/scoring.py:535` trips it naming that line.
- The end-to-end test drives `build_blocks`, not the resolver, because the defect was that the main path never consulted `keys`. A resolver unit test would have passed against the broken code.
- It asserts its own baseline (`assert baseline == 2`) before comparing, so it cannot pass vacuously if the fixture ever stops producing pairs.

The parametrized case list covers all five schema-valid `(strategy, keys, passes)` shapes, including both that shipped a defect.

## Scope

Findings F2, F3 and F10 of the phase-B shared-decision triage. F10 was found while building the remediation for F2 and F3, by comparing the four "correct" sites against each other - they were not in fact the same rule.

There is a fourth category this PR does NOT touch: `core/autoconfig.py` has eight further sites resolving `passes or keys` unconditionally during plan-building. They share the shape but sit in code that constructs configs rather than blocks on them, so whether they are defects needs its own analysis. Recorded rather than swept.

Branched off `main`; independent of #2843 and #2844.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on touched files
- [ ] Package `CHANGELOG.md` - not updated; `resolved_keys()` is additive and no documented behaviour changes except the two bug fixes
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` - no workflow or gotcha changed
