### PR TITLE
fix(deps): floor every workspace-internal dependency, and gate it

### DIFF
--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pydantic>=2.7,<3",
     "openpyxl>=3.1",
     "textual>=1.0",
-    "goldencheck-types",
+    "goldencheck-types>=0.3.0",
     # Levenshtein for the fuzzy_values / cell_quality Python path (the fallback
     # when goldencheck-native is absent). goldenfuzz is our owned string-metric
     # kernel: its normalized similarity IS `1 - dist/max(len)`, the metric this

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     # precedent for how much a pydantic major moves.
     "pydantic>=2.7,<3",
     "pyyaml>=6.0",
-    "goldencheck-types",
+    "goldencheck-types>=0.3.0",
     "infermap>=0.7.0",
 ]
 

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pydantic>=2.7,<3",
     "pyyaml>=6.0",
     "goldencheck-types",
-    "infermap",
+    "infermap>=0.7.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -34,12 +34,12 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.28.1,<2",
-    "goldenmatch[mcp]",
-    "goldencheck[mcp]",
-    "goldenflow[mcp]",
-    "goldenpipe[mcp]",
-    "infermap[mcp]",
-    "goldenanalysis[mcp]",
+    "goldenmatch[mcp]>=3.17.1",
+    "goldencheck[mcp]>=3.5.0",
+    "goldenflow[mcp]>=2.2.0",
+    "goldenpipe[mcp]>=1.5.0",
+    "infermap[mcp]>=0.7.0",
+    "goldenanalysis[mcp]>=0.5.0",
     "uvicorn>=0.30",
     "starlette>=1.0.1",
 ]

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -32,7 +32,12 @@ dependencies = [
     "numpy>=1.26",
     "pyyaml>=6.0",
     "typer>=0.12",
-    "goldencheck-types",
+    # Floor is REQUIRED, not cosmetic: infermap imports UNKNOWN_ROLE /
+    # IDENTITY_KINDS / LAYER_REASONS / DomainPack from goldencheck_types,
+    # and only 0.3.0 exports them. Declared bare, a clean
+    # `pip install infermap` resolved goldencheck-types 0.1.0 and died on
+    # `import infermap`. Shipped broken in 0.7.0.
+    "goldencheck-types>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -132,6 +132,66 @@ def _check(name: str, sources: list[tuple[str, str | None]], errors: list[str]) 
         errors.append(f"{name}: version drift -> {detail}")
 
 
+_REQ_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+# A requirement is floored if it carries ANY version or URL constraint. "!="
+# alone is deliberately NOT enough: it excludes a bad release without
+# establishing a minimum, so the resolver may still pick something older than
+# the symbols the code imports.
+_FLOOR_RE = re.compile(r"(>=|==|~=|>|@|===)")
+
+
+def _workspace_dist_names() -> dict[str, Path]:
+    """Distribution name -> its pyproject, for every in-repo Python package."""
+    out: dict[str, Path] = {}
+    for pyproject in sorted((ROOT / "packages" / "python").glob("*/pyproject.toml")):
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        name = data.get("project", {}).get("name")
+        if name:
+            out[name.lower().replace("_", "-")] = pyproject
+    return out
+
+
+def _check_internal_floors(errors: list[str]) -> int:
+    """Every dependency on a SIBLING workspace package must carry a floor.
+
+    infermap 0.7.0 shipped to PyPI unimportable: it declared a bare
+    ``goldencheck-types`` while importing ``UNKNOWN_ROLE``, which only 0.3.0
+    exports, so a clean resolve took 0.1.0 and ``import infermap`` raised.
+
+    It stayed invisible in every environment that already had a newer
+    goldencheck-types on the path -- which is every environment we develop and
+    test in, because the workspace install satisfies siblings from local
+    source. That is precisely why it needs a STATIC gate: no test run inside
+    this repo can reproduce a fresh outside resolve.
+
+    Scoped to INTERNAL dependencies on purpose. A third-party floor is a
+    judgement call about a maintainer we do not control; a sibling floor is a
+    fact about code in this repo, and a missing one is always a defect.
+    """
+    local = _workspace_dist_names()
+    checked = 0
+    for name, pyproject in sorted(local.items()):
+        project = tomllib.loads(pyproject.read_text(encoding="utf-8")).get("project", {})
+        groups: list[tuple[str, list]] = [("dependencies", project.get("dependencies") or [])]
+        for extra, reqs in (project.get("optional-dependencies") or {}).items():
+            groups.append(("optional-dependencies." + extra, reqs))
+        for group, reqs in groups:
+            for req in reqs:
+                m = _REQ_NAME_RE.match(req.strip())
+                if not m:
+                    continue
+                dep = m.group(1).lower().replace("_", "-")
+                if dep not in local or dep == name:
+                    continue
+                if not _FLOOR_RE.search(req):
+                    errors.append(
+                        f"{pyproject.relative_to(ROOT)} [{group}]: {req!r} depends "
+                        f"on workspace package {dep!r} with no version floor"
+                    )
+        checked += 1
+    return checked
+
+
 def main() -> int:
     errors: list[str] = []
     checked = 0
@@ -213,15 +273,32 @@ def main() -> int:
                 )
         checked += 1
 
