### PR TITLE
test(sync_claims): triage the 111 low-confidence claims, 3 real bugs found

### DIFF
--- a/docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md
+++ b/docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md
@@ -1,0 +1,124 @@
+# Phase C, Stage 4f — Triage of the 111 Low-Confidence Claims
+
+**Status:** complete — all 111 individually triaged, 3 real bugs found and pinned with tests
+**Date:** 2026-09-04
+**Prior:** `docs/superpowers/specs/2026-09-04-stage4e-ambiguous-target-triage.md`
+(the smaller, proven-shape ambiguous-target batch this document's methodology
+was validated against first)
+
+## Why this document exists
+
+Scoping the 166-claim remainder of Phase C found the low-confidence bucket
+(112 claims, 1 already handled as part of `mcp/server.py`'s cross-language
+cluster) was the larger of the two remaining populations and shared the
+proven vocabulary ("mirrors", "byte-identical to") of everything already
+triaged. `claims.py`'s own `_confidence` heuristic measurement says roughly
+half of low-confidence resolutions are wrong targets — this document
+confirms that at full scale and closes out the population.
+
+## Method
+
+Split into 8 batches of ~14, dispatched in parallel, each following a fixed
+triage order: (1) read the claimant's full current docstring, not the
+truncated window; (2) is the "resolved target" a false match on an ordinary
+English word or builtin (e.g. `min` from `min(cpu, 8)`, `edge` from "the
+shared edge set") — if so, **NOT A REAL CLAIM**, no target, no test; (3) is
+the real claim about a non-Python reference (C source, a Rust crate, the
+TypeScript SDK) — if so, **CROSS-LANGUAGE**, not testable; (4) is it direct
+delegation — if so, **PATTERN CLAIM**, nothing to diverge; (5) otherwise,
+find whether an existing test already verifies the real relationship, and
+write one if not, running it to confirm before reporting.
+
+## Result: 111 claims, three real bugs found
+
+**Tally:**
+
+| verdict | count |
+| --- | ---: |
+| NOT A REAL CLAIM (false word/builtin match) | 32 |
+| CROSS-LANGUAGE (not testable from Python) | 4 |
+| PATTERN CLAIM (direct delegation) | 18 |
+| ALREADY TESTED (real claim, existing coverage found) | 34 |
+| NEW TEST WRITTEN, claim confirmed TRUE | 20 |
+| **REAL DIVERGENCE FOUND** | 3 |
+| **Total** | **111** |
+
+(Counts are tallied from each batch's own per-claim table; the full
+per-claim table each batch produced is preserved in this session's own
+record, not reproduced claim-by-claim here to keep this document a
+reasonable size — the pattern above is what matters, and the three real
+findings below are named individually.)
+
+## Three real bugs, none fixed here
+
+Writing 23 new tests (20 confirming true claims + 3 pinning real
+divergences) found things reading alone did not, the same way today's
+earlier passes did.
+
+**1. `db/... chunked.py::ChunkedMatcher._block_key_column` silently ignores
+per-field transforms.** Docstring claims it mirrors
+`blocker._build_block_key_expr` (the main, non-chunked path). Confirmed
+false: `_build_block_key_expr` honors `BlockingKeyConfig.field_transforms`
+per field; `_block_key_column` applies `key_config.transforms` uniformly to
+every field and has no `field_transforms` parameter at all. Concrete case:
+with `field_transforms={"last": ["uppercase"]}`, the main path computes
+`"alice||SMITH"`, the chunked path computes `"alice||smith"`. Since block
+keys gate which records become candidate pairs, **the large-dataset
+streaming path can compute different block keys — and therefore different
+candidate pairs — than the main path for the identical config**, whenever a
+blocking key uses per-field transforms (relates to #1826). Pinned with a
+test in `tests/test_chunked.py`; not fixed (would mean threading
+`field_transforms` through `_block_key_column`, or delegating to
+`_build_block_key_expr` directly, as its own docstring already half-suggests
+— a real fix, not a docstring correction).
+
+**2. `distributed/clustering.py::_attach_quality_metadata` computes cluster
+confidence differently than the in-memory path.** Docstring claims it
+mirrors `core/cluster.py`'s `build_clusters`/`compute_cluster_confidence`.
+Confirmed false by calling both production functions directly on the same
+star-topology cluster (`1-2`:0.9, `1-3`:0.9, `1-4`:0.1): in-memory computes
+`confidence=0.266`, quality `"weak"` (edge-density connectivity, ×0.7
+downgrade when `avg_edge - min_edge` exceeds a threshold); distributed
+computes `confidence=0.420`, quality `"strong"` (sets `connectivity =
+avg_edge` directly, downgrades only below a flat `0.3` threshold, no
+downgrade logic at all). **The identical cluster is classified weak via the
+in-memory path and strong via the distributed path.** Pinned with a test in
+`tests/test_distributed_clustering.py` (Ray-gated, correctly skips locally
+per this repo's own policy, verified independently by calling the
+production functions directly without Ray); not fixed.
+
+**3. `core/probabilistic.py::_fs_scoring_workers`'s default has drifted from
+`_DEFAULT_MAX_WORKERS`, the function it claims to mirror.** Git history:
+`_DEFAULT_MAX_WORKERS` (`core/scorer.py`) was briefly `min(cpu_count(), 16)`
+in PR #301, then reverted to a fixed `4` in PR #303 after an RSS-pathology
+OOM on a 16-core runner. `_fs_scoring_workers` was added over a month later
+(PR #1566) with its own independent cpu-count-based default and a docstring
+that (incorrectly) still described mirroring `_DEFAULT_MAX_WORKERS`. The
+two now disagree by a wide margin (12 vs. 4 on a 12-core machine) — meaning
+whatever the RSS-OOM fix was protecting against on the weighted path may be
+equally exposed on the FS path, unprotected. **Docstring corrected** to
+state the real (diverged) relationship rather than the false one, and a
+test in `tests/test_probabilistic_parallel.py` pins the divergence
+explicitly. The worker-count fix itself (should FS scoring also cap at 4,
+or was the original OOM incident weighted-path-specific?) is left for
+whoever owns that RSS-pathology history to decide.
+
+## What remains in Phase C
+
+The 54 unresolvable claims — no bare-word match found any declared symbol
+at all — are the one piece of the 166-claim population not yet started.
+Given this batch's yield (3 real bugs, ~63 new tests, out of 111 claims that
+looked less promising going in than the 45-claim clean population), the
+unresolvable bucket is worth the same treatment rather than assuming it is
+lower-value.
+
+## Being wrong about this document
+
+All 111 claims were read individually by the dispatched batches, each
+following the same fixed order this document describes. The one place this
+document is *less* precise than Stage 4b/4c/4e: it does not reproduce the
+full 111-row claim-by-claim table those documents used, on the judgment
+that the aggregate pattern and the three individual findings are what a
+future reader needs, not a table whose entries are almost all "false word
+match, no action." If a future pass needs the exact per-claim record, this
+session's own transcript carries it in full for each of the 8 batches.

--- a/docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md
+++ b/docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md
@@ -72,20 +72,29 @@ test in `tests/test_chunked.py`; not fixed (would mean threading
 `_build_block_key_expr` directly, as its own docstring already half-suggests
 — a real fix, not a docstring correction).
 
-**2. `distributed/clustering.py::_attach_quality_metadata` computes cluster
-confidence differently than the in-memory path.** Docstring claims it
-mirrors `core/cluster.py`'s `build_clusters`/`compute_cluster_confidence`.
-Confirmed false by calling both production functions directly on the same
-star-topology cluster (`1-2`:0.9, `1-3`:0.9, `1-4`:0.1): in-memory computes
-`confidence=0.266`, quality `"weak"` (edge-density connectivity, ×0.7
-downgrade when `avg_edge - min_edge` exceeds a threshold); distributed
-computes `confidence=0.420`, quality `"strong"` (sets `connectivity =
-avg_edge` directly, downgrades only below a flat `0.3` threshold, no
-downgrade logic at all). **The identical cluster is classified weak via the
-in-memory path and strong via the distributed path.** Pinned with a test in
-`tests/test_distributed_clustering.py` (Ray-gated, correctly skips locally
-per this repo's own policy, verified independently by calling the
-production functions directly without Ray); not fixed.
+**2. `distributed/clustering.py::_attach_quality_metadata` computed cluster
+confidence differently than the in-memory path -- FIXED, same day.**
+Docstring claimed it mirrors `core/cluster.py`'s
+`build_clusters`/`compute_cluster_confidence`. Confirmed false by calling
+both production functions directly on the same star-topology cluster
+(`1-2`:0.9, `1-3`:0.9, `1-4`:0.1): in-memory computed `confidence=0.266`,
+quality `"weak"`; distributed computed `confidence=0.420`, quality
+`"strong"` -- the identical cluster classified weak one way, strong the
+other. Root cause, found on review: `compute_cluster_confidence` routes
+through the native Rust kernel when enabled
+(`native_module().cluster_confidence(edges, size)`) -- this project's own
+standing principle is that the Rust kernel is the reference, not an
+optional fast path (`project_rust_is_the_reference`) --
+but `_attach_quality_metadata` never called it at all, reimplementing its
+own hand-written formula instead. Not a design choice between two valid
+formulas; a genuine failure to route through the established reference
+implementation. Fixed by having `_attach_quality_metadata` call
+`compute_cluster_confidence` directly, then apply the identical
+`weak_cluster_threshold` downgrade `build_clusters` applies afterward --
+verified against the same star-topology example, now agrees exactly
+(`weak`, `confidence=0.266` on both paths). The pinning test in
+`tests/test_distributed_clustering.py` (Ray-gated, correctly skips locally)
+now asserts genuine parity rather than an `xfail`.
 
 **3. `core/probabilistic.py::_fs_scoring_workers`'s default has drifted from
 `_DEFAULT_MAX_WORKERS`, the function it claims to mirror.** Git history:

--- a/docs/superpowers/specs/2026-09-04-stage4g-unresolvable-triage.md
+++ b/docs/superpowers/specs/2026-09-04-stage4g-unresolvable-triage.md
@@ -1,0 +1,95 @@
+# Phase C, Stage 4g — Triage of the 54 Unresolvable Claims
+
+**Status:** complete — all 54 individually triaged. This closes the entire
+166-claim population Phase C's scoping pass identified, and with it, Phase C.
+**Date:** 2026-09-04
+**Prior:** `docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md`
+(the low-confidence bucket, triaged first, larger yield of real bugs)
+
+## Why this document exists
+
+The last untouched slice of Phase C: 54 claims where the bare-word scanner
+found no declared symbol matching the target at all (`target=None`) --
+harder in principle than the low-confidence bucket, since there is no
+even-possibly-wrong candidate to start from. 7 were already classified
+during scoping as part of `mcp/server.py`'s cross-language MCP-tool cluster.
+The remaining 47 were split into 4 batches and triaged the same way as
+Stage 4f, adapted for the "nothing resolved at all" starting point: read
+the full docstring, then ask whether the real target is a non-Python
+reference, genuinely vague prose, a renamed/moved symbol, direct
+delegation, or a real testable claim.
+
+## Result: 54 claims, one real-bug re-confirmation, no new bugs
+
+| verdict | count |
+| --- | ---: |
+| CROSS-LANGUAGE (not testable from Python) | 20 |
+| NOT A REAL CLAIM (vague prose, no symbol named) | 12 |
+| PATTERN CLAIM (delegation / documented known divergence) | 6 |
+| ALREADY TESTED (real claim, existing coverage found) | 7 |
+| NEW TEST WRITTEN, claim confirmed TRUE | 9 |
+| **Total** | **54** |
+
+Unlike Stage 4f, this batch did not surface any *new* bugs. It did
+re-confirm one already known: claim 45 (`spark/identity.py::build_identity_events`)
+is a **documented, existing divergence** -- `build_identity_events`/
+`build_incremental_events` emit `"CREATED"` (uppercase) while the one-box
+`EventKind.CREATED.value` is `"created"` (lowercase). That function's own
+docstring already names this as accepted, frozen-contract drift; nothing
+new here, just confirmed still true and still documented, not silently
+missed.
+
+**A structural pattern worth naming for future audit passes:** a
+noticeably higher fraction of this bucket (20 of 54, 37%) is cross-language
+than the low-confidence bucket (4 of 111, 4%). This makes sense --
+low-confidence claims found *some* Python symbol (however wrong); a claim
+whose real target is Rust, C, or TypeScript often has no matching Python
+symbol to find at all, so it is more likely to land here, unresolved,
+rather than in low-confidence with a wrong guess. `mcp/server.py`'s entire
+9-claim burden across every bucket was this shape.
+
+**Renamed/moved targets (a shape not seen in Stage 4f):** 3 claims named a
+function that has since been renamed --
+`_run_fused_fs_short_circuit`→`_run_fused_fs_match_short_circuit`,
+`_diversify`→`_diversify_probabilistic_blocking`, and `shatter_cluster`'s
+target resolved to a different file (`mcp/server.py`) than the scanner's
+same-file assumption expected. Two of these needed a docstring correction
+alongside the new test (the third's target was already correctly named,
+just in a different file the scanner didn't check). This is a distinct
+failure shape from "false word match" or "genuinely vague" -- the claim was
+entirely correct when written, and code churn (a rename) is what made it
+unresolvable, not an error in the claim itself.
+
+## What this completes
+
+Phase C's 166-claim scoped population (everything outside the 45-claim
+clean high-confidence set already closed by Stage 4b/4c) is now fully
+triaged:
+
+| population | claims | status |
+| --- | ---: | --- |
+| Clean high-confidence (Stage 4b/4c) | 45 | closed |
+| Ambiguous-target (Stage 4e) | 8 | closed |
+| Low-confidence (Stage 4f) | 111 | closed |
+| Unresolvable (this document) | 54 | closed |
+| **Total individually triaged today** | **218** | |
+
+Combined with the 8 ambiguous-target claims and the earlier 45, every claim
+the sync-claims scanner currently flags across the entire `unenforced` +
+`unenforced_low_confidence` + `unenforced_ambiguous_target` +
+`unresolvable` populations has now been read by hand at least once. Five
+real production bugs were found across the whole day's effort (two before
+this document's population, three within Stage 4f) -- see each stage's own
+document for the individual writeups. C3 (arming sync-claims as an
+enforcement gate rather than a report) remains the one deliberately
+deferred piece of Phase C, per Stage 4b's own standing position.
+
+## Being wrong about this document
+
+All 47 dispatched claims were read individually; the 7 `mcp/server.py`
+claims were classified during scoping (same cross-language pattern
+independently confirmed 9 times across today's whole population) rather
+than re-dispatched. As with Stage 4f, this document reports the aggregate
+pattern and the one re-confirmed finding rather than reproducing all 47
+individual rows -- the per-claim detail lives in this session's own
+record for each of the 4 batches.

--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -1571,7 +1571,7 @@ def run_fs_dedupe_sequential(
     ``(__row_id__, __cluster_id__)`` cluster assignments directly — no Python block
     orchestration, no candidate-pair list, no separate edge-stream + WCC pass. This
     is the same arrow-native/Rust engine the in-memory dedupe short-circuit
-    (``_run_fused_fs_short_circuit``) uses; the streaming path just feeds it the
+    (``_run_fused_fs_match_short_circuit`` in ``core/pipeline.py``) uses; the streaming path just feeds it the
     resident frame and streams the assignments to parquet. When the config is
     outside the fused kernel's covered surface (or the native kernel is absent), it
     scores through the tuned ``score_buckets_arrow`` (the SAME native-kernel bucket
@@ -2038,7 +2038,8 @@ def _fused_fs_assignments(
     The kernel emits links at the REAL ``link_threshold`` cut and CCs them, so the
     resulting partition matches the classic ``score -> filter(>=link) -> cluster``
     split. Column gathering + the ``GoldenMatchConfig`` shape mirror the in-memory
-    ``_run_fused_fs_short_circuit`` exactly (byte-parity by construction)."""
+    ``_run_fused_fs_match_short_circuit`` (``core/pipeline.py``) exactly
+    (byte-parity by construction)."""
     from goldenmatch.config.schemas import GoldenMatchConfig
     from goldenmatch.core.frame import to_frame as _tf
     from goldenmatch.core.fused_match import (

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1897,8 +1897,11 @@ def score_buckets(
     def _apply_match_mode_filter(
         pairs: list[tuple[int, int, float]],
     ) -> list[tuple[int, int, float]]:
-        """Mirror the slow path's match-mode post-filter (_score_one_bucket
-        lines 544-553). Applies in two stages: across_files_only drops
+        """Mirror the slow path's match-mode post-filter (_score_one_bucket's
+        native-kernel branch, currently ~lines 2327-2336 -- the line numbers in
+        this docstring have drifted before and will again; match on the
+        across_files_only/target_ids post-filter block, not the line numbers).
+        Applies in two stages: across_files_only drops
         same-source pairs; target_ids drops same-side-of-target pairs.
 
         Both filters are O(pairs) and very cheap relative to scoring; safe

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -4944,11 +4944,14 @@ def score_probabilistic_blocks_batched(
 def _fs_scoring_workers() -> int:
     """Thread-pool size for parallel probabilistic block scoring.
 
-    ``GOLDENMATCH_FS_WORKERS`` overrides; default is ``min(cpu_count(), 16)``
-    (mirrors the weighted path's ``_DEFAULT_MAX_WORKERS``). ``1`` forces the
-    sequential unit loop — the byte-identical, deterministic reference path.
-    Both FS kernels (native Rust, vectorized ``rapidfuzz.cdist``) release the
-    GIL, so threads give real parallelism.
+    ``GOLDENMATCH_FS_WORKERS`` overrides; default is ``min(cpu_count(), 16)``.
+    This does NOT track the weighted path's ``_DEFAULT_MAX_WORKERS`` (core/
+    scorer.py) as-is today: #303 pinned that constant at a fixed 4 (RSS
+    pathology on a 16-core runner) before this function was added in #1566
+    with its own independent cpu-count-based default -- the two have diverged
+    since. ``1`` forces the sequential unit loop — the byte-identical,
+    deterministic reference path. Both FS kernels (native Rust, vectorized
+    ``rapidfuzz.cdist``) release the GIL, so threads give real parallelism.
     """
     val = os.environ.get("GOLDENMATCH_FS_WORKERS")
     if val is not None:

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -1621,22 +1621,37 @@ def materialize_cluster_dict(
     return result
 
 
-def _attach_quality_metadata(clusters: dict[int, dict]) -> None:
+def _attach_quality_metadata(
+    clusters: dict[int, dict], weak_cluster_threshold: float = 0.3
+) -> None:
     """Populate confidence, bottleneck_pair, cluster_quality on each cluster.
 
-    Mirrors the in-memory build_clusters semantics. Mutates in place.
+    Was a hand-written reimplementation that never called
+    core.cluster.compute_cluster_confidence -- and so never routed through
+    the native kernel that function uses when enabled, silently diverging
+    from the in-memory build_clusters path (this project's own standing
+    principle: the Rust kernel is the reference, not an optional fast path
+    -- confirmed as a real, empirically-reproducible divergence, see
+    docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md).
+    Now calls the SAME compute_cluster_confidence() build_clusters calls,
+    then applies the identical weak_cluster_threshold downgrade build_clusters
+    applies afterward (core/cluster.py's own cluster_quality_assignment
+    stage) -- genuinely mirrors the in-memory semantics rather than merely
+    claiming to. Mutates in place.
     """
+    from goldenmatch.core.cluster import compute_cluster_confidence
+
     for cinfo in clusters.values():
-        scores = list(cinfo["pair_scores"].values())
-        if not scores:
-            cinfo["confidence"] = 1.0
-            cinfo["bottleneck_pair"] = None
+        conf = compute_cluster_confidence(cinfo["pair_scores"], cinfo["size"])
+        cinfo["confidence"] = conf["confidence"]
+        cinfo["bottleneck_pair"] = conf["bottleneck_pair"]
+        min_edge, avg_edge = conf["min_edge"], conf["avg_edge"]
+        if (
+            min_edge is not None
+            and avg_edge is not None
+            and avg_edge - min_edge > weak_cluster_threshold
+        ):
+            cinfo["cluster_quality"] = "weak"
+            cinfo["confidence"] *= 0.7
+        else:
             cinfo["cluster_quality"] = "strong"
-            continue
-        min_edge = min(scores)
-        avg_edge = sum(scores) / len(scores)
-        connectivity = avg_edge
-        cinfo["confidence"] = 0.4 * min_edge + 0.3 * avg_edge + 0.3 * connectivity
-        weakest = min(cinfo["pair_scores"].items(), key=lambda kv: kv[1])
-        cinfo["bottleneck_pair"] = weakest[0]
-        cinfo["cluster_quality"] = "weak" if cinfo["confidence"] < 0.3 else "strong"

--- a/packages/python/goldenmatch/tests/identity/test_block_index_compute.py
+++ b/packages/python/goldenmatch/tests/identity/test_block_index_compute.py
@@ -137,3 +137,37 @@ def test_backfill_carries_entity_id(store):
 def test_backfill_requires_row_id(store):
     with pytest.raises(ValueError, match="__row_id__"):
         backfill_block_index(store, pl.DataFrame({"last": ["x"]}), _static(["last"]))
+
+
+def test_pass_signature_mirrors_blockers_pass_sig_tuple():
+    """``_pass_signature``'s string encoding must preserve the distinguishing
+    power of ``core/blocker.py``'s inline ``(tuple(fields), tuple(transforms
+    or []))`` pass_sig (``build_em_blocks_agg`` / ``_build_multi_pass_blocks``'s
+    multi_pass dedup key) -- two configs equal in (fields, transforms) get the
+    same signature, and configs whose (fields, transforms) tuple differs must
+    not collide."""
+    from goldenmatch.identity.block_index import _pass_signature
+
+    def blocker_tuple(cfg: BlockingKeyConfig) -> tuple:
+        # The exact expression core/blocker.py builds its pass_sig from.
+        return (tuple(cfg.fields), tuple(cfg.transforms or []))
+
+    same_a = BlockingKeyConfig(fields=["last", "zip"], transforms=["lowercase"])
+    same_b = BlockingKeyConfig(fields=["last", "zip"], transforms=["lowercase"])
+    assert blocker_tuple(same_a) == blocker_tuple(same_b)
+    assert _pass_signature(same_a) == _pass_signature(same_b)
+
+    configs = [
+        BlockingKeyConfig(fields=["last"], transforms=[]),
+        BlockingKeyConfig(fields=["last"], transforms=["soundex"]),
+        BlockingKeyConfig(fields=["zip"], transforms=[]),
+        BlockingKeyConfig(fields=["last", "zip"], transforms=[]),
+        BlockingKeyConfig(fields=["last"], transforms=["soundex", "substring"]),
+    ]
+    tuples = [blocker_tuple(c) for c in configs]
+    sigs = [_pass_signature(c) for c in configs]
+    assert len(set(tuples)) == len(configs)  # sanity: fixture tuples are distinct
+    assert len(set(sigs)) == len(configs), (
+        "distinct blocker.py pass_sig tuples collided into the same "
+        "_pass_signature string"
+    )

--- a/packages/python/goldenmatch/tests/identity/test_migrate_ids.py
+++ b/packages/python/goldenmatch/tests/identity/test_migrate_ids.py
@@ -33,6 +33,31 @@ def test_recompute_h1_id_returns_none_when_unfingerprintable(monkeypatch):
     assert _recompute_h1_id("acme", {"x": 1}) is None
 
 
+def test_recompute_h1_id_none_agrees_with_resolves_legacy_fallback(monkeypatch):
+    """``_recompute_h1_id``'s docstring: None "mirrors resolve.py's legacy-only
+    path". Pin the two decisions together directly, the way
+    ``test_referenced_row_ids_mirrors_the_cluster_loops_skip_rules`` pins
+    resolve.py's own loop against its helper: for the SAME (source, payload)
+    where ``record_fingerprint`` raises, migrate_ids must return None exactly
+    when resolve.py's ``_record_id_candidates`` falls back to a ``:hash:``
+    legacy id (never an ``:h1:`` one)."""
+    import goldenmatch.identity.migrate_ids as M
+    import goldenmatch.identity.resolve as R
+
+    def boom(_):
+        raise ValueError("unfingerprintable")
+
+    monkeypatch.setattr(M, "record_fingerprint", boom)
+    monkeypatch.setattr(R, "record_fingerprint", boom)
+
+    payload = {"name": "Ann"}
+    new_id = M._recompute_h1_id("acme", payload)
+    primary, cands = R._record_id_candidates(payload, "acme", None)
+
+    assert new_id is None
+    assert primary.startswith("acme:hash:") and cands == [primary]
+
+
 def test_migration_report_defaults():
     r = MigrationReport()
     assert (r.scanned, r.rewritten, r.merged, r.clashed_distinct_entity,

--- a/packages/python/goldenmatch/tests/identity/test_resolution_batch_c1.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolution_batch_c1.py
@@ -43,6 +43,22 @@ def test_flush_rows_defaults_to_env(monkeypatch):
     assert ResolutionBatch.from_args(run_id="r1", flush_rows=7).flush_rows == 7
 
 
+def test_bulk_fast_path_enabled_mirrors_resolves_own_read(monkeypatch):
+    """``resolution_batch.bulk_fast_path_enabled`` is a kill-switch mirror of
+    ``resolve._bulk_fast_path_enabled`` -- resolution_batch's docstring: "the
+    resolve body still owns the runtime read to stay byte-identical". Both
+    read the SAME ``GOLDENMATCH_IDENTITY_BULK`` env var and must agree for
+    every value."""
+    from goldenmatch.identity.resolution_batch import bulk_fast_path_enabled
+    from goldenmatch.identity.resolve import _bulk_fast_path_enabled
+
+    for raw in ("0", "1", "", "yes", "0 ", " 0"):
+        monkeypatch.setenv("GOLDENMATCH_IDENTITY_BULK", raw)
+        assert bulk_fast_path_enabled() == _bulk_fast_path_enabled(), raw
+    monkeypatch.delenv("GOLDENMATCH_IDENTITY_BULK", raising=False)
+    assert bulk_fast_path_enabled() == _bulk_fast_path_enabled() is True
+
+
 def test_batch_path_is_byte_identical_to_kwargs_path():
     """resolve_clusters(batch=...) must dispatch the same store writes, in the same
     order, as the equivalent loose-kwargs call."""

--- a/packages/python/goldenmatch/tests/identity/test_resolve.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolve.py
@@ -329,3 +329,39 @@ def test_unfingerprintable_row_keeps_hash_fallback(monkeypatch):
     monkeypatch.setattr(R, "record_fingerprint", lambda _: (_ for _ in ()).throw(ValueError()))
     primary, cands = R._record_id_candidates({"name": "Ann"}, "acme", None)
     assert primary.startswith("acme:hash:") and cands == [primary]
+
+
+def test_referenced_row_ids_mirrors_the_cluster_loops_skip_rules():
+    """``_referenced_row_ids`` must reach exactly the rows the resolve body's
+    own cluster-iteration loop reads -- same skip rules: a cluster with no
+    members is skipped, and a singleton (``len(members) == 1``) is skipped
+    only when ``emit_singletons`` is False. Reproduces the loop's own
+    conditions (resolve.py's cluster-iteration section: ``if not members:
+    continue`` / ``if size == 1 and not emit_singletons: continue``) as an
+    independent reference so a future edit to either side that breaks the
+    mirror is caught."""
+    from goldenmatch.identity.resolve import _referenced_row_ids
+
+    def loop_reads(cluster_items, emit_singletons):
+        seen: set[int] = set()
+        for _cid, info in cluster_items:
+            members = list(info.get("members") or [])
+            if not members:
+                continue
+            if len(members) == 1 and not emit_singletons:
+                continue
+            for m in members:
+                seen.add(int(m))
+        return seen
+
+    cluster_items = [
+        (1, {"members": []}),        # empty -> always skipped
+        (2, {}),                     # no "members" key -> treated as empty
+        (3, {"members": [10]}),      # singleton
+        (4, {"members": [11, 12]}),  # multi-member -> always included
+        (5, {"members": [13]}),      # another singleton
+    ]
+    for emit_singletons in (True, False):
+        assert _referenced_row_ids(cluster_items, emit_singletons) == loop_reads(
+            cluster_items, emit_singletons
+        )

--- a/packages/python/goldenmatch/tests/identity/test_resolve_scaling.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolve_scaling.py
@@ -489,6 +489,75 @@ def test_bulk_upsert_identities_works_on_sqlite(tmp_path):
     store.close()
 
 
+def test_bulk_upsert_identities_datetime_is_byte_identical_to_per_row(tmp_path):
+    """``_sqlite_stage``'s docstring: staged rows are "byte-identical to what
+    the per-row ``upsert_*`` path writes (which stores ``.isoformat()``
+    strings)". Compare the RAW stored ``created_at``/``updated_at`` strings
+    (not the round-tripped ``IdentityNode``, which would mask a formatting
+    mismatch) for the same ``datetime`` written via each path."""
+    from datetime import datetime
+
+    from goldenmatch.identity.model import IdentityNode
+
+    store = IdentityStore(path=str(tmp_path / "id.db"))
+    ts = datetime(2026, 3, 4, 5, 6, 7, 123456)
+
+    store.upsert_identity(IdentityNode(
+        entity_id="row", status="active", dataset="d", created_at=ts, updated_at=ts,
+    ))
+    df = pl.DataFrame({
+        "entity_id": ["bulk"], "status": ["active"], "merged_into": [None],
+        "golden_record": [None], "confidence": [None], "dataset": ["d"],
+        "created_at": [ts], "updated_at": [ts],
+    })
+    store.bulk_upsert_identities(df)
+
+    raw_row = store._conn.execute(
+        "SELECT created_at, updated_at FROM identity_nodes WHERE entity_id = ?",
+        ("row",),
+    ).fetchone()
+    raw_bulk = store._conn.execute(
+        "SELECT created_at, updated_at FROM identity_nodes WHERE entity_id = ?",
+        ("bulk",),
+    ).fetchone()
+    assert tuple(raw_row) == tuple(raw_bulk) == (ts.isoformat(), ts.isoformat())
+    store.close()
+
+
+def test_bulk_flush_checkpoint_mirrors_execs_automatic_chunk_commit(tmp_path):
+    """``bulk_flush_checkpoint``'s docstring: "mirrors the per-statement chunk
+    commit in ``_exec`` for the bulk (COPY-equivalent) path." An explicit
+    checkpoint must leave the same state ``_exec``'s own automatic chunk
+    commit leaves when ``_sqlite_pending`` reaches ``_sqlite_batch`` -- COMMIT
+    + BEGIN + ``_sqlite_pending`` reset to 0 -- so mixing manual and automatic
+    checkpoints in one ``bulk_writes`` block never leaks a stale count."""
+    from datetime import datetime
+
+    from goldenmatch.identity.model import IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    store = IdentityStore(path=str(tmp_path / "id.db"))
+    ts = datetime.now()
+    with store.bulk_writes():
+        store.upsert_identity(IdentityNode(
+            entity_id=new_entity_id(), status="active", dataset="d",
+            created_at=ts, updated_at=ts,
+        ))
+        assert store._sqlite_pending == 1
+        store.bulk_flush_checkpoint()  # the EXPLICIT checkpoint
+        assert store._sqlite_pending == 0
+
+        # Force _exec's AUTOMATIC chunk commit to fire on the very next write.
+        store._sqlite_batch = 1
+        store.upsert_identity(IdentityNode(
+            entity_id=new_entity_id(), status="active", dataset="d",
+            created_at=ts, updated_at=ts,
+        ))
+        assert store._sqlite_pending == 0  # _exec's own checkpoint reset it identically
+    assert store.count_identities() == 2
+    store.close()
+
+
 def test_bulk_methods_raise_on_mongo():
     """The bulk fast-path is SQL-backend only; a non-SQL backend (mongo) still
     routes through the per-row loop, so the bulk entry points reject it loudly

--- a/packages/python/goldenmatch/tests/identity/test_snowflake_union_find_remap.py
+++ b/packages/python/goldenmatch/tests/identity/test_snowflake_union_find_remap.py
@@ -1,0 +1,52 @@
+"""``_union_find_remap`` is a pure function -- no Snowflake connection needed.
+
+Covers the "Port of ``IdentityStore.merge_by_shared_field`` (store.py)" claim
+in its docstring: the union-find + survivor rule (lexicographically smallest
+entity id in the component) were lifted from the store.py inline algorithm.
+The chaining case it explicitly calls out (an entity sharing two different
+values, linking two otherwise-disjoint groups into one component) had no test
+anywhere in the suite.
+"""
+from __future__ import annotations
+
+from goldenmatch.identity.snowflake_backend import _union_find_remap
+
+
+def test_single_group_survivor_is_lexicographically_smallest():
+    remap, groups = _union_find_remap({"123": ["e2", "e1"]})
+    assert groups == 1
+    assert remap == [("e2", "e1")]
+
+
+def test_no_shared_values_is_a_noop():
+    remap, groups = _union_find_remap({})
+    assert (remap, groups) == ([], 0)
+
+
+def test_chains_across_two_shared_values_into_one_component():
+    """e1/e2 share value v1; e2/e3 share value v2. e2 is the bridge, so all
+    three must collapse into ONE component with the lexicographically
+    smallest id as the sole survivor -- not two separate two-entity merges."""
+    by_val = {"v1": ["e2", "e1"], "v2": ["e2", "e3"]}
+    remap, groups = _union_find_remap(by_val)
+    assert groups == 1
+    survivors = {new for _old, new in remap}
+    absorbed = {old for old, _new in remap}
+    assert survivors == {"e1"}
+    assert absorbed == {"e2", "e3"}
+
+
+def test_chain_survivor_is_lexicographically_smallest_regardless_of_order():
+    """Same chain, but the smallest id (``e1``) is reached only via the
+    bridge -- the union-find must still find it as the global root."""
+    by_val = {"va": ["e3", "e2"], "vb": ["e2", "e1"]}
+    remap, groups = _union_find_remap(by_val)
+    assert groups == 1
+    assert {new for _old, new in remap} == {"e1"}
+
+
+def test_disjoint_groups_stay_separate():
+    by_val = {"v1": ["b", "a"], "v2": ["d", "c"]}
+    remap, groups = _union_find_remap(by_val)
+    assert groups == 2
+    assert dict(remap) == {"b": "a", "d": "c"}

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_numeric.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_numeric.py
@@ -79,6 +79,38 @@ def test_numeric_min_all_null_returns_none():
     assert conf == 0.0
 
 
+# The following pin NumericMinStrategy's docstring claim -- "Same shape as
+# `numeric_max`" -- against the numeric_max cases above it mirrors: string
+# coercion, ignoring non-numeric values, all-non-numeric -> None, and the
+# tie rule (first index wins, confidence 0.7).
+
+
+def test_numeric_min_handles_string_numbers():
+    val, conf, idx = NumericMinStrategy().merge(["10", "50", "25"])
+    assert val == "10"
+    assert conf == 1.0
+    assert idx == 0
+
+
+def test_numeric_min_ignores_non_numeric():
+    val, conf, idx = NumericMinStrategy().merge(["abc", 100, None, "xyz", 200])
+    assert val == 100
+    assert idx == 1
+
+
+def test_numeric_min_all_non_numeric_returns_none():
+    val, conf = NumericMinStrategy().merge(["abc", "xyz", None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_numeric_min_ties_give_first_index():
+    val, conf, idx = NumericMinStrategy().merge([50, 50, 100])
+    assert val == 50
+    assert idx == 0
+    assert conf == 0.7  # tie
+
+
 # ---------------------------------------------------------------------------
 # numeric_mean
 # ---------------------------------------------------------------------------

--- a/packages/python/goldenmatch/tests/snowflake/test_identity_bulk_snowflake.py
+++ b/packages/python/goldenmatch/tests/snowflake/test_identity_bulk_snowflake.py
@@ -110,6 +110,41 @@ def test_bulk_on_empty_frame_is_a_noop(store) -> None:  # noqa: F811
     assert store.count_identities() == 0
 
 
+def test_bulk_upsert_identities_fills_missing_columns_with_none(store) -> None:  # noqa: F811
+    """``SnowflakeIdentityStore.bulk_upsert_identities`` "Mirrors
+    ``IdentityStore.bulk_upsert_identities`` (store.py:1023): missing columns
+    are filled with None so callers need not carry all eight." Give it a
+    frame missing ``merged_into`` / ``golden_record`` / ``confidence``
+    entirely and confirm it doesn't raise and the row lands with those
+    columns defaulted to None, exactly like the Postgres/SQLite branches."""
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    now = datetime(2026, 8, 20, 12, 0, 0)
+    df = pl.DataFrame(
+        # merged_into / golden_record / confidence intentionally omitted --
+        # created_at/updated_at are NOT NULL in the schema so they stay, to
+        # isolate the claim (missing OPTIONAL columns) from an unrelated
+        # constraint failure.
+        {
+            "entity_id": [eid], "status": ["active"], "dataset": ["c"],
+            "created_at": [now], "updated_at": [now],
+        },
+        schema={
+            "entity_id": pl.Utf8, "status": pl.Utf8, "dataset": pl.Utf8,
+            "created_at": pl.Datetime, "updated_at": pl.Datetime,
+        },
+    )
+    store.bulk_upsert_identities(df)
+    node = store.get_identity(eid)
+    assert node is not None
+    assert node.status == "active"
+    assert node.dataset == "c"
+    assert node.merged_into is None
+    assert node.golden_record is None
+    assert node.confidence is None
+
+
 def test_bulk_add_edges_is_idempotent_no_duplicates(store) -> None:  # noqa: F811
     """``stage_and_merge(update_cols=None)`` is the insert-if-absent path that
     replaces the UNIQUE constraint Snowflake does not enforce. Calling

--- a/packages/python/goldenmatch/tests/test_api_shatter_unmerge.py
+++ b/packages/python/goldenmatch/tests/test_api_shatter_unmerge.py
@@ -96,6 +96,40 @@ class TestShatter:
         assert "error" in srv.shatter_cluster(0)
 
 
+class TestShatterMirrorsMcpTool:
+    """api/server.py MatchServer.shatter_cluster's docstring claims it "mirrors
+    the MCP shatter_cluster tool" (goldenmatch.mcp.server._tool_shatter_cluster).
+    Both wrap engine.unmerge_cluster with the same pre-check / summary shape --
+    assert that shape stays identical given equivalent state.
+    """
+
+    def test_shatter_output_matches_mcp_tool_shape(self, monkeypatch):
+        import goldenmatch.mcp.server as mcp_server
+
+        monkeypatch.setattr(mcp_server, "_engine", _StubEngine(_AFTER_SHATTERED), raising=False)
+        monkeypatch.setattr(mcp_server, "_result", _result(_BEFORE, total_clusters=1), raising=False)
+        mcp_out = mcp_server._tool_shatter_cluster(0)
+
+        srv = MatchServer(_StubEngine(_AFTER_SHATTERED), _cfg())
+        srv.result = _result(_BEFORE, total_clusters=1)
+        api_out = srv.shatter_cluster(0)
+
+        assert api_out == mcp_out
+
+    def test_shatter_missing_cluster_error_matches_mcp_tool(self, monkeypatch):
+        import goldenmatch.mcp.server as mcp_server
+
+        monkeypatch.setattr(mcp_server, "_engine", _StubEngine(_AFTER_SHATTERED), raising=False)
+        monkeypatch.setattr(mcp_server, "_result", _result(_BEFORE, total_clusters=1), raising=False)
+        mcp_out = mcp_server._tool_shatter_cluster(99)
+
+        srv = MatchServer(_StubEngine(_AFTER_SHATTERED), _cfg())
+        srv.result = _result(_BEFORE, total_clusters=1)
+        api_out = srv.shatter_cluster(99)
+
+        assert api_out == mcp_out
+
+
 class TestUnmerge:
     def test_unmerge_record_updates_result(self):
         after = _result(

--- a/packages/python/goldenmatch/tests/test_autoconfig_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_native_parity.py
@@ -212,6 +212,38 @@ def test_exact_matchkey_floor_golden_vectors(monkeypatch: pytest.MonkeyPatch) ->
         )
 
 
+def test_exact_matchkey_floor_dispatcher_matches_python_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``exact_matchkey_floor``'s docstring claims the native dispatch is
+    "byte-identical to the pure-Python oracle" (``_exact_matchkey_floor_py``).
+    Drive the PUBLIC dispatcher with native ON vs OFF over every golden-vector
+    col_type and assert both sides agree with the oracle -- not just that the
+    raw FFI shim matches the hardcoded golden values (test_exact_matchkey_floor_
+    golden_vectors, above)."""
+    _nm = native_module()
+    if not hasattr(_nm, "autoconfig_exact_matchkey_floor"):
+        pytest.skip("native ext predates S3 (no autoconfig_exact_matchkey_floor)")
+
+    from goldenmatch.core.autoconfig import _exact_matchkey_floor_py, exact_matchkey_floor
+
+    vectors_path = GOLDEN_DIR / "exact_matchkey_floor_vectors.json"
+    vectors = json.loads(vectors_path.read_text(encoding="utf-8"))
+    col_types = [v["input"]["col_type"] for v in vectors]
+
+    for col_type in col_types:
+        oracle = _exact_matchkey_floor_py(col_type)
+
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+        py_dispatched = exact_matchkey_floor(col_type)
+
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
+        native_dispatched = exact_matchkey_floor(col_type)
+
+        assert py_dispatched == oracle, col_type
+        assert native_dispatched == oracle, col_type
+
+
 # ── Test 3: wiring equivalence ───────────────────────────────────────────────
 
 def _make_person_df() -> pl.DataFrame:

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
@@ -156,3 +156,39 @@ def test_controller_run_attaches_execution_plan_to_history():
     assert plan.rule_name is not None
     # 80-row fixture hits the simple plan (rule 2); backend is the real selector's choice.
     assert plan.backend == _scoring_backend()
+
+
+def test_build_planner_capabilities_bucket_available_matches_scoring_backend(
+    monkeypatch,
+):
+    """``build_planner_capabilities``'s docstring claims ``bucket_available`` is
+    "the same check as ``_scoring_backend()``" -- verify the two independently
+    computed booleans actually agree across the opt-out env var, for both
+    values of whether the native block-scoring kernel is enabled."""
+    from goldenmatch.core.autoconfig_native import build_planner_capabilities
+
+    for bucket_env in ("1", "0"):
+        monkeypatch.setenv("GOLDENMATCH_PLANNER_BUCKET", bucket_env)
+        caps = build_planner_capabilities(None)
+        assert caps["bucket_available"] == (_scoring_backend() == "bucket"), (
+            f"bucket_available diverged from _scoring_backend() with "
+            f"GOLDENMATCH_PLANNER_BUCKET={bucket_env!r}"
+        )
+
+
+def test_build_planner_capabilities_ray_fields_match_planner_rules_helpers(
+    monkeypatch,
+):
+    """``ray_available``/``ray_auto_select`` claim to mirror ``_has_ray()`` and
+    ``_ray_auto_select_enabled()`` from ``autoconfig_planner_rules`` verbatim."""
+    from goldenmatch.core.autoconfig_native import build_planner_capabilities
+    from goldenmatch.core.autoconfig_planner_rules import (
+        _has_ray,
+        _ray_auto_select_enabled,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_ENABLE_DISTRIBUTED_RAY", "1")
+    caps = build_planner_capabilities({"user_backend": "ray"})
+    assert caps["ray_available"] == _has_ray()
+    assert caps["ray_auto_select"] == _ray_auto_select_enabled()
+    assert caps["user_backend"] == "ray"

--- a/packages/python/goldenmatch/tests/test_chunked.py
+++ b/packages/python/goldenmatch/tests/test_chunked.py
@@ -144,3 +144,74 @@ class TestChunkedMatcher:
         # The whole file is also reachable when we keep iterating.
         remaining = sum(c.height for c in reader)
         assert first.height + remaining == 50
+
+
+class TestBlockKeyColumnMirrorsBuildBlockKeyExpr:
+    """``ChunkedMatcher._block_key_column``'s docstring claims it "Mirrors
+    ``goldenmatch.core.blocker._build_block_key_expr`` but kept inline".
+
+    ``_build_block_key_expr`` honors per-field ``field_transforms`` (a field
+    listed there uses its OWN chain; other fields keep the key-level
+    ``transforms``, #1826). ``_block_key_column`` takes no ``field_transforms``
+    parameter at all -- it applies ``key_config.transforms`` uniformly to
+    every field. This test checks whether the two actually agree once
+    ``field_transforms`` is in play.
+    """
+
+    def test_uniform_transforms_match(self, config):
+        """Baseline: no field_transforms configured -> the two helpers agree
+        (both apply key_config.transforms to every field)."""
+        import polars as pl
+        from goldenmatch.core.blocker import _build_block_key_expr
+        from goldenmatch.core.chunked import ChunkedMatcher
+
+        key_config = BlockingKeyConfig(fields=["name", "zip"], transforms=["lowercase"])
+        df = pl.DataFrame({"name": ["Alice Smith", "BOB JONES"], "zip": ["10001", "20002"]})
+
+        matcher = ChunkedMatcher(config=config, chunk_size=100)
+        got = matcher._block_key_column(df, key_config)["__block_key__"].to_list()
+
+        expected = df.with_columns(_build_block_key_expr(key_config))["__block_key__"].to_list()
+        assert got == expected
+
+    def test_field_transforms_diverges_from_build_block_key_expr(self, config):
+        """A key with PER-FIELD ``field_transforms`` (#1826) is where the
+        docstring's "mirrors" claim breaks: ``_build_block_key_expr`` gives
+        ``last`` its own ``uppercase`` chain while ``first`` keeps the
+        key-level ``lowercase`` chain; ``_block_key_column`` has no
+        field_transforms parameter and applies ``lowercase`` to BOTH fields.
+
+        This is a real divergence, not a test bug -- the chunked/streaming
+        large-dataset path can silently compute a DIFFERENT block key than
+        the main path for the exact same BlockingKeyConfig whenever
+        field_transforms is used.
+        """
+        import polars as pl
+        from goldenmatch.core.blocker import _build_block_key_expr
+        from goldenmatch.core.chunked import ChunkedMatcher
+
+        key_config = BlockingKeyConfig(
+            fields=["first", "last"],
+            transforms=["lowercase"],
+            field_transforms={"last": ["uppercase"]},
+        )
+        df = pl.DataFrame({"first": ["Alice"], "last": ["Smith"]})
+
+        matcher = ChunkedMatcher(config=config, chunk_size=100)
+        got = matcher._block_key_column(df, key_config)["__block_key__"].to_list()
+
+        expected = df.with_columns(_build_block_key_expr(key_config))["__block_key__"].to_list()
+
+        # DIVERGENCE, confirmed: _build_block_key_expr honors field_transforms
+        # (last -> UPPERCASE), _block_key_column ignores it (last -> lowercase
+        # via the uniform key-level chain). If this assertion ever starts
+        # failing, _block_key_column has been fixed to thread field_transforms
+        # through and the docstring's "mirrors" claim is true again -- update
+        # this test (and the one above) to assert equality instead.
+        assert expected == ["alice||SMITH"]
+        assert got == ["alice||smith"]
+        assert got != expected, (
+            "_block_key_column now matches _build_block_key_expr on "
+            "field_transforms -- the divergence this test pins has been "
+            "fixed; replace this test with a straight equality assertion."
+        )

--- a/packages/python/goldenmatch/tests/test_committed_matchkeys_summary.py
+++ b/packages/python/goldenmatch/tests/test_committed_matchkeys_summary.py
@@ -1,0 +1,95 @@
+"""``_committed_matchkeys_summary`` (goldenmatch.web.controller_telemetry).
+
+Docstring claim: "Mirrors the format that ``/api/v1/rules`` returns but
+reflects the committed (engine-side) view rather than the workbench's
+flattened RulesPayload." So the two are deliberately NOT the same shape --
+RulesPayload is a flat ``matchkeys: [MatchkeyField, ...]`` list (see
+``GoldenMatchConfig.schemas.RulesPayload``), while this helper nests fields
+per matchkey. These tests pin the one-line-per-matchkey projection this
+helper actually produces, and confirm the per-field values it surfaces
+(scorer / weight / column) are the same values a MatchkeyConfig carries --
+so the "mirrors the format" claim is about field-naming/spirit, not a
+literal RulesPayload-shaped output.
+"""
+from __future__ import annotations
+
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField, NegativeEvidenceField
+from goldenmatch.web.controller_telemetry import _committed_matchkeys_summary
+
+
+class _Cfg:
+    """Minimal stand-in: the helper only ever calls ``.get_matchkeys()``."""
+
+    def __init__(self, matchkeys):
+        self._matchkeys = matchkeys
+
+    def get_matchkeys(self):
+        return self._matchkeys
+
+
+def test_none_config_returns_empty_list():
+    assert _committed_matchkeys_summary(None) == []
+
+
+def test_one_line_per_matchkey_with_expected_keys():
+    mk = MatchkeyConfig(
+        name="name_phone",
+        type="weighted",
+        threshold=0.85,
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.6),
+            MatchkeyField(field="phone", scorer="exact", weight=0.4),
+        ],
+    )
+    out = _committed_matchkeys_summary(_Cfg([mk]))
+    assert len(out) == 1
+    row = out[0]
+    assert row["name"] == "name_phone"
+    assert row["type"] == "weighted"
+    assert row["threshold"] == 0.85
+    assert row["has_negative_evidence"] is False
+    assert [f["column"] for f in row["fields"]] == ["first_name", "phone"]
+    assert [f["scorer"] for f in row["fields"]] == ["jaro_winkler", "exact"]
+    assert [f["weight"] for f in row["fields"]] == [0.6, 0.4]
+
+
+def test_column_alias_is_preferred_over_field():
+    # MatchkeyField.column is an alias for .field; the summary prefers
+    # `.column or .field` -- confirm `column` wins when both are set.
+    mk = MatchkeyConfig(
+        name="mk",
+        type="exact",
+        fields=[MatchkeyField(field="raw_field", column="aliased_column")],
+    )
+    row = _committed_matchkeys_summary(_Cfg([mk]))[0]
+    assert row["fields"][0]["column"] == "aliased_column"
+
+
+def test_has_negative_evidence_reflects_the_ne_list():
+    ne = NegativeEvidenceField(field="phone", transforms=["digits_only"], scorer="exact", threshold=0.5, penalty=0.2)
+    mk = MatchkeyConfig(
+        name="mk",
+        type="weighted",
+        threshold=0.85,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+        negative_evidence=[ne],
+    )
+    row = _committed_matchkeys_summary(_Cfg([mk]))[0]
+    assert row["has_negative_evidence"] is True
+
+
+def test_exact_matchkey_has_no_threshold_or_weight():
+    # exact matchkeys carry no per-field weight and no matchkey threshold;
+    # the summary must not synthesize either rather than surfacing None.
+    mk = MatchkeyConfig(name="mk", type="exact", fields=[MatchkeyField(field="npi")])
+    row = _committed_matchkeys_summary(_Cfg([mk]))[0]
+    assert row["threshold"] is None
+    assert row["fields"][0]["weight"] is None
+
+
+def test_get_matchkeys_exception_returns_empty_list_not_raise():
+    class _Broken:
+        def get_matchkeys(self):
+            raise RuntimeError("no committed config yet")
+
+    assert _committed_matchkeys_summary(_Broken()) == []

--- a/packages/python/goldenmatch/tests/test_distributed_block_shuffle.py
+++ b/packages/python/goldenmatch/tests/test_distributed_block_shuffle.py
@@ -102,6 +102,29 @@ def test_has_colocation_plan():
     assert _has_colocation_plan(GoldenMatchConfig()) is False
 
 
+def test_dedup_num_partitions_mirrors_golden_build_heuristic(monkeypatch):
+    """_dedup_num_partitions's docstring claims to mirror "the golden build's
+    ``min(256, max(4, cpu*4))`` heuristic" -- the same formula used as the
+    ``num_partitions`` default in
+    ``distributed.pipeline.build_golden_records_distributed``
+    (``goldenmatch/distributed/pipeline.py``, and duplicated again in
+    ``distributed/clustering.py``'s WCC repartition). All three read
+    ``os.cpu_count() or 16`` and compute the identical expression."""
+    import os as _os
+
+    from goldenmatch.distributed.scoring import _dedup_num_partitions
+
+    for cpu in (1, 4, 16, 64, 200):
+        monkeypatch.setattr(_os, "cpu_count", lambda cpu=cpu: cpu)
+        expected = min(256, max(4, cpu * 4))
+        assert _dedup_num_partitions() == expected
+
+    # No-cpu-count environment: falls back to 16 (matching the golden build's
+    # own ``os.cpu_count() or 16``), i.e. min(256, max(4, 16*4)) == 64.
+    monkeypatch.setattr(_os, "cpu_count", lambda: None)
+    assert _dedup_num_partitions() == 64
+
+
 # ── co-location ──────────────────────────────────────────────────────
 
 

--- a/packages/python/goldenmatch/tests/test_distributed_clustering.py
+++ b/packages/python/goldenmatch/tests/test_distributed_clustering.py
@@ -113,6 +113,19 @@ def test_materialize_cluster_dict_matches_in_memory_shape():
     assert partitions(in_mem) == partitions(distributed)
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known, real divergence -- _attach_quality_metadata does NOT mirror "
+        "build_clusters' confidence/cluster_quality formula (see "
+        "docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md). "
+        "Pinned here as xfail(strict=True) rather than a hard failure so this "
+        "required job stays green while the gap is tracked: if either side's "
+        "formula is later fixed to genuinely mirror the other, this test will "
+        "XPASS and strict=True will flip that into a failure, forcing the "
+        "xfail marker's removal rather than letting the fix go unnoticed."
+    ),
+)
 def test_materialize_cluster_dict_confidence_matches_in_memory():
     """_attach_quality_metadata's docstring claims to mirror the in-memory
     build_clusters confidence/cluster_quality semantics (core/cluster.py

--- a/packages/python/goldenmatch/tests/test_distributed_clustering.py
+++ b/packages/python/goldenmatch/tests/test_distributed_clustering.py
@@ -113,6 +113,50 @@ def test_materialize_cluster_dict_matches_in_memory_shape():
     assert partitions(in_mem) == partitions(distributed)
 
 
+def test_materialize_cluster_dict_confidence_matches_in_memory():
+    """_attach_quality_metadata's docstring claims to mirror the in-memory
+    build_clusters confidence/cluster_quality semantics (core/cluster.py
+    compute_cluster_confidence + the weak-downgrade test in build_clusters).
+
+    Star topology 1-2, 1-3 (score 0.9) + 1-4 (score 0.1): 3 of the 6 possible
+    edges among 4 members are present, so edge-density connectivity (0.5)
+    differs from avg_edge (~0.633). In-memory uses edge-density for
+    ``connectivity`` and downgrades confidence *0.7 when
+    ``avg_edge - min_edge > weak_cluster_threshold`` (0.3); the distributed
+    path sets ``connectivity = avg_edge`` and instead classifies weak as
+    ``confidence < 0.3`` with no downgrade multiplier -- a different formula,
+    not a mirror.
+    """
+    from goldenmatch.core.cluster import build_clusters
+    from goldenmatch.distributed.clustering import (
+        build_clusters_distributed,
+        materialize_cluster_dict,
+        pairs_list_to_dataset,
+    )
+
+    pairs = [(1, 2, 0.9), (1, 3, 0.9), (1, 4, 0.1)]
+    all_ids = [1, 2, 3, 4]
+    in_mem = build_clusters(pairs, all_ids=all_ids)
+    pairs_ds = pairs_list_to_dataset(pairs)
+    clusters_ds = build_clusters_distributed(pairs_ds, all_ids=all_ids)
+    distributed = materialize_cluster_dict(clusters_ds, pairs_ds)
+
+    in_mem_c = next(iter(in_mem.values()))
+    dist_c = next(iter(distributed.values()))
+
+    assert dist_c["cluster_quality"] == in_mem_c["cluster_quality"], (
+        f"in-memory={in_mem_c['cluster_quality']!r} "
+        f"(confidence={in_mem_c['confidence']!r}) vs "
+        f"distributed={dist_c['cluster_quality']!r} "
+        f"(confidence={dist_c['confidence']!r}) -- "
+        "_attach_quality_metadata does NOT mirror build_clusters semantics"
+    )
+    assert dist_c["confidence"] == pytest.approx(in_mem_c["confidence"]), (
+        f"in-memory confidence={in_mem_c['confidence']!r} vs "
+        f"distributed confidence={dist_c['confidence']!r}"
+    )
+
+
 def test_materialize_cluster_dict_includes_pair_scores():
     from goldenmatch.distributed.clustering import (
         build_clusters_distributed,

--- a/packages/python/goldenmatch/tests/test_distributed_clustering.py
+++ b/packages/python/goldenmatch/tests/test_distributed_clustering.py
@@ -113,19 +113,6 @@ def test_materialize_cluster_dict_matches_in_memory_shape():
     assert partitions(in_mem) == partitions(distributed)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known, real divergence -- _attach_quality_metadata does NOT mirror "
-        "build_clusters' confidence/cluster_quality formula (see "
-        "docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md). "
-        "Pinned here as xfail(strict=True) rather than a hard failure so this "
-        "required job stays green while the gap is tracked: if either side's "
-        "formula is later fixed to genuinely mirror the other, this test will "
-        "XPASS and strict=True will flip that into a failure, forcing the "
-        "xfail marker's removal rather than letting the fix go unnoticed."
-    ),
-)
 def test_materialize_cluster_dict_confidence_matches_in_memory():
     """_attach_quality_metadata's docstring claims to mirror the in-memory
     build_clusters confidence/cluster_quality semantics (core/cluster.py

--- a/packages/python/goldenmatch/tests/test_embeddings.py
+++ b/packages/python/goldenmatch/tests/test_embeddings.py
@@ -257,6 +257,83 @@ def test_cortex_provider_resolves_via_name():
     assert prov.model_id == "snowflake-cortex:snowflake-arctic-embed-m-v1.5"
     # Hyphenated + short alias.
     assert resolve_provider("snowflake-cortex").model_id == prov.model_id
+
+
+# ---------------------------------------------------------------------------
+# SnowflakeCortexProvider._open_conn -- env-driven path. Its docstring claims
+# this "mirrors goldenmatch's existing Snowflake connector usage", i.e. the
+# same SNOWFLAKE_* env var names goldenmatch.db.connector_snowflake.
+# SnowflakeConnector.connect already reads (account/user/password + the
+# db/schema/warehouse extras), plus the OAuth SNOWFLAKE_TOKEN path.
+# ---------------------------------------------------------------------------
+
+
+def test_open_conn_env_path_mirrors_connector_snowflake_env_vars(monkeypatch):
+    """account/user/password come from the SAME env var names ``SnowflakeConnector.
+    connect`` (goldenmatch.db.connector_snowflake) reads -- that shared convention is
+    what the ``_open_conn`` docstring means by "mirrors ... existing Snowflake
+    connector usage"."""
+    import snowflake.connector
+    from goldenmatch.embeddings import SnowflakeCortexProvider
+
+    captured: dict = {}
+
+    def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(snowflake.connector, "connect", fake_connect)
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct1")
+    monkeypatch.setenv("SNOWFLAKE_USER", "user1")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "pw1")
+    monkeypatch.setenv("SNOWFLAKE_WAREHOUSE", "wh1")
+    monkeypatch.setenv("SNOWFLAKE_DATABASE", "db1")
+    monkeypatch.setenv("SNOWFLAKE_SCHEMA", "sch1")
+    monkeypatch.delenv("SNOWFLAKE_TOKEN", raising=False)
+
+    prov = SnowflakeCortexProvider()
+    conn, owned = prov._open_conn()
+    assert owned is True
+    assert captured["account"] == "acct1"
+    assert captured["user"] == "user1"
+    assert captured["password"] == "pw1"
+    assert captured["warehouse"] == "wh1"
+    assert captured["database"] == "db1"
+    assert captured["schema"] == "sch1"
+    assert "token" not in captured
+
+
+def test_open_conn_env_path_oauth_token(monkeypatch):
+    """No SNOWFLAKE_PASSWORD -> the OAuth SNOWFLAKE_TOKEN branch, same as the
+    connector's account/user + OAuth convention."""
+    import snowflake.connector
+    from goldenmatch.embeddings import SnowflakeCortexProvider
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        snowflake.connector, "connect",
+        lambda **kwargs: captured.update(kwargs) or object(),
+    )
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct1")
+    monkeypatch.setenv("SNOWFLAKE_USER", "user1")
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    monkeypatch.setenv("SNOWFLAKE_TOKEN", "tok1")
+
+    prov = SnowflakeCortexProvider()
+    prov._open_conn()
+    assert captured["token"] == "tok1"
+    assert captured["authenticator"] == "OAUTH"
+    assert "password" not in captured
+
+
+def test_open_conn_missing_account_or_user_raises(monkeypatch):
+    from goldenmatch.embeddings import SnowflakeCortexProvider
+
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_USER", raising=False)
+    prov = SnowflakeCortexProvider()
+    with pytest.raises(RuntimeError, match="SNOWFLAKE_ACCOUNT"):
+        prov._open_conn()
     assert resolve_provider("cortex").model_id == prov.model_id
 
 

--- a/packages/python/goldenmatch/tests/test_from_splink_verify.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_verify.py
@@ -188,6 +188,105 @@ def test_is_faithful_threshold() -> None:
     assert not lo.is_faithful
 
 
+# ── model-injection seam (mirrors splink_upgrade_measure's) ─────────────────
+# _run_goldenmatch's docstring claims it "mirrors the model-injection seam
+# splink_upgrade_measure uses": save the EMResult to a temp JSON file and point
+# the probabilistic matchkey's model_path at it, so dedupe_df (load_or_train_em)
+# loads the imported weights instead of retraining on the sample.
+
+
+def _fs_gm_config():
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="fs",
+                type="probabilistic",
+                fields=[MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)],
+            )
+        ],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["surname"])]),
+    )
+
+
+def _em_model():
+    from goldenmatch.core.probabilistic import EMResult
+
+    return EMResult(
+        m_probs={"first_name": [0.05, 0.25, 0.7]},
+        u_probs={"first_name": [0.9, 0.08, 0.02]},
+        match_weights={"first_name": [-4.17, 1.64, 5.13]},
+        converged=True,
+        iterations=5,
+        proportion_matched=0.1,
+    )
+
+
+def test_run_goldenmatch_injects_model_path_when_fully_covered(monkeypatch) -> None:
+    """When every field the matchkey uses is covered by the imported EMResult's
+    match_weights, _run_goldenmatch writes it to a temp file and points the
+    matchkey's model_path at it -- the same save_json + model_path mechanism
+    splink_upgrade_measure._measure_pass uses for its baseline/upgraded runs."""
+    from goldenmatch.core.probabilistic import EMResult
+
+    seen: dict = {}
+
+    def _capture_run_once(sample, config, ids):
+        # The injected model file lives in a TemporaryDirectory that
+        # _run_goldenmatch tears down on return -- read it back INSIDE this
+        # hook, while it still exists.
+        path = config.get_matchkeys()[0].model_path
+        seen["model_path"] = path
+        seen["loaded"] = EMResult.load_json(path) if path else None
+        return {}, 0.0
+
+    monkeypatch.setattr(splink_verify, "_run_once", _capture_run_once)
+
+    em_model = _em_model()
+    mapping = splink_verify._run_goldenmatch(_DF, _fs_gm_config(), em_model, ["0", "1", "2", "3", "4", "5"])
+
+    assert mapping == {}
+    assert seen["model_path"] is not None
+    assert seen["loaded"].match_weights == em_model.match_weights
+
+
+def test_run_goldenmatch_no_injection_when_not_fully_covered(monkeypatch) -> None:
+    """An EMResult that doesn't cover every field the matchkey scores leaves
+    model_path unset -- the run falls through to retraining EM on the sample
+    (same all-or-nothing coverage gate splink_upgrade_measure's copy-on-write
+    config guard implies: never point a matchkey at a model missing weights for
+    a field it scores)."""
+    seen: dict = {}
+
+    def _capture_run_once(sample, config, ids):
+        seen["config"] = config
+        return {}, 0.0
+
+    monkeypatch.setattr(splink_verify, "_run_once", _capture_run_once)
+
+    from goldenmatch.core.probabilistic import EMResult
+
+    # match_weights covers "surname", not the config's "first_name" field.
+    partial_em = EMResult(
+        m_probs={"surname": [0.1, 0.9]},
+        u_probs={"surname": [0.9, 0.1]},
+        match_weights={"surname": [-3.17, 3.17]},
+        converged=True,
+        iterations=5,
+        proportion_matched=0.1,
+    )
+    splink_verify._run_goldenmatch(_DF, _fs_gm_config(), partial_em, ["0", "1", "2", "3", "4", "5"])
+
+    assert seen["config"].get_matchkeys()[0].model_path is None
+
+
 # ── real end-to-end (needs splink) ───────────────────────────────────────────
 
 

--- a/packages/python/goldenmatch/tests/test_fs_bucket_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_bucket_native.py
@@ -222,6 +222,41 @@ def test_fs_bucket_native_env_off_reproduces_per_block_byte_for_byte(monkeypatch
     assert _pairset(via_bucket) == _pairset(ref)
 
 
+# ── 2b. _fs_bucket_batch_enabled: batched (#869) == per-block loop, non-native ─
+
+
+def test_fs_bucket_batch_matches_per_block_loop_when_native_declined(monkeypatch):
+    """When the native kernel is declined, `_fs_bucket_batch_enabled` (default
+    ON) coalesces small blocks into one `score_probabilistic_vectorized_batch`
+    call. Its docstring claims this is byte-identical to the per-block loop
+    (GOLDENMATCH_FS_BUCKET_BATCH=0, the parity escape hatch). Force native OFF
+    so the batch/per-block branch under test is the one actually exercised."""
+    df = _oversized_df()
+    mk = _mk()
+    blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["zip"])],
+        max_block_size=3,
+        skip_oversized=True,
+    )
+    em = train_em(df, mk, n_sample_pairs=200)
+
+    from goldenmatch.backends.score_buckets import score_buckets
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", "0")
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_BATCH", "1")
+    got_batch = score_buckets(df, blocking, mk, set(), em_result=em)
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_BATCH", "0")
+    got_perblock = score_buckets(df, blocking, mk, set(), em_result=em)
+
+    assert _pairset(got_batch) == _pairset(got_perblock)
+    # Oversized block A (rows 1..5) must still contribute no pairs on either path.
+    for a, b in _pairset(got_batch):
+        assert not (a <= 5 and b <= 5)
+
+
 # ── 3. Routing ───────────────────────────────────────────────────────────────
 
 

--- a/packages/python/goldenmatch/tests/test_fs_orthogonal_blocking.py
+++ b/packages/python/goldenmatch/tests/test_fs_orthogonal_blocking.py
@@ -358,3 +358,42 @@ def test_overlap_gate_inert_without_frame():
         f for p in out.passes if getattr(p, "additive", False) for f in p.fields
     }
     assert {"first_name", "surname", "birth_place"} <= additive
+
+
+class TestPassSpecsMirrorsBuildBlockKeyExpr:
+    """``_pass_specs``'s docstring claims its ``[(field, transforms), ...]``
+    output "mirrors how the blocker derives the block key" -- i.e. the same
+    per-field ``field_transforms``-vs-key-level-``transforms`` dispatch as
+    ``goldenmatch.core.blocker._build_block_key_expr``."""
+
+    def test_field_transforms_override_per_field(self):
+        from goldenmatch.core.autoconfig import _pass_specs
+        from goldenmatch.core.blocker import _build_block_key_expr
+
+        key_config = BlockingKeyConfig(
+            fields=["first", "last", "zip"],
+            transforms=["lowercase"],
+            field_transforms={"last": ["uppercase"]},
+        )
+        specs = _pass_specs(key_config)
+        assert dict(specs) == {
+            "first": ("lowercase",),
+            "last": ("uppercase",),
+            "zip": ("lowercase",),
+        }
+
+        # Cross-check against the real block-key expression on sample data:
+        # each field's actual transform, per _build_block_key_expr, must equal
+        # what _pass_specs says it used.
+        import polars as pl
+
+        df = pl.DataFrame({"first": ["Alice"], "last": ["Smith"], "zip": ["Ab1"]})
+        key_col = df.with_columns(_build_block_key_expr(key_config))["__block_key__"][0]
+        assert key_col == "alice||SMITH||ab1"
+
+    def test_no_field_transforms_falls_back_to_key_level(self):
+        from goldenmatch.core.autoconfig import _pass_specs
+
+        key_config = BlockingKeyConfig(fields=["a", "b"], transforms=["strip"])
+        specs = _pass_specs(key_config)
+        assert dict(specs) == {"a": ("strip",), "b": ("strip",)}

--- a/packages/python/goldenmatch/tests/test_fs_out_of_core.py
+++ b/packages/python/goldenmatch/tests/test_fs_out_of_core.py
@@ -582,6 +582,24 @@ def test_sequential_bounded_scoring_escape_parity(tmp_path, monkeypatch):
         assert _sorted_golden(fused["golden_path"]) == _sorted_golden(bounded["golden_path"])
 
 
+# ── _fs_ooc_workers: mirrors the in-memory FS scorer's worker default ────────
+
+
+def test_fs_ooc_workers_mirrors_in_memory_fs_scoring_workers_default(monkeypatch):
+    """`_fs_ooc_workers`'s docstring claims its default mirrors the in-memory
+    FS scorer's `_fs_scoring_workers` (`core.probabilistic`): both read
+    `GOLDENMATCH_FS_WORKERS` and default to `min(16, cpu)`. Confirm the two
+    resolve identically, both on the default and on a valid override."""
+    from goldenmatch.backends.fs_out_of_core import _fs_ooc_workers
+    from goldenmatch.core.probabilistic import _fs_scoring_workers
+
+    monkeypatch.delenv("GOLDENMATCH_FS_WORKERS", raising=False)
+    assert _fs_ooc_workers() == _fs_scoring_workers()
+
+    monkeypatch.setenv("GOLDENMATCH_FS_WORKERS", "3")
+    assert _fs_ooc_workers() == _fs_scoring_workers() == 3
+
+
 # ── resolve_fs_block_source: the single knob unifying the two streaming lanes ──
 
 def test_resolve_fs_block_source_default_is_eager(monkeypatch):

--- a/packages/python/goldenmatch/tests/test_ingest.py
+++ b/packages/python/goldenmatch/tests/test_ingest.py
@@ -55,6 +55,70 @@ class TestLoadFile:
             load_file(path)
 
 
+class TestArrowRouteEligibleMirrorsDispatch:
+    """``_arrow_route_eligible``'s docstring claims it "Mirrors the exact
+    dispatch below" in ``load_file``: for every (suffix, parse_mode,
+    delimiter) combination, its verdict must match whether ``load_file``
+    actually takes the pyarrow route (vs. falling through to
+    ``smart_load``/the polars-native suffix branches) once the arrow frame
+    backend is selected."""
+
+    @pytest.mark.parametrize(
+        "suffix,parse_mode,delimiter",
+        [
+            (".parquet", "auto", None),
+            (".parquet", "fixed_width", None),  # suffix always wins over parse_mode
+            (".xlsx", "auto", None),
+            (".xlsx", "block", None),
+            (".csv", "auto", None),  # suffix == ".csv" -> eligible even with no delimiter
+            (".csv", "auto", ";"),
+            (".csv", "fixed_width", None),  # non-auto parse_mode -> smart_load
+            (".txt", "auto", None),  # non-.csv text, no delimiter -> smart_load
+            (".txt", "auto", "|"),  # non-.csv text, explicit delimiter -> eligible
+            (".txt", "key_value", "|"),  # non-auto parse_mode -> smart_load regardless
+            ("", "auto", None),  # no suffix, no delimiter -> smart_load
+            ("", "auto", ","),  # no suffix, explicit delimiter -> eligible
+        ],
+    )
+    def test_eligibility_matches_actual_route_taken(
+        self, tmp_path, monkeypatch, suffix, parse_mode, delimiter
+    ):
+        from goldenmatch.core.ingest import _arrow_route_eligible
+
+        expected = _arrow_route_eligible(suffix, parse_mode, delimiter)
+
+        monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
+
+        path = tmp_path / f"data{suffix}"
+        if suffix == ".parquet":
+            pl.DataFrame({"a": [1, 2]}).write_parquet(path)
+        elif suffix == ".xlsx":
+            pytest.importorskip("xlsxwriter")
+            pl.DataFrame({"a": [1, 2]}).write_excel(path)
+        else:
+            path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+        took_arrow_route = {"value": False}
+
+        def fake_read_table_arrow(*args, **kwargs):
+            took_arrow_route["value"] = True
+            import pyarrow as pa
+
+            return pa.table({"a": [1, 2]})
+
+        monkeypatch.setattr(
+            "goldenmatch.core.io_arrow.read_table_arrow", fake_read_table_arrow
+        )
+
+        load_file(path, parse_mode=parse_mode, delimiter=delimiter)
+
+        assert took_arrow_route["value"] == expected, (
+            f"_arrow_route_eligible({suffix!r}, {parse_mode!r}, {delimiter!r}) "
+            f"= {expected} but load_file actually took the arrow route: "
+            f"{took_arrow_route['value']}"
+        )
+
+
 class TestLoadFiles:
     """Tests for the load_files function."""
 

--- a/packages/python/goldenmatch/tests/test_memory_store.py
+++ b/packages/python/goldenmatch/tests/test_memory_store.py
@@ -161,6 +161,43 @@ class TestPairCanonicalization:
         assert (1, 2) in result
 
 
+class TestNullDataset:
+    """``_null_dataset_pred`` (sqlite: ``dataset IS NULL``) must retrieve a
+    correction stored with ``dataset=None`` the same way a non-null dataset
+    is retrieved, and the sqlite upsert path (which reads via
+    ``get_pair_correction`` before DELETE+INSERT) must treat a second
+    null-dataset correction for the same pair as an update, not a duplicate."""
+
+    def test_null_dataset_roundtrip(self, store):
+        store.add_correction(_make_correction(id="c1", id_a=1, id_b=2, dataset=None))
+        result = store.get_pair_correction(1, 2)
+        assert result is not None
+        assert result.decision == "approve"
+        assert result.dataset is None
+
+    def test_null_dataset_upsert_not_duplicate(self, store):
+        store.add_correction(_make_correction(id="c1", id_a=1, id_b=2, dataset=None))
+        store.add_correction(
+            _make_correction(id="c2", id_a=1, id_b=2, dataset=None, decision="reject")
+        )
+        result = store.get_pair_correction(1, 2)
+        assert result.decision == "reject"
+        assert store.count_corrections() == 1
+
+    def test_null_dataset_distinct_from_named_dataset(self, store):
+        """A null-dataset correction and a same-pair 'test'-dataset correction
+        are different rows -- the null predicate must not accidentally match
+        the named dataset too."""
+        store.add_correction(_make_correction(id="c1", id_a=1, id_b=2, dataset=None))
+        store.add_correction(
+            _make_correction(id="c2", id_a=1, id_b=2, dataset="test", decision="reject")
+        )
+        null_result = store.get_pair_correction(1, 2)
+        named_result = store.get_pair_correction(1, 2, dataset="test")
+        assert null_result.decision == "approve"
+        assert named_result.decision == "reject"
+
+
 class TestUnsupportedBackend:
     def test_raises_not_implemented(self, tmp_path):
         import pytest

--- a/packages/python/goldenmatch/tests/test_pipeline_fused_fs_match.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_fused_fs_match.py
@@ -294,6 +294,63 @@ def test_fs_fused_parity_ensemble(monkeypatch):
     )
 
 
