### PR TITLE
fix(sync-claims): prefer a marked-up target over a bare word

### DIFF
--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -34,8 +34,8 @@ this document uses:
 | on a module | 49 | (not triaged, see below) |
 | **total** | **319** | |
 
-**172 of the 216 symbol-level resolvable claims (80%) are unenforced.** 50 of
-the 172 say "byte-identical to" or "identical to".
+**167 of the 216 symbol-level resolvable claims (77%) are unenforced.** 50 of
+the strongest say "byte-identical to" or "identical to".
 
 ### A correction, made while planning
 
@@ -58,6 +58,35 @@ prose, not in markup.
 The cost is a first-match heuristic that can pick the wrong name when a claim
 mentions several symbols. C1 triage classifies those as false positives, and
 the report prints the matched window so a reader can see what it keyed on.
+
+### A third correction, made during C1 triage
+
+Triaging the 50 strongest claims -- the ones saying "byte-identical to", which
+state a property that can actually be checked -- found that **the detector's
+targets were often simply wrong**, and that the rest of this section had been
+measuring the wrong thing.
+
+Not one of the 49 comparable pairs was structurally similar to its resolved
+target. Reading the claim text explained why: `slice` came from "slice one
+bucket off the keyed frame", `min` from "Default ``min(cpu, 8)``", `edge`
+from "the shared edge set", `native` from "the per-block native path". Seven
+of eight sampled targets were wrong. This package declares thousands of
+symbols, many of them ordinary English words, so nearly any prose sentence
+contains one and a first-match rule finds it.
+
+The one correct target in that sample was the one the author had written in
+backticks. `claims()` now prefers a MARKED-UP target -- ``` ``x`` ```,
+`` `x` ``, or a Sphinx role -- and falls back to a bare word only when the
+window carries no markup. That corrects 26 of the 216 resolvable claims
+outright (`slice` -> `score_buckets`, `native` -> `_fs_native_eligible`,
+`dedupe` -> `dedupe_df`, `value` -> `value_frequencies`) and moves the
+unenforced count from 172 to **167**: five findings were false because their
+target was.
+
+**The bare-word fallback is not vestigial.** 103 of the 216 claims carry no
+markup at all, including this phase's motivating incident ("mirrors
+run_dedupe but returns EngineResult"). Deleting the fallback fails the
+incident test -- verified by sabotage.
 
 ### A second correction, made while finishing Task 1
 
@@ -175,7 +204,7 @@ reference `_run_pipeline`, 10 reference `run_dedupe`, **0 reference both**.
 **Sound as a negative, suggestive as a positive.** No co-reference genuinely
 proves that nothing compares the two. Co-reference proves only that one file
 mentions both, never that it compares them. So the finding is the unenforced
-set; the 44 possibly-enforced claims are reported as UNVERIFIED and never as
+set; the 49 possibly-enforced claims are reported as UNVERIFIED and never as
 safe.
 
 This is A and B's inversion. A resolved declared liveness (registries) and
@@ -236,21 +265,23 @@ enforcement check, report. Exit criterion: it extracts
 `_run_pipeline --mirrors--> run_dedupe` from a checked-in fixture and classifies
 it unenforced.
 
-**C1 — triage all 172 symbol-level findings.** Every finding classified as: enforceable and should be /
+**C1 — triage all 167 symbol-level findings.** Every finding classified as: enforceable and should be /
 claim is stale because the coupling is gone / already drifted, therefore a
 defect / false positive. Exit criterion: every finding carries a classification
 and a reason. **Start with the 50 "byte-identical to" / "identical to" claims** — unlike
 "mirrors", that phrasing states a property that can actually be checked, so
 triaging one either produces an enforcing test or discovers a drifted pair.
 Budget for the first-match heuristic's measured cost while triaging the rest:
-13 of the 172 findings (7.6%) resolve to a generic word, picked up because it
-happens to also be the first declared symbol name in the 200-character window,
-rather than because the claim is about it. **The rule that produces 13**, so a
-reader can reproduce the figure rather than take it on trust: a target of three
-characters or fewer, OR one drawn from a fixed common-word set (`min`, `max`,
-`row`, `key`, `run`, `sum`, `len`, `get`, `set`, `add`, `map`, `all`, `any`,
-`col`, `val`, `obj`, `idx`). Both halves independently select the same 13, of
-which `row` accounts for 6 and `key` for 3. Those are false positives by construction, not
+**83 of the 167 findings (50%) resolve their target from author MARKUP** --
+``` ``x`` ```, `` `x` ``, or a Sphinx role -- and the other 84 from the
+bare-word fallback. Triage the bare-word half first: it is where a wrong
+target lives, because this package declares thousands of symbols and many are
+ordinary English words. That split is the reproducible confidence signal, and
+it replaces an earlier "13 of 172 resolve to a generic word (7.6%)" figure
+that was measured with a length-and-common-word proxy. **The proxy was badly
+wrong.** It counted `min`, `row` and `key` but missed `slice`, `edge`,
+`native`, `value` and `pair` -- and reading the claim text for the 50
+strongest claims showed 7 of 8 sampled targets were wrong, not 1 in 13. Those are false positives by construction, not
 edge cases; expect roughly one in thirteen findings to be one.
 
 **C2 — remediation, one per PR.** Enforcing tests where the property holds;
