### PR TITLE
fix(fs): the inert-lever warning was itself at a silenced level

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -424,7 +424,7 @@ def _compute_joint_corrections(
         # {dob, first_name, surname}, leaving one eligible field. The pair
         # the field-dependence DIAGNOSTIC names (first_name x surname, 5.57x
         # lift over random pairs) is inside that exclusion by construction.
-        logger.info(
+        logger.warning(
             "FS field-dependence: enabled, but only %d comparison field(s) "
             "are outside the blocking conditioning (%s), so no field PAIR "
             "can be evaluated. Excluded as blocking-conditioned: %s.",
@@ -440,7 +440,7 @@ def _compute_joint_corrections(
         # correction that measured no excess looked exactly like a flag
         # that was never set. Both now say so.
         observed.sort(key=lambda t: t[2], reverse=True)
-        logger.info(
+        logger.warning(
             "FS field-dependence: enabled, but no field pair cleared "
             "_FD_MIN_BITS=%.2f -- no correction applied. Top observed "
             "excess: %s. NOTE this is measured over the BLOCKED "


### PR DESCRIPTION
Follow-up to #2914 (it was already in the merge queue, so this could not go in with it).

## What the corrected A/B showed

[Run 34372003892](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34372003892), same lever with **no** `calibrated` input:

| dataset | F1 off | F1 on | dF1 | P off | P on |
|---|---|---|---|---|---|
| historical_50k | 0.8320 | 0.8320 | +0.0000 | 0.939 | 0.939 |

The baseline came back **exactly** — F1 0.8320 / P 0.939 / R 0.747 — which settles that the earlier collapse to 0.5122 / 0.361 was entirely `GOLDENMATCH_FS_CALIBRATED=posterior` and nothing else moved. That is a real finding about posterior calibration on this shape, and it needs its own investigation.

## The bug this fixes

The run carried **no field-dependence log line at all**, so `+0.0000` was still uninterpretable — exactly the state #2914's logging was added to end.

Cause: I emitted them with `logger.info`, and these runs filter INFO. The messages that *do* surface in a panel arm (non-monotonic weights, fallback link cutoff) are `logger.warning`.

So the fix written to make silence legible was itself silent. That is the fourth inert signal in this line of work and the only one I authored.

## The change

Both inert paths become `logger.warning`. That is also the right level on the merits: a flag the caller explicitly set, which then does nothing, is a warning condition — they asked for a correction and are not getting one. The success path stays INFO, because there it worked.

Verified by running the probe with **no logging configuration**, the way a panel arm runs it:

```
FS field-dependence: enabled, but only 1 comparison field(s) are outside the
blocking conditioning (birth_place), so no field PAIR can be evaluated.
Excluded as blocking-conditioned: dob, first_name, surname.
```

## What the next run answers

Which of two things is true on `historical_50k` specifically: blocking leaves fewer than two eligible fields there (closing this approach for name-blocked person data), or pairs are evaluated and fall under `_FD_MIN_BITS` (making it a threshold or population question). Both are currently open, and no panel run can distinguish them until this lands.
