### PR TITLE
docs(audit): C1 read of the 55 -- the phase's soundness claim is false

### DIFF
--- a/docs/superpowers/specs/2026-09-02-c1-read-of-55.md
+++ b/docs/superpowers/specs/2026-09-02-c1-read-of-55.md
@@ -1,0 +1,130 @@
+# Phase C1 — Reading the 55 High-Confidence Findings
+
+**Status:** read; one foundational assumption of the phase is refuted
+**Date:** 2026-09-02
+**Spec:** `docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md`
+**Prior:** `docs/superpowers/specs/2026-09-02-c1-triage-findings.md`
+
+The confidence split (#2850) reduced the triage set from 167 to 55. All 55
+have now been read. Precision is much improved -- roughly two thirds carry a
+correct target, against roughly one in eight before #2847.
+
+But reading them refutes the spec's central claim about what the detector
+proves.
+
+## The soundness claim is false
+
+The spec states, as the property that makes the finding set trustworthy:
+
+> **Sound as a negative, suggestive as a positive.** No co-reference
+> genuinely proves that nothing compares the two.
+
+**Finding 25 refutes it.** `core/scorer.py:_alias_score_matrix` says it is
+"byte-identical to the pairwise ``score_field`` (parity-checked in
+``tests/test_semantic_scorers.py``)". The detector reported it UNENFORCED.
+
+It is enforced. `tests/test_semantic_scorers.py` contains
+`test_alias_match_matrix_parity`, which imports `_fuzzy_score_matrix` and
+`score_field` -- and `_fuzzy_score_matrix` calls `_alias_score_matrix` at
+`core/scorer.py:1358`. The test compares exactly what the claim says, one
+level of indirection away from the claimant's name.
+
+So a test CAN compare two functions without naming both, by reaching one
+through a caller. The executable-reference rule cannot see that, and its
+negative verdict is therefore **not sound** -- it is suggestive in both
+directions. Every "unenforced" finding carries an unknown false-negative
+rate.
+
+**Why this matters more than the precision work.** Three rounds of effort
+went into the positive direction (is the target right?). The negative
+direction was assumed correct by construction, and it was that assumption
+which justified reporting "unenforced" as a finding at all. It does not
+hold.
+
+**What it does not mean.** The phase is not worthless: 172 of 216 claims had
+no test naming either half, and the motivating incident was one of them.
+Indirection explains some of the finding set, not all of it. But the
+detector cannot say which, and no count it prints should be read as "these
+are unchecked".
+
+The honest fix is coverage-based enforcement -- the option the spec
+considered and rejected as "buying precision in the direction that does not
+carry the finding". That reasoning was wrong: the finding is exactly what
+the negative direction carries.
+
+## The 55, classified
+
+| class | n | notes |
+| --- | ---: | --- |
+| correct target, real equivalence claim | 36 | the triage set proper |
+| wrong target | 11 | `score`, `filter_eq`, `fields`, `row`, `values`, `keys`, `pair` |
+| pattern claim (arrangement, not behaviour) | 4 | `_do_transform_columnar`, the two `_migrate_*`, `from_dataframe` |
+| post-mortem prose | 1 | see below |
+| already enforced indirectly | 3+ | at least #25; the true number is unknown |
+
+### A new false-positive class: post-mortem prose
+
+Finding 53 is `tui/engine.py:_run_pipeline --mirrors--> run_dedupe` -- this
+phase's own motivating incident. That code was deleted in `6c89042c7`. What
+the detector matched is a docstring in the CURRENT file explaining why the
+copy was removed, which quotes the old claim verbatim: "...run_dedupe' --
+and that copy is why `demo` and `lineage` raised ImportError on a default
+install".
+
+A docstring narrating a fixed incident reads exactly like the incident. This
+is benign here and is worth knowing about before C3 freezes a floor
+containing it.
+
+## Worth enforcing, in priority order
+
+These are correct targets with claims that state a checkable property, and
+nothing tests them:
+
+1. **`core/survivorship/native.py`** -- three claims against the Python
+   survivorship path: `_scalar_value_expr` "byte-identical to
+   ``merge_field``'s winning VALUE", `_scalar_conf_expr` "byte-identical to
+   ``merge_field``'s returned confidence", `_resolve_conditionals`
+   "byte-identical to ``resolve_cluster``'s conditional branch. Mirrors the
+   slow path EXACTLY (the oracle)". A native/Python survivorship divergence
+   produces different golden records with no error -- the highest-severity
+   shape in this codebase, and three claims say so in their own words.
+2. **`utils/transforms.py:canonical_soundex`** -- "byte-identical to
+   score-core ``soundex``", a cross-surface claim with a stated spec
+   (NFKD-fold + uppercase). Cheap to test.
+3. **`core/sketch.py:simhash_band_hashes`** -- "mirrors the MinHash
+   ``band_hashes`` byte layout (u64 band-index prefix + per-element bytes)".
+   A byte layout is exactly testable.
+4. **`spark/config_pipeline.py:_block_key_column`** -- "mirrors
+   ``arrow_derive.block_key``: each field takes its own transform chain".
+   Same class as the block-key defects phase B already found.
+5. **`distributed/clustering.py`** -- two claims that
+   `randomized_contraction_wcc` and `_rc_union_isolated` mirror
+   `two_phase_wcc` "so the two routes agree". Two WCC implementations that
+   must agree is the shape that produced `#2717`.
+
+`identity/snowflake_backend.py:_rel_expr` was in this list and is done --
+PR #2849.
+
+## Recommended order, revised
+
+1. **Decide what to do about the soundness refutation.** Coverage-based
+   enforcement is the only fix that addresses it. Until then C3's ratchet
+   should NOT be armed: a floor built on a finding set with an unknown
+   false-negative rate freezes claims that are already tested.
+2. **Write the five enforcing tests above** regardless. They stand on their
+   own, do not depend on the detector, and each pins a claim the codebase
+   makes about itself. This is where the phase's value actually is.
+3. **C3 last, and only if step 1 produces a signal worth freezing.**
+
+## Being wrong about this document
+
+The finding rests on one example. It is possible `_alias_score_matrix` is
+the only claim in the 55 enforced through indirection, in which case the
+soundness claim is very nearly true and the fix is not worth its cost.
+
+That is measurable and has not been measured: it needs, for each of the 55,
+a check of whether any test transitively reaches both halves. Doing it
+properly means a call graph or a coverage run, which is the same machinery
+the fix would need -- so the measurement and the remedy are the same piece
+of work. That is the argument for doing it, not for assuming the answer
+either way.

