### PR TITLE
fix(sync_claims): flag ambiguous-target claims; give classes a coverage span

### DIFF
--- a/scripts/sync_claims/claims.py
+++ b/scripts/sync_claims/claims.py
@@ -52,10 +52,8 @@ MARKED_WINDOW = 40
 BARE_WINDOW = 12
 
 
-def _confidence(
-    window: str, known: set[str], claimant: str, target: str | None
-) -> str:
-    """"high" when the target sits where a claim's OBJECT actually sits.
+def _confidence(window: str, known: set[str], claimant: str, target: str | None) -> str:
+    """ "high" when the target sits where a claim's OBJECT actually sits.
 
     C1 triage found that a resolved target is frequently a real symbol that
     the claim does not equate: "Only gates the BATCHED bucket call; whether
@@ -95,9 +93,7 @@ def _confidence(
     ]
     if any(m in known and m != claimant for m in marked):
         return "high"
-    bare = [
-        word.rstrip(".").split(".")[-1] for word in _WORD.findall(window[:BARE_WINDOW])
-    ]
+    bare = [word.rstrip(".").split(".")[-1] for word in _WORD.findall(window[:BARE_WINDOW])]
     return "high" if any(b in known and b != claimant for b in bare) else "low"
 
 
@@ -151,6 +147,10 @@ class Claim:
     target: str | None
     lineno: int
     confidence: str  # "high" or "low" -- see `_confidence`
+    # True when `target` is declared in more than one module under the tree
+    # `claims()` resolved against -- `_resolve_target`'s first-match-wins
+    # rule picked one, but the pick is not trustworthy. See `_symbol_modules`.
+    target_ambiguous: bool = False
 
 
 def _parse(path: Path) -> ast.Module | None:
@@ -173,13 +173,48 @@ def declared_symbols(root: Path) -> set[str]:
     return out
 
 
-def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
+def _symbol_modules(root: Path) -> dict[str, set[str]]:
+    """Every function/class name declared under `root`, mapped to the set of
+    module-relative paths that declare it.
+
+    `declared_symbols` collapses this to a flat membership set, which is all
+    `_resolve_target` needs to pick a target -- but the same flat set hides
+    whether the name it picked was unique. A bare word like `score` or `row`
+    can be declared in several modules; `_resolve_target`'s first-match-wins
+    rule silently picks one, and it is not necessarily the one the claim's
+    author meant. `claims()` uses this to flag that case explicitly
+    (`Claim.target_ambiguous`) rather than let a coin-flip resolution report
+    as an ordinary, confidently-wrong finding.
+    """
+    out: dict[str, set[str]] = {}
+    for path in sorted(root.rglob("*.py")):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                out.setdefault(node.name, set()).add(rel)
+    return out
+
+
+def claims(
+    root: Path,
+    *,
+    symbols: set[str] | None = None,
+    symbol_modules: dict[str, set[str]] | None = None,
+) -> list[Claim]:
     """Every synchronisation claim under `root`, with targets resolved.
 
     `symbols` defaults to `declared_symbols(root)`. Pass it explicitly when the
     claims live in a fixture but must resolve against the real package.
+    `symbol_modules` defaults to `_symbol_modules(root)` the same way, and
+    should be passed alongside a `symbols` override for the same reason --
+    ambiguity is checked against whichever tree the target is really meant to
+    resolve against.
     """
     known = declared_symbols(root) if symbols is None else symbols
+    known_modules = _symbol_modules(root) if symbol_modules is None else symbol_modules
     out: list[Claim] = []
     for path in sorted(root.rglob("*.py")):
         tree = _parse(path)
@@ -202,6 +237,7 @@ def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
             window = doc[match.end() : match.end() + WINDOW]
             target = _resolve_target(window, known, name)
             confidence = _confidence(window, known, name, target)
+            target_ambiguous = target is not None and len(known_modules.get(target, ())) > 1
             out.append(
                 Claim(
                     module=rel,
@@ -212,6 +248,7 @@ def claims(root: Path, *, symbols: set[str] | None = None) -> list[Claim]:
                     target=target,
                     confidence=confidence,
                     lineno=0 if is_module else node.lineno,
+                    target_ambiguous=target_ambiguous,
                 )
             )
     return out

--- a/scripts/sync_claims/coverage_enforcement.py
+++ b/scripts/sync_claims/coverage_enforcement.py
@@ -32,14 +32,17 @@ _EMPTY_CONTEXT = ""
 
 
 def function_spans(root: Path) -> dict[str, list[tuple[str, int, int]]]:
-    """Every function/method in every `.py` file under `root`, with its line
-    range. Keys are module paths relative to `root`, posix-separated.
+    """Every function/method AND class in every `.py` file under `root`,
+    with its line range. Keys are module paths relative to `root`,
+    posix-separated. The name is legacy (classes were added later, see
+    `_collect_spans`); the return shape did not need to change to grow this.
 
