### PR TITLE
audit(phase C0): detect sync claims no test enforces

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1074,3 +1074,4 @@ sync_claims:
   - 'packages/python/goldenmatch/goldenmatch/**'
   - 'packages/python/goldenmatch/tests/**'
   - '.github/workflows/ci.yml'
+  - '.github/filters.yml'                # self-test: a narrowing edit here must still re-run the gate

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1057,3 +1057,20 @@ docs_staleness:
   - 'scripts/check_docs_staleness.py'
   - 'scripts/config_matrix/registry.py'  # declares env_prefix + prose_flag_page
   - '.github/filters.yml'
+# Sync-claim audit: docstrings that claim "this mirrors that" with no test
+# enforcing it (scripts/sync_claims/{claims,enforcement,report}.py). Watches
+# the code the audit READS, not just the detector's own files -- a filter
+# scoped to scripts/ would never re-run the job when someone ADDS a claim to
+# a docstring elsewhere, which is precisely the change this job exists to
+# catch. #2839: two jobs whose filter watched only the surface they ran FROM
+# (packages/python/goldenmatch) rather than what they scanned (scripts/) went
+# silently skipped; this filter makes the same mistake in the other direction
+# on purpose -- the scanned tree, not just the runner.
+sync_claims:
+  - 'scripts/sync_claims/**'
+  - 'scripts/test_sync_claims_*.py'
+  - 'scripts/fixtures/incident_6c89042c7/**'
+  - 'scripts/fixtures/sync_enforcement/**'
+  - 'packages/python/goldenmatch/goldenmatch/**'
+  - 'packages/python/goldenmatch/tests/**'
+  - '.github/workflows/ci.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       downstream_symbols: ${{ steps.filter.outputs.downstream_symbols }}
       er_matcher: ${{ steps.filter.outputs.er_matcher }}
       dead_code: ${{ steps.filter.outputs.dead_code }}