--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -207,6 +207,18 @@ mentions both, never that it compares them. So the finding is the unenforced
 set; the 49 possibly-enforced claims are reported as UNVERIFIED and never as
 safe.
 
+> **THIS SOUNDNESS CLAIM WAS REFUTED IN C1.** A test can compare two
+> functions without naming both, by reaching one through a caller.
+> `core/scorer.py:_alias_score_matrix` is reported UNENFORCED, and is in fact
+> parity-checked by `test_alias_match_matrix_parity`, which calls
+> `_fuzzy_score_matrix` -- which calls the claimant. The negative verdict is
+> therefore suggestive, not sound, and every "unenforced" count carries an
+> unknown false-negative rate. See
+> `docs/superpowers/specs/2026-09-02-c1-read-of-55.md`. The fix is
+> coverage-based enforcement, the option rejected below as "buying precision
+> in the direction that does not carry the finding" -- that reasoning was
+> wrong.
+
 This is A and B's inversion. A resolved declared liveness (registries) and
 flagged the unexplained. B resolved declared parity and flagged undeclared
 shared decisions. C resolves declared synchronisation and flags the unenforced


### PR DESCRIPTION
## What and why

All 55 high-confidence sync-claim findings have been read -- C1's actual exit criterion. Precision after #2847 and #2850 is much improved: roughly two thirds carry a correct target, against roughly one in eight before.