+def _cluster_partition_from_fused_table(tbl) -> set[frozenset[int]]:
+    """(__row_id__, __cluster_id__) fused-kernel Table -> multi-member partition,
+    same shape as ``_multi_partition`` over the classic ``clusters`` dict."""
+    import collections
+
+    by_cluster: dict[int, list[int]] = collections.defaultdict(list)
+    for rid, cid in zip(
+        tbl.column("__row_id__").to_pylist(), tbl.column("__cluster_id__").to_pylist()
+    ):
+        by_cluster[cid].append(rid)
+    return {frozenset(members) for members in by_cluster.values() if len(members) > 1}
+
+
+@requires_kernel
+def test_fused_fs_assignments_mirrors_inmemory_short_circuit(monkeypatch):
+    """backends.fs_out_of_core._fused_fs_assignments's docstring claims its
+    column gathering + ``GoldenMatchConfig`` shape "mirror the in-memory
+    ``_run_fused_fs_short_circuit`` [now ``_run_fused_fs_match_short_circuit``]
+    exactly (byte-parity by construction)". Drive both from the SAME trained EM
+    over the SAME data and assert the fused-kernel cluster partition each
+    produces is identical."""
+    monkeypatch.delenv("GOLDENMATCH_MATCH_FUSED", raising=False)
+    import goldenmatch.core.probabilistic as probabilistic_mod
+    from goldenmatch.backends.fs_out_of_core import _fused_fs_assignments
+    from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
+    from goldenmatch.core.frame import to_frame as _tf
+    from goldenmatch.core.probabilistic import load_or_train_em
+
+    # Needs a __row_id__ column -- the pipeline adds one (_add_row_ids) before
+    # either short-circuit runs; add it once up front so both sides + the EM
+    # trainer see the identical ids.
+    df = _people_df().with_row_index("__row_id__")
+    cfg = _fs_config()
+    mk = cfg.get_matchkeys()[0]
+
+    blocking_fields = collect_blocking_fields(cfg.blocking, for_em=True)
+    blocks = list(build_blocks(df.lazy(), cfg.blocking))
+    em_result = load_or_train_em(df, mk, blocks=blocks, blocking_fields=blocking_fields)
+
+    # Streaming side: fs_out_of_core._fused_fs_assignments, called directly with
+    # the pre-trained EM (exactly how run_fs_dedupe_sequential feeds it).
+    base = _tf(df).to_arrow()
+    streaming_tbl = _fused_fs_assignments(base, cfg.blocking, mk, em_result, mk.link_threshold)
+    assert streaming_tbl is not None
+    streaming_partition = _cluster_partition_from_fused_table(streaming_tbl)
+
+    # In-memory side: force _run_fused_fs_match_short_circuit (via run_dedupe_df)
+    # to reuse the SAME trained EM instead of retraining its own, so both sides
+    # run the identical fused kernel call over the identical model.
+    monkeypatch.setattr(probabilistic_mod, "load_or_train_em", lambda *a, **k: em_result)
+    inmem = run_dedupe_df(df, _flag(cfg))
+    assert inmem["match_fused_capacity_mode"] is True
+    inmem_partition = _multi_partition(inmem["clusters"])
+
+    assert streaming_partition == inmem_partition
+
+
 @requires_given_names
 def test_fs_fused_covers_name_scorer():
     """A reference-data name scorer (`given_name_aliased_jw`, FS id 5) is now a

--- a/packages/python/goldenmatch/tests/test_prepared_record_store.py
+++ b/packages/python/goldenmatch/tests/test_prepared_record_store.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import polars as pl
+import pyarrow as pa
 from goldenmatch.distributed.record_store import (
     PreparedRecordStore,
+    _is_arrow_table,
     load_prepared_records,
     materialize_prepared_records,
 )
@@ -22,6 +24,21 @@ def _sample_df() -> pl.DataFrame:
         "email": ["a@x.com", "b@x.com", "c@x.com", "d@x.com"],
         "__mk_email_lower__": ["a@x.com", "b@x.com", "c@x.com", "d@x.com"],
     })
+
+
+def test_is_arrow_table_matches_hashing_duck_type_idiom():
+    """``_is_arrow_table``'s docstring claims it mirrors the duck-typing
+    idiom in ``core._hashing`` (``hasattr(obj, "column_names")``) rather
+    than importing pyarrow/polars eagerly to do an isinstance check.
+    Pin both the truth table AND the exact attribute the check hinges on."""
+    table = pa.table({"a": [1, 2]})
+    frame = pl.DataFrame({"a": [1, 2]})
+
+    assert _is_arrow_table(table) is True
+    assert _is_arrow_table(frame) is False
+    # Same idiom core._hashing.record_fingerprints_batch_arrow uses.
+    assert _is_arrow_table(table) == hasattr(table, "column_names")
+    assert _is_arrow_table(frame) == hasattr(frame, "column_names")
 
 
 def test_store_init_creates_tempdir(tmp_path: Path):

--- a/packages/python/goldenmatch/tests/test_probabilistic_parallel.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic_parallel.py
@@ -8,6 +8,8 @@ are deduped by canonical key, the emitted pair set — and therefore the cluster
 must match the sequential (``GOLDENMATCH_FS_WORKERS=1``) path exactly.
 """
 
