### PR TITLE
chore(benchmarks): refresh native benchmark results

### DIFF
--- a/docs/benchmarks/latest-results.json
+++ b/docs/benchmarks/latest-results.json
@@ -2,13 +2,13 @@
   "results": [
     {
       "name": "DBLP-ACM",
-      "f1": 0.964,
-      "precision": 0.9721,
-      "recall": 0.9559,
-      "tp": 2126,
-      "fp": 61,
-      "fn": 98,
-      "elapsed_seconds": 9.7,
+      "f1": 0.9768,
+      "precision": 0.9894,
+      "recall": 0.9645,
+      "tp": 2145,
+      "fp": 23,
+      "fn": 79,
+      "elapsed_seconds": 10.3,
       "health": "n/a",
       "stop_reason": "n/a"
     },
@@ -20,7 +20,7 @@
       "tp": 6429,
       "fp": 5,
       "fn": 109,
-      "elapsed_seconds": 6.31,
+      "elapsed_seconds": 9.08,
       "health": "n/a",
       "stop_reason": "n/a"
     },
@@ -32,7 +32,7 @@
       "tp": 2499,
       "fp": 37,
       "fn": 1,
-      "elapsed_seconds": 14.61,
+      "elapsed_seconds": 19.64,
       "health": "n/a",
       "stop_reason": "n/a",
       "planning_effort": "normal"
