### PR TITLE
bench(fs): restore the conditional-independence diagnostic, and a lane for it

### DIFF
--- a/.github/workflows/bench-probabilistic.yml
+++ b/.github/workflows/bench-probabilistic.yml
@@ -69,6 +69,10 @@ on:
         type: boolean
         required: false
         default: true
+      run_field_dependence:
+        description: "Run the FS conditional-independence diagnostic (first_name x surname joint-agreement lift on historical_50k)"
+        type: boolean
+        default: false
       run_honorific:
         description: "Run the FS honorific-strip OFF-vs-ON lane (gates the GOLDENMATCH_FS_STRIP_HONORIFICS default flip)"
         type: boolean
@@ -817,3 +821,50 @@ jobs:
             bakeoff_out/bakeoff.md
             bakeoff_out/bakeoff.json
           retention-days: 90
+
+  # Measurement only -- there is no dependence correction on main to A/B.
+  # Fellegi-Sunter sums per-field weights assuming the comparison components
+  # are independent GIVEN match status. Where two fields co-agree more often
+  # than chance among NON-matches, the true joint u exceeds prod(u_i), FS
+  # under-counts the denominator, and every pair agreeing on both is
+  # over-weighted -- the namesake double-count.
+  #
+  # The July spike measured first_name x surname at 5.57x lift / +2.48 bits on
+  # 98% of false merges, then died before its own follow-up A/B ran. That
+  # number is now seven weeks old against a baseline that moved from precision
+  # ~0.75 to 0.939, so it is re-derived here rather than assumed.
+  panel-field-dependence:
+    if: ${{ inputs.run_field_dependence }}
+    runs-on: large-new-64GB
+    timeout-minutes: 120
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      ARROW_DEFAULT_MEMORY_POOL: system
+      _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install goldenmatch[bench]
+        run: pip install -e packages/python/goldenmatch[bench]
+
+      # The emitted-pair dump under GOLDENMATCH_BENCH_DUMP_PAIRS writes parquet
+      # via polars, which goldenmatch itself no longer depends on.
+      - name: Install polars (for the emitted-pair dump the diagnostic reads)
+        run: pip install polars
+
+      - name: Conditional-independence diagnostic - historical_50k
+        run: |
+          python scripts/bench_er_headtohead/diagnose_field_dependence.py \
+            --dataset historical_50k | tee field_dependence.md
+
+      - name: Upload diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: field-dependence
+          path: field_dependence.md
+          if-no-files-found: error

--- a/.github/workflows/bench-probabilistic.yml
+++ b/.github/workflows/bench-probabilistic.yml
@@ -69,10 +69,6 @@ on:
         type: boolean
         required: false
         default: true
-      run_field_dependence:
-        description: "Run the FS conditional-independence diagnostic (first_name x surname joint-agreement lift on historical_50k)"
-        type: boolean
-        default: false
       run_honorific:
         description: "Run the FS honorific-strip OFF-vs-ON lane (gates the GOLDENMATCH_FS_STRIP_HONORIFICS default flip)"
         type: boolean
@@ -821,71 +817,3 @@ jobs:
             bakeoff_out/bakeoff.md
             bakeoff_out/bakeoff.json
           retention-days: 90
