### PR TITLE
test(sync-claims): two genuine gaps fixed, three checked and already enforced

### DIFF
--- a/docs/superpowers/specs/2026-09-02-c1-read-of-55.md
+++ b/docs/superpowers/specs/2026-09-02-c1-read-of-55.md
@@ -60,7 +60,7 @@ the negative direction carries.
 | wrong target | 11 | `score`, `filter_eq`, `fields`, `row`, `values`, `keys`, `pair` |
 | pattern claim (arrangement, not behaviour) | 4 | `_do_transform_columnar`, the two `_migrate_*`, `from_dataframe` |
 | post-mortem prose | 1 | see below |
-| already enforced indirectly | 3+ | at least #25; the true number is unknown |
+| already enforced indirectly | 5+ (was 3+) | #25, plus the three survivorship claims and soundex, below; the true number across all 55 is still unknown |
 
 ### A new false-positive class: post-mortem prose
 
@@ -75,56 +75,109 @@ A docstring narrating a fixed incident reads exactly like the incident. This
 is benign here and is worth knowing about before C3 freezes a floor
 containing it.
 
-## Worth enforcing, in priority order
+## Worth enforcing, in priority order -- and what checking each one found
 
-These are correct targets with claims that state a checkable property, and
-nothing tests them:
+Checking every item on this list before writing anything, the way
+`_alias_score_matrix` should have been checked before it was counted as a
+finding, changed three of five from "write a test" to "already enforced."
 
-1. **`core/survivorship/native.py`** -- three claims against the Python
-   survivorship path: `_scalar_value_expr` "byte-identical to
-   ``merge_field``'s winning VALUE", `_scalar_conf_expr` "byte-identical to
-   ``merge_field``'s returned confidence", `_resolve_conditionals`
-   "byte-identical to ``resolve_cluster``'s conditional branch. Mirrors the
-   slow path EXACTLY (the oracle)". A native/Python survivorship divergence
-   produces different golden records with no error -- the highest-severity
-   shape in this codebase, and three claims say so in their own words.
+1. **`core/survivorship/native.py`** -- three claims: `_scalar_value_expr`
+   "byte-identical to ``merge_field``'s winning VALUE", `_scalar_conf_expr`
+   "byte-identical to ``merge_field``'s returned confidence",
+   `_resolve_conditionals` "byte-identical to ``resolve_cluster``'s
+   conditional branch. Mirrors the slow path EXACTLY (the oracle)".
+   **ALREADY ENFORCED.** `build_survivorship_native` calls all three
+   directly (`native.py:622,628,840`), and
+   `tests/survivorship/test_native_parity.py` -- 1,477 lines, confirmed
+   green at 77 passed -- calls `assert_parity()` roughly 60 times, each
+   comparing `build_survivorship_native()` byte-for-byte against the slow
+   oracle (`build_golden_records_batch` -> `merge_field`/`resolve_cluster`)
+   across every strategy the claims name. The module's own docstring says
+   why the sync-claim detector could not see this: "Built up
+   strategy-by-strategy, each gated by a parity test in
+   test_native_parity.py" -- a *public-contract* test, not one naming the
+   private helpers.
 2. **`utils/transforms.py:canonical_soundex`** -- "byte-identical to
-   score-core ``soundex``", a cross-surface claim with a stated spec
-   (NFKD-fold + uppercase). Cheap to test.
+   score-core ``soundex``". **ALREADY ENFORCED.**
+   `core/scorer.py:_soundex_score_single` calls `canonical_soundex` on both
+   inputs (`scorer.py:1462-1463`), and
+   `tests/test_native_soundex_parity.py` batters that wrapper against the
+   native kernel across an adversarial vocabulary (garbage, accented Latin,
+   exotic non-decomposable letters) -- exactly the property the claim
+   states, one level of indirection from the claimant's name.
 3. **`core/sketch.py:simhash_band_hashes`** -- "mirrors the MinHash
