### PR TITLE
audit(phase B1+B3): triage all 81 shared fields and ratchet the floor

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -534,6 +534,10 @@ dead_code:
 shared_decisions:
   - 'scripts/shared_decisions/**'
   - 'scripts/test_shared_decisions_*.py'
+  # The B3 ratchet does NOT match the glob above -- it is test_no_new_*, not
+  # test_shared_decisions_*. Without this line the job runs a gate whose own
+  # test file cannot re-trigger it. Caught by check_filter_coverage.py.
+  - 'scripts/test_no_new_shared_decisions.py'
   - 'scripts/fixtures/incident_1c843c8a5/**'
   - 'parity/shared_decisions.allow'
   # readers.py rglobs this whole tree to find config-field accessors, so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,6 +890,14 @@ jobs:
         env:
           PYTHONPATH: scripts
         run: uv run python -m shared_decisions.report
+      - name: Ratchet -- no new or diverging shared decision (B3)
+        # Its own step so a failure names the ratchet, not "the self-tests".
+        # No continue-on-error: the floors were triaged in B1 against a real
+        # report, and the central gate (an allowlisted field starting to
+        # diverge) is the 1c843c8a5 recurrence this phase exists to catch.
+        env:
+          PYTHONPATH: scripts
+        run: uv run pytest scripts/test_no_new_shared_decisions.py -q
       - name: Companion A tests
         run: uv run pytest scripts/test_parity_coverage.py -q
       - name: goldenflow suite with native OFF, under coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,7 +881,8 @@ jobs:
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Detector self-tests
-        run: uv run pytest scripts/test_shared_decisions_fields.py scripts/test_shared_decisions_readers.py scripts/test_shared_decisions_allowlist.py scripts/test_shared_decisions_report.py -q
+        # Listed by name, so a new test FILE must be added here or it never runs.
+        run: uv run pytest scripts/test_shared_decisions_fields.py scripts/test_shared_decisions_readers.py scripts/test_shared_decisions_allowlist.py scripts/test_shared_decisions_report.py scripts/test_shared_decisions_shapes.py -q
       - name: Shared-decision inventory
         # Report-only by design: main() returns 0 for a non-empty inventory (a
         # finding is not a failure) and 1 only for a STALE allowlist entry, which

--- a/docs/superpowers/specs/2026-09-02-shared-decision-triage.md
+++ b/docs/superpowers/specs/2026-09-02-shared-decision-triage.md
@@ -1,16 +1,29 @@
 # Phase B1 — Shared-Decision Triage
 
