### PR TITLE
bench(fs): trace which stage lets PYTHONHASHSEED change dblp_scholar's clusters

### DIFF
--- a/scripts/bench_er_headtohead/determinism_probe.py
+++ b/scripts/bench_er_headtohead/determinism_probe.py
@@ -29,15 +29,16 @@ import sys
 # not per runner (two default processes on one runner: 27,035 vs 27,029 pairs), and
 # that RAYON_NUM_THREADS / n_buckets / the numpy route don't separate the outcomes
 # -- so these candidates are the per-process randomness sources.
+# Run 34522839151 settled the SOURCE: a fixed PYTHONHASHSEED makes repeats identical
+# (seed 0: 27,125 pairs twice; seed 1: 27,035 twice), while the default and
+# POLARS_MAX_THREADS=1 drift. So a str-hash-ordered iteration reaches an
+# order-dependent step. This probe now finds the STAGE: the two seeds run once each,
+# with digests of what clustering receives (the pair SET and its ORDER), every refit
+# link threshold, and how often the oversized-cluster splitters fire. The first
+# stage whose digest differs between the seeds is where the order leaks in.
 VARIANTS = (
-    ("default", {}),
-    ("default (repeat)", {}),
     ("PYTHONHASHSEED=0", {"PYTHONHASHSEED": "0"}),
-    ("PYTHONHASHSEED=0 (repeat)", {"PYTHONHASHSEED": "0"}),
     ("PYTHONHASHSEED=1", {"PYTHONHASHSEED": "1"}),
-    ("PYTHONHASHSEED=1 (repeat)", {"PYTHONHASHSEED": "1"}),
-    ("POLARS_MAX_THREADS=1", {"POLARS_MAX_THREADS": "1"}),
-    ("POLARS_MAX_THREADS=1 (repeat)", {"POLARS_MAX_THREADS": "1"}),
 )
 
 _CHILD = r"""
@@ -49,6 +50,46 @@ from goldenmatch.core.evaluate import evaluate_clusters
 from scripts.autoconfig_quality import datasets as D
 from scripts.bench_er_headtohead.ab_lever import _partition_fingerprint
 
+import hashlib
+from goldenmatch.core import cluster as C
+from goldenmatch.core import pipeline as P
+
+def _h(obj):
+    return hashlib.sha256(repr(obj).encode()).hexdigest()[:12]
+
+stages = {"build_clusters": [], "link_threshold": [], "split_calls": 0, "split_members": 0}
+
+_orig_build = C.build_clusters
+def _build_spy(pairs, *a, **k):
+    plist = list(pairs)
+    norm = [(min(x, y), max(x, y), round(float(s), 12)) for x, y, s in plist]
+    stages["build_clusters"].append({
+        "n_pairs": len(plist),
+        "set": _h(sorted(norm)),
+        "order": _h(norm),
+    })
+    return _orig_build(plist, *a, **k)
+C.build_clusters = _build_spy
+
+for _fn in ("split_oversized_cluster", "split_oversized_cluster_to_size"):
+    _orig = getattr(C, _fn, None)
+    if _orig is None:
+        continue
+    def _make(orig):
+        def _split_spy(members, *a, **k):
+            stages["split_calls"] += 1
+            stages["split_members"] += len(members)
+            return orig(members, *a, **k)
+        return _split_spy
+    setattr(C, _fn, _make(_orig))
+
+_orig_refit = P._maybe_refit_link_threshold
+def _refit_spy(mk, link_threshold, **k):
+    t = _orig_refit(mk, link_threshold, **k)
+    stages["link_threshold"].append(repr(t))
+    return t
+P._maybe_refit_link_threshold = _refit_spy
+
 name = sys.argv[1]
 t0 = time.perf_counter()
 loaded = getattr(D, "_" + name)()
@@ -57,17 +98,13 @@ if loaded is None:
     sys.exit(0)
 df, gt = loaded
 cfg = auto_configure_probabilistic_df(df)
-nb = os.environ.get("PROBE_N_BUCKETS")
-if nb:
-    cfg = cfg.model_copy(update={"n_buckets": int(nb)})
 res = goldenmatch.dedupe_df(df, config=cfg)
 ev = evaluate_clusters(res.clusters, gt).summary()
 pairs, digest = _partition_fingerprint(res.clusters)
 print(json.dumps({
-    "f1": round(ev["f1"], 6), "precision": round(ev["precision"], 6),
-    "recall": round(ev["recall"], 6), "pairs": pairs, "digest": digest,
-    "n_buckets": getattr(cfg, "n_buckets", None), "cpu_count": os.cpu_count(),
-    "seconds": round(time.perf_counter() - t0, 1),
+    "f1": round(ev["f1"], 6), "pairs": pairs, "digest": digest,
+    "config": hashlib.sha256(cfg.model_dump_json().encode()).hexdigest()[:12],
+    "stages": stages, "seconds": round(time.perf_counter() - t0, 1),
 }))
 """
 
