### PR TITLE
bench(blocking): scale-safe surname pass: field demotion, entity-sampled scale, per-arm-best A/B

### DIFF
--- a/.github/workflows/fs-lever-gate.yml
+++ b/.github/workflows/fs-lever-gate.yml
@@ -137,6 +137,8 @@ on:
           is what the A/B measures. Point `lever` at an env var nothing reads
           (e.g. GOLDENMATCH_UNUSED) to hold everything else equal. Compound
           keys use "+": "surname:lowercase,soundex+first_name:lowercase,substring:0:1".
+          A leading "~" marks the pass additive, so its fields stay EM-trained
+          instead of being demoted to fixed neutral weights for every pair.
         type: string
         default: ""
 

--- a/.github/workflows/fs-lever-gate.yml
+++ b/.github/workflows/fs-lever-gate.yml
@@ -131,6 +131,14 @@ on:
           the column skips that pass. Empty adds nothing.
         type: string
         default: ""
+      on_extra_passes:
+        description: >-
+          Like extra_passes, but applied to the ON arm only, so the pass itself
+          is what the A/B measures. Point `lever` at an env var nothing reads
+          (e.g. GOLDENMATCH_UNUSED) to hold everything else equal. Compound
+          keys use "+": "surname:lowercase,soundex+first_name:lowercase,substring:0:1".
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -150,7 +158,7 @@ concurrency:
   # branch used to cancel itself down to its last run. PR / push / schedule runs
   # carry empty inputs and keep one cancel-in-progress group per ref.
   group: >-
-    fs-lever-gate-${{ github.ref }}-${{ inputs.tier }}-${{ inputs.lever }}-${{ inputs.on_value }}-${{ inputs.extra_passes }}-${{ inputs.calibrated }}-${{ inputs.evidence_cut }}-${{ inputs.fd_probe }}-${{ inputs.tf_clamp }}-${{ inputs.fd_classes }}
+    fs-lever-gate-${{ github.ref }}-${{ inputs.tier }}-${{ inputs.lever }}-${{ inputs.on_value }}-${{ inputs.extra_passes }}-${{ inputs.on_extra_passes }}-${{ inputs.calibrated }}-${{ inputs.evidence_cut }}-${{ inputs.fd_probe }}-${{ inputs.tf_clamp }}-${{ inputs.fd_classes }}
   cancel-in-progress: true
 
 jobs:
@@ -212,8 +220,10 @@ jobs:
           GOLDENMATCH_FS_FD_CLASSES: ${{ inputs.fd_classes }}
           ON_VALUE: ${{ inputs.on_value || '1' }}
           EXTRA_PASSES: ${{ inputs.extra_passes }}
+          ON_EXTRA_PASSES: ${{ inputs.on_extra_passes }}
         run: |
           uv run python -m scripts.bench_er_headtohead.ab_lever \
             --env "$LEVER" --off 0 --on "$ON_VALUE" \
             --extra-passes "$EXTRA_PASSES" \
+            --on-extra-passes "$ON_EXTRA_PASSES" \
             ${{ steps.scope.outputs.datasets }}

--- a/scripts/bench_er_headtohead/README.md
+++ b/scripts/bench_er_headtohead/README.md
@@ -353,6 +353,62 @@ case for shipping it.
     it is not the rule this harness measured: on historical_50k it sees 27.2M
     candidates against 11.98M.
 