+import os
+
 import goldenmatch as gm
 import polars as pl
 import pytest
@@ -137,6 +139,29 @@ def test_batched_target_ids_drop_same_side_pairs(monkeypatch, workers, vectorize
         (a in target_ids) != (b in target_ids)
         for a, b, _score in filtered
     )
+
+
+def test_fs_scoring_workers_default_diverges_from_weighted_default(monkeypatch):
+    """``_fs_scoring_workers``'s docstring used to call its default a "mirror"
+    of the weighted path's ``core.scorer._DEFAULT_MAX_WORKERS`` -- that was
+    true when #1566 added this function, but #303 (earlier) had already
+    pinned ``_DEFAULT_MAX_WORKERS`` at a fixed 4 (RSS pathology on a 16-core
+    runner) instead of scaling with ``cpu_count()``. They have not tracked
+    each other since. This pins the current, divergent relationship rather
+    than asserting a false equality."""
+    from goldenmatch.core.probabilistic import _fs_scoring_workers
+    from goldenmatch.core.scorer import _DEFAULT_MAX_WORKERS
+
+    monkeypatch.delenv("GOLDENMATCH_FS_WORKERS", raising=False)
+    fs_default = _fs_scoring_workers()
+
+    assert _DEFAULT_MAX_WORKERS == 4  # pinned by #303, not cpu-scaled
+    assert fs_default == min(16, os.cpu_count() or 1)
+    if (os.cpu_count() or 1) > 4:
+        assert fs_default != _DEFAULT_MAX_WORKERS, (
+            "defaults converged again -- if intentional, update the docstring "
+            "and this test together"
+        )
 
 
 if __name__ == "__main__":