@@ -296,7 +327,7 @@ that the sabotage actually landed before reading the test result.
 ## Success criteria
 
 - The detector extracts and reports the motivating incident from a fixture.
-- Every one of the 172 findings carries a classification and a reason.
+- Every one of the 167 findings carries a classification and a reason.
 - Every claim surviving triage is either enforced or recorded with why it stands.
 - No claim is deleted while its coupling remains.
 - Every "byte-identical to" claim is either enforced by a test or recorded as a

--- a/scripts/sync_claims/claims.py
+++ b/scripts/sync_claims/claims.py
@@ -40,6 +40,49 @@ WINDOW = 200
 
 _WORD = re.compile(r"[A-Za-z_][\w.]*")
 
+# A target the author MARKED UP as code: ``x``, `x`, or a Sphinx role such as
+# :func:`~mod.x`. Preferred over a bare word, because a bare word is how the
+# scan went wrong.
+_MARKED = re.compile(r"``([A-Za-z_][\w.]*)``|`([A-Za-z_][\w.]*)`|:\w+:`~?([A-Za-z_][\w.]*)`")
+
+
+def _resolve_target(window: str, known: set[str], claimant: str) -> str | None:
+    """The symbol a claim names, preferring one the author wrote as code.
+
+    MARKED-UP FIRST, bare word only as a fallback. This package declares
+    thousands of symbols, many of them ordinary English words -- `slice`,
+    `edge`, `native`, `value`, `pair`, `min`, `row` -- so almost any prose
+    sentence contains one, and a plain first-match rule finds it instead of
+    the real target. Measured during the C1 triage on the 50 strongest claims
+    ("byte-identical to"), 7 of 8 sampled targets were wrong that way:
+    `slice` came from "slice one bucket off the keyed frame", `min` from
+    "Default ``min(cpu, 8)``", `edge` from "the shared edge set". The one
+    correct target in that sample was the one in backticks.
+
+    Preferring markup corrects 26 of the 216 resolvable claims outright --
+    `slice` -> `score_buckets`, `native` -> `_fs_native_eligible`,
+    `dedupe` -> `dedupe_df`, `value` -> `value_frequencies`.
+
+    The bare-word fallback stays, and is not vestigial: 103 of 216 claims
+    carry no markup at all, INCLUDING this phase's motivating incident, whose
+    docstring reads "mirrors run_dedupe but returns EngineResult". Dropping
+    the fallback would lose the one case the detector exists to catch.
+
+    `_WORD`'s continuation class includes ".", so a word immediately followed
+    by sentence-ending punctuation ("...mirrors helper.") matches WITH the
+    period; rstrip before taking the dotted tail or "helper." never equals
+    "helper".
+    """
+    for pattern, groups in ((_MARKED, True), (_WORD, False)):
+        for found in pattern.findall(window):
+            for word in found if groups else (found,):
+                if not word:
+                    continue
+                tail = word.rstrip(".").split(".")[-1]
+                if tail in known and tail != claimant:
+                    return tail
+    return None
+
 
 @dataclass(frozen=True)
 class Claim:
@@ -101,19 +144,7 @@ def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
             is_module = isinstance(node, ast.Module)
             name = "<module>" if is_module else node.name
             window = doc[match.end() : match.end() + WINDOW]
