### PR TITLE
perf(identity): stop computing the payload and its hash twice per row

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -220,6 +220,8 @@ def _record_id_candidates(
     source_pk_col: str | None,
     *,
     precomputed_h1: object = _NOT_BATCHED,
+    payload: dict[str, Any] | None = None,
+    payload_hash: str | None = None,
 ) -> tuple[str, list[str]]:
     """Return ``(primary_id, lookup_candidates)`` for a record row.
 
@@ -242,8 +244,15 @@ def _record_id_candidates(
         pk = str(row[source_pk_col])
         rid = f"{source}:{pk}"
         return rid, [rid]
-    payload = _row_to_payload(row)
-    legacy_id = f"{source}:hash:{_hash_payload(payload)[:12]}"
+    # The bulk caller has already built both of these for `rowid_to_payload` /
+    # `rowid_to_hash`; recomputing them here doubled the per-row payload build
+    # AND the json.dumps+sha256 for every row. Measured 5.86 us/row of pure
+    # duplicate work (~29s at 5M) -- and it stayed even on the batched-h1 path,
+    # since only the fingerprint was being skipped. Both are deterministic
+    # functions of `row`, so reusing the caller's values is byte-identical.
+    if payload is None:
+        payload = _row_to_payload(row)
+    legacy_id = f"{source}:hash:{(payload_hash or _hash_payload(payload))[:12]}"
     if precomputed_h1 is _NOT_BATCHED:
         try:
             full_h1 = record_fingerprint(_canonical_payload(payload))
@@ -669,15 +678,24 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                 continue
             irid = int(rid)
             source = str(row.get("__source__", "dataframe"))
+            # Build the payload + its hash ONCE and hand them down. Both were
+            # previously computed here AND again inside
+            # `_record_id_candidates` (5.86 us/row of duplicate work, ~29s at
+            # 5M). The caller needs them unconditionally for rowid_to_payload /
+            # rowid_to_hash, so hoisting is a strict win on the PK path too.
+            _payload = _row_to_payload(row)
+            _phash = _hash_payload(_payload)
             primary_id, candidates = _record_id_candidates(
                 row, source, source_pk_col,
                 precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED),
+                payload=_payload,
+                payload_hash=_phash,
             )
             _rowid_primary[irid] = primary_id
             _rowid_candidates[irid] = candidates
-            rowid_to_payload[irid] = _row_to_payload(row)
+            rowid_to_payload[irid] = _payload
             rowid_to_source[irid] = source
-            rowid_to_hash[irid] = _hash_payload(rowid_to_payload[irid])
+            rowid_to_hash[irid] = _phash
 
     # One bulk lookup over the candidate union resolves each record to an
     # existing id (legacy-fallback) and doubles as the pre-flight check the

--- a/packages/python/goldenmatch/tests/identity/test_record_id_payload_reuse.py
+++ b/packages/python/goldenmatch/tests/identity/test_record_id_payload_reuse.py
@@ -1,0 +1,73 @@
+"""`_record_id_candidates` must accept a precomputed payload/hash and produce
+byte-identical ids (ADR 0064 follow-up).
+
+`apply_batch`'s per-row derivation loop needs `_row_to_payload` and
+`_hash_payload` for `rowid_to_payload` / `rowid_to_hash` regardless, and
+`_record_id_candidates` was recomputing BOTH internally on the no-PK path --
+2x the payload build and 2x the json.dumps+sha256 for every row. Measured at
+5.86 us/row of pure duplicate work (~29s at 5M), and it persisted even on the
+batched-h1 path, since only the fingerprint was being skipped.
+
+These lock the two things that make hoisting safe: the ids are identical
+either way, and the helpers really are called once per row rather than twice.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.identity import resolve as R
+
+_ROWS = [
+    {"__row_id__": 0, "id": "1", "first_name": "Ann", "last_name": "Lee", "zip": "10001"},
+    {"__row_id__": 1, "id": "2", "first_name": "Bob", "last_name": "Ray", "zip": None},
+    {"__row_id__": 2, "id": "3", "first_name": "", "last_name": "Ng", "zip": "94105"},
+]
+
+
+@pytest.mark.parametrize("pk_col", [None, "id"], ids=["no-pk", "pk"])
+def test_precomputed_payload_is_byte_identical(pk_col):
+    """Both the content-hash path and the natural-PK early return."""
+    for row in _ROWS:
+        without = R._record_id_candidates(row, "src", pk_col)
+        payload = R._row_to_payload(row)
+        with_ = R._record_id_candidates(
+            row, "src", pk_col, payload=payload, payload_hash=R._hash_payload(payload)
+        )
+        assert without == with_, row
+
+
+def test_precomputed_payload_composes_with_batched_h1():
+    """The two optimisations are independent: supplying both must still match
+    supplying only the batched hash."""
+    for row in _ROWS:
+        h1 = "a" * 64
+        only_h1 = R._record_id_candidates(row, "src", None, precomputed_h1=h1)
+        payload = R._row_to_payload(row)
+        both = R._record_id_candidates(
+            row, "src", None, precomputed_h1=h1,
+            payload=payload, payload_hash=R._hash_payload(payload),
+        )
+        assert only_h1 == both, row
+
+
+def test_helpers_are_called_once_per_row_not_twice(monkeypatch):
+    """The regression guard. A correctness-only test passes just as happily if
+    someone reinstates the internal recomputation, which is the actual defect."""
+    calls = {"payload": 0, "hash": 0}
+    real_payload, real_hash = R._row_to_payload, R._hash_payload
+
+    monkeypatch.setattr(R, "_row_to_payload",
+                        lambda r: (calls.__setitem__("payload", calls["payload"] + 1),
+                                   real_payload(r))[1])
+    monkeypatch.setattr(R, "_hash_payload",
+                        lambda p: (calls.__setitem__("hash", calls["hash"] + 1),
+                                   real_hash(p))[1])
+
+    for row in _ROWS:
+        payload = R._row_to_payload(row)
+        phash = R._hash_payload(payload)
+        R._record_id_candidates(row, "src", None, payload=payload, payload_hash=phash)
+
+    n = len(_ROWS)
+    assert calls["payload"] == n, f"expected {n} payload builds, got {calls['payload']}"
+    assert calls["hash"] == n, f"expected {n} hashes, got {calls['hash']}"


