### PR TITLE
fix(ci): fix the two real failures behind #2835's main-health tracker

### DIFF
--- a/.github/workflows/harvest-test-durations.yml
+++ b/.github/workflows/harvest-test-durations.yml
@@ -288,4 +288,10 @@ jobs:
         with:
           name: test-durations-merged
           path: packages/python/goldenmatch/.test_durations
+          # `.test_durations` starts with a dot; without this flag,
+          # upload-artifact v4 silently treats it as hidden and
+          # `if-no-files-found: error` below then fails the job right after
+          # a successful commit + push (run 33478139969: same root cause
+          # scale-audit.yml already carries a fix + comment for).
+          include-hidden-files: true
           if-no-files-found: error

--- a/.github/workflows/spark-cluster.yml
+++ b/.github/workflows/spark-cluster.yml
@@ -386,7 +386,7 @@ jobs:
           # No GOLDENMATCH_SPARK_PYENV: the executors stay bare.
         run: |
           set -euo pipefail
-          # Deselected BY NAME, with the reason: these four compare the JVM path
+          # Deselected BY NAME, with the reason: these seven compare the JVM path
           # against the PYTHON path, and both arms have to run distributed.
           # These workers have no goldenmatch (and ship a Python too old for it),
           # so that comparison cannot exist here. Deselecting says so; letting
@@ -407,7 +407,9 @@ jobs:
             --deselect 'tests/test_spark_jvm_native_parity.py::test_end_to_end_dedupe_runs_with_every_kernel_in_the_jar' \
             --deselect 'tests/test_spark_jvm_native_parity.py::test_block_key_normalization_routes_to_the_jar_when_asked' \
             --deselect 'tests/test_spark_jvm_native_parity.py::test_derive_record_ids_matches_the_python_path' \
-            --deselect 'tests/test_spark_jvm_native_parity.py::test_rowwise_config_scoring_matches_the_python_path_exactly'             --deselect 'tests/test_spark_jvm_native_parity.py::test_mint_entity_ids_pure_sql_matches_the_udf_path' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_rowwise_config_scoring_matches_the_python_path_exactly' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_mint_entity_ids_pure_sql_matches_the_udf_path' \
+            --deselect 'tests/test_spark_jvm_native_parity.py::test_block_key_column_matches_arrow_derive' \
             | tee pytest.out && rc=0 || rc=$?
           # pytest IGNORES a --deselect that matches nothing, so a wrong node id
           # means the tests simply RUN. That is how run 6 failed: the ids were
@@ -427,7 +429,7 @@ jobs:
           # exactly how test_rowwise_config_scoring... and
           # test_mint_entity_ids... first reddened this lane.
           #
-          # 8, and it is NOT the number of --deselect flags. pytest counts TEST
+          # 9, and it is NOT the number of --deselect flags. pytest counts TEST
           # ITEMS, so a parametrized test contributes one per case:
           #
           #   test_jvm_scoring_matches_the_python_path_exactly   3  (batch_size)
@@ -436,13 +438,23 @@ jobs:
           #   test_derive_record_ids_matches_the_python_path     1
           #   test_rowwise_config_scoring_matches_the_python...  1
           #   test_mint_entity_ids_pure_sql_matches_the_udf...   1
+          #   test_block_key_column_matches_arrow_derive         1
           #                                                     --
-          #                                                      8
+          #                                                      9
           #