-**Status:** complete
+**Status:** complete; revised during B3 after the detector's recall was measured
 **Date:** 2026-09-02
 **Spec:** `docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md`
 **Predecessor:** phase B0a, the shared-decision inventory (PR #2843)
 
-B0a reported 73 config fields accessed by more than one module. This is the
-triage the spec requires: **every finding carries a classification and a
-reason.** 64 are recorded as agreed in `parity/shared_decisions.allow`; 9 are
-held out so the inventory keeps reporting them.
+B0a reported 73 config fields accessed by more than one module, and B3's
+attribution fix took that to **81**. This is the triage the spec requires:
+**every finding carries a classification and a reason.**
 
-## What separated the 64 from the 9
+| bucket | count | meaning |
+| --- | ---: | --- |
+| `parity/shared_decisions.allow` | 65 | agreed; no reader supplies a conflicting default |
+| `KNOWN_ACTIONABLE` | 3 | a signal fires on a field declared by ONE config class |
+| `KNOWN_AMBIGUOUS` | 12 | a signal fires, but the name is declared on several classes |
+| `HELD_BY_HAND` | 1 | no signal fires; `strategy`, held out on judgement |
+
+The four partition the 81 exactly, and
+`test_the_three_sets_partition_the_shared_fields` enforces that.
+
+**Read the "detector recall" section below before trusting any count here.**
+The first cut of this triage ran against a detector that attributed 23% of the
+config-field accesses in the package.
+
+## What separated the 65 from the 16
 
 B0a's inventory answers "which modules touch this field". It does not answer
 whether those modules had to AGREE about anything, and mostly they did not:
@@ -22,14 +35,13 @@ threshold. Two modules supplying different ones is the `1c843c8a5` shape.
 
 | signal | definition | fields |
 | --- | --- | ---: |
-| A — fallback divergence | >1 module falls back to a DIFFERENT value | 3 |
-| B — unguarded optional | field is nullable; some module falls back, another reads it bare | 6 |
-| neither | no reader supplies anything, or they all supply the same thing | 65 |
+| A — fallback divergence | >1 module falls back to a DIFFERENT value | 4 |
+| B — unguarded optional | field is nullable; some module falls back, another reads it bare | 12 |
+| neither | no reader supplies anything, or they all supply the same thing | 66 |
 
-64 of that 65 are allowlisted; `strategy` is the exception, held out by hand
-(below).
-
-(A and B overlap on `golden_rules`, so the two signals name 8 distinct fields.)
+A and B overlap on `golden_rules`, so 15 distinct fields trip a signal. 65 of
+the 66 no-signal fields are allowlisted; `strategy` is the exception, held out
+by hand (below).
 
 **`strategy` is held out as a ninth, against the signals.** Neither fires on it
 -- no reader supplies a fallback; its 14 modules only compare it against
@@ -127,6 +139,14 @@ function: the sizes come from `_fast_static_block_sizes`, which reads
 The consumer is auto-config's controller, so a wrong profile feeds a planning
 decision. Same reachability caveat as F2.
 
+### F9 — `weight` is defaulted in one module and read bare in two
+
+Signal B, single-class (`MatchkeyField`), so actionable but NOT confirmed.
+`core/autoconfig.py` falls back to `0`/`0.0` at four sites; `core/scorer.py`
+and `spark/config_pipeline.py` read it with no fallback and no None-guard.
+Surfaced only after the attribution fix -- `mk: MatchkeyConfig` was invisible
+before it.
+
 ### F4-F8 — nullable fields read bare by some modules
 
 Signal B only, NOT confirmed. Each needs a per-module reachability check that
@@ -155,6 +175,71 @@ triage and could still carry a semantic disagreement.
 
 That bound is the honest limit of a syntactic pass, and it is why the entries
 say what was checked rather than "agreed".
+
+## Detector recall: the first cut read 23% of the surface
+
+Found while sabotage-checking the B3 ratchet, and it is the most consequential
+thing in this document.
+
+To prove the ratchet's central gate fires on a recurrence of `1c843c8a5`, a
+divergent fallback was planted on an allowlisted field in the real package --
+`core/autoconfig.py`'s `k.transforms or []` became `or ["lower"]`. **The gate
+did not fire.** The sabotage turned out to be invalid rather than the gate
+weak: `k` is a loop variable, and the accessor scan never attributed that site
+at all. But the reason it was invalid was a real recall hole.
+
+Measured across the package: of 5,663 attribute accesses to a known config
+field name, the scan attributed **1,313 (23%)**. The largest single miss was
+`mk`, at 626 accesses -- `mk: MatchkeyConfig` appears as a typed PARAMETER 78
+times, and the scan only ever saw names bound from a config-looking
+*expression*, never from an annotation. `current: GoldenMatchConfig` was
+another 54.
+
+`_annotated_config_names` closes that: a name annotated with any of the 41
+declared config classes counts as a config base. Effect:
+
+| | before | after |
+| --- | ---: | ---: |
+| attributed access sites | 1,313 | 1,849 |
+| shared fields | 73 | 81 |
+| modules reading `fields` | 17 | 26 |
+| modules reading `threshold` | 11 | 18 |
+
+The B1 triage in the sections above was re-run against the wider scan; its
+findings survived and one was added (F9).
+
+**Recall is still not complete.** Annotation binding does not reach an
+unannotated parameter, a name bound from a function's return value, or an
+element of a config collection (`for k in blocking.keys: k.transforms` remains
+invisible -- that is the exact site the invalid sabotage landed on). Every
+count in this document is a FLOOR.
+
+## The inventory is keyed by name, and names collide
+
+Widening recall made a second limit unmissable. An access
+(`cfg.transforms`) does not say which class the object is, so fields are
+grouped by NAME -- and 11 of the 15 signal fields are declared on more than one
+config class.
+
+`transforms` is declared on `BlockingKeyConfig`, `MatchkeyField`,
+`NegativeEvidenceField` and `SortKeyField`. It appeared as a fallback
+divergence purely because `web/routers/autoconfig.py:84` defaults a
+**`MatchkeyField`**'s transforms to `["lowercase", "strip"]`, and that was
+compared against ten `BlockingKeyConfig` readers defaulting to `[]`. Two
+different fields. No divergence.
+
+So a signal is only actionable when the name is declared on exactly ONE class,
+which is what `split_by_ambiguity` computes and what separates
+`KNOWN_ACTIONABLE` from `KNOWN_AMBIGUOUS`. Both confirmed findings survive that
+test: `golden_rules` and `passes` are each single-class.
+
+`keys` moved to `KNOWN_AMBIGUOUS` (`BlockingConfig` and
+`SemanticBlockingConfig`), but F2 is unaffected -- it is carried by `passes`,
+which is not ambiguous.
+
+Resolving the class an access refers to would need type inference the scan does
+not do. Until then, 12 findings are parked rather than claimed, and none of
+them is asserted to be a defect.
 
 ## A defect this triage exposed in B0a
 
@@ -195,7 +280,9 @@ Both were defects in this triage's own first cut, and both are pinned by tests.
 
 ## What B1 does not cover
 
-- The 64 are cleared syntactically, not semantically (above).
+- The 65 are cleared syntactically, not semantically (above).
+- Recall is a floor, not a census -- see "Detector recall" above.
+- 12 findings are parked on name ambiguity and are not claimed as defects.
 - Scope is `packages/python/goldenmatch/goldenmatch` only. `goldenflow`,
   `scripts/`, and the TypeScript port are out of reach by construction, and
   their silence is not a clean bill.

--- a/docs/superpowers/specs/2026-09-02-shared-decision-triage.md
+++ b/docs/superpowers/specs/2026-09-02-shared-decision-triage.md
@@ -66,7 +66,7 @@ back to `[]` and `score_buckets_prefix.py` to `blocking_config.keys`, on
 
 ## Findings
 
-### F1 — `distributed/pipeline.py:281` constructs a config that raises
+### F1 — `distributed/pipeline.py:281` constructs a config that raises  **[FIXED, #2844]**
 
 CONFIRMED. Severity: crash, after the expensive work is done.
 
@@ -92,7 +92,7 @@ discarded on a config default.
 Fix: one line, matching the other three lanes. Not applied here — the spec puts
 remediation in B2, one per PR.
 
-### F2 — `distributed/scoring.py:535` blocks on the wrong field
+### F2 — `distributed/scoring.py:535` blocks on the wrong field  **[FIXED, #2845]**
 
 CONFIRMED, narrow reachability. Severity: silent recall loss.
 
@@ -125,7 +125,7 @@ same answer. So this is reachable only through a user-authored config, not
 through anything auto-config emits today. That is a narrower exposure than the
 original incident, which auto-config produced directly.
 
-### F3 — `core/blocker.py:85-88` and `:311-314` report a key set they did not block on
+### F3 — `core/blocker.py:85-88` and `:311-314` report a key set they did not block on  **[FIXED, #2845]**
 
 CONFIRMED. Severity: wrong telemetry, no wrong records.
 
@@ -163,6 +163,30 @@ this triage did not do.
 Signal B says one reader has thought about None and another has not. It does
 not say the bare reader can ever SEE None. Recorded as open rather than
 confirmed or dismissed.
+
+## Status after remediation
+
+F1 fixed in #2844: the Ray lane's `golden_rules` fallback now matches the
+other three lanes.
+
+F2 and F3 fixed in #2845, together with a third defect the remediation work
+uncovered. Reading the four sites that were supposed to agree showed they
+were not the same rule at all: `multi_pass` carrying only `keys` -- valid,
+and advertised as valid by the schema's own error message -- made
+`_build_multi_pass_blocks` return ZERO blocks on the main path. Silent zero
+pairs, the same symptom as `1c843c8a5`. The keys-vs-passes decision now lives
+on `BlockingConfig.resolved_keys()` and all ten call sites route through it.
+
+**The inventory then observed its own remediation.** Four modules --
+`backends/score_buckets.py`, `backends/fs_out_of_core.py`,
+`distributed/scoring.py`, `identity/block_index.py` -- stopped reading
+`.passes`/`.keys` directly and left the accessor set entirely.
+
+`passes` is still ACTIONABLE, and correctly so: `core/autoconfig.py:4500`
+still resolves `compound_config.passes or list(compound_config.keys or [])`
+unconditionally. That is one of eight plan-building sites deliberately left
+out of #2845's scope -- they construct configs rather than block on them, so
+whether they are defects needs its own analysis. Recorded, not swept.
 
 ## What the 64 allowlist entries do and do not claim
 

--- a/docs/superpowers/specs/2026-09-02-shared-decision-triage.md
+++ b/docs/superpowers/specs/2026-09-02-shared-decision-triage.md
@@ -1,0 +1,207 @@
+# Phase B1 — Shared-Decision Triage
+
+**Status:** complete
+**Date:** 2026-09-02
+**Spec:** `docs/superpowers/specs/2026-09-02-duplication-drift-audit-design.md`
+**Predecessor:** phase B0a, the shared-decision inventory (PR #2843)
+
+B0a reported 73 config fields accessed by more than one module. This is the
+triage the spec requires: **every finding carries a classification and a
+reason.** 64 are recorded as agreed in `parity/shared_decisions.allow`; 9 are
+held out so the inventory keeps reporting them.
+
+## What separated the 64 from the 9
+
+B0a's inventory answers "which modules touch this field". It does not answer
+whether those modules had to AGREE about anything, and mostly they did not:
+five modules iterating `config.blocking.keys` share a field but no decision.
+
+`scripts/shared_decisions/shapes.py` asks the second question. A **decision** is
+a reader supplying something the field does not carry — a fallback value, or a
+threshold. Two modules supplying different ones is the `1c843c8a5` shape.
+
+| signal | definition | fields |
+| --- | --- | ---: |
+| A — fallback divergence | >1 module falls back to a DIFFERENT value | 3 |
+| B — unguarded optional | field is nullable; some module falls back, another reads it bare | 6 |
+| neither | no reader supplies anything, or they all supply the same thing | 65 |
+
+64 of that 65 are allowlisted; `strategy` is the exception, held out by hand
+(below).
+
+(A and B overlap on `golden_rules`, so the two signals name 8 distinct fields.)
+
+**`strategy` is held out as a ninth, against the signals.** Neither fires on it
+-- no reader supplies a fallback; its 14 modules only compare it against
+different literals, which this triage classifies as dispatch. But `strategy` is
+the DISCRIMINATOR the incident turns on: it decides which of `keys`/`passes` is
+correct, and F2 and F3 below are both defects in modules that do not consult it.
+B0a's `test_known_incident_fields_rank_near_the_top` names `strategy` alongside
+`keys` and `passes` and warns against letting it sink. Allowlisting it on a
+syntactic signal would have been a suppression of an explicit earlier judgement
+-- the "wrong merge" the phase-B spec warns about -- so it stays visible.
+
+**Comparison divergence is deliberately NOT a signal.** `strategy == "static"`
+in one module and `== "learned"` in another is dispatch on an enum-ish field,
+which is what those fields are for. An early cut counted it and produced 13
+candidates of which 10 were exactly that — `strategy` alone contributed 20
+"distinct decisions" and no defect.
+
+The classifier finds `1c843c8a5` from the checked-in fixture, not from git
+history: on `scripts/fixtures/incident_1c843c8a5/`, `blocker_prefix.py` falls
+back to `[]` and `score_buckets_prefix.py` to `blocking_config.keys`, on
+`passes`. That is `test_the_motivating_incident_is_reported_from_the_checked_in_fixture`.
+
+## Findings
+
+### F1 — `distributed/pipeline.py:281` constructs a config that raises
+
+CONFIRMED. Severity: crash, after the expensive work is done.
+
+Four lanes build the same fallback when `config.golden_rules` is unset:
+
+| lane | fallback |
+| --- | --- |
+| `core/pipeline.py:4631` | `GoldenRulesConfig(default_strategy="most_complete")` |
+| `backends/datafusion_spine.py:134` | `GoldenRulesConfig(default_strategy="most_complete")` |
+| `spark/config_pipeline.py:1486` | `GoldenRulesConfig(default_strategy="most_complete")` |
+| `distributed/pipeline.py:281` | `GoldenRulesConfig()` |
+
+`GoldenRulesConfig()` does not construct. `_validate_default` raises
+`GoldenRulesConfig requires 'default_strategy' or 'default'.`
+
+`golden_rules` is `GoldenRulesConfig | None` (`config/schemas.py:2444`), so it
+is None on any run that does not configure survivorship, and line 281 sits on
+the main path of `_run_phase5_pipeline` — not behind `_skip_golden`. The Ray
+distributed lane therefore dies at the golden step **after** phase-4 matching
+and phase-5 clustering have completed. At 100M rows that is hours of work
+discarded on a config default.
+
+Fix: one line, matching the other three lanes. Not applied here — the spec puts
+remediation in B2, one per PR.
+
+### F2 — `distributed/scoring.py:535` blocks on the wrong field
+
+CONFIRMED, narrow reachability. Severity: silent recall loss.
+
+The canonical dispatch (`core/blocker.py:560-607`, restated by the `1c843c8a5`
+fix) is: `multi_pass` → `passes`, otherwise → `keys`. Never unconditional
+`passes or keys`.
+
+```
+blocking.passes or blocking.keys or []      # distributed/scoring.py:535
+```
+
+Measured on a schema-valid `strategy="static"` config carrying
+`keys=[org_name]` and `passes=[postcode, record_id]`:
+
+| module | blocks on |
+| --- | --- |
+| `core/blocker.py` | `[org_name]` |
+| `backends/score_buckets.py` | `[org_name]` |
+| `distributed/scoring.py` | `[postcode, record_id]` |
+
+`BlockingConfig._validate_keys_or_passes` forbids `keys`/`passes` only for the
+`lsh`, `token` and `simhash` strategies. For `static` it requires `keys` and
+does not forbid `passes`, so that config validates.
+
+**Reachability is the caveat, and it is load-bearing.** Every one of the ten
+in-repo constructions that sets both `keys` and `passes` also sets
+`strategy="multi_pass"` (`config/from_dbt.py`, `config/from_splink.py`,
+`core/autoconfig.py` ×8), and for `multi_pass` the unconditional form gives the
+same answer. So this is reachable only through a user-authored config, not
+through anything auto-config emits today. That is a narrower exposure than the
+original incident, which auto-config produced directly.
+
+### F3 — `core/blocker.py:85-88` and `:311-314` report a key set they did not block on
+
+CONFIRMED. Severity: wrong telemetry, no wrong records.
+
+Both compute `keys_used` as `passes` if truthy else `keys`, with no strategy
+branch, for the emitted `BlockingProfile` and the block-size estimate. On a
+static config carrying both, the profile names `passes` while `:560-607`
+actually blocked on `keys`. At `:311-314` the disagreement is inside one
+function: the sizes come from `_fast_static_block_sizes`, which reads
+`config.keys` correctly at `:152`, while the label beside them says `passes`.
+
+The consumer is auto-config's controller, so a wrong profile feeds a planning
+decision. Same reachability caveat as F2.
+
+### F4-F8 — nullable fields read bare by some modules
+
+Signal B only, NOT confirmed. Each needs a per-module reachability check that
+this triage did not do.
+
+| field | falls back | reads bare |
+| --- | --- | --- |
+| `blocking` | `web/preview.py` | 9 modules incl. `core/fused_match.py`, `core/refit.py`, `spark/config_pipeline.py` |
+| `matchkeys` | 5 modules | `cli/demo.py`, `cli/import_splink.py`, `config/schemas.py`, `core/pipeline.py` |
+| `mode` | `core/autoconfig.py` | `core/lsh_blocker.py` |
+| `path` | `core/pipeline.py` | `cli/dedupe.py`, `semantic/crosswalk.py` |
+| `source_priority` | `core/survivorship/native.py` | `core/golden.py` |
+
+Signal B says one reader has thought about None and another has not. It does
+not say the bare reader can ever SEE None. Recorded as open rather than
+confirmed or dismissed.
+
+## What the 64 allowlist entries do and do not claim
+
+An entry claims: **no two modules supply different fallbacks for this field.**
+
+It does not claim the readers agree about anything a fallback cannot express —
+units, ordering, normalisation, or the meaning of a value both modules read
+identically. A field where every module does `for k in cfg.keys` passes this
+triage and could still carry a semantic disagreement.
+
+That bound is the honest limit of a syntactic pass, and it is why the entries
+say what was checked rather than "agreed".
+
+## A defect this triage exposed in B0a
+
+`report.py` computed stale allowlist entries by comparing the allowlist against
+whatever `--root` was scanned. The allowlist describes `DEFAULT_ROOT`'s field
+population, so under any other root -- a test fixture, one package of several --
+nearly every entry names a field that tree does not contain, and the whole
+allowlist read as stale with `main` exiting 1.
+
+**An empty allowlist could never show this.** An empty set has no stale members
+whatever it is compared against, so the branch was vacuous for exactly as long
+as B0a shipped it empty, and five of B0a's own tests turned red the moment B1
+populated the file. Staleness is now judged against `DEFAULT_ROOT` regardless of
+what was scanned.
+
+The `shared_fields`-called-once test had to change with it: a run under a custom
+root now legitimately parses two DISTINCT trees. Its invariant is that no tree is
+parsed twice, so it pins the roots rather than the tally -- a bare count of 1
+would have forced the fix to either re-couple staleness to the scanned root or
+drop the guard.
+
+## Two false-positive sources found and removed
+
+Both were defects in this triage's own first cut, and both are pinned by tests.
+
+1. **Write-only modules.** `cli/dedupe.py` and `cli/match.py` were reported as
+   unguarded readers of `format` and `run_name`. Their only access is the write
+   that sets the field from a command-line flag. A writer never has to cope
+   with None.
+2. **Validator-total fields.** `default_strategy` is `str | None` by annotation
+   but `GoldenRulesConfig._validate_default` raises unless it resolves, so the
+   three plain reads in `core/survivorship/` and `identity/survivorship.py` are
+   correct — and `core/golden.py:645`'s `or "most_complete"` is unreachable
+   defence. `VALIDATOR_TOTAL` records the exclusion, and a test constructs
+   `GoldenRulesConfig()` and asserts it still raises, so relaxing the validator
+   turns the exclusion back into a reported finding rather than a silent
+   suppression.
+
+## What B1 does not cover
+
+- The 64 are cleared syntactically, not semantically (above).
+- Scope is `packages/python/goldenmatch/goldenmatch` only. `goldenflow`,
+  `scripts/`, and the TypeScript port are out of reach by construction, and
+  their silence is not a clean bill.
+- Field names come from `config/schemas.py` alone; `web/settings.py`'s
+  BaseModels are not read.
+- F1 is the only finding proven to fire on a config the repo itself produces.
+  F2 and F3 need a user-authored config.
+- No remediation. F1 is a one-line fix and is deliberately not applied here:
+  the spec puts fixes in B2, one per PR, so a wrong one reverts cleanly.

--- a/parity/shared_decisions.allow
+++ b/parity/shared_decisions.allow
@@ -3,5 +3,79 @@
 # An entry is a claim that someone checked the readers and they agree -- not
 # that the finding is inconvenient. Format: `field  # reason`.
 #
-# Deliberately EMPTY at B0a. The first inventory is triaged in B1; entries are
-# added there, with the reason recorded at the time the check was done.
+# TRIAGED 2026-09-02 (phase B1). Every entry below was classified by
+# `scripts/shared_decisions/shapes.py`, which asks what DECISION each reader
+# makes -- the fallback or threshold it supplies that the field does not carry.
+#
+# WHAT AN ENTRY CLAIMS, EXACTLY: no two modules supply DIFFERENT fallbacks for
+# this field. It does NOT claim the readers agree about semantics a fallback
+# cannot express (units, ordering, normalisation). That bound is real and is
+# recorded in docs/superpowers/specs/2026-09-02-shared-decision-triage.md.
+#
+# 65 of the 73 shared fields are here. The other 8 are findings and
+# are deliberately absent so the inventory keeps reporting them.
+
+action  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+ann_model  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+ann_top_k  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+auto_fix  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+auto_split  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+auto_suggest  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+auto_threshold  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+backend  # 8 modules, no reader supplies a fallback -- nothing to disagree about
+budget  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+candidate_hi  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+candidate_lo  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+cluster_overrides  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+column  # 9 modules, no reader supplies a fallback -- nothing to disagree about
+columns  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+connection  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+dataset  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+default_strategy  # 6 modules; only core/golden.py supplies a fallback (`or 'most_complete'`), so no second module can contradict it
+deterministic_merge_keys  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+directory  # 3 modules; only core/pipeline.py supplies a fallback (`or config.output.path`), so no second module can contradict it
+domain  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+enabled  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+exclude_columns  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+field  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+field_groups  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+field_rules  # 6 modules, no reader supplies a fallback -- nothing to disagree about
+fields  # 17 modules; only core/autoconfig_negative_evidence.py supplies a fallback (`or []`), so no second module can contradict it
+format  # 3 modules; only core/pipeline.py supplies a fallback (`or 'csv'`), so no second module can contradict it
+identity  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+k  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+learned_min_recall  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+learned_sample_size  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+lineage_provenance  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+llm_auto  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+llm_boost  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+llm_scorer  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+match_settings  # 4 modules, no reader supplies a fallback -- nothing to disagree about
+max_block_size  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+max_cluster_size  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+memory  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+model  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+name  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+num_bands  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+num_perms  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+output  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+prepared_record_store  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+provider  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+quality  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+recall_target  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+relationships  # 2 modules; only config/from_dbt.py supplies a fallback (`or []`), so no second module can contradict it
+rules  # 7 modules; 3 supply a fallback and all use `or state.rules`
+run_name  # 3 modules; only core/pipeline.py supplies a fallback (`or datetime.now().strftime('%Y%m%d_%H%M%S')`), so no second module can contradict it
+scorer  # 4 modules, no reader supplies a fallback -- nothing to disagree about
+seed  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+semantic_blocking  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+skip_oversized  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+source_pk_column  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+standardization  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+threshold  # 11 modules, no reader supplies a fallback -- nothing to disagree about
+throughput  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+token  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+transform  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+transforms  # 12 modules; 8 supply a fallback and all use `or []`
+validation  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+weak_cluster_threshold  # 2 modules, no reader supplies a fallback -- nothing to disagree about

--- a/parity/shared_decisions.allow
+++ b/parity/shared_decisions.allow
@@ -3,60 +3,65 @@
 # An entry is a claim that someone checked the readers and they agree -- not
 # that the finding is inconvenient. Format: `field  # reason`.
 #
-# TRIAGED 2026-09-02 (phase B1). Every entry below was classified by
-# `scripts/shared_decisions/shapes.py`, which asks what DECISION each reader
-# makes -- the fallback or threshold it supplies that the field does not carry.
+# TRIAGED 2026-09-02 (phase B1), re-run after B3 widened accessor attribution
+# to names annotated with a config class (`mk: MatchkeyConfig`) -- that took the
+# inventory from 73 shared fields to 81.
 #
 # WHAT AN ENTRY CLAIMS, EXACTLY: no two modules supply DIFFERENT fallbacks for
-# this field. It does NOT claim the readers agree about semantics a fallback
-# cannot express (units, ordering, normalisation). That bound is real and is
-# recorded in docs/superpowers/specs/2026-09-02-shared-decision-triage.md.
+# this field, and none reads it bare where another defaults it. It does NOT
+# claim the readers agree about semantics a fallback cannot express (units,
+# ordering, normalisation). Where the entry says "declared on N classes", the
+# readers may not even be reading the same field -- the inventory is keyed by
+# NAME, and an access does not say which class the object is.
 #
-# 65 of the 73 shared fields are here. The other 8 are findings and
-# are deliberately absent so the inventory keeps reporting them.
+# Bounds in docs/superpowers/specs/2026-09-02-shared-decision-triage.md.
+#
+# 65 of 81 shared fields. The other 16 are findings or
+# held out by hand, and are absent so the inventory keeps reporting them.
 
 action  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-ann_model  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-ann_top_k  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+ann_model  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+ann_top_k  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
 auto_fix  # 3 modules, no reader supplies a fallback -- nothing to disagree about
 auto_split  # 3 modules, no reader supplies a fallback -- nothing to disagree about
 auto_suggest  # 3 modules, no reader supplies a fallback -- nothing to disagree about
-auto_threshold  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-backend  # 8 modules, no reader supplies a fallback -- nothing to disagree about
-budget  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+auto_threshold  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+backend  # 8 modules, no reader supplies a fallback -- nothing to disagree about; declared on 3 classes, so its readers may not even share a field
+budget  # 3 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
 candidate_hi  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 candidate_lo  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 cluster_overrides  # 3 modules, no reader supplies a fallback -- nothing to disagree about
-column  # 9 modules, no reader supplies a fallback -- nothing to disagree about
-columns  # 5 modules, no reader supplies a fallback -- nothing to disagree about
-connection  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-dataset  # 3 modules, no reader supplies a fallback -- nothing to disagree about
-default_strategy  # 6 modules; only core/golden.py supplies a fallback (`or 'most_complete'`), so no second module can contradict it
+connection  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+dataset  # 3 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+default_strategy  # 6 modules; only core/golden.py supplies a fallback (`or 'most_complete'`), so no second module can contradict it; declared on 2 classes, so its readers may not even share a field
+derive_from  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
 deterministic_merge_keys  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 directory  # 3 modules; only core/pipeline.py supplies a fallback (`or config.output.path`), so no second module can contradict it
-domain  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-enabled  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+domain  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+enabled  # 7 modules, no reader supplies a fallback -- nothing to disagree about; declared on 8 classes, so its readers may not even share a field
 exclude_columns  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-field  # 7 modules, no reader supplies a fallback -- nothing to disagree about
 field_groups  # 5 modules, no reader supplies a fallback -- nothing to disagree about
 field_rules  # 6 modules, no reader supplies a fallback -- nothing to disagree about
-fields  # 17 modules; only core/autoconfig_negative_evidence.py supplies a fallback (`or []`), so no second module can contradict it
+fields  # 26 modules; 5 supply a fallback and all use `or []`; declared on 3 classes, so its readers may not even share a field
 format  # 3 modules; only core/pipeline.py supplies a fallback (`or 'csv'`), so no second module can contradict it
+guard  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
 identity  # 5 modules, no reader supplies a fallback -- nothing to disagree about
 k  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 learned_min_recall  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 learned_sample_size  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+levels  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 lineage_provenance  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+link_threshold  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 llm_auto  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 llm_boost  # 3 modules, no reader supplies a fallback -- nothing to disagree about
-llm_scorer  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+llm_scorer  # 6 modules, no reader supplies a fallback -- nothing to disagree about
 match_settings  # 4 modules, no reader supplies a fallback -- nothing to disagree about
 max_block_size  # 5 modules, no reader supplies a fallback -- nothing to disagree about
 max_cluster_size  # 7 modules, no reader supplies a fallback -- nothing to disagree about
 memory  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-model  # 3 modules, no reader supplies a fallback -- nothing to disagree about
-name  # 5 modules, no reader supplies a fallback -- nothing to disagree about
-num_bands  # 3 modules, no reader supplies a fallback -- nothing to disagree about
+name  # 11 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+negative_evidence  # 7 modules; 4 supply a fallback and all use `or []`
+num_bands  # 3 modules, no reader supplies a fallback -- nothing to disagree about; declared on 3 classes, so its readers may not even share a field
 num_perms  # 3 modules, no reader supplies a fallback -- nothing to disagree about
 output  # 5 modules, no reader supplies a fallback -- nothing to disagree about
 prepared_record_store  # 2 modules, no reader supplies a fallback -- nothing to disagree about
@@ -64,18 +69,18 @@ provider  # 2 modules, no reader supplies a fallback -- nothing to disagree abou
 quality  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 recall_target  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 relationships  # 2 modules; only config/from_dbt.py supplies a fallback (`or []`), so no second module can contradict it
-rules  # 7 modules; 3 supply a fallback and all use `or state.rules`
+rerank  # 2 modules, no reader supplies a fallback -- nothing to disagree about
+rules  # 7 modules; 3 supply a fallback and all use `or state.rules`; declared on 2 classes, so its readers may not even share a field
 run_name  # 3 modules; only core/pipeline.py supplies a fallback (`or datetime.now().strftime('%Y%m%d_%H%M%S')`), so no second module can contradict it
-scorer  # 4 modules, no reader supplies a fallback -- nothing to disagree about
-seed  # 7 modules, no reader supplies a fallback -- nothing to disagree about
+seed  # 7 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
 semantic_blocking  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 skip_oversized  # 3 modules, no reader supplies a fallback -- nothing to disagree about
 source_pk_column  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-standardization  # 7 modules, no reader supplies a fallback -- nothing to disagree about
-threshold  # 11 modules, no reader supplies a fallback -- nothing to disagree about
+standardization  # 7 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
+threshold  # 18 modules, no reader supplies a fallback -- nothing to disagree about; declared on 5 classes, so its readers may not even share a field
 throughput  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 token  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-transform  # 2 modules, no reader supplies a fallback -- nothing to disagree about
-transforms  # 12 modules; 8 supply a fallback and all use `or []`
+transform  # 2 modules, no reader supplies a fallback -- nothing to disagree about; declared on 3 classes, so its readers may not even share a field
+type  # 7 modules, no reader supplies a fallback -- nothing to disagree about; declared on 2 classes, so its readers may not even share a field
 validation  # 3 modules, no reader supplies a fallback -- nothing to disagree about
 weak_cluster_threshold  # 2 modules, no reader supplies a fallback -- nothing to disagree about

--- a/scripts/shared_decisions/fields.py
+++ b/scripts/shared_decisions/fields.py
@@ -7,14 +7,35 @@ whole package and its optional extras, and this must run in a bare CI step.
 from __future__ import annotations
 
 import ast
+from functools import lru_cache
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent.parent
 SCHEMAS = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch" / "config" / "schemas.py"
 
 
+@lru_cache(maxsize=1)
+def _config_fields_cached() -> tuple[tuple[str, frozenset[str]], ...]:
+    """Immutable cached form of `config_fields`.
+
+    `_annotated_config_names` needs the class list once PER MODULE, and the
+    accessor scan walks ~493 of them. Uncached, that re-parsed schemas.py (a
+    2,500-class-line file) once per module and pushed the readers tests past a
+    two-minute timeout. Returned as tuples because `lru_cache` results must not
+    be mutable -- `config_fields` rebuilds the dict for callers.
+    """
+    return tuple(
+        (cls, frozenset(fields)) for cls, fields in _config_fields_uncached().items()
+    )
+
+
 def config_fields() -> dict[str, set[str]]:
-    """Map each Pydantic config class to the field names it declares.
+    """Map each Pydantic config class to the field names it declares."""
+    return {cls: set(fields) for cls, fields in _config_fields_cached()}
+
+
+def _config_fields_uncached() -> dict[str, set[str]]:
+    """The real AST parse. See `config_fields`.
 
     A field is an annotated assignment at class-body level (`name: type = ...`),
     which is how Pydantic models declare fields. Methods, ClassVars and private

--- a/scripts/shared_decisions/readers.py
+++ b/scripts/shared_decisions/readers.py
@@ -182,7 +182,54 @@ def _module_alias_names(
         segments = _base_chain(node.value)
         if segments is not None and _chain_looks_like_config(segments, targets):
             aliases.add(node.targets[0].id.lower())
-    return frozenset(aliases)
+    return frozenset(aliases | _annotated_config_names(tree))
+
+
+def _annotated_config_names(tree: ast.Module) -> set[str]:
+    """Names ANNOTATED with a declared config class: `mk: MatchkeyConfig`.
+
+    The assignment scan above only sees a name bound from a config-looking
+    EXPRESSION. It cannot see a config that arrives as a typed parameter --
+    `def score(mk: MatchkeyConfig)` -- because there is no right-hand side to
+    inspect, and `mk` matches no config class name by word boundary.
+
+    That blind spot was large. Measured 2026-09-02 on goldenmatch: `mk`
+    accounted for 626 attribute accesses to known field names, roughly half
+    again the entire attributed set, and `current: GoldenMatchConfig` another
+    54 -- all invisible. Adding annotations took the inventory from 73 shared
+    fields to 82 and moved `fields` from 17 modules to 26.
+
+    Discovered while sabotage-checking the B3 ratchet: a divergent fallback
+    planted in `core/autoconfig.py` did not trip the gate, because the site
+    read `k.transforms` off a loop variable the scan never attributed. The
+    sabotage was invalid rather than the gate weak -- but the reason it was
+    invalid was a real recall hole.
+
+    Names only, matching `_module_alias_names`' module-scope contract: this
+    does not track shadowing, and a parameter named `mk` in a function with no
+    config in sight is treated as config here. Over-reporting costs one triage
+    decision; under-reporting is invisible.
+    """
+    from shared_decisions.fields import config_fields
+
+    classes = set(config_fields())
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name, annotation = node.target.id, node.annotation
+        elif isinstance(node, ast.arg) and node.annotation is not None:
+            name, annotation = node.arg, node.annotation
+        else:
+            continue
+        try:
+            text = ast.unparse(annotation)
+        except Exception:  # pragma: no cover - unparse is total on parsed trees
+            continue
+        # Substring, not equality: the annotation is often `X | None`,
+        # `list[X]`, or a quoted forward reference.
+        if any(cls in text for cls in classes):
+            out.add(name.lower())
+    return out
 
 
 def unparseable_modules(root: Path) -> list[str]:

--- a/scripts/shared_decisions/report.py
+++ b/scripts/shared_decisions/report.py
@@ -102,7 +102,17 @@ def main(argv: list[str]) -> int:
 
     shared = shared_fields(args.root)  # computed ONCE, passed to inventory()
     items = inventory(args.root, shared=shared)
-    stale = stale_entries(set(shared))
+    # The allowlist describes DEFAULT_ROOT's field population, so staleness is
+    # judged against THAT population -- never against whatever `--root` was
+    # asked to report on. Comparing against a custom root (a test fixture, or
+    # one package of several) reported nearly every entry as stale and exited
+    # 1, because those fields simply are not in that tree. This stayed
+    # invisible for as long as the allowlist was empty: an empty set has no
+    # stale members whatever it is compared against, so it surfaced only when
+    # B1 populated it.
+    stale = stale_entries(
+        set(shared) if args.root == DEFAULT_ROOT else set(shared_fields(DEFAULT_ROOT))
+    )
     skipped = unparseable_modules(args.root)
 
     if args.json:

--- a/scripts/shared_decisions/shapes.py
+++ b/scripts/shared_decisions/shapes.py
@@ -1,0 +1,217 @@
+"""What DECISION does each reader of a shared config field make?
+
+`readers.py` answers "which modules touch this field". That is the inventory.
+It does not say whether those modules had to AGREE about anything, and most do
+not: five modules iterating `config.blocking.keys` share a field but no
+decision.
+
+A decision is a reader supplying something the FIELD DOES NOT CARRY:
+
+  * a FALLBACK value, when the field is unset -- `cfg.x or <value>`
+  * a THRESHOLD to compare against -- `cfg.x >= <value>`
+
+Two modules supplying DIFFERENT ones is the 1c843c8a5 shape, and it is what
+this module reports.
+
+WHAT IS DELIBERATELY NOT A SIGNAL: comparison against different literals.
+`strategy == "static"` here and `strategy == "learned"` there is dispatch on an
+enum-ish field, which is what those fields are for. Counting it produced 13
+"candidates" of which 10 were that -- `strategy` alone contributed 20 distinct
+"decisions" and no defect. Only FALLBACK divergence is reported.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from shared_decisions.readers import (
+    _base_chain,
+    _chain_looks_like_config,
+    _config_look_targets,
+    _known_field_names,
+    _module_alias_names,
+)
+
+# Shapes in which a reader has demonstrably coped with the field being unset or
+# empty. A module whose every access is one of these has thought about None.
+GUARD_SHAPES = frozenset({"FALLBACK", "TRUTHY", "COMPARE", "ITER"})
+
+# Fields annotated `| None` that a `model_validator(mode="after")` nonetheless
+# guarantees non-None on any CONSTRUCTED model, so a plain read is correct and
+# the nullable annotation overstates the risk.
+#
+# `GoldenRulesConfig._validate_default` RAISES unless `default_strategy`
+# resolves (directly, or backfilled from `default`), which is why
+# `core/golden.py:645`'s `or "most_complete"` is unreachable defence and the
+# plain reads in `core/survivorship/` and `identity/survivorship.py` are right.
+#
+# This set is a judgement recorded by hand, not a derivation: proving a
+# validator makes a field total means reasoning about every branch that could
+# leave it None, which AST inspection does not do. An entry here is a claim
+# that someone read the validator.
+VALIDATOR_TOTAL = frozenset({"default_strategy"})
+
+_ITER_BUILTINS = frozenset({"list", "set", "tuple", "len", "sorted", "iter", "any", "all"})
+
+
+@dataclass(frozen=True)
+class Access:
+    """One syntactic access to a config field, and the decision it makes."""
+
+    field: str
+    module: str
+    line: int
+    shape: str
+    detail: str
+
+
+def _snippet(node: ast.AST, limit: int = 60) -> str:
+    try:
+        text = " ".join(ast.unparse(node).split())
+    except Exception:  # pragma: no cover - unparse is total on parsed trees
+        return "?"
+    return text if len(text) <= limit else text[: limit - 1] + "~"
+
+
+def classify(node: ast.Attribute, parent: ast.AST | None) -> tuple[str, str]:
+    """The (shape, detail) of one access, given its parent node.
+
+    FALLBACK's detail is the operand the reader falls back TO, which is the
+    thing two modules can disagree about.
+    """
+    if isinstance(node.ctx, ast.Store):
+        return "WRITE", ""
+    if isinstance(node.ctx, ast.Del):
+        return "DELETE", ""
+    if isinstance(parent, ast.BoolOp):
+        if isinstance(parent.op, ast.Or):
+            values = parent.values
+            index = values.index(node) if node in values else -1
+            if index >= 0 and index + 1 < len(values):
+                return "FALLBACK", _snippet(values[index + 1])
+        return "TRUTHY", ""
+    if isinstance(parent, ast.Compare):
+        if parent.left is node:
+            return "COMPARE", f"{type(parent.ops[0]).__name__} {_snippet(parent.comparators[0])}"
+        return "COMPARE", f"rhs-of {type(parent.ops[0]).__name__} {_snippet(parent.left)}"
+    if isinstance(parent, ast.UnaryOp) and isinstance(parent.op, ast.Not):
+        return "TRUTHY", ""
+    if isinstance(parent, (ast.If, ast.While, ast.IfExp)) and parent.test is node:
+        return "TRUTHY", ""
+    if isinstance(parent, ast.Subscript):
+        return ("INDEX", _snippet(parent.slice)) if parent.value is node else ("OTHER", "")
+    if isinstance(parent, (ast.For, ast.comprehension)) and parent.iter is node:
+        return "ITER", ""
+    if isinstance(parent, ast.Attribute):
+        return "ATTR_BASE", f".{parent.attr}"
+    if isinstance(parent, ast.Call):
+        if parent.func is node:
+            return "CALLED", ""
+        name = _snippet(parent.func, 24)
+        return ("ITER" if name in _ITER_BUILTINS else "CALL_ARG"), name
+    return type(parent).__name__.upper() if parent is not None else "OTHER", ""
+
+
+def access_shapes(root: Path) -> list[Access]:
+    """Every config-field access under `root`, with its decision shape.
+
+    Accessor detection is `readers.py`'s -- the same base-chain and alias rules
+    -- so this cannot report a site the inventory does not, nor miss one it
+    does.
+    """
+    known = _known_field_names()
+    targets = _config_look_targets()
+    out: list[Access] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        aliases = _module_alias_names(tree, targets)
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute) or node.attr not in known:
+                continue
+            segments = _base_chain(node.value)
+            if segments is None or not _chain_looks_like_config(segments, targets, aliases):
+                continue
+            shape, detail = classify(node, parents.get(node))
+            out.append(Access(node.attr, rel, node.lineno, shape, detail))
+    return out
+
+
+def fallback_divergence(accesses: list[Access]) -> dict[str, dict[str, set[str]]]:
+    """Fields where more than one module falls back to a DIFFERENT value.
+
+    Both conditions are required. One module writing two different fallbacks in
+    two branches is a local choice, not a cross-module disagreement, so the
+    distinct fallbacks must be spread over more than one module.
+    """
+    by_field: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for access in accesses:
+        if access.shape == "FALLBACK":
+            by_field[access.field][access.detail].add(access.module)
+    out: dict[str, dict[str, set[str]]] = {}
+    for field, fallbacks in by_field.items():
+        modules = {m for group in fallbacks.values() for m in group}
+        if len(fallbacks) > 1 and len(modules) > 1:
+            out[field] = {value: set(group) for value, group in fallbacks.items()}
+    return out
+
+
+def unguarded_optional(
+    accesses: list[Access], nullable: dict[str, set[str]]
+) -> dict[str, set[str]]:
+    """Nullable fields some module falls back on and another reads bare.
+
+    One reader has thought about None and another has not. Weaker than
+    `fallback_divergence`: it does not prove the bare reader can ever SEE None,
+    only that nothing in that module says it cannot.
+
+    A module whose only access is a WRITE is not a reader and never has to cope
+    with None -- omitting that check flagged `cli/dedupe.py` and `cli/match.py`
+    on `format` and `run_name`, where their single access sets the field from a
+    command-line flag.
+    """
+    by_field: dict[str, list[Access]] = defaultdict(list)
+    for access in accesses:
+        by_field[access.field].append(access)
+    out: dict[str, set[str]] = {}
+    for field, group in by_field.items():
+        if field not in nullable or field in VALIDATOR_TOTAL:
+            continue
+        modules = {access.module for access in group}
+        if len(modules) < 2:
+            continue
+        with_fallback = {a.module for a in group if a.shape == "FALLBACK"}
+        if not with_fallback:
+            continue
+        bare: set[str] = set()
+        for module in modules:
+            shapes = {a.shape for a in group if a.module == module}
+            if shapes <= {"WRITE"}:
+                continue
+            if not (shapes & GUARD_SHAPES):
+                bare.add(module)
+        if bare and (with_fallback - bare):
+            out[field] = bare
+    return out
+
+
+def nullable_fields(schemas: Path) -> dict[str, set[str]]:
+    """Field name -> the config classes that annotate it `| None`."""
+    tree = ast.parse(schemas.read_text(encoding="utf-8-sig"))
+    out: dict[str, set[str]] = defaultdict(set)
+    for cls in (node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)):
+        for body in cls.body:
+            if isinstance(body, ast.AnnAssign) and isinstance(body.target, ast.Name):
+                if "None" in ast.unparse(body.annotation):
+                    out[body.target.id].add(cls.name)
+    return dict(out)

--- a/scripts/shared_decisions/shapes.py
+++ b/scripts/shared_decisions/shapes.py
@@ -215,3 +215,35 @@ def nullable_fields(schemas: Path) -> dict[str, set[str]]:
                 if "None" in ast.unparse(body.annotation):
                     out[body.target.id].add(cls.name)
     return dict(out)
+
+
+def declaring_classes() -> dict[str, set[str]]:
+    """Field name -> the config classes that declare it.
+
+    The inventory is keyed by field NAME, because an access
+    (`cfg.blocking.transforms`) does not say which class the object is. When
+    one name is declared on several classes, readers grouped under it may be
+    reading DIFFERENT fields, and a "divergence" between them can be no
+    divergence at all: `transforms` is declared on `BlockingKeyConfig`,
+    `MatchkeyField`, `NegativeEvidenceField` and `SortKeyField`, and the
+    `or ["lowercase", "strip"]` fallback that made it look divergent is a
+    `MatchkeyField`, compared against ten `BlockingKeyConfig` readers.
+
+    So a signal on a single-class field is ACTIONABLE, and a signal on a
+    multi-class field needs class resolution before it means anything. Both
+    confirmed findings -- `golden_rules` and `passes` -- are single-class.
+    """
+    from shared_decisions.fields import config_fields
+
+    out: dict[str, set[str]] = defaultdict(set)
+    for cls, fields in config_fields().items():
+        for field in fields:
+            out[field].add(cls)
+    return dict(out)
+
+
+def split_by_ambiguity(fields: set[str]) -> tuple[set[str], set[str]]:
+    """(actionable, ambiguous) -- declared on exactly one class, or more."""
+    declared = declaring_classes()
+    ambiguous = {f for f in fields if len(declared.get(f, set())) > 1}
+    return fields - ambiguous, ambiguous

--- a/scripts/test_no_new_shared_decisions.py
+++ b/scripts/test_no_new_shared_decisions.py
@@ -1,0 +1,198 @@
+"""No NEW shared config decision may appear untriaged, and none may diverge.
+
+Phase B3. Same contract as `KNOWN_DEAD` in scripts/test_no_new_dead_code.py:
+these sets are floors to work DOWN, never buckets to top up. Both directions
+are asserted -- a new entry fails, and an entry that no longer reproduces must
+be removed so the ratchet keeps its value.
+
+Every shared field is covered by exactly one of three places:
+
+  parity/shared_decisions.allow   65  agreed; readers supply no conflicting default
+  KNOWN_ACTIONABLE                 3  a signal fires on a SINGLE-class field
+  KNOWN_AMBIGUOUS                 12  a signal fires, but the name is declared on
+                                      several classes, so the readers grouped
+                                      under it may not share a field at all
+  HELD_BY_HAND                     1  no signal fires, held out on judgement
+
+The sharp gate is `test_no_allowlisted_field_starts_diverging`. That is the
+1c843c8a5 recurrence: a field everyone agreed on gains a second, different
+fallback. Nothing caught that in 2026-08, which is why the incident shipped.
+"""
+
+from __future__ import annotations
+
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from shared_decisions.allowlist import load_allowlist  # noqa: E402
+from shared_decisions.readers import shared_fields  # noqa: E402
+from shared_decisions.report import DEFAULT_ROOT  # noqa: E402
+from shared_decisions.shapes import (  # noqa: E402
+    access_shapes,
+    fallback_divergence,
+    nullable_fields,
+    split_by_ambiguity,
+    unguarded_optional,
+)
+
+# A signal fires AND the field name is declared on exactly one config class, so
+# every reader grouped under it really is reading the same field. Actionable.
+# Triaged in B1 -- docs/superpowers/specs/2026-09-02-shared-decision-triage.md
+# carries the finding behind each. Shrinks as B2 lands remediations; never
+# grows without a triage.
+KNOWN_ACTIONABLE: set[str] = {
+    "golden_rules",  # F1  Ray lane's fallback could not construct (fix in #2844)
+    "passes",  # F2  distributed/scoring.py resolves it with no strategy branch
+    "weight",  # F9  autoconfig defaults to 0; scorer.py and Spark read it bare
+}
+
+# A signal fires, but the name is declared on SEVERAL config classes. An access
+# does not say which class the object is, so a "divergence" here may be two
+# different fields that happen to share a name: `transforms` looked divergent
+# only because a `MatchkeyField` fallback was compared against ten
+# `BlockingKeyConfig` readers. These need class resolution before they mean
+# anything, and NONE is claimed as a defect.
+KNOWN_AMBIGUOUS: set[str] = {
+    "blocking",
+    "column",
+    "columns",
+    "field",
+    "keys",
+    "matchkeys",
+    "mode",
+    "model",
+    "path",
+    "scorer",
+    "source_priority",
+    "transforms",
+}
+
+# Held out of the allowlist on judgement, with NO signal firing. `strategy` is
+# the discriminator F2 and F3 fail to consult -- it decides which of
+# keys/passes is correct -- and B0a's ranking test names it alongside them.
+# Allowlisting it would suppress an explicit earlier judgement on a syntactic
+# signal, which is the "wrong merge" the phase-B spec warns about.
+HELD_BY_HAND: set[str] = {"strategy"}
+
+
+@lru_cache(maxsize=1)
+def _signals() -> frozenset[str]:
+    """Cached: five tests need this, and each uncached call re-parses ~493 files.
+
+    Uncached, this module took over two minutes and timed out locally.
+    """
+    accesses = access_shapes(DEFAULT_ROOT)
+    nullable = nullable_fields(DEFAULT_ROOT / "config" / "schemas.py")
+    return frozenset(
+        set(fallback_divergence(accesses)) | set(unguarded_optional(accesses, nullable))
+    )
+
+
+@lru_cache(maxsize=1)
+def _shared() -> frozenset[str]:
+    """Cached for the same reason as `_signals`."""
+    return frozenset(shared_fields(DEFAULT_ROOT))
+
+
+def test_every_shared_field_is_triaged():
+    """A field newly read by a second module is a new shared decision.
+
+    It must be classified before it can ride along: recorded as agreed in the
+    allowlist, or recorded as a finding here.
+    """
+    untriaged = set(_shared()) - load_allowlist()
+    untriaged -= KNOWN_ACTIONABLE | KNOWN_AMBIGUOUS | HELD_BY_HAND
+    assert not untriaged, (
+        f"NEW shared config field(s): {sorted(untriaged)}. A second module now "
+        f"reads each of these, so its readers have to agree about something. "
+        f"Triage them: add to parity/shared_decisions.allow with a reason if "
+        f"the readers agree, or to KNOWN_ACTIONABLE / KNOWN_AMBIGUOUS here if "
+        f"they do not."
+    )
+
+
+def test_no_allowlisted_field_starts_diverging():
+    """THE 1c843c8a5 GATE.
+
+    An allowlisted field is one whose readers were checked and agreed. If a
+    signal starts firing on it, that agreement has broken -- a module has
+    added a second, different fallback for a value the field does not carry.
+    That is exactly the shape that shipped 0 pairs where legacy produced 242,
+    and nothing in the repo could see it at the time.
+    """
+    broke = set(_signals()) & load_allowlist()
+    assert not broke, (
+        f"{sorted(broke)} were recorded as AGREED and now trip a divergence "
+        f"signal: some module supplies a fallback the other readers do not. "
+        f"Reconcile the readers, or move the field to KNOWN_ACTIONABLE / "
+        f"KNOWN_AMBIGUOUS with the finding written down. Do NOT widen the "
+        f"allowlist reason."
+    )
+
+
+def test_findings_that_no_longer_reproduce_are_removed():
+    """A floor to work DOWN. Keeping a fixed finding rots the ratchet.
+
+    `HELD_BY_HAND` is exempt by construction -- no signal fires on it, that is
+    why it is a separate set.
+    """
+    fixed = (KNOWN_ACTIONABLE | KNOWN_AMBIGUOUS) - set(_signals())
+    assert not fixed, (
+        f"{sorted(fixed)} no longer trip any signal. Remove them from "
+        f"KNOWN_ACTIONABLE / KNOWN_AMBIGUOUS and add them to "
+        f"parity/shared_decisions.allow with the reason they are now agreed, "
+        f"so the ratchet keeps its value."
+    )
+
+
+def test_the_ambiguity_split_is_the_real_one():
+    """Guard the split: the two finding sets must match what the code computes.
+
+    Hand-maintained sets that drift from `split_by_ambiguity` would let an
+    ACTIONABLE finding be filed as ambiguous -- which is how a real defect gets
+    excused as a name collision.
+    """
+    actionable, ambiguous = split_by_ambiguity(set(_signals()))
+    assert actionable == KNOWN_ACTIONABLE, (
+        f"actionable drifted: computed {sorted(actionable)}, recorded {sorted(KNOWN_ACTIONABLE)}"
+    )
+    assert ambiguous == KNOWN_AMBIGUOUS, (
+        f"ambiguous drifted: computed {sorted(ambiguous)}, recorded {sorted(KNOWN_AMBIGUOUS)}"
+    )
+
+
+def test_the_three_sets_partition_the_shared_fields():
+    """Guard the guards: the floors must cover the inventory exactly.
+
+    Without this, a field could sit in two sets (double-counted, so a
+    regression in one is masked by the other) or the sets could drift into
+    naming fields that are no longer shared at all -- either way the three
+    tests above would still pass while measuring less than they claim.
+    """
+    shared = set(_shared())
+    allow = load_allowlist()
+
+    sets = {
+        "allowlist": allow,
+        "KNOWN_ACTIONABLE": KNOWN_ACTIONABLE,
+        "KNOWN_AMBIGUOUS": KNOWN_AMBIGUOUS,
+        "HELD_BY_HAND": HELD_BY_HAND,
+    }
+    overlap = set()
+    names = list(sets)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            overlap |= sets[a] & sets[b]
+    assert not overlap, f"a field is in two sets at once: {sorted(overlap)}"
+
+    missing = shared - set().union(*sets.values())
+    assert not missing, f"shared but in no set: {sorted(missing)}"
+
+    phantom = set().union(*sets.values()) - shared
+    assert not phantom, (
+        f"{sorted(phantom)} are recorded but no longer shared fields -- drop "
+        f"them so the floors describe the real inventory."
+    )

--- a/scripts/test_no_new_shared_decisions.py
+++ b/scripts/test_no_new_shared_decisions.py
@@ -44,8 +44,12 @@ from shared_decisions.shapes import (  # noqa: E402
 # carries the finding behind each. Shrinks as B2 lands remediations; never
 # grows without a triage.
 KNOWN_ACTIONABLE: set[str] = {
-    "golden_rules",  # F1  Ray lane's fallback could not construct (fix in #2844)
-    "passes",  # F2  distributed/scoring.py resolves it with no strategy branch
+    "golden_rules",  # F1  Ray lane's fallback could not construct -- FIXED #2844
+    # F2 fixed in #2845 (distributed/scoring.py now calls resolved_keys()), but
+    # `passes` stays actionable: core/autoconfig.py:4500 still resolves
+    # `compound_config.passes or list(compound_config.keys or [])` with no
+    # strategy branch, one of eight plan-building sites left out of that scope.
+    "passes",
     "weight",  # F9  autoconfig defaults to 0; scorer.py and Spark read it bare
 }
 

--- a/scripts/test_shared_decisions_report.py
+++ b/scripts/test_shared_decisions_report.py
@@ -172,7 +172,13 @@ def test_shared_fields_is_computed_once_per_invocation(monkeypatch, capsys):
     inside `inventory()`, once again for the stale-allowlist check -- each
     re-parsing all ~493 files under root. It's a pure function so the two
     calls never disagreed, it was just double the CI cost. Pin the call
-    count so a future edit can't reintroduce the duplicate parse."""
+    count so a future edit can't reintroduce the duplicate parse.
+
+    The invariant is NO TREE IS PARSED TWICE, not "exactly one call". Scoping
+    the stale check to DEFAULT_ROOT means a run under a custom `--root` legally
+    parses two DISTINCT trees; asserting a bare count of 1 would have forced
+    that fix to either re-couple staleness to the scanned root or drop the
+    guard, so it is the roots that are pinned, not the tally."""
     import shared_decisions.report as mod
 
     calls = []
@@ -185,7 +191,12 @@ def test_shared_fields_is_computed_once_per_invocation(monkeypatch, capsys):
     monkeypatch.setattr(mod, "shared_fields", counting)
     rc = main(["--root", str(FIXTURES)])
     assert rc == 0
-    assert len(calls) == 1, f"shared_fields(root) called {len(calls)} times, expected 1"
+    assert len(calls) == len(set(calls)), f"a tree was parsed twice: {calls}"
+
+    # The default root must still be scanned exactly once when it IS the root.
+    calls.clear()
+    assert main([]) == 0
+    assert calls == [DEFAULT_ROOT], f"expected one scan of DEFAULT_ROOT, got {calls}"
 
 
 def test_allowlisted_fields_are_excluded(monkeypatch):
@@ -242,3 +253,28 @@ def test_main_json_with_no_stale_entries_exits_0(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert rc == 0
     assert '"stale_allowlist_entries": []' in captured.out, captured.out
+
+
+def test_stale_check_is_scoped_to_the_default_root(capsys):
+    """Staleness is judged against DEFAULT_ROOT, not against whatever was scanned.
+
+    `stale_entries` used to compare the shipped allowlist against `--root`'s
+    fields. Under a fixture root nearly every entry names a field that root does
+    not contain, so the whole allowlist read as stale and `main` exited 1. An
+    empty allowlist could never show this -- an empty set has no stale members
+    whatever it is compared against -- so it surfaced only when B1 populated it.
+    """
+    from shared_decisions.allowlist import load_allowlist
+
+    assert load_allowlist(), "vacuous: an empty allowlist cannot exercise this"
+    assert main(["--root", str(FIXTURES)]) == 0
+    assert "stale" not in capsys.readouterr().out.lower()
+
+
+def test_stale_check_still_fires_under_a_custom_root(monkeypatch, capsys):
+    """...and re-scoping it must not disable it under a custom root."""
+    import shared_decisions.report as report_mod
+
+    monkeypatch.setattr(report_mod, "stale_entries", lambda known: {"ghost_field"})
+    assert main(["--root", str(FIXTURES)]) == 1
+    assert "ghost_field" in capsys.readouterr().out

--- a/scripts/test_shared_decisions_shapes.py
+++ b/scripts/test_shared_decisions_shapes.py
@@ -1,0 +1,160 @@
+"""Tests for the decision-shape classifier used to triage the B0a inventory."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from shared_decisions.shapes import (
+    Access,
+    access_shapes,
+    classify,
+    fallback_divergence,
+    nullable_fields,
+    unguarded_optional,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "scripts" / "fixtures" / "incident_1c843c8a5"
+SCHEMAS = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch" / "config" / "schemas.py"
+
+
+def _classify_source(source: str, field: str) -> list[tuple[str, str]]:
+    """Every (shape, detail) for accesses to `field` in a source snippet."""
+    tree = ast.parse(source)
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    return [
+        classify(node, parents.get(node))
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == field
+    ]
+
+
+def test_the_motivating_incident_is_reported_from_the_checked_in_fixture():
+    """`1c843c8a5` must be findable without git history staying reachable.
+
+    `scripts/fixtures/incident_1c843c8a5/` holds `blocker.py` and
+    `score_buckets.py` verbatim at `1c843c8a5^`. blocker falls back to `[]`;
+    score_buckets falls back to `blocking_config.keys`. Two modules, two
+    different fallbacks, on `passes` -- the field the incident turned on.
+    """
+    divergence = fallback_divergence(access_shapes(FIXTURE))
+
+    assert "passes" in divergence, (
+        "the incident field is not reported; the classifier cannot find the bug "
+        f"that motivated it. reported: {sorted(divergence)}"
+    )
+    fallbacks = divergence["passes"]
+    assert len(fallbacks) > 1
+    culprits = {module for group in fallbacks.values() for module in group}
+    assert culprits == {"blocker_prefix.py", "score_buckets_prefix.py"}
+    assert "blocking_config.keys" in fallbacks
+    assert fallbacks["blocking_config.keys"] == {"score_buckets_prefix.py"}
+
+
+def test_fallback_detail_is_the_operand_fallen_back_to():
+    """The detail must be what the reader SUPPLIES -- the disagreeable part.
+
+    Recording the field name, or a bare "FALLBACK", would make every fallback
+    look identical and the divergence signal could never fire.
+    """
+    shapes = _classify_source("x = cfg.passes or cfg.keys\n", "passes")
+    assert shapes == [("FALLBACK", "cfg.keys")]
+
+    shapes = _classify_source("x = cfg.passes or []\n", "passes")
+    assert shapes == [("FALLBACK", "[]")]
+
+
+def test_a_final_or_operand_is_truthiness_not_a_fallback():
+    """`a or cfg.x` supplies nothing -- there is no operand after it."""
+    assert _classify_source("x = other or cfg.passes\n", "passes") == [("TRUTHY", "")]
+
+
+def test_one_module_with_two_fallbacks_is_not_a_divergence():
+    """A single module choosing two fallbacks in two branches is a local choice.
+
+    Reporting it would flood the signal: `core/autoconfig.py` alone falls back
+    on `keys` to both `[]` and `[None]` in different helpers, and neither
+    disagrees with another module.
+    """
+    accesses = [
+        Access("keys", "core/autoconfig.py", 10, "FALLBACK", "[]"),
+        Access("keys", "core/autoconfig.py", 20, "FALLBACK", "[None]"),
+    ]
+    assert fallback_divergence(accesses) == {}
+
+
+def test_two_modules_agreeing_on_one_fallback_is_not_a_divergence():
+    accesses = [
+        Access("keys", "a.py", 10, "FALLBACK", "[]"),
+        Access("keys", "b.py", 10, "FALLBACK", "[]"),
+    ]
+    assert fallback_divergence(accesses) == {}
+
+
+def test_two_modules_with_different_fallbacks_is_a_divergence():
+    accesses = [
+        Access("keys", "a.py", 10, "FALLBACK", "[]"),
+        Access("keys", "b.py", 10, "FALLBACK", "cfg.passes"),
+    ]
+    assert fallback_divergence(accesses) == {"keys": {"[]": {"a.py"}, "cfg.passes": {"b.py"}}}
+
+
+def test_a_write_only_module_is_not_an_unguarded_reader():
+    """Setting a field from a CLI flag never has to cope with it being None.
+
+    Without this, `cli/dedupe.py` and `cli/match.py` were reported on `format`
+    and `run_name`, where their single access is the write that sets them.
+    """
+    nullable = {"format": {"OutputConfig"}}
+    accesses = [
+        Access("format", "core/pipeline.py", 10, "FALLBACK", "'csv'"),
+        Access("format", "cli/dedupe.py", 20, "WRITE", ""),
+    ]
+    assert unguarded_optional(accesses, nullable) == {}
+
+    # ... but the same module READING it bare is reported.
+    accesses.append(Access("format", "cli/dedupe.py", 21, "CALL_ARG", "open"))
+    assert unguarded_optional(accesses, nullable) == {"format": {"cli/dedupe.py"}}
+
+
+def test_a_validator_total_field_is_not_reported_unguarded():
+    """`default_strategy` is `| None` by annotation and non-None by validator.
+
+    `GoldenRulesConfig._validate_default` raises unless it resolves, so the
+    plain readers are correct and reporting them would be noise.
+    """
+    nullable = {"default_strategy": {"GoldenRulesConfig"}}
+    accesses = [
+        Access("default_strategy", "core/golden.py", 645, "FALLBACK", "'most_complete'"),
+        Access("default_strategy", "core/survivorship/resolve.py", 10, "KEYWORD", ""),
+    ]
+    assert unguarded_optional(accesses, nullable) == {}
+
+
+def test_validator_total_claim_still_holds_in_the_schema():
+    """Pin the reason `default_strategy` is excluded, not just the exclusion.
+
+    If the validator that makes the field total is ever relaxed, the exclusion
+    becomes a suppression of a real finding and this fails.
+    """
+    pydantic = pytest.importorskip("pydantic")
+    import sys
+
+    sys.path.insert(0, str(REPO / "packages" / "python" / "goldenmatch"))
+    from goldenmatch.config.schemas import GoldenRulesConfig
+
+    with pytest.raises(pydantic.ValidationError, match="default_strategy"):
+        GoldenRulesConfig()
+
+
+def test_nullable_fields_reads_the_real_schema():
+    nullable = nullable_fields(SCHEMAS)
+    assert "GoldenMatchConfig" in nullable["golden_rules"]
+    assert "BlockingConfig" in nullable["passes"]
+    # `keys` is `list[...]` with a default_factory -- never None.
+    assert "keys" not in nullable


### PR DESCRIPTION
## What and why

Phase B stages B1 (triage) and B3 (ratchet), completing the shared-decision half of the audit programme. B0a shipped the inventory in #2843; this classifies what it found and freezes the floor.

## B1 — every shared field triaged

81 config fields are accessed by more than one module. Each is now in exactly one bucket, and a test enforces that the four partition the inventory:

| bucket | n | meaning |
| --- | ---: | --- |
| `parity/shared_decisions.allow` | 65 | agreed; no reader supplies a conflicting default |
| `KNOWN_ACTIONABLE` | 3 | a signal fires on a field declared by ONE config class |
| `KNOWN_AMBIGUOUS` | 12 | a signal fires, but the name is declared on several classes |
| `HELD_BY_HAND` | 1 | `strategy` -- no signal fires, held out on judgement |

**The findings this produced have already landed.** F1 in #2844, F2 and F3 in #2845 -- three confirmed production defects, two of them silent wrong answers. The document records their status rather than describing them as open.

## The detector was reading 23% of its surface, and a failed sabotage found it

Proving the ratchet fires on a `1c843c8a5` recurrence meant planting a divergent fallback on an allowlisted field. **It didn't fire** -- and the sabotage turned out to be invalid, not the gate weak: the planted site read `k.transforms` off a loop variable the scan never attributed.

Measuring the scan's reach: of 5,663 attribute accesses to a known config field name, it attributed **1,313 -- 23%**. The largest single miss was `mk`, at 626 accesses: `mk: MatchkeyConfig` appears as a typed parameter 78 times, and the scan only ever saw names bound from a config-looking *expression*. Annotation binding closes it -- attributed sites 1,313 -> 1,849, shared fields 73 -> 81.

Had the sabotage been valid, a green ratchet would have shipped over a detector reading a quarter of the config surface.

## Name collisions, and why 12 findings are parked

Widening recall made a second limit unmissable: the inventory is keyed by field NAME, and 11 of 15 signal fields are declared on more than one class. `transforms` appeared divergent only because a `MatchkeyField` fallback was compared against ten `BlockingKeyConfig` readers -- two different fields sharing a name.

A signal is actionable only when the name is declared on exactly one class. Both confirmed findings survive that test. Twelve are parked, and **none is claimed as a defect**.

## B3 — the ratchet

Same contract as `KNOWN_DEAD`: floors to work DOWN, both directions asserted. The sharp gate is `test_no_allowlisted_field_starts_diverging` -- a field whose readers were checked and agreed now supplies a second, different fallback. That is the `1c843c8a5` recurrence, and nothing in the repo could see it when the incident shipped.

Sabotage-verified, each gate against the failure it claims to catch: planting `or ["lower"]` on the allowlisted `transforms` trips the divergence gate naming the field; dropping an allowlist entry trips the triage gate; a phantom name trips the partition gate; an un-reproducing finding trips the floor gate.

## A CI defect this branch fixes

`shared_decisions` runs `scripts/test_no_new_shared_decisions.py`, but the filter listed only `scripts/test_shared_decisions_*.py` -- and the ratchet file is `test_no_new_*`, which does not match. **The job ran a gate whose own test file could not re-trigger it.** Caught by `check_filter_coverage.py`'s generic job-vs-filter check, which phase A built for exactly this; it would otherwise have shipped.

## The inventory observed its own remediation

Rebasing onto main after #2845 landed turned three tests red. Four modules -- `score_buckets.py`, `fs_out_of_core.py`, `distributed/scoring.py`, `identity/block_index.py` -- stopped reading `.passes`/`.keys` directly once the decision moved onto `BlockingConfig.resolved_keys()`, and left the accessor set entirely. The shared-decision inventory shrank because the duplication it surfaced was removed.

Those tests were updated, not widened. One carries an explicit warning against widening its window to silence it, and that warning was honoured: `passes` legitimately left the top 10, so the test now pins that it stays VISIBLE rather than that it stays top-ranked.

`passes` remains ACTIONABLE, correctly: `core/autoconfig.py:4500` still resolves `compound_config.passes or list(compound_config.keys or [])` unconditionally -- one of eight plan-building sites deliberately outside #2845's scope, recorded rather than swept.

## Testing

```
49 passed  (shapes, readers, report, fields, allowlist)
 5 passed  (the B3 ratchet)
11 passed  (workflow yaml)
ruff clean;  check_filter_coverage.py OK -- 47 paths / 6 filters, 0 new gaps
```

Rebased onto `main` with `--onto` after #2843 squash-merged.
