### PR TITLE
fix(autoconfig): route the plan-building passes/keys sites through resolved_keys()

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4497,7 +4497,11 @@ def build_blocking(
             # projected guard as the name path; if nothing survives, fall
             # through to single-column fallbacks rather than ship a bomb.
             c_primary = (compound_config.keys or [None])[0]
-            c_passes = compound_config.passes or list(compound_config.keys or [])
+            # resolved_keys() dispatches on strategy (multi_pass -> passes-first,
+            # else keys-first) instead of always preferring `passes` -- the F2/
+            # 1c843c8a5 shape: a schema-valid config carrying BOTH fields, where
+            # the wrong unconditional preference silently used the wrong set.
+            c_passes = compound_config.resolved_keys()
             if c_primary is not None:
                 gated_primary, gated_passes = _gate_passes(c_primary, c_passes)
                 if gated_primary is not None:
@@ -6582,7 +6586,9 @@ def _diversify_probabilistic_blocking(
         return blocking
 
     # Fold into a multi_pass union; keep the original keys/passes as passes.
-    base_passes = list(blocking.passes or []) or list(blocking.keys or [])
+    # resolved_keys() dispatches on strategy instead of unconditionally
+    # preferring `passes` -- see the resolved_keys() call above for the shape.
+    base_passes = blocking.resolved_keys()
     return blocking.model_copy(update={
         "strategy": "multi_pass",
         "passes": base_passes + new_passes,
@@ -6633,7 +6639,10 @@ def _add_atomic_name_soundex_blocking(
     if mode == "auto" and not _dataset_is_person_shaped(profiles):
         return blocking
 
-    passes = list(blocking.passes or []) or list(blocking.keys or [])
+    # resolved_keys() dispatches on strategy instead of unconditionally
+    # preferring `passes` -- the F2/1c843c8a5 shape (a schema-valid config
+    # carrying both fields silently used the wrong one).
+    passes = blocking.resolved_keys()
     if not passes:
         return blocking
 
@@ -6773,10 +6782,10 @@ def _diversify_unused_orthogonal_blocking(
             if cap > 0:
                 row_cap = int(cap**0.5)
             overlap_cap = min(sample_n, _ORTHO_OVERLAP_SAMPLE)
-            base_specs = [
-                _pass_specs(k)
-                for k in (list(blocking.passes or []) or list(blocking.keys or []))
-            ]
+            # resolved_keys() dispatches on strategy instead of unconditionally
+            # preferring `passes` -- see the resolved_keys() call above in this
+            # module for the F2/1c843c8a5 shape this avoids.
+            base_specs = [_pass_specs(k) for k in blocking.resolved_keys()]
             if base_specs:
                 overlap_memb = _coblock_membership(
                     bframe, base_specs, overlap_cap, _col_cache, _tx_cache
@@ -6841,7 +6850,10 @@ def _diversify_unused_orthogonal_blocking(
     if not new_passes:
         return blocking
 
-    base_passes = list(blocking.passes or []) or list(blocking.keys or [])
+    # resolved_keys() dispatches on strategy instead of unconditionally
+    # preferring `passes` -- see the resolved_keys() call above in this
+    # module for the F2/1c843c8a5 shape this avoids.
+    base_passes = blocking.resolved_keys()
     return blocking.model_copy(update={
         "strategy": "multi_pass",
         "passes": base_passes + new_passes,
@@ -7173,7 +7185,10 @@ def _bound_probabilistic_blocking_pairs(
             "n=%d.", total_budget, _FS_TOTAL_PAIR_BUDGET, effective_n_full,
         )
 
-    passes = list(blocking.passes or []) or list(blocking.keys or [])
+    # resolved_keys() dispatches on strategy instead of unconditionally
+    # preferring `passes` -- the F2/1c843c8a5 shape (a schema-valid config
+    # carrying both fields silently used the wrong one).
+    passes = blocking.resolved_keys()
     if not passes:
         return blocking
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -432,7 +432,10 @@ def rule_low_reduction_ratio(
     # Same keys-vs-passes hazard `_carries_own_blocking_plan` (#2488) was added
     # for: "`not blocking.keys` ... is only correct for the keys-driven
     # strategies".
-    existing = list(current.blocking.passes or []) or list(current.blocking.keys or [])
+    # resolved_keys() dispatches on strategy instead of unconditionally
+    # preferring `passes` -- the exact keys-vs-passes hazard the comment
+    # above already names, still present in this unconditional-or form.
+    existing = current.blocking.resolved_keys()
     new_pass = BlockingKeyConfig(fields=[soundex_candidate], transforms=["soundex"])
     new_blocking = current.blocking.model_copy(update={
         "strategy": "multi_pass",

--- a/packages/python/goldenmatch/tests/test_block_key_resolution.py
+++ b/packages/python/goldenmatch/tests/test_block_key_resolution.py
@@ -91,14 +91,41 @@ def test_the_validator_still_accepts_multi_pass_with_only_keys():
     assert config.passes is None
 
 
+def _attr_name(node: ast.expr) -> str | None:
+    """The field name one operand of an `X or Y` chain resolves to, for the
+    two shapes that actually shipped bugs: a bare attribute (`X.passes`) and
+    a `list(X.passes or [])`-wrapped one -- the shape 6 of autoconfig.py's
+    own "plan-building" sites used (constructing a NEW multi_pass config from
+    an existing one's active keys/passes) before they were routed through
+    `resolved_keys()`. Both normalize a value's LIST-ness away identically
+    (`X.passes` is already `list[...] | None`; `list(X.passes or [])` is the
+    same thing spelled defensively), so both are the same decision made by
+    hand and both must resolve to `resolved_keys()` instead."""
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "list"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.BoolOp)
+        and isinstance(node.args[0].op, ast.Or)
+        and node.args[0].values
+        and isinstance(node.args[0].values[0], ast.Attribute)
+    ):
+        return node.args[0].values[0].attr
+    return None
+
+
 def test_no_module_resolves_keys_versus_passes_by_hand():
     """The decision has ONE home. A new copy is how the last two drifted.
 
-    Scans for `X.passes or X.keys` (and the reverse) outside schemas.py.
-    Deliberately narrow: it catches the two shapes that actually shipped
-    defects, not every mention of both fields -- unions
-    (`list(keys or []) + list(passes or [])`) and existence checks
-    (`if keys or passes`) are precedence-free and legitimate.
+    Scans for `X.passes or X.keys` (and the reverse), bare or `list(...)`-
+    wrapped, outside schemas.py. Deliberately narrow: it catches the shapes
+    that actually shipped defects, not every mention of both fields --
+    unions (`list(keys or []) + list(passes or [])`, note the `+`, not
+    `or`) and existence checks (`if keys or passes`) are precedence-free
+    and legitimate.
     """
     offenders: list[str] = []
     for path in sorted(PACKAGE.rglob("*.py")):
@@ -111,7 +138,7 @@ def test_no_module_resolves_keys_versus_passes_by_hand():
         for node in ast.walk(tree):
             if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.Or):
                 continue
-            attrs = [v.attr for v in node.values if isinstance(v, ast.Attribute)]
+            attrs = [n for n in (_attr_name(v) for v in node.values) if n is not None]
             if len(attrs) < 2:
                 continue
             for left, right in zip(attrs, attrs[1:]):

--- a/packages/python/goldenmatch/tests/test_rule_low_reduction_preserves_passes.py
+++ b/packages/python/goldenmatch/tests/test_rule_low_reduction_preserves_passes.py
@@ -170,3 +170,35 @@ def test_a_keys_only_config_is_unchanged():
     )
     assert _sigs(new_cfg.blocking)[0] == (("city",), ("lowercase",))
     assert len(new_cfg.blocking.passes) == 2
+
+
+def test_a_static_config_carrying_both_fields_prefers_keys():
+    """The F2/1c843c8a5 shape, at this exact site: a schema-valid config with
+    strategy='static' carrying BOTH `keys` and `passes` non-empty (unusual,
+    but not rejected -- the validator only requires ONE of them for static).
+
+    `existing = list(passes or []) or list(keys or [])` unconditionally
+    prefers `passes` whenever it's non-empty, regardless of strategy -- wrong
+    here, where `keys` is the field that actually drives blocking for
+    strategy='static' and `passes` may be a stale leftover from an earlier
+    multi_pass edit. `resolved_keys()` dispatches on strategy correctly:
+    keys-first for anything that isn't multi_pass. Neither
+    test_existing_passes_survive nor test_a_keys_only_config_is_unchanged
+    above exercises this -- the first always uses strategy='multi_pass'
+    (where old and new code agree), the second never populates `passes` at
+    all (making the `or` trivial either way)."""
+    cfg = _multipass_config()
+    cfg.blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+        passes=[BlockingKeyConfig(fields=["postcode"], transforms=["strip"])],
+    )
+    new_cfg, _ = rule_low_reduction_ratio(
+        _low_reduction_profile(), cfg, RunHistory(),
+    )
+    sigs = _sigs(new_cfg.blocking)
+    assert sigs[0] == (("city",), ("lowercase",)), (
+        f"expected the static strategy's own key ('city') first, not the "
+        f"stale 'postcode' pass: {sigs}"
+    )
+    assert len(sigs) == 2  # the static key + the new soundex pass, `postcode` dropped

--- a/parity/shared_decisions.allow
+++ b/parity/shared_decisions.allow
@@ -16,7 +16,7 @@
 #
 # Bounds in docs/superpowers/specs/2026-09-02-shared-decision-triage.md.
 #
-# 65 of 81 shared fields. The other 16 are findings or
+# 66 of 81 shared fields. The other 15 are findings or
 # held out by hand, and are absent so the inventory keeps reporting them.
 
 action  # 2 modules, no reader supplies a fallback -- nothing to disagree about
@@ -64,6 +64,7 @@ negative_evidence  # 7 modules; 4 supply a fallback and all use `or []`
 num_bands  # 3 modules, no reader supplies a fallback -- nothing to disagree about; declared on 3 classes, so its readers may not even share a field
 num_perms  # 3 modules, no reader supplies a fallback -- nothing to disagree about
 output  # 5 modules, no reader supplies a fallback -- nothing to disagree about
+passes  # F2, fully fixed: the 4 block-execution readers routed through resolved_keys() in #2845, and the 7 remaining "plan-building" sites (core/autoconfig.py x6, core/autoconfig_rules.py x1) now do too -- no more unconditional `passes or keys` anywhere outside schemas.py, ratcheted by tests/test_block_key_resolution.py::test_no_module_resolves_keys_versus_passes_by_hand
 prepared_record_store  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 provider  # 2 modules, no reader supplies a fallback -- nothing to disagree about
 quality  # 2 modules, no reader supplies a fallback -- nothing to disagree about

--- a/scripts/test_no_new_shared_decisions.py
+++ b/scripts/test_no_new_shared_decisions.py
@@ -7,8 +7,8 @@ be removed so the ratchet keeps its value.
 
 Every shared field is covered by exactly one of three places:
 
-  parity/shared_decisions.allow   65  agreed; readers supply no conflicting default
-  KNOWN_ACTIONABLE                 3  a signal fires on a SINGLE-class field
+  parity/shared_decisions.allow   66  agreed; readers supply no conflicting default
+  KNOWN_ACTIONABLE                 2  a signal fires on a SINGLE-class field
   KNOWN_AMBIGUOUS                 12  a signal fires, but the name is declared on
                                       several classes, so the readers grouped
                                       under it may not share a field at all
@@ -45,11 +45,11 @@ from shared_decisions.shapes import (  # noqa: E402
 # grows without a triage.
 KNOWN_ACTIONABLE: set[str] = {
     "golden_rules",  # F1  Ray lane's fallback could not construct -- FIXED #2844
-    # F2 fixed in #2845 (distributed/scoring.py now calls resolved_keys()), but
-    # `passes` stays actionable: core/autoconfig.py:4500 still resolves
-    # `compound_config.passes or list(compound_config.keys or [])` with no
-    # strategy branch, one of eight plan-building sites left out of that scope.
-    "passes",
+    # F2 FIXED: #2845 routed the block-execution readers through
+    # resolved_keys(); the 7 remaining "plan-building" sites (6 in
+    # core/autoconfig.py, 1 in core/autoconfig_rules.py -- building a NEW
+    # multi_pass config from an existing one's active keys/passes) now do
+    # too, so "passes" moved to parity/shared_decisions.allow.
     "weight",  # F9  autoconfig defaults to 0; scorer.py and Spark read it bare
 }
 


### PR DESCRIPTION
## What and why

Phase B residual (F2's remaining scope): `resolved_keys()` (#2845) fixed the 4 block-EXECUTION readers that resolve keys-vs-passes to build actual blocking plans, but the ratchet's own `KNOWN_ACTIONABLE` comment named "one of eight plan-building sites" as left out -- sites that build a NEW multi_pass config from an EXISTING config's currently-active passes/keys.

## Changes

- `core/autoconfig.py`: 6 confirmed sites routed through `resolved_keys()` -- `build_blocking`, `_diversify_probabilistic_blocking`, `_add_atomic_name_soundex_blocking`, `_diversify_unused_orthogonal_blocking` (x2), `_bound_probabilistic_blocking_pairs`. Each verified guarded by an upstream `blocking is None` check before the fixed line.
- Investigated the 3 other "concatenate" sites (`3230`, `6461`, `6750`) before touching them -- different shape (`+`, not `or`), building a defensive "already covered, don't re-add" set from BOTH lists regardless of strategy. Left unchanged; `resolved_keys()` would be the wrong fix there (it would drop real coverage from the non-active list).
- Widened `test_block_key_resolution.py::test_no_module_resolves_keys_versus_passes_by_hand` (the existing AST-based ratchet for this exact bug class) while verifying the fix -- it only matched the bare `X.passes or X.keys` shape, not the `list(X.passes or []) or list(X.keys or [])` variant these 6 sites used, so a new occurrence of the same bug would slip past it again. Widening it caught a 7th site outside the file I started from: `core/autoconfig_rules.py:435` (`rule_low_reduction_ratio`), whose own adjacent comment already named the hazard without being fixed.
- New targeted regression test in `test_rule_low_reduction_preserves_passes.py` (an existing file documenting a different, already-fixed bug at the same site) for the specific edge case this fix addresses.
- Phase B3 ratchet: `"passes"` moved from `KNOWN_ACTIONABLE` to `parity/shared_decisions.allow` -- confirmed by running the ratchet itself that the divergence signal no longer fires anywhere in the package.

## Testing

```
tests/test_autoconfig*.py tests/test_block_key_resolution.py tests/test_rule_low_reduction_preserves_passes.py tests/test_blocking_key_scoring_2526.py
732 passed, 11 skipped, 0 failed

scripts/test_no_new_shared_decisions.py: 5 passed
```

Every new/widened check sabotage-verified (reverted the fix, confirmed the test fails naming the right thing, restored) -- including the widened AST detector, tested against the 7th site it independently found.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets) - ruff run per touched file
- [ ] Package `CHANGELOG.md` updated if behavior changed - N/A, internal blocking-plan-building fix, not a public API change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed - N/A, self-contained bugfix; ratchet files updated as part of the fix itself
