### PR TITLE
perf(identity): stage-instrument apply_batch's prep + write loop

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -6561,6 +6561,7 @@
             "goldenmatch._polars_lazy",
             "goldenmatch.config.schemas",
             "goldenmatch.core._hashing",
+            "goldenmatch.core.bench",
             "goldenmatch.core.cluster",
             "goldenmatch.core.cluster_pairscores",
             "goldenmatch.core.frame",

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -609,11 +609,23 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     # scale with the identity graph rather than with the input frame.
     # ``emit_singletons=True`` legitimately needs every row and degenerates to
     # the old behaviour.
-    if "__row_id__" in _fa5.columns:
-        _needed = _referenced_row_ids(cluster_items, emit_singletons)
-        if len(_needed) < _fa5.height:
-            _fa5 = _fa5.filter_in("__row_id__", sorted(_needed))
-    rows = _fa5.select_dicts(list(_fa5.columns))
+    # Stage markers (#2893 follow-up). The 5M control-plane profile
+    # (ADR 0064) found ~210s of the cold-load wall and essentially all of the
+    # 12.6 GB peak RSS sitting OUTSIDE the store, in the prep below -- and
+    # backend-independent, to within noise, across SQLite and Postgres. This
+    # module previously had no stage instrumentation at all, so that cost was
+    # only visible by subtraction. These bracket the prep phases so it is
+    # attributable directly. No-ops unless a `bench_capture()` recorder is
+    # active, so the default path is unchanged.
+    from goldenmatch.core.bench import stage as _stage  # noqa: PLC0415
+
+    with _stage("identity_prep_row_filter"):
+        if "__row_id__" in _fa5.columns:
+            _needed = _referenced_row_ids(cluster_items, emit_singletons)
+            if len(_needed) < _fa5.height:
+                _fa5 = _fa5.filter_in("__row_id__", sorted(_needed))
+    with _stage("identity_prep_materialize_rows"):
+        rows = _fa5.select_dicts(list(_fa5.columns))
     rowid_to_recid: dict[int, str] = {}
     rowid_to_payload: dict[int, dict[str, Any]] = {}
     rowid_to_source: dict[int, str] = {}
@@ -650,27 +662,29 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
             if not has_pk:
                 h1_by_rowid[int(rid)] = h1_list[i]
 
-    for row in rows:
-        rid = row.get("__row_id__")
-        if rid is None:
-            continue
-        irid = int(rid)
-        source = str(row.get("__source__", "dataframe"))
-        primary_id, candidates = _record_id_candidates(
-            row, source, source_pk_col,
-            precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED),
-        )
-        _rowid_primary[irid] = primary_id
-        _rowid_candidates[irid] = candidates
-        rowid_to_payload[irid] = _row_to_payload(row)
-        rowid_to_source[irid] = source
-        rowid_to_hash[irid] = _hash_payload(rowid_to_payload[irid])
+    with _stage("identity_prep_record_ids"):
+        for row in rows:
+            rid = row.get("__row_id__")
+            if rid is None:
+                continue
+            irid = int(rid)
+            source = str(row.get("__source__", "dataframe"))
+            primary_id, candidates = _record_id_candidates(
+                row, source, source_pk_col,
+                precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED),
+            )
+            _rowid_primary[irid] = primary_id
+            _rowid_candidates[irid] = candidates
+            rowid_to_payload[irid] = _row_to_payload(row)
+            rowid_to_source[irid] = source
+            rowid_to_hash[irid] = _hash_payload(rowid_to_payload[irid])
 
     # One bulk lookup over the candidate union resolves each record to an
     # existing id (legacy-fallback) and doubles as the pre-flight check the
     # bulk fast-path below uses to spot brand-new clusters (the 500K-cluster
     # bench, #368 Phase 6, depends on this single pre-flight lookup).
-    _all_candidates = sorted({c for cs in _rowid_candidates.values() for c in cs})
+    with _stage("identity_prep_candidate_union"):
+        _all_candidates = sorted({c for cs in _rowid_candidates.values() for c in cs})
     _existing_by_id: dict[str, str] = (
         store.lookup_entity_ids(_all_candidates) if _all_candidates else {}
     )
@@ -878,7 +892,11 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
         if _ilw is not None
         else contextlib.nullcontext()
     )
-    with _initial_ctx, store.bulk_writes():
+    # Brackets the whole write region (cluster loop + mid-loop and final bulk
+    # flushes). Subtracting the store's own wall from this is what separates
+    # "time spent deciding and building rows in Python" from "time spent in the
+    # backend" -- the split ADR 0064 could only infer.
+    with _stage("identity_write_loop"), _initial_ctx, store.bulk_writes():
         with store.write_pipeline():
             # 3. Iterate clusters.
             for cluster_id, info in cluster_items:

--- a/scripts/bench_identity_control_plane.py
+++ b/scripts/bench_identity_control_plane.py
@@ -273,6 +273,7 @@ def run_phase(
     dataset: str,
     run_name: str,
 ) -> dict:
+    from goldenmatch.core.bench import bench_capture
     from goldenmatch.identity.resolve import resolve_clusters
 
     probe.reset()
@@ -280,18 +281,29 @@ def run_phase(
     rss_before = _vmrss_mb()
     sampler.start()
     t0 = time.perf_counter()
-    summary = resolve_clusters(
-        clusters=clusters,
-        df=df,
-        store=store,
-        run_name=run_name,
-        dataset=dataset,
-        # SQLite carries a singleton ceiling warning (store.py:118) and
-        # singletons are not what the write path is being judged on here.
-        emit_singletons=False,
-    )
+    # apply_batch's prep phases carry `stage()` markers as of the #2893
+    # follow-up; without a recorder active they no-op, so capture one to get
+    # the breakdown of the backend-independent wall that ADR 0064 could only
+    # see by subtraction.
+    with bench_capture() as bench_rec:
+        summary = resolve_clusters(
+            clusters=clusters,
+            df=df,
+            store=store,
+            run_name=run_name,
+            dataset=dataset,
+            # SQLite carries a singleton ceiling warning (store.py:118) and
+            # singletons are not what the write path is being judged on here.
+            emit_singletons=False,
+        )
     wall = time.perf_counter() - t0
     sampler.halt()
+    try:
+        _bd = bench_rec.to_dict()
+    except Exception as exc:  # noqa: BLE001 -- diagnostic only
+        _bd = {"_capture_error": repr(exc)[:120]}
+    _stage_wall = _bd.get("stage_timings_seconds") or {}
+    _stage_rss = _bd.get("stage_peak_rss_kb") or {}
 
     n_members = sum(len(v.get("members") or []) for v in clusters.values())
     total_store_calls = sum(probe.counts.values())
@@ -308,6 +320,9 @@ def run_phase(
         "store_wall_s": round(sum(probe.wall.values()), 3),
         "store_share_of_wall": round(sum(probe.wall.values()) / wall, 3) if wall else None,
         "by_method": probe.report(),
+        "stage_wall_s": {k: round(v, 3) for k, v in sorted(
+            _stage_wall.items(), key=lambda kv: -float(kv[1] or 0))},
+        "stage_peak_rss_mb": {k: round(v / 1024.0, 1) for k, v in _stage_rss.items()},
         "summary": {
             k: v for k, v in vars(summary).items() if isinstance(v, (int, float, str, bool))
         },


### PR DESCRIPTION
Follow-on from ADR 0064. Instrumentation only — no behaviour change.

## Why

ADR 0064 found ~210 s of the 5M cold-load wall and essentially all of the 12.6 GB peak RSS sitting **outside** the store, backend-independent to within noise across SQLite and Postgres. But `identity/` had no `stage()` markers at all, so that cost was only visible **by subtraction** (wall minus the harness's store-method timing) — which tells you where it *isn't*, never where it *is*.

The ADR deliberately deferred adding permanent markers on the grounds that doing so before knowing which boundaries matter is guessing. The 5M profile identified them, so here they are.

## What

| marker | covers |
|---|---|
| `identity_prep_row_filter` | `_referenced_row_ids` + `filter_in` |
| `identity_prep_materialize_rows` | `select_dicts` → N Python row dicts |
| `identity_prep_record_ids` | the per-row derivation loop |
| `identity_prep_candidate_union` | the candidate-set build |
| `identity_write_loop` | cluster loop + mid-loop and final bulk flushes |

No-ops unless a `bench_capture()` recorder is active, so the default path is unchanged. The write-loop marker composes into the existing `with` tuple rather than re-indenting ~400 lines of loop body. Subtracting the probe's store wall from `identity_write_loop` separates *deciding and building rows in Python* from *time in the backend* — the split ADR 0064 could only infer.

The harness also now opens a `bench_capture()` and reports `stage_wall_s` / `stage_peak_rss_mb` per phase. Without that the new markers would no-op there and this PR would have instrumented nothing.

## Local sanity (20K, SQLite, cold)

```
wall 1.495s   store 0.604s   non-store 0.891s
  identity_write_loop             0.849   (store 0.604 within -> ~0.245 python)
  identity_prep_record_ids        0.218
  identity_prep_materialize_rows  0.102
  identity_prep_candidate_union   0.006
  identity_prep_row_filter        0.002
```

Ratios will shift at 5M — `materialize_rows` scales with rows, the write loop with clusters — which is exactly why this is measured rather than assumed. The 5M breakdown is the next run.

## Test plan

- [x] 383 identity tests pass, 10 skipped — unchanged.
- [x] `ruff check` clean.
- [x] Markers verified to actually emit (not just compile) via a local 20K run.
- [x] `docs/agent-codemap.json` regenerated per the pre-push docs gate.