### PR TITLE
bench(fs-lever-gate): widen the full panel (febrl4, dblp_scholar, amazon_google) and require it

### DIFF
--- a/.github/workflows/bench-fs-histograms.yml
+++ b/.github/workflows/bench-fs-histograms.yml
@@ -108,7 +108,10 @@ jobs:
           L=https://dbs.uni-leipzig.de/file
           fetch DBLP-ACM "$L/DBLP-ACM.zip" DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv
           fetch DBLP-Scholar "$L/DBLP-Scholar.zip" DBLP1.csv Scholar.csv DBLP-Scholar_perfectMapping.csv
-          fetch Amazon-GoogleProducts "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
+          # The zip is named Amazon-GoogleProducts but the loader reads
+          # Amazon-Google/ (scripts/test_run_benchmarks_download.py pins it).
+          # Writing to the zip's name left amazon_google silently skipped.
+          fetch Amazon-Google "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
 
       - name: Dump histograms
         env:

--- a/.github/workflows/bench-fs-threshold-sweep.yml
+++ b/.github/workflows/bench-fs-threshold-sweep.yml
@@ -107,7 +107,10 @@ jobs:
           L=https://dbs.uni-leipzig.de/file
           fetch DBLP-ACM "$L/DBLP-ACM.zip" DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv
           fetch DBLP-Scholar "$L/DBLP-Scholar.zip" DBLP1.csv Scholar.csv DBLP-Scholar_perfectMapping.csv
-          fetch Amazon-GoogleProducts "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
+          # The zip is named Amazon-GoogleProducts but the loader reads
+          # Amazon-Google/ (scripts/test_run_benchmarks_download.py pins it).
+          # Writing to the zip's name left amazon_google silently skipped.
+          fetch Amazon-Google "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
 
       - name: Sweep
         env:

--- a/.github/workflows/fs-lever-gate.yml
+++ b/.github/workflows/fs-lever-gate.yml
@@ -190,7 +190,13 @@ jobs:
              [ "${{ github.event.inputs.tier }}" = "full" ]; then
             echo "datasets=" >> "$GITHUB_OUTPUT"        # empty -> ab_lever default (whole panel)
             echo "label=full panel" >> "$GITHUB_OUTPUT"
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            # Every real dataset the steps below provision. ncvr_real is absent on
+            # purpose: it is local-only PII and never reaches CI.
+            echo "require=febrl3,febrl4,dblp_acm,dblp_scholar,amazon_google,historical_50k" >> "$GITHUB_OUTPUT"
           else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+            echo "require=" >> "$GITHUB_OUTPUT"
             # ncvr_synthetic is in the PR tier deliberately (#2518): it is the
             # dataset that CAUGHT the #2387 regression, and leaving it to the
             # nightly is what turned a catchable defect into five red nights. It
@@ -198,6 +204,38 @@ jobs:
             echo "datasets=--datasets person,household_hardneg,cotenant_hardneg,ncvr_synthetic" >> "$GITHUB_OUTPUT"
             echo "label=synthetic over-merge panel" >> "$GITHUB_OUTPUT"
           fi
