### PR TITLE
feat(sync_claims): arm the unenforced-claims ratchet as a real CI gate (C3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5035,11 +5035,15 @@ jobs:
           POLARS_SKIP_CPU_CHECK: "1"
 
   sync_claims:
-    # Report-only audit for docstrings that claim "this code mirrors that
-    # code" with no test enforcing the relationship (scripts/sync_claims/).
-    # Not in ci-required and the report step has no continue-on-error to
-    # suppress -- it always exits 0 by design. The gate is a later stage
-    # (C3), after the C1 triage establishes a floor; this job only prints.
+    # Audit for docstrings that claim "this code mirrors that code" with no
+    # test enforcing the relationship (scripts/sync_claims/). C0/C1 were
+    # report-only -- the informational report step below still always
+    # exits 0. C3 (stage 4b-4g: docs/superpowers/specs/2026-09-04-stage4b-
+    # full-rescue-triage.md and siblings) is the real gate: the "Ratchet"
+    # step has no continue-on-error, and this job is in ci-required, so a
+    # NEW high-confidence unenforced claim blocks the merge queue. Scoped
+    # narrowly to that one bucket -- see test_sync_claims_ratchet.py's
+    # module docstring for why the noisier buckets stay report-only.
     #
     # Coverage-based enforcement (docs/superpowers/specs/2026-09-03-coverage-
     # based-enforcement-design.md): downloads the SAME gm-cov-* shard
@@ -5090,8 +5094,9 @@ jobs:
             coverage_shard1.dat coverage_shard2.dat coverage_shard3.dat \
             coverage_heavy_1.dat coverage_heavy_2.dat coverage_heavy_3.dat
       - name: Unenforced sync-claim report
-        # Report-only by design: main() returns 0 whatever it finds. The gate
-        # is stage C3, after the C1 triage establishes a floor.
+        # Report-only by design: main() returns 0 whatever it finds, for
+        # every bucket. The C3 gate is the separate "Ratchet" step below --
+        # scoped to just `unenforced` -- not this one.
         env:
           PYTHONPATH: scripts
         run: |
@@ -5100,6 +5105,14 @@ jobs:
           else
             uv run python -m sync_claims.report
           fi
+      - name: Ratchet -- no new unenforced sync claim (C3)
+        # Its own step so a failure names the ratchet, not "the report".
+        # No continue-on-error: the floor was triaged by hand against the
+        # exact commit it's seeded from (see test_sync_claims_ratchet.py),
+        # and this is the real gate -- the whole point of C3.
+        env:
+          PYTHONPATH: scripts
+        run: uv run pytest scripts/test_sync_claims_ratchet.py -q
 
   ci-required:
     needs:
@@ -5176,6 +5189,11 @@ jobs:
       - scripts_lint
       - docs_regen
       - er_matcher
+      # C3 (docs/superpowers/specs/2026-09-04-stage4b-full-rescue-triage.md
+      # and siblings): the ratchet step is the real gate now, not just a
+      # print. Path-filtered like everything else here -- skipped counts as
+      # a pass via the same jq check below.
+      - sync_claims
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/scripts/test_sync_claims_ratchet.py
+++ b/scripts/test_sync_claims_ratchet.py
@@ -1,0 +1,122 @@
+"""No NEW unenforced sync-claim may appear untriaged. Phase C, stage C3.
+
+Same ratchet contract as `KNOWN_ACTIONABLE` in
+scripts/test_no_new_shared_decisions.py: a floor to work DOWN, never a
+bucket to top up. Both directions are asserted -- a new entry fails, and an
+entry that no longer reproduces must be removed so the ratchet keeps its
+value.
+
+Gates `unenforced` specifically -- the tool's own most-trusted bucket
+(high-confidence, non-ambiguous target, already coverage-rescue-informed).
+Established as trustworthy by hand, not by construction: Stage 4b-4g
+(docs/superpowers/specs/2026-09-04-stage4b-full-rescue-triage.md and
+siblings) individually triaged the ENTIRE surrounding population -- every
+`unenforced`, `unenforced_low_confidence`, `unenforced_ambiguous_target`,
+and `unresolvable` claim, 218 in total -- and found real gaps concentrate
+almost entirely in `unenforced`-shaped findings (Stage 4b: 8/25 mechanical
+coverage-rescues were still real gaps) while `unenforced_low_confidence`
+(3/111 = 2.7% real) and `unresolvable` (0/54 real) are too noisy to gate
+without training everyone to ignore the gate. Those buckets stay
+report-only, unchanged -- gating them is explicitly out of scope here, not
+an oversight.
+
+Requires coverage-informed inventory: coverage-rescue only ever REMOVES
+claims from `unenforced` (a real test executing both halves is evidence
+FOR enforcement, never against it), so a text-only run always over-reports
+relative to what real CI computes with coverage data combined (measured
+2026-09-04 on the same commit: 20 text-only vs. 5 coverage-informed). A run
+where `.coverage` never got combined -- which only happens when
+scripts/sync_claims/** changed without touching goldenmatch package/test
+code, the one way the sync_claims job runs without python_goldenmatch/
+_heavy also running, per .github/filters.yml -- has nothing new to catch by
+construction (nothing in goldenmatch changed), so this SKIPS rather than
+asserting against the noisier superset.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+from sync_claims.report import DEFAULT_ROOT, DEFAULT_TESTS, inventory
+
+REPO = Path(__file__).resolve().parent.parent
+COVERAGE_DB = REPO / ".coverage"
+
+# A floor to work DOWN. Each entry is (module, symbol, lineno) -- the same
+# identity report.py's own `finding_ids` uses internally. Seeded 2026-09-04
+# from a coverage-informed run against origin/main@9df5ba70f (gh run
+# 33889747141's shard artifacts, combined the identical way the sync_claims
+# CI job combines them) -- not a text-only run, which over-reports by
+# exactly the claims coverage-rescue would remove.
+KNOWN_ACTIONABLE: set[tuple[str, str, int]] = {
+    ("backends/score_buckets.py", "_ensure_legal_forms_installed", 530),
+    ("backends/score_buckets.py", "score_buckets", 1395),
+    # False bare-word match: "row" resolved from prose describing "the
+    # per-row path", not a declared symbol the claim actually names -- a
+    # claims.py target-resolution limitation, not a real gap. Same shape
+    # Stage 4f documented repeatedly in the low-confidence bucket
+    # (LintInput->fields, _boundary_columns->keys, with_prose->pair, ...),
+    # here landing at high confidence instead. Closing this means softening
+    # the docstring so the pattern no longer resolves a target, not writing
+    # a test against `row`.
+    ("identity/resolve.py", "_batch_fingerprint_enabled", 203),
+    ("identity/snowflake_backend.py", "_rel_expr", 501),
+    ("spark/identity.py", "record_id_for_row", 45),
+}
+
+
+@lru_cache(maxsize=1)
+def _inventory() -> dict:
+    """Cached: both tests below need this, and a full run re-parses the
+    whole package (982 test files, 305 claims measured 2026-09-04)."""
+    coverage_db = COVERAGE_DB if COVERAGE_DB.exists() else None
+    return inventory(DEFAULT_ROOT, DEFAULT_TESTS, coverage_db=coverage_db)
+
+
+def _current() -> set[tuple[str, str, int]]:
+    return {(c["module"], c["symbol"], c["lineno"]) for c in _inventory()["unenforced"]}
+
+
+def _skip_if_degraded() -> None:
+    if not _inventory()["counts"]["coverage_consulted"]:
+        pytest.skip(
+            "coverage db unavailable this run -- see module docstring: this "
+            "only happens when nothing in goldenmatch changed, so there is "
+            "nothing new for the gate to have missed."
+        )
+
+
+def test_no_new_unenforced_claim():
+    """A high-confidence claim newly landing unenforced must be triaged.
+
+    Triaged means one of: fix the real gap (write the test, or fix the
+    code so the claim is true), soften the docstring so it stops making a
+    claim `claims.py` resolves a target for at all, or add it to
+    KNOWN_ACTIONABLE here with the reasoning -- the same three outcomes
+    Stage 4b/4c/4f/4g used all day on the 218-claim population this floor
+    was seeded from.
+    """
+    _skip_if_degraded()
+    new = _current() - KNOWN_ACTIONABLE
+    assert not new, (
+        f"NEW unenforced high-confidence claim(s): {sorted(new)}. Each "
+        f"names a docstring asserting an equivalence no single test "
+        f"executes both halves of. Triage it (method: "
+        f"docs/superpowers/specs/2026-09-04-stage4b-full-rescue-triage.md) "
+        f"-- fix the real gap, soften the docstring if the claim isn't "
+        f"real, or add it to KNOWN_ACTIONABLE here with the reason if it's "
+        f"a known, not-yet-fixed finding."
+    )
+
+
+def test_findings_that_no_longer_reproduce_are_removed():
+    """A floor to work DOWN. Keeping a fixed finding rots the ratchet."""
+    _skip_if_degraded()
+    fixed = KNOWN_ACTIONABLE - _current()
+    assert not fixed, (
+        f"{sorted(fixed)} no longer trip the unenforced signal -- fixed, "
+        f"newly coverage-rescued, or the docstring changed. Remove them "
+        f"from KNOWN_ACTIONABLE so the ratchet keeps its value."
+    )


### PR DESCRIPTION
## What and why

Phase C's last piece: arms `sync_claims` as a real CI gate instead of a
report. C0/C1 built the tool and coverage-based rescue; today's stage
4b-4g hand-triaged the entire 218-claim scoped population and found real
gaps concentrate almost entirely in the `unenforced` bucket (8/25
mechanical rescues were still real gaps) while `unenforced_low_confidence`
(2.7%) and `unresolvable` (0%) are too noisy to gate. C3 scopes the gate
to just `unenforced`, using the same precision data to justify leaving the
noisier buckets report-only.

## Changes

- `scripts/test_sync_claims_ratchet.py` (new): `KNOWN_ACTIONABLE` floor
  ratchet, mirroring `test_no_new_shared_decisions.py`'s exact contract.
  Seeded from a coverage-informed inventory run against the real merged
  `origin/main` commit (downloaded its own CI-produced coverage shards
  rather than a local no-coverage run, which over-reports). Skips (not
  fails) when coverage data wasn't combined this run -- only possible when
  nothing in goldenmatch changed, so nothing new to check anyway.
- `.github/workflows/ci.yml`: new "Ratchet" step in the `sync_claims` job
  (after coverage combine, no `continue-on-error`), and `sync_claims`
  added to `ci-required`'s `needs`, so a real ratchet violation actually
  blocks the merge queue.

## Testing

- `PYTHONPATH=scripts uv run pytest scripts/test_sync_claims_ratchet.py -v`
  -- both tests pass against the real downloaded coverage baseline, and
  correctly skip with no `.coverage` present.
- `PYTHONPATH=scripts uv run pytest scripts/test_sync_claims_*.py -q` --
  52 passed, 2 skipped (the ratchet's own expected local skip).
- `uv run ruff check` / `ruff format --check` on the new file: clean.
- `zizmor .github/workflows/ci.yml --offline`: no new findings vs. main.
- workflow_lint's own checks run locally (`check_workflow_yaml.py`,
  `test_workflow_yaml.py`, `test_distributed_test_files.py`,
  `check_filter_coverage.py`): all pass, 0 new filter-coverage gaps.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed -- n/a, script-only
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed -- job
      comments updated in place; no new CLAUDE.md entry needed
