### PR TITLE
chore(infermap-bench): bump fast-uri 3.1.2 -> 3.1.7 (security)

### DIFF
--- a/packages/python/infermap/benchmark/runners/ts/package-lock.json
+++ b/packages/python/infermap/benchmark/runners/ts/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "../../../../../typescript/infermap": {
-      "version": "0.5.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "goldencheck-types": "workspace:^"
@@ -34,12 +34,13 @@
         "infermap-mcp": "dist/node/mcp/server.cjs"
       },
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^25.9.5",
         "goldenmatch": "workspace:*",
+        "goldenmatch-wasm-runtime": "workspace:^",
         "rimraf": "^6.1.3",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.11"
       },
       "engines": {
         "node": ">=20"
@@ -1637,9 +1638,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

The `Dependabot Updates` workflow has been crashing on every run for
days (`unknown_error`, no further detail from the updater) trying to
auto-fix six open **HIGH**-severity `fast-uri` Dependabot alerts
(#80/#85/#92/#118/#119/#120 — host confusion + SSRF via IPv6/IDN/
percent-decoding/backslash-authority normalization bugs, all fixed
upstream in `fast-uri` 3.1.6) against
`packages/python/infermap/benchmark/runners/ts/package-lock.json`.
Tracked by the automated `main-health` issue #2835 (alongside two other,
unrelated failing lanes I'm handling separately).

## Fix

`fast-uri` is a transitive dep of `ajv` (`^3.0.1` range there), so
bumping to **3.1.7** — the latest 3.x patch, still inside that range —
resolves all six alerts without touching `ajv` or crossing a major
version (this repo's `dependabot.yml` policy deliberately ignores major
bumps for routine updates; 3.1.7 doesn't need one).

This directory is a standalone npm project (its own
`package-lock.json`, not listed in `pnpm-workspace.yaml`'s globs), so
`npm update fast-uri` is the correct tool here, not pnpm.

## Test plan

- [x] `npm audit` no longer lists `fast-uri` (2 unrelated pre-existing
      high alerts remain — `nanoid`, `postcss` — not touched: out of
      scope for this fix and not implicated in the Dependabot crash).
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test`: 112/113 pass. The one failure (a stale `REPO_ROOT`
      path assertion expecting `packages/infermap-js`) reproduces
      identically on a clean `origin/main` checkout — pre-existing,
      unrelated to this change.