+      # Full panel only. febrl3/febrl4 ship inside recordlinkage, which is not a
+      # goldenmatch dependency.
+      - name: Install recordlinkage (febrl3 / febrl4)
+        if: steps.scope.outputs.full == 'true'
+        run: uv pip install recordlinkage
+      # The Leipzig benchmarks are gitignored. A failed download only warns here;
+      # --require-datasets on the A/B step is what turns a missing dataset into a
+      # failed run, so the panel cannot shrink without anyone noticing.
+      - name: Fetch Leipzig benchmarks (DBLP-ACM, DBLP-Scholar, Amazon-Google)
+        if: steps.scope.outputs.full == 'true'
+        run: |
+          BASE=packages/python/goldenmatch/tests/benchmarks/datasets
+          fetch() {
+            local name="$1" url="$2"; shift 2
+            local dest="$BASE/$name"
+            mkdir -p "$dest"
+            if curl -fsSL --retry 3 -o "/tmp/$name.zip" "$url"; then
+              mkdir -p "/tmp/$name" && unzip -o -q "/tmp/$name.zip" -d "/tmp/$name"
+              for f in "$@"; do
+                found=$(find "/tmp/$name" -name "$f" | head -1)
+                if [ -n "$found" ]; then cp "$found" "$dest/$f"
+                else echo "::warning::$name: $f not in archive"; fi
+              done
+            else
+              echo "::warning::$name download failed; --require-datasets will fail the run"
+            fi
+          }
+          L=https://dbs.uni-leipzig.de/file
+          fetch DBLP-ACM "$L/DBLP-ACM.zip" DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv
+          fetch DBLP-Scholar "$L/DBLP-Scholar.zip" DBLP1.csv Scholar.csv DBLP-Scholar_perfectMapping.csv
+          # The zip is named Amazon-GoogleProducts; the loader reads Amazon-Google/.
+          fetch Amazon-Google "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
       - name: Partition-fingerprint self-test
         # The A/B reports whether the lever changed the CLUSTERING, not only
         # the F1. That column's useful answer is "same", which is also what a
@@ -223,9 +261,12 @@ jobs:
           ON_VALUE: ${{ inputs.on_value || '1' }}
           EXTRA_PASSES: ${{ inputs.extra_passes }}
           ON_EXTRA_PASSES: ${{ inputs.on_extra_passes }}
+          # Empty on the PR tier -> no requirement.
+          REQUIRE_DATASETS: ${{ steps.scope.outputs.require }}
         run: |
           uv run python -m scripts.bench_er_headtohead.ab_lever \
             --env "$LEVER" --off 0 --on "$ON_VALUE" \
             --extra-passes "$EXTRA_PASSES" \
             --on-extra-passes "$ON_EXTRA_PASSES" \
+            --require-datasets "$REQUIRE_DATASETS" \
             ${{ steps.scope.outputs.datasets }}

--- a/scripts/autoconfig_quality/datasets.py
+++ b/scripts/autoconfig_quality/datasets.py
@@ -10,6 +10,7 @@ The committed baseline scorecard is the single source of pinned expectations for
 anchors (the gate compares current signals against the baseline), so Dataset
 carries no separate `expected` block.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -58,6 +59,7 @@ def _household_hardneg() -> tuple[pl.DataFrame, set]:
     over-merge, so the F1-optimal threshold sits above 0.50 (committed 0.50 F1
     ~0.90 vs oracle link=0.70 F1 ~0.98). See anchors.gen_household_hardneg."""
     from scripts.autoconfig_quality.anchors import gen_household_hardneg
+
     return gen_household_hardneg(n_households=350, seed=41)
 
 
@@ -68,11 +70,14 @@ def _cotenant_hardneg() -> tuple[pl.DataFrame, set]:
     P ~0.26); the threshold-refit loop recovers it (~0.41 -> ~1.00). See
     anchors.gen_cotenant_hardneg."""
     from scripts.autoconfig_quality.anchors import gen_cotenant_hardneg
+
     return gen_cotenant_hardneg(n_addresses=300, seed=29)
 
 
 # ── real labeled datasets (skip-when-absent) ───────────────────────────────────