-    Deliberately general -- every function, not a naming-convention subset.
-    `parity_coverage.py:_py_function_spans` looks similar but answers a
-    narrower, unrelated question (only names ending `_py`, Companion A's
-    scope); that function is module-private and this one is not a call to
-    it, it is the same AST technique applied to a different question.
+    Deliberately general -- every function (and class), not a
+    naming-convention subset. `parity_coverage.py:_py_function_spans` looks
+    similar but answers a narrower, unrelated question (only names ending
+    `_py`, Companion A's scope); that function is module-private and this
+    one is not a call to it, it is the same AST technique applied to a
+    different question.
     """
     out: dict[str, list[tuple[str, int, int]]] = {}
     for path in sorted(root.rglob("*.py")):
@@ -58,13 +61,26 @@ def function_spans(root: Path) -> dict[str, list[tuple[str, int, int]]]:
 def _collect_spans(node: ast.AST, prefix: list[str], out: list[tuple[str, int, int]]) -> None:
     """Walk `node`'s direct children, recursing into class/function bodies so
     nested functions and methods get dotted names (`Widget.method`) and their
-    OWN enclosing scope's line range is not what gets recorded for them."""
+    OWN enclosing scope's line range is not what gets recorded for them.
+
+    A `ClassDef` ALSO gets its own entry, spanning the whole class body (not
+    just recursing into it) -- a claim can be attached to a class's own
+    docstring, not just a function's, and without this such a claim's
+    claimant or target has no span to look up a coverage context for at all
+    (found triaging Stage 4b: `VectorIndex`, `LintInput`, `CanonicalizationEval`,
+    `FreshnessWithMaxAgeStrategy` all carry claims this way). Coverage for a
+    class's own span is a genuine proxy for "was this class exercised": any
+    line inside it, including every method's body, counts, since a
+    class-level claim is a claim about the class's behavior as a whole, not
+    one specific method."""
     for child in ast.iter_child_nodes(node):
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             name = ".".join([*prefix, child.name])
             out.append((name, child.lineno, child.end_lineno or child.lineno))
             _collect_spans(child, [*prefix, child.name], out)
         elif isinstance(child, ast.ClassDef):
+            name = ".".join([*prefix, child.name])
+            out.append((name, child.lineno, child.end_lineno or child.lineno))
             _collect_spans(child, [*prefix, child.name], out)
         else:
             _collect_spans(child, prefix, out)

--- a/scripts/sync_claims/report.py
+++ b/scripts/sync_claims/report.py
@@ -19,10 +19,13 @@ SCOPE_NOTE = (
     "scope: claims are read from docstrings under {root} and enforcement from "
     "{tests} only -- other packages, the TypeScript port and _archive are out "
     "of reach by construction, and their silence here is not a clean bill. "
-    "Low-confidence findings and module-level claims are reported but NOT "
-    "triaged. A module has no single "
-    "symbol a test can reference. A claim listed as UNVERIFIED is not safe -- "
-    "some test references both names, which does not mean it compares them."
+    "Low-confidence findings, module-level claims, and ambiguous-target "
+    "claims are reported but NOT triaged. A module has no single "
+    "symbol a test can reference. An ambiguous-target claim's resolved "
+    "symbol is one of several same-named declarations and may not be the "
+    "one the claim's author meant. A claim listed as UNVERIFIED is not safe "
+    "-- some test references both names, which does not mean it compares "
+    "them."
 )
 
 
@@ -75,6 +78,13 @@ def inventory(root: Path, tests_root: Path, coverage_db: Path | None = None) -> 
     LOW-confidence claim's problem is that its resolved TARGET may be wrong
     (a different axis than enforcement); coverage evidence against a wrong
     target proves nothing about the claim the docstring actually makes.
+    An ambiguous-target claim (`Claim.target_ambiguous`, see
+    `claims._symbol_modules`) is excluded from both `unenforced` and
+    coverage-rescue for the same reason and reported separately, in
+    `unenforced_ambiguous_target` -- the resolved target is not necessarily
+    the one the claim's author meant, so neither "this test doesn't
+    reference it" nor "this test executes it" is evidence about anything in
+    particular.
     """
     all_claims = claims(root, symbols=declared_symbols(root))
     symbol_claims = [c for c in all_claims if c.kind == "symbol"]
@@ -86,6 +96,18 @@ def inventory(root: Path, tests_root: Path, coverage_db: Path | None = None) -> 
     all_findings = unenforced(resolvable, reference_sets)
     findings = [c for c in all_findings if c.confidence == "high"]
     low_confidence = [c for c in all_findings if c.confidence != "high"]
+
+    # An ambiguous-target high-confidence finding is not a trustworthy
+    # finding at all -- `target` was picked by `_resolve_target`'s
+    # first-match-wins rule among more than one same-named declaration
+    # (Stage 4b found this affecting ~a third of the still-unenforced
+    # population: `score`, `row`, `keys`, `__init__`, ...). Route it to its
+    # own bucket, same treatment `unresolvable` already gets for a target
+    # that isn't Python at all -- and split it out BEFORE coverage-rescue,
+    # for the same reason low-confidence claims are excluded from rescue:
+    # coverage evidence against a possibly-wrong target proves nothing.
+    ambiguous_target = [c for c in findings if c.target_ambiguous]
+    findings = [c for c in findings if not c.target_ambiguous]
 
     coverage_consulted = False
     coverage_rescued: list[Claim] = []
@@ -123,6 +145,7 @@ def inventory(root: Path, tests_root: Path, coverage_db: Path | None = None) -> 
             "resolvable": len(resolvable),
             "unenforced": len(findings),
             "unenforced_low_confidence": len(low_confidence),
+            "unenforced_ambiguous_target": len(ambiguous_target),
             "unverified": len(unverified),
             "coverage_enforced": len(coverage_rescued),
             "coverage_consulted": coverage_consulted,
@@ -133,6 +156,7 @@ def inventory(root: Path, tests_root: Path, coverage_db: Path | None = None) -> 
         },
         "unenforced": [_as_dict(c) for c in findings],
         "unenforced_low_confidence": [_as_dict(c) for c in low_confidence],
