### PR TITLE
fix(cluster): oversized-cluster split broke score ties by insertion order

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2677,6 +2677,7 @@
             "_is_pairs_dataframe",
             "_measure_bridges",
             "_measure_bridges_frames",
+            "_pair_key",
             "_pairs_df_to_list_numpy",
             "_record_unmerge_corrections",
             "_severe_bridge_count",

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -143,11 +143,26 @@ class UnionFind:
         return list(groups.values())
 
 
+def _pair_key(item: tuple[tuple[int, int], float]) -> tuple[int, int]:
+    """Sort key for ``pair_scores`` items: the endpoint pair alone (keys are unique,
+    so the score never needs comparing)."""
+    return item[0]
+
+
 def _build_mst(
     members: list[int], pair_scores: dict[tuple[int, int], float],
 ) -> list[tuple[int, int, float]]:
-    """Build max-weight spanning tree using Kruskal's algorithm."""
-    edges = [(a, b, s) for (a, b), s in pair_scores.items()]
+    """Build max-weight spanning tree using Kruskal's algorithm.
+
+    Equal-score edges are ordered by endpoint pair, never by ``pair_scores``
+    insertion order. FS scores are sums of discrete level weights, so ties are
+    common, and both splitters cut the FIRST minimum of this tree's edge order.
+    Taking edges as inserted made that cut follow the order pairs were scored in,
+    which follows Python's per-process string hashing: on dblp_scholar the same
+    232-member cluster split differently under PYTHONHASHSEED 0 and 1 (27,125 vs
+    27,035 predicted pairs, fs-determinism-probe run 34525109806).
+    """
+    edges = [(a, b, s) for (a, b), s in sorted(pair_scores.items(), key=_pair_key)]
     # operator.itemgetter(2) is a C-level key extractor; the equivalent
     # `lambda e: e[2]` invokes a Python frame per comparison-key fetch and
     # showed up as a hotspot in the profile-hotspots cProfile run.