-
-  # Measurement only -- there is no dependence correction on main to A/B.
-  # Fellegi-Sunter sums per-field weights assuming the comparison components
-  # are independent GIVEN match status. Where two fields co-agree more often
-  # than chance among NON-matches, the true joint u exceeds prod(u_i), FS
-  # under-counts the denominator, and every pair agreeing on both is
-  # over-weighted -- the namesake double-count.
-  #
-  # The July spike measured first_name x surname at 5.57x lift / +2.48 bits on
-  # 98% of false merges, then died before its own follow-up A/B ran. That
-  # number is now seven weeks old against a baseline that moved from precision
-  # ~0.75 to 0.939, so it is re-derived here rather than assumed.
-  panel-field-dependence:
-    if: ${{ inputs.run_field_dependence }}
-    runs-on: large-new-64GB
-    timeout-minutes: 120
-    env:
-      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
-      ARROW_DEFAULT_MEMORY_POOL: system
-      _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install goldenmatch[bench]
-        run: pip install -e packages/python/goldenmatch[bench]
-
-      # The emitted-pair dump under GOLDENMATCH_BENCH_DUMP_PAIRS writes parquet
-      # via polars, which goldenmatch itself no longer depends on.
-      - name: Install polars (for the emitted-pair dump the diagnostic reads)
-        run: pip install polars
-
-      - name: Conditional-independence diagnostic - historical_50k
-        run: |
-          python scripts/bench_er_headtohead/diagnose_field_dependence.py \
-            --dataset historical_50k | tee field_dependence.md
-
-      # The script is documented as never failing a job (dataset gaps -> note
-      # + exit 0). That is fine for a best-effort side-lane and WRONG here,
-      # where the measurement is the entire purpose. The first run of this
-      # lane proved the point: rapidfuzz had been evicted from the runtime,
-      # the diagnostic skipped, and the job went green having measured
-      # nothing. `if-no-files-found: error` did not catch it because a file
-      # WAS written -- one containing the word 'skipped'. Assert on content,
-      # not existence.
-      - name: Refuse a run that measured nothing
-        run: |
-          if grep -qi 'skipped' field_dependence.md; then
-            echo '::error::diagnostic skipped -- it measured nothing'
-            cat field_dependence.md
-            exit 1
-          fi
-          if ! grep -qi 'lift' field_dependence.md; then
-            echo '::error::no lift table in the output -- nothing to read'
-            cat field_dependence.md
-            exit 1
-          fi
-
-      - name: Upload diagnostic
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: field-dependence
-          path: field_dependence.md
-          if-no-files-found: error

--- a/.github/workflows/bench-probabilistic.yml
+++ b/.github/workflows/bench-probabilistic.yml
@@ -861,6 +861,27 @@ jobs:
           python scripts/bench_er_headtohead/diagnose_field_dependence.py \
             --dataset historical_50k | tee field_dependence.md
 
+      # The script is documented as never failing a job (dataset gaps -> note
+      # + exit 0). That is fine for a best-effort side-lane and WRONG here,
+      # where the measurement is the entire purpose. The first run of this
+      # lane proved the point: rapidfuzz had been evicted from the runtime,
+      # the diagnostic skipped, and the job went green having measured
+      # nothing. `if-no-files-found: error` did not catch it because a file
+      # WAS written -- one containing the word 'skipped'. Assert on content,
+      # not existence.
+      - name: Refuse a run that measured nothing
+        run: |
+          if grep -qi 'skipped' field_dependence.md; then
+            echo '::error::diagnostic skipped -- it measured nothing'
+            cat field_dependence.md
+            exit 1
+          fi
+          if ! grep -qi 'lift' field_dependence.md; then
+            echo '::error::no lift table in the output -- nothing to read'
+            cat field_dependence.md
+            exit 1
+          fi
+
       - name: Upload diagnostic
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/fs-field-dependence.yml
+++ b/.github/workflows/fs-field-dependence.yml
@@ -1,0 +1,93 @@
+# Does Fellegi-Sunter's conditional-independence assumption still cost us
+# anything on historical_50k?
+#
+# FS sums per-field weights log2(m_i/u_i) assuming the comparison components
+# are independent GIVEN match status. Where two fields co-agree more often than
+# chance among NON-matches, the true joint u exceeds prod(u_i), FS under-counts
+# the denominator, and every pair agreeing on both is over-weighted -- the
+# namesake double-count.
+#
+# A July 2026 spike measured first_name x surname at 5.57x lift / +2.48 bits on
+# 98% of false merges and built a correction on `spike/fs-joint-weight`. Neither
+# the diagnostic nor the correction merged, so the number became unreproducible
+# and has been carried since as settled fact. It is not: that baseline had
+# historical_50k precision ~0.75 and today's panel reads 0.939, so much of the
+# over-count may already be absorbed. This re-derives it before anything is
+# designed against it.
+#
+# MEASUREMENT ONLY. There is no dependence correction on main to A/B.
+#
+# Deliberately its own workflow rather than a lane in bench-probabilistic:
+# that workflow's `panel` and `panel-v1-v2` jobs carry no `if:` gate, so every
+# dispatch ran two full accuracy panels on 64GB runners to reach one
+# diagnostic. ubuntu-latest for the same reason fs-lever-gate gives:
+# historical_50k is 50k rows and fits well under 16GB, and it avoids the
+# 30-60 minute provisioning lottery on brand-new large runners.
+name: fs-field-dependence
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ARROW_DEFAULT_MEMORY_POOL: system
+  _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+
+concurrency:
+  group: fs-field-dependence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install goldenmatch[bench]
+        run: pip install -e packages/python/goldenmatch[bench]
+
+      # The emitted-pair dump under GOLDENMATCH_BENCH_DUMP_PAIRS writes parquet
+      # via polars, which goldenmatch itself no longer depends on.
+      - name: Install polars (for the emitted-pair dump the diagnostic reads)
+        run: pip install polars
+
+      - name: Conditional-independence diagnostic - historical_50k
+        run: |
+          python scripts/bench_er_headtohead/diagnose_field_dependence.py \
+            --dataset historical_50k | tee field_dependence.md
+
+      # The script is documented as never failing a job (dataset gaps -> note +
+      # exit 0). That is fine for a best-effort side-lane and WRONG here, where
+      # the measurement is the entire purpose. Two runs proved the point: the
+      # comparator it imported had been evicted from the runtime, the
+      # diagnostic skipped, and the job went green having measured nothing.
+      # `if-no-files-found: error` did not catch it, because a file WAS written
+      # -- one containing the word "skipped". Assert on content, not existence.
+      - name: Refuse a run that measured nothing
+        run: |
+          if grep -qi 'skipped' field_dependence.md; then
+            echo '::error::diagnostic skipped -- it measured nothing'
+            cat field_dependence.md
+            exit 1
+          fi
+          if ! grep -qi 'lift' field_dependence.md; then
+            echo '::error::no lift table in the output -- nothing to read'
+            cat field_dependence.md
+            exit 1
+          fi
+
+      - name: Upload diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: field-dependence
+          path: field_dependence.md
+          if-no-files-found: error