+## Scale-safe surname pass (historical_50k, 2026-09-10)
+
+`measure_surname_passes.py [--candidate spec ...]` measures candidate passes on
+`build_blocks` at full N, reporting true-pair coverage and the marginal gain over
+auto-config's passes. It also measures growth across nested **entity** samples:
+connected components of the true pairs, keeping every record of a sampled entity.
+`ab_lever --on-extra-passes` / `fs-lever-gate on_extra_passes` A/B a pass on the ON arm
+only. Specs: `field:t1,t2`, compound `field:t1,t2+field:t3`, and a leading `~` for
+`additive=True`.
+
+- **A name pass hurts FS by DEMOTING its fields, not by adding candidates.** Every
+  field a non-additive pass keys on reaches `train_em`'s `always_conditioned` through
+  `collect_blocking_fields(for_em=True)`. That gives it a fixed neutral weight for
+  EVERY pair, not only the pass's own.
+  - Surname soundex x birth year, non-additive: historical_50k 0.8320 -> 0.7689 at
+    the per-arm best cutoff.
+  - The first-initial compound LOST recall (0.747 -> 0.679) while only adding
+    candidates.
+  - `additive=True` keeps the fields EM-trained.
+- **Measure scale on entities, not rows.** Sampling rows shrinks each entity's
+  duplicate count too, and made all five candidates look like they grow in proportion
+  to N. With entities x4:
+
+  | pass | extra true pairs | pairs/row growth | largest group growth |
+  |---|---|---|---|
+  | surname soundex | 17,823 | x2.91 | x3.66 |
+  | surname soundex x first initial | 9,152 | x1.76 | x3.55 |
+  | surname soundex x birth year | 3,849 | x1.17 | x1.90 |
+  | surname soundex x first initial x birth decade | 2,620 | x1.24 | x3.75 |
+
+  The first-initial growth is mostly ONE artifact block, "Baronet" as surname with
+  "Sir" as first name (571 rows, ~163k of 461k comparisons). Dropping groups over
+  200 rows gives x1.14 and costs 5 of its 9,152 extra true pairs.
+- **End-to-end F1, each arm at its own best evidence cut** (default, 3, 5, 9, 12).
+  historical_50k baseline best 0.8320:
+
+  | pass (ON arm only) | ON best | dF1 | worst single cut |
+  |---|---|---|---|
+  | surname soundex x birth year | 0.7689 | -0.0631 | all lower |
+  | `GOLDENMATCH_FS_ATOMIC_NAME_BLOCKING=1` | 0.8165 | -0.0155 | -0.0267 (c9) |
+  | `~` surname soundex x birth year | 0.8359 | +0.0039 | -0.0064 (c9) |
+  | **`~` surname soundex x first initial** | **0.8417** | **+0.0097** | **-0.0703 (c9)** |
+  | `~` surname soundex (default only) | 0.8345 | +0.0025 | |
+
+  Every other available panel dataset ties at its best in every additive run.
+  - The additive first-initial compound is the first per-arm-best improvement. It is
+    one dataset, and it loses precision hard at cut 9.
+  - The existing atomic-name lever reproduces its documented -0.0148. Plain additive
+    surname soundex alone is +0.0025, so its first-name soundex pass is the likely
+    cause.
+  - Runs: non-additive 34510170513/34510174182/34510177687/34510181443/34510184656/
+    34510187829; additive year 34511165021/34511167779/34511171018/34511174495/
+    34511177550; additive initial 34511181174/34511907514/34511911235/34511915287/
+    34511919186; additive soundex 34511184594; atomic-name lever 34512434367/
+    34512438140/34512442554/34512446637/34512450531.
+
 ## Honest caveats (carried into the results doc)
 
 - **Blocking asymmetry is reported, not hidden.** GoldenMatch's bucket path does

--- a/scripts/bench_er_headtohead/ab_lever.py
+++ b/scripts/bench_er_headtohead/ab_lever.py
@@ -68,28 +68,29 @@ def _load(name: str):
 
 
 def _with_extra_passes(cfg, df, specs: list[str]):
-    """Append blocking passes (``field:t1,t2``) to an auto-configured config.
+    """Append blocking passes to an auto-configured config.
 