@@ -95,29 +132,44 @@ def main() -> int:
         print(f"{label:30s} {json.dumps(results[-1][1])}", flush=True)
 
     ok = dict((label, r) for label, r in results if "error" not in r)
-    if len(ok) < 2:
-        print("\nPROBE: FAIL -- fewer than two variants ran; nothing to compare.")
+    a, b = ok.get(VARIANTS[0][0]), ok.get(VARIANTS[1][0])
+    if a is None or b is None:
+        print("\nPROBE: FAIL -- a seed run failed; nothing to compare.")
         return 1
-    print("\nrepeat pairs (a setting only removes the drift if its own two runs agree):")
-    default_stable = None
-    for label, _ in VARIANTS:
-        if not label.endswith(" (repeat)"):
+    print(f"\nstage comparison, {VARIANTS[0][0]} vs {VARIANTS[1][0]}:")
+    print(f"  config digest      {'same' if a['config'] == b['config'] else 'DIFFERS'}")
+    sa, sb = a["stages"], b["stages"]
+    calls = max(len(sa["build_clusters"]), len(sb["build_clusters"]))
+    if calls == 0:
+        print("  build_clusters     never called (a columnar / native cluster route?)")
+    for i in range(calls):
+        ca = sa["build_clusters"][i] if i < len(sa["build_clusters"]) else None
+        cb = sb["build_clusters"][i] if i < len(sb["build_clusters"]) else None
+        if ca is None or cb is None:
+            print(f"  build_clusters #{i} called under only one seed")
             continue
-        base_label = label[: -len(" (repeat)")]
-        a, b = ok.get(base_label), ok.get(label)
-        if a is None or b is None:
-            print(f"  {base_label:24s} could not compare (a run failed)")
-            continue
-        same = a["digest"] == b["digest"]
-        if base_label == "default":
-            default_stable = same
         print(
-            f"  {base_label:24s} {'IDENTICAL' if same else 'DIFFERS'}  "
-            f"pairs {a['pairs']} vs {b['pairs']}  digests {a['digest']} vs {b['digest']}"
+            f"  build_clusters #{i}  pairs {ca['n_pairs']} vs {cb['n_pairs']}  "
+            f"SET {'same' if ca['set'] == cb['set'] else 'DIFFERS'}  "
+            f"ORDER {'same' if ca['order'] == cb['order'] else 'DIFFERS'}"
         )
-    # Exit non-zero when the default drifts: that is the defect this probe tracks,
-    # and a green job would read as "deterministic".
-    return 0 if default_stable else 1
+    same_thr = sa["link_threshold"] == sb["link_threshold"]
+    print(
+        f"  link thresholds    {'same' if same_thr else 'DIFFERS'}  "
+        f"{sa['link_threshold']} vs {sb['link_threshold']}"
+    )
+    print(
+        f"  MST splitter calls {sa['split_calls']} vs {sb['split_calls']}  "
+        f"(members {sa['split_members']} vs {sb['split_members']})"
+    )
+    same_final = a["digest"] == b["digest"]
+    print(
+        f"  final partition    {'same' if same_final else 'DIFFERS'}  "
+        f"pairs {a['pairs']} vs {b['pairs']}"
+    )
+    # Non-zero while the seeds disagree: that is the defect being traced, and a
+    # green job would read as "deterministic".
+    return 0 if same_final else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What the last probe found

Run 34522839151: fixing `PYTHONHASHSEED` makes dblp_scholar deterministic. Seed 0 gave 27,125 pairs twice, seed 1 gave 27,035 twice. The default and `POLARS_MAX_THREADS=1` still drifted.

Seed 0's partition digest matched the one an earlier probe produced on a different CPU, so for a given seed the result doesn't depend on the CPU. The drift comes from a string-hash-ordered iteration reaching an order-dependent step. Auto-config and EM are already known to be deterministic across seeds.

**The suspect is oversized-cluster splitting.** `cluster._build_mst` stable-sorts edges by score, and FS scores are sums of discrete level weights, so ties are common. Both MST splitters then cut the *first* minimum edge, so the cut depends on the order pairs arrived in.

A local 25k-row slice didn't reproduce the drift (seeds 0 and 1 identical, 4,294 pairs), probably because nothing grows to a 100-member cluster at that size. The full dataset runs out of memory locally, so the stage trace runs in CI.

## What this changes

The probe runs seed 0 and seed 1 once each on the full dataset, and records for each:

- the config digest;
- per `build_clusters` call: the pair count, a digest of the pair **set**, and a digest of its **order**;
- every link threshold the refit returns;
- how many times the MST splitters fire, and on how many members.

It then prints the first stage where the two seeds differ.

- **Same set, different order, and a changed partition** points at the tie-break inside clustering.
- **A different set** points upstream, at scoring or the refit.

No library changes. The job still exits non-zero while the seeds disagree.
