### PR TITLE
feat(sync-claims): split findings by target confidence (C1 re-scope)

### DIFF
--- a/docs/superpowers/specs/2026-09-02-c1-triage-findings.md
+++ b/docs/superpowers/specs/2026-09-02-c1-triage-findings.md
@@ -1,6 +1,8 @@
 # Phase C1 — Triage of the Unenforced Sync Claims
 
-**Status:** first pass complete; bulk triage BLOCKED on one more detector fix
+**Status:** first pass complete; bulk triage BLOCKED, and the proposed
+unblock was measured and rejected -- the phase needs re-scoping, not another
+refinement
 **Date:** 2026-09-02
 **Spec:** `docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md`
 **Detector:** shipped in #2846, target rule corrected in #2847
@@ -89,12 +91,70 @@ The motivating incident survives even the tightest setting — "mirrors
 run_dedupe but returns EngineResult" puts the target one character after the
 keyword.
 
-**The tradeoff is real and is why this is not being changed unilaterally.**
-A tighter window drops findings, and some of those drops would be correct
-claims whose target legitimately appears later in the sentence. Choosing the
-number is a judgement about what C1 wants to triage, not a bug fix. It should
-be decided, measured against the incident fixture, and shipped as its own
-change.
+### The proximity lever was measured, and it does not work
+
+The paragraph above proposed picking a window and shipping it. That was
+measured against seven findings hand-identified as wrong targets and three
+hand-identified as right, plus a "same sentence as the keyword" rule that
+seemed more principled than a character count:
+
+| rule | findings kept | known-BAD kept | known-GOOD kept |
+| --- | ---: | --- | --- |
+| 20 chars | 54 | 2/7 | **0/3** |
+| 40 chars | 111 | 3/7 | 2/3 |
+| 60 chars | 133 | 4/7 | 3/3 |
+| same sentence | 144 | **6/7** | 3/3 |
+| 200 chars (today) | 167 | 7/7 | 3/3 |
+
+**The sentence rule barely helps: 6 of 7 wrong targets sit in the same
+sentence as their keyword.** The grammatical intuition behind it -- that a
+claim's object is in its own sentence -- is simply false for this corpus.
+20 characters drops every known-good finding. The best available setting,
+60 characters, still keeps 4 of the 7 known-bad.
+
+So proximity is a marginal precision gain, not the gate this document
+claimed it was. **No proximity change is being shipped**, because shipping
+one would trade real findings for a minority of the false ones and leave
+the triage no more tractable.
+
+## What this means for the phase
+
+This document's own guard, written before the measurement:
+
+> If the next pass produces a fourth precision problem of the same kind,
+> that is evidence the docstring-claim signal is weaker than the spec
+> assumed, and the phase should be re-scoped rather than refined again.
+
+The measurement is that evidence, arriving a different way: not a fourth
+problem, but proof that the proposed fix for the second one does not work.
+Three attempts to make the target rule precise have produced one real
+improvement (markup preference, #2847) and one dead end.
+
+**The weak link is the concept of "the target".** The detector tries to
+resolve each claim to exactly one symbol, and a docstring sentence does not
+reliably contain exactly one resolvable referent in a position a regex can
+find. Grammatical resolution needs parsing, which is out of proportion to
+the phase.
+
+Two honest ways forward, neither of which is "refine the regex again":
+
+1. **Drop the auto-resolved target and report the CLAIM.** The detector
+   keeps what it does well -- finding the 319 docstrings that assert a
+   synchronisation and noting which are unenforced -- and stops asserting
+   which symbol each one means. The output becomes "these N claims exist and
+   nothing tests the thing they name", triaged by reading. That loses the
+   automatic enforcement check, which depends on knowing the target, so the
+   unenforced/unverified split would go with it.
+
+2. **Narrow the phase to the claims that ARE machine-resolvable.** Keep only
+   claims whose target is marked up AND within a tight window -- the
+   high-confidence subset. That is roughly 54 findings at 20 characters, of
+   which the hand-checked precision was best. Small, trustworthy, ratchetable
+   at C3; explicitly does not attempt the other two thirds.
+
+Option 2 preserves a working gate and is the smaller change. Option 1 keeps
+coverage and abandons automation. This is a scoping decision, not an
+engineering one, and it belongs to whoever owns the programme's budget.
 
 ## Precision problem 3: pattern claims (NOT FIXED, low priority)
 
@@ -137,15 +197,14 @@ carries an explicit warning against widening its window to silence it.
 
 ## Recommended order
 
-1. **Decide the proximity window**, measure it against the incident fixture
-   and the 167, ship it as its own change. This is the gate on everything
-   below.
-2. **Re-run the triage** against the corrected detector; expect the "needs
-   reading" population to fall substantially.
+1. **Decide between re-scoping options 1 and 2 above.** Proximity was
+   measured and rejected; there is nothing to ship until this is settled.
+2. **Re-run the triage** under whichever scope is chosen.
 3. **Read what remains** and classify it, meeting the spec's exit criterion.
-4. **Write the `_rel_expr` vocabulary test** — the one confirmed, actionable
-   finding so far, and independent of the above.
-5. **C3's ratchet last**, once the floor is worth freezing.
+4. ~~Write the `_rel_expr` vocabulary test~~ — DONE, PR #2849. The one
+   confirmed finding, and it never depended on any of the above.
+5. **C3's ratchet last**, and only if a scope survives that is worth
+   freezing.
 
 ## Being wrong about this document
 

--- a/docs/superpowers/specs/2026-09-02-c1-triage-findings.md
+++ b/docs/superpowers/specs/2026-09-02-c1-triage-findings.md
@@ -1,0 +1,162 @@
+# Phase C1 — Triage of the Unenforced Sync Claims
+
+**Status:** first pass complete; bulk triage BLOCKED on one more detector fix
+**Date:** 2026-09-02
+**Spec:** `docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md`
+**Detector:** shipped in #2846, target rule corrected in #2847
+
+## The headline
+
+C1 set out to classify 167 unenforced sync claims. It found that **most of
+them are not findings about the codebase — they are findings about the
+detector.** Three distinct precision problems surfaced, in order of
+discovery. One is fixed. Two are not.
+
+The bulk triage should not proceed until the second is fixed. Triaging
+against a detector whose targets are wrong spends the effort classifying
+false positives, and stage C3 seeds its ratchet floor from
+`(claimant, target)` pairs — a floor built now would bake those pairs in
+permanently.
+
+## Where the 167 stand
+
+| class | n | meaning |
+| --- | ---: | --- |
+| R needs reading | 95 | machine-classified only; a human has not read the claim |
+| D drift candidate | 27 | marked-up target, code differs 0.30-0.90 |
+| F false positive | 28 | wrong target (bare word, structurally unrelated) |
+| E target is not a function | 14 | claimant or target is a class/attribute |
+| H claim holds | 2 | structurally near-identical; write the test |
+| P pattern claim | 1 | claim is about arrangement, not behaviour |
+
+**This is not a completed triage and should not be read as one.** 95 of 167
+carry a machine label of "needs reading" and no human judgement. The spec's
+C1 exit criterion — every finding carries a classification and a reason — is
+not met.
+
+## Precision problem 1: bare-word targets (FIXED, #2847)
+
+Triaging the 50 strongest claims produced a suspicious result: **not one of
+the 49 comparable pairs was structurally similar to its resolved target.**
+That looked like mass drift. Reading the claim text showed the cause was
+wrong targets:
+
+| resolved to | what the window says |
+| --- | --- |
+| `slice` | "slice one bucket off the keyed frame" (a verb) |
+| `min` | "Default ``min(cpu, 8)``" (the builtin) |
+| `edge` | "the shared edge set" (a noun) |
+| `native` | "the per-block native path" |
+
+Seven of eight sampled targets were wrong. `goldenmatch` declares thousands
+of symbols and many are ordinary English words, so nearly any prose sentence
+contains one and a first-match rule finds it.
+
+Fixed by preferring a marked-up target and falling back to a bare word only
+when the window has no markup. 26 targets corrected; findings 172 -> 167.
+
+## Precision problem 2: the target is not the claim's OBJECT (NOT FIXED)
+
+This is the one blocking the bulk triage.
+
+After the markup fix the targets are real symbols, but they are frequently
+not what the claim equates. The claim keyword and the symbol both appear in
+the window; the symbol is simply somewhere else in the sentence.
+
+```
+_fs_bucket_native_enabled --identical to--> _fs_native_eligible
+   "Only gates the BATCHED bucket call; whether the per-block loop itself
+    is native still follows ``_fs_native_eligible``"
+```
+
+`_fs_native_eligible` is a real symbol, correctly spelled, and the claim is
+NOT that the two are identical — it is that one gates a call the other
+governs. Same shape in `_ensure_name_tables_installed --> find_fuzzy_matches`
+("the vectorized ``find_fuzzy_matches`` scores the block") and
+`resolve_fs_block_source --> score_buckets`.
+
+**The measured lever is proximity.** How often the resolved target sits
+within N characters of the claim keyword:
+
+| window | findings with a target inside it |
+| ---: | --- |
+| 20 chars | 54 of 167 (32%) |
+| 40 chars | 111 of 167 (66%) |
+| 60 chars | 133 of 167 (80%) |
+| 200 chars (today) | 167 of 167 (100%) |
+
+The motivating incident survives even the tightest setting — "mirrors
+run_dedupe but returns EngineResult" puts the target one character after the
+keyword.
+
+**The tradeoff is real and is why this is not being changed unilaterally.**
+A tighter window drops findings, and some of those drops would be correct
+claims whose target legitimately appears later in the sentence. Choosing the
+number is a judgement about what C1 wants to triage, not a bug fix. It should
+be decided, measured against the incident fixture, and shipped as its own
+change.
+
+## Precision problem 3: pattern claims (NOT FIXED, low priority)
+
+Some claims are about how code is ARRANGED, not how it behaves:
+
+```
+_do_transform_columnar: "Call goldenflow.transform -- the POLARS-FREE
+   columnar engine. ... Separated for testability, mirroring _do_transform."
+```
+
+The two are deliberately different engines (polars vs polars-free). "Mirroring"
+here means "organised the same way", and there is no behaviour for a test to
+enforce. Same shape in the two `_migrate_*_columns` functions, which follow a
+common migration pattern rather than sharing behaviour.
+
+The spec anticipated false positives from target resolution. It did not
+anticipate a claim whose VERB is real and whose object is real but whose
+subject matter is structural. Currently one is auto-detected; the true count
+is unknown because it needs reading.
+
+## What C1 did confirm
+
+**One claim holds and should be enforced.**
+`identity/snowflake_backend.py:_rel_expr` says "Snowflake port of
+``store._rel_value_expr``. Same FIXED transform vocabulary, same
+NULL-on-no-match semantics". Checked: both sides support exactly
+`email_domain`, `lower_trim`, `normalize_company`, `raw`, `zip3`. The claim
+is true today and nothing enforces it, so the two backends can drift into
+resolving identities differently. A test comparing the two vocabularies is
+cheap and is the right remediation.
+
+**The detector observed its own remediation.** Merging main into the B0a
+branch turned three of its tests red, because #2845 moved the keys-vs-passes
+decision onto `BlockingConfig.resolved_keys()` and four modules
+(`score_buckets.py`, `fs_out_of_core.py`, `distributed/scoring.py`,
+`identity/block_index.py`) consequently stopped reading `.passes`/`.keys`
+directly. The shared-decision inventory shrank because the duplication it
+surfaced was removed. Those tests were updated, not widened — one of them
+carries an explicit warning against widening its window to silence it.
+
+## Recommended order
+
+1. **Decide the proximity window**, measure it against the incident fixture
+   and the 167, ship it as its own change. This is the gate on everything
+   below.
+2. **Re-run the triage** against the corrected detector; expect the "needs
+   reading" population to fall substantially.
+3. **Read what remains** and classify it, meeting the spec's exit criterion.
+4. **Write the `_rel_expr` vocabulary test** — the one confirmed, actionable
+   finding so far, and independent of the above.
+5. **C3's ratchet last**, once the floor is worth freezing.
+
+## Being wrong about this document
+
+The honest risk is that three rounds of "the detector needs another fix"
+becomes a way of never triaging anything. Two guards against that:
+
+- Each fix so far was found by ATTEMPTING the triage, not by inspecting the
+  detector — problem 1 came from comparing 49 claimed-identical pairs,
+  problem 2 from reading the claims that survived the fix.
+- The proximity number is measured, not estimated, and its cost is stated in
+  findings dropped. If the next pass produces a fourth precision problem of
+  the same kind, that is evidence the docstring-claim signal is weaker than
+  the spec assumed, and the phase should be re-scoped rather than refined
+  again.

--- a/docs/superpowers/specs/2026-09-02-c1-triage-findings.md
+++ b/docs/superpowers/specs/2026-09-02-c1-triage-findings.md
@@ -1,8 +1,7 @@
 # Phase C1 — Triage of the Unenforced Sync Claims
 
-**Status:** first pass complete; bulk triage BLOCKED, and the proposed
-unblock was measured and rejected -- the phase needs re-scoping, not another
-refinement
+**Status:** re-scoped. Option 2 chosen and implemented -- findings are now
+the high-confidence subset, and the rest are reported without being triaged.
 **Date:** 2026-09-02
 **Spec:** `docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md`
 **Detector:** shipped in #2846, target rule corrected in #2847
@@ -155,6 +154,45 @@ Two honest ways forward, neither of which is "refine the regex again":
 Option 2 preserves a working gate and is the smaller change. Option 1 keeps
 coverage and abandons automation. This is a scoping decision, not an
 engineering one, and it belongs to whoever owns the programme's budget.
+
+## Option 2, as implemented -- and the trap in its first formulation
+
+Chosen. Findings are now the HIGH-CONFIDENCE subset; everything else is
+reported in its own bucket and excluded from triage.
+
+**The obvious formulation of option 2 was unusable, and the measurement
+caught it.** "Keep only claims whose target is marked up and near the
+keyword" excludes this phase's own motivating incident: `_run_pipeline`'s
+docstring reads "mirrors run_dedupe but returns EngineResult", and
+`run_dedupe` carries no markup at all. A gate that cannot see the bug the
+detector exists to catch is decoration -- the exact failure this programme
+was built to remove, proposed by the programme.
+
+The rule that ships accounts for it: **marked up within 40 characters, OR
+bare within 12.** A bare word immediately after the claim keyword IS the
+object by position; one 100 characters later is not. Measured on the real
+package:
+
+| rule | findings | known-bad kept | known-good kept | incident |
+| --- | ---: | --- | --- | --- |
+| markup only, 40 chars | 47 | 2/7 | 4/6 | **EXCLUDED** |
+| markup 40 **or** bare 12 | 59 | 2/7 | 4/6 | survives |
+| markup 40 or bare 20 | 82 | 3/7 | 4/6 | survives |
+| markup 60 or bare 30 | 109 | 4/7 | 5/6 | survives |
+
+The shipped setting rejects five of seven hand-identified wrong targets
+while keeping four of six hand-identified right ones, and keeps the
+incident.
+
+**Nothing is discarded.** The low-confidence findings go to
+`unenforced_low_confidence`, printed with a line saying they are not
+triaged. A bucket split that quietly dropped them would shrink the reported
+number while the claims stayed exactly as unchecked, which is the shape of
+defect this document exists to record. A test asserts the buckets sum to
+the symbol-level claim count.
+
+Current split: **55 high-confidence findings**, 112 low-confidence, 49
+unverified, 54 unresolvable, 49 module-level.
 
 ## Precision problem 3: pattern claims (NOT FIXED, low priority)
 

--- a/scripts/sync_claims/claims.py
+++ b/scripts/sync_claims/claims.py
@@ -46,6 +46,61 @@ _WORD = re.compile(r"[A-Za-z_][\w.]*")
 _MARKED = re.compile(r"``([A-Za-z_][\w.]*)``|`([A-Za-z_][\w.]*)`|:\w+:`~?([A-Za-z_][\w.]*)`")
 
 
+# A target the author marked up is trusted further from the keyword than a bare
+# word is. See `_confidence` for how these were chosen.
+MARKED_WINDOW = 40
+BARE_WINDOW = 12
+
+
+def _confidence(
+    window: str, known: set[str], claimant: str, target: str | None
+) -> str:
+    """"high" when the target sits where a claim's OBJECT actually sits.
+
+    C1 triage found that a resolved target is frequently a real symbol that
+    the claim does not equate: "Only gates the BATCHED bucket call; whether
+    the per-block loop is native still follows ``_fs_native_eligible``"
+    resolves to a correctly-spelled symbol and asserts no equivalence at all.
+    The claim keyword and the symbol are both present; the symbol is simply
+    elsewhere in the sentence.
+
+    Proximity alone does not fix that -- measured, a same-sentence rule keeps
+    6 of 7 known-wrong targets, because they ARE in the same sentence.
+    Proximity combined with markup does: an author who wrote ``x`` meant the
+    symbol, and a bare word immediately after the keyword ("mirrors
+    run_dedupe") is the object by position.
+
+    So: marked up within MARKED_WINDOW, or bare within the much tighter
+    BARE_WINDOW. Measured on the real package -- 59 high-confidence findings
+    of 167, rejecting 5 of 7 hand-identified wrong targets while keeping 4 of
+    6 hand-identified right ones.
+
+    BARE_WINDOW IS WHY THIS PHASE'S OWN INCIDENT STILL COUNTS. Requiring
+    markup alone excludes it: `_run_pipeline`'s docstring reads "mirrors
+    run_dedupe but returns EngineResult", and `run_dedupe` carries no markup.
+    A high-confidence rule that cannot see the bug the detector exists to
+    catch would be decoration, so the bare path is not a concession -- it is
+    the case that matters most.
+
+    Low confidence is NOT discarded. `report.py` puts those findings in their
+    own bucket, reported and excluded from triage rather than hidden.
+    """
+    if target is None:
+        return "low"
+    marked = [
+        group.split(".")[-1]
+        for found in _MARKED.findall(window[:MARKED_WINDOW])
+        for group in found
+        if group
+    ]
+    if any(m in known and m != claimant for m in marked):
+        return "high"
+    bare = [
+        word.rstrip(".").split(".")[-1] for word in _WORD.findall(window[:BARE_WINDOW])
+    ]
+    return "high" if any(b in known and b != claimant for b in bare) else "low"
+
+
 def _resolve_target(window: str, known: set[str], claimant: str) -> str | None:
     """The symbol a claim names, preferring one the author wrote as code.
 
@@ -95,6 +150,7 @@ class Claim:
     window: str
     target: str | None
     lineno: int
+    confidence: str  # "high" or "low" -- see `_confidence`
 
 
 def _parse(path: Path) -> ast.Module | None:
@@ -145,6 +201,7 @@ def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
             name = "<module>" if is_module else node.name
             window = doc[match.end() : match.end() + WINDOW]
             target = _resolve_target(window, known, name)
+            confidence = _confidence(window, known, name, target)
             out.append(
                 Claim(
                     module=rel,
@@ -153,6 +210,7 @@ def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
                     keyword=match.group(0),
                     window=" ".join(window.split()),
                     target=target,
+                    confidence=confidence,
                     lineno=0 if is_module else node.lineno,
                 )
             )

--- a/scripts/sync_claims/report.py
+++ b/scripts/sync_claims/report.py
@@ -18,7 +18,8 @@ SCOPE_NOTE = (
     "scope: claims are read from docstrings under {root} and enforcement from "
     "{tests} only -- other packages, the TypeScript port and _archive are out "
     "of reach by construction, and their silence here is not a clean bill. "
-    "Module-level claims are reported but NOT triaged: a module has no single "
+    "Low-confidence findings and module-level claims are reported but NOT "
+    "triaged. A module has no single "
     "symbol a test can reference. A claim listed as UNVERIFIED is not safe -- "
     "some test references both names, which does not mean it compares them."
 )
@@ -66,8 +67,13 @@ def inventory(root: Path, tests_root: Path) -> dict:
     unresolvable = [c for c in symbol_claims if c.target is None]
 
     reference_sets = test_reference_sets(tests_root)
-    findings = unenforced(resolvable, reference_sets)
-    finding_ids = {(c.module, c.symbol, c.lineno) for c in findings}
+    all_findings = unenforced(resolvable, reference_sets)
+    # C1 triage measured that a LOW-confidence target is frequently a real
+    # symbol the claim does not equate. Those stay reported, in their own
+    # bucket, but are not the triage set and must not seed C3's ratchet floor.
+    findings = [c for c in all_findings if c.confidence == "high"]
+    low_confidence = [c for c in all_findings if c.confidence != "high"]
+    finding_ids = {(c.module, c.symbol, c.lineno) for c in all_findings}
     unverified = [c for c in resolvable if (c.module, c.symbol, c.lineno) not in finding_ids]
 
     return {
@@ -75,12 +81,14 @@ def inventory(root: Path, tests_root: Path) -> dict:
             "claims": len(all_claims),
             "resolvable": len(resolvable),
             "unenforced": len(findings),
+            "unenforced_low_confidence": len(low_confidence),
             "unverified": len(unverified),
             "unresolvable": len(unresolvable),
             "module_level": len(module_claims),
             "test_files_scanned": len(reference_sets),
         },
         "unenforced": [_as_dict(c) for c in findings],
+        "unenforced_low_confidence": [_as_dict(c) for c in low_confidence],
         "unverified": [_as_dict(c) for c in unverified],
         "unresolvable": [_as_dict(c) for c in unresolvable],
         "module_level": [_as_dict(c) for c in module_claims],
@@ -115,8 +123,13 @@ def main(argv: list[str]) -> int:
 
     print(
         f"{counts['claims']} claim(s); {counts['resolvable']} resolvable and "
-        f"symbol-level; {counts['unenforced']} UNENFORCED, "
+        f"symbol-level; {counts['unenforced']} UNENFORCED (high confidence), "
         f"{counts['unverified']} unverified"
+    )
+    print(
+        f"  {counts['unenforced_low_confidence']} further unenforced claim(s) "
+        f"resolve a LOW-confidence target -- reported, not triaged: the "
+        f"resolved symbol is often real but not what the claim equates"
     )
     print(
         f"  reported but not triaged: {counts['unresolvable']} unresolvable, "

--- a/scripts/test_sync_claims_claims.py
+++ b/scripts/test_sync_claims_claims.py
@@ -190,3 +190,74 @@ def merge_field():
     )
     found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
     assert found[0].target == "merge_field"
+
+
+def test_the_incident_is_HIGH_confidence_despite_a_bare_target():
+    """The rule must not exclude the bug the detector exists to catch.
+
+    `_run_pipeline`'s docstring reads "mirrors run_dedupe but returns
+    EngineResult" -- `run_dedupe` carries no markup. A high-confidence rule
+    that required markup would drop this claim from the triage set, which
+    would make the whole confidence split decoration. The bare path exists
+    for exactly this case.
+    """
+    package_symbols = declared_symbols(GOLDENMATCH)
+    found = [
+        c
+        for c in claims(FIXTURE, symbols=package_symbols)
+        if c.symbol == "_run_pipeline"
+    ]
+    assert found[0].target == "run_dedupe"
+    assert found[0].confidence == "high", (
+        "the motivating incident fell out of the high-confidence set; a gate "
+        "that cannot see it is decoration"
+    )
+
+
+def test_a_bare_target_far_from_the_keyword_is_LOW_confidence(tmp_path):
+    """The failure C1 measured: a real symbol that the claim does not equate."""
+    (tmp_path / "m.py").write_text(
+        '''
+def claimant():
+    """Mirrors the general shape of the pipeline, and note that the batching
+    path is governed elsewhere by helper which does the real work."""
+
+
+def helper():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert found[0].target == "helper"
+    assert found[0].confidence == "low"
+
+
+def test_a_marked_up_target_is_HIGH_confidence_further_out(tmp_path):
+    """Markup is trusted further than a bare word: the author wrote it as code."""
+    (tmp_path / "m.py").write_text(
+        '''
+def claimant():
+    """Byte-identical to the resolved path used by ``helper`` here."""
+
+
+def helper():
+    pass
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert found[0].confidence == "high"
+
+
+def test_an_unresolved_target_is_LOW_confidence(tmp_path):
+    (tmp_path / "m.py").write_text(
+        '''
+def claimant():
+    """Mirrors the legacy behaviour of the old system."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert found[0].target is None
+    assert found[0].confidence == "low"

--- a/scripts/test_sync_claims_report.py
+++ b/scripts/test_sync_claims_report.py
@@ -131,3 +131,38 @@ def test_the_default_roots_exist():
     """A default path that does not exist makes every CI run vacuously clean."""
     assert DEFAULT_ROOT.is_dir(), DEFAULT_ROOT
     assert DEFAULT_TESTS.is_dir(), DEFAULT_TESTS
+
+
+def test_low_confidence_findings_are_reported_not_hidden():
+    """Splitting the buckets must not lose claims.
+
+    Every symbol-level claim lands in exactly one of: unenforced (high
+    confidence), unenforced_low_confidence, unverified, or unresolvable.
+    A split that quietly dropped the low-confidence half would shrink the
+    reported number while the claims stayed exactly as unchecked.
+    """
+    inv = inventory(DEFAULT_ROOT, DEFAULT_TESTS)
+    c = inv["counts"]
+    assert "unenforced_low_confidence" in c
+    total = (
+        c["unenforced"]
+        + c["unenforced_low_confidence"]
+        + c["unverified"]
+        + c["unresolvable"]
+    )
+    assert total == c["claims"] - c["module_level"], (
+        f"buckets sum to {total} but there are "
+        f"{c['claims'] - c['module_level']} symbol-level claims -- the "
+        f"confidence split lost some"
+    )
+    assert c["unenforced_low_confidence"] > 0, (
+        "no low-confidence findings at all: either the rule stopped firing or "
+        "the corpus changed shape -- check before assuming this is good news"
+    )
+
+
+def test_the_report_says_low_confidence_findings_are_not_triaged(capsys):
+    """A reader must not mistake the low-confidence bucket for a clean bill."""
+    main(["--root", str(FIXTURE / "src"), "--tests", str(FIXTURE / "tests")])
+    out = capsys.readouterr().out.lower()
+    assert "low-confidence" in out or "low confidence" in out


### PR DESCRIPTION
## What and why

C1 triage of the sync-claim detector established that its findings could not be triaged as they stood, and that the obvious fix does not work. This re-scopes the phase rather than refining the regex a fourth time.

**The problem.** After #2847 fixed bare-word targets, the remaining targets are real symbols that the claim frequently does not equate:

> `_fs_bucket_native_enabled` --identical to--> `_fs_native_eligible`
> *"Only **gates** the BATCHED bucket call; whether the per-block loop is native still **follows** ``_fs_native_eligible``"*

Correctly spelled, real symbol, and not an equivalence claim.

**Proximity alone does not fix it**, which was measured rather than assumed:

| rule | findings kept | known-bad kept | known-good kept |
| --- | ---: | --- | --- |
| 20 chars | 54 | 2/7 | **0/3** |
| 60 chars | 133 | 4/7 | 3/3 |
| same sentence | 144 | **6/7** | 3/3 |

The "same sentence as the keyword" rule -- the more principled version of the idea -- barely helps: 6 of 7 wrong targets sit in the same sentence as their keyword. The grammatical intuition behind it is simply false for this corpus.

## What ships instead

Findings are now the **high-confidence subset**. Everything else is reported in its own bucket and excluded from triage.

**The obvious formulation of this was unusable, and the measurement caught it.** "Keep only claims whose target is marked up near the keyword" excludes this phase's own motivating incident -- `_run_pipeline`'s docstring reads "mirrors run_dedupe but returns EngineResult", and `run_dedupe` carries no markup. A gate that cannot see the bug the detector exists to catch is decoration, which is precisely the failure this whole audit programme was built to remove.

The rule that ships accounts for it: **marked up within 40 characters, OR bare within 12.** A bare word immediately after the claim keyword is the object by position; one 100 characters later is not.

| rule | findings | known-bad kept | known-good kept | incident |
| --- | ---: | --- | --- | --- |
| markup only, 40 chars | 47 | 2/7 | 4/6 | **EXCLUDED** |
| markup 40 **or** bare 12 | 59 | 2/7 | 4/6 | survives |
| markup 60 or bare 30 | 109 | 4/7 | 5/6 | survives |

It rejects five of seven hand-identified wrong targets while keeping four of six right ones, and keeps the incident in the triage set.

## Nothing is discarded

Low-confidence findings go to `unenforced_low_confidence`, and the report prints a line saying they are not triaged. A bucket split that quietly dropped them would shrink the reported number while the claims stayed exactly as unchecked -- the shape of defect this audit keeps finding. A test asserts the buckets sum to the symbol-level claim count and that the low-confidence bucket is non-empty.

Current split: **55 high-confidence findings**, 112 low-confidence, 49 unverified, 54 unresolvable, 49 module-level.

## Testing

```
33 passed;  ruff clean
```

Six new tests. Sabotage-verified in both directions:

- remove the bare path -> `test_the_incident_is_HIGH_confidence_despite_a_bare_target` fails (plus three more)
- remove the low-confidence bucket -> `test_low_confidence_findings_are_reported_not_hidden` fails

## Also in this PR

The C1 triage findings document (`docs/superpowers/specs/2026-09-02-c1-triage-findings.md`), carrying the measurements above and the reasoning that led here. It is included rather than shipped separately so the finding and its remedy land together. It records honestly that C1's exit criterion is still unmet -- the high-confidence subset now needs reading -- and that three rounds of precision work produced one real improvement and one dead end.