+      sync_claims: ${{ steps.filter.outputs.sync_claims }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
@@ -4950,6 +4951,32 @@ jobs:
         env:
           GOLDENMATCH_NATIVE: "0"
           POLARS_SKIP_CPU_CHECK: "1"
+
+  sync_claims:
+    # Report-only audit for docstrings that claim "this code mirrors that
+    # code" with no test enforcing the relationship (scripts/sync_claims/).
+    # Not in ci-required and the report step has no continue-on-error to
+    # suppress -- it always exits 0 by design. The gate is a later stage
+    # (C3), after the C1 triage establishes a floor; this job only prints.
+    needs: changes
+    if: needs.changes.outputs.sync_claims == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - name: Detector self-tests
+        # Listed by name, so a new test FILE must be added here or it never runs.
+        env:
+          PYTHONPATH: scripts
+        run: uv run pytest scripts/test_sync_claims_claims.py scripts/test_sync_claims_enforcement.py scripts/test_sync_claims_report.py -q
+      - name: Unenforced sync-claim report
+        # Report-only by design: main() returns 0 whatever it finds. The gate
+        # is stage C3, after the C1 triage establishes a floor.
+        env:
+          PYTHONPATH: scripts
+        run: uv run python -m sync_claims.report
 
   ci-required:
     needs:

--- a/docs/superpowers/plans/2026-09-02-sync-claim-detector.md
+++ b/docs/superpowers/plans/2026-09-02-sync-claim-detector.md
@@ -37,7 +37,7 @@
 - Consumes: nothing.
 - Produces:
   - `@dataclass(frozen=True) class Claim` with fields `module: str`, `symbol: str`, `kind: str` (`"module"` or `"symbol"`), `keyword: str`, `window: str`, `target: str | None`, `lineno: int`
-  - `def claims(root: Path) -> list[Claim]` — every claim under `root`, targets resolved where possible
+  - `def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]` — every claim under `root`, targets resolved against `symbols` (defaulting to `declared_symbols(root)`)
   - `def declared_symbols(root: Path) -> set[str]` — every function/class name declared under `root`
   - `CLAIM_PATTERN: re.Pattern` and `WINDOW = 200`
 
@@ -88,6 +88,7 @@ from sync_claims.claims import Claim, claims, declared_symbols
 
 REPO = Path(__file__).resolve().parent.parent
 FIXTURE = REPO / "scripts" / "fixtures" / "incident_6c89042c7"
+GOLDENMATCH = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
 
 
 def test_the_incident_claim_is_extracted_with_its_target():
@@ -96,8 +97,24 @@ def test_the_incident_claim_is_extracted_with_its_target():
     `_run_pipeline`'s docstring says "mirrors run_dedupe but returns
     EngineResult". The target is a BARE identifier -- no backticks, no call
     suffix -- which is exactly what an earlier target rule could not see.
+
+    Targets resolve against the REAL package, not the fixture: `run_dedupe`
+    lives in `core/pipeline.py`, not in `tui/engine.py`, so resolving against
+    the fixture alone returns None and this test could never pass. That is
+    what the `symbols` keyword is for.
     """
-    found = [c for c in claims(FIXTURE) if c.symbol == "_run_pipeline"]
+    package_symbols = declared_symbols(GOLDENMATCH)
+    assert "run_dedupe" in package_symbols, (
+        "run_dedupe is no longer declared in goldenmatch -- the fixture's claim "
+        "names a symbol that has been renamed or removed, so this test's premise "
+        "is gone. Fix the premise, do not weaken the assertion."
+    )
+
+    found = [
+        c
+        for c in claims(FIXTURE, symbols=package_symbols)
+        if c.symbol == "_run_pipeline"
+    ]
 
     assert len(found) == 1, f"expected one claim on _run_pipeline, got {found}"
     claim = found[0]
@@ -422,7 +439,7 @@ Three test files against one source file. The third is the trap that decides the
 `scripts/fixtures/sync_enforcement/src/lane.py`:
 
 ```python
-"""Synthetic fixture: three claims with three enforcement states."""
+"""Synthetic fixture: four claims -- enforced, unenforced, prose-only, unresolvable."""
 
 
 def fast_lane():
@@ -442,7 +459,17 @@ def orphan_lane():
 def prose_lane():
     """Mirrors slow_lane; a test mentions both only in prose."""
     return 1
+
+
+def stray_lane():
+    """Mirrors the legacy pipeline that no longer exists here."""
+    return 1
 ```
+
+`stray_lane`'s claim names nothing declared in the fixture, so its target
+resolves to `None`. It exists so the unresolvable-claim bucket has a member to
+assert on — without it those assertions iterate an empty list and pass while
+checking nothing.
 
 `scripts/fixtures/sync_enforcement/tests/test_enforced.py`:
 
@@ -535,10 +562,17 @@ def test_the_enforced_claim_is_not_reported():
 
 def test_a_claim_with_no_target_is_never_reported_unenforced():
     """An unresolvable claim has nothing to be enforced against. Reporting it
-    as unenforced would inflate the finding count with claims nobody can act
-    on."""
+    as unenforced would inflate the finding count with claims nobody can act on.
+
+    `stray_lane` exists in the fixture to give this something to assert on. An
+    earlier draft filtered for `target is None` against a fixture that had no
+    such claim, so it iterated an empty list and passed while checking nothing.
+    """
     unresolved = [c for c in _claims() if c.target is None]
-    assert all(c not in unenforced(_claims(), []) for c in unresolved)
+    assert {c.symbol for c in unresolved} == {"stray_lane"}, (
+        "the fixture must contain an unresolvable claim or this test is vacuous"
+    )
+    assert unenforced(unresolved, []) == []
 
 
 def test_executable_references_covers_all_three_node_kinds():
@@ -549,10 +583,11 @@ def test_executable_references_covers_all_three_node_kinds():
     assert {"fast_lane", "slow_lane"} <= names
 
 
-def test_an_empty_tests_directory_reports_everything_unenforced(tmp_path):
-    """Distinguish 'nothing enforced' from 'nothing scanned'. If the tests
-    root is wrong, every claim looks unenforced -- the report must be able to
-    say so rather than present it as a finding."""
+def test_an_empty_tests_directory_yields_no_reference_sets(tmp_path):
+    """An empty list is how 'nothing was scanned' reaches the report.
+
+    Distinguishing that from 'nothing is enforced' is the report's job
+    (test_sync_claims_report.py); this pins the signal it keys on."""
     assert test_reference_sets(tmp_path) == []
 ```
 
@@ -733,6 +768,7 @@ def test_inventory_buckets_the_fixture():
     inv = inventory(FIXTURE / "src", FIXTURE / "tests")
     assert {c["symbol"] for c in inv["unenforced"]} == {"orphan_lane", "prose_lane"}
     assert {c["symbol"] for c in inv["unverified"]} == {"fast_lane"}
+    assert {c["symbol"] for c in inv["unresolvable"]} == {"stray_lane"}
 
 
 def test_claim_count_and_finding_count_are_separate():
@@ -748,7 +784,6 @@ def test_claim_count_and_finding_count_are_separate():
 def test_the_report_names_the_matched_window(capsys):
     """A wrong target resolution must be visible, not silent. The first-match
     rule can pick the wrong symbol when a claim mentions several."""
-    inventory(FIXTURE / "src", FIXTURE / "tests")
     rc = main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
     out = capsys.readouterr().out
     assert rc == 0
@@ -1005,7 +1040,17 @@ sync_claims:
   - '.github/workflows/ci.yml'
 ```
 
-- [ ] **Step 2: Add the job**
+- [ ] **Step 2: Wire the filter into the `changes` job's outputs**
+
+**Without this the job never runs.** `ci.yml`'s `changes` job declares one explicit output line per filter (see its `outputs:` block). A filter that has no line produces an empty output, `needs.changes.outputs.sync_claims` is falsy, and the `if:` gate below is never true — the job is skipped on every run and the lane reports green having measured nothing. PR #2839 shipped exactly this, with two jobs silently skipped.
+
+Add to the `changes` job's `outputs:` block, alongside `scripts_lint` and `docs_regen`:
+
+```yaml
+      sync_claims: ${{ steps.filter.outputs.sync_claims }}
+```
+
+- [ ] **Step 3: Add the job**
 
 In `.github/workflows/ci.yml`, after the `shared_decisions` job:
 
@@ -1032,13 +1077,13 @@ In `.github/workflows/ci.yml`, after the `shared_decisions` job:
         run: uv run python -m sync_claims.report
 ```
 
-- [ ] **Step 3: Do NOT add an entry to `check_filter_coverage.py`'s `REQUIRED` map**
+- [ ] **Step 4: Do NOT add an entry to `check_filter_coverage.py`'s `REQUIRED` map**
 
 Called out because it is the tempting move and it is wrong. That map's own comment reads: *"Each entry is a real regression or a real near-miss, not a hypothetical."* A `sync_claims` entry today would be a hypothetical, and adding one dilutes a curated list whose value is that every line records something that actually happened.
 
 The generic `check_job_filter_coverage` in the same file already checks every job in `ci.yml` against the filter gating it, with no curation needed. That is what covers this job. If it reports a NEW gap for `sync_claims`, the filter is wrong — widen the filter; never add the job to `KNOWN_JOB_FILTER_GAPS`.
 
-- [ ] **Step 4: Run the gates**
+- [ ] **Step 5: Run the gates**
 
 ```bash
 python scripts/check_filter_coverage.py
@@ -1047,12 +1092,40 @@ PYTHONPATH=scripts python -m pytest scripts/test_workflow_yaml.py -q
 
 Expected: `CI filter coverage OK (...)`, `CI job-vs-filter coverage OK (...)`, and the workflow-yaml tests passing. If the job-vs-filter gate reports a NEW gap, the filter is wrong — fix the filter, do not add the job to the known-gaps list.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Prove the job is not skipped**
+
+A filter gate that is wired wrong fails silently, so assert the wiring rather than trusting it. `scripts/test_workflow_yaml.py` already parses `ci.yml`; add:
+
+```python
+def test_sync_claims_job_is_reachable():
+    """A job whose gating output is never emitted is skipped on every run.
+
+    The `changes` job needs an explicit `outputs:` line per filter. Without it
+    `needs.changes.outputs.sync_claims` is empty, the `if:` is false, and the
+    lane reports green having measured nothing -- PR #2839's defect.
+    """
+    spec = _load_ci()  # existing helper in this file
+    outputs = spec["jobs"]["changes"]["outputs"]
+    assert "sync_claims" in outputs, (
+        "the changes job emits no sync_claims output, so the job can never run"
+    )
+    assert "sync_claims" in spec["jobs"]["sync_claims"]["if"]
+```
+
+Run: `PYTHONPATH=scripts python -m pytest scripts/test_workflow_yaml.py -q`
+Expected: all pass, including the new test. If `_load_ci` is named differently in that file, use whatever helper the existing tests use — do not add a second YAML loader.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add .github/filters.yml .github/workflows/ci.yml
+git add .github/filters.yml .github/workflows/ci.yml scripts/test_workflow_yaml.py
 git commit -F - <<'EOF'
 ci: report-only sync-claim job on its own filter
+
+The changes job emits an explicit sync_claims output. Without that line the
+gating expression is empty, the if: is false, and the job is skipped on
+every run while the lane reports green -- PR #2839's defect. A workflow
+test asserts the output exists.
 
 The filter watches the goldenmatch package and its tests, not just the
 detector: a claim is added by editing a docstring in the scanned tree, and

--- a/docs/superpowers/plans/2026-09-02-sync-claim-detector.md
+++ b/docs/superpowers/plans/2026-09-02-sync-claim-detector.md
@@ -1,0 +1,1100 @@
+# Unenforced Sync-Claim Detector (Phase C0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the report-only detector that finds docstring claims of the form "X mirrors Y" whose relationship no test enforces, validated against the `6c89042c7` incident from a checked-in fixture.
+
+**Architecture:** Three small AST modules under `scripts/sync_claims/`, mirroring the proven `scripts/shared_decisions/` layout from phase B. `claims.py` extracts claims from docstrings and resolves their targets against the package's symbol table. `enforcement.py` collects the executable references in each test file and reports which claims no single test file references both halves of. `report.py` prints the three buckets and the counts. Nothing gates in this stage.
+
+**Tech Stack:** Python 3.12, stdlib `ast` and `re` only. pytest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md`
+
+## Global Constraints
+
+- **Scope is `packages/python/goldenmatch/goldenmatch`**, tests at `packages/python/goldenmatch/tests`. No other package.
+- **Read every source file with `encoding="utf-8-sig"`.** Two goldenmatch modules carry a UTF-8 BOM (`core/autoconfig_planner.py`, `core/execution_plan.py`); reading them as plain utf-8 silently drops them from the scan. This cost phase B two modules before it was caught.
+- **Enforcement counts EXECUTABLE references only** — `ast.Name.id`, `ast.Attribute.attr`, `ast.alias` (using `asname or name`, last dotted segment). Never raw text. At `6c89042c7^` a test names both halves of the incident inside a docstring; counting text classifies the incident as enforced and the phase misses the bug it exists to catch.
+- **The signal is sound as a negative and only suggestive as a positive.** The finding is the unenforced set. Claims with a co-reference are labelled `UNVERIFIED`, never `enforced` and never `safe`.
+- **Module-level claims are extracted and reported in their own bucket, never triaged.** A module has no single symbol a test can reference.
+- **The report prints claim count and finding count separately**, so a drop in total claims cannot masquerade as progress.
+- **The report prints the matched claim window** for each finding, so a wrong target resolution is visible rather than silent.
+- **Every test is sabotage-verified**, and each sabotage must assert it actually applied before the test result is read. A sabotage that does not apply is not a sabotage — phase B's ratchet check planted a change at a site the scan never saw and read the resulting green as proof the gate worked.
+- **No Claude attribution in any commit message, ever.** No `Co-Authored-By`, no `Claude-Session`, no footer.
+- Report-only. No CI gate, no allowlist, no ratchet — those are stages C3.
+
+---
+
+### Task 1: Claim extraction and target resolution
+
+**Files:**
+- Create: `scripts/sync_claims/__init__.py` (empty)
+- Create: `scripts/sync_claims/claims.py`
+- Create: `scripts/fixtures/incident_6c89042c7/engine_at_6c89042c7.py`
+- Test: `scripts/test_sync_claims_claims.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `@dataclass(frozen=True) class Claim` with fields `module: str`, `symbol: str`, `kind: str` (`"module"` or `"symbol"`), `keyword: str`, `window: str`, `target: str | None`, `lineno: int`
+  - `def claims(root: Path) -> list[Claim]` — every claim under `root`, targets resolved where possible
+  - `def declared_symbols(root: Path) -> set[str]` — every function/class name declared under `root`
+  - `CLAIM_PATTERN: re.Pattern` and `WINDOW = 200`
+
+- [ ] **Step 1: Create the incident fixture, verbatim**
+
+The detector must find the motivating incident without git history staying reachable, so the pre-fix file is checked in. Run from the repo root:
+
+```bash
+mkdir -p scripts/fixtures/incident_6c89042c7
+git show "6c89042c7^:packages/python/goldenmatch/goldenmatch/tui/engine.py" \
+  > scripts/fixtures/incident_6c89042c7/engine_at_6c89042c7.py
+```
+
+Verify it is 530 lines and parses standalone (it is never imported, only parsed):
+
+```bash
+wc -l scripts/fixtures/incident_6c89042c7/engine_at_6c89042c7.py
+python -c "import ast,pathlib; ast.parse(pathlib.Path('scripts/fixtures/incident_6c89042c7/engine_at_6c89042c7.py').read_text(encoding='utf-8-sig')); print('parses')"
+```
+
+Expected: `530` and `parses`.
+
+Add a `README.md` beside it:
+
+```markdown
+# Fixture: `tui/engine.py` at `6c89042c7^`
+
+Verbatim copy of the file immediately BEFORE `6c89042c7` ("delete
+MatchEngine's copy of the pipeline"). `_run_pipeline`'s docstring reads
+"Core pipeline logic - mirrors run_dedupe but returns EngineResult", and
+nothing enforced that: 2 tests referenced `_run_pipeline`, 10 referenced
+`run_dedupe`, 0 referenced both.
+
+Checked in so the detector can be validated without git history staying
+reachable. Parsed by AST only, never imported. Do not edit.
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+"""Tests for sync-claim extraction and target resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sync_claims.claims import Claim, claims, declared_symbols
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "incident_6c89042c7"
+
+
+def test_the_incident_claim_is_extracted_with_its_target():
+    """The motivating example, from a checked-in fixture, not git history.
+
+    `_run_pipeline`'s docstring says "mirrors run_dedupe but returns
+    EngineResult". The target is a BARE identifier -- no backticks, no call
+    suffix -- which is exactly what an earlier target rule could not see.
+    """
+    found = [c for c in claims(FIXTURE) if c.symbol == "_run_pipeline"]
+
+    assert len(found) == 1, f"expected one claim on _run_pipeline, got {found}"
+    claim = found[0]
+    assert claim.keyword.lower() == "mirrors"
+    assert claim.target == "run_dedupe", (
+        f"target did not resolve to run_dedupe: {claim.target!r}. The claim "
+        f"names it as a bare word, so resolution -- not punctuation -- has to "
+        f"be the filter."
+    )
+    assert claim.kind == "symbol"
+    assert "run_dedupe" in claim.window
+
+
+def test_declared_symbols_finds_functions_and_classes():
+    symbols = declared_symbols(FIXTURE)
+    assert "_run_pipeline" in symbols
+    assert "MatchEngine" in symbols
+
+
+def test_a_docstring_with_no_claim_yields_nothing(tmp_path):
+    (tmp_path / "m.py").write_text(
+        '''
+def plain():
+    """Does a thing. Returns a value."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    assert claims(tmp_path) == []
+
+
+def test_an_unresolvable_claim_is_kept_with_target_none(tmp_path):
+    """A claim naming nothing real is still a claim -- it is reported in its
+    own bucket, not dropped. Dropping it would hide that someone wrote a
+    synchronisation promise nobody can check."""
+    (tmp_path / "m.py").write_text(
+        '''
+def widget():
+    """Mirrors the legacy behaviour of the old system."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = claims(tmp_path)
+    assert len(found) == 1
+    assert found[0].target is None
+    assert found[0].keyword.lower() == "mirrors"
+
+
+def test_a_claim_never_resolves_to_its_own_claimant(tmp_path):
+    """`def build(): "mirrors build"` is a self-reference, not a relationship."""
+    (tmp_path / "m.py").write_text(
+        '''
+def build():
+    """Mirrors build exactly."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    assert claims(tmp_path)[0].target is None
+
+
+def test_module_level_claims_are_kept_and_marked(tmp_path):
+    """Module claims are reported but never triaged -- a module has no single
+    symbol a test can reference. Marking the kind is what lets the report
+    separate them."""
+    (tmp_path / "m.py").write_text(
+        '''
+"""This module mirrors helper."""
+
+
+def helper():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = claims(tmp_path)
+    assert [c.kind for c in found] == ["module"]
+    assert found[0].symbol == "<module>"
+    assert found[0].target == "helper"
+
+
+def test_a_bom_prefixed_file_is_not_skipped(tmp_path):
+    """Two goldenmatch modules carry a UTF-8 BOM. Reading as plain utf-8
+    raises on the first line and the file vanishes from the scan -- phase B
+    lost two modules to exactly this before it was caught."""
+    (tmp_path / "bom.py").write_bytes(
+        b"\xef\xbb\xbf" + b'def a():\n    """Mirrors b."""\n\n\ndef b():\n    pass\n'
+    )
+    assert [c.target for c in claims(tmp_path)] == ["b"]
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd /d/show_case/gm-rel3161
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_claims.py -q
+```
+
+Expected: collection error, `ModuleNotFoundError: No module named 'sync_claims'`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `scripts/sync_claims/__init__.py` empty, then `scripts/sync_claims/claims.py`:
+
+```python
+"""Docstring claims that one piece of code must stay in step with another.
+
+The codebase says where its traps are. 319 docstrings in goldenmatch assert a
+synchronisation relationship -- "mirrors", "byte-identical to", "must match",
+"keep in sync with" -- and nothing checks any of them. `MatchEngine._run_pipeline`
+said "mirrors run_dedupe", stopped mirroring it, and shipped an ImportError on a
+default install (6c89042c7).
+
+TARGET RESOLUTION IS THE FILTER, deliberately. An earlier rule accepted a target
+only in backticks or with a call suffix, and could not extract this phase's own
+motivating example -- the incident names `run_dedupe` as a bare word. So any word
+in the window after the claim keyword counts if it names a declared symbol, first
+match wins. The cost is that a claim mentioning several symbols can resolve to the
+wrong one; `Claim.window` carries the matched text so triage can see what it keyed
+on.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Phrases that assert a relationship to another symbol. Kept narrow on purpose:
+# every entry states that two things must AGREE, not merely that they are
+# related. "see also" and "used by" are not claims.
+CLAIM_PATTERN = re.compile(
+    r"\b(mirror(s|ed|ing)?|keep (in|them) sync|in sync with|stay(s)? in sync|"
+    r"parallel (to|of)|same (rule|logic|order|shape|contract) as|must match|"
+    r"byte-identical to|identical to|counterpart|duplicat(e|ed|es) of|"
+    r"copy of|port of)\b",
+    re.IGNORECASE,
+)
+
+# How much text after the keyword can name the target. 200 characters is about
+# two sentences -- long enough for "mirrors run_dedupe but returns EngineResult",
+# short enough that an unrelated symbol three paragraphs down is not picked up.
+WINDOW = 200
+
+_WORD = re.compile(r"[A-Za-z_][\w.]*")
+
+
+@dataclass(frozen=True)
+class Claim:
+    """One docstring assertion that this code must stay in step with `target`."""
+
+    module: str
+    symbol: str
+    kind: str  # "module" or "symbol"
+    keyword: str
+    window: str
+    target: str | None
+    lineno: int
+
+
+def _parse(path: Path) -> ast.Module | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+    except SyntaxError:
+        return None
+
+
+def declared_symbols(root: Path) -> set[str]:
+    """Every function and class name declared under `root`."""
+    out: set[str] = set()
+    for path in sorted(root.rglob("*.py")):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                out.add(node.name)
+    return out
+
+
+def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
+    """Every synchronisation claim under `root`, with targets resolved.
+
+    `symbols` defaults to `declared_symbols(root)`. Pass it explicitly when the
+    claims live in a fixture but must resolve against the real package.
+    """
+    known = declared_symbols(root) if symbols is None else symbols
+    out: list[Claim] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                continue
+            doc = ast.get_docstring(node)
+            if not doc:
+                continue
+            match = CLAIM_PATTERN.search(doc)
+            if match is None:
+                continue
+            is_module = isinstance(node, ast.Module)
+            name = "<module>" if is_module else node.name
+            window = doc[match.end() : match.end() + WINDOW]
+            target = next(
+                (
+                    word.split(".")[-1]
+                    for word in _WORD.findall(window)
+                    if word.split(".")[-1] in known and word.split(".")[-1] != name
+                ),
+                None,
+            )
+            out.append(
+                Claim(
+                    module=rel,
+                    symbol=name,
+                    kind="module" if is_module else "symbol",
+                    keyword=match.group(0),
+                    window=" ".join(window.split()),
+                    target=target,
+                    lineno=0 if is_module else node.lineno,
+                )
+            )
+    return out
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_claims.py -q
+```
+
+Expected: `7 passed`.
+
+- [ ] **Step 6: Sabotage-verify the two load-bearing rules**
+
+Each sabotage must be confirmed to have landed before the result is read. Run both, restoring in between:
+
+```bash
+cp scripts/sync_claims/claims.py /tmp/claims.bak && test -s /tmp/claims.bak && echo "backup ok"
+
+# (a) Narrow the target rule back to backticks-or-call-suffix.
+python - <<'EOF'
+import pathlib
+p = pathlib.Path("scripts/sync_claims/claims.py"); s = p.read_text(encoding="utf-8")
+old = '_WORD = re.compile(r"[A-Za-z_][\\w.]*")'
+new = '_WORD = re.compile(r"`([A-Za-z_][\\w.]*)`")'
+assert s.count(old) == 1, "sabotage did not apply"
+p.write_text(s.replace(old, new), encoding="utf-8")
+print("sabotage (a) applied")
+EOF
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_claims.py -q
+# Expected: test_the_incident_claim_is_extracted_with_its_target FAILS
+cp /tmp/claims.bak scripts/sync_claims/claims.py
+
+# (b) Read as plain utf-8 so a BOM file is skipped.
+python - <<'EOF'
+import pathlib
+p = pathlib.Path("scripts/sync_claims/claims.py"); s = p.read_text(encoding="utf-8")
+old = 'encoding="utf-8-sig"'
+new = 'encoding="utf-8"'
+assert s.count(old) == 1, "sabotage did not apply"
+p.write_text(s.replace(old, new), encoding="utf-8")
+print("sabotage (b) applied")
+EOF
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_claims.py -q
+# Expected: test_a_bom_prefixed_file_is_not_skipped FAILS
+cp /tmp/claims.bak scripts/sync_claims/claims.py
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_claims.py -q
+# Expected: 7 passed
+```
+
+Both sabotages must print "sabotage applied" AND produce the named failure. If a sabotage prints nothing or the tests stay green, the sabotage did not land and has measured nothing.
+
+- [ ] **Step 7: Run ruff and commit**
+
+```bash
+python -m ruff check scripts/sync_claims/ scripts/test_sync_claims_claims.py
+git add scripts/sync_claims/ scripts/test_sync_claims_claims.py scripts/fixtures/incident_6c89042c7/
+git commit -F - <<'EOF'
+feat(sync-claims): extract docstring sync claims and resolve their targets
+
+319 docstrings in goldenmatch assert that one piece of code must stay in
+step with another -- "mirrors", "byte-identical to", "must match" -- and
+nothing checks any of them. MatchEngine._run_pipeline said "mirrors
+run_dedupe", stopped, and shipped an ImportError on a default install.
+
+Target resolution is the filter rather than punctuation. A rule accepting
+only backticked or called names could not extract this phase's own
+motivating example: the incident names run_dedupe as a bare word.
+
+Proven against a checked-in copy of tui/engine.py at 6c89042c7^, so the
+detector does not depend on git history staying reachable.
+EOF
+```
+
+---
+
+### Task 2: Enforcement check
+
+**Files:**
+- Create: `scripts/sync_claims/enforcement.py`
+- Create: `scripts/fixtures/sync_enforcement/src/lane.py`
+- Create: `scripts/fixtures/sync_enforcement/tests/test_enforced.py`
+- Create: `scripts/fixtures/sync_enforcement/tests/test_unenforced.py`
+- Create: `scripts/fixtures/sync_enforcement/tests/test_docstring_only.py`
+- Test: `scripts/test_sync_claims_enforcement.py`
+
+**Interfaces:**
+- Consumes: `Claim` and `claims(root, *, symbols=None)` from `sync_claims.claims`.
+- Produces:
+  - `def executable_references(path: Path) -> set[str]` — the `Name`/`Attribute`/`alias` names in one file
+  - `def test_reference_sets(tests_root: Path) -> list[set[str]]`
+  - `def unenforced(claim_list: list[Claim], reference_sets: list[set[str]]) -> list[Claim]`
+
+- [ ] **Step 1: Create the synthetic enforcement fixture**
+
+Three test files against one source file. The third is the trap that decides the phase.
+
+`scripts/fixtures/sync_enforcement/src/lane.py`:
+
+```python
+"""Synthetic fixture: three claims with three enforcement states."""
+
+
+def fast_lane():
+    """Mirrors slow_lane but skips validation."""
+    return 1
+
+
+def slow_lane():
+    return 1
+
+
+def orphan_lane():
+    """Mirrors slow_lane and nothing tests them together."""
+    return 1
+
+
+def prose_lane():
+    """Mirrors slow_lane; a test mentions both only in prose."""
+    return 1
+```
+
+`scripts/fixtures/sync_enforcement/tests/test_enforced.py`:
+
+```python
+from lane import fast_lane, slow_lane
+
+
+def test_the_lanes_agree():
+    assert fast_lane() == slow_lane()
+```
+
+`scripts/fixtures/sync_enforcement/tests/test_unenforced.py`:
+
+```python
+from lane import orphan_lane
+
+
+def test_orphan_runs():
+    assert orphan_lane() == 1
+```
+
+`scripts/fixtures/sync_enforcement/tests/test_docstring_only.py`:
+
+```python
+from lane import prose_lane
+
+
+def test_prose_runs():
+    """`prose_lane` must behave the same way `slow_lane` does.
+
+    This docstring names both symbols. Nothing in the CODE references
+    slow_lane, so nothing compares them -- which is exactly the shape that
+    made tests/test_engine.py look like it enforced the 6c89042c7 incident.
+    """
+    assert prose_lane() == 1
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+"""Tests for the executable-reference enforcement check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sync_claims.claims import claims, declared_symbols
+from sync_claims.enforcement import (
+    executable_references,
+    test_reference_sets,
+    unenforced,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "sync_enforcement"
+SRC = FIXTURE / "src"
+TESTS = FIXTURE / "tests"
+
+
+def _claims():
+    return claims(SRC, symbols=declared_symbols(SRC))
+
+
+def test_a_docstring_only_co_mention_is_not_enforcement():
+    """THE TRAP THIS PHASE TURNS ON.
+
+    At 6c89042c7^, tests/test_engine.py named both `_run_pipeline` and
+    `run_dedupe` -- inside a docstring. A text scan calls that enforced, and
+    the phase misses the bug that motivates it.
+    """
+    names = executable_references(TESTS / "test_docstring_only.py")
+    assert "prose_lane" in names
+    assert "slow_lane" not in names, (
+        "slow_lane appears only in a docstring; counting it means counting "
+        "prose as enforcement"
+    )
+
+
+def test_the_unenforced_claims_are_reported():
+    found = {c.symbol for c in unenforced(_claims(), test_reference_sets(TESTS))}
+    assert found == {"orphan_lane", "prose_lane"}, found
+
+
+def test_the_enforced_claim_is_not_reported():
+    found = {c.symbol for c in unenforced(_claims(), test_reference_sets(TESTS))}
+    assert "fast_lane" not in found, (
+        "test_enforced.py references both fast_lane and slow_lane in code"
+    )
+
+
+def test_a_claim_with_no_target_is_never_reported_unenforced():
+    """An unresolvable claim has nothing to be enforced against. Reporting it
+    as unenforced would inflate the finding count with claims nobody can act
+    on."""
+    unresolved = [c for c in _claims() if c.target is None]
+    assert all(c not in unenforced(_claims(), []) for c in unresolved)
+
+
+def test_executable_references_covers_all_three_node_kinds():
+    """Name, Attribute and alias. Missing `alias` loses every symbol a test
+    only imports, which is most of them."""
+    path = TESTS / "test_enforced.py"
+    names = executable_references(path)
+    assert {"fast_lane", "slow_lane"} <= names
+
+
+def test_an_empty_tests_directory_reports_everything_unenforced(tmp_path):
+    """Distinguish 'nothing enforced' from 'nothing scanned'. If the tests
+    root is wrong, every claim looks unenforced -- the report must be able to
+    say so rather than present it as a finding."""
+    assert test_reference_sets(tmp_path) == []
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_enforcement.py -q
+```
+
+Expected: `ModuleNotFoundError: No module named 'sync_claims.enforcement'`.
+
+- [ ] **Step 4: Write the implementation**
+
+`scripts/sync_claims/enforcement.py`:
+
+```python
+"""Does any test exercise a claimant alongside what it claims to mirror?
+
+A claim is UNENFORCED when no single test file references both the claimant
+and its target in EXECUTABLE code. That definition is load-bearing in both
+directions:
+
+  * EXECUTABLE, not textual. At 6c89042c7^ `tests/test_engine.py` named both
+    `_run_pipeline` and `run_dedupe` -- in a docstring. Counting text marks
+    the motivating incident enforced and the whole phase misses it. Counting
+    Name/Attribute/alias nodes: 2 tests referenced the claimant, 10 the
+    target, 0 both.
+
+  * SOUND AS A NEGATIVE, SUGGESTIVE AS A POSITIVE. No co-reference genuinely
+    proves nothing compares them. Co-reference proves only that one file
+    mentions both -- never that it compares them. So the finding is the
+    unenforced set, and a co-referenced claim is UNVERIFIED, never "safe".
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from sync_claims.claims import Claim
+
+
+def executable_references(path: Path) -> set[str]:
+    """Names this file references in code. Docstrings and comments are not code."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+    except SyntaxError:
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            out.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            out.add(node.attr)
+        elif isinstance(node, ast.alias):
+            out.add((node.asname or node.name).split(".")[-1])
+    return out
+
+
+def test_reference_sets(tests_root: Path) -> list[set[str]]:
+    """One reference set per test file. Empty list means nothing was scanned."""
+    return [executable_references(p) for p in sorted(tests_root.rglob("*.py"))]
+
+
+def unenforced(
+    claim_list: list[Claim], reference_sets: list[set[str]]
+) -> list[Claim]:
+    """Claims no single test file references both halves of.
+
+    Claims with no resolved target are excluded: there is nothing for a test to
+    enforce them against, and counting them would inflate the finding list with
+    items nobody can act on. They are reported in their own bucket instead.
+    """
+    out: list[Claim] = []
+    for claim in claim_list:
+        if claim.target is None:
+            continue
+        if not any(
+            claim.symbol in names and claim.target in names
+            for names in reference_sets
+        ):
+            out.append(claim)
+    return out
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_enforcement.py -q
+```
+
+Expected: `6 passed`.
+
+- [ ] **Step 6: Sabotage-verify the docstring trap**
+
+```bash
+cp scripts/sync_claims/enforcement.py /tmp/enf.bak && test -s /tmp/enf.bak && echo "backup ok"
+python - <<'EOF'
+import pathlib
+p = pathlib.Path("scripts/sync_claims/enforcement.py"); s = p.read_text(encoding="utf-8")
+old = """    try:
+        tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+    except SyntaxError:
+        return set()"""
+new = """    import re
+    return set(re.findall(r"[A-Za-z_]\\w*", path.read_text(encoding="utf-8-sig", errors="ignore")))
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+    except SyntaxError:
+        return set()"""
+assert s.count(old) == 1, "sabotage did not apply"
+p.write_text(s.replace(old, new), encoding="utf-8")
+print("sabotage applied: executable_references now counts raw text")
+EOF
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_enforcement.py -q
+# Expected: test_a_docstring_only_co_mention_is_not_enforcement FAILS,
+#           and test_the_unenforced_claims_are_reported FAILS (prose_lane vanishes)
+cp /tmp/enf.bak scripts/sync_claims/enforcement.py
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_enforcement.py -q
+# Expected: 6 passed
+```
+
+- [ ] **Step 7: Run ruff and commit**
+
+```bash
+python -m ruff check scripts/sync_claims/ scripts/test_sync_claims_enforcement.py
+git add scripts/sync_claims/enforcement.py scripts/test_sync_claims_enforcement.py scripts/fixtures/sync_enforcement/
+git commit -F - <<'EOF'
+feat(sync-claims): report claims no test enforces
+
+A claim is unenforced when no single test file references both the
+claimant and its target in EXECUTABLE code.
+
+Executable, not textual, and the distinction decides the phase. At
+6c89042c7^ tests/test_engine.py named both halves of the incident -- in a
+docstring. A text scan marks the motivating bug enforced and the detector
+misses it. The fixture pins that case: test_docstring_only.py mentions
+both symbols in prose and must still come out unenforced.
+
+The signal is sound as a negative and only suggestive as a positive. No
+co-reference proves nothing compares them; co-reference proves only that
+one file mentions both. Claims with no resolved target are excluded --
+there is nothing to enforce them against.
+EOF
+```
+
+---
+
+### Task 3: Report
+
+**Files:**
+- Create: `scripts/sync_claims/report.py`
+- Test: `scripts/test_sync_claims_report.py`
+
+**Interfaces:**
+- Consumes: `claims`, `declared_symbols` from `sync_claims.claims`; `test_reference_sets`, `unenforced` from `sync_claims.enforcement`.
+- Produces:
+  - `DEFAULT_ROOT: Path`, `DEFAULT_TESTS: Path`
+  - `def inventory(root: Path, tests_root: Path) -> dict` with keys `counts`, `unenforced`, `unverified`, `unresolvable`, `module_level`
+  - `def main(argv: list[str]) -> int` — always returns 0 in C0 (report-only)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for the sync-claim report."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sync_claims.report import DEFAULT_ROOT, DEFAULT_TESTS, inventory, main
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "sync_enforcement"
+
+
+def test_inventory_buckets_the_fixture():
+    inv = inventory(FIXTURE / "src", FIXTURE / "tests")
+    assert {c["symbol"] for c in inv["unenforced"]} == {"orphan_lane", "prose_lane"}
+    assert {c["symbol"] for c in inv["unverified"]} == {"fast_lane"}
+
+
+def test_claim_count_and_finding_count_are_separate():
+    """Deleting a claim must not read as progress. Reporting only a finding
+    count lets six words removed from a docstring look like a fix."""
+    inv = inventory(FIXTURE / "src", FIXTURE / "tests")
+    counts = inv["counts"]
+    assert counts["claims"] >= counts["unenforced"]
+    assert {"claims", "resolvable", "unenforced", "unverified",
+            "unresolvable", "module_level"} <= set(counts)
+
+
+def test_the_report_names_the_matched_window(capsys):
+    """A wrong target resolution must be visible, not silent. The first-match
+    rule can pick the wrong symbol when a claim mentions several."""
+    inventory(FIXTURE / "src", FIXTURE / "tests")
+    rc = main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "slow_lane" in out
+    assert "orphan_lane" in out
+
+
+def test_the_report_states_its_scope(capsys):
+    """Silence outside the scanned tree is not a clean bill, and the header
+    has to say so -- module-level claims are reported but never triaged."""
+    main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    out = capsys.readouterr().out.lower()
+    assert "scope" in out
+    assert "module-level" in out
+
+
+def test_an_empty_tests_root_is_reported_not_presented_as_findings(capsys, tmp_path):
+    """If the tests root is wrong every claim looks unenforced. That is a
+    broken run, not 100% findings, and the report must say which."""
+    rc = main(["--root", str(FIXTURE / "src"), "--tests", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "NO TEST FILES SCANNED" in out
+
+
+def test_main_exits_zero_on_findings():
+    """C0 is report-only. A finding is not a failure -- the gate is C3."""
+    assert main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")]) == 0
+
+
+def test_the_default_roots_exist():
+    """A default path that does not exist makes every CI run vacuously clean."""
+    assert DEFAULT_ROOT.is_dir(), DEFAULT_ROOT
+    assert DEFAULT_TESTS.is_dir(), DEFAULT_TESTS
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_report.py -q
+```
+
+Expected: `ModuleNotFoundError: No module named 'sync_claims.report'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`scripts/sync_claims/report.py`:
+
+```python
+"""Report docstring sync claims that no test enforces. C0 is report-only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sync_claims.claims import Claim, claims, declared_symbols
+from sync_claims.enforcement import test_reference_sets, unenforced
+
+REPO = Path(__file__).resolve().parent.parent.parent
+DEFAULT_ROOT = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+DEFAULT_TESTS = REPO / "packages" / "python" / "goldenmatch" / "tests"
+
+SCOPE_NOTE = (
+    "scope: claims are read from docstrings under {root} and enforcement from "
+    "{tests} only -- other packages, the TypeScript port and _archive are out "
+    "of reach by construction, and their silence here is not a clean bill. "
+    "Module-level claims are reported but NOT triaged: a module has no single "
+    "symbol a test can reference. A claim listed as UNVERIFIED is not safe -- "
+    "some test references both names, which does not mean it compares them."
+)
+
+
+def _as_dict(claim: Claim) -> dict:
+    return {
+        "module": claim.module,
+        "symbol": claim.symbol,
+        "lineno": claim.lineno,
+        "keyword": claim.keyword,
+        "target": claim.target,
+        "window": claim.window,
+    }
+
+
+def inventory(root: Path, tests_root: Path) -> dict:
+    """Bucket every claim under `root` by enforcement state."""
+    all_claims = claims(root, symbols=declared_symbols(root))
+    symbol_claims = [c for c in all_claims if c.kind == "symbol"]
+    module_claims = [c for c in all_claims if c.kind == "module"]
+    resolvable = [c for c in symbol_claims if c.target is not None]
+    unresolvable = [c for c in symbol_claims if c.target is None]
+
+    reference_sets = test_reference_sets(tests_root)
+    findings = unenforced(resolvable, reference_sets)
+    finding_ids = {(c.module, c.symbol, c.lineno) for c in findings}
+    unverified = [
+        c for c in resolvable if (c.module, c.symbol, c.lineno) not in finding_ids
+    ]
+
+    return {
+        "counts": {
+            "claims": len(all_claims),
+            "resolvable": len(resolvable),
+            "unenforced": len(findings),
+            "unverified": len(unverified),
+            "unresolvable": len(unresolvable),
+            "module_level": len(module_claims),
+            "test_files_scanned": len(reference_sets),
+        },
+        "unenforced": [_as_dict(c) for c in findings],
+        "unverified": [_as_dict(c) for c in unverified],
+        "unresolvable": [_as_dict(c) for c in unresolvable],
+        "module_level": [_as_dict(c) for c in module_claims],
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--tests", type=Path, default=DEFAULT_TESTS)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    inv = inventory(args.root, args.tests)
+    if args.json:
+        print(json.dumps(inv, indent=2))
+        return 0
+
+    counts = inv["counts"]
+    print(SCOPE_NOTE.format(root=args.root, tests=args.tests))
+    print()
+    if counts["test_files_scanned"] == 0:
+        # Every claim looks unenforced when nothing was scanned. That is a
+        # broken run, not a perfect score, and it must not read as findings.
+        print(
+            f"NO TEST FILES SCANNED under {args.tests} -- every claim below "
+            f"would be reported unenforced for that reason alone. Fix --tests "
+            f"before reading this as a result."
+        )
+        print()
+
+    print(
+        f"{counts['claims']} claim(s); {counts['resolvable']} resolvable and "
+        f"symbol-level; {counts['unenforced']} UNENFORCED, "
+        f"{counts['unverified']} unverified"
+    )
+    print(
+        f"  reported but not triaged: {counts['unresolvable']} unresolvable, "
+        f"{counts['module_level']} module-level"
+    )
+    print(f"  test files scanned: {counts['test_files_scanned']}")
+    print()
+
+    for entry in sorted(
+        inv["unenforced"], key=lambda e: (e["module"], e["lineno"])
+    ):
+        print(f"  {entry['module']}:{entry['lineno']}  {entry['symbol']}")
+        print(f"      --{entry['keyword']}--> {entry['target']}")
+        print(f"      claim: {entry['window'][:100]}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_report.py -q
+```
+
+Expected: `7 passed`.
+
+- [ ] **Step 5: Run the report against the real package**
+
+```bash
+cd scripts && PYTHONPATH=. python -m sync_claims.report | head -30
+```
+
+Expected: roughly `319 claim(s); 212 resolvable and symbol-level; 168 UNENFORCED, 44 unverified`. These counts drift as docstrings change — they are NOT asserted in any test. Record the actual numbers in the commit message.
+
+- [ ] **Step 6: Sabotage-verify the empty-tests guard**
+
+```bash
+cp scripts/sync_claims/report.py /tmp/rep.bak && test -s /tmp/rep.bak && echo "backup ok"
+python - <<'EOF'
+import pathlib
+p = pathlib.Path("scripts/sync_claims/report.py"); s = p.read_text(encoding="utf-8")
+old = 'if counts["test_files_scanned"] == 0:'
+new = 'if False:'
+assert s.count(old) == 1, "sabotage did not apply"
+p.write_text(s.replace(old, new), encoding="utf-8")
+print("sabotage applied: empty-tests guard disabled")
+EOF
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_report.py -q
+# Expected: test_an_empty_tests_root_is_reported_not_presented_as_findings FAILS
+cp /tmp/rep.bak scripts/sync_claims/report.py
+PYTHONPATH=scripts python -m pytest scripts/test_sync_claims_report.py -q
+# Expected: 7 passed
+```
+
+- [ ] **Step 7: Run ruff and commit**
+
+```bash
+python -m ruff check scripts/sync_claims/ scripts/test_sync_claims_report.py
+git add scripts/sync_claims/report.py scripts/test_sync_claims_report.py
+git commit -F - <<'EOF'
+feat(sync-claims): report the four buckets with separate counts
+
+Unenforced findings, unverified co-references, unresolvable claims and
+module-level claims, each in its own bucket.
+
+Claim count and finding count print separately, so deleting six words from
+a docstring cannot read as progress. Each finding prints the matched claim
+window, so a wrong first-match target resolution is visible to triage
+rather than silent.
+
+An empty tests root prints NO TEST FILES SCANNED before the findings.
+Without that, pointing --tests at the wrong directory reports every claim
+as unenforced and looks like a result rather than a broken run.
+
+Exits 0 on findings. C0 is report-only; the gate is C3.
+EOF
+```
+
+---
+
+### Task 4: CI job and path filter
+
+**Files:**
+- Modify: `.github/filters.yml`
+- Modify: `.github/workflows/ci.yml`
+- Test: `scripts/test_workflow_yaml.py` (existing; the filter-coverage gate reads it)
+
+**Interfaces:**
+- Consumes: `scripts/sync_claims/report.py` as `python -m sync_claims.report`.
+- Produces: a `sync_claims` job, report-only.
+
+- [ ] **Step 1: Add the path filter**
+
+In `.github/filters.yml`, add a `sync_claims` entry. It must watch the code the audit reads, not just the audit itself — a filter that does not cover the scanned tree means the job never re-runs when a claim is added:
+
+```yaml
+sync_claims:
+  - 'scripts/sync_claims/**'
+  - 'scripts/test_sync_claims_*.py'
+  - 'scripts/fixtures/incident_6c89042c7/**'
+  - 'scripts/fixtures/sync_enforcement/**'
+  - 'packages/python/goldenmatch/goldenmatch/**'
+  - 'packages/python/goldenmatch/tests/**'
+  - '.github/workflows/ci.yml'
+```
+
+- [ ] **Step 2: Add the job**
+
+In `.github/workflows/ci.yml`, after the `shared_decisions` job:
+
+```yaml
+  sync_claims:
+    needs: changes
+    if: needs.changes.outputs.sync_claims == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - name: Detector self-tests
+        # Listed by name, so a new test FILE must be added here or it never runs.
+        env:
+          PYTHONPATH: scripts
+        run: uv run pytest scripts/test_sync_claims_claims.py scripts/test_sync_claims_enforcement.py scripts/test_sync_claims_report.py -q
+      - name: Unenforced sync-claim report
+        # Report-only by design: main() returns 0 whatever it finds. The gate
+        # is stage C3, after the C1 triage establishes a floor.
+        env:
+          PYTHONPATH: scripts
+        run: uv run python -m sync_claims.report
+```
+
+- [ ] **Step 3: Do NOT add an entry to `check_filter_coverage.py`'s `REQUIRED` map**
+
+Called out because it is the tempting move and it is wrong. That map's own comment reads: *"Each entry is a real regression or a real near-miss, not a hypothetical."* A `sync_claims` entry today would be a hypothetical, and adding one dilutes a curated list whose value is that every line records something that actually happened.
+
+The generic `check_job_filter_coverage` in the same file already checks every job in `ci.yml` against the filter gating it, with no curation needed. That is what covers this job. If it reports a NEW gap for `sync_claims`, the filter is wrong — widen the filter; never add the job to `KNOWN_JOB_FILTER_GAPS`.
+
+- [ ] **Step 4: Run the gates**
+
+```bash
+python scripts/check_filter_coverage.py
+PYTHONPATH=scripts python -m pytest scripts/test_workflow_yaml.py -q
+```
+
+Expected: `CI filter coverage OK (...)`, `CI job-vs-filter coverage OK (...)`, and the workflow-yaml tests passing. If the job-vs-filter gate reports a NEW gap, the filter is wrong — fix the filter, do not add the job to the known-gaps list.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/filters.yml .github/workflows/ci.yml
+git commit -F - <<'EOF'
+ci: report-only sync-claim job on its own filter
+
+The filter watches the goldenmatch package and its tests, not just the
+detector: a claim is added by editing a docstring in the scanned tree, and
+a filter covering only scripts/ would never re-run the audit when that
+happens. Phase A shipped a dead-code job whose filter had exactly that
+hole, and it passed green with the job skipped.
+
+Report-only. The report exits 0 whatever it finds; the gate is C3, after
+C1 establishes a triaged floor.
+EOF
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every requirement maps to a task:
+
+| spec requirement | task |
+| --- | --- |
+| claim extraction from docstrings | 1 |
+| target resolution, bare identifiers, first match | 1 |
+| incident fixture at `6c89042c7^`, claim extracted | 1 |
+| module-level claims extracted and marked | 1 |
+| executable references only | 2 |
+| docstring-only co-mention is not enforcement | 2 |
+| synthetic enforcement fixture, three states | 2 |
+| unresolvable claims in their own bucket | 2, 3 |
+| UNVERIFIED never presented as safe | 3 (SCOPE_NOTE) |
+| claim count and finding count separate | 3 |
+| report prints the matched window | 3 |
+| "no findings" vs "detector did not run" | 3 (empty-tests guard) |
+| every test sabotage-verified, sabotage asserted to apply | 1, 2, 3 |
+| report-only, no gate | 3, 4 |
+
+Not in this plan, by design: C1 triage, C2 remediation, C3 ratchet.
+
+**Placeholder scan.** No TBD/TODO; every code step carries the code.
+
+**Type consistency.** `Claim` is defined in Task 1 and used unchanged in Tasks 2 and 3. `claims(root, *, symbols=None)` keeps its keyword-only `symbols` argument across Tasks 2 and 3. `unenforced(claim_list, reference_sets)` and `test_reference_sets(tests_root)` match their Task-2 definitions where Task 3 calls them. `inventory(root, tests_root)` and `main(argv)` match their Task-3 test.
+
+**Two defects found and fixed during this self-review**, both in Task 4:
+
+1. `check_filter_coverage.py`'s `REQUIRED` map takes `(path, reason)` tuples, not bare strings — the draft would not have parsed.
+2. More importantly, that file states its own contract: *"Each entry is a real regression or a real near-miss, not a hypothetical."* Adding speculative `sync_claims` entries would violate it. The generic `check_job_filter_coverage` added in phase A already checks every job against its filter automatically, so Task 4 relies on that and touches no curated list.

--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -243,10 +243,14 @@ and a reason. **Start with the 50 "byte-identical to" / "identical to" claims** 
 "mirrors", that phrasing states a property that can actually be checked, so
 triaging one either produces an enforcing test or discovers a drifted pair.
 Budget for the first-match heuristic's measured cost while triaging the rest:
-13 of the 172 findings (7.5%) resolve to a generic word -- `min`, `row`,
-`key`, `max`, `run` and the like -- picked up because it happens to also be
-the first declared symbol name in the 200-character window, not because the
-claim is actually about it. Those are false positives by construction, not
+13 of the 172 findings (7.6%) resolve to a generic word, picked up because it
+happens to also be the first declared symbol name in the 200-character window,
+rather than because the claim is about it. **The rule that produces 13**, so a
+reader can reproduce the figure rather than take it on trust: a target of three
+characters or fewer, OR one drawn from a fixed common-word set (`min`, `max`,
+`row`, `key`, `run`, `sum`, `len`, `get`, `set`, `add`, `map`, `all`, `any`,
+`col`, `val`, `obj`, `idx`). Both halves independently select the same 13, of
+which `row` accounts for 6 and `key` for 3. Those are false positives by construction, not
 edge cases; expect roughly one in thirteen findings to be one.
 
 **C2 — remediation, one per PR.** Enforcing tests where the property holds;

--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -1,0 +1,262 @@
+# Codebase Audit Programme — Phase C: Unenforced Synchronisation Claims
+
+**Status:** design approved, not yet planned
+**Date:** 2026-09-02
+**Phase:** C of a three-phase programme (A → B → C)
+**Predecessors:**
+`docs/superpowers/specs/2026-09-01-dead-code-audit-design.md` (A, complete)
+`docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md` (B)
+`docs/superpowers/specs/2026-09-02-shared-decision-triage.md` (B1 triage)
+
+## Why
+
+The codebase tells you where its traps are. 319 docstrings in `goldenmatch`
+assert that a piece of code must stay in step with another piece of code —
+*mirrors*, *byte-identical to*, *must match*, *keep in sync with*, *copy of*,
+*counterpart*. Nothing checks any of them.
+
+That is the shape of the incident this phase was originally scoped around.
+`MatchEngine._run_pipeline`'s own docstring read:
+
+> Core pipeline logic — mirrors run_dedupe but returns EngineResult.
+
+It stopped mirroring `run_dedupe`. The shipped pipeline moved to an eager arrow
+path while the copy kept driving the polars LazyFrame API, and `demo` and
+`lineage` raised `ImportError` on a default install. Deleted in `6c89042c7`;
+203 lines became 54.
+
+Measured 2026-09-02 on `goldenmatch`, and these are the numbers the rest of
+this document uses:
+
+| | claims | resolvable target |
+| --- | ---: | ---: |
+| on a function or class | 270 | 119 |
+| on a module | 49 | 21 |
+| **total** | **319** | **140** |
+
+**87 of the 119 symbol-level resolvable claims (73%) are unenforced.** 18 of
+the 87 say "byte-identical to".
+
+## What this phase was going to be, and why it is not
+
+Phase C was scoped as **module cohesion and splitting**, with B0b — structural
+clone detection — folded in. Both halves were refuted by measurement before
+design began. Recording that here, with the numbers, because a future phase
+will otherwise propose them again.
+
+### Module splitting has no mechanical basis
+
+`goldenmatch` is 493 modules and 168,347 lines, median module 189 lines; 428 of
+493 are under 500 lines. The distribution is healthy and the large modules do
+not decompose. Partitioning each module's top-level definitions into connected
+components by intra-module reference:
+
+| module | top-level defs | components | largest |
+| --- | ---: | ---: | ---: |
+| `core/autoconfig.py` | 127 | 5 | 123 |
+| `core/probabilistic.py` | 119 | 8 | 111 |
+| `core/pipeline.py` | 69 | 3 | 66 |
+| `core/scorer.py` | 80 | 7 | 73 |
+
+Every large module is one connected component plus a handful of isolated
+helpers. There are no natural split lines; splitting would cut through the call
+graph rather than along it, which is a design project, not an audit finding.
+
+*Bound on this measurement:* it counts top-level name references, so a module
+can be one component and still lack cohesion. What it rules out is a cheap
+mechanical split, not the existence of a cohesion problem.
+
+### B0b's premise was wrong
+
+The phase-B spec states that incident 1 is "detectable by structural clone
+detection". It is not. That sentence was written from the commit message's
+phrasing — "a ~200-line reimplementation whose own docstring said 'mirrors
+run_dedupe'" — rather than from the diff.
+
+Structural similarity, measured as `difflib` ratio over normalised AST
+node-type sequences (identifiers and literals erased):
+
+| pair | similarity |
+| --- | ---: |
+| a function vs itself, every identifier renamed | 1.000 |
+| a function vs itself with 20% of statements deleted | 0.562 |
+| **`_run_pipeline` vs `run_dedupe` (the incident)** | **0.033** |
+| median of 400 random large-function pairs | 0.036 |
+
+The incident scores **below** the median random pair, and 56% of random pairs
+score at or above it. The two positive controls establish that the measure
+detects both identifier-renamed clones and genuinely drifted copies, so the
+negative is about the incident, not the instrument. `_run_pipeline` and
+`run_dedupe` shared a purpose, not a structure.
+
+A clone detector tuned to find the incident would flag more than half of all
+large-function pairs. B0b is dropped.
+
+### What survived
+
+The incident had a different detectable property: **it said what it was doing.**
+That generalises to a population of 319 claims -- 119 of them both
+symbol-level and resolvable, which is what this phase triages -- and unlike
+clone detection it finds the motivating incident by construction rather than
+by threshold.
+
+## Architecture
+
+### Evidence model — invert, as A and B did
+
+A **claim** is a docstring on a module, class or function asserting a
+relationship to another symbol. A **resolvable claim** names a symbol that
+exists in the package. A claim is **unenforced** when no single test file
+references both the claimant and its target in *executable* code.
+
+**The enforcement check needs a claimant SYMBOL, so it applies to the 119
+symbol-level resolvable claims only.** A module-level claim has no single name
+a test can reference — "this module MIRRORS the datafusion backend" is a claim
+about a file, and the check would have to guess which of its symbols carries
+it. The 49 module-level claims are extracted and reported in their own bucket,
+and C1 does not triage them. That is a real gap, stated rather than hidden: it
+is 15% of the claim population, and a later pass can address it with a
+per-module rule once the symbol-level pass has shown what a good rule looks
+like.
+
+Two properties of that definition carry the phase:
+
+**Executable references only.** At `6c89042c7^`, `tests/test_engine.py` names
+both `_run_pipeline` and `run_dedupe` — inside a docstring. A text scan
+classifies the incident as enforced and this phase misses the bug that
+motivates it. Counting only `Name`, `Attribute` and `alias` nodes: 2 tests
+reference `_run_pipeline`, 10 reference `run_dedupe`, **0 reference both**.
+
+**Sound as a negative, suggestive as a positive.** No co-reference genuinely
+proves that nothing compares the two. Co-reference proves only that one file
+mentions both, never that it compares them. So the finding is the unenforced
+set; the 32 possibly-enforced claims are reported as UNVERIFIED and never as
+safe.
+
+This is A and B's inversion. A resolved declared liveness (registries) and
+flagged the unexplained. B resolved declared parity and flagged undeclared
+shared decisions. C resolves declared synchronisation and flags the unenforced
+— with the difference that the codebase has already written the declarations
+down.
+
+### Rejected alternatives
+
+| option | why not |
+| --- | --- |
+| Coverage co-execution (per-test contexts; enforced if one test executes lines in both) | Measures execution rather than mention, and reuses A/B's coverage machinery — but co-execution still does not prove comparison. It buys precision in the POSITIVE direction, which carries no finding; the negative direction is already sound. Not worth the per-test-context cost. |
+| Inventory only, no enforcement signal | Yields no automatic finding and nothing to ratchet. Would be the first phase here with no gate, and A's durable value came from the gate, not the report. |
+| Structural clone detection | Refuted above. |
+
+## Being wrong
+
+**Phase C's dangerous failure is making a finding disappear without removing the
+trap.** It is quieter than A's (deleting live code) or B's (a bad merge), and
+more likely than either.
+
+**1. Deleting the claim.** The cheapest way to clear a finding is to delete six
+words from a docstring. That leaves the coupling as dangerous as it was and
+destroys the only record that it exists — strictly worse than the status quo,
+because the next person no longer gets the warning. **Deleting a claim is never
+a remediation.** A claim goes only when the coupling itself is gone, which means
+the code changed, not the prose.
+
+**2. Writing a test that pins drift as correct.** `resolve_fs_block_source`
+claims to be "byte-identical to `score_buckets`". If those have already drifted,
+an enforcing test fails, and the tempting repairs are to weaken the assertion
+until it passes or to align one side by picking whichever is convenient. That is
+finding F10 again: when two copies disagree, deciding which is canonical is a
+judgement, and getting it wrong ships a bug under a green test. **Verify the
+claimed property holds today BEFORE writing anything to enforce it. If it does
+not hold, that is a defect finding, not a test-writing task.**
+
+**3. The ratchet teaching people not to write claims.** If unenforced claims are
+gated, the way never to trip the gate is to stop writing "mirrors X" in
+docstrings — suppressing the declarations this phase depends on while the
+reported number improves. This is the failure most likely to happen by accident.
+
+The defence against all three: **the ratchet floor is a set of
+`(claimant, target)` pairs, not a count**, matching `KNOWN_DEAD`. Removing a
+pair means deleting a named line from a checked-in file, with a reason, in a
+reviewable diff. A count can be improved by deletion silently; a named set
+cannot. The report also prints claim-count and finding-count separately, so a
+drop in total claims cannot masquerade as progress.
+
+Carried from B: **no automated remediation** — C proposes, a person disposes —
+and **one remediation per PR**, so a wrong one reverts cleanly.
+
+## Delivery stages
+
+**C0 — detector, report-only.** Claim extraction, target resolution,
+enforcement check, report. Exit criterion: it extracts
+`_run_pipeline --mirrors--> run_dedupe` from a checked-in fixture and classifies
+it unenforced.
+
+**C1 — triage all 87 symbol-level findings.** Every finding classified as: enforceable and should be /
+claim is stale because the coupling is gone / already drifted, therefore a
+defect / false positive. Exit criterion: every finding carries a classification
+and a reason. **Start with the 18 "byte-identical to" claims** — unlike
+"mirrors", that phrasing states a property that can actually be checked, so
+triaging one either produces an enforcing test or discovers a drifted pair.
+
+**C2 — remediation, one per PR.** Enforcing tests where the property holds;
+defect fixes where it does not; claim removal only where the coupling is gone.
+
+**C3 — ratchet on.** Gate at the triaged floor, matching `KNOWN_DEAD`,
+`KNOWN_ACTIONABLE` and `KNOWN_JOB_FILTER_GAPS`.
+
+## Testing
+
+The detector is tested like a product component, because a detector that
+silently measures nothing is the failure mode this repository keeps hitting.
+Phase A caught five instances; phase B found its own accessor scan reading 23%
+of the config surface, and found that only because a sabotage check was invalid.
+
+**Fixtures split in two**, because the enforcement half cannot check in 972 test
+files:
+
+- *Claim extraction* validates against the real `tui/engine.py` at
+  `6c89042c7^`, checked in as a prefix fixture the way
+  `scripts/fixtures/incident_1c843c8a5/` already is. It must extract the claim
+  and name `run_dedupe` as the target.
+- *Enforcement* validates against a small synthetic tree: one test referencing
+  both symbols in code (enforced), one referencing only the claimant
+  (unenforced), and one whose ONLY co-mention is inside a docstring, which must
+  come out unenforced.
+
+Required tests, each verified by sabotage — breaking the detector and confirming
+the test fails naming the right thing — not by observing a pass:
+
+- the incident fixture is extracted and reported unenforced;
+- a docstring-only co-mention does not count as enforcement;
+- a genuinely co-referenced pair is not reported;
+- an unresolvable claim lands in its own bucket, never as a finding;
+- the report distinguishes "no findings" from "detector did not run";
+- claim-count and finding-count are reported separately.
+
+**A sabotage that does not apply is not a sabotage.** Phase B's ratchet check
+planted a divergent fallback at a site the scan never attributed, and read the
+resulting green as proof the gate worked. Every sabotage in this phase asserts
+that the sabotage actually landed before reading the test result.
+
+## Success criteria
+
+- The detector extracts and reports the motivating incident from a fixture.
+- Every one of the 87 findings carries a classification and a reason.
+- Every claim surviving triage is either enforced or recorded with why it stands.
+- No claim is deleted while its coupling remains.
+- Every "byte-identical to" claim is either enforced by a test or recorded as a
+  defect.
+- The ratchet gates at the triaged floor, as a named set of pairs.
+
+## Out of scope
+
+- Module splitting and cohesion, and structural clone detection — both refuted
+  above.
+- The 179 unresolvable claims (they name nothing that exists): reported in
+  their own bucket, not triaged.
+- The 49 module-level claims: extracted and reported, not triaged — the
+  enforcement check needs a claimant symbol. See the evidence model.
+- Packages other than `goldenmatch`. `goldenflow` carries 37 claims and gets its
+  own pass if this one pays off.
+- Cross-language claims (a Python docstring naming a TypeScript symbol).
+- `_archive/`, retained pre-fold history.

--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -30,12 +30,12 @@ this document uses:
 
 | | claims | resolvable target |
 | --- | ---: | ---: |
-| on a function or class | 270 | 212 |
+| on a function or class | 270 | 216 |
 | on a module | 49 | (not triaged, see below) |
 | **total** | **319** | |
 
-**168 of the 212 symbol-level resolvable claims (79%) are unenforced.** 48 of
-the 168 say "byte-identical to" or "identical to".
+**172 of the 216 symbol-level resolvable claims (80%) are unenforced.** 50 of
+the 172 say "byte-identical to" or "identical to".
 
 ### A correction, made while planning
 
@@ -58,6 +58,29 @@ prose, not in markup.
 The cost is a first-match heuristic that can pick the wrong name when a claim
 mentions several symbols. C1 triage classifies those as false positives, and
 the report prints the matched window so a reader can see what it keyed on.
+
+### A second correction, made while finishing Task 1
+
+Every count in this document was re-measured against what the shipped
+detector reports today, and it does not match what an earlier version of
+this document said, either: 212 resolvable became **216**, 168 unenforced
+became **172**, and the "48 byte-identical / identical claims" line became
+**50**. The cause is a one-line fix to the same rule this correction already
+covers. `_WORD`'s continuation class includes `.`, so a target word
+immediately followed by sentence-ending punctuation (`"...mirrors helper."`)
+matched WITH the trailing period, and `"helper."` was never equal to
+`"helper"` in the known-symbols set — the resolver silently missed it.
+`claims()` now strips that trailing period before comparing, and four more
+targets resolve as a result.
+
+**The "179 unresolvable claims" line under Out of scope, below, was wrong
+under either measurement, not just the current one.** 270 symbol-level claims
+minus 212 (the earlier resolvable count) is 58; minus 216 (the current one)
+is 54. Neither arithmetic produces 179 — it is not a stale snapshot of a real
+intermediate state, it is simply an error, and the fix is to read it off the
+detector rather than to explain it. Every count in this document is now
+generated from a live run of `python -m sync_claims.report`, not typed by
+hand from an intermediate measurement.
 
 ## What this phase was going to be, and why it is not
 
@@ -117,7 +140,7 @@ large-function pairs. B0b is dropped.
 ### What survived
 
 The incident had a different detectable property: **it said what it was doing.**
-That generalises to a population of 319 claims -- 212 of them both
+That generalises to a population of 319 claims -- 216 of them both
 symbol-level and resolvable, which is what this phase triages -- and unlike
 clone detection it finds the motivating incident by construction rather than
 by threshold.
@@ -131,7 +154,7 @@ relationship to another symbol. A **resolvable claim** names a symbol that
 exists in the package. A claim is **unenforced** when no single test file
 references both the claimant and its target in *executable* code.
 
-**The enforcement check needs a claimant SYMBOL, so it applies to the 212
+**The enforcement check needs a claimant SYMBOL, so it applies to the 216
 symbol-level resolvable claims only.** A module-level claim has no single name
 a test can reference — "this module MIRRORS the datafusion backend" is a claim
 about a file, and the check would have to guess which of its symbols carries
@@ -213,12 +236,18 @@ enforcement check, report. Exit criterion: it extracts
 `_run_pipeline --mirrors--> run_dedupe` from a checked-in fixture and classifies
 it unenforced.
 
-**C1 — triage all 168 symbol-level findings.** Every finding classified as: enforceable and should be /
+**C1 — triage all 172 symbol-level findings.** Every finding classified as: enforceable and should be /
 claim is stale because the coupling is gone / already drifted, therefore a
 defect / false positive. Exit criterion: every finding carries a classification
-and a reason. **Start with the 48 "byte-identical to" / "identical to" claims** — unlike
+and a reason. **Start with the 50 "byte-identical to" / "identical to" claims** — unlike
 "mirrors", that phrasing states a property that can actually be checked, so
 triaging one either produces an enforcing test or discovers a drifted pair.
+Budget for the first-match heuristic's measured cost while triaging the rest:
+13 of the 172 findings (7.5%) resolve to a generic word -- `min`, `row`,
+`key`, `max`, `run` and the like -- picked up because it happens to also be
+the first declared symbol name in the 200-character window, not because the
+claim is actually about it. Those are false positives by construction, not
+edge cases; expect roughly one in thirteen findings to be one.
 
 **C2 — remediation, one per PR.** Enforcing tests where the property holds;
 defect fixes where it does not; claim removal only where the coupling is gone.
@@ -263,7 +292,7 @@ that the sabotage actually landed before reading the test result.
 ## Success criteria
 
 - The detector extracts and reports the motivating incident from a fixture.
-- Every one of the 168 findings carries a classification and a reason.
+- Every one of the 172 findings carries a classification and a reason.
 - Every claim surviving triage is either enforced or recorded with why it stands.
 - No claim is deleted while its coupling remains.
 - Every "byte-identical to" claim is either enforced by a test or recorded as a
@@ -276,7 +305,7 @@ that the sabotage actually landed before reading the test result.
 
 - Module splitting and cohesion, and structural clone detection — both refuted
   above.
-- The 179 unresolvable claims (they name nothing that exists): reported in
+- The 54 unresolvable claims (they name nothing that exists): reported in
   their own bucket, not triaged.
 - The 49 module-level claims: extracted and reported, not triaged — the
   enforcement check needs a claimant symbol. See the evidence model.

--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -30,12 +30,34 @@ this document uses:
 
 | | claims | resolvable target |
 | --- | ---: | ---: |
-| on a function or class | 270 | 119 |
-| on a module | 49 | 21 |
-| **total** | **319** | **140** |
+| on a function or class | 270 | 212 |
+| on a module | 49 | (not triaged, see below) |
+| **total** | **319** | |
 
-**87 of the 119 symbol-level resolvable claims (73%) are unenforced.** 18 of
-the 87 say "byte-identical to".
+**168 of the 212 symbol-level resolvable claims (79%) are unenforced.** 48 of
+the 168 say "byte-identical to" or "identical to".
+
+### A correction, made while planning
+
+An earlier draft of this spec reported 119 resolvable and 87 unenforced. Those
+came from a target-extraction rule that only accepted a name in backticks
+(`` `run_dedupe` ``) or with a call suffix (`run_dedupe()`).
+
+**That rule could not extract this phase's own motivating example.**
+`_run_pipeline`'s docstring says "mirrors run_dedupe but returns EngineResult"
+-- a BARE identifier. The rule found nothing, the incident was not in the
+resolvable set, and C0's exit criterion as originally written was
+unsatisfiable.
+
+The rule is now: any word in the 200-character window after the claim keyword
+that names a symbol declared in the package, taking the first match.
+**Resolution is the filter**, so no punctuation convention is required. That is
+also why the population nearly doubled: most claims name their target in
+prose, not in markup.
+
+The cost is a first-match heuristic that can pick the wrong name when a claim
+mentions several symbols. C1 triage classifies those as false positives, and
+the report prints the matched window so a reader can see what it keyed on.
 
 ## What this phase was going to be, and why it is not
 
@@ -95,7 +117,7 @@ large-function pairs. B0b is dropped.
 ### What survived
 
 The incident had a different detectable property: **it said what it was doing.**
-That generalises to a population of 319 claims -- 119 of them both
+That generalises to a population of 319 claims -- 212 of them both
 symbol-level and resolvable, which is what this phase triages -- and unlike
 clone detection it finds the motivating incident by construction rather than
 by threshold.
@@ -109,7 +131,7 @@ relationship to another symbol. A **resolvable claim** names a symbol that
 exists in the package. A claim is **unenforced** when no single test file
 references both the claimant and its target in *executable* code.
 
-**The enforcement check needs a claimant SYMBOL, so it applies to the 119
+**The enforcement check needs a claimant SYMBOL, so it applies to the 212
 symbol-level resolvable claims only.** A module-level claim has no single name
 a test can reference — "this module MIRRORS the datafusion backend" is a claim
 about a file, and the check would have to guess which of its symbols carries
@@ -130,7 +152,7 @@ reference `_run_pipeline`, 10 reference `run_dedupe`, **0 reference both**.
 **Sound as a negative, suggestive as a positive.** No co-reference genuinely
 proves that nothing compares the two. Co-reference proves only that one file
 mentions both, never that it compares them. So the finding is the unenforced
-set; the 32 possibly-enforced claims are reported as UNVERIFIED and never as
+set; the 44 possibly-enforced claims are reported as UNVERIFIED and never as
 safe.
 
 This is A and B's inversion. A resolved declared liveness (registries) and
@@ -191,10 +213,10 @@ enforcement check, report. Exit criterion: it extracts
 `_run_pipeline --mirrors--> run_dedupe` from a checked-in fixture and classifies
 it unenforced.
 
-**C1 — triage all 87 symbol-level findings.** Every finding classified as: enforceable and should be /
+**C1 — triage all 168 symbol-level findings.** Every finding classified as: enforceable and should be /
 claim is stale because the coupling is gone / already drifted, therefore a
 defect / false positive. Exit criterion: every finding carries a classification
-and a reason. **Start with the 18 "byte-identical to" claims** — unlike
+and a reason. **Start with the 48 "byte-identical to" / "identical to" claims** — unlike
 "mirrors", that phrasing states a property that can actually be checked, so
 triaging one either produces an enforcing test or discovers a drifted pair.
 
@@ -241,11 +263,13 @@ that the sabotage actually landed before reading the test result.
 ## Success criteria
 
 - The detector extracts and reports the motivating incident from a fixture.
-- Every one of the 87 findings carries a classification and a reason.
+- Every one of the 168 findings carries a classification and a reason.
 - Every claim surviving triage is either enforced or recorded with why it stands.
 - No claim is deleted while its coupling remains.
 - Every "byte-identical to" claim is either enforced by a test or recorded as a
   defect.
+- C0's report names the matched claim window, so a wrong target resolution is
+  visible to triage rather than silent.
 - The ratchet gates at the triaged floor, as a named set of pairs.
 
 ## Out of scope

--- a/scripts/fixtures/incident_6c89042c7/README.md
+++ b/scripts/fixtures/incident_6c89042c7/README.md
@@ -1,0 +1,10 @@
+# Fixture: `tui/engine.py` at `6c89042c7^`
+
+Verbatim copy of the file immediately BEFORE `6c89042c7` ("delete
+MatchEngine's copy of the pipeline"). `_run_pipeline`'s docstring reads
+"Core pipeline logic - mirrors run_dedupe but returns EngineResult", and
+nothing enforced that: 2 tests referenced `_run_pipeline`, 10 referenced
+`run_dedupe`, 0 referenced both.
+
+Checked in so the detector can be validated without git history staying
+reachable. Parsed by AST only, never imported. Do not edit.

--- a/scripts/fixtures/incident_6c89042c7/README.md
+++ b/scripts/fixtures/incident_6c89042c7/README.md
@@ -4,7 +4,12 @@ Verbatim copy of the file immediately BEFORE `6c89042c7` ("delete
 MatchEngine's copy of the pipeline"). `_run_pipeline`'s docstring reads
 "Core pipeline logic - mirrors run_dedupe but returns EngineResult", and
 nothing enforced that: 2 tests referenced `_run_pipeline`, 10 referenced
-`run_dedupe`, 0 referenced both.
+`run_dedupe`, 0 referenced both -- counted by the detector's EXECUTABLE-reference
+rule (`Name`/`Attribute`/`alias` AST nodes only, docstrings and comments excluded;
+see `scripts/sync_claims/enforcement.py`). A plain text grep over the same file at
+that revision gives 7, 14 and 0 respectively -- higher on both sides because it
+also matches the docstring mention this fixture exists to NOT count as
+enforcement.
 
 Checked in so the detector can be validated without git history staying
 reachable. Parsed by AST only, never imported. Do not edit.

--- a/scripts/fixtures/incident_6c89042c7/engine_at_6c89042c7.py
+++ b/scripts/fixtures/incident_6c89042c7/engine_at_6c89042c7.py
@@ -1,0 +1,530 @@
+"""MatchEngine — shared foundation for TUI and preview mode.
+
+Wraps the existing pipeline modules into a clean API with sample
+extraction, scored-pairs caching, and threshold re-clustering.
+No Textual dependency — pure Python + Polars.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from goldenmatch._polars_lazy import pl
+from goldenmatch.core.frame import frame_from_records as _frame_from_records
+from goldenmatch.core.frame import to_frame as _to_frame
+
+
+@dataclass
+class EngineStats:
+    total_records: int
+    total_clusters: int
+    singleton_count: int
+    match_rate: float
+    cluster_sizes: list[int]
+    avg_cluster_size: float
+    max_cluster_size: int
+    oversized_count: int
+    hit_rate: float | None = None
+    avg_score: float | None = None
+    llm_cost: dict | None = None
+
+
+@dataclass
+class EngineResult:
+    clusters: dict[int, dict]
+    golden: pl.DataFrame | None
+    unique: pl.DataFrame | None
+    dupes: pl.DataFrame | None
+    quarantine: pl.DataFrame | None
+    matched: pl.DataFrame | None
+    unmatched: pl.DataFrame | None
+    scored_pairs: list[tuple[int, int, float]]
+    stats: EngineStats
+    # Trained Fellegi-Sunter models keyed by probabilistic matchkey name, for
+    # FS-native explainability (match-weight waterfall). None when no
+    # probabilistic matchkey ran.
+    em_results: dict[str, Any] | None = None
+
+
+@dataclass
+class ControllerTelemetry:
+    """v1.7-v1.12 AutoConfigController output, captured by ``auto_configure``.
+
+    Loosely typed (Any) to dodge import cycles — the consumer
+    (``tabs/controller_tab.py``) uses ``getattr`` on the inner sub-profiles.
+    Populated only when the user actually triggered auto-config from the TUI;
+    None on every cold start and after manual ConfigTab edits.
+    """
+    profile: Any = None          # ComplexityProfile
+    history: Any = None          # RunHistory
+    committed_config: Any = None # GoldenMatchConfig the controller committed
+    source: str = "auto_configure"
+    recorded_at: str | None = None
+    column_priors: dict[str, Any] = field(default_factory=dict)
+
+
+class MatchEngine:
+    """Wraps the pipeline into a clean API for the TUI and preview mode."""
+
+    def __init__(self, files: list[Path | str]):
+        self._files = [Path(f) for f in files]
+        self._data: pl.DataFrame | None = None
+        self._profile: dict | None = None
+        self._last_result: EngineResult | None = None
+        self._last_telemetry: ControllerTelemetry | None = None
+        self._load()
+
+    def _load(self) -> None:
+        from goldenmatch.core.ingest import load_file
+        from goldenmatch.core.profiler import profile_dataframe
+
+        frames = []
+        for f in self._files:
+            lf = load_file(f)
+            lf = lf.with_columns(pl.lit(f.stem).alias("__source__"))
+            frames.append(lf.collect())
+        combined = pl.concat(frames)
+        # Add row IDs
+        combined = combined.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+        self._data = combined
+        # Profile without internal columns
+        profile_cols = [c for c in combined.columns if not c.startswith("__")]
+        self._profile = profile_dataframe(combined.select(profile_cols))
+
+    @classmethod
+    def from_dataframe(cls, df: pl.DataFrame) -> MatchEngine:
+        """Build an engine over an in-memory frame (no file loading).
+
+        For callers like config-suggestion review (``core/suggest``) that
+        already hold the data and only need ``_run_pipeline``/``run_full``.
+        Mirrors every instance field ``__init__`` assigns so it can't break
+        silently if ``__init__`` evolves -- ``_data`` is the passed frame,
+        the rest take ``__init__``'s post-load defaults.
+        Note: ``profile`` is None until a file-constructor run populates it;
+        callers that need it should use the file constructor instead.
+        """
+        engine = object.__new__(cls)
+        engine._files = []
+        engine._data = df
+        engine._profile = None  # not populated by from_dataframe
+        engine._last_result = None
+        engine._last_telemetry = None
+        return engine
+
+    @property
+    def data(self) -> pl.DataFrame:
+        return self._data
+
+    @property
+    def profile(self) -> dict | None:
+        return self._profile
+
+    @property
+    def columns(self) -> list[str]:
+        return [c for c in self._data.columns if not c.startswith("__")]
+
+    @property
+    def row_count(self) -> int:
+        return self._data.height
+
+    def get_sample(self, n: int) -> pl.DataFrame:
+        if n >= self._data.height:
+            return self._data
+        return self._data.head(n)
+
+    def _compute_stats(self, clusters: dict[int, dict], total_records: int) -> EngineStats:
+        """Compute statistics from cluster results."""
+        multi = [cid for cid, c in clusters.items() if c["size"] > 1]
+        singletons = len(clusters) - len(multi)
+        cluster_sizes = [clusters[cid]["size"] for cid in multi]
+        oversized_count = sum(1 for cid in multi if clusters[cid]["oversized"])
+        avg_size = sum(cluster_sizes) / len(cluster_sizes) if cluster_sizes else 0.0
+        max_size = max(cluster_sizes) if cluster_sizes else 0
+        matched_records = sum(cluster_sizes)
+        match_rate = matched_records / total_records if total_records > 0 else 0.0
+
+        return EngineStats(
+            total_records=total_records,
+            total_clusters=len(multi),
+            singleton_count=singletons,
+            match_rate=match_rate,
+            cluster_sizes=cluster_sizes,
+            avg_cluster_size=avg_size,
+            max_cluster_size=max_size,
+            oversized_count=oversized_count,
+        )
+
+    def _run_pipeline(self, df: pl.DataFrame, config) -> EngineResult:
+        """Core pipeline logic — mirrors run_dedupe but returns EngineResult."""
+        from goldenmatch.config.schemas import GoldenRulesConfig
+        from goldenmatch.core.autofix import auto_fix_dataframe
+        from goldenmatch.core.blocker import build_blocks
+        from goldenmatch.core.cluster import build_clusters
+        from goldenmatch.core.golden import build_golden_record
+        from goldenmatch.core.matchkey import compute_matchkeys
+        from goldenmatch.core.scorer import (
+            find_exact_matches,
+            rerank_top_pairs,
+            score_blocks_parallel,
+        )
+        from goldenmatch.core.standardize import apply_standardization
+        from goldenmatch.core.validate import ValidationRule, validate_dataframe
+
+        combined_lf = df.lazy()
+        quarantine_df = None
+
+        # ── Auto-fix ──
+        if config.validation and config.validation.auto_fix:
+            combined_df_tmp = combined_lf.collect()
+            combined_df_tmp, _fix_log = auto_fix_dataframe(combined_df_tmp)
+            combined_lf = combined_df_tmp.lazy()
+
+        # ── Validation ──
+        if config.validation and config.validation.rules:
+            rules = [
+                ValidationRule(
+                    column=rc.column,
+                    rule_type=rc.rule_type,
+                    params=rc.params,
+                    action=rc.action,
+                )
+                for rc in config.validation.rules
+            ]
+            combined_df_tmp = combined_lf.collect()
+            valid_df, quarantine_df, _val_report = validate_dataframe(combined_df_tmp, rules)
+            combined_lf = valid_df.lazy()
+
+        # ── Standardization ──
+        if config.standardization and config.standardization.rules:
+            # W5: LazyFrame expression engines; rewire with the core pipeline flip.
+            combined_lf = apply_standardization(combined_lf, config.standardization.rules)
+
+        # ── Domain feature extraction ──
+        # Materializes derived columns (e.g. ``__title_key__``) that auto-config
+        # may reference from matchkeys / blocking keys. Must run BEFORE
+        # compute_matchkeys, mirroring ``_run_dedupe_pipeline`` -- without it this
+        # path crashes with ColumnNotFoundError whenever auto-config detects a
+        # domain (bibliographic / product shapes, e.g. DBLP-ACM). See issue #1300.
+        from goldenmatch.core.pipeline import _apply_domain_extraction
+        combined_lf = _apply_domain_extraction(combined_lf, config)
+
+        # ── Compute matchkeys ──
+        matchkeys = config.get_matchkeys()
+        combined_lf = compute_matchkeys(combined_lf, matchkeys)
+
+        # ── Auto-suggest blocking keys ──
+        collected_df = combined_lf.collect()
+        if config.blocking and config.blocking.auto_suggest:
+            from goldenmatch.core.pipeline import _run_auto_suggest
+            _run_auto_suggest(collected_df, config)
+
+        # ── Score all pairs (cascading: exact first, then fuzzy) ──
+        all_pairs: list[tuple[int, int, float]] = []
+        matched_pairs: set[tuple[int, int]] = set()
+        em_results: dict[str, Any] = {}  # FS models by matchkey name (waterfall)
+
+        # Phase 1: Exact matchkeys (fast)
+        for mk in matchkeys:
+            if mk.type == "exact":
+                pairs = find_exact_matches(combined_lf, mk)
+                all_pairs.extend(pairs)
+                for a, b, s in pairs:
+                    matched_pairs.add((min(a, b), max(a, b)))
+
+        # Phase 2: Fuzzy matchkeys (parallel block scoring)
+        for mk in matchkeys:
+            if mk.type == "weighted":
+                if config.blocking is None:
+                    continue
+                blocks = build_blocks(combined_lf, config.blocking)
+                pairs = score_blocks_parallel(blocks, mk, matched_pairs)
+                all_pairs.extend(pairs)
+
+        # Phase 2b: Probabilistic matchkeys (Fellegi-Sunter with EM)
+        for mk in matchkeys:
+            if mk.type == "probabilistic":
+                if config.blocking is None:
+                    continue
+                from goldenmatch.core.pipeline import (
+                    _score_probabilistic_matchkey,
+                )
+                # Route through the ONE shared FS scorer the dedupe / match
+                # pipelines use (#1804 item 3): memory-bounded bucket routing,
+                # multi_pass-correct blocking-field collection, and the #1798
+                # build_blocks skip -- replacing the TUI's stale per-block loop
+                # (eager build_blocks + the `block.df` accessor + a keys-only
+                # blocking_fields that missed multi_pass `.passes`). The trained
+                # model is stored in `em_results` for the waterfall; review-band
+                # pairs are discarded (the TUI shows the >= link cut, unchanged).
+                _score_probabilistic_matchkey(
+                    mk, config,
+                    block_frame=combined_lf,
+                    score_frame=collected_df,
+                    matched_pairs=matched_pairs,
+                    all_pairs=all_pairs,
+                    review_pairs=[],
+                    em_results=em_results,
+                )
+
+        # ── Rerank (optional) ──
+        for mk in matchkeys:
+            if mk.type == "weighted" and mk.rerank:
+                all_pairs = rerank_top_pairs(all_pairs, collected_df, mk)
+                break
+
+        # ── LLM scorer (optional) ──
+        llm_budget_summary = None
+        if config.llm_scorer and config.llm_scorer.enabled and all_pairs:
+            has_budget = config.llm_scorer.budget is not None
+            if config.llm_scorer.mode == "cluster":
+                from goldenmatch.core.llm_cluster import llm_cluster_pairs
+                result = llm_cluster_pairs(
+                    all_pairs, collected_df,
+                    config=config.llm_scorer,
+                    return_budget=has_budget,
+                )
+            else:
+                from goldenmatch.core.llm_scorer import llm_score_pairs
+                result = llm_score_pairs(
+                    all_pairs, collected_df,
+                    config=config.llm_scorer,
+                    return_budget=has_budget,
+                )
+            if has_budget:
+                all_pairs, llm_budget_summary = result
+            else:
+                all_pairs = result
+            all_pairs = [(a, b, s) for a, b, s in all_pairs if s > 0.5]
+
+        # ── Cluster ──
+        all_ids = collected_df["__row_id__"].to_list()
+        max_cluster_size = 100
+        if config.golden_rules and hasattr(config.golden_rules, "max_cluster_size"):
+            max_cluster_size = config.golden_rules.max_cluster_size
+
+        clusters = build_clusters(all_pairs, all_ids, max_cluster_size=max_cluster_size)
+
+        # ── Golden records ──
+        golden_rules = config.golden_rules or GoldenRulesConfig(default_strategy="most_complete")
+        golden_records = []
+        for cluster_id, cluster_info in clusters.items():
+            if cluster_info["size"] > 1 and not cluster_info["oversized"]:
+                member_ids = cluster_info["members"]
+                cluster_df = _to_frame(collected_df).filter_in("__row_id__", member_ids).native
+                golden = build_golden_record(cluster_df, golden_rules)
+                golden["__cluster_id__"] = cluster_id
+                golden_records.append(golden)
+
+        golden_df = None
+        if golden_records:
+            golden_rows = []
+            for rec in golden_records:
+                row = {"__cluster_id__": rec["__cluster_id__"]}
+                row["__golden_confidence__"] = rec.get("__golden_confidence__", 0.0)
+                for col, val_info in rec.items():
+                    if col in ("__cluster_id__", "__golden_confidence__"):
+                        continue
+                    if isinstance(val_info, dict) and "value" in val_info:
+                        row[col] = val_info["value"]
+                golden_rows.append(row)
+            golden_df = _frame_from_records(golden_rows, backend="polars").native
+
+        # ── Classify dupes / unique ──
+        multi_cluster_ids = [cid for cid, c in clusters.items() if c["size"] > 1]
+        dupe_row_ids = set()
+        for cid in multi_cluster_ids:
+            dupe_row_ids.update(clusters[cid]["members"])
+        unique_row_ids = set(all_ids) - dupe_row_ids
+
+        dupes_df = _to_frame(collected_df).filter_in("__row_id__", list(dupe_row_ids)).native
+        unique_df = _to_frame(collected_df).filter_in("__row_id__", list(unique_row_ids)).native
+
+        # ── Stats ──
+        stats = self._compute_stats(clusters, collected_df.height)
+        if llm_budget_summary:
+            stats.llm_cost = llm_budget_summary
+
+        return EngineResult(
+            clusters=clusters,
+            golden=golden_df,
+            unique=unique_df,
+            dupes=dupes_df,
+            quarantine=quarantine_df,
+            matched=None,
+            unmatched=None,
+            scored_pairs=all_pairs,
+            stats=stats,
+            em_results=em_results or None,
+        )
+
+    def auto_configure(self, domain: str | None = None) -> tuple[Any, ControllerTelemetry]:
+        """Run AutoConfigController on the loaded data, capture telemetry.
+
+        Returns ``(committed_config, telemetry)``. The committed config is the
+        same shape ``ConfigTab.set_config`` accepts, so callers can apply it
+        directly. ``telemetry`` is stashed on the engine for later inspection
+        by the Controller tab.
+
+        Mirrors the web router's ``_LAST_CONTROLLER_RUN`` capture (see
+        ``web/routers/autoconfig.py``) so we surface the same stop_reason /
+        decisions / NE the workbench shows.
+        """
+        # Lazy imports: ``auto_configure_df`` pulls in the policy + indicator
+        # graph (heavy). Keeping the import here means ``MatchEngine.__init__``
+        # stays cheap for TUI sessions that never trigger Ctrl+A.
+        from datetime import UTC, datetime
+
+        from goldenmatch.config.schemas import DomainConfig
+        from goldenmatch.core.autoconfig import (
+            _LAST_CONTROLLER_RUN,
+            auto_configure_df,
+        )
+
+        # Profile/extract priors before the controller wipes the ContextVar
+        # state — these come from the eager indicator pass and aren't on
+        # ComplexityProfile.data.column_priors until the controller publishes.
+        domain_cfg = DomainConfig(enabled=True, mode=domain) if domain else None
+        config = auto_configure_df(
+            self._data,
+            allow_remote_assets=False,
+            domain_config=domain_cfg,
+        )
+        ctrl_state = _LAST_CONTROLLER_RUN.get()
+        profile = ctrl_state[0] if ctrl_state else None
+        history = ctrl_state[1] if ctrl_state else None
+
+        # Lift column_priors off DataProfile so the tab can render without
+        # walking the frozen dataclass tree at render time.
+        priors: dict[str, Any] = {}
+        if profile is not None:
+            data_profile = getattr(profile, "data", None)
+            cp = getattr(data_profile, "column_priors", None) or {}
+            for col, p in cp.items():
+                priors[col] = {
+                    "identity_score": float(getattr(p, "identity_score", 0.0)),
+                    "corruption_score": float(getattr(p, "corruption_score", 0.0)),
+                }
+
+        telemetry = ControllerTelemetry(
+            profile=profile,
+            history=history,
+            committed_config=config,
+            source="auto_configure",
+            recorded_at=datetime.now(UTC).isoformat(),
+            column_priors=priors,
+        )
+        self._last_telemetry = telemetry
+        return config, telemetry
+
+    @property
+    def last_telemetry(self) -> ControllerTelemetry | None:
+        """Most recent controller telemetry from ``auto_configure``, if any."""
+        return self._last_telemetry
+
+    def run_sample(self, config, sample_size: int = 1000) -> EngineResult:
+        """Run the pipeline on a sample of the data."""
+        sample_df = self.get_sample(sample_size)
+        result = self._run_pipeline(sample_df, config)
+        self._last_result = result
+        return result
+
+    def run_full(self, config) -> EngineResult:
+        """Run the pipeline on the full dataset."""
+        result = self._run_pipeline(self._data, config)
+        self._last_result = result
+        return result
+
+    def unmerge_record(self, record_id: int, threshold: float = 0.0) -> EngineResult | None:
+        """Remove a record from its cluster and return updated results."""
+        if self._last_result is None:
+            return None
+
+        from goldenmatch.core.cluster import unmerge_record
+
+        clusters = unmerge_record(
+            record_id, self._last_result.clusters, threshold,
+            scored_pairs=self._last_result.scored_pairs,
+        )
+        stats = self._compute_stats(clusters, self._data.height)
+
+        self._last_result = EngineResult(
+            clusters=clusters,
+            golden=self._last_result.golden,
+            unique=self._last_result.unique,
+            dupes=self._last_result.dupes,
+            quarantine=self._last_result.quarantine,
+            matched=self._last_result.matched,
+            unmatched=self._last_result.unmatched,
+            scored_pairs=self._last_result.scored_pairs,
+            stats=stats,
+            em_results=self._last_result.em_results,
+        )
+        return self._last_result
+
+    def unmerge_cluster(self, cluster_id: int) -> EngineResult | None:
+        """Shatter a cluster into singletons and return updated results."""
+        if self._last_result is None:
+            return None
+
+        from goldenmatch.core.cluster import unmerge_cluster
+
+        clusters = unmerge_cluster(cluster_id, self._last_result.clusters)
+        stats = self._compute_stats(clusters, self._data.height)
+
+        self._last_result = EngineResult(
+            clusters=clusters,
+            golden=self._last_result.golden,
+            unique=self._last_result.unique,
+            dupes=self._last_result.dupes,
+            quarantine=self._last_result.quarantine,
+            matched=self._last_result.matched,
+            unmatched=self._last_result.unmatched,
+            scored_pairs=self._last_result.scored_pairs,
+            stats=stats,
+            em_results=self._last_result.em_results,
+        )
+        return self._last_result
+
+    def match_one(self, record: dict, config) -> list[tuple[int, float]]:
+        """Match a single record against the loaded dataset.
+
+        Uses brute-force scoring against the full dataset. For ANN-accelerated
+        matching, use core.match_one directly with a pre-built ANNBlocker.
+        """
+        from goldenmatch.core.match_one import match_one
+
+        matchkeys = config.get_matchkeys()
+        results = []
+        for mk in matchkeys:
+            if mk.type == "weighted":
+                matches = match_one(record, self._data, mk)
+                results.extend(matches)
+        # Deduplicate by row_id, keep highest score
+        best: dict[int, float] = {}
+        for row_id, score in results:
+            if row_id not in best or score > best[row_id]:
+                best[row_id] = score
+        return sorted(best.items(), key=lambda x: x[1], reverse=True)
+
+    def recluster_at_threshold(self, threshold: float) -> EngineStats:
+        """Re-cluster cached scored pairs at a new threshold. No re-scoring."""
+        if self._last_result is None:
+            raise RuntimeError("No previous run exists. Call run_sample or run_full first.")
+
+        from goldenmatch.core.cluster import build_clusters
+
+        filtered_pairs = [
+            (a, b, s) for a, b, s in self._last_result.scored_pairs if s >= threshold
+        ]
+
+        # Gather all IDs from the last result's clusters
+        all_ids = []
+        for cluster_info in self._last_result.clusters.values():
+            all_ids.extend(cluster_info["members"])
+        all_ids = sorted(set(all_ids))
+
+        clusters = build_clusters(filtered_pairs, all_ids)
+        return self._compute_stats(clusters, len(all_ids))

--- a/scripts/fixtures/sync_enforcement/src/lane.py
+++ b/scripts/fixtures/sync_enforcement/src/lane.py
@@ -1,4 +1,9 @@
-"""Synthetic fixture: four claims -- enforced, unenforced, prose-only, unresolvable."""
+"""Synthetic fixture: five claims -- enforced, unenforced, prose-only,
+unresolvable, module-level.
+
+Module-level claim: this module mirrors slow_lane as a whole and is never
+triaged -- a module has no single symbol a test can reference.
+"""
 
 
 def fast_lane():
@@ -22,4 +27,9 @@ def prose_lane():
 
 def stray_lane():
     """Mirrors the legacy pipeline that no longer exists here."""
+    return 1
+
+
+def arrow_lane():
+    """Mirrors slow_lane: caller → callee directly, no wrapper indirection."""
     return 1

--- a/scripts/fixtures/sync_enforcement/src/lane.py
+++ b/scripts/fixtures/sync_enforcement/src/lane.py
@@ -1,0 +1,25 @@
+"""Synthetic fixture: four claims -- enforced, unenforced, prose-only, unresolvable."""
+
+
+def fast_lane():
+    """Mirrors slow_lane but skips validation."""
+    return 1
+
+
+def slow_lane():
+    return 1
+
+
+def orphan_lane():
+    """Mirrors slow_lane and nothing tests them together."""
+    return 1
+
+
+def prose_lane():
+    """Mirrors slow_lane; a test mentions both only in prose."""
+    return 1
+
+
+def stray_lane():
+    """Mirrors the legacy pipeline that no longer exists here."""
+    return 1

--- a/scripts/fixtures/sync_enforcement/tests/test_docstring_only.py
+++ b/scripts/fixtures/sync_enforcement/tests/test_docstring_only.py
@@ -1,0 +1,11 @@
+from lane import prose_lane
+
+
+def test_prose_runs():
+    """`prose_lane` must behave the same way `slow_lane` does.
+
+    This docstring names both symbols. Nothing in the CODE references
+    slow_lane, so nothing compares them -- which is exactly the shape that
+    made tests/test_engine.py look like it enforced the 6c89042c7 incident.
+    """
+    assert prose_lane() == 1

--- a/scripts/fixtures/sync_enforcement/tests/test_enforced.py
+++ b/scripts/fixtures/sync_enforcement/tests/test_enforced.py
@@ -1,0 +1,5 @@
+from lane import fast_lane, slow_lane
+
+
+def test_the_lanes_agree():
+    assert fast_lane() == slow_lane()

--- a/scripts/fixtures/sync_enforcement/tests/test_unenforced.py
+++ b/scripts/fixtures/sync_enforcement/tests/test_unenforced.py
@@ -1,0 +1,5 @@
+from lane import orphan_lane
+
+
+def test_orphan_runs():
+    assert orphan_lane() == 1

--- a/scripts/sync_claims/claims.py
+++ b/scripts/sync_claims/claims.py
@@ -1,0 +1,128 @@
+"""Docstring claims that one piece of code must stay in step with another.
+
+The codebase says where its traps are. 319 docstrings in goldenmatch assert a
+synchronisation relationship -- "mirrors", "byte-identical to", "must match",
+"keep in sync with" -- and nothing checks any of them. `MatchEngine._run_pipeline`
+said "mirrors run_dedupe", stopped mirroring it, and shipped an ImportError on a
+default install (6c89042c7).
+
+TARGET RESOLUTION IS THE FILTER, deliberately. An earlier rule accepted a target
+only in backticks or with a call suffix, and could not extract this phase's own
+motivating example -- the incident names `run_dedupe` as a bare word. So any word
+in the window after the claim keyword counts if it names a declared symbol, first
+match wins. The cost is that a claim mentioning several symbols can resolve to the
+wrong one; `Claim.window` carries the matched text so triage can see what it keyed
+on.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Phrases that assert a relationship to another symbol. Kept narrow on purpose:
+# every entry states that two things must AGREE, not merely that they are
+# related. "see also" and "used by" are not claims.
+CLAIM_PATTERN = re.compile(
+    r"\b(mirror(s|ed|ing)?|keep (in|them) sync|in sync with|stay(s)? in sync|"
+    r"parallel (to|of)|same (rule|logic|order|shape|contract) as|must match|"
+    r"byte-identical to|identical to|counterpart|duplicat(e|ed|es) of|"
+    r"copy of|port of)\b",
+    re.IGNORECASE,
+)
+
+# How much text after the keyword can name the target. 200 characters is about
+# two sentences -- long enough for "mirrors run_dedupe but returns EngineResult",
+# short enough that an unrelated symbol three paragraphs down is not picked up.
+WINDOW = 200
+
+_WORD = re.compile(r"[A-Za-z_][\w.]*")
+
+
+@dataclass(frozen=True)
+class Claim:
+    """One docstring assertion that this code must stay in step with `target`."""
+
+    module: str
+    symbol: str
+    kind: str  # "module" or "symbol"
+    keyword: str
+    window: str
+    target: str | None
+    lineno: int
+
+
+def _parse(path: Path) -> ast.Module | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+    except SyntaxError:
+        return None
+
+
+def declared_symbols(root: Path) -> set[str]:
+    """Every function and class name declared under `root`."""
+    out: set[str] = set()
+    for path in sorted(root.rglob("*.py")):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                out.add(node.name)
+    return out
+
+
+def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
+    """Every synchronisation claim under `root`, with targets resolved.
+
+    `symbols` defaults to `declared_symbols(root)`. Pass it explicitly when the
+    claims live in a fixture but must resolve against the real package.
+    """
+    known = declared_symbols(root) if symbols is None else symbols
+    out: list[Claim] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                continue
+            doc = ast.get_docstring(node)
+            if not doc:
+                continue
+            match = CLAIM_PATTERN.search(doc)
+            if match is None:
+                continue
+            is_module = isinstance(node, ast.Module)
+            name = "<module>" if is_module else node.name
+            window = doc[match.end() : match.end() + WINDOW]
+            # _WORD's continuation class includes "." so a word immediately
+            # followed by sentence-ending punctuation (e.g. "...mirrors
+            # helper.") is matched WITH the trailing period. rstrip it before
+            # taking the dotted tail, or "helper." never equals "helper".
+            target = next(
+                (
+                    tail
+                    for word in _WORD.findall(window)
+                    for tail in (word.rstrip(".").split(".")[-1],)
+                    if tail in known and tail != name
+                ),
+                None,
+            )
+            out.append(
+                Claim(
+                    module=rel,
+                    symbol=name,
+                    kind="module" if is_module else "symbol",
+                    keyword=match.group(0),
+                    window=" ".join(window.split()),
+                    target=target,
+                    lineno=0 if is_module else node.lineno,
+                )
+            )
+    return out

--- a/scripts/sync_claims/enforcement.py
+++ b/scripts/sync_claims/enforcement.py
@@ -1,0 +1,70 @@
+"""Does any test exercise a claimant alongside what it claims to mirror?
+
+A claim is UNENFORCED when no single test file references both the claimant
+and its target in EXECUTABLE code. That definition is load-bearing in both
+directions:
+
+  * EXECUTABLE, not textual. At 6c89042c7^ `tests/test_engine.py` named both
+    `_run_pipeline` and `run_dedupe` -- in a docstring. Counting text marks
+    the motivating incident enforced and the whole phase misses it. Counting
+    Name/Attribute/alias nodes: 2 tests referenced the claimant, 10 the
+    target, 0 both.
+
+  * SOUND AS A NEGATIVE, SUGGESTIVE AS A POSITIVE. No co-reference genuinely
+    proves nothing compares them. Co-reference proves only that one file
+    mentions both -- never that it compares them. So the finding is the
+    unenforced set, and a co-referenced claim is UNVERIFIED, never "safe".
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from sync_claims.claims import Claim
+
+
+def executable_references(path: Path) -> set[str]:
+    """Names this file references in code. Docstrings and comments are not code."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+    except SyntaxError:
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            out.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            out.add(node.attr)
+        elif isinstance(node, ast.alias):
+            out.add((node.asname or node.name).split(".")[-1])
+    return out
+
+
+def test_reference_sets(tests_root: Path) -> list[set[str]]:
+    """One reference set per test file. Empty list means nothing was scanned."""
+    return [executable_references(p) for p in sorted(tests_root.rglob("*.py"))]
+
+
+# Named `test_reference_sets` per the required interface, but it is a helper,
+# not a pytest test. Once a caller imports it into a test module, its
+# module-level name matches pytest's default `test_*` collection and pytest
+# tries to run it as a test (and fails: it takes a required `tests_root` arg,
+# not a fixture). `__test__ = False` is pytest's documented escape hatch.
+test_reference_sets.__test__ = False
+
+
+def unenforced(claim_list: list[Claim], reference_sets: list[set[str]]) -> list[Claim]:
+    """Claims no single test file references both halves of.
+
+    Claims with no resolved target are excluded: there is nothing for a test to
+    enforce them against, and counting them would inflate the finding list with
+    items nobody can act on. They are reported in their own bucket instead.
+    """
+    out: list[Claim] = []
+    for claim in claim_list:
+        if claim.target is None:
+            continue
+        if not any(claim.symbol in names and claim.target in names for names in reference_sets):
+            out.append(claim)
+    return out

--- a/scripts/sync_claims/enforcement.py
+++ b/scripts/sync_claims/enforcement.py
@@ -60,10 +60,27 @@ def unenforced(claim_list: list[Claim], reference_sets: list[set[str]]) -> list[
     Claims with no resolved target are excluded: there is nothing for a test to
     enforce them against, and counting them would inflate the finding list with
     items nobody can act on. They are reported in their own bucket instead.
+
+    Module-level claims (`kind != "symbol"`) are excluded too, and for a
+    sharper reason than "out of scope": `claim.symbol` for a module-level
+    claim is the literal string `"<module>"`, which can never appear in a
+    test's reference set (no test references a module by that name). So
+    every RESOLVABLE module-level claim would become a permanent, unfixable
+    finding -- measured on the real package, 213 findings with no filter
+    versus 172 scoped, 41 of them module-level. The spec excludes
+    module-level claims from triage by construction (a module has no single
+    symbol a test can reference); this filter is what makes that true here
+    rather than only in whichever caller remembers to pre-scope its input.
+    `inventory()` already filters to `kind == "symbol"` before calling this,
+    so the check is a no-op for the shipped caller today -- it exists for
+    every future one that doesn't pre-scope so carefully, and matters
+    concretely once C3 seeds a ratchet floor from a call here.
     """
     out: list[Claim] = []
     for claim in claim_list:
         if claim.target is None:
+            continue
+        if claim.kind != "symbol":
             continue
         if not any(claim.symbol in names and claim.target in names for names in reference_sets):
             out.append(claim)

--- a/scripts/sync_claims/report.py
+++ b/scripts/sync_claims/report.py
@@ -1,0 +1,113 @@
+"""Report docstring sync claims that no test enforces. C0 is report-only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sync_claims.claims import Claim, claims, declared_symbols
+from sync_claims.enforcement import test_reference_sets, unenforced
+
+REPO = Path(__file__).resolve().parent.parent.parent
+DEFAULT_ROOT = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+DEFAULT_TESTS = REPO / "packages" / "python" / "goldenmatch" / "tests"
+
+SCOPE_NOTE = (
+    "scope: claims are read from docstrings under {root} and enforcement from "
+    "{tests} only -- other packages, the TypeScript port and _archive are out "
+    "of reach by construction, and their silence here is not a clean bill. "
+    "Module-level claims are reported but NOT triaged: a module has no single "
+    "symbol a test can reference. A claim listed as UNVERIFIED is not safe -- "
+    "some test references both names, which does not mean it compares them."
+)
+
+
+def _as_dict(claim: Claim) -> dict:
+    return {
+        "module": claim.module,
+        "symbol": claim.symbol,
+        "lineno": claim.lineno,
+        "keyword": claim.keyword,
+        "target": claim.target,
+        "window": claim.window,
+    }
+
+
+def inventory(root: Path, tests_root: Path) -> dict:
+    """Bucket every claim under `root` by enforcement state."""
+    all_claims = claims(root, symbols=declared_symbols(root))
+    symbol_claims = [c for c in all_claims if c.kind == "symbol"]
+    module_claims = [c for c in all_claims if c.kind == "module"]
+    resolvable = [c for c in symbol_claims if c.target is not None]
+    unresolvable = [c for c in symbol_claims if c.target is None]
+
+    reference_sets = test_reference_sets(tests_root)
+    findings = unenforced(resolvable, reference_sets)
+    finding_ids = {(c.module, c.symbol, c.lineno) for c in findings}
+    unverified = [c for c in resolvable if (c.module, c.symbol, c.lineno) not in finding_ids]
+
+    return {
+        "counts": {
+            "claims": len(all_claims),
+            "resolvable": len(resolvable),
+            "unenforced": len(findings),
+            "unverified": len(unverified),
+            "unresolvable": len(unresolvable),
+            "module_level": len(module_claims),
+            "test_files_scanned": len(reference_sets),
+        },
+        "unenforced": [_as_dict(c) for c in findings],
+        "unverified": [_as_dict(c) for c in unverified],
+        "unresolvable": [_as_dict(c) for c in unresolvable],
+        "module_level": [_as_dict(c) for c in module_claims],
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--tests", type=Path, default=DEFAULT_TESTS)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    inv = inventory(args.root, args.tests)
+    if args.json:
+        print(json.dumps(inv, indent=2))
+        return 0
+
+    counts = inv["counts"]
+    print(SCOPE_NOTE.format(root=args.root, tests=args.tests))
+    print()
+    if counts["test_files_scanned"] == 0:
+        # Every claim looks unenforced when nothing was scanned. That is a
+        # broken run, not a perfect score, and it must not read as findings.
+        print(
+            f"NO TEST FILES SCANNED under {args.tests} -- every claim below "
+            f"would be reported unenforced for that reason alone. Fix --tests "
+            f"before reading this as a result."
+        )
+        print()
+
+    print(
+        f"{counts['claims']} claim(s); {counts['resolvable']} resolvable and "
+        f"symbol-level; {counts['unenforced']} UNENFORCED, "
+        f"{counts['unverified']} unverified"
+    )
+    print(
+        f"  reported but not triaged: {counts['unresolvable']} unresolvable, "
+        f"{counts['module_level']} module-level"
+    )
+    print(f"  test files scanned: {counts['test_files_scanned']}")
+    print()
+
+    for entry in sorted(inv["unenforced"], key=lambda e: (e["module"], e["lineno"])):
+        print(f"  {entry['module']}:{entry['lineno']}  {entry['symbol']}")
+        print(f"      --{entry['keyword']}--> {entry['target']}")
+        print(f"      claim: {entry['window'][:100]}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/sync_claims/report.py
+++ b/scripts/sync_claims/report.py
@@ -24,6 +24,28 @@ SCOPE_NOTE = (
 )
 
 
+def _degrade_non_utf8_stdout() -> None:
+    """Never let an unprintable claim-window character kill a report-only run.
+
+    Some claim windows carry non-ASCII text (arrows, smart quotes, ...) and
+    the platform's default stdout encoding cannot always encode it -- on
+    Windows cp1252, a `UnicodeEncodeError` partway through the findings loop
+    would exit non-zero after printing only the first few findings. That
+    reads as a short, complete report; it is actually a truncated one, and
+    `main` is contracted to exit 0 whatever it finds. Degrade the character
+    instead of crashing. `reconfigure` does not exist on every stream object
+    (a plain redirected file, pytest's `capsys`), so this is a guarded no-op
+    wherever it is unavailable or refused.
+    """
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is None:
+        return
+    try:
+        reconfigure(errors="backslashreplace")
+    except (AttributeError, ValueError, OSError):
+        pass
+
+
 def _as_dict(claim: Claim) -> dict:
     return {
         "module": claim.module,
@@ -66,6 +88,7 @@ def inventory(root: Path, tests_root: Path) -> dict:
 
 
 def main(argv: list[str]) -> int:
+    _degrade_non_utf8_stdout()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     parser.add_argument("--tests", type=Path, default=DEFAULT_TESTS)

--- a/scripts/test_sync_claims_claims.py
+++ b/scripts/test_sync_claims_claims.py
@@ -1,0 +1,120 @@
+"""Tests for sync-claim extraction and target resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sync_claims.claims import claims, declared_symbols
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "incident_6c89042c7"
+GOLDENMATCH = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+
+def test_the_incident_claim_is_extracted_with_its_target():
+    """The motivating example, from a checked-in fixture, not git history.
+
+    `_run_pipeline`'s docstring says "mirrors run_dedupe but returns
+    EngineResult". The target is a BARE identifier -- no backticks, no call
+    suffix -- which is exactly what an earlier target rule could not see.
+
+    Targets resolve against the REAL package, not the fixture: `run_dedupe`
+    lives in `core/pipeline.py`, not in `tui/engine.py`, so resolving against
+    the fixture alone returns None and this test could never pass. That is
+    what the `symbols` keyword is for.
+    """
+    package_symbols = declared_symbols(GOLDENMATCH)
+    assert "run_dedupe" in package_symbols, (
+        "run_dedupe is no longer declared in goldenmatch -- the fixture's claim "
+        "names a symbol that has been renamed or removed, so this test's premise "
+        "is gone. Fix the premise, do not weaken the assertion."
+    )
+
+    found = [c for c in claims(FIXTURE, symbols=package_symbols) if c.symbol == "_run_pipeline"]
+
+    assert len(found) == 1, f"expected one claim on _run_pipeline, got {found}"
+    claim = found[0]
+    assert claim.keyword.lower() == "mirrors"
+    assert claim.target == "run_dedupe", (
+        f"target did not resolve to run_dedupe: {claim.target!r}. The claim "
+        f"names it as a bare word, so resolution -- not punctuation -- has to "
+        f"be the filter."
+    )
+    assert claim.kind == "symbol"
+    assert "run_dedupe" in claim.window
+
+
+def test_declared_symbols_finds_functions_and_classes():
+    symbols = declared_symbols(FIXTURE)
+    assert "_run_pipeline" in symbols
+    assert "MatchEngine" in symbols
+
+
+def test_a_docstring_with_no_claim_yields_nothing(tmp_path):
+    (tmp_path / "m.py").write_text(
+        '''
+def plain():
+    """Does a thing. Returns a value."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    assert claims(tmp_path) == []
+
+
+def test_an_unresolvable_claim_is_kept_with_target_none(tmp_path):
+    """A claim naming nothing real is still a claim -- it is reported in its
+    own bucket, not dropped. Dropping it would hide that someone wrote a
+    synchronisation promise nobody can check."""
+    (tmp_path / "m.py").write_text(
+        '''
+def widget():
+    """Mirrors the legacy behaviour of the old system."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = claims(tmp_path)
+    assert len(found) == 1
+    assert found[0].target is None
+    assert found[0].keyword.lower() == "mirrors"
+
+
+def test_a_claim_never_resolves_to_its_own_claimant(tmp_path):
+    """`def build(): "mirrors build"` is a self-reference, not a relationship."""
+    (tmp_path / "m.py").write_text(
+        '''
+def build():
+    """Mirrors build exactly."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    assert claims(tmp_path)[0].target is None
+
+
+def test_module_level_claims_are_kept_and_marked(tmp_path):
+    """Module claims are reported but never triaged -- a module has no single
+    symbol a test can reference. Marking the kind is what lets the report
+    separate them."""
+    (tmp_path / "m.py").write_text(
+        '''
+"""This module mirrors helper."""
+
+
+def helper():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = claims(tmp_path)
+    assert [c.kind for c in found] == ["module"]
+    assert found[0].symbol == "<module>"
+    assert found[0].target == "helper"
+
+
+def test_a_bom_prefixed_file_is_not_skipped(tmp_path):
+    """Two goldenmatch modules carry a UTF-8 BOM. Reading as plain utf-8
+    raises on the first line and the file vanishes from the scan -- phase B
+    lost two modules to exactly this before it was caught."""
+    (tmp_path / "bom.py").write_bytes(
+        b"\xef\xbb\xbf" + b'def a():\n    """Mirrors b."""\n\n\ndef b():\n    pass\n'
+    )
+    assert [c.target for c in claims(tmp_path)] == ["b"]

--- a/scripts/test_sync_claims_enforcement.py
+++ b/scripts/test_sync_claims_enforcement.py
@@ -1,0 +1,78 @@
+"""Tests for the executable-reference enforcement check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sync_claims.claims import claims, declared_symbols
+from sync_claims.enforcement import (
+    executable_references,
+    test_reference_sets,
+    unenforced,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "sync_enforcement"
+SRC = FIXTURE / "src"
+TESTS = FIXTURE / "tests"
+
+
+def _claims():
+    return claims(SRC, symbols=declared_symbols(SRC))
+
+
+def test_a_docstring_only_co_mention_is_not_enforcement():
+    """THE TRAP THIS PHASE TURNS ON.
+
+    At 6c89042c7^, tests/test_engine.py named both `_run_pipeline` and
+    `run_dedupe` -- inside a docstring. A text scan calls that enforced, and
+    the phase misses the bug that motivates it.
+    """
+    names = executable_references(TESTS / "test_docstring_only.py")
+    assert "prose_lane" in names
+    assert "slow_lane" not in names, (
+        "slow_lane appears only in a docstring; counting it means counting prose as enforcement"
+    )
+
+
+def test_the_unenforced_claims_are_reported():
+    found = {c.symbol for c in unenforced(_claims(), test_reference_sets(TESTS))}
+    assert found == {"orphan_lane", "prose_lane"}, found
+
+
+def test_the_enforced_claim_is_not_reported():
+    found = {c.symbol for c in unenforced(_claims(), test_reference_sets(TESTS))}
+    assert "fast_lane" not in found, (
+        "test_enforced.py references both fast_lane and slow_lane in code"
+    )
+
+
+def test_a_claim_with_no_target_is_never_reported_unenforced():
+    """An unresolvable claim has nothing to be enforced against. Reporting it
+    as unenforced would inflate the finding count with claims nobody can act on.
+
+    `stray_lane` exists in the fixture to give this something to assert on. An
+    earlier draft filtered for `target is None` against a fixture that had no
+    such claim, so it iterated an empty list and passed while checking nothing.
+    """
+    unresolved = [c for c in _claims() if c.target is None]
+    assert {c.symbol for c in unresolved} == {"stray_lane"}, (
+        "the fixture must contain an unresolvable claim or this test is vacuous"
+    )
+    assert unenforced(unresolved, []) == []
+
+
+def test_executable_references_covers_all_three_node_kinds():
+    """Name, Attribute and alias. Missing `alias` loses every symbol a test
+    only imports, which is most of them."""
+    path = TESTS / "test_enforced.py"
+    names = executable_references(path)
+    assert {"fast_lane", "slow_lane"} <= names
+
+
+def test_an_empty_tests_directory_yields_no_reference_sets(tmp_path):
+    """An empty list is how 'nothing was scanned' reaches the report.
+
+    Distinguishing that from 'nothing is enforced' is the report's job
+    (test_sync_claims_report.py); this pins the signal it keys on."""
+    assert test_reference_sets(tmp_path) == []

--- a/scripts/test_sync_claims_enforcement.py
+++ b/scripts/test_sync_claims_enforcement.py
@@ -23,8 +23,9 @@ def _claims():
 
 def _symbol_claims():
     """Symbol-level claims only, scoped the way `inventory()` scopes its
-    input to `unenforced()`. `unenforced()` itself only filters on
-    `target is None`, not on `kind` -- a module-level claim with a
+    input to `unenforced()`. This mirrors the caller rather than relying on
+    the callee: `unenforced()` now filters on `kind` as well as
+    `target is None`, but it did not always -- a module-level claim with a
     resolved target (the fixture now has one) would otherwise flow
     straight into a finding set that is supposed to hold only claims a
     test COULD reference both halves of."""

--- a/scripts/test_sync_claims_enforcement.py
+++ b/scripts/test_sync_claims_enforcement.py
@@ -21,6 +21,16 @@ def _claims():
     return claims(SRC, symbols=declared_symbols(SRC))
 
 
+def _symbol_claims():
+    """Symbol-level claims only, scoped the way `inventory()` scopes its
+    input to `unenforced()`. `unenforced()` itself only filters on
+    `target is None`, not on `kind` -- a module-level claim with a
+    resolved target (the fixture now has one) would otherwise flow
+    straight into a finding set that is supposed to hold only claims a
+    test COULD reference both halves of."""
+    return [c for c in _claims() if c.kind == "symbol"]
+
+
 def test_a_docstring_only_co_mention_is_not_enforcement():
     """THE TRAP THIS PHASE TURNS ON.
 
@@ -36,8 +46,8 @@ def test_a_docstring_only_co_mention_is_not_enforcement():
 
 
 def test_the_unenforced_claims_are_reported():
-    found = {c.symbol for c in unenforced(_claims(), test_reference_sets(TESTS))}
-    assert found == {"orphan_lane", "prose_lane"}, found
+    found = {c.symbol for c in unenforced(_symbol_claims(), test_reference_sets(TESTS))}
+    assert found == {"orphan_lane", "prose_lane", "arrow_lane"}, found
 
 
 def test_the_enforced_claim_is_not_reported():

--- a/scripts/test_sync_claims_enforcement.py
+++ b/scripts/test_sync_claims_enforcement.py
@@ -51,10 +51,27 @@ def test_the_unenforced_claims_are_reported():
 
 
 def test_the_enforced_claim_is_not_reported():
-    found = {c.symbol for c in unenforced(_claims(), test_reference_sets(TESTS))}
+    found = {c.symbol for c in unenforced(_symbol_claims(), test_reference_sets(TESTS))}
     assert "fast_lane" not in found, (
         "test_enforced.py references both fast_lane and slow_lane in code"
     )
+
+
+def test_a_resolvable_module_level_claim_is_never_reported_unenforced():
+    """`unenforced()` now filters `kind != "symbol"` itself, not just
+    `inventory()`'s pre-scoping of its input. The fixture's module-level
+    claim ("this module mirrors slow_lane") has a RESOLVABLE target
+    (`slow_lane` is a declared symbol), so without the kind filter it would
+    slip past the `target is None` check and become a permanent finding: no
+    test can ever reference the literal string "<module>" in code, because
+    it names no real symbol."""
+    module_claims = [c for c in _claims() if c.kind == "module"]
+    assert {c.symbol for c in module_claims} == {"<module>"}
+    assert all(c.target is not None for c in module_claims), (
+        "the fixture must contain a RESOLVABLE module-level claim or this test is vacuous"
+    )
+    found = unenforced(module_claims, test_reference_sets(TESTS))
+    assert found == []
 
 
 def test_a_claim_with_no_target_is_never_reported_unenforced():
@@ -86,3 +103,32 @@ def test_an_empty_tests_directory_yields_no_reference_sets(tmp_path):
     Distinguishing that from 'nothing is enforced' is the report's job
     (test_sync_claims_report.py); this pins the signal it keys on."""
     assert test_reference_sets(tmp_path) == []
+
+
+def test_the_incident_claim_is_classified_unenforced_against_the_real_package():
+    """C0's exit criterion is BOTH halves: the detector must extract
+    `_run_pipeline --mirrors--> run_dedupe` from the checked-in fixture AND
+    classify it unenforced. `test_sync_claims_claims.py` pins the extraction;
+    every enforcement test above this one runs only the synthetic
+    `sync_enforcement` fixture. Nothing else runs the whole path -- extract,
+    resolve against the real package, scan the real test tree, classify --
+    on the incident that motivates this phase. That is the branch's headline
+    promise, and until this test existed nothing pinned it."""
+    incident_fixture = REPO / "scripts" / "fixtures" / "incident_6c89042c7"
+    goldenmatch = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
+    goldenmatch_tests = REPO / "packages" / "python" / "goldenmatch" / "tests"
+
+    package_symbols = declared_symbols(goldenmatch)
+    incident_claims = [
+        c for c in claims(incident_fixture, symbols=package_symbols) if c.symbol == "_run_pipeline"
+    ]
+    assert len(incident_claims) == 1, f"expected one claim on _run_pipeline, got {incident_claims}"
+    claim = incident_claims[0]
+    assert claim.target == "run_dedupe"
+
+    reference_sets = test_reference_sets(goldenmatch_tests)
+    findings = unenforced(incident_claims, reference_sets)
+    assert claim in findings, (
+        "the incident claim (_run_pipeline --mirrors--> run_dedupe) must come "
+        "back as a finding when run against the real goldenmatch test tree"
+    )

--- a/scripts/test_sync_claims_report.py
+++ b/scripts/test_sync_claims_report.py
@@ -23,9 +23,13 @@ def test_inventory_buckets_the_fixture():
     assert {c["symbol"] for c in inv["unresolvable"]} == {"stray_lane"}
 
 
-def test_claim_count_and_finding_count_are_separate():
+def test_claim_count_and_finding_count_are_separate(capsys):
     """Deleting a claim must not read as progress. Reporting only a finding
-    count lets six words removed from a docstring look like a fix."""
+    count lets six words removed from a docstring look like a fix -- so this
+    has to pin the printed report, not just the dict `main()` builds it
+    from. A mutation that dropped the `{counts['claims']} claim(s);` prose
+    fragment (but kept the dict intact) passed this test when it only
+    inspected `inventory()`."""
     inv = inventory(FIXTURE / "src", FIXTURE / "tests")
     counts = inv["counts"]
     assert counts["claims"] >= counts["unenforced"]
@@ -37,6 +41,12 @@ def test_claim_count_and_finding_count_are_separate():
         "unresolvable",
         "module_level",
     } <= set(counts)
+
+    rc = main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"{counts['claims']} claim(s)" in out
+    assert f"{counts['unenforced']} UNENFORCED" in out
 
 
 def test_module_level_claims_are_reported_but_never_triaged():
@@ -57,12 +67,18 @@ def test_module_level_claims_are_reported_but_never_triaged():
 
 def test_the_report_names_the_matched_window(capsys):
     """A wrong target resolution must be visible, not silent. The first-match
-    rule can pick the wrong symbol when a claim mentions several."""
+    rule can pick the wrong symbol when a claim mentions several.
+
+    "slow_lane" and "orphan_lane" alone are not enough to pin the
+    `claim: {window}` print line: both strings also appear on the
+    `--mirrors--> slow_lane` and symbol header lines that print regardless.
+    `orphan_lane`'s docstring reads "...and nothing tests them together" --
+    text that exists nowhere else in the fixture or the report, so it can
+    only reach stdout through the window print itself."""
     rc = main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "slow_lane" in out
-    assert "orphan_lane" in out
+    assert "nothing tests them together" in out
 
 
 def test_the_report_states_its_scope(capsys):

--- a/scripts/test_sync_claims_report.py
+++ b/scripts/test_sync_claims_report.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import sys
 from pathlib import Path
 
 from sync_claims.report import DEFAULT_ROOT, DEFAULT_TESTS, inventory, main
@@ -12,7 +14,11 @@ FIXTURE = REPO / "scripts" / "fixtures" / "sync_enforcement"
 
 def test_inventory_buckets_the_fixture():
     inv = inventory(FIXTURE / "src", FIXTURE / "tests")
-    assert {c["symbol"] for c in inv["unenforced"]} == {"orphan_lane", "prose_lane"}
+    assert {c["symbol"] for c in inv["unenforced"]} == {
+        "orphan_lane",
+        "prose_lane",
+        "arrow_lane",
+    }
     assert {c["symbol"] for c in inv["unverified"]} == {"fast_lane"}
     assert {c["symbol"] for c in inv["unresolvable"]} == {"stray_lane"}
 
@@ -33,6 +39,22 @@ def test_claim_count_and_finding_count_are_separate():
     } <= set(counts)
 
 
+def test_module_level_claims_are_reported_but_never_triaged():
+    """A module has no single symbol a test can reference. An earlier
+    version of this suite had no module-level claim in the fixture at all,
+    so a mutation folding module claims into triage (`resolvable`,
+    `unenforced`) passed every test unnoticed."""
+    inv = inventory(FIXTURE / "src", FIXTURE / "tests")
+    assert inv["counts"]["module_level"] == 1
+    assert len(inv["module_level"]) == 1
+    entry = inv["module_level"][0]
+    assert entry["symbol"] == "<module>"
+    assert entry["target"] == "slow_lane"
+    assert "<module>" not in {c["symbol"] for c in inv["unenforced"]}
+    assert "<module>" not in {c["symbol"] for c in inv["unverified"]}
+    assert "<module>" not in {c["symbol"] for c in inv["unresolvable"]}
+
+
 def test_the_report_names_the_matched_window(capsys):
     """A wrong target resolution must be visible, not silent. The first-match
     rule can pick the wrong symbol when a claim mentions several."""
@@ -50,6 +72,10 @@ def test_the_report_states_its_scope(capsys):
     out = capsys.readouterr().out.lower()
     assert "scope" in out
     assert "module-level" in out
+    # Substance, not just presence: a co-referenced claim must be described
+    # as UNSAFE, never as verified or enforced. A mutation that flipped this
+    # to "is safe and enforced" passed every earlier test in this file.
+    assert "unverified is not safe" in out
 
 
 def test_an_empty_tests_root_is_reported_not_presented_as_findings(capsys, tmp_path):
@@ -64,6 +90,25 @@ def test_an_empty_tests_root_is_reported_not_presented_as_findings(capsys, tmp_p
 def test_main_exits_zero_on_findings():
     """C0 is report-only. A finding is not a failure -- the gate is C3."""
     assert main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")]) == 0
+
+
+def test_main_survives_non_utf8_stdout(monkeypatch):
+    """main() is contracted to exit 0 whatever it finds. `arrow_lane`'s claim
+    window carries a real non-ASCII character (an arrow) on purpose, and the
+    fixed stdout below uses cp1252 with strict errors -- the codepage this
+    broke on for real, unpatched by any PYTHONIOENCODING invocation-side
+    workaround. Without the guarded `sys.stdout.reconfigure` in `main`, this
+    raises UnicodeEncodeError partway through the findings loop: the process
+    exits non-zero after printing only a few findings, which reads as a
+    short complete report rather than the truncated one it actually is."""
+    buf = io.BytesIO()
+    stream = io.TextIOWrapper(buf, encoding="cp1252", errors="strict", newline="")
+    monkeypatch.setattr(sys, "stdout", stream)
+    rc = main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    stream.flush()
+    out = buf.getvalue().decode("cp1252")
+    assert rc == 0
+    assert "arrow_lane" in out
 
 
 def test_the_default_roots_exist():

--- a/scripts/test_sync_claims_report.py
+++ b/scripts/test_sync_claims_report.py
@@ -1,0 +1,72 @@
+"""Tests for the sync-claim report."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sync_claims.report import DEFAULT_ROOT, DEFAULT_TESTS, inventory, main
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "sync_enforcement"
+
+
+def test_inventory_buckets_the_fixture():
+    inv = inventory(FIXTURE / "src", FIXTURE / "tests")
+    assert {c["symbol"] for c in inv["unenforced"]} == {"orphan_lane", "prose_lane"}
+    assert {c["symbol"] for c in inv["unverified"]} == {"fast_lane"}
+    assert {c["symbol"] for c in inv["unresolvable"]} == {"stray_lane"}
+
+
+def test_claim_count_and_finding_count_are_separate():
+    """Deleting a claim must not read as progress. Reporting only a finding
+    count lets six words removed from a docstring look like a fix."""
+    inv = inventory(FIXTURE / "src", FIXTURE / "tests")
+    counts = inv["counts"]
+    assert counts["claims"] >= counts["unenforced"]
+    assert {
+        "claims",
+        "resolvable",
+        "unenforced",
+        "unverified",
+        "unresolvable",
+        "module_level",
+    } <= set(counts)
+
+
+def test_the_report_names_the_matched_window(capsys):
+    """A wrong target resolution must be visible, not silent. The first-match
+    rule can pick the wrong symbol when a claim mentions several."""
+    rc = main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "slow_lane" in out
+    assert "orphan_lane" in out
+
+
+def test_the_report_states_its_scope(capsys):
+    """Silence outside the scanned tree is not a clean bill, and the header
+    has to say so -- module-level claims are reported but never triaged."""
+    main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    out = capsys.readouterr().out.lower()
+    assert "scope" in out
+    assert "module-level" in out
+
+
+def test_an_empty_tests_root_is_reported_not_presented_as_findings(capsys, tmp_path):
+    """If the tests root is wrong every claim looks unenforced. That is a
+    broken run, not 100% findings, and the report must say which."""
+    rc = main(["--root", str(FIXTURE / "src"), "--tests", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "NO TEST FILES SCANNED" in out
+
+
+def test_main_exits_zero_on_findings():
+    """C0 is report-only. A finding is not a failure -- the gate is C3."""
+    assert main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")]) == 0
+
+
+def test_the_default_roots_exist():
+    """A default path that does not exist makes every CI run vacuously clean."""
+    assert DEFAULT_ROOT.is_dir(), DEFAULT_ROOT
+    assert DEFAULT_TESTS.is_dir(), DEFAULT_TESTS

--- a/scripts/test_workflow_yaml.py
+++ b/scripts/test_workflow_yaml.py
@@ -11,10 +11,22 @@ import textwrap
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import check_workflow_yaml as mod  # noqa: E402
+
+
+def _load_ci_workflow() -> dict:
+    """Parse the real `.github/workflows/ci.yml`, not a synthetic fixture.
+
+    The wiring-reachability test below asserts something about the actual
+    file this repo ships, not about a scratch workflow built by the `wf`
+    fixture -- so it needs its own loader rather than that fixture.
+    """
+    ci_path = mod.WORKFLOW_DIR / "ci.yml"
+    return yaml.safe_load(ci_path.read_text(encoding="utf-8"))
 
 
 @pytest.fixture
@@ -151,3 +163,18 @@ def test_the_repo_as_it_stands_passes():
     problems, scanned = mod.check(mod.WORKFLOW_DIR)
     assert scanned >= mod.MIN_EXPECTED_WORKFLOWS, scanned
     assert problems == [], problems
+
+
+def test_sync_claims_job_is_reachable():
+    """A job whose gating output is never emitted is skipped on every run.
+
+    The `changes` job needs an explicit `outputs:` line per filter. Without it
+    `needs.changes.outputs.sync_claims` is empty, the `if:` is false, and the
+    lane reports green having measured nothing -- PR #2839's defect.
+    """
+    spec = _load_ci_workflow()
+    outputs = spec["jobs"]["changes"]["outputs"]
+    assert "sync_claims" in outputs, (
+        "the changes job emits no sync_claims output, so the job can never run"
+    )
+    assert "sync_claims" in spec["jobs"]["sync_claims"]["if"]


### PR DESCRIPTION
## What and why

Phase C0 of the codebase audit programme. Ships a report-only detector for docstring claims of the form "X mirrors Y" that no test enforces.

The motivating incident is `6c89042c7`. `MatchEngine._run_pipeline`'s docstring read:

> Core pipeline logic - mirrors run_dedupe but returns EngineResult.

It stopped mirroring `run_dedupe`. The shipped pipeline moved to an eager arrow path while the copy kept driving the polars LazyFrame API, and `demo` and `lineage` raised `ImportError` on a default install. 203 lines became 54.

Measured on `goldenmatch`: **319 such claims exist; 216 are symbol-level with a resolvable target; 172 of those (80%) are unenforced.** 50 say "byte-identical to" or "identical to".

## Phase C was scoped as something else, and the spec records why it is not

C was scoped as module cohesion and splitting, with B0b (structural clone detection) folded in. **Both halves were refuted by measurement before design began**, and the spec keeps the numbers so a later phase does not propose them again.

*Module splitting has no mechanical basis.* Partitioning each large module's top-level definitions into connected components by intra-module reference:

| module | top-level defs | components | largest |
| --- | ---: | ---: | ---: |
| `core/autoconfig.py` | 127 | 5 | 123 |
| `core/probabilistic.py` | 119 | 8 | 111 |
| `core/pipeline.py` | 69 | 3 | 66 |

Every large module is one connected component plus a few isolated helpers. Splitting would cut through the call graph, not along it.

*B0b's premise was wrong.* The phase-B spec claims incident 1 is "detectable by structural clone detection". Measured similarity (difflib over normalised AST node-type sequences):

| pair | similarity |
| --- | ---: |
| a function vs itself, every identifier renamed | 1.000 |
| a function vs itself with 20% of statements deleted | 0.562 |
| **`_run_pipeline` vs `run_dedupe` (the incident)** | **0.033** |
| median of 400 random large-function pairs | 0.036 |

The incident scores *below* the median random pair; 56% of random pairs score at or above it. The two positive controls show the instrument works, so the negative is about the incident. Those functions shared a purpose, not a structure. A detector tuned to find it would flag half the codebase.

What survived is the property the incident actually had: **it said what it was doing**, and nothing checked.

## How "enforced" is defined, and why the definition is the whole design

A claim is UNENFORCED when no single test file references both the claimant and its target in **executable** code -- `ast.Name`, `ast.Attribute`, `ast.alias`. Never raw text.

That distinction decides the phase. At `6c89042c7^`, `tests/test_engine.py` names both `_run_pipeline` and `run_dedupe` -- **inside a docstring**. A text scan classifies the motivating incident as enforced and the tool misses the bug it exists to catch. Counting executable references only: 2 tests reference the claimant, 10 the target, **0 both**.

The signal is **sound as a negative and only suggestive as a positive**. No co-reference genuinely proves nothing compares them; co-reference proves only that one file mentions both. So the finding is the unenforced set, and the 44 co-referenced claims are reported `UNVERIFIED`, never "safe".

## Changes

`scripts/sync_claims/` -- three stdlib-`ast` modules, no new dependencies:
- `claims.py` extracts claims and resolves targets. **Resolution is the filter, not punctuation** -- an earlier rule accepting only backticked or called names could not extract this phase's own motivating example, which names `run_dedupe` as a bare word.
- `enforcement.py` computes executable references per test file and returns the unenforced set.
- `report.py` prints four buckets with counts.

Two fixtures, because the enforcement half cannot check in 972 test files:
- `scripts/fixtures/incident_6c89042c7/` -- `tui/engine.py` verbatim at `6c89042c7^`, so the detector is validated without git history staying reachable.
- `scripts/fixtures/sync_enforcement/` -- synthetic, four claims across four enforcement states. **The one that matters is `test_docstring_only.py`**, whose only co-mention of both symbols is in prose and which must still come out unenforced.

A report-only CI job on its own path filter. The filter watches the goldenmatch package and its tests, not just the detector -- a claim is added by editing a docstring in the scanned tree.

## Testing

35 tests. `ruff` clean. `check_filter_coverage.py` green: `47 required paths across 6 filters`, `0 new` job-vs-filter gaps.

The C0 exit criterion is verified end to end, not by test name: the detector extracts `_run_pipeline --mirrors--> run_dedupe` from the checked-in fixture **and classifies it unenforced**. Sabotaging `unenforced()` to `return []` fails that test on the classification assertion while the extraction assertions still pass.

Every test was sabotage-verified, and **each sabotage asserts it actually landed before the result is read** -- a lesson from phase B, where a sabotage was planted at a site the scan never attributed and the resulting green was read as proof the gate worked.

## What review found, because the numbers are the point

Ten defects were found in text I authored -- six in the plan before execution, four during. Some worth naming:

- The plan's own reference code failed 2 of its own 7 tests: `_WORD`'s `[\w.]*` swallowed a trailing sentence period, so `word.split(".")[-1]` returned `""`.
- An interface named `test_reference_sets` is auto-collected by pytest as a test once imported into a test module.
- Task 4 added a filter and a job but **not** the `changes` job's explicit `outputs:` line -- without it the gate is never true and the job is silently skipped on every run while the lane reports green. PR #2839 shipped exactly that.
- The final reviewer **mutation-tested** two spec success criteria and found both unprotected: deleting the `claim: {window}` print and the `claim(s)` count fragment left all 9 report tests passing. One assertion was passing for the wrong reason; the other never looked at stdout.

The wiring test deliberately lives in `workflow_lint`'s lane rather than this job's own self-tests: **a test asserting "this job is reachable", run inside that job, cannot fail** -- if the wiring breaks, the job is skipped and the test never runs.

## Scope

Report-only. No gate, no allowlist, no ratchet -- those are C3, after C1 triages the 172. The 54 unresolvable and 49 module-level claims are reported in their own buckets and not triaged; a module has no single symbol a test can reference, and the spec states that gap rather than hiding it.

Branched off `main`; independent of #2843, #2844 and #2845.
