### PR TITLE
perf(identity): store _rowid_candidates sparsely (182 B/row of duplication)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -641,6 +641,15 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     rowid_to_pk: dict[int, str] = {}
     rowid_to_hash: dict[int, str] = {}
     _rowid_primary: dict[int, str] = {}
+    # SPARSE: only rows whose candidate list differs from the singleton
+    # ``[primary_id]``. Every current return in ``_record_id_candidates`` is
+    # ``(x, [x])`` (verified across all four branches -- natural PK, per-row
+    # fingerprint, batched h1, un-fingerprintable), so today this stays empty
+    # and the 182 B/row it used to cost per row is not paid at all (~0.9 GB at
+    # 5M). Storing the exception rather than the rule keeps the multi-candidate
+    # contract the docstring describes: if the helper ever returns a real
+    # alternate list again (the legacy-migration shape), it is recorded here and
+    # both readers below pick it up.
     _rowid_candidates: dict[int, list[str]] = {}
 
     # Optional batch fingerprinting (GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1):
@@ -692,7 +701,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                 payload_hash=_phash,
             )
             _rowid_primary[irid] = primary_id
-            _rowid_candidates[irid] = candidates
+            if candidates != [primary_id]:
+                _rowid_candidates[irid] = candidates
             rowid_to_payload[irid] = _payload
             rowid_to_source[irid] = source
             rowid_to_hash[irid] = _phash
@@ -702,15 +712,18 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     # bulk fast-path below uses to spot brand-new clusters (the 500K-cluster
     # bench, #368 Phase 6, depends on this single pre-flight lookup).
     with _stage("identity_prep_candidate_union"):
-        _all_candidates = sorted({c for cs in _rowid_candidates.values() for c in cs})
+        _all_candidates = sorted({
+            c
+            for _i, _pid in _rowid_primary.items()
+            for c in (_rowid_candidates.get(_i) or (_pid,))
+        })
     _existing_by_id: dict[str, str] = (
         store.lookup_entity_ids(_all_candidates) if _all_candidates else {}
     )
     preflight_existing: dict[str, str] = {}
-    for irid, candidates in _rowid_candidates.items():
-        chosen = next(
-            (c for c in candidates if c in _existing_by_id), _rowid_primary[irid]
-        )
+    for irid, _pid in _rowid_primary.items():
+        candidates = _rowid_candidates.get(irid) or (_pid,)
+        chosen = next((c for c in candidates if c in _existing_by_id), _pid)
         rowid_to_recid[irid] = chosen
         src = rowid_to_source[irid]
         rowid_to_pk[irid] = (

--- a/packages/python/goldenmatch/tests/identity/test_record_id_payload_reuse.py
+++ b/packages/python/goldenmatch/tests/identity/test_record_id_payload_reuse.py
@@ -71,3 +71,32 @@ def test_helpers_are_called_once_per_row_not_twice(monkeypatch):
     n = len(_ROWS)
     assert calls["payload"] == n, f"expected {n} payload builds, got {calls['payload']}"
     assert calls["hash"] == n, f"expected {n} hashes, got {calls['hash']}"
+
+
+def test_candidates_is_the_singleton_primary_on_every_branch():
+    """`apply_batch` stores `_rowid_candidates` SPARSELY -- only rows whose
+    candidate list differs from `[primary_id]` -- because today every branch
+    returns `(x, [x])`, making a per-row list pure duplication of
+    `_rowid_primary` (182 B/row, ~0.9 GB at 5M).
+
+    That storage choice is safe for multi-candidate lists (both readers fall
+    back to `[primary]` only when no entry exists), but this test is the
+    tripwire: if the helper starts returning a genuinely different candidate
+    list again, this fails and points whoever did it at the sparse-storage
+    assumption so they can confirm the readers still do what they want.
+    """
+    row = {"__row_id__": 7, "id": "42", "name": "Ann"}
+    cases = [
+        ("natural PK", dict(source_pk_col="id")),
+        ("per-row fingerprint", dict(source_pk_col=None)),
+        ("batched h1", dict(source_pk_col=None, precomputed_h1="b" * 64)),
+        ("un-fingerprintable", dict(source_pk_col=None, precomputed_h1=None)),
+    ]
+    for label, kw in cases:
+        pk = kw.pop("source_pk_col")
+        primary, candidates = R._record_id_candidates(row, "src", pk, **kw)
+        assert candidates == [primary], (
+            f"{label}: candidates {candidates!r} != [{primary!r}] -- the sparse "
+            "_rowid_candidates storage in apply_batch assumes this; re-check "
+            "both readers before changing it"
+        )


### PR DESCRIPTION
Going after the RSS half of ADR 0064 — the derivation loop doubling peak from 6.5 GB to 12.5 GB at 5M.

## Attribution first

tracemalloc, 200K rows, of the ~769 B/row the loop adds on top of `select_dicts`:

| structure | B/row | share |
|---|---|---|
| `rowid_to_payload` (new dict/row) | 324 | 42% |
| **`_rowid_candidates` (list/row)** | **182** | **24%** |
| `rowid_to_hash` | 157 | 20% |
| `_rowid_primary` | 118 | 15% |
| `rowid_to_source` | 52 | 7% |

## The change

`_rowid_candidates` is pure duplication of `_rowid_primary` today — every `return` in `_record_id_candidates` is `(x, [x])`. Verified empirically rather than by reading: **210,000 calls across all four branches** (natural PK, per-row fingerprint, batched h1, un-fingerprintable), every candidate list a singleton equal to its primary. So each row stores the same string twice.

Now stored **sparsely** — only rows whose list differs from `[primary_id]`. Today that's none, so the 182 B/row isn't paid at all (~0.9 GB at 5M by Python-tracked allocation; CI gives the RSS figure).

Both readers fall back to `(primary,)` only when a row has *no* entry, so a genuine multi-candidate list still works exactly as before. Storing the exception rather than the rule is the safe direction: a future multi-candidate return is picked up automatically rather than silently dropped.

## Tripwire

A test asserts the singleton invariant across all four branches. If someone makes the helper return a real alternate list again, that test fails and names the sparse-storage assumption, pointing them at both readers — rather than the optimization quietly changing behaviour.

## What this does *not* fix, and why it matters

`rowid_to_payload` is bigger (324 B/row), and underneath everything sits ~6.5 GB of `select_dicts` row dicts.

I checked whether simply freeing `rows` after the loop helps: **it recovers only 37% of its own size**, because the remaining 63% is string data still referenced by the payload dicts. So the incremental bookkeeping wins here top out around 20% of peak. **The real memory win requires not materializing 5M Python row dicts at all** — the Arrow-native derivation path ADR 0064 points at. Worth knowing before anyone spends more effort on tweaks at this layer.

## Test plan

- [x] 387 identity tests pass.
- [x] Singleton invariant verified over 210,000 calls across all four branches before relying on it.
- [x] End-to-end harness at 200K: 40,000 clusters created, cold-store guard satisfied, stage shape unchanged.
- [x] `ruff check` clean.
- [ ] 5M CI run for the actual RSS delta.