+    # --- Internal dependency floors (a different defect from lockstep drift) ---
+    floor_errors: list[str] = []
+    _check_internal_floors(floor_errors)
+    if floor_errors:
+        print(f"Internal dependency floor check FAILED ({len(floor_errors)}):")
+        for e in floor_errors:
+            print(f"  - {e}")
+        print()
+        print("A bare sibling dependency resolves to the OLDEST published version")
+        print("for anyone installing from an index, while every workspace env")
+        print("silently satisfies it from local source. Give it a >= floor at the")
+        print("version that exports the symbols you import.")
+
     if errors:
-        print(f"Version consistency check FAILED ({len(errors)} of {checked} packages drifted):")
+        print(f"Version consistency check FAILED ({len(errors)} problem(s) across {checked} packages):")
         for e in errors:
             print(f"  - {e}")
         print("\nBump every version-bearing file for the package in lockstep (see the")
         print("package's CLAUDE.md). This is the gate goldenflow 1.1.x lacked.")
         return 1
 
-    print(f"Version consistency OK: {checked} packages, all files in lockstep.")
+    if floor_errors:
+        return 1
+
+    print(f"Version consistency OK: {checked} packages, all files in lockstep,")
+    print("and every workspace-internal dependency carries a version floor.")
     return 0
 
 


### PR DESCRIPTION
## The report

`infermap 0.7.0` is unimportable as published:

```
uv run --no-project --with 'infermap==0.7.0' python -c "import infermap"
ImportError: cannot import name 'UNKNOWN_ROLE' from 'goldencheck_types'
```

`infermap/layers.py:38` imports `UNKNOWN_ROLE` (also `IDENTITY_KINDS`, `LAYER_REASONS`, `DomainPack`) but `pyproject.toml:35` declared `"goldencheck-types"` bare. Of the three published versions only 0.3.0 exports those names, so a clean resolve takes 0.1.0. It was the only unfloored dependency among its siblings (`numpy>=1.26`, `pyyaml>=6.0`, `typer>=0.12`) — an oversight, not a decision.

## Why it survived, and why the fix is a gate

Every environment we develop and test in satisfies siblings from **local source**, so a missing floor is invisible here by construction. No test run inside this repo can reproduce a fresh outside resolve. That makes it a static-gate problem rather than a test problem, so `check_version_consistency.py` now asserts that a dependency on a sibling workspace package carries a version constraint.

Scoped to **internal** dependencies deliberately: a third-party floor is a judgement call about a maintainer we don't control; a sibling floor is a fact about code in this repo, and a missing one is always a defect. `!=` alone doesn't count as a floor — it excludes a bad release without establishing a minimum.

## What the gate found

Seven more beyond the reported one, six in a single published package:

| package | bare sibling deps |
|---|---|
| `goldencheck` | `goldencheck-types` |
| `goldenpipe` | `goldencheck-types`, `infermap` |
| `goldensuite-mcp` | `goldenmatch`, `goldencheck`, `goldenflow`, `goldenpipe`, `infermap` — all five |

`goldensuite-mcp` is the worst: installed from an index it would resolve **every** sibling to its oldest published version. Each is now floored at the version this workspace builds and tests against.

## Verification

I reintroduced a bare declaration and watched the gate fail, rather than trusting a green run. The job carries no path filter by design ("a drift can be introduced by any change"), so it's enforced on every PR.

## Not included

An `infermap` version bump. The pyproject fix only reaches users on the next publish, and cutting that release is a separate decision.