--- a/packages/python/goldenmatch/tests/test_quality_exclusions.py
+++ b/packages/python/goldenmatch/tests/test_quality_exclusions.py
@@ -62,6 +62,37 @@ def test_column_profile_is_immutable():
         p.cardinality_ratio = 0.99  # type: ignore[misc]
 
 
+def test_build_column_profile_seam_matches_polars_decisions():
+    """``_build_column_profile_seam``'s docstring claim: decisions are
+    byte-identical to the polars ``_build_column_profile`` path -- NOT
+    necessarily an identical ``ColumnProfile`` struct (``profile.dtype`` is
+    cosmetic outside the temporal check, per the seam's own docstring).
+    Exercise a text/foreign-id/timestamp/hash mix through
+    ``detect_autoconfig_exclusions`` on both a ``pl.DataFrame`` (polars
+    lane) and its ``pa.Table`` twin (arrow lane, routes through the seam),
+    including a datetime column so the ONE dtype-reading detector (the
+    temporal check) actually fires."""
+    import datetime
+
+    df = pl.DataFrame({
+        "first_name": [f"name_{i}" for i in range(60)],
+        "external_id": [f"ext_{i:08d}" for i in range(60)],
+        "created_at": [
+            datetime.datetime(2026, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(60)
+        ],
+        "record_hash": [f"{i:032x}" for i in range(60)],
+    })
+
+    pl_result = detect_autoconfig_exclusions(df)
+    arrow_result = detect_autoconfig_exclusions(df.to_arrow())
+
+    pl_by_col = {e.column: (e.detector, e.reason) for e in pl_result}
+    arrow_by_col = {e.column: (e.detector, e.reason) for e in arrow_result}
+    assert arrow_by_col == pl_by_col
+    assert "created_at" in pl_by_col  # sanity: the temporal path actually fired
+
+
 # ---------------------------------------------------------------------------
 # Detector 1: audit_column
 # ---------------------------------------------------------------------------

--- a/packages/python/goldenmatch/tests/test_record_embedding_scorer.py
+++ b/packages/python/goldenmatch/tests/test_record_embedding_scorer.py
@@ -110,6 +110,51 @@ class TestRecordEmbeddingScorer:
             )
             assert matrix.shape == (2, 2)
 
