### PR TITLE
feat(fs): correct the joint on blocking-conditioned pairs too

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -394,8 +394,32 @@ def _compute_joint_corrections(
     if W <= 0:
         return []
 
-    # Top-level agreement mask per regular (non-blocking) field.
-    fields = [(j, f) for j, f in enumerate(mk.fields) if f.field not in always_conditioned]
+    # Top-level agreement mask per field -- INCLUDING blocking-conditioned
+    # ones, which this deliberately no longer excludes.
+    #
+    # The exclusion was defensible and aimed at the wrong quantity. A
+    # conditioned field carries no MARGINAL information inside the block, so
+    # `_neutral_u_for` gives it a fixed u ([0.50, 0.50] at 2 levels) instead
+    # of a random-pair estimate -- a bounded agreement weight, roughly
+    # log2(0.95/0.50) = +0.93 bits, plus a disagreement penalty. That fixes
+    # the marginal explosion. It says nothing about the JOINT.
+    #
+    # On a name-blocked person shape both first_name and surname are
+    # conditioned, each contributing ~0.93 bits, SUMMED as independent --
+    # while among blocked non-matches they co-agree at ~0.97 against an
+    # independence baseline of 0.50*0.50 = 0.25. That is log2(0.97/0.25) =
+    # ~+1.96 bits over-counted on 97% of false merges (ADR 0065), almost
+    # exactly the pair's whole summed contribution -- which is the right
+    # answer, because inside the block name agreement is not merely
+    # uninformative but ANTI-informative: false merges agree on first_name
+    # 98.5% of the time against 83.7% for true merges.
+    #
+    # Excluding them is why this correction measured nothing on the panel
+    # three times: the dominant correlated pair IS the blocking key, so
+    # zero pairs were ever evaluated. The neutral prior is what makes the
+    # arithmetic well-defined here -- it is a known independence baseline
+    # rather than an estimate conditioned on the same population.
+    fields = list(enumerate(mk.fields))
     top = {}
     for j, f in fields:
         lv = comp_matrix[:, j]
@@ -416,21 +440,14 @@ def _compute_joint_corrections(
             out.append((fa.field, fb.field, excess))
     out.sort(key=lambda t: t[2], reverse=True)
     if len(fields) < 2:
-        # The correction only considers fields NOT conditioned by blocking.
-        # When the blocking key covers most comparison fields, fewer than
-        # two remain and NO pair is ever evaluated -- so it returns empty
-        # for a structural reason, not because it measured low excess.
-        # Measured on a name-blocked person shape: always_conditioned =
-        # {dob, first_name, surname}, leaving one eligible field. The pair
-        # the field-dependence DIAGNOSTIC names (first_name x surname, 5.57x
-        # lift over random pairs) is inside that exclusion by construction.
+        # Reachable only on a matchkey with fewer than two comparison fields
+        # now that blocking-conditioned fields are included. It used to fire
+        # constantly on person shapes, where the exclusion left one field.
         logger.warning(
-            "FS field-dependence: enabled, but only %d comparison field(s) "
-            "are outside the blocking conditioning (%s), so no field PAIR "
-            "can be evaluated. Excluded as blocking-conditioned: %s.",
+            "FS field-dependence: enabled, but the matchkey has only %d "
+            "comparison field(s) (%s), so no field PAIR can be evaluated.",
             len(fields),
             ", ".join(f.field for _, f in fields) or "none",
-            ", ".join(sorted(always_conditioned)) or "none",
         )
         return []
 

--- a/packages/python/goldenmatch/tests/test_fs_field_dependence.py
+++ b/packages/python/goldenmatch/tests/test_fs_field_dependence.py
@@ -101,3 +101,55 @@ def test_emresult_roundtrip_carries_corrections():
     assert back.joint_corrections == [("first_name", "surname", 1.5)]
     # off -> not serialized
     assert "joint_corrections" not in _em(None).to_dict()
+
+
+def test_detects_a_pair_the_blocking_key_conditions():
+    """A BLOCKING-conditioned pair must be corrected too — the case that
+    matters, and the one this used to exclude.
+
+    `_neutral_u_for` gives a conditioned field a fixed u ([0.50, 0.50]) rather
+    than a random-pair estimate, which bounds its MARGINAL weight to about
+    log2(0.95/0.50) = +0.93 bits. That says nothing about the joint: two
+    conditioned fields each contribute ~0.93 bits SUMMED as independent, while
+    among blocked non-matches they co-agree far above the 0.25 independence
+    baseline their neutral priors imply.
+
+    On a name-blocked person shape both first_name and surname are conditioned,
+    so excluding them meant the dominant correlated pair — 5.57x lift, +2.48
+    bits, 97% of false merges (ADR 0065) — could never be evaluated, and the
+    panel measured +0.0000 three times over.
+
+    Same data as test_detects_correlated_pair; the ONLY difference is that both
+    fields are declared blocking-conditioned.
+    """
+    rows = [[1, 1, 0]] * 40 + [[0, 0, 0]] * 40 + [[1, 0, 0]] * 10 + [[0, 1, 0]] * 10
+    comp = np.array(rows, dtype=np.int64)
+    cond = np.zeros((len(comp), 3), dtype=bool)
+    m = {"first_name": [0.1, 0.9], "surname": [0.1, 0.9], "city": [0.5, 0.5]}
+    u = {"first_name": [0.5, 0.5], "surname": [0.5, 0.5], "city": [0.5, 0.5]}
+    jc = _compute_joint_corrections(
+        comp, _mk(), m, u, 0.05, cond, {"first_name", "surname"},
+    )
+    pair = [t for t in jc if {t[0], t[1]} == {"first_name", "surname"}]
+    assert pair, (
+        "a blocking-conditioned pair must still be corrected: the exclusion is "
+        "about MARGINAL information, not the joint double-count"
+    )
+    assert pair[0][2] >= P._FD_MIN_BITS
+
+
+def test_single_comparison_field_is_reported_not_silent():
+    """Fewer than two comparison fields cannot produce a pair. That must SAY so
+    rather than return an empty list, because 'enabled and found nothing' and
+    'never enabled' were indistinguishable for three panel runs."""
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[MatchkeyField(field="only", scorer="exact", levels=2)],
+    )
+    comp = np.array([[1]] * 20 + [[0]] * 20, dtype=np.int64)
+    cond = np.zeros((len(comp), 1), dtype=bool)
+    m = {"only": [0.1, 0.9]}
+    u = {"only": [0.5, 0.5]}
+    assert _compute_joint_corrections(comp, mk, m, u, 0.05, cond, set()) == []


### PR DESCRIPTION
The field-dependence correction evaluated only fields **outside** the blocking conditioning, so on person data it never evaluated a single pair — the dominant correlated pair *is* the blocking key. Three panel A/Bs returned `+0.0000` and none was a verdict (ADR 0065).

## Why the exclusion was aimed at the wrong quantity

A conditioned field carries no **marginal** information inside its block. That is why `_neutral_u_for` gives it a fixed `u` (`[0.50, 0.50]` at 2 levels) rather than a random-pair estimate — a bounded agreement weight of roughly `log2(0.95/0.50) = +0.93` bits, plus a disagreement penalty. It exists to stop a near-unique key contributing 28 bits and dominating the score.

It fixes the marginal explosion. It says nothing about the **joint**.

Two conditioned fields each contribute ~0.93 bits, *summed as independent*. Among blocked non-matches on `historical_50k` they co-agree at ~0.97, against the `0.50 × 0.50 = 0.25` baseline their neutral priors imply:

```
excess = log2(0.97 / 0.25) ≈ +1.96 bits
```

over-counted on **97% of false merges** — almost exactly the pair's entire summed contribution. Which is the right answer, because inside the block name agreement is not merely uninformative but **anti-informative**:

| field | FP pairs agree | TP pairs agree |
|---|---|---|
| first_name | **0.985** | 0.837 |
| surname | **0.982** | 0.925 |
| occupation | **0.949** | 0.370 |

The neutral prior is what makes this well-posed: a *known* independence baseline rather than an estimate conditioned on the same population, so the excess is measured against a fixed reference instead of against itself.

## Scope

Default **OFF**; nothing shipped moves. Machinery unchanged from #2914 — EM estimation, subtraction at all four scoring sites, serialization, the flag. This removes one exclusion and rewords the guard that used to fire because of it.

## What this does not claim

That it helps. The arithmetic predicts ~2 bits on the pair carrying 97% of false merges; whether that improves F1 depends on where those pairs sit relative to the cut, which reasoning cannot settle — and subtracting evidence moves recall as well as precision. The panel A/B decides, and I'll dispatch it.

Local shapes cannot validate this: autoconfig there makes the names blocking keys *without* making them comparison fields, so the pair is absent from `mk.fields` entirely. `historical_50k` has them as both. The test therefore pins the behaviour directly, against the same data as the existing detection test, differing only in declaring both fields conditioned.