-   ``band_hashes`` byte layout (u64 band-index prefix + per-element bytes)".
-   A byte layout is exactly testable.
+   ``band_hashes`` byte layout (u64 band-index prefix + per-element
+   bytes)". **RECLASSIFIED, not a gap.** Reading both functions:
+   `band_hashes` packs each signature element as 8 little-endian bytes
+   (`sig[...].to_bytes(8, "little")`); `simhash_band_hashes` packs each
+   element as ONE byte (`bytes(sig[...])`), because a SimHash plane-bit is
+   0/1 and a MinHash hash value needs 8 bytes. The claim is that the two
+   share a byte-packing CONVENTION (u64 prefix, then per-element data), not
+   that their outputs are equal -- they cannot be, on different-width
+   inputs. This is the "pattern claim" class the spec's Being-wrong section
+   names (arrangement, not behaviour), not an untested equivalence.
 4. **`spark/config_pipeline.py:_block_key_column`** -- "mirrors
-   ``arrow_derive.block_key``: each field takes its own transform chain".
-   Same class as the block-key defects phase B already found.
-5. **`distributed/clustering.py`** -- two claims that
-   `randomized_contraction_wcc` and `_rc_union_isolated` mirror
-   `two_phase_wcc` "so the two routes agree". Two WCC implementations that
-   must agree is the shape that produced `#2717`.
+   ``arrow_derive.block_key``". **CONFIRMED GENUINE GAP, now fixed.** The
+   only existing reference
+   (`test_block_key_normalization_routes_to_the_jar_when_asked`) checks
+   that a UDF name threads through, never that the resulting key matches
+   Arrow's. New test:
+   `tests/test_spark_jvm_native_parity.py::test_block_key_column_matches_arrow_derive`.
+   Pins the any-null guard specifically -- `_block_key_column`'s own
+   docstring explains plain `concat_ws` would collapse `("a", null)` and
+   `("a", "")` into the same key, which is exactly the class of defect
+   phase B already found twice (F2/F10).
+5. **`distributed/clustering.py`** -- `randomized_contraction_wcc` and
+   `_rc_union_isolated` "mirror `two_phase_wcc`". **CONFIRMED GENUINE GAP,
+   now fixed.** No existing test ran both algorithms on the same input;
+   each is asserted independently. New test:
+   `tests/test_distributed_randomized_contraction_wcc.py::test_randomized_contraction_agrees_with_two_phase_wcc`
+   -- compares PARTITIONS (which ids end up grouped together) rather than
+   label values, since pinning the internal min-id convention would be a
+   stricter claim than either docstring actually makes. Same shape as
+   `#2717`.
 
 `identity/snowflake_backend.py:_rel_expr` was in this list and is done --
 PR #2849.
 
-## Recommended order, revised
+## Recommended order, revised again
 
-1. **Decide what to do about the soundness refutation.** Coverage-based
-   enforcement is the only fix that addresses it. Until then C3's ratchet
-   should NOT be armed: a floor built on a finding set with an unknown
-   false-negative rate freezes claims that are already tested.
-2. **Write the five enforcing tests above** regardless. They stand on their
-   own, do not depend on the detector, and each pins a claim the codebase
-   makes about itself. This is where the phase's value actually is.
-3. **C3 last, and only if step 1 produces a signal worth freezing.**
+1. ~~Write the five enforcing tests above~~ -- **done, partially by NOT
+   writing them.** Checking each one first found three already enforced
+   (items 1-2 above; item 3 reclassified) and two genuine gaps, now fixed
+   (items 4-5, this branch). Writing all five blind would have shipped two
+   redundant test files duplicating a 1,477-line harness and a
+   thousands-of-pairs adversarial soundex sweep that already existed.
+2. **Decide what to do about the soundness refutation.** Still open, and
+   now on stronger evidence: checking exactly the 8 items this document
+   named as worth enforcing (the 5 priority items, where item 1 covers 3
+   claims) found 5 confirmed false negatives, not 1. That is not a random
+   sample -- these were chosen FOR being high-confidence, checkable claims,
+   which likely correlates with the module also carrying rigorous existing
+   tests (the same engineering discipline that produces a careful docstring
+   tends to also produce a careful test suite, just one that tests the
+   public contract rather than naming the private helper). Whether that
+   correlation holds for the other 47 is still unmeasured. Coverage-based
+   enforcement remains the only fix that addresses the soundness gap
+   directly.
+3. **C3's ratchet still should NOT be armed** until step 2 is settled. A
+   floor built on this finding set would freeze claims some of which are
+   already tested -- confirmed, now, not merely possible.
 
 ## Being wrong about this document
 