-_DATASETS_ROOT = Path(__file__).resolve().parents[2] / "packages/python/goldenmatch/tests/benchmarks/datasets"
+_DATASETS_ROOT = (
+    Path(__file__).resolve().parents[2] / "packages/python/goldenmatch/tests/benchmarks/datasets"
+)
 
 
 def _pairs_to_row_index(
@@ -93,6 +98,7 @@ def _febrl3() -> tuple[pl.DataFrame, set] | None:
     """FEBRL3 (recordlinkage-bundled). rec_id-pair truth -> row-index via df['id'].
     Returns None when recordlinkage isn't installed (skip-when-absent)."""
     from scripts.dqbench_adapters.febrl3 import load_febrl3_df_and_gt
+
     loaded = load_febrl3_df_and_gt()
     if loaded is None:
         return None
@@ -107,6 +113,7 @@ def _ncvr_synthetic() -> tuple[pl.DataFrame, set]:
     """PII-free NCVR-shaped corpus (seed 42, committable, runs in CI). Its F1 is its
     OWN baseline, never the real-data number."""
     from scripts.dqbench_adapters.ncvr import build_ncvr_synthetic_df_and_gt
+
     df, ncid_pairs = build_ncvr_synthetic_df_and_gt(seed=42)
     return df, _pairs_to_row_index(df, "ncid", ncid_pairs)
 
@@ -114,6 +121,7 @@ def _ncvr_synthetic() -> tuple[pl.DataFrame, set]:
 def _ncvr_real() -> tuple[pl.DataFrame, set] | None:
     """Real NCVR sample (gitignored PII, local-only). None when the file is absent."""
     from scripts.dqbench_adapters.ncvr import build_ncvr_df_and_gt
+
     loaded = build_ncvr_df_and_gt(_NCVR_REAL_PATH, seed=42)
     if loaded is None:
         return None
@@ -163,12 +171,74 @@ def _dblp_acm() -> tuple[pl.DataFrame, set] | None:
         cols = mapping.columns  # standard headers: idDBLP, idACM
         a_col, b_col = cols[0], cols[1]
         str_pairs = {
-            (str(a), str(b))
-            for a, b in zip(mapping[a_col].to_list(), mapping[b_col].to_list())
+            (str(a), str(b)) for a, b in zip(mapping[a_col].to_list(), mapping[b_col].to_list())
         }
         return df, _pairs_to_row_index(df, "id", str_pairs)
     except Exception:
         return None  # any malformed piece -> skip, never crash the run
+
+
+# ── held-out real datasets via the head-to-head loaders (skip-when-absent) ────
+# Not in REGISTRY: the auto-config quality gate's scorecard is unchanged. They
+# exist so `ab_lever` can measure a lever on more than one dataset with headroom.
+def _records_truth_to_frame(records, truth) -> tuple[pl.DataFrame, set]:
+    """(records, truth) pyarrow tables keyed by ``record_id`` -> this registry's
+    contract: a polars frame WITHOUT the ``record_id`` surrogate (so the kernel
+    cannot match on it) and within-cluster row-index pairs (i < j)."""
+    ids = [str(v) for v in records.column("record_id").to_pylist()]
+    cluster_of = {
+        str(r): c
+        for r, c in zip(
+            truth.column("record_id").to_pylist(), truth.column("cluster_id").to_pylist()
+        )
+    }
+    by_cluster: dict[object, list[int]] = {}
+    for row, rid in enumerate(ids):
+        cid = cluster_of.get(rid)
+        if cid is not None:
+            by_cluster.setdefault(cid, []).append(row)
+    gt: set[tuple[int, int]] = set()
+    for members in by_cluster.values():
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                gt.add((members[i], members[j]))
+    keep = [c for c in records.column_names if c != "record_id"]
+    df = pl.from_arrow(records.select(keep))
+    assert isinstance(df, pl.DataFrame)
+    return df, gt
+
+
+def _from_headtohead(name: str) -> tuple[pl.DataFrame, set] | None:
+    """Load ``name`` through ``scripts.bench_er_headtohead.datasets`` (the owner of
+    these loaders -- a second copy of where each dataset lives is how a fetch step
+    ends up writing somewhere the loader never reads). None when the data or its
+    loader dependency is absent."""
+    from scripts.bench_er_headtohead import datasets as headtohead
+
+    try:
+        records, truth = headtohead.load_dataset(name)
+    except headtohead.DatasetUnavailable:
+        return None
+    return _records_truth_to_frame(records, truth)
+
+
+def _febrl4() -> tuple[pl.DataFrame, set] | None:
+    """recordlinkage's Febrl4 person LINKAGE set (5k originals + 5k duplicates,
+    1:1 links). None when recordlinkage isn't installed."""
+    return _from_headtohead("febrl4")
+
+
+def _dblp_scholar() -> tuple[pl.DataFrame, set] | None:
+    """Leipzig DBLP-Scholar: larger, noisier bibliographic linkage (web-scraped
+    Scholar side). None when the CSVs aren't under tests/benchmarks/datasets."""
+    return _from_headtohead("dblp_scholar")
+
+
+def _amazon_google() -> tuple[pl.DataFrame, set] | None:
+    """Leipzig Amazon-GoogleProducts: product linkage, a different domain from the
+    person and bibliographic sets. Reads ``Amazon-Google/`` (not the zip's
+    ``Amazon-GoogleProducts`` name). None when the CSVs are absent."""
+    return _from_headtohead("amazon_google")
 
 
 REGISTRY: list[Dataset] = [

--- a/scripts/autoconfig_quality/tests/test_datasets.py
+++ b/scripts/autoconfig_quality/tests/test_datasets.py
@@ -19,17 +19,51 @@ def test_anchors_always_load():
 def test_person_anchor_has_gt_others_none():
     by_name = {d.name: d for d in REGISTRY}
     _, gt = by_name["anchor_person_match"].loader()
-    assert len(gt) > 0                              # gen_labeled has GT
+    assert len(gt) > 0  # gen_labeled has GT
     _, gt2 = by_name["anchor_sparse_zip"].loader()
-    assert gt2 == set()                             # blocking-shape anchor, no F1
+    assert gt2 == set()  # blocking-shape anchor, no F1
 
 
 def test_real_loader_skips_when_absent():
     by_name = {d.name: d for d in REGISTRY}
     dblp = by_name["dblp_acm"]
     assert dblp.kind == "real"
-    res = dblp.loader()                             # data absent locally -> None
+    res = dblp.loader()  # data absent locally -> None
     assert res is None or (isinstance(res, tuple) and len(res) == 2)
+
+
+def test_records_truth_to_frame_drops_the_surrogate_and_pairs_clusters():
+    """The head-to-head loaders key rows by `record_id`; the adapter must drop it
+    (a unique surrogate the kernel could otherwise match on) and turn cluster ids
+    into row-index pairs, including a 3-member cluster and a singleton."""
+    import pyarrow as pa
+
+    from scripts.autoconfig_quality.datasets import _records_truth_to_frame
+
+    ids = ["a:1", "b:1", "a:2", "b:9", "a:3"]
+    records = pa.table({"record_id": ids, "title": ["x", "x", "y", "z", "x"]})
+    truth = pa.table({"record_id": ids, "cluster_id": [0, 0, 2, 3, 0]})
+    df, gt = _records_truth_to_frame(records, truth)
+    assert df.columns == ["title"]
+    assert gt == {(0, 1), (0, 4), (1, 4)}
+
+
+def test_every_ab_lever_panel_dataset_resolves_to_a_loader():
+    """ab_lever looks loaders up by name; a panel entry with no loader raises
+    only when the gate runs. Catch the typo here instead."""
+    from scripts.autoconfig_quality import datasets as D
+    from scripts.bench_er_headtohead import ab_lever
+
+    missing = [n for n in ab_lever._PANEL if not callable(getattr(D, f"_{n}", None))]
+    assert not missing, missing
+
+
+def test_ab_lever_required_datasets_must_be_measured():
+    from scripts.bench_er_headtohead.ab_lever import _missing_required
+
+    assert _missing_required("febrl3, dblp_acm", {"febrl3"}) == ["dblp_acm"]
+    assert _missing_required("febrl3", {"febrl3", "person"}) == []
+    assert _missing_required("", set()) == []
 
 
 def test_pairs_to_row_index_maps_and_canonicalizes():
@@ -42,6 +76,7 @@ def test_pairs_to_row_index_maps_and_canonicalizes():
 def test_febrl3_loader_shape_or_skip():
     pytest.importorskip("recordlinkage")
     from scripts.autoconfig_quality.datasets import _febrl3
+
     loaded = _febrl3()
     assert loaded is not None
     df, gt = loaded
@@ -50,6 +85,7 @@ def test_febrl3_loader_shape_or_skip():
 
 def test_ncvr_synthetic_always_loads_with_row_index_gt():
     from scripts.autoconfig_quality.datasets import _ncvr_synthetic
+
     df, gt = _ncvr_synthetic()
     assert "ncid" in df.columns
     assert gt and all(0 <= a < b < df.height for a, b in gt)
@@ -57,12 +93,14 @@ def test_ncvr_synthetic_always_loads_with_row_index_gt():
 
 def test_ncvr_real_skips_when_absent(monkeypatch):
     import scripts.autoconfig_quality.datasets as ds
+
     monkeypatch.setattr(ds, "_NCVR_REAL_PATH", ds.Path("does/not/exist.txt"))
     assert ds._ncvr_real() is None
 
 
 def test_historical_50k_loads_drops_truth_and_has_row_index_gt():
     from scripts.autoconfig_quality.datasets import _historical_50k
+
     loaded = _historical_50k()
     assert loaded is not None  # parquet is committed
     df, gt = loaded
@@ -72,5 +110,6 @@ def test_historical_50k_loads_drops_truth_and_has_row_index_gt():
 
 def test_historical_50k_registered_full_scan():
     from scripts.autoconfig_quality.datasets import REGISTRY
+
     h = next(d for d in REGISTRY if d.name == "historical_50k")
     assert h.full_scan is True

--- a/scripts/bench_er_headtohead/ab_lever.py
+++ b/scripts/bench_er_headtohead/ab_lever.py
@@ -37,15 +37,31 @@ import time
 # 0.50 cutoff over-merges and a lever (the threshold-refit loop) can actually
 # move F1. Including them means a lever A/B is measured on both the at-ceiling
 # regime (must-not-regress) AND the has-headroom regime (can-it-win).
+#
+# febrl4, dblp_scholar and amazon_google widen the real panel beyond the one
+# dataset (historical_50k) where a lever could show headroom: a person LINKAGE
+# set, a larger and noisier bibliographic set, and a different domain (products).
+# The full CI tier provisions every real dataset here and passes
+# --require-datasets, so a failed fetch fails the run instead of quietly
+# shrinking the panel.
 _PANEL = [
     "person",
     "febrl3",
+    "febrl4",
     "ncvr_synthetic",
     "dblp_acm",
+    "dblp_scholar",
+    "amazon_google",
     "historical_50k",
     "household_hardneg",
     "cotenant_hardneg",
 ]
+
+
+def _missing_required(required: str, measured: set[str]) -> list[str]:
+    """Datasets named in ``required`` (comma list) that were not measured."""
+    wanted = [d.strip() for d in required.split(",") if d.strip()]
+    return [d for d in wanted if d not in measured]
 
 
 def _load(name: str):
@@ -217,6 +233,12 @@ def main() -> int:
         '"field:t1,t2" specs (e.g. "surname:lowercase,soundex")',
     )
     ap.add_argument(
+        "--require-datasets",
+        default="",
+        help="comma list of datasets that MUST be measured; the run fails if any was "
+        "not (the full CI tier provisions them, so a skip means a broken fetch)",
+    )
+    ap.add_argument(
         "--self-test",
         action="store_true",
         help="verify the partition fingerprint distinguishes partitions, then exit",
@@ -256,6 +278,7 @@ def main() -> int:
             f"[skipped] {len(skipped)} unavailable dataset(s): {', '.join(skipped)}",
             file=sys.stderr,
         )
+    missing_required = _missing_required(args.require_datasets, {name for name, _, _ in rows})
     # A regression gate that measured NOTHING must FAIL, never PASS -- an empty
     # panel is a broken environment, not a clean bill of health.
     if not rows:
@@ -305,6 +328,14 @@ def main() -> int:
             "PARTITION: identical on every dataset -- the lever altered no "
             "cluster anywhere, so a flat dF1 says INERT, not neutral."
         )