@@ -175,11 +190,12 @@ def split_oversized_cluster(
     if native_enabled("clustering"):  # pragma: no cover - exercised by the native CI lane (test_native_parity), not the no-ext python lane
         # Native kernel does MST (Kruskal) + weakest-edge removal + re-union
         # and returns the post-split subcluster member lists. Edges are passed
-        # in pair_scores iteration order so the native stable score-desc sort
-        # and first-minimum tie-break reproduce the Python path exactly. An
-        # empty return means the MST was empty -> unsplittable (handled by the
-        # shared guard below, mirroring the pure-Python `if not mst`).
-        edges = [(a, b, s) for (a, b), s in pair_scores.items()]
+        # in the SAME canonical endpoint order `_build_mst` uses, so the native
+        # stable score-desc sort and first-minimum tie-break reproduce the Python
+        # path exactly -- and neither depends on insertion order. An empty
+        # return means the MST was empty -> unsplittable (handled by the shared
+        # guard below, mirroring the pure-Python `if not mst`).
+        edges = [(a, b, s) for (a, b), s in sorted(pair_scores.items(), key=_pair_key)]
         subclusters: list = native_module().mst_split_components(members, edges)
     else:
         mst = _build_mst(members, pair_scores)

--- a/packages/python/goldenmatch/tests/test_cluster_split_deterministic_ties.py
+++ b/packages/python/goldenmatch/tests/test_cluster_split_deterministic_ties.py
@@ -1,0 +1,74 @@
+"""The MST splitters must not depend on ``pair_scores`` insertion order when scores tie.
+
+FS scores are sums of discrete level weights, so equal-score edges are common, and
+both splitters cut the FIRST minimum edge of the spanning tree. With edges taken in
+``pair_scores`` insertion order, that cut followed the order pairs were scored in --
+which follows Python's per-process string hashing. Measured on dblp_scholar
+(fs-determinism-probe run 34525109806): the same pair SET reached clustering under
+PYTHONHASHSEED 0 and 1 in a different ORDER, the one 232-member oversized cluster was
+split differently, and the partition differed (27,125 vs 27,035 predicted pairs).
+"""
+
+from __future__ import annotations
+
+import random
+
+from goldenmatch.core.cluster import split_oversized_cluster, split_oversized_cluster_to_size
+
+# A path 0-1-2-3-4-5 whose two weakest edges tie at 0.5.
+_PATH = [(0, 1, 0.9), (1, 2, 0.5), (2, 3, 0.9), (3, 4, 0.5), (4, 5, 0.9)]
+
+
+def _scores(order: list[int]) -> dict[tuple[int, int], float]:
+    return {(a, b): s for a, b, s in (_PATH[i] for i in order)}
+
+
+def _partition(subs: list[dict]) -> list[tuple[int, ...]]:
+    return sorted(tuple(sorted(s["members"])) for s in subs)
+
+
+def test_tied_weakest_edges_split_the_same_way_in_any_insertion_order():
+    """KNOWN-POSITIVE: with insertion-order tie-breaking, inserting (1,2) first cut
+    {0,1} | {2,3,4,5} and inserting (3,4) first cut {0,1,2,3} | {4,5}."""
+    members = list(range(6))
+    forward = _partition(split_oversized_cluster(members, _scores([0, 1, 2, 3, 4])))
+    backward = _partition(split_oversized_cluster(members, _scores([4, 3, 2, 1, 0])))
+    assert forward == backward
+    # Ties resolve by endpoint pair: (1, 2) sorts before (3, 4), so it is the cut.
+    assert forward == [(0, 1), (2, 3, 4, 5)]
+
+
+def test_split_to_size_is_independent_of_insertion_order_on_ties():
+    members = list(range(6))
+    forward = _partition(split_oversized_cluster_to_size(members, _scores([0, 1, 2, 3, 4]), 4))
+    backward = _partition(split_oversized_cluster_to_size(members, _scores([4, 3, 2, 1, 0]), 4))
+    assert forward == backward == [(0, 1), (2, 3, 4, 5)]
+
+
+def test_random_tied_graphs_split_identically_under_shuffled_insertion():
+    rng = random.Random(7)
+    checked = 0
+    for _ in range(40):
+        n = rng.randint(6, 14)
+        members = list(range(n))
+        pairs = {
+            (a, b): rng.choice((0.5, 0.7, 0.9))
+            for a in range(n)
+            for b in range(a + 1, n)
+            if rng.random() < 0.35
+        }
+        if len(pairs) < n:
+            continue
+        items = list(pairs.items())
+        seen = None
+        for _ in range(4):
+            rng.shuffle(items)
+            got = (
+                _partition(split_oversized_cluster(members, dict(items))),
+                _partition(split_oversized_cluster_to_size(members, dict(items), 3)),
+            )
+            if seen is None:
+                seen = got
+            assert got == seen
+        checked += 1
+    assert checked >= 20, "too few graphs exercised the splitters"


### PR DESCRIPTION
## The bug

The oversized-cluster split decided ties by `pair_scores` **insertion order**, so the same scored pairs could produce different clusters in different processes.

- `_build_mst` stable-sorted edges by score as they came out of the dict.
- `split_oversized_cluster` and `split_oversized_cluster_to_size` then cut the **first** minimum edge.
- FS scores are sums of discrete level weights, so equal-score edges are common, and the cut followed the order pairs were scored in.
- That order follows Python's per-process string hashing.

## How it was found

`fs-lever-gate` gave dblp_scholar a different baseline on every full-panel run of one commit: F1 0.3750 / 0.3757 / 0.3759. The probe from #2932–#2934 narrowed it down:

- **Two fresh processes on one runner disagree** (27,035 vs 27,029 pairs). The numpy route drifts too, so it isn't the native kernel. Threads, bucket count, available RAM and CPU are ruled out.
- **A fixed `PYTHONHASHSEED` makes repeats identical.** Seed 0 gives 27,125 pairs twice on two different CPUs; seed 1 gives 27,035 twice.
- **The stage trace (run 34525109806), comparing seed 0 with seed 1:**
  - config identical;
  - the pair **set** reaching clustering identical, but its **order** different;
  - refit link threshold identical (0.5);
  - the MST splitter fires once, on the same 232-member cluster;
  - the partition differs.

## The fix

- Edges are taken in canonical endpoint order, `sorted(pair_scores.items())` by key, before the stable score sort.
- The native `mst_split_components` receives the same ordered list, so the native and Python paths still agree and neither depends on insertion order.
- No Rust change.

## Tests

`test_cluster_split_deterministic_ties.py` covers both splitters. All three tests **failed before the fix**:
- a path whose two weakest edges tie: inserting `(1,2)` first used to cut `{0,1}|{2..5}`, inserting `(3,4)` first cut `{0..3}|{4,5}`;
- the same property for `split_oversized_cluster_to_size`;
- 40 random tied graphs, each split under four shuffled insertion orders.

Existing cluster, split-to-size and native split-parity tests pass. pyright on `cluster.py`: 0 errors.

**End to end:** determinism probe run 34526263599 on this branch, full dblp_scholar, seed 0 vs seed 1.
- The pair **order** reaching clustering still differs, as expected: the fix removes the dependence rather than the upstream order.
- The splitter fires on the same 232-member cluster.
- **The final partition is now identical: 27,035 pairs under both seeds** (before: 27,125 vs 27,035).

**Behaviour change:** where tied weakest edges exist, the cut is now the lowest endpoint pair rather than the first inserted. On dblp_scholar that fixes the partition to one of the three outcomes the gate had been flipping between.