-          # Six flags, eight items. Counting the flags is how this guard shipped
-          # saying 6 and would have failed the lane on its own error message.
-          if ! grep -qE ' 8 deselected' pytest.out; then
-            echo "::error::expected 8 deselected (six --deselect flags, but the batch_size test contributes three items). Either a --deselect node id no longer matches (pytest IGNORES one that matches nothing) or a two-path test was added without one. pytest's rootdir is packages/python/goldenmatch, so ids start at 'tests/', NOT 'packages/python/goldenmatch/tests/'. Either way, a test needing a Python worker just ran on a cluster that has none, and its failure reads as a defect in the path under test."
+          # #2835's main-health tracker caught this the hard way: a 7th
+          # two-path test (test_block_key_column_matches_arrow_derive,
+          # comparing _block_key_column's default no-transform_udf fallback --
+          # a Python arrow_udf -- against arrow_derive.block_key) landed
+          # without a --deselect, so it ran on a cluster with no goldenmatch
+          # and a worker Python too old for it, hit PYTHON_VERSION_MISMATCH
+          # first, and read as a defect in the block-key path rather than
+          # what it was: an eighth reproduction of the exact gap this guard's
+          # own comment already named. Seven flags, nine items. Counting the
+          # flags is how this guard shipped saying 6 and would have failed
+          # the lane on its own error message.
+          if ! grep -qE ' 9 deselected' pytest.out; then
+            echo "::error::expected 9 deselected (seven --deselect flags, but the batch_size test contributes three items). Either a --deselect node id no longer matches (pytest IGNORES one that matches nothing) or a two-path test was added without one. pytest's rootdir is packages/python/goldenmatch, so ids start at 'tests/', NOT 'packages/python/goldenmatch/tests/'. Either way, a test needing a Python worker just ran on a cluster that has none, and its failure reads as a defect in the path under test."
             exit 1
           fi
           exit "$rc"


### PR DESCRIPTION
## What and why

Fixes the two real, fixable failures behind #2835's automated main-health
tracker. The third lane it names (Dependabot Updates, npm_and_yarn in
packages/python/infermap/benchmark/runners/ts for fast-uri) didn't
reproduce locally -- `npm install --package-lock-only --dry-run` against
the current manifest/lockfile resolves cleanly -- so it's left as-is here;
trying a manual re-run separately in case it was transient.

## Changes

- `.github/workflows/harvest-test-durations.yml`: the merge job's final
  step uploads `packages/python/goldenmatch/.test_durations` as an
  artifact right after successfully committing and pushing it to a branch.
  `actions/upload-artifact@v4` excludes hidden files by default, and that
  path is itself a dotfile -- so the upload always failed immediately
  after a real, successful harvest (both runs this workflow has ever had).
  `scale-audit.yml` already carries a fix + comment for the identical bug;
  matched that pattern with `include-hidden-files: true`.
- `.github/workflows/spark-cluster.yml`: a new two-path test
  (`test_block_key_column_matches_arrow_derive`, added by an earlier
  phase-C session to pin a sync-claims finding) needs a Python worker with
  goldenmatch installed on the executor -- this cluster's workers
  deliberately have neither. The job already guards exactly this shape
  (named `--deselect` flags plus a self-checking deselected-item-count
  assertion, with a comment describing this exact failure mode) but the
  new test was never added, so it ran for real and hit
  `PYTHON_VERSION_MISMATCH` first. Added it as a 7th `--deselect`, updated
  the item-count math and comment, and fixed a stale "these four" count
  and a line-wrapping glitch found adjacent to it.

## Testing

- `uv run python scripts/check_workflow_yaml.py` (same check
  `workflow_lint` runs): both files parse clean, no duplicate keys.
- `zizmor .github/workflows/harvest-test-durations.yml
  .github/workflows/spark-cluster.yml --offline`: zero new findings (only
  a pre-existing, unrelated `setup-java@v4` pin warning untouched by this
  diff).
- The `spark-cluster` fix is CI-verified-only by construction (needs the
  real GCE-backed docker cluster, which this repo's own standing rule is
  never to spin up locally) -- the item-count arithmetic was checked by
  hand against the guard's own documented accounting.

## Checklist

- [x] Tests added/updated and passing locally for the changed package --
      n/a, CI-workflow-only change; see Testing above
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed -- n/a, CI-only
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed -- fixed
      in place inside each workflow's own comments; no CLAUDE.md entry
      needed