+    if missing_required:
+        # After the table, so the datasets that WERE measured still get reported.
+        print(
+            f"\nREQUIRED: FAIL -- {len(missing_required)} required dataset(s) were not "
+            f"measured: {', '.join(missing_required)}. A panel that silently shrank is "
+            f"not the panel the verdict claims to cover."
+        )
+        return 1
     return 1 if any_regress else 0
 
 


### PR DESCRIPTION
## Why

Every FS-lever verdict so far rested on one real dataset. Of the datasets `fs-lever-gate`'s full tier reached, only historical_50k had headroom. person, ncvr_synthetic and the two synthetic hard-negative shapes score 0.99–1.00, and febrl3 and dblp_acm were silently skipped on the runner. So a gain like the additive surname-pass +0.0097 (#2930) couldn't be checked anywhere else.

## What this changes

- **The full tier installs `recordlinkage`**, which provides febrl3 and febrl4.
- **It fetches the Leipzig DBLP-ACM, DBLP-Scholar and Amazon-Google benchmarks.**
- **The full tier passes `--require-datasets febrl3,febrl4,dblp_acm,dblp_scholar,amazon_google,historical_50k`.** A failed install or fetch now fails the run, rather than shrinking the panel. The table still prints for everything that was measured. The PR tier is unchanged.
- **`ab_lever`'s panel gains febrl4, dblp_scholar and amazon_google.**
  - They load through `scripts/bench_er_headtohead/datasets.py`, which already owns those loaders.
  - An adapter drops the `record_id` surrogate and turns cluster ids into row-index pairs.
  - They are not added to the auto-config quality gate's `REGISTRY`, so its scorecard is unchanged.
