### PR TITLE
bench(blocking): measure meta-blocking and pass-signature pruning on historical_50k

### DIFF
--- a/scripts/bench_er_headtohead/README.md
+++ b/scripts/bench_er_headtohead/README.md
@@ -300,6 +300,17 @@ Current operating point: auto-config's 8 passes, **11,977,484 candidates, PC 0.8
 Open: one dataset; the phi threshold and mode rule were chosen after seeing these
 curves (phi 0.7 fails on the 8-pass set); PC is not F1.
 
+**The `surname` soundex pass carries an earlier refutation (2026-07-24).**
+Auto-config does not produce it: `surname` fails `_is_scale_safe` (#876/#715),
+because Zipf-concentrated surname blocks grow with N and blow the pairs-per-row
+budget. Forcing the pass in at 20k rows also made FS F1 **worse** (+surname soundex
++ birth_place: 0.8136 to 0.7697 linear, 0.4972 under the evidence cut), because FS
+estimates m, u and the prior from the candidate population. Pruning answers the
+second problem at most, since FS would train on the pruned set; it does nothing for
+the first, because the pairs are still generated before they are pruned. Pair
+completeness here is therefore an upper bound on what the pass could buy, not a
+case for shipping it.
+
 ## Honest caveats (carried into the results doc)
 
 - **Blocking asymmetry is reported, not hidden.** GoldenMatch's bucket path does

--- a/scripts/bench_er_headtohead/README.md
+++ b/scripts/bench_er_headtohead/README.md
@@ -263,6 +263,42 @@ python scripts/bench_er_headtohead/orchestrate.py \
 | `orchestrate.py` | Lane x shape x scale sweep; subprocess-per-datapoint; `{header, results}` aggregate; per-shape/lane markdown. |
 | `merge_results.py` | Union N dispatch artifacts (later-timestamp-wins); render final tables. |
 | `../../.github/workflows/bench-er-headtohead.yml` | CI lane (64 GB runner shape matrix, builds native, pinned splink, merge job). |
+| `measure_meta_blocking.py` | Standard meta-blocking (CBS/JS/ECBS weights x WEP/CEP/WNP/CNP pruning) over the pipeline's own multi-pass candidate set; pair completeness vs candidates. |
+| `measure_blocking_signatures.py` | Pass-signature pruning: label oracle, unsupervised EM over pass co-fire bits, and EM over phi-grouped passes. |
+
+## Meta-blocking measurement (historical_50k, 2026-09-10)
+
+Both scripts rebuild the candidate set with `build_blocks`, one static pass at a
+time, and refuse to report unless the rebuilt comparison count equals
+`measure_blocking_profile` for the same passes. They measure **pair completeness
+(PC) against candidate count**, not end-to-end F1. Run locally on the vendored
+parquet: `python scripts/bench_er_headtohead/measure_blocking_signatures.py
+[--extra surname:lowercase,soundex] [--phi 0.5] [--out f.json]`; `--signatures-json
+f.json` reruns the analysis without the rebuild.
+
+Current operating point: auto-config's 8 passes, **11,977,484 candidates, PC 0.8793**.
+
+- **Standard meta-blocking loses about 20 PC points** at any useful pruning level.
+  Five of the eight passes derive from name fields, so namesakes share several
+  blocks from one fact: pairs sharing exactly 4 blocks are 1.1% true.
+- **The pass signature carries the signal, with labels.** With one added
+  `surname` soundex pass (reachable PC 0.9379 over 13.61M), ranking signatures by
+  true purity reaches PC 0.8793 at 4.06M candidates and 0.93 at 9.53M.
+- **Unsupervised EM over the raw pass bits fails** (PC 0.6327 within 12M). It fits
+  a match prior of 0.24 where the true share is 0.021 and learns name passes as
+  strong match evidence.
+- **Merging correlated passes first recovers most of it without labels.** Passes
+  whose phi over the candidate pairs is at least 0.5 become one feature. EM then
+  finds two modes. The textbook maximum-likelihood mode is the wrong one (prior
+  0.54), and **the smallest-prior mode** (0.0073) reaches PC 0.8793 at 7.29M, 0.93
+  at 9.61M and 0.9319 within 12M, against 0.8793 today.
+- **Fixing u from random record pairs, Splink-style, does not help**: PC 0.8793
+  needs 12.17M.
+- On auto-config's 8 passes alone, the same rule matches the grouped oracle
+  (PC 0.85 at 7.07M) but cannot exceed the 0.8793 those passes allow.
+
+Open: one dataset; the phi threshold and mode rule were chosen after seeing these
+curves (phi 0.7 fails on the 8-pass set); PC is not F1.
 
 ## Honest caveats (carried into the results doc)
 

--- a/scripts/bench_er_headtohead/measure_blocking_signatures.py
+++ b/scripts/bench_er_headtohead/measure_blocking_signatures.py
@@ -1,0 +1,469 @@
+"""Does WHICH blocking passes a pair co-fires in separate true pairs from noise?
+
+``measure_meta_blocking.py`` found standard meta-blocking loses 20+ points of pair
+completeness on historical_50k, and the reason is structural: 5 of auto-config's 8
+passes derive from name fields, so namesakes accumulate several shared blocks from
+one fact (pairs sharing exactly 4 blocks are 1.1% true), while typo'd true
+duplicates fall out of the name passes and share only 1-2 blocks. Counting shared
+blocks double-counts correlated passes.
+
+This asks whether the SET of passes a pair co-fires in carries the signal the count
+lacks, in three steps:
+
+1. ORACLE (labels): group candidate pairs by pass signature (bitmask of passes they
+   share a block in), rank signatures by true purity, and read the pair-completeness
+   vs candidate-count curve. This is an upper bound for any signature-based pruning;
+   if it cannot beat the current operating point, the idea is dead.
+2. ZERO-CONFIG (no labels): fit a two-class Bernoulli mixture over the signature bits
+   by EM (Fellegi-Sunter applied to blocking passes), rank signatures by the match
+   log-likelihood ratio, and read the same curve. The gap to the oracle is what a
+   real implementation would forfeit.
+3. GROUPED (no labels): the mixture assumes passes are independent within a class,
+   which correlated name passes break. Measure pass-to-pass co-firing (phi over the
+   candidate pairs, no labels), merge passes whose phi clears a threshold into one
+   "any of these fired" feature, and rerun the oracle and EM over the groups.
+
+EM is run from several starts and two label-free rules pick among the modes it finds:
+``max-likelihood`` (the textbook choice) and ``smallest-prior`` (matches are rare
+among candidate pairs, so keep the mode that says so). A third variant fixes u from
+RANDOM record pairs, Splink-style, and fits only m and the prior over the full pair
+space; it is kept as a measured negative.
+
+The candidate set is the pipeline's own: rebuilt with ``build_blocks`` and checked
+against ``measure_blocking_profile`` before anything is reported. ``--signatures-json``
+reuses a previous run's ``--out`` and skips the rebuild.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+PC_TARGETS = (0.80, 0.85, 0.8793, 0.90, 0.93)
+BUDGETS = (1_000_000, 2_000_000, 4_000_000, 6_000_000, 8_000_000, 11_977_484)
+EM_STARTS = tuple(
+    (pi, pm, pu)
+    for pi in (0.001, 0.01, 0.05, 0.2, 0.5)
+    for pm, pu in ((0.8, 0.05), (0.6, 0.3), (0.9, 0.5))
+)
+
+
+def _signatures(df_rowid, cfg, keys, gt):
+    import duckdb
+    import pyarrow as pa
+    from goldenmatch.core.blocker import measure_blocking_profile
+    from goldenmatch.core.frame import to_frame
+    from measure_meta_blocking import _members_for_passes
+
+    passes, blocks, rids, per_pass = _members_for_passes(to_frame(df_rowid), cfg.blocking, keys)
+    rebuilt = sum(p["comparisons"] for p in per_pass)
+    probe = cfg.model_copy(
+        update={"blocking": cfg.blocking.model_copy(update={"passes": list(keys)})}
+    )
+    prof = measure_blocking_profile(df_rowid, probe)
+    if prof is None or int(prof.total_comparisons) != rebuilt:
+        raise SystemExit(
+            f"RECONSTRUCTION MISMATCH: rebuilt {rebuilt:,} vs profile {None if prof is None else prof.total_comparisons}"
+        )
+
+    con = duckdb.connect()
+    con.execute("PRAGMA memory_limit='3GB'")
+    con.register(
+        "members_arrow",
+        pa.table(
+            {
+                "pass": pa.array(passes, pa.int32()),
+                "block": pa.array(blocks, pa.int64()),
+                "rid": pa.array(rids, pa.int64()),
+            }
+        ),
+    )
+    con.register(
+        "gt_arrow",
+        pa.table(
+            {
+                "i": pa.array([a for a, _ in gt], pa.int64()),
+                "j": pa.array([b for _, b in gt], pa.int64()),
+            }
+        ),
+    )
+    con.execute("CREATE TEMP TABLE m AS SELECT * FROM members_arrow")
+    con.execute("CREATE TEMP TABLE g AS SELECT least(i, j) AS i, greatest(i, j) AS j FROM gt_arrow")
+    con.execute(
+        "CREATE TEMP TABLE e AS SELECT a.rid AS i, b.rid AS j, bit_or((1::BIGINT) << a.pass) AS mask "
+        "FROM m a JOIN m b ON a.block = b.block AND a.rid < b.rid GROUP BY 1, 2"
+    )
+    rows = con.execute(
+        "SELECT e.mask, count(*) AS pairs, sum((g.i IS NOT NULL)::INT) AS true_pairs "
+        "FROM e LEFT JOIN g ON g.i = e.i AND g.j = e.j GROUP BY 1"
+    ).fetchall()
+    total_pairs = con.execute("SELECT count(*) FROM e").fetchone()[0]
+    con.close()
+    sigs = [{"mask": int(mk), "pairs": int(p), "true_pairs": int(t or 0)} for mk, p, t in rows]
+    return sigs, per_pass, rebuilt, int(total_pairs)
+
+
+def _curve(sigs_sorted, n_gt):
+    cum_pairs = cum_true = 0
+    pts = []
+    for s in sigs_sorted:
+        cum_pairs += s["pairs"]
+        cum_true += s["true_pairs"]
+        pts.append((cum_pairs, cum_true / n_gt))
+    return pts
+
+
+def _read_curve(pts):
+    at_target = {}
+    for t in PC_TARGETS:
+        hit = next((c for c, pc in pts if pc >= t - 1e-12), None)
+        at_target[t] = hit
+    at_budget = {}
+    for b in BUDGETS:
+        best = 0.0
+        for c, pc in pts:
+            if c <= b:
+                best = pc
+            else:
+                break
+        at_budget[b] = best
+    return at_target, at_budget
+
+
+def _clip(v):
+    return min(max(v, 1e-4), 1 - 1e-4)
+
+
+def _em(sigs, n, start=(0.02, 0.8, 0.05), iters=500):
+    """Two-class Bernoulli mixture over signature bits, weighted by pair counts.
+
+    Returns (llr per signature, prior, m, u, log-likelihood)."""
+    pi, pm0, pu0 = start
+    X = [[(s["mask"] >> k) & 1 for k in range(n)] for s in sigs]
+    w = [s["pairs"] for s in sigs]
+    total = float(sum(w))
+    pm, pu = [pm0] * n, [pu0] * n
+    ll = 0.0
+    for _ in range(iters):
+        resp, ll = [], 0.0
+        for x, c in zip(X, w):
+            lm = math.log(pi) + sum(math.log(pm[k] if x[k] else 1 - pm[k]) for k in range(n))
+            lu = math.log(1 - pi) + sum(math.log(pu[k] if x[k] else 1 - pu[k]) for k in range(n))
+            mx = max(lm, lu)
+            z = math.exp(lm - mx) + math.exp(lu - mx)
+            ll += c * (mx + math.log(z))
+            resp.append(math.exp(lm - mx) / z)
+        wm = sum(r * c for r, c in zip(resp, w))
+        wu = total - wm
+        pi = min(max(wm / total, 1e-6), 1 - 1e-6)
+        pm = [
+            _clip(sum(r * c * x[k] for r, c, x in zip(resp, w, X)) / max(wm, 1e-12))
+            for k in range(n)
+        ]
+        pu = [
+            _clip(sum((1 - r) * c * x[k] for r, c, x in zip(resp, w, X)) / max(wu, 1e-12))
+            for k in range(n)
+        ]
+    # Label guard: the match class is the one whose passes co-fire more.
+    if sum(pm) < sum(pu):
+        pm, pu, pi = pu, pm, 1 - pi
+    llr = [
+        sum(
+            math.log((pm[k] if x[k] else 1 - pm[k]) / (pu[k] if x[k] else 1 - pu[k]))
+            for k in range(n)
+        )
+        for x in X
+    ]
+    return llr, pi, pm, pu, ll
+
+
+def _em_fixed_u(sigs, n, all_pairs, iters=300):
+    """Splink-style: u from random record pairs, fit m and the prior over ALL pairs.
+
+    The all-zero cell is every non-candidate pair. Returns (llr, prior, m, u)."""
+    cand = sum(s["pairs"] for s in sigs)
+    cells = list(sigs) + [{"mask": 0, "pairs": all_pairs - cand}]
+    u = [sum(s["pairs"] for s in sigs if (s["mask"] >> k) & 1) / all_pairs for k in range(n)]
+    X = [[(c["mask"] >> k) & 1 for k in range(n)] for c in cells]
+    w = [c["pairs"] for c in cells]
+    lu = [sum(math.log(u[k] if x[k] else 1 - u[k]) for k in range(n)) for x in X]
+    pi, m = 1e-4, [0.9] * n
+    for _ in range(iters):
+        resp = []
+        for x, luc in zip(X, lu):
+            lm = math.log(pi) + sum(math.log(m[k] if x[k] else 1 - m[k]) for k in range(n))
+            l0 = math.log(1 - pi) + luc
+            mx = max(lm, l0)
+            resp.append(math.exp(lm - mx) / (math.exp(lm - mx) + math.exp(l0 - mx)))
+        wm = sum(r * c for r, c in zip(resp, w))
+        pi = min(max(wm / all_pairs, 1e-9), 1 - 1e-9)
+        m = [_clip(sum(r * c * x[k] for r, c, x in zip(resp, w, X)) / wm) for k in range(n)]
+    llr = [
+        sum(math.log((m[k] if x[k] else 1 - m[k]) / (u[k] if x[k] else 1 - u[k])) for k in range(n))
+        for x in X[:-1]
+    ]
+    return llr, pi, m, u
+
+
+def _phi(sigs, n_passes):
+    """Pass-to-pass phi coefficient over candidate pairs. Uses no labels."""
+    total = float(sum(s["pairs"] for s in sigs))
+    ones = [0.0] * n_passes
+    both = [[0.0] * n_passes for _ in range(n_passes)]
+    for s in sigs:
+        bits = [k for k in range(n_passes) if (s["mask"] >> k) & 1]
+        for a in bits:
+            ones[a] += s["pairs"]
+            for b in bits:
+                both[a][b] += s["pairs"]
+    phi = [[0.0] * n_passes for _ in range(n_passes)]
+    for a in range(n_passes):
+        for b in range(n_passes):
+            pa, pb, pab = ones[a] / total, ones[b] / total, both[a][b] / total
+            den = math.sqrt(pa * (1 - pa) * pb * (1 - pb))
+            phi[a][b] = (pab - pa * pb) / den if den > 0 else 0.0
+    return phi
+
+
+def _groups(phi, threshold):
+    """Single-linkage merge of passes whose phi clears the threshold."""
+    n = len(phi)
+    parent = list(range(n))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a in range(n):
+        for b in range(a + 1, n):
+            if phi[a][b] >= threshold:
+                parent[find(a)] = find(b)
+    by_root: dict[int, list[int]] = {}
+    for k in range(n):
+        by_root.setdefault(find(k), []).append(k)
+    return sorted(by_root.values())
+
+
+def _regroup(sigs, groups):
+    """Collapse pass signatures onto group signatures: a group fires if any member did."""
+    agg: dict[int, dict] = {}
+    for s in sigs:
+        gm = 0
+        for g, members in enumerate(groups):
+            if any((s["mask"] >> k) & 1 for k in members):
+                gm |= 1 << g
+        a = agg.setdefault(gm, {"mask": gm, "pairs": 0, "true_pairs": 0})
+        a["pairs"] += s["pairs"]
+        a["true_pairs"] += s["true_pairs"]
+    return list(agg.values())
+
+
+def _label(mask, per_pass):
+    names = []
+    for p in per_pass:
+        if (mask >> p["pass"]) & 1:
+            t = "+".join(x for x in p["transforms"] if x not in ("lowercase", "strip")) or "raw"
+            names.append(f"{'/'.join(p['fields'])}[{t}]")
+    return " & ".join(names)
+
+
+def _rank(sigs, llr):
+    order = sorted(range(len(sigs)), key=lambda i: -llr[i])
+    return [sigs[i] for i in order]
+
+
+def _report_curve(name, ranked, n_gt, report):
+    at_t, at_b = _read_curve(_curve(ranked, n_gt))
+    report["curves"][name] = {
+        "candidates_for_pc": {str(k): v for k, v in at_t.items()},
+        "pc_at_budget": {str(k): v for k, v in at_b.items()},
+    }
+    print(f"\n{name}:")
+    print(
+        "  candidates needed for PC:  "
+        + "  ".join(
+            f"{t:.4f}->{('%.2fM' % (v / 1e6)) if v else 'unreachable'}" for t, v in at_t.items()
+        )
+    )
+    print(
+        "  best PC within budget:     "
+        + "  ".join(f"{b / 1e6:.1f}M->{v:.4f}" for b, v in at_b.items())
+    )
+
+
+def _oracle(sigs):
+    return sorted(sigs, key=lambda s: (-(s["true_pairs"] / s["pairs"]), -s["true_pairs"]))
+
+
+def _evaluate_features(title, sigs, names, n_gt, all_pairs, out):
+    """Oracle, multi-start EM under both mode rules, and fixed-u EM over one feature set."""
+    n = len(names)
+    print(f"\n=== {title}: {n} features, {len(sigs)} signatures ===")
+    for g, name in enumerate(names):
+        print(f"  feature {g}: {name}")
+    fits = [_em(sigs, n, start) for start in EM_STARTS]
+    modes = sorted({(round(f[1], 6), round(f[4])) for f in fits})
+    print(
+        f"  EM modes over {len(EM_STARTS)} starts (prior, log-likelihood): "
+        + "  ".join(f"({p:.4f}, {ll:,})" for p, ll in modes)
+    )
+    ml = max(fits, key=lambda f: f[4])
+    small = min(fits, key=lambda f: f[1])
+    for rule, fit in (("max-likelihood", ml), ("smallest-prior", small)):
+        _, pi, pm, pu, ll = fit
+        print(
+            f"  {rule} mode: prior {pi:.4f}; weights "
+            + " ".join(f"{math.log2(pm[g] / pu[g]):+.2f}b" for g in range(n))
+        )
+        out.setdefault("em", {})[rule] = {"pi": pi, "m": pm, "u": pu, "loglik": ll}
+    _report_curve(f"{title} | oracle (labels)", _oracle(sigs), n_gt, out)
+    _report_curve(f"{title} | EM max-likelihood mode (no labels)", _rank(sigs, ml[0]), n_gt, out)
+    _report_curve(f"{title} | EM smallest-prior mode (no labels)", _rank(sigs, small[0]), n_gt, out)
+    llr, pi, m, u = _em_fixed_u(sigs, n, all_pairs)
+    print(
+        f"\n  fixed-u prior {pi:.2e}; weights "
+        + " ".join(f"{math.log2(m[g] / u[g]):+.1f}b" for g in range(n))
+    )
+    out["em"]["fixed-u"] = {"pi": pi, "m": m, "u": u}
+    _report_curve(
+        f"{title} | EM fixed-u from random pairs (no labels)", _rank(sigs, llr), n_gt, out
+    )
+
+
+def _n_records_historical_50k():
+    import pyarrow.parquet as pq
+
+    from scripts.autoconfig_quality import datasets as D
+
+    return pq.ParquetFile(D._VENDORED / "historical_50k.parquet").metadata.num_rows
+
+
+def _load_or_build(args):
+    if args.signatures_json:
+        data = json.loads(Path(args.signatures_json).read_text(encoding="utf-8"))
+        sigs = [
+            {"mask": s["mask"], "pairs": s["pairs"], "true_pairs": s["true_pairs"]}
+            for s in data["signatures"]
+        ]
+        n_records = data.get("n_records") or _n_records_historical_50k()
+        print(f"loaded {len(sigs)} signatures from {args.signatures_json} (rebuild skipped)")
+        return sigs, data["passes"], int(data["total_pairs"]), int(data["gt_pairs"]), n_records
+
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    from goldenmatch.config.schemas import BlockingKeyConfig
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
+    from scripts.autoconfig_quality import datasets as D
+
+    df, gt = D._historical_50k()
+    cfg = auto_configure_probabilistic_df(df)
+    df_rowid = df.with_row_index("__row_id__") if "__row_id__" not in df.columns else df
+    keys = list(cfg.blocking.resolved_keys())
+    for spec in args.extra:
+        field, _, tr = spec.partition(":")
+        keys.append(BlockingKeyConfig(fields=[field], transforms=[t for t in tr.split(",") if t]))
+    sigs, per_pass, rebuilt, total_pairs = _signatures(df_rowid, cfg, keys, gt)
+    print(f"passes={len(keys)}  comparisons rebuilt {rebuilt:,} == profile (known-positive OK)")
+    return sigs, per_pass, total_pairs, len(gt), df.height
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--extra", action="append", default=[], help='extra pass "field:t1,t2" (repeatable)'
+    )
+    ap.add_argument(
+        "--phi",
+        action="append",
+        type=float,
+        default=[],
+        help="merge passes whose phi clears this threshold (repeatable; default 0.2 0.5 0.7)",
+    )
+    ap.add_argument("--signatures-json", default=None, help="reuse a previous --out")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    thresholds = args.phi or [0.2, 0.5, 0.7]
+
+    sigs, per_pass, total_pairs, n_gt, n_records = _load_or_build(args)
+    all_pairs = n_records * (n_records - 1) // 2
+    n_passes = len(per_pass)
+    reachable = sum(s["true_pairs"] for s in sigs) / n_gt
+    print(
+        f"records {n_records:,}; distinct candidate pairs {total_pairs:,}; signatures {len(sigs)}; "
+        f"reachable PC {reachable:.4f}; true share of candidates "
+        f"{sum(s['true_pairs'] for s in sigs) / total_pairs:.4f}"
+    )
+
+    print("\nlargest signatures (pairs, true, purity):")
+    for s in sorted(sigs, key=lambda s: -s["pairs"])[:12]:
+        print(
+            f"  {s['pairs']:>10,} {s['true_pairs']:>8,} {s['true_pairs'] / s['pairs']:.3f}  {_label(s['mask'], per_pass)}"
+        )
+    print("\npurest signatures carrying >= 2,000 true pairs:")
+    for s in sorted(
+        (s for s in sigs if s["true_pairs"] >= 2000), key=lambda s: -s["true_pairs"] / s["pairs"]
+    )[:12]:
+        print(
+            f"  {s['pairs']:>10,} {s['true_pairs']:>8,} {s['true_pairs'] / s['pairs']:.3f}  {_label(s['mask'], per_pass)}"
+        )
+
+    phi = _phi(sigs, n_passes)
+    print("\npass-to-pass phi over candidate pairs (no labels):")
+    for a in range(n_passes):
+        print(
+            f"  {a} {_label(1 << a, per_pass):40s} "
+            + " ".join(f"{phi[a][b]:+.2f}" for b in range(n_passes))
+        )
+
+    report = {
+        "passes": per_pass,
+        "n_records": n_records,
+        "total_pairs": total_pairs,
+        "gt_pairs": n_gt,
+        "reachable_pc": reachable,
+        "phi": phi,
+        "feature_sets": {},
+    }
+    ungrouped = {"groups": [[k] for k in range(n_passes)], "curves": {}}
+    _evaluate_features(
+        "ungrouped",
+        sigs,
+        [_label(1 << k, per_pass) for k in range(n_passes)],
+        n_gt,
+        all_pairs,
+        ungrouped,
+    )
+    report["feature_sets"]["ungrouped"] = ungrouped
+    for thr in thresholds:
+        groups = _groups(phi, thr)
+        sub = {"groups": groups, "curves": {}}
+        _evaluate_features(
+            f"grouped phi>={thr}",
+            _regroup(sigs, groups),
+            [" | ".join(_label(1 << k, per_pass) for k in g) for g in groups],
+            n_gt,
+            all_pairs,
+            sub,
+        )
+        report["feature_sets"][f"phi>={thr}"] = sub
+
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps({"signatures": sigs, **report}, indent=2), encoding="utf-8"
+        )
+        print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_er_headtohead/measure_meta_blocking.py
+++ b/scripts/bench_er_headtohead/measure_meta_blocking.py
@@ -1,0 +1,313 @@
+"""Can meta-blocking keep the recall extra blocking passes add while dropping the noise?
+
+On historical_50k, blocking is the recall ceiling: a richer key set lifts reachable
+recall from ~0.83 to ~0.93 at fewer candidates, yet adding those passes made F1
+WORSE. FS estimates m, u and lambda FROM the candidate population, so a flood of
+weak candidates degrades the model that scores the good ones (see the project note
+on the blocking ceiling). Meta-blocking (Papadakis et al., TKDE) weights every
+candidate pair by how the blocks it co-occurs in overlap, and prunes the weakest
+edges BEFORE scoring -- reported at two orders of magnitude fewer comparisons for
+under 3% pair-completeness loss.
+
+This measures that, without touching the pipeline:
+
+1. Rebuild each blocking pass with GoldenMatch's own ``build_blocks`` (a multi_pass
+   config IS N static passes -- ``_build_multi_pass_blocks`` delegates each to
+   ``_build_static_blocks``), so transforms and oversized-block auto-split are the
+   shipped behaviour, not a lookalike.
+2. KNOWN-POSITIVE: the rebuilt per-pass comparison total must equal the pipeline's
+   own ``measure_blocking_profile(...).total_comparisons``. If it does not, the
+   script stops -- a meta-blocking number over a wrong candidate set means nothing.
+3. Build the blocking graph in duckdb: an edge per co-occurring pair, weighted by
+   CBS (common blocks), JS (Jaccard of the two records' block sets) and ECBS (CBS
+   scaled by each record's block rarity).
+4. Prune with WEP, CEP, WNP and CNP (the node-centric schemes in both the
+   "either endpoint" and "reciprocal" forms) and report, per scheme, candidates
+   kept, pair completeness (share of true pairs kept) and pair quality (share of
+   kept pairs that are true).
+
+Usage (main venv, worktree packages on PYTHONPATH):
+    python scripts/bench_er_headtohead/measure_meta_blocking.py \\
+        [--extra "surname:lowercase,soundex"] [--out results.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+
+def _members_for_passes(frame, blocking_cfg, keys):
+    """(pass, block, rid) rows for blocks of size >= 2, plus per-pass comparisons."""
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.frame import to_frame
+
+    passes, blocks, rids = [], [], []
+    per_pass = []
+    block_id = 0
+    for p, key in enumerate(keys):
+        static = blocking_cfg.model_copy(
+            update={"strategy": "static", "keys": [key], "passes": None}
+        )
+        comparisons = 0
+        n_blocks = 0
+        for b in build_blocks(frame, static):
+            ids = to_frame(b.materialize()).column("__row_id__").to_list()
+            n = len(ids)
+            if n < 2:
+                continue
+            comparisons += n * (n - 1) // 2
+            n_blocks += 1
+            passes.extend([p] * n)
+            blocks.extend([block_id] * n)
+            rids.extend(int(r) for r in ids)
+            block_id += 1
+        per_pass.append(
+            {
+                "pass": p,
+                "fields": list(key.fields),
+                "transforms": list(getattr(key, "transforms", None) or []),
+                "blocks": n_blocks,
+                "comparisons": comparisons,
+            }
+        )
+    return passes, blocks, rids, per_pass
+
+
+def _prune_report(con, n_gt: int, bc: int, n_nodes: int) -> list[dict]:
+    all_edges, all_matches = con.execute("SELECT count(*), sum(is_match::INT) FROM ew").fetchone()
+    rows = [
+        {"scheme": "none (all passes)", "weight": "-", "kept": all_edges, "matches": all_matches}
+    ]
+    cep_k = bc // 2
+    cnp_k = max(1, bc // max(1, n_nodes) - 1)
+    for w in ("cbs", "js", "ecbs"):
+        kept, m = con.execute(
+            f"SELECT count(*), sum(is_match::INT) FROM ew WHERE {w} >= (SELECT avg({w}) FROM ew)"
+        ).fetchone()
+        rows.append({"scheme": "WEP", "weight": w, "kept": kept, "matches": m})
+
+        kept, m = con.execute(
+            f"SELECT count(*), sum(is_match::INT) FROM (SELECT is_match FROM ew ORDER BY {w} DESC, i, j LIMIT {cep_k})"
+        ).fetchone()
+        rows.append({"scheme": f"CEP (K={cep_k})", "weight": w, "kept": kept, "matches": m})
+
+        con.execute(
+            f"CREATE OR REPLACE TEMP TABLE inc AS "
+            f"SELECT i AS node, i, j, {w} AS w FROM ew UNION ALL SELECT j AS node, i, j, {w} AS w FROM ew"
+        )
+        either, m_either, recip, m_recip = con.execute(
+            "WITH mean AS (SELECT node, avg(w) AS mw FROM inc GROUP BY node), "
+            f"k AS (SELECT ew.is_match, ew.{w} >= mi.mw AS ki, ew.{w} >= mj.mw AS kj "
+            "FROM ew JOIN mean mi ON mi.node = ew.i JOIN mean mj ON mj.node = ew.j) "
+            "SELECT sum((ki OR kj)::INT), sum(((ki OR kj) AND is_match)::INT), "
+            "sum((ki AND kj)::INT), sum((ki AND kj AND is_match)::INT) FROM k"
+        ).fetchone()
+        rows.append({"scheme": "WNP (either)", "weight": w, "kept": either, "matches": m_either})
+        rows.append({"scheme": "WNP (reciprocal)", "weight": w, "kept": recip, "matches": m_recip})
+
+        either, m_either, recip, m_recip = con.execute(
+            "WITH ranked AS (SELECT node, i, j, row_number() OVER (PARTITION BY node ORDER BY w DESC, i, j) AS rn FROM inc), "
+            f"top AS (SELECT i, j, count(*) AS c FROM ranked WHERE rn <= {cnp_k} GROUP BY i, j) "
+            "SELECT count(*), sum(ew.is_match::INT), sum((top.c = 2)::INT), sum((top.c = 2 AND ew.is_match)::INT) "
+            "FROM top JOIN ew USING (i, j)"
+        ).fetchone()
+        rows.append(
+            {"scheme": f"CNP (either, k={cnp_k})", "weight": w, "kept": either, "matches": m_either}
+        )
+        rows.append(
+            {
+                "scheme": f"CNP (reciprocal, k={cnp_k})",
+                "weight": w,
+                "kept": recip,
+                "matches": m_recip,
+            }
+        )
+        con.execute("DROP TABLE inc")
+
+    for r in rows:
+        r["matches"] = int(r["matches"] or 0)
+        r["kept"] = int(r["kept"] or 0)
+        r["pair_completeness"] = r["matches"] / n_gt if n_gt else 0.0
+        r["pair_quality"] = r["matches"] / r["kept"] if r["kept"] else 0.0
+        r["reduction_vs_all"] = 1.0 - r["kept"] / all_edges if all_edges else 0.0
+    return rows
+
+
+def run_scenario(name, df_rowid, cfg, keys, gt, duck_mem: str) -> dict:
+    import duckdb
+    import pyarrow as pa
+    from goldenmatch.core.blocker import measure_blocking_profile
+    from goldenmatch.core.frame import to_frame
+
+    t0 = time.perf_counter()
+    frame = to_frame(df_rowid)
+    passes, blocks, rids, per_pass = _members_for_passes(frame, cfg.blocking, keys)
+    rebuilt = sum(p["comparisons"] for p in per_pass)
+
+    # KNOWN-POSITIVE: the reconstruction must be the pipeline's candidate set.
+    probe_cfg = cfg.model_copy(
+        update={"blocking": cfg.blocking.model_copy(update={"passes": list(keys)})}
+    )
+    profile = measure_blocking_profile(df_rowid, probe_cfg)
+    expected = None if profile is None else int(profile.total_comparisons)
+    if expected is None or expected != rebuilt:
+        raise SystemExit(
+            f"[{name}] RECONSTRUCTION MISMATCH: rebuilt {rebuilt:,} comparisons, "
+            f"measure_blocking_profile says {expected}. Refusing to report meta-blocking "
+            "numbers over a candidate set that is not the pipeline's."
+        )
+
+    tmp = Path(tempfile.gettempdir()) / "gm_metablock_duckdb"
+    tmp.mkdir(exist_ok=True)
+    con = duckdb.connect()
+    con.execute(f"PRAGMA memory_limit='{duck_mem}'")
+    con.execute(f"PRAGMA temp_directory='{tmp.as_posix()}'")
+    members = pa.table(
+        {
+            "pass": pa.array(passes, pa.int32()),
+            "block": pa.array(blocks, pa.int64()),
+            "rid": pa.array(rids, pa.int64()),
+        }
+    )
+    gt_tbl = pa.table(
+        {
+            "i": pa.array([a for a, _ in gt], pa.int64()),
+            "j": pa.array([b for _, b in gt], pa.int64()),
+        }
+    )
+    con.register("members_arrow", members)
+    con.register("gt_arrow", gt_tbl)
+    con.execute("CREATE TEMP TABLE m AS SELECT * FROM members_arrow")
+    con.execute("CREATE TEMP TABLE g AS SELECT least(i, j) AS i, greatest(i, j) AS j FROM gt_arrow")
+    n_blocks_total = con.execute("SELECT count(DISTINCT block) FROM m").fetchone()[0]
+    bc = con.execute("SELECT count(*) FROM m").fetchone()[0]
+    n_nodes = con.execute("SELECT count(DISTINCT rid) FROM m").fetchone()[0]
+    con.execute("CREATE TEMP TABLE nb AS SELECT rid, count(*)::DOUBLE AS nb FROM m GROUP BY rid")
+    con.execute(
+        "CREATE TEMP TABLE e AS SELECT a.rid AS i, b.rid AS j, count(*)::DOUBLE AS cbs "
+        "FROM m a JOIN m b ON a.block = b.block AND a.rid < b.rid GROUP BY 1, 2"
+    )
+    con.execute(
+        "CREATE TEMP TABLE ew AS SELECT e.i, e.j, e.cbs, "
+        "e.cbs / (ni.nb + nj.nb - e.cbs) AS js, "
+        f"e.cbs * ln({n_blocks_total} / ni.nb) * ln({n_blocks_total} / nj.nb) AS ecbs, "
+        "(g.i IS NOT NULL) AS is_match "
+        "FROM e JOIN nb ni ON ni.rid = e.i JOIN nb nj ON nj.rid = e.j "
+        "LEFT JOIN g ON g.i = e.i AND g.j = e.j"
+    )
+    cbs_hist = con.execute(
+        "SELECT cbs::INT AS shared_blocks, count(*) AS pairs, sum(is_match::INT) AS true_pairs "
+        "FROM ew GROUP BY 1 ORDER BY 1"
+    ).fetchall()
+    rows = _prune_report(con, len(gt), bc, n_nodes)
+    con.close()
+    return {
+        "scenario": name,
+        "passes": per_pass,
+        "rebuilt_comparisons": rebuilt,
+        "profile_comparisons": expected,
+        "distinct_pairs": rows[0]["kept"],
+        "gt_pairs": len(gt),
+        "blocks": n_blocks_total,
+        "block_assignments": bc,
+        "nodes_in_blocks": n_nodes,
+        "shared_block_histogram": [
+            {"shared_blocks": s, "pairs": int(p), "true_pairs": int(t or 0)} for s, p, t in cbs_hist
+        ],
+        "schemes": rows,
+        "seconds": round(time.perf_counter() - t0, 1),
+    }
+
+
+def _print(result: dict) -> None:
+    print(f"\n=== {result['scenario']} ===")
+    print(
+        f"comparisons: rebuilt {result['rebuilt_comparisons']:,} == profile {result['profile_comparisons']:,} (known-positive OK)"
+    )
+    print(
+        f"distinct candidate pairs {result['distinct_pairs']:,}; true pairs {result['gt_pairs']:,}; "
+        f"blocks {result['blocks']:,}; {result['seconds']}s"
+    )
+    for p in result["passes"]:
+        print(
+            f"  pass {p['pass']}: {p['fields']} {p['transforms']}  blocks={p['blocks']:,} comparisons={p['comparisons']:,}"
+        )
+    print("  pairs by number of shared blocks (CBS):")
+    for h in result["shared_block_histogram"]:
+        share = h["true_pairs"] / h["pairs"] if h["pairs"] else 0.0
+        print(
+            f"    {h['shared_blocks']:>2}: {h['pairs']:>10,} pairs, {h['true_pairs']:>8,} true ({share:.3f})"
+        )
+    print(f"  {'scheme':28s} {'weight':6s} {'kept':>11s} {'reduction':>9s} {'PC':>7s} {'PQ':>7s}")
+    for r in result["schemes"]:
+        print(
+            f"  {r['scheme']:28s} {r['weight']:6s} {r['kept']:>11,} {r['reduction_vs_all']:>9.3f} "
+            f"{r['pair_completeness']:>7.4f} {r['pair_quality']:>7.4f}"
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--extra",
+        action="append",
+        default=[],
+        help='extra pass as "field:transform1,transform2" (repeatable) for the second scenario',
+    )
+    ap.add_argument("--out", default=None, help="write results as JSON")
+    ap.add_argument("--duckdb-memory", default="3GB")
+    args = ap.parse_args()
+
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    from goldenmatch.config.schemas import BlockingKeyConfig
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
+    from scripts.autoconfig_quality import datasets as D
+
+    loaded = D._historical_50k()
+    if loaded is None:
+        print("historical_50k parquet not present", file=sys.stderr)
+        return 2
+    df, gt = loaded
+    cfg = auto_configure_probabilistic_df(df)
+    df_rowid = df.with_row_index("__row_id__") if "__row_id__" not in df.columns else df
+    base_keys = list(cfg.blocking.resolved_keys())
+    print(
+        f"historical_50k: {df.height:,} rows, {len(gt):,} true pairs; auto-config blocking "
+        f"{cfg.blocking.strategy}, max_block_size={cfg.blocking.max_block_size}, "
+        f"skip_oversized={cfg.blocking.skip_oversized}, {len(base_keys)} passes"
+    )
+
+    results = [run_scenario("auto-config passes", df_rowid, cfg, base_keys, gt, args.duckdb_memory)]
+    _print(results[-1])
+    if args.extra:
+        extra_keys = []
+        for spec in args.extra:
+            field, _, transforms = spec.partition(":")
+            extra_keys.append(
+                BlockingKeyConfig(
+                    fields=[field], transforms=[t for t in transforms.split(",") if t]
+                )
+            )
+        name = "auto-config + " + ", ".join(args.extra)
+        results.append(
+            run_scenario(name, df_rowid, cfg, base_keys + extra_keys, gt, args.duckdb_memory)
+        )
+        _print(results[-1])
+    if args.out:
+        Path(args.out).write_text(json.dumps(results, indent=2), encoding="utf-8")
+        print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this adds

Two measurement scripts and a README section. No library code changes.

Both scripts rebuild the pipeline's own multi-pass candidate set with `build_blocks`, one static pass at a time. They refuse to report unless the rebuilt comparison count equals `measure_blocking_profile` for the same passes. On historical_50k it does: 23,439,513 for auto-config's 8 passes and 25,499,555 with a ninth.

## Why

The academic-gap review named meta-blocking (Papadakis et al.) as something GoldenMatch doesn't do. historical_50k's F1 is capped by blocking, so the question was whether pruning the candidate set by block co-occurrence could buy recall back.

## Measured

This is pair completeness (PC) against candidate count, not end-to-end F1. Today's operating point is **11.98M candidates at PC 0.8793**.

**`measure_meta_blocking.py`** runs standard meta-blocking: CBS/JS/ECBS edge weights with WEP/CEP/WNP/CNP pruning. It loses about 20 PC points at any useful pruning level. Five of the eight passes derive from name fields, so namesakes share several blocks from one fact; pairs sharing exactly 4 blocks are 1.1% true.

**`measure_blocking_signatures.py`** ranks pairs by *which* passes they share a block in. Adding a `surname` soundex pass raises reachable PC to 0.9379 over 13.61M candidates:

| ranking | PC 0.8793 needs | PC 0.93 needs | best PC within 12M |
|---|---|---|---|
| label oracle | 4.06M | 9.53M | 0.9366 |
| EM over raw pass bits (no labels) | 13.60M | 13.61M | 0.6327 |
| EM over phi≥0.5 pass groups, smallest-prior mode (no labels) | **7.29M** | **9.61M** | **0.9319** |
| EM with u fixed from random pairs (no labels) | 12.17M | 13.61M | 0.8699 |

- **Raw-bit EM fails** because the correlated name passes break its independence assumption. It fits a match prior of 0.24 where the true share is 0.021.
- **Grouping first fixes most of that.** Passes whose phi over the candidate pairs is at least 0.5 are merged into one feature. EM then finds two modes. The maximum-likelihood mode is wrong (prior 0.54), and the smallest-prior mode is the one in the table. That held across 15 starts.
- **The auto-config passes alone** reach the grouped oracle's PC 0.85 at 7.07M with the same rule, but can't go past the 0.8793 they allow.

## Caveats

- One dataset.
- The phi threshold and mode rule were chosen after seeing these curves. phi 0.7 fails on the 8-pass set.
- PC is not F1. Fewer candidates also changes what FS's EM trains on.
- **The ninth pass was refuted once already (2026-07-24).** Auto-config doesn't produce `surname` soundex, because `surname` fails `_is_scale_safe` (#876/#715): Zipf-concentrated surname blocks grow with N. Forcing it in at 20k rows made FS F1 worse (0.8136 to 0.7697 with `birth_place` also added; 0.4972 under the evidence cut), because FS estimates its weights from the candidate population. Pruning could address the second problem, since FS would train on the pruned set. It does nothing for the first, because the pairs are generated before they are pruned. The PC numbers are an upper bound, not a case for shipping the pass. The README section says the same.
