### PR TITLE
fix(sync-claims): match coverage paths across environments

### DIFF
--- a/scripts/sync_claims/coverage_enforcement.py
+++ b/scripts/sync_claims/coverage_enforcement.py
@@ -84,13 +84,32 @@ def function_contexts(
     spuriously share that context with every other.
     """
     import coverage
+    from coverage_paths import normalize
 
     data = coverage.CoverageData(basename=str(coverage_db))
     data.read()
 
+    # Coverage emits `measured_files()` in whatever path shape the run that
+    # produced them used -- a Linux CI checkout's absolute path is never a
+    # subpath of a local Windows `root`, so literal path containment
+    # (`.resolve().relative_to(root)`) silently matches nothing the moment
+    # the data is read somewhere other than where it was produced. Confirmed
+    # by hand: `coverage_functions_with_data` read 0 against a real CI
+    # artifact downloaded and read locally -- coverage_consulted was True,
+    # the read succeeded, every file was just invisible to this check.
+    # `coverage_paths.normalize()` was already built and proven for exactly
+    # this problem (phase A's per-module floor table went silently vacuous
+    # the same way); reused here instead of a second bespoke reconciliation.
+    # .resolve() first (lexical only for a path that doesn't exist on this
+    # machine, e.g. a CI-produced absolute path read locally -- pathlib does
+    # not require the path to exist) so same-environment matches stay robust
+    # to `..`/`.` segments and redundant separators; normalize() alone then
+    # carries the cross-environment case via its substring match.
+    canonical_to_relative = {normalize(str((root / rel).resolve())): rel for rel in spans}
+
     line_contexts_by_file: dict[str, dict[int, set[str]]] = {}
     for measured in data.measured_files():
-        rel = _relative_to_root(measured, root)
+        rel = canonical_to_relative.get(normalize(str(Path(measured).resolve())))
         if rel is None:
             continue
         line_contexts_by_file[rel] = data.contexts_by_lineno(measured)
@@ -108,19 +127,6 @@ def function_contexts(
             if ctxs:
                 out[(module, name)] = frozenset(ctxs)
     return out
-
-
-def _relative_to_root(measured_path: str, root: Path) -> str | None:
-    """`coverage.py` reports measured files with whatever path shape the run
-    that produced them used (absolute, or relative to that run's CWD) -- not
-    guaranteed to match `root`-relative posix paths. Returns None for a file
-    outside `root` rather than raising, since a coverage run's `source`
-    scope and this scan's `root` are configured independently and are not
-    guaranteed identical."""
-    try:
-        return Path(measured_path).resolve().relative_to(root.resolve()).as_posix()
-    except ValueError:
-        return None
 
 
 def coverage_enforced(

--- a/scripts/test_sync_claims_coverage_enforcement.py
+++ b/scripts/test_sync_claims_coverage_enforcement.py
@@ -228,3 +228,74 @@ def test_coverage_enforced_survives_xdist_and_combine(tmp_path):
         "target (shard1 only) and only_shard_2_calls_this (shard2 only) "
         f"share NO test -- must not be reported enforced. contexts: {contexts}"
     )
+
+
+def test_function_contexts_matches_paths_across_environments(tmp_path):
+    """A CI-produced `.coverage`'s `measured_files()` are absolute paths
+    shaped by wherever the run happened (e.g. a Linux CI checkout); `root`
+    when the data is later read can be a completely different absolute
+    location (e.g. a local dev machine's own checkout). Literal path
+    containment (`.resolve().relative_to(root)`) matches nothing across that
+    gap -- confirmed directly against a real downloaded CI artifact:
+    `coverage_functions_with_data` read 0 despite `coverage_consulted` being
+    True, the read succeeded, every file was simply invisible to that check.
+
+    This pins the fix: two genuinely different absolute directory trees,
+    sharing only a `goldenmatch/`-rooted tail, must still match via
+    `coverage_paths.normalize()`'s substring-based canonical form."""
+    from sync_claims.coverage_enforcement import coverage_enforced, function_contexts
+
+    module_src = "def claimant():\n    return target()\n\n\ndef target():\n    return 1\n"
+    test_src = (
+        "from m import claimant, target\n\ndef test_it():\n    assert claimant() == target()\n"
+    )
+
+    # The "CI" checkout: coverage actually runs here.
+    ci_root = tmp_path / "home_runner_work" / "goldenmatch" / "goldenmatch"
+    ci_root.mkdir(parents=True)
+    (ci_root / "m.py").write_text(module_src, encoding="utf-8")
+    (ci_root / "test_it.py").write_text(test_src, encoding="utf-8")
+    (ci_root / "pyproject.toml").write_text(
+        '[tool.coverage.run]\nsource = ["."]\n', encoding="utf-8"
+    )
+
+    data_file = ci_root / "probe.dat"
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--with",
+            "pytest-cov",
+            "pytest",
+            "test_it.py",
+            "--cov=.",
+            "--cov-context=test",
+            "--cov-report=",
+            "-q",
+        ],
+        cwd=str(ci_root),
+        env={**__import__("os").environ, "COVERAGE_FILE": str(data_file)},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+
+    # A DIFFERENT, unrelated absolute directory -- simulating a local dev
+    # checkout -- containing a COPY of the same module. Coverage never ran
+    # here; only `root` for the span scan and the later lookup points at it.
+    local_root = tmp_path / "d_show_case" / "goldenmatch" / "goldenmatch"
+    local_root.mkdir(parents=True)
+    (local_root / "m.py").write_text(module_src, encoding="utf-8")
+
+    spans = function_spans(local_root)
+    contexts = function_contexts(data_file, local_root, spans)
+
+    assert contexts, (
+        "no functions resolved any coverage data across the two different "
+        "roots -- the cross-environment path match failed"
+    )
+    assert coverage_enforced(("m.py", "claimant"), ("m.py", "target"), contexts), (
+        f"claimant and target share test_it's context; the CI-vs-local root "
+        f"mismatch must not hide that. contexts: {contexts}"
+    )


### PR DESCRIPTION
## What and why

Found while running Stage 4 of the coverage-based-enforcement work (docs/superpowers/specs/2026-09-03-coverage-based-enforcement-design.md): the mechanism merged in #2855 read `coverage_consulted: True` but `coverage_functions_with_data: 0` against a real CI-produced coverage artifact downloaded and read locally. Every one of 4340 real, covered functions was invisible to the path-matching logic -- no high-confidence finding could ever have been coverage-rescued outside the exact environment that produced the data.

Root cause: `_relative_to_root` required a measured file's path to be a literal subpath of `root` (`.resolve().relative_to(root)`). That only holds when the coverage data is read in the SAME environment it was produced in. A Linux CI checkout's absolute path is never a subpath of a Windows local root.

## Changes

- `scripts/sync_claims/coverage_enforcement.py`: `function_contexts` now matches paths via `scripts/coverage_paths.py`'s `normalize()` -- already built and proven for exactly this problem (phase A's per-module floor table went silently vacuous the same way) -- instead of requiring literal path containment. Removes the now-dead `_relative_to_root` helper.
- `scripts/test_sync_claims_coverage_enforcement.py`: new regression test constructing two genuinely different absolute directory trees (no literal containment possible) sharing only a `goldenmatch/`-rooted tail, proving the match still succeeds.

## Testing

```
scripts/test_sync_claims_coverage_enforcement.py scripts/test_sync_claims_report.py
27 passed, 0 failed
```

Verified against the real CI artifact from PR #2856's run (33793047003): `coverage_functions_with_data` went from 0 to 4340 after the fix, and `_alias_score_matrix` -- the whole programme's motivating case -- now has real per-test coverage data. Sabotage-verified: reverted to the old containment check, confirmed the new test fails naming exactly this, restored.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets) - ruff run per touched file
- [ ] Package `CHANGELOG.md` updated if behavior changed - N/A, audit tooling only
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed - N/A, self-contained bugfix