- **Real NCVR stays out:** it is local-only personal data.

## Also fixed: amazon_google was skipped in two workflows

`bench-fs-threshold-sweep` and `bench-fs-histograms` fetched Amazon-Google into `Amazon-GoogleProducts/`, the zip's name. The loader reads `Amazon-Google/`, and `scripts/test_run_benchmarks_download.py` already pins that directory. So both workflows ran without it. They now write to `Amazon-Google/`.

## Verified

Locally, from the Leipzig archives:

| dataset | rows | true pairs |
|---|---|---|
| dblp_acm | 4,910 | 2,224 (matches the published mapping) |
| dblp_scholar | 66,879 | 13,763 |
| amazon_google | 4,589 | 1,553 |

DBLP-Scholar's and Amazon-Google's pair counts exceed their published mappings (5,347 and 1,300 matches). Their clusters come from connected components of the mapping, and one record can match several on the other side.

Tests: the adapter (surrogate dropped, a 3-member cluster, a singleton); every `ab_lever` panel name resolves to a loader; `--require-datasets` reports what wasn't measured.

zizmor finds the same 18 findings on the three touched workflows as on main.

CI full tier, run 34516811290, with a lever nothing reads (so both arms are identical by construction). All 10 datasets were measured, with identical partitions. The installs and fetches took seconds, and the A/B step 8.5 minutes.

## What the wider panel shows immediately

Zero-config FS is at ceiling on the person sets but not on bibliographic or product data. Those three are the panel's first real headroom beyond historical_50k:

| dataset | F1 | P | R |
|---|---|---|---|
| person | 1.0000 | 1.000 | 1.000 |
| febrl3 | 0.9942 | 1.000 | 0.989 |
| febrl4 | 0.9945 | 1.000 | 0.989 |
| ncvr_synthetic | 0.9976 | 0.996 | 0.999 |
| **dblp_acm** | **0.3758** | 0.639 | 0.266 |
| **dblp_scholar** | **0.3750** | 0.283 | 0.557 |
| **amazon_google** | **0.0217** | 0.013 | 0.083 |
| historical_50k | 0.8320 | 0.939 | 0.747 |
| household_hardneg | 1.0000 | 1.000 | 1.000 |
| cotenant_hardneg | 0.9959 | 0.994 | 0.998 |

**Caveat:** the gate dedupes the two sources concatenated rather than linking them, so these aren't linkage-mode numbers. dblp_acm's existing loader also keeps its `id` column.