-The finding rests on one example. It is possible `_alias_score_matrix` is
-the only claim in the 55 enforced through indirection, in which case the
-soundness claim is very nearly true and the fix is not worth its cost.
+The original version of this section said the finding rested on one
+example, and that it was possible `_alias_score_matrix` was the only claim
+in the 55 enforced through indirection. Checking the next 8 -- the "worth
+enforcing" list -- found 4 more, all indirect, in a sample chosen for
+looking like genuine gaps. That doesn't settle the question; it moves it.
 
-That is measurable and has not been measured: it needs, for each of the 55,
-a check of whether any test transitively reaches both halves. Doing it
-properly means a call graph or a coverage run, which is the same machinery
-the fix would need -- so the measurement and the remedy are the same piece
-of work. That is the argument for doing it, not for assuming the answer
-either way.
+**What is still unmeasured:** the true false-negative rate across all 55,
+and whether the correlation this document now suspects (rigorous docstring
+-> rigorous but indirect tests) actually holds, or whether the 8 checked
+here were unusually lucky/unlucky in some way not yet identified. Both of
+those need, for each of the 55, a check of whether any test transitively
+reaches both halves -- a call graph or a coverage run, which is the same
+machinery a real fix would need. The measurement and the remedy are still
+the same piece of work; there is simply less doubt now about whether the
+measurement would find something.

--- a/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
+++ b/docs/superpowers/specs/2026-09-02-sync-claim-audit-design.md
@@ -207,13 +207,20 @@ mentions both, never that it compares them. So the finding is the unenforced
 set; the 49 possibly-enforced claims are reported as UNVERIFIED and never as
 safe.
 
-> **THIS SOUNDNESS CLAIM WAS REFUTED IN C1.** A test can compare two
-> functions without naming both, by reaching one through a caller.
-> `core/scorer.py:_alias_score_matrix` is reported UNENFORCED, and is in fact
-> parity-checked by `test_alias_match_matrix_parity`, which calls
-> `_fuzzy_score_matrix` -- which calls the claimant. The negative verdict is
-> therefore suggestive, not sound, and every "unenforced" count carries an
-> unknown false-negative rate. See
+> **THIS SOUNDNESS CLAIM WAS REFUTED IN C1, THEN CONFIRMED FIVE TIMES OVER.**
+> A test can compare two functions without naming both, by reaching one
+> through a caller. `core/scorer.py:_alias_score_matrix` is reported
+> UNENFORCED, and is in fact parity-checked by `test_alias_match_matrix_parity`,
+> which calls `_fuzzy_score_matrix` -- which calls the claimant. Checking the
+> next 8 findings this phase specifically flagged as high-value (the
+> "worth enforcing" list) found 4 more of the same shape --
+> `core/survivorship/native.py`'s three byte-identical claims, all satisfied
+> by a 1,477-line, 77-test parity harness that tests the public entry point
+> rather than the private helpers; and `canonical_soundex`, satisfied by an
+> adversarial soundex sweep reached through `_soundex_score_single`. The
+> negative verdict is therefore suggestive, not sound, and every "unenforced"
+> count carries an unknown false-negative rate -- not a small one, on the
+> evidence so far. See
 > `docs/superpowers/specs/2026-09-02-c1-read-of-55.md`. The fix is
 > coverage-based enforcement, the option rejected below as "buying precision
 > in the direction that does not carry the finding" -- that reasoning was