**Reading them refutes the phase's foundational assumption**, and that is the substance of this PR.

## The soundness claim is false

The spec states, as the property that made "unenforced" reportable as a finding at all:

> **Sound as a negative, suggestive as a positive.** No co-reference genuinely proves that nothing compares the two.

`core/scorer.py:_alias_score_matrix` says it is "byte-identical to the pairwise ``score_field`` (parity-checked in ``tests/test_semantic_scorers.py``)". **The detector reports it UNENFORCED. It is enforced.**

`test_alias_match_matrix_parity` imports `_fuzzy_score_matrix` and `score_field`, and `_fuzzy_score_matrix` calls `_alias_score_matrix` at `core/scorer.py:1358`. The test compares exactly what the claim says -- one level of indirection from the claimant's name, which the executable-reference rule cannot see.

So a test can compare two functions without naming both. The negative verdict is **suggestive, not sound**, and every "unenforced" count carries an unknown false-negative rate.

Three rounds of work went into the positive direction (is the target right?). The negative direction was assumed correct by construction, and that assumption is what the finding set rested on.

**What it does not mean.** 172 of 216 claims had no test naming either half, and the motivating incident was among them. Indirection explains some of the finding set, not all of it -- but the detector cannot say which.

The honest fix is coverage-based enforcement, the option the spec considered and rejected as "buying precision in the direction that does not carry the finding". That reasoning was wrong: the finding is exactly what the negative direction carries. The main spec now carries the refutation inline rather than continuing to assert soundness.

## The 55, classified

| class | n |
| --- | ---: |
| correct target, real equivalence claim | 36 |
| wrong target | 11 |
| pattern claim (arrangement, not behaviour) | 4 |
| post-mortem prose | 1 |
| already enforced indirectly | 3+, true number unknown |

**A new false-positive class.** Finding 53 is this phase's own motivating incident, `_run_pipeline --mirrors--> run_dedupe`. That code was deleted in `6c89042c7`; what the detector matched is a docstring in the CURRENT file explaining why, quoting the old claim verbatim. A docstring narrating a fixed incident reads exactly like the incident -- benign here, worth knowing before C3 freezes a floor containing it.

## Five claims worth enforcing regardless

These have correct targets, state a checkable property, and nothing tests them. They do not depend on the detector's fate:

1. **`core/survivorship/native.py`** -- three claims of byte-identical results to the Python path (`merge_field`'s winning value, `merge_field`'s confidence, `resolve_cluster`'s conditional branch, the last saying "Mirrors the slow path EXACTLY (the oracle)"). A native/Python survivorship divergence produces different golden records with no error.
2. `utils/transforms.py:canonical_soundex` -- "byte-identical to score-core ``soundex``", with a stated spec.
3. `core/sketch.py:simhash_band_hashes` -- mirrors the MinHash `band_hashes` byte layout.
4. `spark/config_pipeline.py:_block_key_column` -- mirrors `arrow_derive.block_key`; same class as the block-key defects phase B found.
5. `distributed/clustering.py` -- two claims that the WCC routes agree; the shape that produced #2717.

`identity/snowflake_backend.py:_rel_expr` was on this list and is done, PR #2849.

## Recommendation

**Do not arm C3's ratchet yet.** A floor built on a finding set with an unknown false-negative rate would freeze claims that are already tested. Settle the soundness question first; write the five tests regardless, since that is where the phase's value actually is.

## Being wrong about this

The refutation rests on one example. It is possible `_alias_score_matrix` is the only claim in the 55 enforced through indirection, in which case the soundness claim is very nearly true and the fix is not worth its cost.

That is measurable and has not been measured -- it needs, for each of the 55, a check of whether any test transitively reaches both halves. Doing it properly needs a call graph or a coverage run, which is the same machinery the fix would need. The measurement and the remedy are the same piece of work, which is an argument for doing it rather than for assuming the answer.

Documentation only; no code changes.
