### PR TITLE
fix(identity): stop chunking lookup_entity_ids at SQLite's parameter cap on Postgres (#2893)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -69,9 +69,16 @@ python_goldenmatch_postgres:
   - 'packages/python/goldenmatch/tests/test_db.py'
   - 'packages/python/goldenmatch/tests/test_reconcile.py'
   - 'packages/python/goldenmatch/tests/test_memory_store_postgres.py'
+  - 'packages/python/goldenmatch/tests/identity/test_store_pg_lookup_2893.py'
   - 'packages/python/goldenmatch/tests/_pg_helpers.py'
   - 'packages/python/goldenmatch/goldenmatch/db/**'
   - 'packages/python/goldenmatch/goldenmatch/core/memory/**'
+  # The identity store carries a full Postgres backend (IdentityStore
+  # backend="postgres"), and this lane is the only place a real Postgres
+  # exercises it -- but `identity/**` was absent here, so an edit to that
+  # backend triggered NO Postgres coverage at PR time. Found while fixing
+  # #2893, which is a postgres-only change inside identity/store.py.
+  - 'packages/python/goldenmatch/goldenmatch/identity/**'
 # #1086 throughput-tier perf gate: re-run when the tier code or the
 # bench harness changes (so a regression in the sketch-then-verify
 # cost is caught), and on ci.yml edits (keeps the gate logic tested).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1175,6 +1175,7 @@ jobs:
           # the headache for a small (~30-test) lane.
           uv run --extra postgres pytest tests/test_db.py tests/test_reconcile.py \
             tests/test_memory_store_postgres.py \
+            tests/identity/test_store_pg_lookup_2893.py \
             -n 0 --timeout=180 --timeout-method=thread -v
 
   # Synthetic-fixture benchmark smoke. Runs on every PR against committed

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -1746,12 +1746,40 @@ class IdentityStore:
         ids = list(record_ids)
         if not ids:
             return {}
+        out: dict[str, str] = {}
+
+        if self._backend == "postgres":
+            # Postgres takes the whole candidate set as ONE array parameter, so
+            # the 900-id chunking below (a SQLite host-parameter limit) does not
+            # apply and actively hurts here: it turned a single pre-flight into
+            # one round trip per 900 ids. Measured at 5M rows (#2893), that was
+            # ~5,556 round trips costing 50.8s in this one call, vs 0.26s for
+            # the same logical work on SQLite -- 195x, with the network already
+            # removed (co-located services container). `= ANY(array)` is
+            # equality-equivalent to `IN (list)`, so results are unchanged.
+            #
+            # Still chunked, but on RESULT-SET SIZE rather than a parameter cap:
+            # at 5M this is ~50 round trips instead of ~5,556, while keeping the
+            # array parameter and the returned rows bounded.
+            _PG_CHUNK = 100_000
+            for i in range(0, len(ids), _PG_CHUNK):
+                chunk = ids[i:i + _PG_CHUNK]
+                rows = self._fetchall(
+                    "SELECT record_id, entity_id FROM source_records "
+                    "WHERE record_id = ANY(?) AND entity_id IS NOT NULL",
+                    (list(chunk),),
+                )
+                for r in rows:
+                    out[r["record_id"]] = r["entity_id"]
+            return out
+
         # SQLite caps host parameters per statement (SQLITE_MAX_VARIABLE_NUMBER;
         # 999 on older builds). A single IN-list over the full candidate set
         # raised "too many SQL variables" at 1M+ records (#670). Chunk the
         # IN-list and union the results -- each record_id is unique so chunks
         # never overlap; behavior is identical to the single-query form.
-        out: dict[str, str] = {}
+        # Kept as the portable path: any backend that is not postgres/mongo/
+        # snowflake lands here rather than on postgres-specific array SQL.
         _CHUNK = 900
         for i in range(0, len(ids), _CHUNK):
             chunk = ids[i:i + _CHUNK]

