### PR TITLE
fix(bench): stamp __row_id__ in the #2633 biblio bench, fail on an unmeasured rung

### DIFF
--- a/scripts/bench_biblio_scale_2633.py
+++ b/scripts/bench_biblio_scale_2633.py
@@ -184,6 +184,19 @@ def _exact_block_metrics(df: Any, cfg: Any) -> dict:
     if blocking is None:
         return {"error": "config has no blocking section"}
     try:
+        # Stamp `__row_id__` the way ingest does. Domain extraction requires it,
+        # and the >=50K learned-blocking configs key on it directly -- without
+        # this, those rungs died with ColumnNotFoundError and reported NO
+        # candidate-pair number at exactly the scales worth measuring. Confined
+        # to this measurement helper so it cannot perturb the measured path
+        # (auto_configure_df / dedupe_df each stamp their own internally).
+        import polars as pl  # noqa: PLC0415
+        from goldenmatch.core.frame import to_frame as _tf  # noqa: PLC0415
+
+        if "__row_id__" not in _tf(df).columns:
+            df = _tf(df).with_row_index("__row_id__").native
+            if isinstance(df, pl.DataFrame):
+                df = df.with_columns(pl.col("__row_id__").cast(pl.Int64))
         prepared = _apply_domain_extraction(df, cfg)
         total_pairs = 0
         max_block = 0
@@ -284,6 +297,20 @@ def main(argv: list[str] | None = None) -> int:
     out = {"tiers": records, "meta": {"seed": args.seed, "tiers_requested": tiers}}
     Path(args.out_json).write_text(json.dumps(out, indent=2, default=str), encoding="utf-8")
     print(f"[bench-biblio-2633] wrote {args.out_json}", flush=True)
+
+    # Candidate pairs is THE metric this bench exists for (#2633 is a
+    # candidate-set-ceiling issue and says outright that recall is not the
+    # constraint). A rung that failed to measure it is a hole in the result,
+    # not a passing run -- the first sweep went green with 2 of 4 rungs
+    # unmeasured, which is how a bench ends up certifying nothing.
+    unmeasured = [r["n_rows"] for r in records if r.get("candidate_pairs") is None]
+    if unmeasured:
+        print(
+            f"[bench-biblio-2633] FAILED to measure candidate_pairs at rungs "
+            f"{unmeasured} -- see the per-rung `error` field.",
+            flush=True,
+        )
+        return 1
     return 0
 
 


### PR DESCRIPTION
## What

The first #2633 scale sweep ([run 34140339925](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34140339925)) measured candidate pairs at only **2 of its 4 rungs**, and still exited 0. Two fixes.

## 1. The unmeasured rungs

50K and 200K died with `ColumnNotFoundError: "__row_id__" not found` — inside the *measurement helper*, not the product. `dedupe_df` ran fine on those rungs and returned real F1; only `_exact_block_metrics` failed. Domain extraction requires `__row_id__`, and the ≥50K learned-blocking configs key on it directly — so the two rungs where the blocking code path actually flips are precisely the ones that reported nothing.

Same root cause as the bug already fixed in `bench_identity_control_plane.py`: a QIS-style synthetic frame carries no `__row_id__` because the real pipeline stamps it at ingest. Fixed the same way, and confined to the measurement helper so it can't perturb the measured path (`auto_configure_df` and `dedupe_df` each stamp their own internally).

## 2. The green run that measured nothing

Candidate pairs is *the* metric this bench exists for — #2633 is a candidate-set-ceiling issue and says outright that recall is not the constraint. A rung that fails to measure it is a hole in the result, not a pass. The script now exits non-zero and names the offending rungs.

## What the partial sweep did establish

Worth recording, since it survives this fix: the `__title_key__` + `year` compound fires at 5K but **not** at 1M, where selection flips to `authors`. That's real scale-dependent behaviour and it's the thing #2633's exit condition was asking about. The re-run should tell us what happens at the 50K/200K learned-blocking flip.

Separately — the absolute F1 numbers from that sweep are **not** interpretable as a product signal. Precision sits at ~0.2 even on the healthy rungs, which says the synthetic generator is degenerate for the scorer (two-member clusters over heavily-shared title words). Calibrating it against real DBLP-ACM statistics is a separate question from this fix.

## Test plan

- [x] `ruff check` clean.
- [x] Smoke at n=2000: `candidate_pairs: 2476`, keys `[__title_key__, year]`, exit 0.
- [x] Guard verified by construction — a rung with `candidate_pairs: None` now returns 1.