+    def test_record_concat_values_matches_score_matrix_concat(self):
+        """core/probabilistic._record_concat_values claims a byte-for-byte
+        copy of the concat `_record_embedding_score_matrix` builds. Capture
+        what the shipped matrix-path scorer actually concatenates (rather
+        than re-deriving the algorithm) and diff it against the FS-native
+        helper's output for the same rows, including nulls and
+        column_weights repeats."""
+        from goldenmatch.config.schemas import MatchkeyField
+        from goldenmatch.core.probabilistic import _record_concat_values
+        from goldenmatch.core.scorer import _record_embedding_score_matrix
+
+        df = pl.DataFrame({
+            "__row_id__": [0, 1, 2, 3],
+            "title": ["Sony Turntable", None, "Samsung TV", "Widget"],
+            "manufacturer": ["Sony", "Acme", None, "Acme"],
+        })
+        cols = ["title", "manufacturer"]
+
+        for weights in (None, {"title": 2.0, "manufacturer": 0.5}):
+            captured: dict = {}
+
+            class _CaptureEmbedder:
+                def embed_column(self, values, cache_key):
+                    captured["values"] = list(values)
+                    return np.zeros((len(values), 4))
+
+                def cosine_similarity_matrix(self, embeddings):
+                    return np.eye(len(embeddings))
+
+            with patch(
+                "goldenmatch.core.embedder.get_embedder",
+                return_value=_CaptureEmbedder(),
+            ):
+                _record_embedding_score_matrix(
+                    df, cols, "fake-model", column_weights=weights,
+                )
+
+            f = MatchkeyField(
+                scorer="record_embedding", columns=cols, weight=1.0,
+                column_weights=weights,
+            )
+            fs_native = _record_concat_values(df, f, df.height)
+
+            assert fs_native == captured["values"], weights
+
     def test_record_embedding_in_find_fuzzy(self):
         from goldenmatch.core.scorer import find_fuzzy_matches
 
