### PR TITLE
perf(identity): derive the two post-prep row maps instead of storing them

### DIFF
--- a/context-network/decisions/0064-identity-control-plane-stays-on-postgres-sqlite.md
+++ b/context-network/decisions/0064-identity-control-plane-stays-on-postgres-sqlite.md
@@ -55,7 +55,7 @@ removed on purpose — the honest way to isolate engine cost):
      item on both, though already COPY/staged and possibly near its floor.
   2. The ~210 s prep path and the 12.6 GB, both untouched and with obvious
      headroom. Riskier than it looks: `apply_batch` is load-bearing correctness
-     code with many branches.
+     code with many branches. **Partly done — see the addendum below.**
   3. Residual `lookup_entity_ids` gap: 10.4 s (PG) vs 1.9 s (SQLite) post-#2893.
 - **One real defect came out of the profile.** #2893: `lookup_entity_ids`
   chunked its IN-list at 900 — `SQLITE_MAX_VARIABLE_NUMBER` (#670) — for *every*
@@ -92,3 +92,47 @@ zeros — and a result that confirms your prior is the one to re-derive from the
 other direction before filing it. Each guard now asserts the thing it assumed:
 the zero-work check, and the cold-phase check that `created` equals the clusters
 processed (verified to fire, not assumed to).
+
+## Addendum, 2026-09-08: follow-on item 2, first results
+
+The 12.6 GB figure above is superseded. Item 2 was attacked in four slices;
+the peak RSS at 5M cold is now **9,009.6 MB (sqlite) / 8,996.5 MB (postgres)**,
+[run 34256747975](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34256747975)
+against the same rungs, backends and `pair_scores=spanning` as the original.
+
+| slice | what | peak RSS at 5M |
+|---|---|---|
+| — | baseline | 12,554.8 MB |
+| #2900 | payload + hash computed once, not twice | (wall only, −42% on `identity_prep_record_ids`) |
+| #2902 | `_rowid_candidates` stored sparsely | −0.08% — **a negative result** |
+| #2903 | streamed prep, row dicts bounded at O(chunk) | **8,996–9,010 MB (−28%)** |
+
+Two things worth carrying forward.
+
+**The instruments disagreed with the outcome twice, in opposite directions.**
+#2902 was sized from tracemalloc at ~0.9 GB and delivered 0.08%: tracemalloc
+counts requested Python allocation, not resident pages, and the difference is
+allocator behaviour, not arithmetic. #2903 was shipped with *no* local memory
+evidence at all — the only A/B available compared new-1-chunk against
+new-2-chunks, both of which release row dicts, so it measured the wrong
+contrast — and it delivered the full predicted 3.5 GB. The usable rule is that
+peak RSS is only knowable from `ru_maxrss` on the real rung; a local proxy is
+worth running for a signal but never for a number.
+
+**Stage boundaries decide what you can see.** The `+935 MB` that appeared to
+belong to `identity_write_loop` was not in the write loop: it was an unstaged
+pass between two markers that built `rowid_to_recid` and `rowid_to_pk`, two
+whole-frame dicts duplicating values already in hand. It was invisible while
+the prep peak (12,557 MB) sat above it and only became attributable once #2903
+lowered the peak beneath it. A stage marker that does not bracket a loop hides
+that loop inside its neighbour.
+
+**Residual, and where the next slice has to go.** Of the 9.0 GB: ~2.1 GB before
+prep, ~0.4 GB the filtered frame, **~5.5 GB the derived structures**, ~0.9 GB
+the post-prep maps. The 5.5 GB is five per-row Python maps over an identical
+5M-key set — payload 324 B/row, hash 157, primary 118, source 52 — where the
+container overhead is paid five times and the values are stored as individual
+Python objects. Streaming cannot touch it, because those values outlive the
+chunk. The columnar reshape (one rowid→ordinal index plus dense arrays, and a
+payload representation that is not a dict per row) is the remaining item, and
+it is a materially larger change than any of the four above.

--- a/context-network/decisions/0064-identity-control-plane-stays-on-postgres-sqlite.md
+++ b/context-network/decisions/0064-identity-control-plane-stays-on-postgres-sqlite.md
@@ -96,12 +96,13 @@ processed (verified to fire, not assumed to).
 ## Addendum, 2026-09-08: follow-on item 2, first results
 
 The 12.6 GB figure above is superseded. Item 2 was attacked in four slices;
-the peak RSS at 5M cold is now **8,390.6 MB (sqlite) / 8,404.8 MB (postgres)**
-— **−33%** — measured against the same rungs, backends and
+the peak RSS at 5M cold is now **8,197.4 MB (sqlite) / 8,200.3 MB (postgres)**
+— **−35%** — measured against the same rungs, backends and
 `pair_scores=spanning` as the original
 ([run 34256747975](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34256747975)
 for #2903,
 [run 34266817099](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34266817099)
+and [run 34270540909](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34270540909)
 for #2904). Wall is unchanged throughout: every slice is inside the ~19%
 run-to-run variance the store wall already carries, which is the point — this
 is a memory result, not a speed one.
@@ -113,6 +114,7 @@ is a memory result, not a speed one.
 | #2902 | `_rowid_candidates` stored sparsely | −0.08% — **a negative result** |
 | #2903 | streamed prep, row dicts bounded at O(chunk) | **8,996–9,010 MB (−28%)** |
 | #2904 | post-prep maps derived, not stored | **8,390–8,405 MB (−33% cumulative)** |
+| #2904 | one rowid index + dense lists, not four dicts | **8,197–8,200 MB (−35% cumulative)** |
 
 Three things worth carrying forward.
 
@@ -146,8 +148,31 @@ write loop's non-store wall rose a few seconds on both backends, consistently
 and as expected. ~600 MB for that is the right trade at this scale; it is
 still a trade.
 
-**Residual, and where the next slice has to go.** Of the 8.4 GB: ~2.1 GB before
-prep, ~0.4 GB the filtered frame, **~5.5 GB the derived structures**, ~0.34 GB
+**The container theory is mostly wrong, and that is the useful result.** The
+ordinal collapse was sized at ~600 MB on the reasoning that four dicts over an
+identical 5M-key set pay for the hash table four times. It returned **−204 MB
+(postgres) / −193 MB (sqlite)**, about a third. Netting off what it ADDED — 5M
+ordinal `int` objects (~140 MB) and three list slots per row (~120 MB) — the
+gross saving is ~470 MB across three removed dicts, i.e. **~31 B/row/dict**,
+not the ~100 B assumed. A dict whose keys are already shared with another dict
+is far cheaper than an isolated one.
+
+So the ~5.3 GB of derived structures is overwhelmingly **content, not
+container**, and the full columnar reshape can only pay if it changes how the
+VALUES are represented: the payload dict per row (~324 B/row, ~1.6 GB), the
+64-char hash string (~157 B/row, ~785 MB → ~320 MB as a fixed-width buffer),
+the primary id (~118 B/row). The honest ceiling on that work is perhaps 2–2.5
+GB of the 5.3, and most of it requires replacing the payload dict — the one
+change that touches `_golden_record_from_payloads` and both write paths.
+
+This is what the slice was for. It cost one small, low-risk change and it
+converted the reshape from a guess into a bounded estimate; had it returned
+600 MB the container argument would have carried the larger rewrite on its own.
+It also came free on wall — prep fell ~3–5 s, one dict write per row instead
+of four.
+
+**Residual, and where the next slice has to go.** Of the 8.2 GB: ~2.1 GB before
+prep, ~0.4 GB the filtered frame, **~5.3 GB the derived structures**, ~0.35 GB
 the write loop. The 5.5 GB is five per-row Python maps over an identical
 5M-key set — payload 324 B/row, hash 157, primary 118, source 52 — where the
 container overhead is paid five times and the values are stored as individual

--- a/context-network/decisions/0064-identity-control-plane-stays-on-postgres-sqlite.md
+++ b/context-network/decisions/0064-identity-control-plane-stays-on-postgres-sqlite.md
@@ -96,9 +96,15 @@ processed (verified to fire, not assumed to).
 ## Addendum, 2026-09-08: follow-on item 2, first results
 
 The 12.6 GB figure above is superseded. Item 2 was attacked in four slices;
-the peak RSS at 5M cold is now **9,009.6 MB (sqlite) / 8,996.5 MB (postgres)**,
-[run 34256747975](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34256747975)
-against the same rungs, backends and `pair_scores=spanning` as the original.
+the peak RSS at 5M cold is now **8,390.6 MB (sqlite) / 8,404.8 MB (postgres)**
+— **−33%** — measured against the same rungs, backends and
+`pair_scores=spanning` as the original
+([run 34256747975](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34256747975)
+for #2903,
+[run 34266817099](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34266817099)
+for #2904). Wall is unchanged throughout: every slice is inside the ~19%
+run-to-run variance the store wall already carries, which is the point — this
+is a memory result, not a speed one.
 
 | slice | what | peak RSS at 5M |
 |---|---|---|
@@ -106,8 +112,9 @@ against the same rungs, backends and `pair_scores=spanning` as the original.
 | #2900 | payload + hash computed once, not twice | (wall only, −42% on `identity_prep_record_ids`) |
 | #2902 | `_rowid_candidates` stored sparsely | −0.08% — **a negative result** |
 | #2903 | streamed prep, row dicts bounded at O(chunk) | **8,996–9,010 MB (−28%)** |
+| #2904 | post-prep maps derived, not stored | **8,390–8,405 MB (−33% cumulative)** |
 
-Two things worth carrying forward.
+Three things worth carrying forward.
 
 **The instruments disagreed with the outcome twice, in opposite directions.**
 #2902 was sized from tracemalloc at ~0.9 GB and delivered 0.08%: tracemalloc
@@ -127,9 +134,21 @@ the prep peak (12,557 MB) sat above it and only became attributable once #2903
 lowered the peak beneath it. A stage marker that does not bracket a loop hides
 that loop inside its neighbour.
 
-**Residual, and where the next slice has to go.** Of the 9.0 GB: ~2.1 GB before
-prep, ~0.4 GB the filtered frame, **~5.5 GB the derived structures**, ~0.9 GB
-the post-prep maps. The 5.5 GB is five per-row Python maps over an identical
+**A stage gap is an upper bound on what lives in it.** #2904 was sized at
+−935 MB — the entire unstaged gap between the prep peak and the write-loop
+peak — and delivered **−592 MB (postgres) / −619 MB (sqlite)**, about 65%. The
+prediction assumed the whole gap was the two maps; measured, ~620 MB was, and
+the remaining ~340 MB is the write loop's own accumulators, which were simply
+never visible on their own. An unstaged region attributes to whatever you
+guess is in it until you remove one candidate and re-measure. It also is not
+free: deriving `source_pk` on read costs a slice per member access, and the
+write loop's non-store wall rose a few seconds on both backends, consistently
+and as expected. ~600 MB for that is the right trade at this scale; it is
+still a trade.
+
+**Residual, and where the next slice has to go.** Of the 8.4 GB: ~2.1 GB before
+prep, ~0.4 GB the filtered frame, **~5.5 GB the derived structures**, ~0.34 GB
+the write loop. The 5.5 GB is five per-row Python maps over an identical
 5M-key set — payload 324 B/row, hash 157, primary 118, source 52 — where the
 container overhead is paid five times and the values are stored as individual
 Python objects. Streaming cannot touch it, because those values outlive the

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -6532,6 +6532,8 @@
           "purpose": "Identity resolution -- map run-local clusters to durable identity_ids.",
           "defines": [
             "ResolveSummary",
+            "_RecordIdView",
+            "_SourcePkView",
             "_batch_fingerprint_enabled",
             "_bulk_fast_path_enabled",
             "_bulk_flush_rows",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -6532,6 +6532,7 @@
           "purpose": "Identity resolution -- map run-local clusters to durable identity_ids.",
           "defines": [
             "ResolveSummary",
+            "_HashView",
             "_OrdinalView",
             "_RecordIdView",
             "_SourcePkView",
@@ -6545,6 +6546,7 @@
             "_golden_record_from_members",
             "_golden_record_from_payloads",
             "_hash_payload",
+            "_hash_payload_digest",
             "_initial_load_enabled",
             "_initial_load_unlogged",
             "_match_record_rows",

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -6532,8 +6532,10 @@
           "purpose": "Identity resolution -- map run-local clusters to durable identity_ids.",
           "defines": [
             "ResolveSummary",
+            "_OrdinalView",
             "_RecordIdView",
             "_SourcePkView",
+            "_SourceView",
             "_batch_fingerprint_enabled",
             "_bulk_fast_path_enabled",
             "_bulk_flush_rows",

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -189,9 +189,20 @@ def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in row.items() if not k.startswith("__")}
 
 
-def _hash_payload(payload: dict[str, Any]) -> str:
+# sha256 digest width. The stored form is the RAW digest; the 64-char hex is
+# regenerated on read (`_HashView`). Hex is 2x the bytes and, as a Python str,
+# ~113 B per row against 32 -- and it has to be built per row anyway for
+# `legacy_id`, so what this saves is retaining 5M of them, not making them.
+_HASH_BYTES = 32
+
+
+def _hash_payload_digest(payload: dict[str, Any]) -> bytes:
     blob = json.dumps(payload, sort_keys=True, default=str)
-    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+    return hashlib.sha256(blob.encode("utf-8")).digest()
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    return _hash_payload_digest(payload).hex()
 
 
 # Sentinel: ``_record_id_candidates`` was called WITHOUT a precomputed batch
@@ -329,6 +340,47 @@ class _OrdinalView(Mapping):
     def get(self, key: int, default: Any = None) -> Any:  # type: ignore[override]
         o = self._ord.get(key)
         return default if o is None else self._values[o]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._ord
+
+    def __iter__(self):
+        return iter(self._ord)
+
+    def __len__(self) -> int:
+        return len(self._ord)
+
+
+class _HashView(Mapping[int, str]):
+    """``rowid -> record_hash`` hex, stored as one contiguous digest buffer.
+
+    A sha256 hex digest is 64 characters; as a Python ``str`` that is ~113 B of
+    object plus a list slot, against 32 B for the digest it encodes. At 5M rows
+    the difference is ~445 MB of pure representation.
+
+    Regenerating the hex on read is affordable because each row's hash is read
+    at most twice in the write loop (the bulk row payload and the per-row
+    ``SourceRecord``), while it was retained for the whole of ``apply_batch``.
+    ``bytes.hex()`` and ``hashlib.sha256(...).hexdigest()`` are both lowercase,
+    so the value handed to the store is byte-identical to the old one.
+    """
+
+    __slots__ = ("_ord", "_buf")
+
+    def __init__(self, ordinals: dict[int, int], buf: bytearray) -> None:
+        self._ord = ordinals
+        self._buf = buf
+
+    def _hex(self, o: int) -> str:
+        start = o * _HASH_BYTES
+        return self._buf[start:start + _HASH_BYTES].hex()
+
+    def __getitem__(self, key: int) -> str:
+        return self._hex(self._ord[key])
+
+    def get(self, key: int, default: Any = None) -> Any:  # type: ignore[override]
+        o = self._ord.get(key)
+        return default if o is None else self._hex(o)
 
     def __contains__(self, key: object) -> bool:
         return key in self._ord
@@ -828,7 +880,10 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     _ord: dict[int, int] = {}
     _primaries: list[str] = []
     _payloads: list[dict[str, Any]] = []
-    _hashes: list[str] = []
+    # Preallocated to the frame height and truncated once the prepped count is
+    # known: appending 32 B five million times makes a bytearray double its way
+    # up, and the copy at the top end is transiently larger than the buffer.
+    _hash_buf = bytearray()
     # `source` is one scalar for the overwhelmingly common single-source case;
     # see `_SourceView`. `_src_default` is fixed by the first prepped row.
     _src_default: str | None = None
@@ -866,6 +921,7 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
         _batch_fp = _batch_fingerprint_enabled()
         _total_rows = _fa5.height
         _chunk_rows_n = _prep_chunk_rows() or max(_total_rows, 1)
+        _hash_buf = bytearray(_total_rows * _HASH_BYTES)
         for _off in range(0, max(_total_rows, 1), _chunk_rows_n):
             _chunk = _fa5.slice(_off, _chunk_rows_n)
             _crows = _chunk.select_dicts(_cols)
@@ -891,7 +947,10 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                 # were previously recomputed inside `_record_id_candidates`
                 # (5.86 us/row, ~29s at 5M).
                 _payload = _row_to_payload(row)
-                _phash = _hash_payload(_payload)
+                _digest = _hash_payload_digest(_payload)
+                # Transient: `_record_id_candidates` needs hex[:12] for
+                # `legacy_id`, but only the digest is retained.
+                _phash = _digest.hex()
                 primary_id, candidates = _record_id_candidates(
                     row, source, source_pk_col,
                     precomputed_h1=_pre,
@@ -910,11 +969,10 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                 if _o == len(_primaries):
                     _primaries.append(primary_id)
                     _payloads.append(_payload)
-                    _hashes.append(_phash)
                 else:
                     _primaries[_o] = primary_id
                     _payloads[_o] = _payload
-                    _hashes[_o] = _phash
+                _hash_buf[_o * _HASH_BYTES:(_o + 1) * _HASH_BYTES] = _digest
                 if source != _src_default:
                     _src_overrides[irid] = source
                 elif irid in _src_overrides:
@@ -925,7 +983,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
 
     _rowid_primary: Mapping[int, str] = _OrdinalView(_ord, _primaries)
     rowid_to_payload: Mapping[int, dict[str, Any]] = _OrdinalView(_ord, _payloads)
-    rowid_to_hash: Mapping[int, str] = _OrdinalView(_ord, _hashes)
+    del _hash_buf[len(_primaries) * _HASH_BYTES:]
+    rowid_to_hash: Mapping[int, str] = _HashView(_ord, _hash_buf)
     rowid_to_source: Mapping[int, str] = _SourceView(
         _ord, _src_default if _src_default is not None else "dataframe", _src_overrides
     )

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -299,6 +299,88 @@ def _record_id_candidates(
     return h1_id, [h1_id]
 
 
+class _OrdinalView(Mapping):
+    """A per-row map stored as one shared rowid->ordinal index plus a dense list.
+
+    `apply_batch`'s prep built four dicts over an IDENTICAL key set -- every
+    prepped rowid, written unconditionally in the same loop iteration. Four
+    dicts means the hash table is allocated, probed and grown four times for
+    one set of keys; only the values differ. Splitting that into one index and
+    N dense lists pays the table once and 8 bytes per row per value after that.
+
+    It is also the shape the remaining work needs: with an ordinal in hand the
+    values can become genuinely columnar (a fixed-width hash buffer, an Arrow
+    array) instead of a Python object per row. This change does NOT do that --
+    the lists still hold the same objects -- so what it measures cleanly is how
+    much of the derived-structure cost is CONTAINER rather than content.
+
+    Read-only, and keyed exactly like the dict it replaces.
+    """
+
+    __slots__ = ("_ord", "_values")
+
+    def __init__(self, ordinals: dict[int, int], values: list) -> None:
+        self._ord = ordinals
+        self._values = values
+
+    def __getitem__(self, key: int):
+        return self._values[self._ord[key]]
+
+    def get(self, key: int, default: Any = None) -> Any:  # type: ignore[override]
+        o = self._ord.get(key)
+        return default if o is None else self._values[o]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._ord
+
+    def __iter__(self):
+        return iter(self._ord)
+
+    def __len__(self) -> int:
+        return len(self._ord)
+
+
+class _SourceView(Mapping[int, str]):
+    """``rowid -> source``, as one scalar plus the rows that disagree with it.
+
+    A single-frame dedupe has no ``__source__`` column at all, so every row
+    takes the same ``"dataframe"`` default -- literally the same Python object,
+    since ``str()`` of a ``str`` is identity. The 52 B/row this cost at 5M
+    (ADR 0064) was never the strings; it was the dict holding 5M references to
+    one of them. Linkage flows DO carry a real ``__source__``, typically with a
+    handful of distinct values, so the exception map stays small there too and
+    degenerates to the old cost only if every row differs from the first.
+    """
+
+    __slots__ = ("_ord", "_default", "_overrides")
+
+    def __init__(
+        self, ordinals: dict[int, int], default: str, overrides: dict[int, str]
+    ) -> None:
+        self._ord = ordinals
+        self._default = default
+        self._overrides = overrides
+
+    def __getitem__(self, key: int) -> str:
+        if key not in self._ord:
+            raise KeyError(key)
+        return self._overrides.get(key, self._default)
+
+    def get(self, key: int, default: Any = None) -> Any:  # type: ignore[override]
+        if key not in self._ord:
+            return default
+        return self._overrides.get(key, self._default)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._ord
+
+    def __iter__(self):
+        return iter(self._ord)
+
+    def __len__(self) -> int:
+        return len(self._ord)
+
+
 class _RecordIdView(Mapping[int, str]):
     """``rowid -> chosen record_id``, without a second whole-frame dict.
 
@@ -321,7 +403,7 @@ class _RecordIdView(Mapping[int, str]):
 
     __slots__ = ("_primary", "_override")
 
-    def __init__(self, primary: dict[int, str], override: dict[int, str]) -> None:
+    def __init__(self, primary: Mapping[int, str], override: dict[int, str]) -> None:
         self._primary = primary
         self._override = override
 
@@ -358,7 +440,7 @@ class _SourcePkView(Mapping[int, str]):
 
     __slots__ = ("_recids", "_sources")
 
-    def __init__(self, recids: Mapping[int, str], sources: dict[int, str]) -> None:
+    def __init__(self, recids: Mapping[int, str], sources: Mapping[int, str]) -> None:
         self._recids = recids
         self._sources = sources
 
@@ -445,7 +527,7 @@ def _golden_record_from_members(
 
 
 def _golden_record_from_payloads(
-    payload_by_row_id: dict[int, dict[str, Any]],
+    payload_by_row_id: Mapping[int, dict[str, Any]],
     row_ids: list[int],
     field_strategies: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -740,10 +822,17 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
             _needed = _referenced_row_ids(cluster_items, emit_singletons)
             if len(_needed) < _fa5.height:
                 _fa5 = _fa5.filter_in("__row_id__", sorted(_needed))
-    rowid_to_payload: dict[int, dict[str, Any]] = {}
-    rowid_to_source: dict[int, str] = {}
-    rowid_to_hash: dict[int, str] = {}
-    _rowid_primary: dict[int, str] = {}
+    # ONE index over the prepped rowids, plus a dense list per derived value.
+    # These four were four dicts over an identical key set (every one written
+    # unconditionally in the same loop iteration below); see `_OrdinalView`.
+    _ord: dict[int, int] = {}
+    _primaries: list[str] = []
+    _payloads: list[dict[str, Any]] = []
+    _hashes: list[str] = []
+    # `source` is one scalar for the overwhelmingly common single-source case;
+    # see `_SourceView`. `_src_default` is fixed by the first prepped row.
+    _src_default: str | None = None
+    _src_overrides: dict[int, str] = {}
     # SPARSE: only rows whose candidate list differs from the singleton
     # ``[primary_id]``. Every current return in ``_record_id_candidates`` is
     # ``(x, [x])`` (verified across all four branches -- natural PK, per-row
@@ -809,15 +898,37 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
                     payload=_payload,
                     payload_hash=_phash,
                 )
-                _rowid_primary[irid] = primary_id
                 if candidates != [primary_id]:
                     _rowid_candidates[irid] = candidates
-                rowid_to_payload[irid] = _payload
-                rowid_to_source[irid] = source
-                rowid_to_hash[irid] = _phash
+                if _src_default is None:
+                    _src_default = source
+                # `setdefault` returns the EXISTING ordinal, or the one just
+                # inserted -- which equals the pre-append length. A repeated
+                # __row_id__ therefore overwrites in place, exactly as the dict
+                # form did, rather than appending a second row.
+                _o = _ord.setdefault(irid, len(_primaries))
+                if _o == len(_primaries):
+                    _primaries.append(primary_id)
+                    _payloads.append(_payload)
+                    _hashes.append(_phash)
+                else:
+                    _primaries[_o] = primary_id
+                    _payloads[_o] = _payload
+                    _hashes[_o] = _phash
+                if source != _src_default:
+                    _src_overrides[irid] = source
+                elif irid in _src_overrides:
+                    del _src_overrides[irid]
             # Release the chunk's row dicts before building the next one --
             # this is what bounds the working set.
             del _crows, _h1, _chunk
+
+    _rowid_primary: Mapping[int, str] = _OrdinalView(_ord, _primaries)
+    rowid_to_payload: Mapping[int, dict[str, Any]] = _OrdinalView(_ord, _payloads)
+    rowid_to_hash: Mapping[int, str] = _OrdinalView(_ord, _hashes)
+    rowid_to_source: Mapping[int, str] = _SourceView(
+        _ord, _src_default if _src_default is not None else "dataframe", _src_overrides
+    )
 
     # One bulk lookup over the candidate union resolves each record to an
     # existing id (legacy-fallback) and doubles as the pre-flight check the
@@ -826,8 +937,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     with _stage("identity_prep_candidate_union"):
         _all_candidates = sorted({
             c
-            for _i, _pid in _rowid_primary.items()
-            for c in (_rowid_candidates.get(_i) or (_pid,))
+            for _i, _o in _ord.items()
+            for c in (_rowid_candidates.get(_i) or (_primaries[_o],))
         })
     _existing_by_id: dict[str, str] = (
         store.lookup_entity_ids(_all_candidates) if _all_candidates else {}
@@ -842,7 +953,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
     # already in hand (~935 MB and ~5M iterations at 5M, ADR 0064).
     _recid_override: dict[int, str] = {}
     if _existing_by_id:
-        for irid, _pid in _rowid_primary.items():
+        for irid, _o in _ord.items():
+            _pid = _primaries[_o]
             candidates = _rowid_candidates.get(irid) or (_pid,)
             chosen = next((c for c in candidates if c in _existing_by_id), _pid)
             if chosen != _pid:

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -296,6 +297,84 @@ def _record_id_candidates(
         full_h1 = precomputed_h1  # type: ignore[assignment]
     h1_id = f"{source}:h1:{full_h1[:12]}"
     return h1_id, [h1_id]
+
+
+class _RecordIdView(Mapping[int, str]):
+    """``rowid -> chosen record_id``, without a second whole-frame dict.
+
+    The chosen id is the primary id from ``_record_id_candidates`` UNLESS the
+    candidate-union pre-flight found an existing record under an alternate
+    candidate -- which requires a non-empty ``_existing_by_id``, i.e. records
+    already in the store. On a cold load nothing is resident, so the override
+    is empty for every row and this view is a pure alias of ``_rowid_primary``.
+
+    Measured at 5M (ADR 0064): materializing this as its own dict cost ~500 MB
+    of the 935 MB the un-staged post-prep loop added on top of the prep peak,
+    duplicating a string reference already held by ``_rowid_primary`` for
+    every row. Same reasoning as the sparse ``_rowid_candidates`` (#2902):
+    store the exception, not the rule.
+
+    Read-only and keyed exactly like the dict it replaces -- ``__contains__``
+    and ``get`` answer from ``_rowid_primary``, whose key set is every prepped
+    row, so a rowid that never reached prep still misses.
+    """
+
+    __slots__ = ("_primary", "_override")
+
+    def __init__(self, primary: dict[int, str], override: dict[int, str]) -> None:
+        self._primary = primary
+        self._override = override
+
+    def __getitem__(self, key: int) -> str:
+        chosen = self._override.get(key)
+        return self._primary[key] if chosen is None else chosen
+
+    def get(self, key: int, default: Any = None) -> Any:  # type: ignore[override]
+        chosen = self._override.get(key)
+        if chosen is not None:
+            return chosen
+        return self._primary.get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._primary
+
+    def __iter__(self):
+        return iter(self._primary)
+
+    def __len__(self) -> int:
+        return len(self._primary)
+
+
+class _SourcePkView(Mapping[int, str]):
+    """``rowid -> source_pk``, derived on read instead of stored.
+
+    The source_pk is a pure function of the record_id and its source: strip a
+    leading ``"{source}:"`` if present. Storing it built a fresh string per row
+    plus a 5M-entry dict (~600 MB at 5M) to hold values recomputable in a few
+    hundred nanoseconds, at two call sites that each touch a member once.
+
+    Byte-identical to the eager form: ``len(source) + 1 == len(source + ":")``.
+    """
+
+    __slots__ = ("_recids", "_sources")
+
+    def __init__(self, recids: Mapping[int, str], sources: dict[int, str]) -> None:
+        self._recids = recids
+        self._sources = sources
+
+    def __getitem__(self, key: int) -> str:
+        rid = self._recids[key]
+        prefix = self._sources[key] + ":"
+        return rid[len(prefix):] if rid.startswith(prefix) else rid
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._sources
+
+    def __iter__(self):
+        return iter(self._sources)
+
+    def __len__(self) -> int:
+        return len(self._sources)
 
 
 def derive_record_id(
@@ -661,10 +740,8 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
             _needed = _referenced_row_ids(cluster_items, emit_singletons)
             if len(_needed) < _fa5.height:
                 _fa5 = _fa5.filter_in("__row_id__", sorted(_needed))
-    rowid_to_recid: dict[int, str] = {}
     rowid_to_payload: dict[int, dict[str, Any]] = {}
     rowid_to_source: dict[int, str] = {}
-    rowid_to_pk: dict[int, str] = {}
     rowid_to_hash: dict[int, str] = {}
     _rowid_primary: dict[int, str] = {}
     # SPARSE: only rows whose candidate list differs from the singleton
@@ -756,16 +833,24 @@ def apply_batch(store: IdentityStore, batch: ResolutionBatch) -> ResolveSummary:
         store.lookup_entity_ids(_all_candidates) if _all_candidates else {}
     )
     preflight_existing: dict[str, str] = {}
-    for irid, _pid in _rowid_primary.items():
-        candidates = _rowid_candidates.get(irid) or (_pid,)
-        chosen = next((c for c in candidates if c in _existing_by_id), _pid)
-        rowid_to_recid[irid] = chosen
-        src = rowid_to_source[irid]
-        rowid_to_pk[irid] = (
-            chosen[len(src) + 1:] if chosen.startswith(f"{src}:") else chosen
-        )
-        if chosen in _existing_by_id:
-            preflight_existing[chosen] = _existing_by_id[chosen]
+    # SPARSE, and empty unless the pre-flight actually hit something: the
+    # chosen id differs from the primary id only when an ALTERNATE candidate is
+    # already resident, which requires a non-empty `_existing_by_id`. With an
+    # empty pre-flight every `chosen` is `_pid` and every `chosen in
+    # _existing_by_id` is False, so the whole pass is provably a no-op -- skip
+    # it rather than walk 5M rows to write two dicts that duplicate values
+    # already in hand (~935 MB and ~5M iterations at 5M, ADR 0064).
+    _recid_override: dict[int, str] = {}
+    if _existing_by_id:
+        for irid, _pid in _rowid_primary.items():
+            candidates = _rowid_candidates.get(irid) or (_pid,)
+            chosen = next((c for c in candidates if c in _existing_by_id), _pid)
+            if chosen != _pid:
+                _recid_override[irid] = chosen
+            if chosen in _existing_by_id:
+                preflight_existing[chosen] = _existing_by_id[chosen]
+    rowid_to_recid: Mapping[int, str] = _RecordIdView(_rowid_primary, _recid_override)
+    rowid_to_pk: Mapping[int, str] = _SourcePkView(rowid_to_recid, rowid_to_source)
 
     # 2. ``scored_pairs`` is accepted for call-signature compatibility but is
     # NOT read: evidence edges come from the per-cluster ``pair_scores`` /

--- a/packages/python/goldenmatch/tests/identity/test_postprep_map_views_2904.py
+++ b/packages/python/goldenmatch/tests/identity/test_postprep_map_views_2904.py
@@ -189,3 +189,95 @@ def test_source_pk_column_matches_the_record_id_it_was_derived_from(tmp_path):
     for r in rows:
         rid, src, pk = r["record_id"], r["source"], r["source_pk"]
         assert pk == (rid[len(src) + 1:] if rid.startswith(f"{src}:") else rid)
+
+
+# --- the ordinal collapse: one index, dense lists -----------------------------
+
+def test_ordinal_view_reads_like_the_dict_it_replaced():
+    from goldenmatch.identity.resolve import _OrdinalView
+
+    v = _OrdinalView({10: 0, 20: 1, 30: 2}, ["a", "b", "c"])
+    assert v[10] == "a" and v[30] == "c"
+    assert v.get(20) == "b"
+    assert dict(v) == {10: "a", 20: "b", 30: "c"}
+    assert len(v) == 3
+    assert 20 in v and 21 not in v
+    assert v.get(21) is None
+    assert v.get(21, "fallback") == "fallback"
+    with pytest.raises(KeyError):
+        v[21]
+
+
+def test_source_view_default_and_overrides():
+    from goldenmatch.identity.resolve import _SourceView
+
+    v = _SourceView({1: 0, 2: 1, 3: 2}, "dataframe", {2: "crm"})
+    assert v[1] == "dataframe"
+    assert v[2] == "crm"
+    assert dict(v) == {1: "dataframe", 2: "crm", 3: "dataframe"}
+    assert v.get(9) is None
+    with pytest.raises(KeyError):
+        v[9]
+    # a rowid in the override but NOT prepped must still miss, or the view
+    # would resurrect a row the dict form never held
+    assert 9 not in _SourceView({1: 0}, "dataframe", {9: "ghost"})
+
+
+def test_repeated_row_id_overwrites_in_place(tmp_path):
+    """The dict form let a repeated `__row_id__` overwrite all four values.
+    The ordinal form must too -- `setdefault` returns the existing ordinal, so
+    the second row writes over the first rather than appending a second entry.
+    """
+    df = pl.DataFrame([
+        {"__row_id__": 0, "name": "First", "city": "A"},
+        {"__row_id__": 0, "name": "Second", "city": "B"},   # same row id
+        {"__row_id__": 1, "name": "Other", "city": "C"},
+    ])
+    store = IdentityStore(backend="sqlite", path=str(tmp_path / "dup.db"))
+    try:
+        resolve_clusters(
+            clusters={0: {"members": [0, 1]}}, df=df, store=store,
+            run_name="dup", dataset="views", emit_singletons=False,
+        )
+        rows = store._fetchall("SELECT record_id, payload FROM source_records", ())
+    finally:
+        store.close()
+
+    # two distinct rowids -> two records, not three
+    assert len(rows) == 2
+    payloads = [r["payload"] for r in rows]
+    assert any("Second" in p for p in payloads), "last write for rowid 0 must win"
+    assert not any("First" in p for p in payloads), "overwritten row must not survive"
+
+
+def test_multi_source_frame_keeps_per_row_source_and_pk(tmp_path):
+    """`_SourceView` degenerates to a scalar only when every row agrees. A
+    linkage frame carries a real `__source__`, so the override map is exercised
+    and every record's source / source_pk must still be its own."""
+    df = pl.DataFrame([
+        {
+            "__row_id__": i,
+            "__source__": "crm" if i % 2 else "erp",
+            "name": f"Name{i // 2}",
+        }
+        for i in range(12)
+    ])
+    store = IdentityStore(backend="sqlite", path=str(tmp_path / "multi.db"))
+    try:
+        resolve_clusters(
+            clusters={c: {"members": [2 * c, 2 * c + 1]} for c in range(6)},
+            df=df, store=store, run_name="multi", dataset="views",
+            emit_singletons=False,
+        )
+        rows = store._fetchall(
+            "SELECT record_id, source, source_pk FROM source_records", ()
+        )
+    finally:
+        store.close()
+
+    assert len(rows) == 12
+    assert {r["source"] for r in rows} == {"crm", "erp"}
+    for r in rows:
+        rid, src, pk = r["record_id"], r["source"], r["source_pk"]
+        assert rid.startswith(f"{src}:"), "record id must carry its own source"
+        assert pk == rid[len(src) + 1:]

--- a/packages/python/goldenmatch/tests/identity/test_postprep_map_views_2904.py
+++ b/packages/python/goldenmatch/tests/identity/test_postprep_map_views_2904.py
@@ -1,0 +1,191 @@
+"""`rowid_to_recid` / `rowid_to_pk` are views, and must read like the dicts.
+
+`apply_batch`'s prep used to end with a pass over every prepped row that built
+two more whole-frame dicts. Both duplicated values already in hand: the chosen
+record_id is `_rowid_primary`'s value unless the candidate-union pre-flight
+found an existing record under an ALTERNATE candidate, and the source_pk is a
+pure function of that id and its source. Measured at 5M (ADR 0064) they cost
+~935 MB -- the entire gap between the prep peak (8,061 MB) and the process
+peak recorded during the write loop (8,996 MB).
+
+They are now `_RecordIdView` (sparse override over `_rowid_primary`) and
+`_SourcePkView` (derived on read). Nine call sites read them unchanged, so the
+risk is entirely in the views answering differently from a dict. That is what
+this pins: the mapping protocol each call site actually uses, the override
+precedence the multi-candidate contract depends on, and -- through the real
+`resolve_clusters` -- a WARM store, which is the only way `_existing_by_id` is
+non-empty and the skipped loop is not skipped.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.identity import IdentityStore
+from goldenmatch.identity.resolve import (
+    _RecordIdView,
+    _SourcePkView,
+    resolve_clusters,
+)
+
+_PRIMARY = {1: "src:h1:aaaaaaaaaaaa", 2: "src:h1:bbbbbbbbbbbb", 3: "other:h1:cccccccccccc"}
+_SOURCES = {1: "src", 2: "src", 3: "other"}
+
+
+def test_recid_view_with_empty_override_is_the_primary_dict():
+    """The cold-load case: nothing resident, so the view IS `_rowid_primary`."""
+    v = _RecordIdView(_PRIMARY, {})
+    assert dict(v) == _PRIMARY
+    assert len(v) == len(_PRIMARY)
+    for k, want in _PRIMARY.items():
+        assert v[k] == want
+        assert v.get(k) == want
+        assert k in v
+
+
+def test_recid_view_misses_exactly_where_the_dict_missed():
+    """Every call site guards on `.get(...) is None` or `in`. A rowid that
+    never reached prep has no `_rowid_primary` entry, so it must still miss --
+    an override-only hit would resurrect a row the dict form dropped."""
+    v = _RecordIdView(_PRIMARY, {99: "ghost:h1:dddddddddddd"})
+    assert v.get(404) is None
+    assert v.get(404, "fallback") == "fallback"
+    assert 404 not in v
+    assert 99 not in v
+    with pytest.raises(KeyError):
+        v[404]
+
+
+def test_recid_view_override_wins():
+    """The multi-candidate contract: a pre-flight hit on an ALTERNATE candidate
+    replaces the primary id. Unreachable today (every `_record_id_candidates`
+    return is `(x, [x])`), which is exactly why it is pinned here rather than
+    left to an integration test that cannot construct it."""
+    v = _RecordIdView(_PRIMARY, {2: "src:legacy:eeeeeeeeeeee"})
+    assert v[2] == "src:legacy:eeeeeeeeeeee"
+    assert v.get(2) == "src:legacy:eeeeeeeeeeee"
+    assert v[1] == _PRIMARY[1]
+
+
+@pytest.mark.parametrize(
+    ("recid", "source", "want"),
+    [
+        ("src:h1:aaaaaaaaaaaa", "src", "h1:aaaaaaaaaaaa"),
+        ("src:12345", "src", "12345"),
+        # no "{source}:" prefix -> the whole id, matching the eager `else`
+        ("bare-id", "src", "bare-id"),
+        # a source that is a PREFIX of the id but not followed by ":" must not
+        # be stripped -- `startswith(source + ":")`, not `startswith(source)`
+        ("srcery:9", "src", "srcery:9"),
+        # empty source: eager form sliced [len("")+1:] == [1:]
+        (":tail", "", "tail"),
+    ],
+)
+def test_source_pk_view_matches_the_eager_slice(recid, source, want):
+    v = _SourcePkView({7: recid}, {7: source})
+    assert v[7] == want
+    # the eager expression this replaced, verbatim
+    assert v[7] == (
+        recid[len(source) + 1:] if recid.startswith(f"{source}:") else recid
+    )
+
+
+def test_source_pk_view_follows_the_recid_override():
+    """source_pk is derived from the CHOSEN id, not the primary one."""
+    recids = _RecordIdView(_PRIMARY, {1: "src:legacy:ffffffffffff"})
+    assert _SourcePkView(recids, _SOURCES)[1] == "legacy:ffffffffffff"
+
+
+# --- integration: the warm path, where the skipped loop is not skipped -------
+
+_N_ROWS = 60
+_PER_CLUSTER = 3
+
+
+def _frame() -> pl.DataFrame:
+    return pl.DataFrame([
+        {
+            "__row_id__": c * _PER_CLUSTER + m,
+            "name": f"Name{c}",
+            "city": f"City{c % 7}",
+            "note": None if m == 1 else f"n{c}",
+        }
+        for c in range(_N_ROWS // _PER_CLUSTER)
+        for m in range(_PER_CLUSTER)
+    ])
+
+
+def _clusters() -> dict[int, dict]:
+    return {
+        c: {"members": [c * _PER_CLUSTER + m for m in range(_PER_CLUSTER)]}
+        for c in range(_N_ROWS // _PER_CLUSTER)
+    }
+
+
+def _derived(store) -> list[tuple]:
+    return [
+        (r["record_id"], r["source"], r["source_pk"], r["record_hash"], r["payload"])
+        for r in store._fetchall(
+            "SELECT record_id, source, source_pk, record_hash, payload "
+            "FROM source_records ORDER BY record_id", (),
+        )
+    ]
+
+
+def test_warm_resolve_reuses_ids_and_derives_the_same_source_pks(tmp_path):
+    """Second pass over the same batch: `_existing_by_id` is non-empty, so the
+    pre-flight loop runs and `preflight_existing` must still be populated --
+    the one behaviour the early-out could plausibly have dropped."""
+    store = IdentityStore(backend="sqlite", path=str(tmp_path / "warm.db"))
+    try:
+        resolve_clusters(
+            clusters=_clusters(), df=_frame(), store=store,
+            run_name="cold", dataset="views", emit_singletons=False,
+        )
+        cold = _derived(store)
+        cold_entities = {
+            r["record_id"]: r["entity_id"]
+            for r in store._fetchall(
+                "SELECT record_id, entity_id FROM source_records", ()
+            )
+        }
+        assert cold, "cold pass wrote nothing -- the test measures nothing"
+
+        resolve_clusters(
+            clusters=_clusters(), df=_frame(), store=store,
+            run_name="warm", dataset="views", emit_singletons=False,
+        )
+        warm = _derived(store)
+        warm_entities = {
+            r["record_id"]: r["entity_id"]
+            for r in store._fetchall(
+                "SELECT record_id, entity_id FROM source_records", ()
+            )
+        }
+    finally:
+        store.close()
+
+    assert warm == cold
+    # The pre-flight found every record already resident and kept its entity,
+    # rather than minting new ones -- i.e. `preflight_existing` was populated.
+    assert warm_entities == cold_entities
+
+
+def test_source_pk_column_matches_the_record_id_it_was_derived_from(tmp_path):
+    """End-to-end shape of the derivation, read back out of the store."""
+    store = IdentityStore(backend="sqlite", path=str(tmp_path / "pk.db"))
+    try:
+        resolve_clusters(
+            clusters=_clusters(), df=_frame(), store=store,
+            run_name="pk", dataset="views", emit_singletons=False,
+        )
+        rows = store._fetchall(
+            "SELECT record_id, source, source_pk FROM source_records", ()
+        )
+    finally:
+        store.close()
+
+    assert rows
+    for r in rows:
+        rid, src, pk = r["record_id"], r["source"], r["source_pk"]
+        assert pk == (rid[len(src) + 1:] if rid.startswith(f"{src}:") else rid)

--- a/packages/python/goldenmatch/tests/identity/test_postprep_map_views_2904.py
+++ b/packages/python/goldenmatch/tests/identity/test_postprep_map_views_2904.py
@@ -281,3 +281,63 @@ def test_multi_source_frame_keeps_per_row_source_and_pk(tmp_path):
         rid, src, pk = r["record_id"], r["source"], r["source_pk"]
         assert rid.startswith(f"{src}:"), "record id must carry its own source"
         assert pk == rid[len(src) + 1:]
+
+
+# --- the hash digest buffer ---------------------------------------------------
+
+def test_hash_view_returns_the_same_hex_hexdigest_would():
+    import hashlib
+
+    from goldenmatch.identity.resolve import _HASH_BYTES, _HashView
+
+    payloads = [b"alpha", b"beta", b"gamma"]
+    buf = bytearray()
+    for p in payloads:
+        buf.extend(hashlib.sha256(p).digest())
+    v = _HashView({7: 0, 8: 1, 9: 2}, buf)
+    for i, p in enumerate(payloads):
+        assert v[7 + i] == hashlib.sha256(p).hexdigest()
+        assert len(v[7 + i]) == 2 * _HASH_BYTES
+    assert v.get(99) is None
+    assert v.get(99, "x") == "x"
+    assert 8 in v and 99 not in v
+    with pytest.raises(KeyError):
+        v[99]
+
+
+def test_hash_payload_helpers_agree():
+    from goldenmatch.identity.resolve import _hash_payload, _hash_payload_digest
+
+    payload = {"name": "Ann", "city": None, "n": 3}
+    assert _hash_payload(payload) == _hash_payload_digest(payload).hex()
+
+
+def test_record_hash_written_to_the_store_is_unchanged(tmp_path):
+    """The digest buffer must not change what lands in `source_records`.
+
+    Pinned against an INDEPENDENT recomputation of the documented hash --
+    json.dumps(sort_keys, default=str) over the non-dunder columns -- not
+    against the function under test, so a change to either side shows up.
+    """
+    import hashlib
+    import json
+
+    store = IdentityStore(backend="sqlite", path=str(tmp_path / "hash.db"))
+    try:
+        resolve_clusters(
+            clusters=_clusters(), df=_frame(), store=store,
+            run_name="hash", dataset="views", emit_singletons=False,
+        )
+        rows = store._fetchall(
+            "SELECT record_hash, payload FROM source_records", ()
+        )
+    finally:
+        store.close()
+
+    assert rows
+    for r in rows:
+        payload = json.loads(r["payload"])
+        want = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        assert r["record_hash"] == want

--- a/scripts/test_sync_claims_ratchet.py
+++ b/scripts/test_sync_claims_ratchet.py
@@ -61,12 +61,14 @@ KNOWN_ACTIONABLE: set[tuple[str, str, int]] = {
     # here landing at high confidence instead. Closing this means softening
     # the docstring so the pattern no longer resolves a target, not writing
     # a test against `row`.
-    # Line moved 203 -> 231 when `_prep_chunk_rows` was added above it
-    # (the streamed-prep change). Same finding, same docstring, same
-    # reason -- this registry keys on line number, so a pure insertion
-    # above an entry reads as one finding vanishing and a new one
-    # appearing.
-    ("identity/resolve.py", "_batch_fingerprint_enabled", 231),
+    # NOTE FOR THE NEXT EDITOR: this registry keys on LINE NUMBER, so any
+    # insertion above a tracked symbol fails BOTH tests at once -- the old
+    # line "no longer reproduces" and the new one is "new and untriaged" --
+    # while the finding itself is unchanged. Seen twice on 2026-09-08 alone
+    # (203 -> 231 when `_prep_chunk_rows` landed, 231 -> 243 when the
+    # derived-structure views landed). If the failure names this symbol and
+    # only the number differs, update the number; it is not a new gap.
+    ("identity/resolve.py", "_batch_fingerprint_enabled", 243),
     ("identity/snowflake_backend.py", "_rel_expr", 501),
     ("spark/identity.py", "record_id_for_row", 45),
 }


### PR DESCRIPTION
Second slice of the Arrow-native derivation path ADR 0064 points at, after #2903.

## What the 5M run actually said

[Run 34256747975](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34256747975) confirmed #2903: peak RSS at 5M cold went **12,554.8 → 9,009.6 MB (sqlite) / 12,557.6 → 8,996.5 MB (postgres)**, −28%, reproduced on both backends to within 0.15% of each other.

It also moved the peak. The stage profile now reads:

```
row_filter 2,547.7 → record_ids 8,061.5 → candidate_union 8,061.5 → write_loop 8,996.5
```

That last **+935 MB is not the write loop**. It is an *unstaged* pass between the two markers, which builds `rowid_to_recid` and `rowid_to_pk`. It was invisible while the prep peak sat at 12,557 MB above it, and only became attributable once #2903 lowered the peak beneath it.

## The change

Both maps duplicate values already in hand:

- **`rowid_to_recid`** — the chosen record_id is `_rowid_primary`'s value *unless* the candidate-union pre-flight matched an alternate candidate, which requires a non-empty `_existing_by_id`. On a cold load that is every row. Now `_RecordIdView`: a sparse override over `_rowid_primary`, the same store-the-exception shape as `_rowid_candidates` in #2902.
- **`rowid_to_pk`** — a pure function of that id and its source (strip a leading `"{source}:"`), previously materialized as a fresh string per row plus a 5M-entry dict. Now `_SourcePkView`, derived on read at the two call sites that touch it.

Both implement the mapping protocol the nine call sites already use, so **no call site changes**. The risk is confined to the views answering differently from a dict.

The pre-flight loop is also skipped outright when `_existing_by_id` is empty — with an empty pre-flight every `chosen` is `_pid` and every `chosen in _existing_by_id` is False, so the pass is provably a no-op. That is 5M iterations on a cold load.

## Tests

`tests/identity/test_postprep_map_views_2904.py`, 11 cases. The integration half runs a **warm** store, which is the only way `_existing_by_id` is non-empty and the skipped loop is not skipped; it asserts derived values and entity assignment are unchanged across cold→warm, i.e. `preflight_existing` is still populated.

The unit half pins what an integration test cannot reach: the override branch is unreachable through the public API today (every `_record_id_candidates` return is `(x, [x])`), so it is constructed directly. Also pinned: a rowid that never reached prep must still miss (`.get() is None`, `not in`) — an override-only hit would resurrect a row the dict form dropped — and the `startswith(source + ":")` boundary, so a source that is a prefix of the id but not followed by `:` is not stripped.

404 passed / 10 skipped in `tests/identity` on both the native and `GOLDENMATCH_NATIVE=0` paths, plus the snowflake-bulk and three frames-parity suites.

## What I am not claiming

The −935 MB is a prediction from the stage profile, not a measurement. I will run 5M against merged main and report it either way — #2902 predicted 0.9 GB from tracemalloc and delivered 0.08%, so a stage-boundary attribution is a better instrument than that was but still not the rung itself.

## ADR

0064 amended: the four-slice result, the residual (of the 9.0 GB: ~2.1 baseline, ~0.4 filtered frame, **~5.5 derived structures**, ~0.9 these maps), and the two places local instruments disagreed with the real rung in opposite directions. The remaining 5.5 GB is five per-row Python maps over an identical 5M-key set — streaming cannot touch it, because those values outlive the chunk. That is the columnar reshape, and it is a materially larger change than any of these four.