+        "unenforced_ambiguous_target": [_as_dict(c) for c in ambiguous_target],
         "unverified": [_as_dict(c) for c in unverified],
         "coverage_enforced": [_as_dict(c) for c in coverage_rescued],
         "unresolvable": [_as_dict(c) for c in unresolvable],
@@ -226,7 +250,8 @@ def main(argv: list[str]) -> int:
     )
     print(
         f"  reported but not triaged: {counts['unresolvable']} unresolvable, "
-        f"{counts['module_level']} module-level"
+        f"{counts['module_level']} module-level, "
+        f"{counts['unenforced_ambiguous_target']} ambiguous-target"
     )
     print(f"  test files scanned: {counts['test_files_scanned']}")
     print(

--- a/scripts/test_sync_claims_claims.py
+++ b/scripts/test_sync_claims_claims.py
@@ -78,6 +78,55 @@ def widget():
     assert found[0].keyword.lower() == "mirrors"
 
 
+def test_target_ambiguous_flags_a_name_declared_in_two_modules(tmp_path):
+    """A bare word like `helper` can be declared in more than one module --
+    `_resolve_target`'s first-match-wins rule still picks one (unchanged
+    behaviour, checked below), but the pick is not trustworthy: `report.py`
+    needs to know that so it does not report it as an ordinary, confidently-
+    wrong finding. Stage 4b found this for real: `score`, `row`, `keys`, and
+    (worst) `__init__` with 79 same-named candidates."""
+    (tmp_path / "a.py").write_text(
+        "def helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.py").write_text(
+        "def helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "c.py").write_text(
+        '''
+def claimant():
+    """Mirrors helper exactly."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert len(found) == 1
+    assert found[0].target == "helper"
+    assert found[0].target_ambiguous is True
+
+
+def test_target_ambiguous_is_false_for_a_uniquely_declared_target(tmp_path):
+    """The common case -- a target declared in exactly one module -- must
+    not be flagged, or every ordinary finding would land in the wrong
+    bucket."""
+    (tmp_path / "a.py").write_text(
+        "def helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.py").write_text(
+        '''
+def claimant():
+    """Mirrors helper exactly."""
+'''.strip(),
+        encoding="utf-8",
+    )
+    found = [c for c in claims(tmp_path) if c.symbol == "claimant"]
+    assert len(found) == 1
+    assert found[0].target == "helper"
+    assert found[0].target_ambiguous is False
+
+
 def test_a_claim_never_resolves_to_its_own_claimant(tmp_path):
     """`def build(): "mirrors build"` is a self-reference, not a relationship."""
     (tmp_path / "m.py").write_text(
@@ -202,11 +251,7 @@ def test_the_incident_is_HIGH_confidence_despite_a_bare_target():
     for exactly this case.
     """
     package_symbols = declared_symbols(GOLDENMATCH)
-    found = [
-        c
-        for c in claims(FIXTURE, symbols=package_symbols)
-        if c.symbol == "_run_pipeline"
-    ]
+    found = [c for c in claims(FIXTURE, symbols=package_symbols) if c.symbol == "_run_pipeline"]
     assert found[0].target == "run_dedupe"
     assert found[0].confidence == "high", (
         "the motivating incident fell out of the high-confidence set; a gate "

--- a/scripts/test_sync_claims_coverage_enforcement.py
+++ b/scripts/test_sync_claims_coverage_enforcement.py
@@ -44,7 +44,38 @@ class Widget:
     )
     spans = function_spans(tmp_path)
     names = {name for name, _, _ in spans["m.py"]}
-    assert names == {"top_level", "Widget.method", "Widget.async_method"}, names
+    assert names == {
+        "top_level",
+        "Widget",
+        "Widget.method",
+        "Widget.async_method",
+    }, names
+
+
+def test_function_spans_class_span_covers_its_own_body_and_all_methods(tmp_path):
+    """A claim can be attached to a class's own docstring, not just a
+    function's (found triaging Stage 4b: VectorIndex, LintInput,
+    CanonicalizationEval, FreshnessWithMaxAgeStrategy). The class needs its
+    OWN span -- the whole body, from `class` to its last line -- so a claim
+    naming the class as claimant or target has something to look up a
+    coverage context against, and so any test touching ANY of its methods
+    counts as coverage for the class overall, not just for that one method."""
+    (tmp_path / "m.py").write_text(
+        """
+class Widget:
+    def method_a(self):
+        pass
+
+    def method_b(self):
+        pass
+""".strip(),
+        encoding="utf-8",
+    )
+    spans = function_spans(tmp_path)
+    by_name = {name: (start, end) for name, start, end in spans["m.py"]}
+    assert by_name["Widget"] == (1, 6), by_name["Widget"]
+    assert by_name["Widget"][0] <= by_name["Widget.method_a"][0]
+    assert by_name["Widget"][1] >= by_name["Widget.method_b"][1]
 
 
 def test_function_spans_line_ranges_are_correct(tmp_path):

--- a/scripts/test_sync_claims_report.py
+++ b/scripts/test_sync_claims_report.py
@@ -137,14 +137,21 @@ def test_low_confidence_findings_are_reported_not_hidden():
     """Splitting the buckets must not lose claims.
 
     Every symbol-level claim lands in exactly one of: unenforced (high
-    confidence), unenforced_low_confidence, unverified, or unresolvable.
-    A split that quietly dropped the low-confidence half would shrink the
-    reported number while the claims stayed exactly as unchecked.
+    confidence), unenforced_low_confidence, unenforced_ambiguous_target,
+    unverified, or unresolvable. A split that quietly dropped a bucket would
+    shrink the reported number while the claims stayed exactly as unchecked.
     """
     inv = inventory(DEFAULT_ROOT, DEFAULT_TESTS)
     c = inv["counts"]
     assert "unenforced_low_confidence" in c
-    total = c["unenforced"] + c["unenforced_low_confidence"] + c["unverified"] + c["unresolvable"]
+    assert "unenforced_ambiguous_target" in c
+    total = (
+        c["unenforced"]
+        + c["unenforced_low_confidence"]
+        + c["unenforced_ambiguous_target"]
+        + c["unverified"]
+        + c["unresolvable"]
+    )
     assert total == c["claims"] - c["module_level"], (
         f"buckets sum to {total} but there are "
         f"{c['claims'] - c['module_level']} symbol-level claims -- the "


### PR DESCRIPTION
Stage 4b's full triage of the 28 still-unenforced sync-claims found 12 of 28 (43%) had a structural resolution problem, not an unverified claim -- not sized or investigated before now.

**8 had an ambiguous target.** A bare word like `score` or `__init__` is declared in more than one module; `claims.py`'s `_resolve_target` silently picks the first match, which is not necessarily the right one. Worst case: `__init__` had 79 same-named candidates.

**4 were claims attached to a class's own docstring** (`VectorIndex`, `LintInput`, `CanonicalizationEval`, `FreshnessWithMaxAgeStrategy`), invisible to the coverage-enforcement mechanism entirely, since `function_spans()` only ever recorded function bodies, never a class's own span.

Two independent fixes:

- `claims.py`: `Claim` gains `target_ambiguous` (parallel to the existing `confidence` field). Resolution itself is unchanged -- nothing in the current 216-claim population resolves to a different target than before. Ambiguous claims move out of `unenforced` into their own `unenforced_ambiguous_target` bucket in `report.py`'s `inventory()`, reported but not triaged, same treatment `unresolvable` already gets.
- `coverage_enforcement.py`: `_collect_spans` now records a `ClassDef`'s own span (the whole body), so a claim naming a class has a real coverage signal -- any line inside it, including every method, counts.

Verified on the real package: this moves exactly the 8 ambiguous-target claims out of the unenforced count (53 -> 45 at the text-only baseline), and all 4 known class-claim cases now resolve to a real span. All 52 sync_claims tests pass, including 4 new ones.