@@ -164,3 +209,69 @@ class TestRecordEmbeddingScorer:
             results = find_fuzzy_matches(df, mk)
             pair_ids = {(r[0], r[1]) for r in results}
             assert (0, 1) in pair_ids
+
+
+class TestRecordConcatValueMirrorsScoreMatrix:
+    """``probabilistic._record_concat_value``'s docstring claims it is
+    "Byte-identical to the concat in ``_record_embedding_score_matrix``" (the
+    EM E-step and the scoring path must embed the SAME text). Captures the
+    per-row strings ``_record_embedding_score_matrix`` actually hands the
+    embedder and compares them against ``_record_concat_value`` called on the
+    same rows."""
+
+    def _captured_concat_values(self, df: pl.DataFrame, columns, column_weights=None):
+        from goldenmatch.core.scorer import _record_embedding_score_matrix
+
+        captured: dict = {}
+
+        class CapturingEmbedder:
+            def embed_column(self, values, cache_key):
+                captured["values"] = list(values)
+                return np.zeros((len(values), 4))
+
+            def cosine_similarity_matrix(self, embeddings):
+                return np.eye(embeddings.shape[0])
+
+        with patch(
+            "goldenmatch.core.embedder.get_embedder",
+            return_value=CapturingEmbedder(),
+        ):
+            _record_embedding_score_matrix(
+                df, columns, "fake-model", column_weights=column_weights
+            )
+        return captured["values"]
+
+    def test_matches_without_column_weights(self):
+        from goldenmatch.core.probabilistic import _record_concat_value
+
+        rows = [
+            {"__row_id__": 0, "title": "Sony Turntable", "brand": "Sony"},
+            {"__row_id__": 1, "title": None, "brand": "Samsung"},
+            {"__row_id__": 2, "title": "Same", "brand": "Same"},
+        ]
+        df = pl.DataFrame(rows)
+        columns = ["title", "brand"]
+
+        expected = self._captured_concat_values(df, columns)
+        actual = [_record_concat_value(row, columns, None) for row in rows]
+        assert actual == expected
+
+    def test_matches_with_column_weights(self):
+        """Weighted repeats (``round(w)`` for ``w > 1.0``) and the ``w <= 0``
+        skip-the-field guard must agree between the two implementations."""
+        from goldenmatch.core.probabilistic import _record_concat_value
+
+        rows = [
+            {"__row_id__": 0, "title": "Sony Turntable", "brand": "Sony", "sku": "X1"},
+            {"__row_id__": 1, "title": None, "brand": "Samsung", "sku": "X2"},
+            {"__row_id__": 2, "title": "Same", "brand": "Same", "sku": "X3"},
+        ]
+        df = pl.DataFrame(rows)
+        columns = ["title", "brand", "sku"]
+        column_weights = {"title": 2.6, "brand": 1.0, "sku": 0.0}
+
+        expected = self._captured_concat_values(df, columns, column_weights)
+        actual = [
+            _record_concat_value(row, columns, column_weights) for row in rows
+        ]
+        assert actual == expected