-            # _WORD's continuation class includes "." so a word immediately
-            # followed by sentence-ending punctuation (e.g. "...mirrors
-            # helper.") is matched WITH the trailing period. rstrip it before
-            # taking the dotted tail, or "helper." never equals "helper".
-            target = next(
-                (
-                    tail
-                    for word in _WORD.findall(window)
-                    for tail in (word.rstrip(".").split(".")[-1],)
-                    if tail in known and tail != name
-                ),
-                None,
-            )
+            target = _resolve_target(window, known, name)
             out.append(
                 Claim(
                     module=rel,

--- a/scripts/test_sync_claims_claims.py
+++ b/scripts/test_sync_claims_claims.py
@@ -118,3 +118,75 @@ def test_a_bom_prefixed_file_is_not_skipped(tmp_path):
         b"\xef\xbb\xbf" + b'def a():\n    """Mirrors b."""\n\n\ndef b():\n    pass\n'
     )
     assert [c.target for c in claims(tmp_path)] == ["b"]
+
+
+def test_a_marked_up_target_wins_over_an_earlier_bare_word(tmp_path):
+    """The bare word comes FIRST in the window and must still lose.
+
+    This package declares thousands of symbols, many of them ordinary English
+    words, so a plain first-match rule resolves "slice one bucket off the
+    keyed frame" to `slice`. Measured on the 50 strongest claims during C1
+    triage, 7 of 8 sampled targets were wrong that way.
+    """
+    (tmp_path / "m.py").write_text(
+        '''
+def claimant():
+    """Byte-identical to the slice path -- see ``score_buckets``."""
+
+
+def slice():
+    pass
+
+
+def score_buckets():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert len(found) == 1
+    assert found[0].target == "score_buckets", (
+        f"resolved to {found[0].target!r}; `slice` appears earlier in the window "
+        f"but ``score_buckets`` is the one the author marked up as code"
+    )
+
+
+def test_the_bare_word_fallback_still_resolves_when_there_is_no_markup(tmp_path):
+    """103 of 216 real claims carry no markup at all -- including this
+    phase's motivating incident ("mirrors run_dedupe but returns
+    EngineResult"). Dropping the fallback loses the one case the detector
+    exists to catch."""
+    (tmp_path / "m.py").write_text(
+        '''
+def claimant():
+    """Mirrors run_dedupe but returns EngineResult."""
+
+
+def run_dedupe():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert found[0].target == "run_dedupe"
+
+
+def test_a_sphinx_role_target_is_treated_as_marked_up(tmp_path):
+    """`:func:`~mod.name`` is how several goldenmatch docstrings name a target."""
+    (tmp_path / "m.py").write_text(
+        '''
+def claimant():
+    """Mirrors the value path, see :func:`~core.golden.merge_field`."""
+
+
+def value():
+    pass
+
+
+def merge_field():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert found[0].target == "merge_field"


### PR DESCRIPTION
## What and why

C1 triage of the sync-claim detector shipped in #2846 found that its **targets are often simply wrong**, and this fixes the rule that resolves them.

The detector reports docstring claims of the form "X mirrors Y" that no test enforces. Triaging the 50 strongest -- the "byte-identical to" ones, which state a property that can actually be checked -- produced a suspicious result: **not one of the 49 comparable pairs was structurally similar to its resolved target.** That looked like mass drift. Reading the claim text showed the real cause:

| claim resolved to | what the window actually says |
| --- | --- |
| `slice` | "**slice** one bucket off the keyed frame" (a verb) |
| `min` | "Default ``min(cpu, 8)``" (the builtin) |
| `edge` | "the shared **edge** set" (a noun) |
| `native` | "the per-block **native** path" |
| `value` | "the same **value** pairs" |
| `pair` | "the per-**pair** score_pair(...)" |

Seven of eight sampled targets were wrong. `goldenmatch` declares thousands of symbols and plenty are ordinary English words, so nearly any prose sentence contains one -- and a first-match rule finds it instead of the real target.

**The one correct target in that sample was the one the author had written in backticks.**

## The fix

`_resolve_target` now prefers a MARKED-UP target -- ``` ``x`` ```, `` `x` ``, or a Sphinx role such as `` :func:`~mod.x` `` -- and falls back to a bare word only when the window carries no markup.

Measured on the real package:

- **26 of the 216** resolvable claims get a corrected target: `slice` -> `score_buckets`, `native` -> `_fs_native_eligible`, `dedupe` -> `dedupe_df`, `value` -> `value_frequencies`, `transform` -> `apply_transforms`, `materialize` -> `profile_column`.
- Unenforced findings drop **172 -> 167**. Those five were false *only* because their target was.

**The bare-word fallback is not vestigial, and this is the important half.** 103 of the 216 claims carry no markup at all -- including this phase's own motivating incident, whose docstring reads "mirrors run_dedupe but returns EngineResult". Deleting the fallback fails the incident test, which is the case the detector exists to catch.

Sabotage-verified in both directions:
- drop the markup preference -> `test_a_marked_up_target_wins_over_an_earlier_bare_word` and `test_a_sphinx_role_target_is_treated_as_marked_up` fail
- drop the bare-word fallback -> `test_the_incident_claim_is_extracted_with_its_target` fails, along with three others

## The spec's false-positive figure is replaced, not adjusted

It said "13 of 172 resolve to a generic word (7.6%)". That was measured with a length-and-common-word proxy which counted `min`, `row` and `key` but missed `slice`, `edge`, `native`, `value` and `pair`. **It was not 1 in 13; it was closer to 7 in 8.**

The reproducible signal is now the split between targets resolved from markup (**83 of 167**) and from the bare-word fallback (**84**). C1 should triage the bare-word half first, because that is where a wrong target lives. Unlike the old figure, this one is read off a live run rather than derived from a heuristic.

This is the third correction to that one number, each smaller than the error it replaced. The spec now records why the earlier ones were wrong rather than quietly restating a new value.

## Testing

```
scripts/test_sync_claims_{claims,enforcement,report}.py  ->  27 passed
ruff check                                               ->  clean
scripts/check_filter_coverage.py  ->  47 paths / 6 filters, 0 new job-vs-filter gaps
```

Three new tests, each pinning one half of the rule: markup beats an earlier bare word; a Sphinx role counts as markup; the bare-word fallback still resolves when there is no markup.

## Scope

One remediation: the target-resolution rule. No change to enforcement, the report format, the CI job, or the buckets. The full C1 triage of the remaining 167 runs against this corrected detector -- triaging against known-wrong targets would spend the effort classifying false positives and would seed C3's ratchet floor with them.

Branched off `main` after #2846 landed.
