### PR TITLE
fix(refdata): given_name_aliased_jw score_matrix promoted non-aliases

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7277,8 +7277,10 @@
             "aliases_of",
             "are_equivalent",
             "canonical_form",
+            "canonicals_of",
             "export_alias_forms",
-            "is_available"
+            "is_available",
+            "normalize_given_name"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/refdata/given_names.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/given_names.py
@@ -174,6 +174,25 @@ def aliases_of(name: str | None) -> frozenset[str]:
     return frozenset(out)
 
 
+
+def normalize_given_name(name: str) -> str:
+    """The normalization ``are_equivalent`` compares names on."""
+    return _normalize(name)
+
+
+def canonicals_of(name: str | None) -> frozenset[str]:
+    """The canonical names ``name`` belongs to -- the sets ``are_equivalent``
+    intersects. Unlike ``aliases_of``, this does NOT expand to class members."""
+    if name is None:
+        return frozenset()
+    norm = _normalize(name)
+    if not norm:
+        return frozenset()
+    _load()
+    if _state is None:
+        return frozenset()
+    return frozenset(_state.canonicals.get(norm) or ())
+
 def are_equivalent(a: str | None, b: str | None) -> bool:
     """True iff ``a`` and ``b`` share at least one canonical.
 

--- a/packages/python/goldenmatch/goldenmatch/refdata/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/scorer.py
@@ -28,8 +28,9 @@ import numpy as np
 from goldenmatch.core import strsim
 from goldenmatch.plugins.registry import PluginRegistry
 from goldenmatch.refdata.given_names import (
-    aliases_of,
     are_equivalent,
+    canonicals_of,
+    normalize_given_name,
 )
 from goldenmatch.refdata.given_names import is_available as given_names_available
 from goldenmatch.refdata.surnames import is_available, surname_idf, surname_rank
@@ -213,8 +214,9 @@ class GivenNameAliasedJW(ScorerPlugin):
 
         Algorithm:
             1. base = cdist(values, JaroWinkler.similarity)
-            2. For each input, compute its alias frozenset once.
-            3. equiv_mask[i,j] = aliases[i] & aliases[j] is non-empty.
+            2. For each input, compute its normalized form and CANONICAL set once.
+            3. equiv_mask[i,j] = normalized-equal, or canonicals intersect
+               (exactly ``are_equivalent``, the rule ``score_pair`` applies).
             4. final = where(equiv_mask, 1.0, base).
         """
         n = len(values)
@@ -226,43 +228,37 @@ class GivenNameAliasedJW(ScorerPlugin):
         if n == 0 or not given_names_available():
             return base
 
-        # Cache aliases_of per unique value — many records in a block
-        # often share the same first name (Bob, Bob, Bob...). Without
-        # this dedup, we'd call aliases_of() up to N times for identical
-        # inputs.
-        unique_lookup: dict[str, frozenset[str]] = {}
-        per_row: list[frozenset[str]] = []
-        for v in clean:
-            cache = unique_lookup.get(v)
-            if cache is None:
-                cache = aliases_of(v) if v else frozenset()
-                unique_lookup[v] = cache
-            per_row.append(cache)
+        # Equivalence must be EXACTLY `are_equivalent`, the rule `score_pair`
+        # applies and the native kernel mirrors: normalized-equal, or the two
+        # names' CANONICAL sets intersect. This used to intersect `aliases_of`
+        # MEMBER sets, which is looser: 'catherine' (canonical catherine) and
+        # 'kathy' (canonical kathleen) share the members kate/katie, so the matrix
+        # promoted a non-alias to 1.0 while score_pair and the kernel gave 0.644.
+        norm_ids: dict[str, int] = {}
+        per_value: dict[str, tuple[int, frozenset[str]]] = {}
+        norm_code = np.full(n, -1, dtype=np.int64)
+        canons: list[frozenset[str]] = []
+        for i, v in enumerate(clean):
+            cached = per_value.get(v)
+            if cached is None:
+                norm = normalize_given_name(v) if v else ""
+                code = norm_ids.setdefault(norm, len(norm_ids)) if norm else -1
+                cached = (code, canonicals_of(v) if v else frozenset())
+                per_value[v] = cached
+            norm_code[i] = cached[0]
+            canons.append(cached[1])
 
-        # Identify rows that have a non-empty alias set; pairs where
-        # either side is OOV can't be promoted by the alias rule.
-        has_aliases = np.array(
-            [bool(s) for s in per_row], dtype=bool,
-        )
-        if not has_aliases.any():
-            return base
-
-        # equiv_mask[i,j] = aliases[i] ∩ aliases[j] non-empty. Set
-        # intersection is fast on small frozensets; the worst case is
-        # O(N²) intersections, which is the same cost class as cdist
-        # itself. Skip when neither side has aliases.
-        equiv_mask = np.zeros((n, n), dtype=bool)
-        for i in range(n):
-            if not has_aliases[i]:
-                continue
-            ai = per_row[i]
-            for j in range(i + 1, n):
-                if not has_aliases[j]:
-                    continue
-                if ai & per_row[j]:
-                    equiv_mask[i, j] = True
-                    equiv_mask[j, i] = True
-
+        # Normalized-equal pairs, vectorized.
+        equiv_mask = (norm_code[:, None] == norm_code[None, :]) & (norm_code[:, None] >= 0)
+        # Canonical intersection, only among rows that have canonicals at all.
+        with_canon = [k for k in range(n) if canons[k]]
+        for x, a in enumerate(with_canon):
+            ca = canons[a]
+            for b in with_canon[x + 1:]:
+                if not ca.isdisjoint(canons[b]):
+                    equiv_mask[a, b] = True
+                    equiv_mask[b, a] = True
+        np.fill_diagonal(equiv_mask, False)  # the diagonal keeps base, as before
         return np.where(equiv_mask, np.float32(1.0), base)
 
 

