### PR TITLE
docs(goldenmatch): correct the [native] extra's stale comment

### DIFF
--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -239,10 +239,15 @@ quality = [
 transform = [
     "goldenflow>=1.0.0",
 ]
-# Optional native acceleration runtime (compiled Rust/PyO3 abi3 wheel, shipped
-# separately, polars / polars-runtime style). goldenmatch.core._native_loader
-# discovers it automatically; absent it, the pure-Python paths run unchanged.
-# Kept out of `all` (compiled, platform-specific — like `ray`/`duckdb`).
+# Back-compat alias only: `goldenmatch-native` (compiled Rust/PyO3 abi3 wheel,
+# shipped separately, polars / polars-runtime style) is ALSO a marker-guarded
+# entry in `dependencies` above (#667, 2026-06-01) -- `pip install goldenmatch`
+# already auto-installs it on the platforms with a prebuilt wheel; this extra
+# just keeps `[native]` resolving for anyone still requesting it explicitly.
+# goldenmatch.core._native_loader discovers it automatically; absent (an
+# unlisted platform, or this extra deliberately uninstalled), the pure-Python
+# paths run unchanged. Kept out of `all` (compiled, platform-specific -- like
+# `ray`/`duckdb`).
 native = [
     "goldenmatch-native>=0.1.0",
 ]


### PR DESCRIPTION
## What and why

Corrects a stale comment found while investigating whether goldenmatch's
Rust/Python fallback strategy should be sunset (it already isn't
optional-by-default -- see below). No dependency or behavior change.

## Changes

- `packages/python/goldenmatch/pyproject.toml`: the `[native]` extra's
  comment described `goldenmatch-native` as purely optional. #667
  (2026-06-01) made it a marker-guarded DEFAULT dependency instead (see
  the main `dependencies` list's own, correct comment) -- `pip install
  goldenmatch` already auto-installs it on the platforms with a prebuilt
  wheel. The `[native]` extra is now just a back-compat alias so
  `pip install goldenmatch[native]` keeps resolving explicitly; its
  comment never caught up to say so.

## Testing

- `python -c "import tomllib; tomllib.load(...)"`: TOML still parses.
- Diff is comment-only; no dependency, version, or install-behavior
  change.

## Checklist

- [x] Tests added/updated and passing locally for the changed package --
      n/a, comment-only
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed -- n/a, no
      behavior change
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed -- fixed
      in place; no CLAUDE.md entry needed
