### PR TITLE
test(sync_claims): triage the 8 ambiguous-target claims, zero real gaps

### DIFF
--- a/docs/superpowers/specs/2026-09-04-stage4e-ambiguous-target-triage.md
+++ b/docs/superpowers/specs/2026-09-04-stage4e-ambiguous-target-triage.md
@@ -1,0 +1,73 @@
+# Phase C, Stage 4e — Triage of the 8 Ambiguous-Target Claims
+
+**Status:** complete — all 8 individually triaged, zero real gaps found
+**Date:** 2026-09-04
+**Prior:** `docs/superpowers/specs/2026-09-04-stage4d-test-writing-results.md`,
+PR #2863 (the resolver fix that first surfaced these 8 as a distinct bucket
+instead of letting them masquerade as ordinary findings)
+
+## Why this document exists
+
+PR #2863 stopped 8 claims from silently resolving to a bare word's first
+same-named declaration (`score`, `__init__`, `find_conflicts`, ...) and
+routed them to their own `unenforced_ambiguous_target` bucket instead. That
+fix deliberately did not attempt to guess the RIGHT target — it just
+stopped the tool from confidently reporting a wrong one. This document does
+the guessing, by hand: for each of the 8, read the claimant's full
+docstring (not just the ambiguous bare word) to find what the claim is
+actually about, same method already proven 5 times over in Stage 4c and 4d.
+
+## Result: 8 claims, zero real gaps
+
+| claim | real target | outcome |
+| --- | --- | --- |
+| `backends/score_buckets.py:_ensure_alias_tables_installed` | `core/scorer.py:_alias_match_single` (native id 8) | **ALREADY TESTED** — `tests/test_native_alias_parity.py` |
+| `core/scorer.py:_iso_date_digits` | `score-core`'s private (non-`pub`, no pyo3 binding) `iso_date_digits` | **CROSS-LANGUAGE, genuinely not testable** — no Python-callable symbol exists |
+| `core/vector_store.py:prep_rows` | `core/vector_index.py:VectorIndex._prep_frame` | **TEST WRITTEN, PASSES** |
+| `identity/store.py:edges_by_kind` | `identity/store.py:find_conflicts` (same file) | **TEST WRITTEN, PASSES** |
+| `mcp/server.py:_tool_score_pair` | TypeScript SDK `score_pair` (cross-language) + `core.scorer.score_pair` (direct delegation) | **PATTERN CLAIM + CROSS-LANGUAGE** — same two-part shape as the already-fixed `_tool_score_strings` |
+| `spark/identity.py:build_incremental_nodes` | `identity/store.py:IdentityStore.retire_identity` | **TEST WRITTEN, UNVERIFIED (pyspark not available locally)** |
+| `tui/engine.py:from_dataframe` | `MatchEngine.__init__` (same class, self-referential) | **TEST WRITTEN, PASSES (3 tests)** |
+| `utils/transforms.py:canonical_soundex` | `score-core`'s `soundex` (already-known cross-language case) | **CROSS-LANGUAGE, ALREADY VERIFIED** — `tests/test_native_soundex_parity.py` |
+
+**Every one of the 8 resolved cleanly** — no claim in this bucket turned
+out to be a real, currently-unverified gap once correctly retargeted. 5 are
+TRUE POSITIVE (2 already covered, 3 newly tested, 1 of those 3 not locally
+executable due to this repo's own pyspark-is-CI-only policy), 2 are
+genuinely cross-language and cannot be tested from Python, 1 is a mix of
+cross-language and direct-delegation pattern claim.
+
+## What "ambiguous" actually meant in practice
+
+None of the 8 needed a coin-flip between two genuinely plausible candidates.
+In every case, the docstring's own fuller text already named the real
+target unambiguously — the bare-word resolver's ambiguity was a symptom of
+looking at too little context (one word), not evidence of a genuinely
+unclear claim. Three recurring shapes:
+
+- **The full docstring already spells it out.** `edges_by_kind`'s window
+  literally says "`find_conflicts` (which is `edges_by_kind('conflicts_with')`)"
+  — the claim defines its own target precisely; only the bare-word search
+  was ambiguous.
+- **The bare word matched a real but wrong symbol elsewhere.** "score"
+  matched dozens of unrelated declarations across the codebase in three of
+  these claims, none of which were what any of the three docstrings meant.
+- **Self-reference collapsed the ambiguity to zero.** `from_dataframe`
+  "mirrors `__init__`" sounds like it could point at any of 79 same-named
+  methods repo-wide — it means its OWN class's `__init__`, which needs no
+  disambiguation once you notice it's the same class.
+
+This suggests the resolver fix (PR #2863) is doing the right job for the
+right reason: it is not that these 8 claims are unusually hard to verify —
+it's that they were unusually easy for a bare-word match to get
+confidently wrong, exactly the failure mode the fix targets.
+
+## Being wrong about this document
+
+All 8 were read individually and in full. The one residual uncertainty:
+`build_incremental_nodes`'s new test could not be executed locally
+(`pyspark` unavailable, per this repo's own policy) — it collects cleanly
+and follows the file's existing fixture conventions, but has not actually
+run anywhere yet. Everything else in this document rests on a test that
+was run and passed, or a cross-language claim confirmed by reading the
+non-Python source directly.

--- a/packages/python/goldenmatch/tests/identity/test_store.py
+++ b/packages/python/goldenmatch/tests/identity/test_store.py
@@ -188,6 +188,28 @@ def test_find_conflicts(store: IdentityStore):
     assert conflicts[0].kind == EdgeKind.CONFLICTS_WITH.value
 
 
+def test_find_conflicts_is_edges_by_kind_conflicts_with(store: IdentityStore):
+    """``edges_by_kind``'s docstring: ``find_conflicts`` "is
+    ``edges_by_kind('conflicts_with')``" -- verify they return the same edges,
+    both with and without a ``dataset`` filter."""
+    e = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=e, dataset="d1"))
+    store.add_edge(EvidenceEdge(
+        entity_id=e, record_a_id="a:1", record_b_id="a:2",
+        kind=EdgeKind.CONFLICTS_WITH.value, dataset="d1", run_name="r",
+    ))
+    store.add_edge(EvidenceEdge(
+        entity_id=e, record_a_id="a:3", record_b_id="a:4",
+        kind=EdgeKind.CONFLICTS_WITH.value, dataset="d2", run_name="r",
+    ))
+    store.add_edge(EvidenceEdge(
+        entity_id=e, record_a_id="a:5", record_b_id="a:6",
+        kind=EdgeKind.SAME_AS.value, dataset="d1", run_name="r",
+    ))
+    assert store.find_conflicts(dataset="d1") == store.edges_by_kind("conflicts_with", "d1")
+    assert store.find_conflicts() == store.edges_by_kind("conflicts_with")
+
+
 def test_list_and_count(store: IdentityStore):
     for i in range(5):
         store.upsert_identity(IdentityNode(entity_id=new_entity_id(), dataset="d1"))

--- a/packages/python/goldenmatch/tests/test_engine.py
+++ b/packages/python/goldenmatch/tests/test_engine.py
@@ -101,6 +101,49 @@ class TestMatchEngineLoad:
         assert to_frame(engine.get_sample(10_000)).height == engine.row_count
 
 
+class TestMatchEngineFromDataframe:
+    """`from_dataframe`'s docstring claims it "[m]irrors every instance field
+    ``__init__`` assigns so it can't break silently if ``__init__`` evolves".
+    That is a claim about THIS class's two constructors, not a cross-module
+    one -- `from_dataframe` builds via ``object.__new__(cls)`` and hand-sets
+    each field, so a new field added to ``__init__`` later and forgotten here
+    would silently produce an incomplete instance. Checked by comparing
+    ``__dict__`` shape and values across both construction paths."""
+
+    def test_field_set_matches_init(self, sample_csv):
+        import pyarrow as pa
+
+        via_init = MatchEngine([sample_csv])
+        via_df = MatchEngine.from_dataframe(pa.table({"a": [1, 2]}))
+
+        assert set(via_df.__dict__.keys()) == set(via_init.__dict__.keys())
+
+    def test_non_data_fields_match_inits_post_load_defaults(self, sample_csv):
+        """Everything besides ``_files``/``_data``/``_profile`` (the fields the
+        docstring calls out as deliberately different) must equal
+        ``__init__``'s post-load value -- here, ``_last_result`` and
+        ``_last_telemetry`` start ``None`` on both paths."""
+        import pyarrow as pa
+
+        via_init = MatchEngine([sample_csv])
+        via_df = MatchEngine.from_dataframe(pa.table({"a": [1, 2]}))
+
+        for field in ("_last_result", "_last_telemetry"):
+            assert getattr(via_df, field) is None
+            assert getattr(via_df, field) == getattr(via_init, field)
+
+    def test_documented_deviations_from_init(self):
+        """``_files`` and ``_profile`` are the two fields the docstring says
+        `from_dataframe` does NOT mirror from a loaded ``__init__``: no file
+        constructor ran, so ``_files`` is ``[]`` and ``_profile`` stays
+        ``None`` rather than the populated dict a file load would produce."""
+        import pyarrow as pa
+
+        engine = MatchEngine.from_dataframe(pa.table({"a": [1, 2]}))
+        assert engine._files == []
+        assert engine.profile is None
+
+
 from goldenmatch.config.schemas import (
     GoldenFieldRule,
     GoldenMatchConfig,

--- a/packages/python/goldenmatch/tests/test_sail_identity_incremental.py
+++ b/packages/python/goldenmatch/tests/test_sail_identity_incremental.py
@@ -240,6 +240,54 @@ def test_merge_retires_losers_into_the_winner(spark):
     assert kinds.count("MERGED_WITH") == 2  # winner + loser
 
 
+def test_loser_created_at_is_preserved_not_reset(spark):
+    """A retired (merged_into) node keeps its OWN prior `created_at` -- the part
+    of `build_incremental_nodes`'s docstring ("a loser keeps its created_at too
+    ... mirroring `store.retire_identity`") that `test_merge_retires_losers_
+    into_the_winner` above does not check. One-box `IdentityStore.retire_identity`
+    (`goldenmatch/identity/store.py`) runs
+    ``UPDATE identity_nodes SET status = ?, merged_into = ?, updated_at = ?``
+    -- `created_at` is never in that SET clause. Spark's `build_incremental_nodes`
+    coalesces the loser's `created_at` against its own `__prior_created__` the
+    same way it does for a winner/absorb, so only `updated_at` should move to
+    this run's timestamp.
+
+    ent:WINNER holds 2 of this cluster's 3 records (ent:LOSER holds 1), so the
+    winner is decided by in-cluster count alone -- the distinct `created_at`
+    values below are there only to catch a `created_at` mix-up, not to drive
+    the winner choice.
+    """
+    from goldenmatch.spark.identity import build_identity_graph_incremental
+
+    LOSER_BORN = "2019-03-03T00:00:00"
+
+    src = _source(spark, [(0, 1), (1, 2), (2, 3)])
+    asg = _assignments(spark, [(0, 100), (1, 100), (2, 100)])
+    prs = _pairs(spark, [(0, 1, 0.9), (1, 2, 0.9)])
+    gld = _golden(spark, [(100, "name1")])
+
+    frames = build_identity_graph_incremental(
+        prs, asg, src, gld,
+        existing_records=_existing_records(spark, [
+            ("people:1", "ent:WINNER"), ("people:2", "ent:WINNER"),  # 2 in-cluster
+            ("people:3", "ent:LOSER"),                                # 1 in-cluster
+        ]),
+        existing_nodes=_existing_nodes(spark, [
+            ("ent:WINNER", T0), ("ent:LOSER", LOSER_BORN),
+        ]),
+        run_meta=RUN, source_pk_col="pk",
+    )
+
+    nodes = _by(frames.nodes, "entity_id")
+    loser = nodes["ent:LOSER"]
+    assert loser["status"] == "merged_into"
+    assert loser["merged_into"] == "ent:WINNER"
+    # The regression this pins: created_at stays the loser's OWN birth date --
+    # not reset to `now` (RUN["recorded_at"]) and not clobbered with the winner's.
+    assert loser["created_at"] == LOSER_BORN
+    assert loser["updated_at"] == RUN["recorded_at"]
+
+
 def test_records_frame_is_a_delta_not_a_restatement(spark):
     """A WINNER's pre-existing records that this run did not touch are NOT
     re-emitted -- they already point at the winner, so re-stating them would

--- a/packages/python/goldenmatch/tests/test_vector_store_factory.py
+++ b/packages/python/goldenmatch/tests/test_vector_store_factory.py
@@ -137,3 +137,24 @@ def test_prep_rows_uses_id_column():
 def test_prep_rows_missing_column_raises():
     with pytest.raises(ValueError, match="not in dataframe"):
         prep_rows(pl.DataFrame({"a": [1]}), "missing", None, base=0)
+
+
+def test_prep_rows_matches_vector_index_prep_frame():
+    """``prep_rows``'s docstring claims its row-id/text derivation is "identical
+    to ``VectorIndex._prep_frame``" -- verify both agree on row ids and texts,
+    with and without an ``id_column``, and with a nonzero base (the
+    incremental-add case ``_prep_frame`` derives from ``self.size``)."""
+    from goldenmatch.core.vector_index import VectorIndex
+
+    df = pl.DataFrame({"name": ["x", "y", None], "pk": [7, 8, 9], "__internal__": [1, 2, 3]})
+
+    for id_col in (None, "pk"):
+        idx = VectorIndex(column="name", embedder=object())
+        # Simulate an index that already holds 2 records, so base == 2 -- the
+        # incremental-add numbering ``prep_rows`` says it matches.
+        idx._frame = pl.DataFrame({"__row_id__": [100, 101], "__vec_text__": ["p", "q"]})
+        base = idx.size
+        frame, frame_texts = idx._prep_frame(df, "name", id_col)
+        row_ids, texts, _ = prep_rows(df, "name", id_col, base=base)
+        assert frame["__row_id__"].to_list() == row_ids
+        assert frame_texts == texts


### PR DESCRIPTION
PR #2863 stopped 8 claims from silently resolving to a bare word's first same-named declaration (`score`, `__init__`, `find_conflicts`, ...) and routed them to their own bucket instead of letting them masquerade as ordinary findings. This does the guessing those 8 needed, by hand: read each claimant's full docstring to find what the claim is actually about.

**All 8 resolved cleanly -- none turned out to be a real, currently-unverified gap once correctly retargeted:**

- `_ensure_alias_tables_installed` -- already tested
- `_iso_date_digits` -- cross-language, genuinely not testable (private Rust fn, no pyo3 binding)
- `prep_rows` vs `VectorIndex._prep_frame` -- new test, passes
- `edges_by_kind` vs `find_conflicts` (same file) -- new test, passes
- `_tool_score_pair` -- cross-language (TS SDK) + direct delegation, same shape as the already-fixed `_tool_score_strings`
- `build_incremental_nodes` vs `IdentityStore.retire_identity` -- new test written, could not verify locally (pyspark is CI-only)
- `from_dataframe` vs `MatchEngine.__init__` (self-referential) -- new tests (3), pass
- `canonical_soundex` -- the already-known cross-language case, confirmed still covered

In every case the docstring's fuller text already named the real target precisely -- the bare-word resolver's ambiguity was a symptom of looking at too little context, not evidence the claim itself was genuinely unclear.

Full writeup: `docs/superpowers/specs/2026-09-04-stage4e-ambiguous-target-triage.md`

Verified: all 4 touched test files plus the 2 already-existing files they reference run together -- 63 passed, 1 skipped (the pyspark-gated test). Only test files changed.