--- a/packages/python/goldenmatch/tests/test_distributed_randomized_contraction_wcc.py
+++ b/packages/python/goldenmatch/tests/test_distributed_randomized_contraction_wcc.py
@@ -311,3 +311,86 @@ def test_build_clusters_distributed_algorithm_kwarg_overrides_env(monkeypatch, c
     assert any("randomized_contraction" in m for m in msgs), msgs
     rows = {r["member_id"]: r["cluster_size"] for r in out.take_all()}
     assert rows[1] == 3 and rows[5] == 2
+
+
+def test_randomized_contraction_agrees_with_two_phase_wcc(tmp_path):
+    """The claim this pins: `randomized_contraction_wcc`'s docstring says
+    "Same {id,label} contract as two_phase_wcc", and `_rc_union_isolated`
+    says it "mirrors two_phase_wcc's isolated-node handling so the two routes
+    agree on the build_clusters_distributed contract". NOTHING previously ran
+    both algorithms on the same input and compared -- the existing tests each
+    assert one algorithm's output independently, never both against each
+    other. Surfaced by the phase-C sync-claim audit
+    (docs/superpowers/specs/2026-09-02-c1-read-of-55.md), the same shape as
+    `#2717`: two WCC implementations disagreeing on cluster membership is a
+    silent wrong answer with no exception, not a crash.
+
+    Compares PARTITIONS (which ids end up grouped together), not label
+    VALUES. Both algorithms use min-id-of-component as their label today
+    (`_rc_normalize_distributed`'s "per-partition min(orig_id) == global
+    component min" comment), but pinning that internal convention would be a
+    stricter and more fragile claim than the one either docstring actually
+    makes -- "the two routes agree" means the same clustering, not
+    necessarily the same representative id.
+
+    The input graph is deliberately not one component: a 5-node chain (the
+    shape `two_phase_wcc`'s own docstring calls label-prop's worst case, and
+    RC's rival), an isolated triangle, a pair, and two singletons seeded only
+    through `all_ids` -- so isolated-node handling (the specific thing
+    `_rc_union_isolated`'s docstring calls out) is exercised by both routes.
+    """
+    pytest.importorskip("ray")
+    from goldenmatch.distributed.clustering import (
+        pairs_list_to_dataset,
+        randomized_contraction_wcc,
+        two_phase_wcc,
+    )
+
+    edges = [
+        (1, 2, 0.9), (2, 3, 0.9), (3, 4, 0.9), (4, 5, 0.9),  # chain
+        (10, 11, 0.9), (11, 12, 0.9), (10, 12, 0.9),  # triangle
+        (20, 21, 0.9),  # pair
+    ]
+    all_ids = [1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 99, 100]  # 99, 100: isolated
+    expected_partition = {
+        frozenset({1, 2, 3, 4, 5}),
+        frozenset({10, 11, 12}),
+        frozenset({20, 21}),
+        frozenset({99}),
+        frozenset({100}),
+    }
+
+    def _partition(rows):
+        groups: dict[int, set[int]] = {}
+        for r in rows:
+            groups.setdefault(r["label"], set()).add(r["id"])
+        return {frozenset(members) for members in groups.values()}
+
+    two_phase = two_phase_wcc(
+        pairs_list_to_dataset(edges), all_ids=list(all_ids)
+    ).take_all()
+    randomized = randomized_contraction_wcc(
+        pairs_list_to_dataset(edges),
+        all_ids=list(all_ids),
+        scratch_dir=str(tmp_path),
+        seed=0,
+    ).take_all()
+
+    two_phase_partition = _partition(two_phase)
+    randomized_partition = _partition(randomized)
+
+    # Guard the guard: if the fixture graph does not produce the intended
+    # shape, the comparison below would be comparing two WRONG answers and
+    # agreeing on that would prove nothing.
+    assert two_phase_partition == expected_partition, (
+        f"two_phase_wcc did not produce the intended fixture shape: "
+        f"{two_phase_partition}"
+    )
+
+    assert randomized_partition == two_phase_partition, (
+        f"randomized_contraction_wcc disagrees with two_phase_wcc on cluster "
+        f"membership -- the two routes do NOT agree, contradicting both "
+        f"docstrings' claim.\n"
+        f"two_phase_wcc:              {sorted(map(sorted, two_phase_partition))}\n"
+        f"randomized_contraction_wcc: {sorted(map(sorted, randomized_partition))}"
+    )

--- a/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_spark_jvm_native_parity.py
@@ -970,3 +970,79 @@ def test_fs_training_runs_with_no_python_on_the_executors(spark, registered):
     # `last` keys pass 2, so it must carry the #1835 neutral prior rather than
     # an estimate the blocking made unrepresentative.
     assert got.u_probs["last"] == pytest.approx([0.5, 0.5], abs=1e-12)
+
+
+def test_block_key_column_matches_arrow_derive(spark):
+    """The claim this pins: `_block_key_column`'s docstring says "Mirrors
+    `arrow_derive.block_key`". Nothing previously compared the two column
+    builders' OUTPUT on the same input -- the existing block-key test
+    (`test_block_key_normalization_routes_to_the_jar_when_asked`) only checks
+    that a UDF name threads through, never that the resulting key matches
+    Arrow's. Surfaced by the phase-C sync-claim audit
+    (docs/superpowers/specs/2026-09-02-c1-read-of-55.md), the same class as
+    the block-key defects phase B already found (F2/F10 in
+    docs/superpowers/specs/2026-09-02-shared-decision-triage.md): a wrong or
+    differently-null'd block key silently changes which rows compare to which,
+    with no exception.
+
+    The case worth pinning by name is the any-null guard.
+    `_block_key_column`'s own docstring explains why it exists: plain
+    `concat_ws` SKIPS nulls, so `("a", null)` and `("a", "")` would collide
+    into the same joined string if the guard were ever removed. Row 2 below
+    (`b=None`) and row 3 (`b=""`) are adjacent and otherwise identical
+    specifically so that collapse would be visible as a wrong answer, not an
+    exception.
+
+    Lives here (not the session-free unit file, per this module's own
+    documented gotcha above `test_block_key_normalization_routes_to_the_jar_
+    when_asked`) because building the column expression needs an active
+    Spark session.
+    """
+    import pyarrow as pa
+    from goldenmatch.config.schemas import BlockingKeyConfig
+    from goldenmatch.core.arrow_derive import block_key
+    from goldenmatch.spark.config_pipeline import _block_key_column
+    from pyspark.sql import Row
+
+    rows = [
+        {"a": "Foo", "b": "Bar"},  # both present -> joined
+        {"a": "Foo", "b": None},  # b null -> WHOLE KEY null
+        {"a": "Foo", "b": ""},  # b empty string -> NOT null; distinct from above
+        {"a": None, "b": "Bar"},  # a null -> whole key null
+    ]
+
+    def _oracle(field_chains):
+        a_arr = pa.array([r["a"] for r in rows], type=pa.large_string())
+        b_arr = pa.array([r["b"] for r in rows], type=pa.large_string())
+        return block_key([a_arr, b_arr], transforms=[], field_chains=field_chains).to_pylist()
+
+    df = spark.createDataFrame([Row(a=r["a"], b=r["b"]) for r in rows])
+
+    # Shared transform chain (the key-level `transforms` field).
+    shared_key = BlockingKeyConfig(fields=["a", "b"], transforms=["lowercase"])
+    shared_expr, _ = _block_key_column(shared_key)
+    shared_spark = [r[0] for r in df.select(shared_expr).collect()]
+    shared_oracle = _oracle([["lowercase"], ["lowercase"]])
+    assert shared_spark == shared_oracle, (
+        f"shared-chain block keys diverge:\n  spark={shared_spark}\n  arrow={shared_oracle}"
+    )
+    # The any-null guard, named: row 1 (b=None) must be null; row 2 (b="")
+    # must NOT be null and must differ from row 0. A `concat_ws`-only
+    # implementation would collapse rows 1 and 2 into the same string.
+    assert shared_spark[1] is None
+    assert shared_spark[2] is not None
+    assert shared_spark[2] != shared_spark[0]
+
+    # Per-field transform chain (the `field_transforms` slot overriding the
+    # shared chain for one field) -- the other half of the claim's "each
+    # field takes its own transform chain (the per-field slot when set, else
+    # the key-level chain)".
+    per_field_key = BlockingKeyConfig(
+        fields=["a", "b"], transforms=["lowercase"], field_transforms={"b": ["uppercase"]}
+    )
+    per_field_expr, _ = _block_key_column(per_field_key)
+    per_field_spark = [r[0] for r in df.select(per_field_expr).collect()]
+    per_field_oracle = _oracle([["lowercase"], ["uppercase"]])
+    assert per_field_spark == per_field_oracle, (
+        f"per-field-chain block keys diverge:\n  spark={per_field_spark}\n  arrow={per_field_oracle}"
+    )


### PR DESCRIPTION
## What and why

C1's read-out (`docs/superpowers/specs/2026-09-02-c1-read-of-55.md`) named five items as the highest-value claims still worth enforcing regardless of the sync-claim detector's fate. This PR was going to write tests for all five. Checking each one first, before writing anything, found only two actually needed a test.

**Three were already enforced, and finding that out is the more important part of this PR.**

## Three false negatives found by checking, not by writing

1. **`core/survivorship/native.py`'s three byte-identical claims** (`_scalar_value_expr`, `_scalar_conf_expr`, `_resolve_conditionals`, all claiming parity with the Python survivorship oracle) are already enforced by `tests/survivorship/test_native_parity.py` -- 1,477 lines, confirmed green at **77 passed**, calling `assert_parity()` roughly 60 times against `build_survivorship_native`'s public entry point, which calls all three claimants directly. The module's own docstring explains why the sync-claim detector missed it: "Built up strategy-by-strategy, each gated by a parity test in test_native_parity.py" -- a public-contract test, never naming the private helpers.

2. **`utils/transforms.py:canonical_soundex`**'s "byte-identical to score-core soundex" claim is enforced by `tests/test_native_soundex_parity.py`, reached through `core/scorer.py:_soundex_score_single`, which calls `canonical_soundex` directly (`scorer.py:1462-1463`) and is battered against the native kernel across an adversarial vocabulary.

3. **`core/sketch.py:simhash_band_hashes`**'s claim, read closely, isn't a byte-identity claim at all. `band_hashes` packs each signature element as 8 little-endian bytes; `simhash_band_hashes` packs each element as ONE byte -- a MinHash element is a hash value needing 8 bytes, a SimHash plane-bit is 0/1 and fits in one. "Mirrors the byte layout" means they share a packing CONVENTION (u64 band-index prefix, then per-element data), not that their outputs are equal. Reclassified as a pattern claim, not a gap.

This is the same false-negative shape the phase already confirmed once on `_alias_score_matrix` -- and finding it four more times, specifically in the set this phase itself flagged as highest-confidence, is a much stronger signal than the original single instance. Both spec documents are updated with the full accounting.

## The two genuine gaps, now fixed

**`distributed/clustering.py`: `randomized_contraction_wcc` and `_rc_union_isolated` claim to "mirror `two_phase_wcc`" so the two WCC routes agree.** Nothing ran both algorithms on the same input and compared -- each was asserted independently. New test builds a graph with a chain (the shape `two_phase_wcc`'s own docstring calls label-prop's worst case), a triangle, a pair, and two isolated singletons seeded via `all_ids`, runs both algorithms, and asserts they produce the **same partition** of ids into components -- not the same label values, since pinning the internal min-id convention would be a stricter claim than either docstring actually makes. Same defect class as `#2717`: two clustering implementations silently disagreeing, no exception.

**`spark/config_pipeline.py:_block_key_column` claims to "mirror `arrow_derive.block_key`".** The only existing reference (`test_block_key_normalization_routes_to_the_jar_when_asked`) checks that a UDF name threads through, never that the resulting key matches Arrow's. New test pins the any-null guard by name: the function's own docstring explains that plain `concat_ws` would collapse `("a", null)` and `("a", "")` into the same key, which is exactly the block-key defect class phase B found twice already (F2/F10). Also pins the per-field-transform-chain override (`field_transforms` vs the shared `transforms` chain).

## Testing

Neither Ray nor pyspark is installed on this box (standing policy -- both are CI-only). Both new tests are verified as far as locally possible:

- The pure-PyArrow oracle side of the block-key test (`arrow_derive.block_key`) was run directly and its output hand-checked against the assertions before trusting them -- confirmed the any-null guard produces exactly `['foo||bar', None, 'foo||', None]` on the fixture rows.
- Both files confirmed to still collect and skip cleanly (`pytest.importorskip`), same posture as their neighboring Ray/pyspark-gated tests in the same files.
- `ruff check` clean.
- The three suites the "already enforced" items turned out to depend on were re-run and confirmed green: `tests/survivorship/test_native_parity.py` + `tests/test_native_soundex_parity.py` = **80 passed**.
- `check_filter_coverage.py` clean.

Both new tests run for real in CI, in the lanes that already have Ray/pyspark built.

## Scope

Documentation-only changes to the two C1 spec documents (no code) plus the two new test files. Branched off `main`, independent of everything else in the sync-claim audit queue.