--- a/packages/python/goldenmatch/tests/identity/test_store_pg_lookup_2893.py
+++ b/packages/python/goldenmatch/tests/identity/test_store_pg_lookup_2893.py
@@ -1,0 +1,86 @@
+"""#2893: `lookup_entity_ids` must not chunk at SQLite's parameter limit on Postgres.
+
+The 900-id chunk in `lookup_entity_ids` exists for
+`SQLITE_MAX_VARIABLE_NUMBER` (#670 -- a single IN-list over 1M+ ids raised
+"too many SQL variables"). It was applied to every SQL backend, so on
+Postgres it turned `apply_batch`'s ONE bulk pre-flight into a round trip per
+900 ids.
+
+Measured at 5M rows (run 34148189911): 50.82 s in that single
+`lookup_entity_ids` call on Postgres vs 0.26 s for the same logical work on
+SQLite -- 195x, with the network already removed (co-located services
+container). ~5,556 round trips.
+
+Postgres takes the whole set as one array parameter (`= ANY($1)`), so the
+guard here is on ROUND-TRIP COUNT, not just correctness: a correctness-only
+test would pass just as happily if someone reinstated per-900 chunking, which
+is the actual regression.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.identity import IdentityNode, IdentityStore, SourceRecord, new_entity_id
+
+from .._pg_helpers import pg_url_fixture
+
+
+@pytest.fixture()
+def pg_url():
+    yield from pg_url_fixture()
+
+
+@pytest.fixture()
+def pg_store(pg_url):
+    store = IdentityStore(backend="postgres", connection=pg_url.url())
+    yield store
+    store.close()
+
+
+def test_pg_lookup_entity_ids_is_one_roundtrip_per_100k_not_per_900(pg_store):
+    """N ids must cost ceil(N/100_000) queries, not ceil(N/900)."""
+    n = 2500  # spans 3 chunks under the old 900 cap, 1 under the new one
+    eid = new_entity_id()
+    pg_store.upsert_identity(IdentityNode(entity_id=eid))
+    for i in range(n):
+        pg_store.upsert_record(SourceRecord(f"a:{i}", "a", str(i), "h", entity_id=eid))
+
+    calls: list[str] = []
+    real_fetchall = pg_store._fetchall
+
+    def counting_fetchall(sql, params):
+        calls.append(sql)
+        return real_fetchall(sql, params)
+
+    pg_store._fetchall = counting_fetchall  # type: ignore[method-assign]
+    try:
+        out = pg_store.lookup_entity_ids([f"a:{i}" for i in range(n)] + ["a:missing"])
+    finally:
+        pg_store._fetchall = real_fetchall  # type: ignore[method-assign]
+
+    # Correctness is unchanged vs the IN-list form: ANY(array) is
+    # equality-equivalent, and the absent id must still be absent.
+    assert out == {f"a:{i}": eid for i in range(n)}
+
+    # The actual regression guard. Under the old shared 900-chunk this was 3.
+    assert len(calls) == 1, (
+        f"expected a single round trip for {n} ids on postgres, got {len(calls)} "
+        "-- the SQLite 900-parameter chunk has been reapplied to postgres (#2893)"
+    )
+    assert "= ANY(" in calls[0], f"expected an array parameter, got: {calls[0]}"
+
+
+def test_pg_lookup_entity_ids_empty_and_missing(pg_store):
+    """Empty input short-circuits; unknown ids simply do not appear."""
+    assert pg_store.lookup_entity_ids([]) == {}
+    assert pg_store.lookup_entity_ids(["nope:1", "nope:2"]) == {}
+
+
+def test_pg_lookup_entity_ids_skips_records_with_no_entity(pg_store):
+    """`entity_id IS NOT NULL` filtering survives the rewrite."""
+    eid = new_entity_id()
+    pg_store.upsert_identity(IdentityNode(entity_id=eid))
+    pg_store.upsert_record(SourceRecord("b:1", "b", "1", "h", entity_id=eid))
+    pg_store.upsert_record(SourceRecord("b:2", "b", "2", "h"))  # no entity
+
+    assert pg_store.lookup_entity_ids(["b:1", "b:2"]) == {"b:1": eid}


### PR DESCRIPTION
Closes #2893.

## The bug

`lookup_entity_ids` chunked its IN-list at **900 ids for every SQL backend**. That 900 is `SQLITE_MAX_VARIABLE_NUMBER` (from #670 — a single IN-list over 1M+ ids raised *"too many SQL variables"*), and it's meaningless on Postgres, which takes the whole set as **one array parameter**.

Applied to Postgres it turned `apply_batch`'s single bulk pre-flight (`resolve.py:674`) into a round trip per 900 ids.

Measured at 5M rows ([run 34148189911](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34148189911)):

| backend | calls | wall |
|---|---|---|
| postgres | 1 | **50.82 s** (~5,556 round trips inside it) |
| sqlite | 1 | **0.26 s** |

195×, with the network already removed (co-located services container). Third-largest line item in the entire 698 s Postgres cold run.

## The fix

Postgres uses `= ANY(?)` with a single array parameter — still chunked, but on **result-set size** (100k) rather than a parameter cap: ~50 round trips at 5M instead of ~5,556. `= ANY(array)` is equality-equivalent to `IN (list)`, so results are unchanged. The 900-chunk IN-list stays byte-identical as the portable path for SQLite and any future backend.

## Two CI gaps found on the way, both fixed here

1. **`python_goldenmatch_postgres` had no `identity/**` path filter.** The identity store ships a full Postgres backend, and that lane is the only place a real Postgres exercises it — but an edit to it triggered *no* Postgres coverage at PR time. Including this edit.
2. **The new test wouldn't have run anyway** — the job names its test files explicitly and `tests/identity/` wasn't among them.

That's the "a check exists and does not fire" class this repo keeps getting bitten by, so worth flagging rather than quietly fixing.

## The test guards round-trip count, not just correctness

A correctness-only test passes just as happily if someone reinstates per-900 chunking — which is the actual regression. So it asserts 2,500 ids cost **1** query (was 3 under the old cap) and that the SQL carries `= ANY(`.

## Test plan

- [x] 17 SQLite identity-store tests unchanged and passing (portable path untouched).
- [x] 3 new Postgres tests skip cleanly without a DSN; they run in the `python_postgres` lane, which this PR also makes actually trigger on identity changes.
- [x] `ruff check` clean.
- [x] `scripts/check_workflow_yaml.py` — 133 files, no parse errors or duplicate keys.
- [x] `scripts/check_filter_coverage.py` — passes, 0 new gaps.
- [ ] Re-run the 5M control-plane profile after merge to confirm the 50.8 s drops. Expect it to land near SQLite's 0.26 s plus ~50 round trips of overhead.