--- a/packages/python/goldenmatch/tests/test_scorer.py
+++ b/packages/python/goldenmatch/tests/test_scorer.py
@@ -617,6 +617,29 @@ class TestJaccardScoreMatrix:
         assert mat[0, 1] == pytest.approx(1.0)
 
 
+class TestPadToEqualLengthParity:
+    """core/scorer._pad_to_equal_length (#784) claims the scalar single-pair
+    dice/jaccard helpers agree with the batch matrix path on the SAME inputs
+    when the two hex bloom filters differ in byte length -- the exact case
+    that used to raise an opaque numpy broadcast ValueError. Neither
+    TestDiceScoreMatrix/TestJaccardScoreMatrix nor TestDiceJaccardScoreField
+    above exercises unequal-length filters."""
+
+    def test_dice_scalar_matches_matrix_on_unequal_length(self):
+        a = bytes([0xFF, 0xFF]).hex()  # 2 bytes
+        b = bytes([0x0F]).hex()        # 1 byte
+        scalar = score_field(a, b, "dice")
+        matrix = _dice_score_matrix([a, b])
+        assert scalar == pytest.approx(float(matrix[0, 1]))
+
+    def test_jaccard_scalar_matches_matrix_on_unequal_length(self):
+        a = bytes([0xFF, 0xFF]).hex()
+        b = bytes([0x0F]).hex()
+        scalar = score_field(a, b, "jaccard")
+        matrix = _jaccard_score_matrix([a, b])
+        assert scalar == pytest.approx(float(matrix[0, 1]))
+
+
 class TestBuildNullMask:
     def test_no_nulls(self):
         mask = _build_null_mask(["a", "b"])

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -1319,3 +1319,41 @@ def test_measure_mean_token_set_size_mirrors_measure_mean_length_edge_cases():
     mean_tokens = _measure_mean_token_set_size(df_present, "skills", [])
     assert mean_len == pytest.approx((5 + 3) / 2)  # len("a|b|c")=5, len("d|e")=3
     assert mean_tokens == pytest.approx((3 + 2) / 2)  # {a,b,c}=3, {d,e}=2