@@ -40,8 +40,8 @@
     {
       "name": "DQbench",
       "composite": 83.16,
-      "elapsed_seconds": 299.4,
-      "raw_output_tail": "\u2502 T3   \u2502 88.8%     \u2502 100.0% \u2502 94.1% \u2502 171.75s \u2502 105.0 MB \u2502\n\u2502 T4   \u2502 85.1%     \u2502 100.0% \u2502 92.0% \u2502 29.51s  \u2502 10.9 MB  \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\n\nDQBench ER Score: 83.16 / 100\n\n            Confusion Matrix (pairs) & B\u00b3 (clusters)            \n\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n\u2502 Tier \u2502   TP \u2502  FP \u2502 FN \u2502       TN \u2502 B\u00b3 Prec \u2502 B\u00b3 Rec \u2502 B\u00b3 F1 \u2502\n\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n\u2502 T1   \u2502  100 \u2502  24 \u2502  0 \u2502   499376 \u2502   98.1% \u2502 100.0% \u2502 99.1% \u2502\n\u2502 T2   \u2502  750 \u2502 668 \u2502  0 \u2502 12496082 \u2502   90.2% \u2502 100.0% \u2502 94.8% \u2502\n\u2502 T3   \u2502 2000 \u2502 252 \u2502  0 \u2502 49992748 \u2502   98.8% \u2502 100.0% \u2502 99.4% \u2502\n\u2502 T4   \u2502   80 \u2502  14 \u2502  0 \u2502   319506 \u2502   98.5% \u2502 100.0% \u2502 99.2% \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\n\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nauto-config committed best-effort RED config (iter=v0, stop_reason=BUDGET_TIME, failing_subprofile=scoring); downstream pipeline will run but output may be low-precision\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nauto-config committed best-effort RED config (iter=v0, stop_reason=BUDGET_ITERATIONS, failing_subprofile=scoring); downstream pipeline will run but output may be low-precision"
+      "elapsed_seconds": 350.5,
+      "raw_output_tail": "\u2502 T3   \u2502 88.8%     \u2502 100.0% \u2502 94.1% \u2502 200.18s \u2502 105.0 MB \u2502\n\u2502 T4   \u2502 85.1%     \u2502 100.0% \u2502 92.0% \u2502 32.80s  \u2502 10.9 MB  \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\n\nDQBench ER Score: 83.16 / 100\n\n            Confusion Matrix (pairs) & B\u00b3 (clusters)            \n\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n\u2502 Tier \u2502   TP \u2502  FP \u2502 FN \u2502       TN \u2502 B\u00b3 Prec \u2502 B\u00b3 Rec \u2502 B\u00b3 F1 \u2502\n\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n\u2502 T1   \u2502  100 \u2502  24 \u2502  0 \u2502   499376 \u2502   98.1% \u2502 100.0% \u2502 99.1% \u2502\n\u2502 T2   \u2502  750 \u2502 668 \u2502  0 \u2502 12496082 \u2502   90.2% \u2502 100.0% \u2502 94.8% \u2502\n\u2502 T3   \u2502 2000 \u2502 252 \u2502  0 \u2502 49992748 \u2502   98.8% \u2502 100.0% \u2502 99.4% \u2502\n\u2502 T4   \u2502   80 \u2502  14 \u2502  0 \u2502   319506 \u2502   98.5% \u2502 100.0% \u2502 99.2% \u2502\n\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\n\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nauto-config committed best-effort RED config (iter=v0, stop_reason=BUDGET_TIME, failing_subprofile=scoring); downstream pipeline will run but output may be low-precision\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'city' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'state' (col_type=geo is a blocking signal, not an identity claim). Column remains a blocking candidate.\nSkipping exact matchkey for 'zip' (col_type=zip is a blocking signal, not an identity claim). Column remains a blocking candidate.\nauto-config committed best-effort RED config (iter=v0, stop_reason=BUDGET_TIME, failing_subprofile=scoring); downstream pipeline will run but output may be low-precision"
     },
     {
       "name": "Abt-Buy (linkage)",
@@ -51,7 +51,7 @@
       "tp": 655,
       "fp": 113,
       "fn": 442,
-      "elapsed_seconds": 6.09,
+      "elapsed_seconds": 8.57,
       "health": "yellow",
       "stop_reason": "policy_satisfied",
       "domain": "product",
@@ -66,7 +66,7 @@
       "tp": 493,
       "fp": 334,
       "fn": 807,
-      "elapsed_seconds": 43.05,
+      "elapsed_seconds": 37.33,
       "health": "yellow",
       "stop_reason": "budget_time",
       "domain": "product",
@@ -75,7 +75,7 @@
     }
   ],
   "metadata": {
-    "date": "2026-09-04",
+    "date": "2026-09-05",
     "with_llm": false,
     "llm_keys_suppressed": false,
     "planning_effort": "normal",

--- a/docs/benchmarks/latest-results.md
+++ b/docs/benchmarks/latest-results.md
@@ -6,16 +6,16 @@
 gate fails any PR whose doc drifts from its JSON, so these numbers are the
 current truth, not a stale copy pasted from a case study.
 
-**Run date:** 2026-09-04 &nbsp;·&nbsp; **path:** pure-Python &nbsp;·&nbsp; **planning_effort:** normal &nbsp;·&nbsp; **LLM features:** off
+**Run date:** 2026-09-05 &nbsp;·&nbsp; **path:** pure-Python &nbsp;·&nbsp; **planning_effort:** normal &nbsp;·&nbsp; **LLM features:** off
 
 | Dataset | Domain | F1 | Precision | Recall | Time |
 |---|---|---|---|---|---|
-| DBLP-ACM | record | 0.9640 | 0.9721 | 0.9559 | 9.7s |
-| Febrl3 | record | 0.9912 | 0.9992 | 0.9833 | 6.31s |
-| NCVR-synthetic | record | 0.9925 | 0.9854 | 0.9996 | 14.61s |
-| DQbench | benchmark-suite | composite=83.16 | — | — | 299.4s |
-| Abt-Buy (linkage) | product | 0.7024 | 0.8529 | 0.5971 | 6.09s |
-| Amazon-Google (linkage) | product | 0.4636 | 0.5961 | 0.3792 | 43.05s |
+| DBLP-ACM | record | 0.9768 | 0.9894 | 0.9645 | 10.3s |
+| Febrl3 | record | 0.9912 | 0.9992 | 0.9833 | 9.08s |
+| NCVR-synthetic | record | 0.9925 | 0.9854 | 0.9996 | 19.64s |
+| DQbench | benchmark-suite | composite=83.16 | — | — | 350.5s |
+| Abt-Buy (linkage) | product | 0.7024 | 0.8529 | 0.5971 | 8.57s |
+| Amazon-Google (linkage) | product | 0.4636 | 0.5961 | 0.3792 | 37.33s |
 
 ## Reading these numbers
 


### PR DESCRIPTION
Refreshed benchmark source-of-truth from the weekly native run
(`.github/workflows/benchmarks.yml` → `scripts/run_benchmarks.py`).

These are the published numbers on the perf path; the report is
regenerated wholesale, so read the diff rather than the commit.
