### PR TITLE
ci(fs-lever-gate): let a dispatch A/B any lever, not just the refit threshold

### DIFF
--- a/.github/workflows/fs-lever-gate.yml
+++ b/.github/workflows/fs-lever-gate.yml
@@ -56,6 +56,14 @@ on:
         type: choice
         options: [pr, full]
         default: full
+      lever:
+        description: >-
+          Env var to A/B. Defaults to the default-ON refit threshold, which is
+          what the scheduled/PR runs guard. Point it at a default-OFF lever
+          (e.g. GOLDENMATCH_FS_TF_ADJUSTMENT) to measure whether that lever has
+          earned its flip against the same over-merge panel.
+        type: string
+        default: GOLDENMATCH_FS_REFIT_THRESHOLD
 
 permissions:
   contents: read
@@ -108,8 +116,15 @@ jobs:
             echo "datasets=--datasets person,household_hardneg,cotenant_hardneg,ncvr_synthetic" >> "$GITHUB_OUTPUT"
             echo "label=synthetic over-merge panel" >> "$GITHUB_OUTPUT"
           fi
-      - name: FS refit-threshold lever A/B (${{ steps.scope.outputs.label }})
+      - name: FS lever A/B (${{ steps.scope.outputs.label }})
+        # `lever` reaches the script through env, never interpolated into
+        # the shell: a `${{ }}` expansion inside `run:` is the
+        # template-injection shape zizmor rejects. `inputs.lever` is empty
+        # on schedule/push/PR, so the fallback keeps those runs
+        # byte-identical to the hardcoded form.
+        env:
+          LEVER: ${{ inputs.lever || 'GOLDENMATCH_FS_REFIT_THRESHOLD' }}
         run: |
           uv run python -m scripts.bench_er_headtohead.ab_lever \
-            --env GOLDENMATCH_FS_REFIT_THRESHOLD --off 0 --on 1 \
+            --env "$LEVER" --off 0 --on 1 \
             ${{ steps.scope.outputs.datasets }}


### PR DESCRIPTION
The gate hardcoded `--env GOLDENMATCH_FS_REFIT_THRESHOLD`, so the one harness built to answer *"has this lever earned its flip against the over-merge panel"* could only ever ask it about the lever already flipped.

A `lever` dispatch input now feeds `ab_lever`. It defaults to the refit threshold, and `inputs.lever` is empty on schedule/push/PR, so the standing guard those events provide is byte-identical.

Immediate use is #2908: `GOLDENMATCH_FS_TF_ADJUSTMENT`, whose own docstring names this workflow as its gate — *"flip only after the accuracy panel + qis_gate scale-neutrality prove it"*. The first dispatch through this input is what surfaced that TF was not running at all.

The input reaches the script through `env:` rather than an expression expansion inside `run:`, which is the template-injection shape zizmor rejects; the file's finding count is unchanged against main (1, pre-existing).