### PR DESCRIPTION
Follow-on from ADR 0064 / PR #2898. First real optimisation off the 5M stage breakdown.

## How it was found

The 5M breakdown attributed ~64 s of cold-load wall to `identity_prep_record_ids`. Profiling the three helpers inside that loop put **76%** in `_record_id_candidates` — not in the `json.dumps` + sha256 I'd assumed, which is only 20%.

Reading it explained why. On the no-PK path `_record_id_candidates` calls `_row_to_payload` and `_hash_payload` internally — and the caller then calls **both again** to populate `rowid_to_payload` / `rowid_to_hash`:

```python
primary_id, candidates = _record_id_candidates(row, source, source_pk_col, ...)  # builds payload + hash
rowid_to_payload[irid] = _row_to_payload(row)                                    # again
rowid_to_hash[irid]    = _hash_payload(rowid_to_payload[irid])                   # again
```

Every row built its payload twice and ran `json.dumps` + sha256 twice. **5.86 µs/row of pure duplicate work (~29 s at 5M)** — and it persisted on the batched-h1 path too, since `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT` only skips the fingerprint, not these.

## The fix

The loop builds both once and passes them down via two new keyword-only params. Strictly a win on the natural-PK path as well, because the caller already computed both unconditionally there.

## Why the ids are provably unchanged

Both helpers are deterministic functions of `row`, so reuse is byte-identical — verified rather than asserted: **20,000 rows through both the no-PK and natural-PK paths, 0 mismatches** between call forms.

## No wall-clock number is claimed here, deliberately

This machine is under memory pressure and per-row medians swung ±30% between reps — enough to invert the sign of the comparison. Reporting a speedup from it would be dressing noise up as a result. The win is proven by **call count** instead, which is exact:

```
50,000 rows:  _row_to_payload  100,000 -> 50,000   (2x -> 1x per row)
              _hash_payload    100,000 -> 50,000   (2x -> 1x per row)
```

The wall figure comes from the next 5M CI run, on a stable machine.

## Second finding, not in this PR

`GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1` (existing, shipped, default **off**) supplies a batched h1 and skips the per-row `record_fingerprint`, worth a further ~15.8 µs/row locally. That's a default-flip decision with its own risk surface, so it wants its own measurement and PR rather than riding along here.

## Test plan

- [x] New `tests/identity/test_record_id_payload_reuse.py`: byte-identical ids across both paths, composition with a batched h1, and a **call-count guard** — a correctness-only test would pass just as happily if someone reinstated the recomputation, which is the actual defect.
- [x] 383 identity tests pass unchanged.
- [x] `ruff check` clean.
- [ ] 5M CI re-run for the wall delta.