### PR TITLE
bench(fs): probe why dblp_scholar's zero-config baseline drifts between runners

### DIFF
--- a/.github/workflows/fs-determinism-probe.yml
+++ b/.github/workflows/fs-determinism-probe.yml
@@ -1,0 +1,86 @@
+# FS determinism probe: run one panel dataset under zero-config FS in fresh
+# processes, varying the knobs a result could silently depend on (native thread
+# count, bucket count, native vs numpy route), and report which ones change the
+# partition. Exists because three fs-lever-gate full-panel runs on one commit gave
+# dblp_scholar three different baselines while both arms of each run agreed -- the
+# drift follows the runner, and a gate whose baseline moves between runs cannot
+# resolve a small lever effect.
+#
+# Runs on the PR that touches it (a workflow_dispatch trigger only exists once the
+# file is on the default branch) and by manual dispatch after. Not in ci-required.
+name: fs-determinism-probe
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/fs-determinism-probe.yml"
+      - "scripts/bench_er_headtohead/determinism_probe.py"
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "scripts.autoconfig_quality.datasets loader name"
+        type: string
+        default: dblp_scholar
+
+permissions:
+  contents: read
+
+env:
+  ARROW_DEFAULT_MEMORY_POOL: system
+  _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+
+concurrency:
+  group: fs-determinism-probe-${{ github.ref }}-${{ inputs.dataset }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Sync workspace (installs goldenmatch @ HEAD)
+        run: uv sync --all-packages
+      - name: Build the native kernel (mirror the real default FS path)
+        run: uv run python scripts/build_native.py
+      - name: Runner hardware
+        run: |
+          nproc
+          lscpu | head -20
+          free -g
+      - name: Install recordlinkage (febrl3 / febrl4)
+        run: uv pip install recordlinkage
+      - name: Fetch Leipzig benchmarks (DBLP-ACM, DBLP-Scholar, Amazon-Google)
+        run: |
+          BASE=packages/python/goldenmatch/tests/benchmarks/datasets
+          fetch() {
+            local name="$1" url="$2"; shift 2
+            local dest="$BASE/$name"
+            mkdir -p "$dest"
+            if curl -fsSL --retry 3 -o "/tmp/$name.zip" "$url"; then
+              mkdir -p "/tmp/$name" && unzip -o -q "/tmp/$name.zip" -d "/tmp/$name"
+              for f in "$@"; do
+                found=$(find "/tmp/$name" -name "$f" | head -1)
+                if [ -n "$found" ]; then cp "$found" "$dest/$f"
+                else echo "::warning::$name: $f not in archive"; fi
+              done
+            else
+              echo "::warning::$name download failed"
+            fi
+          }
+          L=https://dbs.uni-leipzig.de/file
+          fetch DBLP-ACM "$L/DBLP-ACM.zip" DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv
+          fetch DBLP-Scholar "$L/DBLP-Scholar.zip" DBLP1.csv Scholar.csv DBLP-Scholar_perfectMapping.csv
+          # The zip is named Amazon-GoogleProducts; the loader reads Amazon-Google/.
+          fetch Amazon-Google "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
+      - name: Probe
+        env:
+          DATASET: ${{ inputs.dataset || 'dblp_scholar' }}
+        run: uv run python -m scripts.bench_er_headtohead.determinism_probe --dataset "$DATASET"

--- a/scripts/bench_er_headtohead/determinism_probe.py
+++ b/scripts/bench_er_headtohead/determinism_probe.py
@@ -1,0 +1,112 @@
+"""Is zero-config FS deterministic across runners? Probe one dataset under variants.
+
+Context: three `fs-lever-gate` full-panel runs on ONE commit gave dblp_scholar a
+different baseline each time (F1 0.3750 / 0.3757 / 0.3759; predicted pairs
+27,125 / 27,033 / 27,029), while BOTH arms inside every run agreed exactly. So one
+process on one runner is deterministic and the drift follows the RUNNER. Auto-config
+and EM are identical across processes locally, and forcing the memory-aware pair
+budget from 300M to 1B leaves the config unchanged -- so the cause is downstream.
+
+Each variant runs zero-config dedupe in a FRESH process (so thread pools and env
+are honoured) and prints F1, predicted pairs and the partition digest. A variant
+that changes the digest names the knob the result depends on; two identical
+default runs are the control that the probe itself is deterministic.
+
+Usage:
+    python -m scripts.bench_er_headtohead.determinism_probe --dataset dblp_scholar
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+VARIANTS = (
+    ("default", {}),
+    ("default (repeat)", {}),
+    ("rayon 1 thread", {"RAYON_NUM_THREADS": "1"}),
+    ("rayon 2 threads", {"RAYON_NUM_THREADS": "2"}),
+    ("n_buckets 16", {"PROBE_N_BUCKETS": "16"}),
+    ("n_buckets 64", {"PROBE_N_BUCKETS": "64"}),
+    ("numpy route", {"GOLDENMATCH_NATIVE": "0"}),
+)
+
+_CHILD = r"""
+import json, logging, os, sys, time
+logging.disable(logging.WARNING)
+import goldenmatch
+from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+from goldenmatch.core.evaluate import evaluate_clusters
+from scripts.autoconfig_quality import datasets as D
+from scripts.bench_er_headtohead.ab_lever import _partition_fingerprint
+
+name = sys.argv[1]
+t0 = time.perf_counter()
+loaded = getattr(D, "_" + name)()
+if loaded is None:
+    print(json.dumps({"error": f"{name} unavailable"}))
+    sys.exit(0)
+df, gt = loaded
+cfg = auto_configure_probabilistic_df(df)
+nb = os.environ.get("PROBE_N_BUCKETS")
+if nb:
+    cfg = cfg.model_copy(update={"n_buckets": int(nb)})
+res = goldenmatch.dedupe_df(df, config=cfg)
+ev = evaluate_clusters(res.clusters, gt).summary()
+pairs, digest = _partition_fingerprint(res.clusters)
+print(json.dumps({
+    "f1": round(ev["f1"], 6), "precision": round(ev["precision"], 6),
+    "recall": round(ev["recall"], 6), "pairs": pairs, "digest": digest,
+    "n_buckets": getattr(cfg, "n_buckets", None), "cpu_count": os.cpu_count(),
+    "seconds": round(time.perf_counter() - t0, 1),
+}))
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--dataset", default="dblp_scholar")
+    args = ap.parse_args()
+
+    results = []
+    for label, extra in VARIANTS:
+        env = {**os.environ, "GOLDENMATCH_AUTOCONFIG_MEMORY": "0", **extra}
+        proc = subprocess.run(
+            [sys.executable, "-c", _CHILD, args.dataset],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        line = next((ln for ln in reversed(proc.stdout.splitlines()) if ln.startswith("{")), None)
+        if proc.returncode != 0 or line is None:
+            tail = (proc.stderr or proc.stdout).strip().splitlines()[-5:]
+            results.append((label, {"error": f"exit {proc.returncode}: {' | '.join(tail)}"}))
+        else:
+            results.append((label, json.loads(line)))
+        print(f"{label:18s} {json.dumps(results[-1][1])}", flush=True)
+
+    ok = [(label, r) for label, r in results if "error" not in r]
+    if len(ok) < 2:
+        print("\nPROBE: FAIL -- fewer than two variants ran; nothing to compare.")
+        return 1
+    base_label, base = ok[0]
+    print(f"\ncontrol: {base_label} digest {base['digest']} pairs {base['pairs']}")
+    control_ok = (
+        len(ok) > 1 and ok[1][0] == "default (repeat)" and ok[1][1]["digest"] == base["digest"]
+    )
+    print(f"control repeat identical: {control_ok}")
+    for label, r in ok[1:]:
+        same = r["digest"] == base["digest"]
+        delta = r["pairs"] - base["pairs"]
+        print(
+            f"  {label:18s} {'same' if same else 'DIFFERS'}  pairs {r['pairs']} ({delta:+d})  "
+            f"F1 {r['f1']:.4f}"
+        )
+    return 0 if control_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Three `fs-lever-gate` full-panel runs on one commit gave dblp_scholar three different baselines:

| run | F1 | predicted pairs |
|---|---|---|
| 34516811290 | 0.3750 | 27,125 |
| 34518306218 | 0.3757 | 27,033 |
| 34518589139 | 0.3759 | 27,029 |

Both arms inside every run agreed exactly, so one process on one runner is deterministic, and the drift follows the runner. A gate whose baseline moves between runs can't resolve a small lever effect. Every other panel dataset gave the same baseline in all three runs.

## Ruled out

- **Auto-config and EM:** identical across two processes locally, with different Python hash seeds. Same config hash, same 23,494 blocks, same learned weights.
- **Available RAM:** the candidate-pair budget depends on it, but forcing it from 300M to 1B leaves dblp_scholar's config unchanged.
- **The threshold refit:** it picks its cutoff from the score histogram and raw component sizes, so pair order shouldn't matter.
- **A local full-dedupe repeat couldn't run.** The box ran out of memory, so the rest has to be probed in CI.

## What this adds

- **`scripts/bench_er_headtohead/determinism_probe.py`** runs one dataset's zero-config dedupe in fresh processes under these variants:
  - default, run twice (the control);
  - `RAYON_NUM_THREADS` 1 and 2;
  - `n_buckets` 16 and 64;
  - the numpy route.

  It prints F1, predicted pairs and the partition digest for each, and fails if the two default runs differ.
- **`.github/workflows/fs-determinism-probe.yml`** runs the probe on this PR and by manual dispatch afterwards. It fetches the same datasets as the lever gate and prints the runner's CPU. Not in ci-required.

No library changes. A variant that changes the digest names the knob the result depends on, and the fix follows in a separate PR.