-    Measurement-only: applied identically to BOTH arms, after auto-config, so an
-    extra pass is a held constant rather than a second variable. Auto-config's own
-    guards (``_is_scale_safe``) are deliberately bypassed -- that is the point of
-    forcing a pass in. A spec naming a column the dataset lacks is skipped and
-    reported, not silently dropped.
+    Specs are ``field:t1,t2``, or a compound ``field:t1,t2+field:t3`` with
+    per-field transforms. Measurement-only, after auto-config: ``--extra-passes``
+    applies them to BOTH arms (a held constant), ``--on-extra-passes`` to the ON
+    arm only (the pass IS the variable). Auto-config's own guards
+    (``_is_scale_safe``) are deliberately bypassed -- that is the point of forcing
+    a pass in. A spec naming a column the dataset lacks is skipped and reported,
+    not silently dropped.
     """
     if not specs or cfg.blocking is None:
         return cfg, []
-    from goldenmatch.config.schemas import BlockingKeyConfig
+    from scripts.bench_er_headtohead.measure_surname_passes import pass_from_spec
 
     keys = list(cfg.blocking.resolved_keys())
     added = []
     for spec in specs:
-        field, _, transforms = spec.partition(":")
-        if field not in df.columns:
-            print(f"  [extra pass] skipped {spec!r}: no column {field!r}", file=sys.stderr)
+        key = pass_from_spec(spec)
+        missing = [f for f in key.fields if f not in df.columns]
+        if missing:
+            print(f"  [extra pass] skipped {spec!r}: no column(s) {missing}", file=sys.stderr)
             continue
-        keys.append(
-            BlockingKeyConfig(fields=[field], transforms=[t for t in transforms.split(",") if t])
-        )
+        keys.append(key)
         added.append(spec)
     if not added:
         return cfg, []
@@ -204,6 +205,12 @@ def main() -> int:
         "--tol", type=float, default=0.005, help="max allowed per-dataset F1 regression before FAIL"
     )
     ap.add_argument(
+        "--on-extra-passes",
+        default="",
+        help='blocking passes added to the ON arm only, ";"-separated specs -- A/B a pass '
+        "itself (pair with a lever env nothing reads, e.g. --env GOLDENMATCH_UNUSED)",
+    )
+    ap.add_argument(
         "--extra-passes",
         default="",
         help='blocking passes added to BOTH arms after auto-config, ";"-separated '
@@ -223,6 +230,9 @@ def main() -> int:
     os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"
     datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
     extra_passes = [s.strip() for s in args.extra_passes.split(";") if s.strip()]
+    on_extra_passes = [s.strip() for s in args.on_extra_passes.split(";") if s.strip()]
+    if on_extra_passes:
+        print(f"extra blocking passes on the ON arm only: {on_extra_passes}", file=sys.stderr)
     if extra_passes:
         print(f"extra blocking passes on BOTH arms: {extra_passes}", file=sys.stderr)
 
@@ -237,7 +247,7 @@ def main() -> int:
             skipped.append(name)
             continue
         os.environ[args.env] = args.on
-        on = _f1(name, extra_passes)
+        on = _f1(name, extra_passes + on_extra_passes)
         assert on is not None, f"{name}: measurable OFF but unmeasurable ON"
         rows.append((name, off, on))
 

--- a/scripts/bench_er_headtohead/measure_blocking_signatures.py
+++ b/scripts/bench_er_headtohead/measure_blocking_signatures.py
@@ -360,8 +360,8 @@ def _load_or_build(args):
         return sigs, data["passes"], int(data["total_pairs"]), int(data["gt_pairs"]), n_records
 
     os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
-    from goldenmatch.config.schemas import BlockingKeyConfig
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from measure_surname_passes import pass_from_spec
 
     from scripts.autoconfig_quality import datasets as D
 
@@ -372,9 +372,8 @@ def _load_or_build(args):
     cfg = auto_configure_probabilistic_df(df)
     df_rowid = df.with_row_index("__row_id__") if "__row_id__" not in df.columns else df
     keys = list(cfg.blocking.resolved_keys())
-    for spec in args.extra:
-        field, _, tr = spec.partition(":")
-        keys.append(BlockingKeyConfig(fields=[field], transforms=[t for t in tr.split(",") if t]))
+    # "field:t1,t2" or a compound "field:t1,t2+field:t3" with per-field transforms.
+    keys.extend(pass_from_spec(spec) for spec in args.extra)
     sigs, per_pass, rebuilt, total_pairs = _signatures(df_rowid, cfg, keys, gt)
     print(f"passes={len(keys)}  comparisons rebuilt {rebuilt:,} == profile (known-positive OK)")
     return sigs, per_pass, total_pairs, len(gt), df.height

--- a/scripts/bench_er_headtohead/measure_surname_passes.py
+++ b/scripts/bench_er_headtohead/measure_surname_passes.py
@@ -1,0 +1,215 @@
+"""Can a surname blocking pass recover recall without the common-surname blow-up?
+
+historical_50k loses recall at candidate generation, and the one pass that
+recovers the most of it -- ``surname`` soundex -- is rejected by auto-config's
+``_is_scale_safe`` (#876/#715): Zipf-concentrated surnames make blocks that grow
+with N. Forcing it in also cost 0.0276 F1 at 50k (#2929).
+
+This measures candidate passes on the pipeline's own blocking (``build_blocks``,
+auto-config's ``max_block_size`` and ``skip_oversized``), two ways:
+
+* RECALL at full N: true pairs the pass puts in a shared block, the MARGINAL true
+  pairs no auto-config pass covers, and the comparisons it adds.
+* SCALE across nested samples of ENTITIES (25% / 50% / 100%), keeping every record
+  of a sampled entity: comparisons per row and the largest raw key group before any
+  oversized-block splitting. Sampling ROWS instead would shrink every entity's
+  duplicate count with the sample, so every key -- concentrated or not -- would
+  look like it grows in proportion to N (measured: x3.6-x4.2 for all five default
+  candidates). Holding duplicates per entity fixed leaves only growth from more
+  DISTINCT people colliding on the key, which is what scale adds. A concentrated
+  key's largest group still grows with the entity count; a bounded one's should not.
+
+Entities are the connected components of the ground-truth pairs; a record in no
+true pair is its own entity.
+
+Pass specs: ``field:t1,t2`` for one field, ``field:t1,t2+field:t3`` for a compound
+key with per-field transforms (e.g. ``surname:lowercase,soundex+dob:substring:0:4``).
+
+Known-positive: the union coverage of auto-config's own passes is printed and must
+match ``measure_blocking_signatures.py``'s reachable pair completeness for the same
+dataset (0.8793 on historical_50k).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+DEFAULT_CANDIDATES = (
+    "surname:lowercase,soundex",
+    "surname:lowercase,soundex+dob:substring:0:4",
+    "surname:lowercase,soundex+first_name:lowercase,substring:0:1",
+    "surname:lowercase,soundex+birth_place:lowercase,strip",
+    "surname:lowercase,substring:0:4+dob:substring:0:4",
+)
+FRACTIONS = (0.25, 0.5, 1.0)
+
+
+def pass_from_spec(spec: str):
+    """``field:t1,t2`` or ``field:t1,t2+field:t3`` -> ``BlockingKeyConfig``."""
+    from goldenmatch.config.schemas import BlockingKeyConfig
+
+    parts = [p for p in spec.split("+") if p]
+    if not parts:
+        raise ValueError(f"empty blocking pass spec {spec!r}")
+    fields: list[str] = []
+    chains: dict[str, list[str]] = {}
+    for part in parts:
+        field, _, transforms = part.partition(":")
+        if not field:
+            raise ValueError(f"blocking pass spec {spec!r} has a part with no field")
+        fields.append(field)
+        chains[field] = [t for t in transforms.split(",") if t]
+    if len(fields) == 1:
+        return BlockingKeyConfig(fields=fields, transforms=chains[fields[0]])
+    return BlockingKeyConfig(fields=fields, transforms=[], field_transforms=chains)
+
+
+def label(key) -> str:
+    chains = getattr(key, "field_transforms", None) or {}
+    out = []
+    for f in key.fields:
+        ts = chains.get(f, key.transforms or [])
+        shown = "+".join(t for t in ts if t not in ("lowercase", "strip")) or "raw"
+        out.append(f"{f}[{shown}]")
+    return " x ".join(out)
+
+
+def _block_sets(frame, blocking_cfg, keys):
+    """Per pass: {row_id: set(block ids)} plus comparisons, via the pipeline's build_blocks."""
+    from measure_meta_blocking import _members_for_passes
+
+    passes, blocks, rids, per_pass = _members_for_passes(frame, blocking_cfg, keys)
+    sets: list[dict[int, set[int]]] = [{} for _ in keys]
+    for p, b, r in zip(passes, blocks, rids):
+        sets[p].setdefault(r, set()).add(b)
+    return sets, [pp["comparisons"] for pp in per_pass]
+
+
+def _raw_max_group(frame, key) -> int:
+    chains = getattr(key, "field_transforms", None) or None
+    col = frame.derive_block_key(
+        list(key.fields), list(key.transforms or []), field_transforms=chains
+    )
+    keyed = frame.with_column("__block_key__", col).filter_valid_key("__block_key__")
+    if keyed.height == 0:
+        return 0
+    return int(keyed.group_len(["__block_key__"]).column("len").max() or 0)
+
+
+def _covers(sets: dict[int, set[int]], a: int, b: int) -> bool:
+    sa = sets.get(a)
+    return bool(sa) and bool(sa & sets.get(b, set()))
+
+
+def _entities(n_rows: int, gt_pairs) -> list[int]:
+    """Entity id per row: connected components of the true pairs."""
+    parent = list(range(n_rows))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in gt_pairs:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    return [find(i) for i in range(n_rows)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--dataset", default="historical_50k")
+    ap.add_argument(
+        "--candidate",
+        action="append",
+        default=[],
+        help="pass spec (repeatable; default: built-in list)",
+    )
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
+    import numpy as np
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from goldenmatch.core.frame import to_frame
+
+    from scripts.autoconfig_quality import datasets as D
+
+    loaded = getattr(D, f"_{args.dataset}")()
+    if loaded is None:
+        raise SystemExit(f"dataset {args.dataset!r} is unavailable here")
+    df, gt = loaded
+    gt_pairs = sorted((min(a, b), max(a, b)) for a, b in gt)
+    cfg = auto_configure_probabilistic_df(df)
+    base = list(cfg.blocking.resolved_keys())
+    candidates = [pass_from_spec(s) for s in (args.candidate or DEFAULT_CANDIDATES)]
+    frame = to_frame(df.with_row_index("__row_id__"))
+    entity = _entities(df.height, gt_pairs)
+    n_entities = len(set(entity))
+    print(
+        f"{args.dataset}: rows {df.height:,}, entities {n_entities:,}, true pairs {len(gt_pairs):,}, "
+        f"auto-config passes {len(base)}, max_block_size {cfg.blocking.max_block_size}, "
+        f"skip_oversized {cfg.blocking.skip_oversized}"
+    )
+
+    all_keys = base + candidates
+    sets, comparisons = _block_sets(frame, cfg.blocking, all_keys)
+    base_sets = sets[: len(base)]
+    covered_base = [any(_covers(s, a, b) for s in base_sets) for a, b in gt_pairs]
+    base_pc = sum(covered_base) / len(gt_pairs)
+    print(
+        f"auto-config union coverage (known-positive, should equal the harness's reachable PC): "
+        f"{base_pc:.4f}; comparisons {sum(comparisons[: len(base)]):,}"
+    )
+
+    print("\nRECALL at full N")
+    print(f"  {'pass':58s} {'alone':>7s} {'marginal':>9s} {'union':>7s} {'comparisons':>12s}")
+    for k, key in enumerate(candidates):
+        s = sets[len(base) + k]
+        alone = [_covers(s, a, b) for a, b in gt_pairs]
+        marginal = sum(1 for cb, al in zip(covered_base, alone) if al and not cb)
+        print(
+            f"  {label(key):58s} {sum(alone) / len(gt_pairs):7.4f} {marginal:9,d} "
+            f"{(sum(covered_base) + marginal) / len(gt_pairs):7.4f} {comparisons[len(base) + k]:12,d}"
+        )
+
+    rng = np.random.default_rng(args.seed)
+    entity_ids = sorted(set(entity))
+    entity_order = [entity_ids[i] for i in rng.permutation(len(entity_ids))]
+    print(
+        "\nSCALE over nested ENTITY samples (all records of each sampled entity): "
+        "comparisons per row | largest raw key group (before splitting)"
+    )
+    header = "  ".join(f"{int(f * 100):>3d}%: pairs/row  max group" for f in FRACTIONS)
+    print(f"  {'pass':58s} {header}   growth 25%->100%")
+    rows = {}
+    for f in FRACTIONS:
+        keep = set(entity_order[: int(round(len(entity_order) * f))])
+        idx = [i for i, e in enumerate(entity) if e in keep]
+        sub = to_frame(df[idx].with_row_index("__row_id__"))
+        _, sub_comparisons = _block_sets(sub, cfg.blocking, candidates)
+        rows[f] = [
+            (c / len(idx), _raw_max_group(sub, key)) for c, key in zip(sub_comparisons, candidates)
+        ]
+    for k, key in enumerate(candidates):
+        cells = "  ".join(f"{rows[f][k][0]:15.1f} {rows[f][k][1]:10,d}" for f in FRACTIONS)
+        p0, p1 = rows[FRACTIONS[0]][k][0], rows[FRACTIONS[-1]][k][0]
+        g0, g1 = rows[FRACTIONS[0]][k][1], rows[FRACTIONS[-1]][k][1]
+        print(
+            f"  {label(key):58s} {cells}   pairs/row x{(p1 / p0) if p0 else float('nan'):.2f}, "
+            f"group x{(g1 / g0) if g0 else float('nan'):.2f} (entities x4)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_er_headtohead/measure_surname_passes.py
+++ b/scripts/bench_er_headtohead/measure_surname_passes.py
@@ -52,9 +52,18 @@ FRACTIONS = (0.25, 0.5, 1.0)
 
 
 def pass_from_spec(spec: str):
-    """``field:t1,t2`` or ``field:t1,t2+field:t3`` -> ``BlockingKeyConfig``."""
+    """``field:t1,t2`` or ``field:t1,t2+field:t3`` -> ``BlockingKeyConfig``.
+
+    A leading ``~`` marks the pass ``additive``: its fields stay EM-trained. Without
+    it, every field a pass keys on is demoted to a fixed neutral weight for EVERY
+    pair (``collect_blocking_fields(for_em=True)`` -> ``train_em``'s
+    ``always_conditioned``), which is how a surname pass silently removes the
+    surname weight from the whole model.
+    """
     from goldenmatch.config.schemas import BlockingKeyConfig
 
+    additive = spec.startswith("~")
+    spec = spec[1:] if additive else spec
     parts = [p for p in spec.split("+") if p]
     if not parts:
         raise ValueError(f"empty blocking pass spec {spec!r}")
@@ -67,8 +76,10 @@ def pass_from_spec(spec: str):
         fields.append(field)
         chains[field] = [t for t in transforms.split(",") if t]
     if len(fields) == 1:
-        return BlockingKeyConfig(fields=fields, transforms=chains[fields[0]])
-    return BlockingKeyConfig(fields=fields, transforms=[], field_transforms=chains)
+        return BlockingKeyConfig(fields=fields, transforms=chains[fields[0]], additive=additive)
+    return BlockingKeyConfig(
+        fields=fields, transforms=[], field_transforms=chains, additive=additive
+    )
 
 
 def label(key) -> str:


### PR DESCRIPTION
## What this adds

Measurement tooling and findings for a surname blocking pass that doesn't blow up on common surnames at scale. **No library code changes.**

- **`scripts/bench_er_headtohead/measure_surname_passes.py`** measures candidate passes on the pipeline's own `build_blocks`:
  - true-pair coverage, and the marginal gain over auto-config's passes, at full N;
  - growth across nested **entity** samples.

  Known-positive: auto-config's union coverage reproduces the harness's 0.8793.
- **`ab_lever --on-extra-passes` and a matching `fs-lever-gate` `on_extra_passes` input** add passes to the ON arm only, so the pass itself is what the A/B measures.
- **Pass specs** accept compound keys with per-field transforms (`field:t1,t2+field:t3`). A leading `~` marks the pass `additive`.
- **README section** with the findings below.

## Finding 1: a name pass hurts FS by demoting its fields, not by adding candidates

Every field a non-additive pass keys on goes through `collect_blocking_fields(for_em=True)` into `train_em`'s `always_conditioned`. That gives it a **fixed neutral weight for every pair**, not just the pass's own pairs. So adding a surname pass removes the surname weight from the whole model.

- The non-additive surname soundex × birth-year pass took historical_50k from **0.8320 to 0.7689** at the per-arm best cutoff.
- The first-initial compound **lost recall** (0.747 → 0.679) while only adding candidates, which extra candidates alone can't do.

`BlockingKeyConfig(additive=True)` is the existing escape hatch.

## Finding 2: measure scale on entities, not rows

Sampling rows also shrinks each entity's duplicate count, so every candidate looked like it grows in proportion to N.

With whole entities sampled (x4):

| pass | extra true pairs caught | pairs/row growth | largest group growth |
|---|---|---|---|
| surname soundex | 17,823 | x2.91 | x3.66 |
| surname soundex × first initial | 9,152 | x1.76 | x3.55 |
| surname soundex × birth year | 3,849 | **x1.17** | x1.90 |

Most of the first-initial growth is one artifact. Its largest block is "Baronet" parsed as a surname with "Sir" as a first name: 571 rows, about 163k of its 461k comparisons. With groups over 200 rows dropped it grows **x1.14**. Doing so drops exactly that group, which costs **5** of the pass's 9,152 extra true pairs.

## Finding 3: end-to-end F1 (full panel, each arm at its own best evidence cut)

historical_50k baseline best: 0.8320, at the default cutoff.

| pass (ON arm only) | ON best | dF1 | default / c3 / c5 / c9 / c12 |
|---|---|---|---|
| surname soundex × birth year, not additive | 0.7689 | −0.0631 | all lower |
| existing `GOLDENMATCH_FS_ATOMIC_NAME_BLOCKING=1` | 0.8165 | −0.0155 | −0.0155 / −0.0072 / −0.0028 / −0.0267 / −0.0168 |
| `~` surname soundex × birth year | 0.8359 | +0.0039 | +0.0039 / +0.0008 / −0.0012 / −0.0064 / −0.0062 |
| **`~` surname soundex × first initial** | **0.8417** | **+0.0097** | +0.0097 / +0.0119 / +0.0106 / **−0.0703** / −0.0092 |
| `~` plain surname soundex | — | +0.0025 (default only) | |

person, ncvr_synthetic, household_hardneg and cotenant_hardneg tie at their best in every additive run. febrl3 and dblp_acm aren't available on the runner.

- **The additive surname soundex × first-initial pass is the first per-arm-best improvement** in this line of work. It's one dataset, though, and it loses precision badly at cut 9.
- **The existing atomic-name lever reproduces its documented −0.0148.** Plain additive surname soundex alone is +0.0025, so its first-name soundex pass is the likely cause.

Run IDs are in the README section.