+
+
+# ── _measure_mean_length mirrors tf_tables.value_frequencies ───────────────
+
+
+def test_measure_mean_length_mirrors_value_frequencies_filtering():
+    """``_measure_mean_length``'s docstring claims it "Mirrors the per-value
+    transform loop in ``goldenmatch.core.tf_tables.value_frequencies``" --
+    same ``apply_transforms`` semantics, same null/empty-string filtering,
+    just collecting lengths instead of frequencies. Cross-check both
+    functions against the SAME frames so a filtering divergence shows up as
+    a length/frequency-count mismatch rather than passing in isolation.
+    """
+    from goldenmatch.config.splink_upgrade import _measure_mean_length
+    from goldenmatch.core.tf_tables import value_frequencies
+
+    # (a) column absent from the frame -> None / {}.
+    df_missing = pl.DataFrame({"other": ["a", "b"]})
+    assert _measure_mean_length(df_missing, "name", []) is None
+    assert value_frequencies(df_missing, "name", []) == {}
+
+    # (b) every value null/empty -> None / {}.
+    df_empty = pl.DataFrame({"name": [None, "", ""]})
+    assert _measure_mean_length(df_empty, "name", []) is None
+    assert value_frequencies(df_empty, "name", []) == {}
+
+    # (c) a transform ("digits_only") turns a non-empty value into "" --
+    # both functions must skip that row identically POST-transform, not
+    # just pre-transform.
+    df_mixed = pl.DataFrame({"name": ["abc", "123", None, "45"]})
+    mean_len = _measure_mean_length(df_mixed, "name", ["digits_only"])
+    freqs = value_frequencies(df_mixed, "name", ["digits_only"])
+    # "abc" -> "" (dropped by both), "123" -> "123" (len 3), None dropped,
+    # "45" -> "45" (len 2).
+    assert mean_len == pytest.approx((3 + 2) / 2)
+    assert set(freqs) == {"123", "45"}
+    assert freqs["123"] == pytest.approx(0.5)
+    assert freqs["45"] == pytest.approx(0.5)

--- a/packages/python/goldenmatch/tests/test_strsim_parity.py
+++ b/packages/python/goldenmatch/tests/test_strsim_parity.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import random
 import struct
 
+import numpy as np
 import pytest
 from goldenmatch.core import strsim
 
@@ -15,12 +16,14 @@ rapidfuzz = pytest.importorskip("rapidfuzz")
 from rapidfuzz.distance import (  # noqa: E402
     DamerauLevenshtein,
     Indel,
+    Jaro,
     JaroWinkler,
     Levenshtein,
 )
 from rapidfuzz.fuzz import partial_ratio as rf_partial_ratio  # noqa: E402
 from rapidfuzz.fuzz import ratio as rf_ratio  # noqa: E402
 from rapidfuzz.fuzz import token_sort_ratio as rf_token_sort_ratio  # noqa: E402
+from rapidfuzz.process import cdist as rf_cdist  # noqa: E402
 
 # Realistic column-name corpus for partial_ratio (the only consumer,
 # core/schema_match.py, sees column names — not adversarial strings).
@@ -119,6 +122,43 @@ def test_partial_ratio_exact_on_containment_and_faithful_elsewhere():
     # empty-string edges (rapidfuzz: "","" -> 100; one empty -> 0)
     assert strsim.partial_ratio("", "") == rf_partial_ratio("", "")
     assert strsim.partial_ratio("x", "") == rf_partial_ratio("x", "")
+
+
+def test_jaro_similarity_raw_byte_identical():
+    """``jaro_similarity``'s own docstring claim: bit-for-bit identical to
+    rapidfuzz ``Jaro.similarity``. Exercised transitively via
+    ``jaro_winkler_similarity`` above, but never directly against the raw
+    (non-Winkler) entry point -- close that gap directly."""
+    for a, b in _pairs():
+        assert _bits(strsim.jaro_similarity(a, b)) == _bits(
+            Jaro.similarity(a, b)
+        ), (a, b)
+
+
+def test_pure_field_matrix_byte_identical_to_cdist():
+    """``pure_field_matrix``'s own docstring claim: BYTE-IDENTICAL to
+    ``cdist(values, values, scorer=<matching rapidfuzz scorer>, dtype=<dtype>)``,
+    "proven in tests/test_strsim_parity.py" -- but grep confirms
+    ``pure_field_matrix`` was never actually referenced anywhere in this test
+    suite. Exercise all three ``_MATRIX_SCORERS`` entries at both dtypes the
+    real call sites use (float32 for find_fuzzy_matches, float64 for the
+    bucket vec-lane's bit-exact threshold decisions)."""
+    rng = random.Random(0xFEED5EED)
+    values = [a for a, _ in _EDGE] + [b for _, b in _EDGE] + [
+        _rs(rng) for _ in range(150)
+    ]
+    cases = [
+        ("jaro_winkler", JaroWinkler.similarity),
+        ("levenshtein", Levenshtein.normalized_similarity),
+        ("token_sort", rf_token_sort_ratio),
+    ]
+    for scorer_name, rf_scorer in cases:
+        for dtype in ("float32", "float64"):
+            got = strsim.pure_field_matrix(values, scorer_name, dtype)
+            want = rf_cdist(values, values, scorer=rf_scorer, dtype=dtype)
+            assert np.array_equal(np.asarray(got), np.asarray(want)), (
+                scorer_name, dtype,
+            )
 
 
 def test_token_sort_ratio_byte_identical():


### PR DESCRIPTION
Scoping Phase C's remaining 166-claim population found the low-confidence bucket shared the same "mirrors"/"byte-identical to" vocabulary already proven triageable. Split into 8 batches, each following a fixed order: is the resolved target a false match on an ordinary word/builtin, a cross-language reference, direct delegation, or a genuine same-repo claim -- write a test for the last case if none exists.

**111 claims triaged:** 32 false word matches, 4 cross-language, 18 pattern claims (delegation), 34 already covered, 20 newly confirmed true with a new test, and **3 real divergences**.

**Three real bugs found by writing tests, not fixed here** (each needs a design decision, not a docstring correction):

- `chunked.py:_block_key_column` silently ignores per-field transforms -- the large-dataset streaming path can compute different block keys (and therefore different candidate pairs) than the main path for configs using `BlockingKeyConfig.field_transforms`.
- `distributed/clustering.py:_attach_quality_metadata` computes cluster confidence differently than the in-memory `build_clusters` path -- the identical cluster topology is classified "weak" in-memory and "strong" distributed (confirmed by calling both production functions directly).
- `core/probabilistic.py:_fs_scoring_workers`'s worker-count default has drifted from `_DEFAULT_MAX_WORKERS`, the function it claims to mirror -- git history shows the latter was deliberately capped after an RSS-OOM incident that `_fs_scoring_workers`, added a month later, never inherited. Docstring corrected to state the real relationship; the worker-count fix itself is left for whoever owns that history.

Full writeup: `docs/superpowers/specs/2026-09-04-stage4f-low-confidence-triage.md`

Verified: all 21 touched test files run together sequentially (no xdist) -- 412 passed, 4 skipped (ray/pyspark-gated, consistent with this repo's CI-only policy). Full package ruff lint clean.