--- a/packages/python/goldenmatch/tests/test_given_name_alias_matrix_parity.py
+++ b/packages/python/goldenmatch/tests/test_given_name_alias_matrix_parity.py
@@ -1,0 +1,52 @@
+"""``GivenNameAliasedJW.score_matrix`` must apply exactly ``score_pair``'s alias rule.
+
+``score_pair`` (which EM trains with) and the native kernel treat two given names as
+aliases when they are normalized-equal or their CANONICAL sets intersect
+(``are_equivalent``). ``score_matrix`` used to intersect ``aliases_of`` MEMBER sets,
+which is looser: 'catherine' (canonical catherine) and 'kathy' (canonical kathleen)
+share the members kate/katie, so the numpy FS route scored them 1.0 while the scalar
+route and the kernel scored 0.644. historical_50k scores ``first_name`` with this
+scorer.
+"""
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from goldenmatch.refdata import given_names as G
+from goldenmatch.refdata import scorer as S
+from goldenmatch.refdata.scorer import GivenNameAliasedJW
+
+pytestmark = pytest.mark.skipif(
+    not S.given_names_available(), reason="given-name alias pack not bundled",
+)
+
+
+def test_known_positive_the_pair_shares_members_but_not_canonicals():
+    """If this stops holding, the regression below tests nothing."""
+    assert G.are_equivalent("catherine", "kathy") is False
+    assert G.aliases_of("catherine") & G.aliases_of("kathy")
+
+
+def test_matrix_does_not_promote_names_that_share_only_a_member():
+    sc = GivenNameAliasedJW()
+    got = float(sc.score_matrix(["catherine", "kathy"])[0][1])
+    assert got == pytest.approx(sc.score_pair("catherine", "kathy"), abs=1e-6)
+
+
+def test_matrix_matches_score_pair_over_the_whole_alias_table():
+    """Every name the table knows, plus OOV, empty, and case/whitespace variants."""
+    sc = GivenNameAliasedJW()
+    forms = G.export_alias_forms()
+    names: list[str | None] = sorted({c for c, _ in forms} | {n for _, fs in forms for n in fs})
+    assert len(names) > 50, "alias table unexpectedly small; the sweep would prove little"
+    names += ["zzqx", "", "Bob", " bob ", "KATHY"]
+    m = sc.score_matrix(names)
+    bad = []
+    for i, j in itertools.combinations(range(len(names)), 2):
+        want = sc.score_pair(names[i], names[j])
+        if want is None:
+            continue
+        if abs(float(m[i][j]) - want) > 1e-6:
+            bad.append((names[i], names[j], float(m[i][j]), want))
+    assert not bad, f"{len(bad)} pairs disagree with score_pair, e.g. {bad[:5]}"


### PR DESCRIPTION
Closes #2925.

## The bug

`GivenNameAliasedJW.score_matrix` and `score_pair` disagreed about which given names are aliases.

| rule | used by | equivalent when |
|---|---|---|
| `are_equivalent(a, b)` | `score_pair` (EM training), native kernel | normalized-equal, or **canonical** sets intersect |
| `aliases_of(a) & aliases_of(b)` | `score_matrix` (numpy FS route), before this PR | **member** sets intersect |

Member intersection is looser. `catherine` (canonical `catherine`) and `kathy` (canonical `kathleen`) share the members `kate` and `katie`, so the matrix scored them **1.0** while `score_pair` and the kernel scored **0.644**. Swept over every name in the bundled alias table, plus unknown, empty and case/whitespace variants, the two disagreed on **275 pairs** (for example `al` vs `alexa`: 1.0 vs 0.84).

The numpy FS route uses this matrix, so wherever FS scoring fell back to numpy, non-aliases got the top level and maximum match weight. Those are different levels from the ones EM trained on, and different results from the native route.

## The fix

`score_matrix` now applies `are_equivalent`'s rule exactly. Normalized-equal pairs are computed vectorized; canonical intersection loops only over rows that have canonicals. New helpers `canonicals_of` and `normalize_given_name` expose exactly the sets and normalization `are_equivalent` compares on, so the matrix and pair rules can't drift apart again.

## Evidence

- **Whole-table sweep test:** red on the old matrix (275 disagreements), green on the new. Its known-positive asserts `catherine`/`kathy` share members but not canonicals, so it can't pass vacuously.
- **Native vs numpy, fixed-seed fixture, fresh kernel:** `given_name_aliased_jw` differing pairs **18 → 0** under both missing-value modes.
- **Panel, native vs numpy, TF off** ([run 34482807520](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34482807520)): identical partitions on all five datasets, including historical_50k (241,767 / 241,767). historical_50k scores `first_name` with this scorer; this was the residual after #2924's float32 fix.
- **312 related tests pass**, including the native alias and name-scorer parity suites and the existing `score_matrix` tests. None depended on the looser rule.

That panel run was on a branch stacking this fix on #2924. This PR is rebased onto `main` after #2924 merged, so its diff is this fix alone.