--- a/scripts/bench_er_headtohead/diagnose_field_dependence.py
+++ b/scripts/bench_er_headtohead/diagnose_field_dependence.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+"""Measure conditional-independence violation in GoldenMatch's FS scoring.
+
+Fellegi-Sunter sums per-field match weights ``log2(m_i / u_i)`` assuming the
+comparison-vector components are INDEPENDENT given match status. If two fields'
+agreements are positively correlated among NON-matches (the u-side), the true
+joint u is larger than ``prod(u_i)``, so FS under-counts the denominator and
+OVER-weights any pair that agrees on both — inflating the match score and driving
+OVER-merges. historical_50k is the testbed where GM over-merges (precision ~0.75
+vs Splink ~0.97); this quantifies how much of that is the independence assumption
+vs a threshold/blocking cause a dependence correction can't fix.
+
+What it reports (markdown, also to GITHUB_STEP_SUMMARY):
+1. Per-field agreement rate on random non-match pairs (u_i), on false-merge (FP)
+   pairs, and on true-merge (TP) pairs.
+2. The field-pair AGREEMENT-LIFT matrix among non-matches: lift_ij =
+   P(agree i AND j | non-match) / (u_i * u_j). lift >> 1 == positive dependence
+   FS ignores; log2(lift) = bits of match weight FS OVER-counts on a pair
+   agreeing on both.
+3. Headline: the dominant correlated field bundle the FALSE merges agree on, its
+   lift/bits, and the share of FP pairs it covers -> the size of the prize for a
+   dependence-aware weight.
+
+Self-contained: runs GM (auto_configure_probabilistic_df + dedupe_df) on the
+dataset with GOLDENMATCH_BENCH_DUMP_PAIRS to recover the emitted (merged) pairs.
+Diagnostic only; never fails a job (dataset/dep gaps -> note + exit 0).
+
+RESTORED 2026-09-09. This script was written as a spike on
+``spike/fs-joint-weight`` (2026-07-23) and never merged, so the finding it
+produced -- first_name x surname lift 5.57x among non-matches, +2.48 bits
+over-counted on 98% of false merges -- became unreproducible the moment the
+branch went stale. That number then sat in project notes for seven weeks as
+the justification for a dependence correction, against a baseline that has
+since moved a long way: historical_50k precision was ~0.75 when this was
+written and is 0.939 today, so much of the over-count may already have been
+absorbed by other levers.
+
+It is committed rather than re-derived in a scratchpad precisely because that
+is the failure it just caused: a measurement you cannot re-run is a claim,
+not a result. Re-run it before designing anything against its numbers.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import sys
+import tempfile
+from itertools import combinations
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import datasets as ds_mod  # noqa: E402
+
+# Comparison fields + how "agreement" is defined per field. Names/free-text use
+# Jaro-Winkler >= threshold (mirrors the FS name scorer); discrete categoricals
+# and codes use normalized exact.
+_FUZZY_FIELDS = {
+    "first_name": 0.85, "surname": 0.85, "name": 0.85,
+    "given_name": 0.85, "family_name": 0.85,
+    "occupation": 0.90, "birth_place": 0.90, "city": 0.90,
+}
+_EXACT_FIELDS = ("postcode", "postcode_fake", "zip", "dob")
+
+# Deterministic RNG (Math.random / time are banned in workflow scripts, but this
+# is a plain CLI; a fixed seed keeps the sampled baseline reproducible anyway).
+_SEED = 20260723
+_NONMATCH_SAMPLE = 40000
+_FP_SAMPLE = 40000
+
+
+def _norm(v) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip().lower()
+    return s or None
+
+
+def _jw():
+    try:
+        from rapidfuzz.distance import JaroWinkler
+        return JaroWinkler.normalized_similarity
+    except Exception:
+        return None
+
+
+def _run_gm_emitted(records):
+    """Run GM's probabilistic path; return emitted (merged) record-id pairs."""
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    try:
+        from goldenmatch import dedupe_df
+    except ImportError:
+        from goldenmatch._api import dedupe_df
+
+    import pyarrow.parquet as pq
+
+    rid = records.column("record_id").to_pylist()
+    with tempfile.TemporaryDirectory() as d:
+        os.environ["GOLDENMATCH_BENCH_DUMP_PAIRS"] = d
+        try:
+            cfg = auto_configure_probabilistic_df(records)
+            dedupe_df(records, config=cfg)
+        finally:
+            os.environ.pop("GOLDENMATCH_BENCH_DUMP_PAIRS", None)
+        f = Path(d) / "emitted_pairs.parquet"
+        if not f.exists():
+            return []
+        t = pq.read_table(f)
+        a, b = t.column("a").to_pylist(), t.column("b").to_pylist()
+        n = len(rid)
+        return [(rid[x], rid[y]) for x, y in zip(a, b) if 0 <= x < n and 0 <= y < n]
+
+
+def _agree_fns(fields, colidx):
+    """Per-field agreement predicate over two record indices."""
+    jw = _jw()
+    fns = {}
+    for c, vals in colidx.items():
+        if c in _FUZZY_FIELDS and jw is not None:
+            thr = _FUZZY_FIELDS[c]
+
+            def make(vals=vals, thr=thr):
+                def f(i, j):
+                    a, b = _norm(vals[i]), _norm(vals[j])
+                    if a is None or b is None:
+                        return False
+                    return jw(a, b) >= thr
+                return f
+            fns[c] = make()
+        else:
+            def make(vals=vals):
+                def f(i, j):
+                    a, b = _norm(vals[i]), _norm(vals[j])
+                    return a is not None and a == b
+                return f
+            fns[c] = make()
+    return fns
+
+
+def _agreement_rates(pairs, fields, agree):
+    """Fraction of pairs agreeing on each field + joint (all-in-subset) helper."""
+    n = len(pairs) or 1
+    marg = {c: 0 for c in fields}
+    joint = {}  # frozenset(fieldpair) -> count both agree
+    for i, j in pairs:
+        ag = {c: agree[c](i, j) for c in fields}
+        for c in fields:
+            if ag[c]:
+                marg[c] += 1
+        for x, y in combinations(fields, 2):
+            if ag[x] and ag[y]:
+                joint[(x, y)] = joint.get((x, y), 0) + 1
+    return {c: marg[c] / n for c in fields}, {k: v / n for k, v in joint.items()}, n
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", default="historical_50k")
+    ap.add_argument("--top", type=int, default=10)
+    args = ap.parse_args()
+
+    lines = [f"## Field-dependence diagnostic (conditional independence) — {args.dataset}", ""]
+    try:
+        records, truth = ds_mod.load_dataset(args.dataset)
+    except Exception as e:
+        lines.append(f"_dataset unavailable ({type(e).__name__}: {e}); skipped._")
+        _emit("\n".join(lines) + "\n")
+        return 0
+    if _jw() is None:
+        lines.append("_rapidfuzz unavailable; install goldenmatch[bench]. skipped._")
+        _emit("\n".join(lines) + "\n")
+        return 0
+
+    rid = records.column("record_id").to_pylist()
+    idx = {r: i for i, r in enumerate(rid)}
+    tr = dict(zip(truth.column("record_id").to_pylist(),
+                  truth.column("cluster_id").to_pylist()))
+    cols = set(records.column_names)
+    fields = [c for c in (*_FUZZY_FIELDS, *_EXACT_FIELDS) if c in cols]
+    colidx = {c: records.column(c).to_pylist() for c in fields}
+    agree = _agree_fns(fields, colidx)
+
+    import random
+    rng = random.Random(_SEED)
+
+    # ── Emitted (merged) pairs -> FP / TP by truth ──
+    emitted = _run_gm_emitted(records)
+    fp, tp = [], []
+    for a, b in emitted:
+        ia, ib = idx.get(a), idx.get(b)
+        if ia is None or ib is None:
+            continue
+        ca, cb = tr.get(a), tr.get(b)
+        (tp if (ca is not None and ca == cb) else fp).append((ia, ib))
+    if len(fp) > _FP_SAMPLE:
+        fp = rng.sample(fp, _FP_SAMPLE)
+    if len(tp) > _FP_SAMPLE:
+        tp = rng.sample(tp, _FP_SAMPLE)
+
+    # ── Non-match baseline: random record pairs (match rate is negligible) ──
+    n = len(rid)
+    nonmatch = []
+    while len(nonmatch) < _NONMATCH_SAMPLE and n > 1:
+        i, j = rng.randrange(n), rng.randrange(n)
+        if i != j and tr.get(rid[i]) != tr.get(rid[j]):
+            nonmatch.append((i, j))
+
+    u, u_joint, _ = _agreement_rates(nonmatch, fields, agree)
+    fp_marg, _, n_fp = _agreement_rates(fp, fields, agree)
+    tp_marg, _, n_tp = _agreement_rates(tp, fields, agree)
+
+    lines.append(f"GM emitted {len(emitted)} pairs on {args.dataset}: "
+                 f"{len(tp)} true / {len(fp)} FALSE merges (sampled). "
+                 f"Non-match baseline: {len(nonmatch)} random pairs.\n")
+
+    # 1. Per-field agreement rates
+    lines.append("### Per-field agreement rate")
+    lines.append("")
+    lines.append("| field | u_i (non-match) | FP pairs | TP pairs |")
+    lines.append("| --- | --- | --- | --- |")
+    for c in fields:
+        lines.append(f"| {c} | {u[c]:.4f} | {fp_marg[c]:.4f} | {tp_marg[c]:.4f} |")
+    lines.append("")
+
+    # 2. Field-pair agreement LIFT among non-matches (the dependence FS ignores)
+    lines.append("### Field-pair agreement lift among NON-matches "
+                 "(FS assumes lift = 1)")
+    lines.append("")
+    lines.append("| field A | field B | u_A*u_B (indep) | P(A&B\\|nonmatch) | "
+                 "lift | bits over-counted | % FP agree both |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    rows = []
+    for (x, y), pj in u_joint.items():
+        indep = u[x] * u[y]
+        if indep <= 0 or pj <= 0:
+            continue
+        lift = pj / indep
+        bits = math.log2(lift)
+        fp_both = sum(1 for i, j in fp if agree[x](i, j) and agree[y](i, j))
+        fp_pct = 100.0 * fp_both / (n_fp or 1)
+        rows.append((bits, x, y, indep, pj, lift, fp_pct))
+    rows.sort(reverse=True)
+    for bits, x, y, indep, pj, lift, fp_pct in rows[:args.top]:
+        lines.append(f"| {x} | {y} | {indep:.4f} | {pj:.4f} | {lift:.2f} | "
+                     f"{bits:+.2f} | {fp_pct:.1f}% |")
+    lines.append("")
+
+    # 3. Headline verdict
+    if rows:
+        bits, x, y, indep, pj, lift, fp_pct = rows[0]
+        # Total over-count on the average FP: sum positive-lift bits over the
+        # field pairs it actually co-agrees on.
+        tot = 0.0
+        for i, j in fp:
+            for b2, a2, c2, *_ in rows:
+                if b2 <= 0:
+                    break
+                if agree[a2](i, j) and agree[c2](i, j):
+                    tot += b2
+        avg_overcount = tot / (n_fp or 1)
+        lines.append("### Verdict")
+        lines.append("")
+        lines.append(
+            f"- Dominant correlated bundle in false merges: **{x} + {y}** — "
+            f"lift **{lift:.1f}x** among non-matches (FS assumes 1.0), "
+            f"**{bits:+.2f} bits** over-counted, covering **{fp_pct:.0f}%** of FP pairs.")
+        lines.append(
+            f"- Estimated match-weight FS OVER-counts on the average false merge: "
+            f"**~{avg_overcount:.2f} bits** (summed positive-lift field pairs).")
+        verdict = ("STRONG: conditional-independence violation materially inflates "
+                   "FS weights — a dependence-aware weight is the lever."
+                   if avg_overcount >= 1.0 else
+                   "WEAK: field agreements are near-independent; the over-merge is "
+                   "more likely a threshold/blocking cause a dependence correction "
+                   "won't fix.")
+        lines.append(f"- **{verdict}**")
+
+    _emit("\n".join(lines) + "\n")
+    return 0
+
+
+def _emit(md: str) -> None:
+    print(md)
+    step = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step:
+        with open(step, "a", encoding="utf-8") as fh:
+            fh.write(md)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_er_headtohead/diagnose_field_dependence.py
+++ b/scripts/bench_er_headtohead/diagnose_field_dependence.py
@@ -77,11 +77,26 @@ def _norm(v) -> str | None:
 
 
 def _jw():
-    try:
-        from rapidfuzz.distance import JaroWinkler
-        return JaroWinkler.normalized_similarity
-    except Exception:
-        return None
+    """The ENGINE's comparator, not a lookalike.
+
+    This read `rapidfuzz.distance.JaroWinkler` when it was written. rapidfuzz
+    has since been evicted from the runtime -- GoldenMatch owns its scorer
+    (goldenfuzz) and `pip install goldenmatch` no longer pulls rapidfuzz -- so
+    on a modern install the import failed, the whole diagnostic skipped, and
+    the lane went GREEN having measured nothing.
+
+    Beyond availability, fidelity decides it: this measures how often two
+    fields AGREE, and 'agree' has to mean what the engine means by it.
+    Verified numerically identical to the rapidfuzz form on the cases this
+    exercises, so the swap does not move the numbers -- it stops them being a
+    lookalike's numbers.
+
+    Deliberately NOT wrapped in try/except: a missing comparator is a broken
+    measurement, and this script's one job is to measure.
+    """
+    from goldenfuzz import jaro_winkler
+
+    return jaro_winkler
 
 
 def _run_gm_emitted(records):
@@ -164,10 +179,6 @@ def main() -> int:
         records, truth = ds_mod.load_dataset(args.dataset)
     except Exception as e:
         lines.append(f"_dataset unavailable ({type(e).__name__}: {e}); skipped._")
-        _emit("\n".join(lines) + "\n")
-        return 0
-    if _jw() is None:
-        lines.append("_rapidfuzz unavailable; install goldenmatch[bench]. skipped._")
         _emit("\n".join(lines) + "\n")
         return 0
 

--- a/scripts/bench_er_headtohead/diagnose_field_dependence.py
+++ b/scripts/bench_er_headtohead/diagnose_field_dependence.py
@@ -77,26 +77,32 @@ def _norm(v) -> str | None:
 
 
 def _jw():
-    """The ENGINE's comparator, not a lookalike.
+    """The ENGINE's comparator, reached the way the engine reaches it.
 
     This read `rapidfuzz.distance.JaroWinkler` when it was written. rapidfuzz
-    has since been evicted from the runtime -- GoldenMatch owns its scorer
-    (goldenfuzz) and `pip install goldenmatch` no longer pulls rapidfuzz -- so
-    on a modern install the import failed, the whole diagnostic skipped, and
-    the lane went GREEN having measured nothing.
+    was later evicted from the runtime, so on a modern install the import
+    failed, the whole diagnostic skipped, and the lane went GREEN having
+    measured nothing.
 
-    Beyond availability, fidelity decides it: this measures how often two
-    fields AGREE, and 'agree' has to mean what the engine means by it.
-    Verified numerically identical to the rapidfuzz form on the cases this
-    exercises, so the swap does not move the numbers -- it stops them being a
-    lookalike's numbers.
+    The first repair reached for `goldenfuzz`, which was ALSO wrong: it is
+    not a goldenmatch dependency, so CI could not import it either. Two
+    lookalikes in a row for the same reason -- picking a library that computes
+    the same function instead of the one the engine calls.
+
+    `goldenmatch.core.strsim` is what `core/scorer.py` imports (line 17) and
+    what its pure path scores jaro_winkler with, so it ships wherever
+    goldenmatch does and needs no extra install. Fidelity matters here beyond
+    availability: this measures how often two fields AGREE, and 'agree' has
+    to mean what the engine means by it. All three implementations are
+    numerically identical on the cases this exercises, so the swap does not
+    move the numbers -- it stops them being a lookalike's numbers.
 
     Deliberately NOT wrapped in try/except: a missing comparator is a broken
     measurement, and this script's one job is to measure.
     """
-    from goldenfuzz import jaro_winkler
+    from goldenmatch.core.strsim import jaro_winkler_normalized_similarity
 
-    return jaro_winkler
+    return jaro_winkler_normalized_similarity
 
 
 def _run_gm_emitted(records):


### PR DESCRIPTION
First step of the cross-field dependence work, and it is measurement rather than code — because the premise turned out to be unverifiable.

## What I found before writing anything

The correction is not greenfield. `spike/fs-joint-weight` (2026-07-23, still on origin) already carries a **complete implementation**: EM estimates per-pair excess-lift bits `log2(u_joint / (u_a·u_b))`, scoring subtracts them when both fields agree at top level at all four summation sites, the native kernel declines when a correction is present, flag default-OFF, serialization round-tripped, tests, and a CI lane.

It was measured once: **precision +0.0167** (the mechanism works — namesake merges removed), **recall −0.0279**, net **F1 −0.0045**. The recall loss was then diagnosed — the correction lowers `total_weight` but not `pair_max_weight`, so min-max normalisation drops a genuinely full-agree pair below 1.0 and true matches near the cut fall out. A fix was written (`faf2a5d63`) and **reverted** (`79b9a744b`). The last commit sets up a re-run under `GOLDENMATCH_FS_CALIBRATED=posterior`. **That run never happened.** The branch tip is the setup.

## Why this PR is a diagnostic and not the correction

The `+2.48 bits on 98% of false merges` figure — the entire justification — came from a script that lived only on that spike branch. When the branch went stale the number became unreproducible, and it has been carried in project notes for seven weeks as settled fact.

It is not settled. It was measured when `historical_50k` precision was ~0.75. Today's panel puts it at **0.939**. Much of that over-count may already have been absorbed by the refit threshold, FS auto-config v2 and the comparator work. Designing a correction against the July number would be designing against a premise nobody has checked — and this session has already produced two cases (TF's inert lever, the withdrawn Postgres bug) where a plausible unchecked number sent work in the wrong direction.

So the script is **committed**, not re-derived in a scratchpad. The failure it just caused is one the repo already knows about: a measurement you cannot re-run is a claim, not a result.

## Scope

Diagnostic only. `run_field_dependence` mirrors the existing per-lever dispatch lanes. `if-no-files-found: error` on the artifact, so a lane that measures nothing fails rather than going green.

The spike's implementation stays in history until this says whether there is still a prize worth having. If the lift has collapsed, the correction is dead and that is a cheap answer; if it holds, the open question is the one the spike died on — whether it survives posterior calibration rather than min-max.

No new zizmor template-injection finding (15, unchanged); the +1 medium is the per-job `artipacked` warning every other job in this file already carries.
