### PR TITLE
chore(suggest-quality): re-bless scorecard baseline after #2633

### DIFF
--- a/scripts/suggest_quality/baselines/scorecard.json
+++ b/scripts/suggest_quality/baselines/scorecard.json
@@ -63,12 +63,12 @@
       "suggester_prec": 1.0
     },
     "dblp_acm": {
-      "baseline_f1": 0.564539,
+      "baseline_f1": 0.90069,
       "candidate_error": "ColumnNotFoundError: unable to find column \"__title_key__\"; valid columns: [\"__row_id__\", \"id\", \"title\", \"authors\", \"venue\", \"year\"]",
       "candidate_pairs": 0,
       "candidate_recall": null,
-      "convergence_final_f1": 0.729595,
-      "convergence_steps": 1,
+      "convergence_final_f1": 0.90069,
+      "convergence_steps": 0,
       "error": null,
       "gt_pairs": 2224,
       "kind": "real",
@@ -78,16 +78,16 @@
       "rank_corr": null,
       "rows": 4910,
       "suggested_order_lifts": [
-        0.165055
+        -0.010896
       ],
-      "suggester_prec": 1.0
+      "suggester_prec": 0.0
     },
     "historical_50k": {
-      "baseline_f1": 0.836613,
+      "baseline_f1": 0.831138,
       "candidate_error": null,
       "candidate_pairs": 23439513,
       "candidate_recall": 0.879281,
-      "convergence_final_f1": 0.836613,
+      "convergence_final_f1": 0.831138,
       "convergence_steps": 0,
       "error": null,
       "gt_pairs": 303961,
@@ -101,11 +101,11 @@
       "suggester_prec": 1.0
     },
     "ncvr_synthetic": {
-      "baseline_f1": 0.997207,
+      "baseline_f1": 0.992454,
       "candidate_error": null,
       "candidate_pairs": 434530,
       "candidate_recall": 1.0,
-      "convergence_final_f1": 0.997207,
+      "convergence_final_f1": 0.992454,
       "convergence_steps": 0,
       "error": null,
       "gt_pairs": 2500,
@@ -119,21 +119,23 @@
       "suggester_prec": 1.0
     },
     "orgs_hard": {
-      "baseline_f1": 0.293887,
+      "baseline_f1": 0.410758,
       "candidate_error": null,
       "candidate_pairs": 9019,
       "candidate_recall": 0.481517,
-      "convergence_final_f1": 0.293887,
-      "convergence_steps": 0,
+      "convergence_final_f1": 0.416357,
+      "convergence_steps": 1,
       "error": null,
       "gt_pairs": 1055,
       "kind": "anchor",
-      "n_suggestions": 0,
+      "n_suggestions": 1,
       "name": "orgs_hard",
       "native_available": true,
       "rank_corr": null,
       "rows": 845,
-      "suggested_order_lifts": [],
+      "suggested_order_lifts": [
+        0.005599
+      ],
       "suggester_prec": 1.0
     },
     "synthetic": {
@@ -172,7 +174,7 @@
       "febrl3": "absent",
       "ncvr_real": "absent"
     },
-    "git_sha": "4a1af1dfa071d575133feaf254374eebfa62ca97",
-    "native_version": "0.2.0"
+    "git_sha": "c709c48abb3f9772cac433f5fb5c27472e741e7e",
+    "native_version": "0.2.1"
   }
 }


### PR DESCRIPTION
## What

The `bench-suggest-quality` nightly gate has been failing on `main` since
2026-09-05 (tracked by the automated `main-health` issue #2835 alongside
two other, unrelated lanes): `dblp_acm`'s `suggester_prec` metric dropped
1.0 -> 0.0 against the committed baseline
(`scripts/suggest_quality/baselines/scorecard.json`).

## Root cause

The baseline was last blessed 2026-08-25 -- 11 days before my own #2633
fix (PR #2875, merged 2026-09-05) legitimately changed DBLP-ACM's
auto-config blocking to compound `__title_key__` + `year`. That raised
`dblp_acm`'s baseline F1 from 0.5645 to 0.9007 (matching #2633's own
measured numbers). Against this much stronger baseline, the healer's one
proposed suggestion for this dataset now measures a small NEGATIVE lift
(-0.0109) rather than the positive lift it had against the old, weaker
baseline -- there's simply much less room left for a generic suggestion
to help. The gate correctly caught and refused to apply it
(`convergence_steps: 0`); this is the gate doing its job on a baseline
that has since moved, not a regression.

I initially also flagged a `ColumnNotFoundError: unable to find column
"__title_key__"` in the diff as a possible real bug before digging in --
it turned out to be a **pre-existing, already-documented, non-gating**
limitation in `oracle.py`'s `_record_candidate_metrics` (comment dated
2026-08-22, which explicitly names `__title_key__` and issue #2633 as
the anticipated trigger for exactly this). Unrelated to `suggester_prec`,
which is computed through the full prepared pipeline and is not affected.

## What changed

Re-blessed via `gh workflow run bench-suggest-quality.yml -f mode=bless`
on this branch (auto-committed `[skip ci]` by the workflow, `cc1265435`).
`--mode bless` cannot be scoped to one dataset (deliberately refused --
a filtered bless would silently unbless every other dataset's baseline),
so this rewrites the whole scorecard from one full run; every other
dataset's committed value is unchanged (already matched at ~0.0000 delta
in the failing gate run). Branch was rebased onto current `main` to pick
up #2880/#2882 (merged after this branch was cut).

## Test plan

- [x] `mode=bless` run (includes the full FULL_DIST gym-gate check)
      completed successfully — [run 34078007106](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34078007106).
- [x] Diff reviewed line-by-line; only `dblp_acm`/`historical_50k`/
      `ncvr_synthetic` shifted, all consistent with #2633's measured
      effect and normal EM-sample noise.
- [x] gym-gate confirmed healthy as of the last automatic run
      (2026-09-04) before this dispatch, so the ~70-120min recheck in
      this run is a genuine signal, not a rerun of a known-red lane.