### PR TITLE
feat(quality): FS link-cut routing P3 -- frozen held-out corpus + per-rule matrix

### DIFF
--- a/.github/workflows/fs-cut-rule-matrix-unit.yml
+++ b/.github/workflows/fs-cut-rule-matrix-unit.yml
@@ -1,0 +1,63 @@
+# The cheap unit signal for the fs-cut-rule-matrix code (corpus, loaders, the
+# generator knob, and the sweep itself). NOT in ci-required -- it exists so a
+# PR that touches this code gets fast feedback without waiting on the full
+# weekly sweep, which stays on its own workflow (fs-cut-rule-matrix.yml) and
+# fetches real benchmark data.
+name: fs-cut-rule-matrix-unit
+
+on:
+  pull_request:
+    paths:
+      - "scripts/autoconfig_quality/**"
+      - "scripts/bench_er_headtohead/datasets.py"
+      - "scripts/bench_er_headtohead/generate_fixture.py"
+      - "scripts/bench_er_headtohead/test_heldout_loaders.py"
+      - "scripts/bench_er_headtohead/test_generate_fixture_corruption.py"
+      - "packages/python/goldenmatch/goldenmatch/core/fs_cut_rules.py"
+      - "packages/python/goldenmatch/goldenmatch/core/probabilistic.py"
+      - ".github/workflows/fs-cut-rule-matrix-unit.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/autoconfig_quality/**"
+      - "scripts/bench_er_headtohead/datasets.py"
+      - "scripts/bench_er_headtohead/generate_fixture.py"
+      - "scripts/bench_er_headtohead/test_heldout_loaders.py"
+      - "scripts/bench_er_headtohead/test_generate_fixture_corruption.py"
+      - "packages/python/goldenmatch/goldenmatch/core/fs_cut_rules.py"
+      - "packages/python/goldenmatch/goldenmatch/core/probabilistic.py"
+      - ".github/workflows/fs-cut-rule-matrix-unit.yml"
+
+permissions:
+  contents: read
+
+env:
+  # pyarrow's bundled mimalloc SIGSEGVs on goldenmatch's pipeline worker threads.
+  ARROW_DEFAULT_MEMORY_POOL: system
+  # jemalloc page-decay: return freed polars pages to the OS between arms.
+  _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Sync workspace
+        run: uv sync --all-packages
+      - name: Unit tests for the corpus, loaders, generator knob and sweep
+        run: >-
+          uv run python -m pytest -q
+          scripts/autoconfig_quality/tests/test_corpus.py
+          scripts/autoconfig_quality/tests/test_rule_sweep.py
+          scripts/bench_er_headtohead/test_heldout_loaders.py
+          scripts/bench_er_headtohead/test_generate_fixture_corruption.py

--- a/.github/workflows/fs-cut-rule-matrix-unit.yml
+++ b/.github/workflows/fs-cut-rule-matrix-unit.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/bench_er_headtohead/datasets.py"
       - "scripts/bench_er_headtohead/generate_fixture.py"
       - "scripts/bench_er_headtohead/test_heldout_loaders.py"
+      - "scripts/bench_er_headtohead/test_design_loaders.py"
       - "scripts/bench_er_headtohead/test_generate_fixture_corruption.py"
       - "packages/python/goldenmatch/goldenmatch/core/fs_cut_rules.py"
       - "packages/python/goldenmatch/goldenmatch/core/probabilistic.py"
@@ -23,6 +24,7 @@ on:
       - "scripts/bench_er_headtohead/datasets.py"
       - "scripts/bench_er_headtohead/generate_fixture.py"
       - "scripts/bench_er_headtohead/test_heldout_loaders.py"
+      - "scripts/bench_er_headtohead/test_design_loaders.py"
       - "scripts/bench_er_headtohead/test_generate_fixture_corruption.py"
       - "packages/python/goldenmatch/goldenmatch/core/fs_cut_rules.py"
       - "packages/python/goldenmatch/goldenmatch/core/probabilistic.py"
@@ -60,4 +62,5 @@ jobs:
           scripts/autoconfig_quality/tests/test_corpus.py
           scripts/autoconfig_quality/tests/test_rule_sweep.py
           scripts/bench_er_headtohead/test_heldout_loaders.py
+          scripts/bench_er_headtohead/test_design_loaders.py
           scripts/bench_er_headtohead/test_generate_fixture_corruption.py

--- a/.github/workflows/fs-cut-rule-matrix.yml
+++ b/.github/workflows/fs-cut-rule-matrix.yml
@@ -65,6 +65,7 @@ jobs:
           scripts/autoconfig_quality/tests/test_corpus.py
           scripts/autoconfig_quality/tests/test_rule_sweep.py
           scripts/bench_er_headtohead/test_heldout_loaders.py
+          scripts/bench_er_headtohead/test_design_loaders.py
           scripts/bench_er_headtohead/test_generate_fixture_corruption.py
       - name: List the corpus
         id: list
@@ -102,6 +103,7 @@ jobs:
             local name="$1" url="$2"; shift 2
             local dest="$BASE/$name"
             mkdir -p "$dest"
+            mkdir -p "$(dirname "/tmp/$name")"
             if curl -fsSL --retry 3 -o "/tmp/$name.zip" "$url"; then
               mkdir -p "/tmp/$name"
               unzip -o -q "/tmp/$name.zip" -d "/tmp/$name" || echo "::warning::$name: unzip failed"
@@ -135,6 +137,19 @@ jobs:
               "https://raw.githubusercontent.com/J535D165/recordlinkage/master/recordlinkage/datasets/febrl/$f.csv" \
               || echo "::warning::FEBRL $f download failed"
           done
+          # Leipzig clustering trio (DESIGN, P3 widening): CC-BY, Database Group
+          # Leipzig; Saeedi, Peukert & Rahm, ADBIS 2017.
+          LC="$BASE/Leipzig-Clustering"
+          mkdir -p "$LC/MusicBrainz"
+          curl -fsSL --retry 3 -o "$LC/MusicBrainz/musicbrainz-20-A01.csv" \
+            "https://dbs.uni-leipzig.de/files/datasets/saeedi/musicbrainz-20-A01.csv.dapo" \
+            || echo "::warning::MusicBrainz musicbrainz-20-A01.csv download failed"
+          fetch_zip Leipzig-Clustering/GeoSettlements \
+            "https://dbs.uni-leipzig.de/files/datasets/geographicalSettelments.zip" \
+            settlements.json "combinedSettlements(PerfectMatch).json"
+          fetch_zip Leipzig-Clustering/Affiliations \
+            "https://dbs.uni-leipzig.de/files/datasets/affiliationstrings.zip" \
+            affiliationstrings_ids.csv affiliationstrings_mapping.csv
       - name: Sweep every link-cut rule
         env:
           DATASET: ${{ matrix.dataset }}

--- a/.github/workflows/fs-cut-rule-matrix.yml
+++ b/.github/workflows/fs-cut-rule-matrix.yml
@@ -138,6 +138,12 @@ jobs:
       - name: Sweep every link-cut rule
         env:
           DATASET: ${{ matrix.dataset }}
+          # Arm watchdog (rule_sweep.py). The dataset budget keeps every arm inside the
+          # 150-minute job after setup, so a slow dataset records timed-out arms
+          # instead of the job timing out and the dataset going MISSING.
+          GOLDENMATCH_CUT_RULES_ARM_TIMEOUT_S: "1200"
+          GOLDENMATCH_CUT_RULES_DATASET_BUDGET_S: "7200"
+          GOLDENMATCH_CUT_RULES_ARM_MEM_MB: "12000"
         run: |
           uv run python -m scripts.autoconfig_quality.rule_sweep \
             --datasets "$DATASET" --require-datasets "$DATASET" \

--- a/.github/workflows/fs-cut-rule-matrix.yml
+++ b/.github/workflows/fs-cut-rule-matrix.yml
@@ -1,0 +1,190 @@
+# FS link-cut routing P3 -- the per-rule measurement matrix
+# (docs/superpowers/specs/2026-09-11-fs-cut-rule-routing-design.md).
+#
+# For every dataset in the frozen design + held-out corpus
+# (scripts/autoconfig_quality/corpus.py), runs the full pipeline once per
+# link_cut_rule on one shared EM model and records F1 / precision / recall plus
+# the cut diagnostics. One job per dataset; a final job merges the per-dataset
+# scorecards into the cut-rule-matrix artifact and a step-summary table.
+#
+# Measurement only: it chooses no rule and gates nothing. NOT in ci-required.
+# Held-out data is fetched here and never committed: Leipzig Abt-Buy (CC-BY),
+# Magellan/DeepMatcher (cite-only, evaluation only), FEBRL dataset1/2 (ANU
+# open-source licence). ncvr_real is local-only PII and never provisioned.
+name: fs-cut-rule-matrix
+
+on:
+  pull_request:
+    paths:
+      - "scripts/autoconfig_quality/rule_sweep.py"
+      - "scripts/autoconfig_quality/corpus.py"
+      - ".github/workflows/fs-cut-rule-matrix.yml"
+  schedule:
+    - cron: "0 9 * * 0" # weekly, Sunday 09:00 UTC
+  workflow_dispatch:
+    inputs:
+      corpus:
+        description: "Which corpus to measure"
+        type: choice
+        options: [all, design, holdout]
+        default: all
+
+permissions:
+  contents: read
+
+env:
+  # pyarrow's bundled mimalloc SIGSEGVs on goldenmatch's pipeline worker threads.
+  ARROW_DEFAULT_MEMORY_POOL: system
+  # jemalloc page-decay: return freed polars pages to the OS between arms.
+  _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+
+concurrency:
+  group: fs-cut-rule-matrix-${{ github.ref }}-${{ inputs.corpus }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      datasets: ${{ steps.list.outputs.datasets }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Sync workspace
+        run: uv sync --all-packages
+      - name: Unit tests for the corpus, loaders, generator knob and sweep
+        run: >-
+          uv run python -m pytest -q
+          scripts/autoconfig_quality/tests/test_corpus.py
+          scripts/autoconfig_quality/tests/test_rule_sweep.py
+          scripts/bench_er_headtohead/test_heldout_loaders.py
+          scripts/bench_er_headtohead/test_generate_fixture_corruption.py
+      - name: List the corpus
+        id: list
+        env:
+          CORPUS: ${{ inputs.corpus || 'all' }}
+        run: |
+          echo "datasets=$(uv run python -m scripts.autoconfig_quality.corpus --list "$CORPUS" --ci)" >> "$GITHUB_OUTPUT"
+
+  sweep:
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        dataset: ${{ fromJSON(needs.plan.outputs.datasets) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Sync workspace (installs goldenmatch @ HEAD)
+        run: uv sync --all-packages
+      - name: Build the native kernel (mirror the real default FS path)
+        run: uv run python scripts/build_native.py
+      - name: Install recordlinkage (febrl3 / febrl4)
+        run: uv pip install recordlinkage
+      - name: Fetch benchmark data
+        run: |
+          BASE=packages/python/goldenmatch/tests/benchmarks/datasets
+          fetch_zip() {
+            local name="$1" url="$2"; shift 2
+            local dest="$BASE/$name"
+            mkdir -p "$dest"
+            if curl -fsSL --retry 3 -o "/tmp/$name.zip" "$url"; then
+              mkdir -p "/tmp/$name" && unzip -o -q "/tmp/$name.zip" -d "/tmp/$name"
+              for f in "$@"; do
+                found=$(find "/tmp/$name" -name "$f" | head -1)
+                if [ -n "$found" ]; then cp "$found" "$dest/$f"
+                else echo "::warning::$name: $f not in archive"; fi
+              done
+            else
+              echo "::warning::$name download failed; --require-datasets will fail the run"
+            fi
+          }
+          L=https://dbs.uni-leipzig.de/file
+          fetch_zip DBLP-ACM "$L/DBLP-ACM.zip" DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv
+          fetch_zip DBLP-Scholar "$L/DBLP-Scholar.zip" DBLP1.csv Scholar.csv DBLP-Scholar_perfectMapping.csv
+          fetch_zip Amazon-Google "$L/Amazon-GoogleProducts.zip" Amazon.csv GoogleProducts.csv Amzon_GoogleProducts_perfectMapping.csv
+          fetch_zip Abt-Buy "$L/Abt-Buy.zip" Abt.csv Buy.csv abt_buy_perfectMapping.csv
+          # Magellan/DeepMatcher: cite-only -- fetched for evaluation, never committed.
+          M=https://pages.cs.wisc.edu/~anhai/data1/deepmatcher_data/Structured
+          for name in Walmart-Amazon iTunes-Amazon Fodors-Zagats; do
+            mkdir -p "$BASE/Magellan/$name"
+            for f in tableA tableB train valid test; do
+              curl -fsSL --retry 3 -o "$BASE/Magellan/$name/$f.csv" "$M/$name/exp_data/$f.csv" \
+                || echo "::warning::Magellan $name $f.csv download failed"
+            done
+          done
+          # FEBRL dataset1/2 raw CSVs (ANU open-source licence) from recordlinkage.
+          mkdir -p "$BASE/FEBRL"
+          for f in dataset1 dataset2; do
+            curl -fsSL --retry 3 -o "$BASE/FEBRL/$f.csv" \
+              "https://raw.githubusercontent.com/J535D165/recordlinkage/master/recordlinkage/datasets/febrl/$f.csv" \
+              || echo "::warning::FEBRL $f download failed"
+          done
+      - name: Sweep every link-cut rule
+        env:
+          DATASET: ${{ matrix.dataset }}
+        run: |
+          uv run python -m scripts.autoconfig_quality.rule_sweep \
+            --datasets "$DATASET" --require-datasets "$DATASET" \
+            --out "cut-rules/$DATASET.json"
+      - name: Upload this dataset's scorecard
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: cut-rules-${{ matrix.dataset }}
+          path: cut-rules/
+          if-no-files-found: warn
+
+  merge:
+    needs: [plan, sweep]
+    if: always() && needs.plan.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Sync workspace
+        run: uv sync --all-packages
+      - name: Download the per-dataset scorecards
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: cut-rules-*
+          merge-multiple: true
+          path: cut-rules
+      - name: Merge and summarize
+        run: |
+          uv run python -m scripts.autoconfig_quality.rule_sweep merge cut-rules/*.json \
+            --out cut-rule-matrix.json --summary-md cut-rule-matrix.md
+          {
+            echo "## FS link-cut rule matrix"
+            echo ""
+            echo "Default = link_cut_rule unset on the loaded model; below default = F1 more than 0.01 under it."
+            echo ""
+            cat cut-rule-matrix.md
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload the merged matrix
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: cut-rule-matrix
+          path: |
+            cut-rule-matrix.json
+            cut-rule-matrix.md

--- a/.github/workflows/fs-cut-rule-matrix.yml
+++ b/.github/workflows/fs-cut-rule-matrix.yml
@@ -103,7 +103,8 @@ jobs:
             local dest="$BASE/$name"
             mkdir -p "$dest"
             if curl -fsSL --retry 3 -o "/tmp/$name.zip" "$url"; then
-              mkdir -p "/tmp/$name" && unzip -o -q "/tmp/$name.zip" -d "/tmp/$name"
+              mkdir -p "/tmp/$name"
+              unzip -o -q "/tmp/$name.zip" -d "/tmp/$name" || echo "::warning::$name: unzip failed"
               for f in "$@"; do
                 found=$(find "/tmp/$name" -name "$f" | head -1)
                 if [ -n "$found" ]; then cp "$found" "$dest/$f"
@@ -171,9 +172,12 @@ jobs:
           merge-multiple: true
           path: cut-rules
       - name: Merge and summarize
+        env:
+          EXPECT: ${{ needs.plan.outputs.datasets }}
         run: |
           uv run python -m scripts.autoconfig_quality.rule_sweep merge cut-rules/*.json \
-            --out cut-rule-matrix.json --summary-md cut-rule-matrix.md
+            --out cut-rule-matrix.json --holdout-out cut-rule-matrix-holdout.json \
+            --summary-md cut-rule-matrix.md --expect-json "$EXPECT"
           {
             echo "## FS link-cut rule matrix"
             echo ""
@@ -182,9 +186,17 @@ jobs:
             cat cut-rule-matrix.md
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload the merged matrix
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: cut-rule-matrix
           path: |
             cut-rule-matrix.json
             cut-rule-matrix.md
+      - name: Upload the held-out gate scorecard
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: cut-rule-matrix-holdout
+          path: cut-rule-matrix-holdout.json
+          if-no-files-found: warn

--- a/scripts/autoconfig_quality/README.md
+++ b/scripts/autoconfig_quality/README.md
@@ -81,6 +81,42 @@ routing off):
 The probabilistic strategy carries a small EM-convergence wobble (±0.004, recall
 stable); the 0.01 floor tolerance absorbs it.
 
+## Per-rule link-cut matrix (FS link-cut routing P3)
+
+`rule_sweep.py` measures every Fellegi-Sunter link-cut rule on every labelled
+dataset in the frozen corpus (`corpus.py`). For each dataset it auto-configures the
+probabilistic config once, then runs the full pipeline once per arm on one shared
+EM model (`MatchkeyConfig.model_path`):
+
+- `default` trains and saves the model;
+- `default_loaded` reloads it and is the baseline;
+- each `link_cut_rule` arm reloads it too.
+
+A pinned arm that an earlier precedence step overrode is **voided** and fails the
+run, so a leaked `GOLDENMATCH_FS_EVIDENCE_CUT` cannot quietly turn nine arms into
+nine copies of the default. The sweep also refuses to start while any cut-moving
+env var is set.
+
+```bash
+python -m scripts.autoconfig_quality.rule_sweep --datasets person --out person.json
+python -m scripts.autoconfig_quality.rule_sweep merge a.json b.json --out m.json --summary-md m.md
+```
+
+Measurement only: it writes no routing row. Large datasets run in the
+`fs-cut-rule-matrix` workflow (one job per dataset), never on a laptop.
+
+| Corpus | Datasets | Source and licence |
+|---|---|---|
+| design | person, household_hardneg, cotenant_hardneg, febrl3, febrl4, ncvr_synthetic, ncvr_real (local only), historical_50k, dblp_acm, dblp_scholar, amazon_google | as listed above |
+| holdout | abt_buy | Leipzig, CC-BY: Database Group Leipzig; Köpcke, Thor & Rahm, VLDB 2010 |
+| holdout | walmart_amazon, itunes_amazon, fodors_zagats | Magellan/DeepMatcher, cite-only, fetched for evaluation and never committed: Konda et al. 2016; Mudgal et al. 2018 |
+| holdout | febrl1, febrl2 | FEBRL raw CSVs from recordlinkage, ANU open-source licence: Christen 2008 |
+| holdout | synth_{person,biblio}_c{05,20}_d{10,40} | `generate_fixture.py`, seed 1009, corruption 0.5/2.0, dupe rate 0.10/0.40 |
+
+The held-out set is frozen: a routing row ships only if it is never more than 0.01
+F1 below the default on every design **and** held-out dataset. Changing the
+held-out list after any row exists means re-running the full gate.
+
 ## The gate
 
 `gate` diffs the current scorecard against the committed baseline

--- a/scripts/autoconfig_quality/README.md
+++ b/scripts/autoconfig_quality/README.md
@@ -117,6 +117,25 @@ The held-out set is frozen: a routing row ships only if it is never more than 0.
 F1 below the default on every design **and** held-out dataset. Changing the
 held-out list after any row exists means re-running the full gate.
 
+**Row authors (P4) read the `cut-rule-matrix` design artifact only.** The
+held-out json and the per-dataset `cut-rules-<holdout dataset>` artifacts are
+gate inputs, not evidence -- they must not be read while writing a row, or the
+held-out set stops being held out.
+
+**Magellan truth bias.** The Magellan/DeepMatcher truth (walmart_amazon,
+itunes_amazon, fodors_zagats) covers only DeepMatcher's labelled candidate
+pairs, so an unlabelled true match a rule links is scored as a false positive
+and lower cuts are penalised -- the bias favours high-cut rules such as
+`evidence_12` and `posterior_099`. A labelled-pairs-only metric is a P4
+prerequisite before these datasets gate a row.
+
+**Held-out independence.** Not every held-out dataset is an independent check:
+`febrl1`/`febrl2` share the FEBRL generator with design's `febrl3`/`febrl4`, the
+eight `synth_*` variants share one generator, and `fodors_zagats` is
+near-saturated (F1 ~1.0, little room to show a regression). The genuinely
+independent real held-out sets are `abt_buy`, `walmart_amazon` and
+`itunes_amazon`.
+
 ## The gate
 
 `gate` diffs the current scorecard against the committed baseline

--- a/scripts/autoconfig_quality/README.md
+++ b/scripts/autoconfig_quality/README.md
@@ -125,6 +125,9 @@ Measurement only: it writes no routing row. Large datasets run in the
 | Corpus | Datasets | Source and licence |
 |---|---|---|
 | design | person, household_hardneg, cotenant_hardneg, febrl3, febrl4, ncvr_synthetic, ncvr_real (local only), historical_50k, dblp_acm, dblp_scholar, amazon_google | as listed above |
+| design | musicbrainz_20k, geo_settlements, affiliations | Leipzig clustering trio, CC-BY: Database Group Leipzig; Saeedi, Peukert & Rahm, ADBIS 2017 |
+| design | synth_biblio_d02, synth_person_d02, synth_product_d02, synth_product_d20 | `generate_fixture.py`, seed 7, corruption 1.0, dupe rate 0.02/0.20 |
+| design | ncvr_synthetic_s7, household_hardneg_s7, cotenant_hardneg_s7 | seed-7 variants of the same generators as their default-seed design entries |
 | holdout | abt_buy | Leipzig, CC-BY: Database Group Leipzig; Köpcke, Thor & Rahm, VLDB 2010 |
 | holdout | walmart_amazon, itunes_amazon, fodors_zagats | Magellan/DeepMatcher, cite-only, fetched for evaluation and never committed: Konda et al. 2016; Mudgal et al. 2018 |
 | holdout | febrl1, febrl2 | FEBRL raw CSVs from recordlinkage, ANU open-source licence: Christen 2008 |
@@ -151,7 +154,9 @@ prerequisite before these datasets gate a row.
 eight `synth_*` variants share one generator, and `fodors_zagats` is
 near-saturated (F1 ~1.0, little room to show a regression). The genuinely
 independent real held-out sets are `abt_buy`, `walmart_amazon` and
-`itunes_amazon`.
+`itunes_amazon`. The design synthetic variants (`synth_*_d02`, `synth_product_d20`)
+share a generator with the held-out synthetic variants, so they are weaker
+evidence than the real datasets.
 
 ## The gate
 

--- a/scripts/autoconfig_quality/README.md
+++ b/scripts/autoconfig_quality/README.md
@@ -98,12 +98,21 @@ nine copies of the default. The sweep also refuses to start while any cut-moving
 env var is set.
 
 Each arm runs in its own child process, reading one shared config file, under a
-memory cap (`GOLDENMATCH_CUT_RULES_ARM_MEM_MB`, default 12000) and a timeout
-(`GOLDENMATCH_CUT_RULES_ARM_TIMEOUT_S`, default 3600). A rule arm that is killed
-or crashes is recorded (`crashed`: `memory_cap`, `timeout` or `crashed`, with its
-peak RSS) and counts as below default, since blowing up is worse than the
-baseline; the rest of the dataset's arms still run. A crashed `default` or
-`default_loaded` arm leaves no baseline, so it fails the dataset.
+watchdog:
+
+- an RSS cap on the child tree (`GOLDENMATCH_CUT_RULES_ARM_MEM_MB`, default 12000);
+- a floor on the machine's available memory (`GOLDENMATCH_CUT_RULES_MIN_AVAILABLE_MB`,
+  default 1500; lower it on a laptop that already runs below that);
+- a per-arm timeout (`GOLDENMATCH_CUT_RULES_ARM_TIMEOUT_S`, default 3600);
+- an optional budget for all of a dataset's arms
+  (`GOLDENMATCH_CUT_RULES_DATASET_BUDGET_S`). Each arm gets at most its share of what
+  is left, and arms the budget cannot fit are recorded as timed out without starting.
+
+A rule arm that is killed or crashes is recorded (`crashed`: `memory_cap`, `timeout`
+or `crashed`, plus `kill_reason`, `peak_rss_mb` and `process_seconds`) and counts as
+below default, since blowing up is worse than the baseline; the rest of the
+dataset's arms still run. A crashed `default` or `default_loaded` arm leaves no
+baseline, so it fails the dataset.
 
 ```bash
 python -m scripts.autoconfig_quality.rule_sweep --datasets person --out person.json

--- a/scripts/autoconfig_quality/README.md
+++ b/scripts/autoconfig_quality/README.md
@@ -97,6 +97,14 @@ run, so a leaked `GOLDENMATCH_FS_EVIDENCE_CUT` cannot quietly turn nine arms int
 nine copies of the default. The sweep also refuses to start while any cut-moving
 env var is set.
 
+Each arm runs in its own child process, reading one shared config file, under a
+memory cap (`GOLDENMATCH_CUT_RULES_ARM_MEM_MB`, default 12000) and a timeout
+(`GOLDENMATCH_CUT_RULES_ARM_TIMEOUT_S`, default 3600). A rule arm that is killed
+or crashes is recorded (`crashed`: `memory_cap`, `timeout` or `crashed`, with its
+peak RSS) and counts as below default, since blowing up is worse than the
+baseline; the rest of the dataset's arms still run. A crashed `default` or
+`default_loaded` arm leaves no baseline, so it fails the dataset.
+
 ```bash
 python -m scripts.autoconfig_quality.rule_sweep --datasets person --out person.json
 python -m scripts.autoconfig_quality.rule_sweep merge a.json b.json --out m.json --summary-md m.md

--- a/scripts/autoconfig_quality/corpus.py
+++ b/scripts/autoconfig_quality/corpus.py
@@ -1,0 +1,85 @@
+"""Frozen corpus for FS link-cut routing (spec 2026-09-11-fs-cut-rule-routing-design, P3).
+
+DESIGN is the labelled part of the auto-config quality registry plus the
+`ab_lever` panel. The two unlabelled blocking-shape anchors (sparse_zip,
+shared_email) cannot be scored and are left out. Routing rows may be written from
+these datasets' results.
+
+HOLDOUT is never used to write or tune a row. A row ships only if it is also never
+below the default on every HOLDOUT dataset. Changing HOLDOUT after any row exists
+means re-running the full gate, so tests/test_corpus.py pins it verbatim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+DESIGN: tuple[str, ...] = (
+    "person",
+    "household_hardneg",
+    "cotenant_hardneg",
+    "febrl3",
+    "febrl4",
+    "ncvr_synthetic",
+    "ncvr_real",
+    "historical_50k",
+    "dblp_acm",
+    "dblp_scholar",
+    "amazon_google",
+)
+
+HOLDOUT: tuple[str, ...] = (
+    "abt_buy",
+    "walmart_amazon",
+    "itunes_amazon",
+    "fodors_zagats",
+    "febrl1",
+    "febrl2",
+    "synth_person_c05_d10",
+    "synth_person_c05_d40",
+    "synth_person_c20_d10",
+    "synth_person_c20_d40",
+    "synth_biblio_c05_d10",
+    "synth_biblio_c05_d40",
+    "synth_biblio_c20_d10",
+    "synth_biblio_c20_d40",
+)
+
+#: Never provisioned in CI: real voter PII stays on the laptop.
+LOCAL_ONLY: frozenset[str] = frozenset({"ncvr_real"})
+
+_SETS = {"design": DESIGN, "holdout": HOLDOUT, "all": DESIGN + HOLDOUT}
+
+
+def corpus_of(name: str) -> str:
+    """``"design"``, ``"holdout"``, or ``"unlisted"`` for an ad-hoc dataset name."""
+    if name in DESIGN:
+        return "design"
+    if name in HOLDOUT:
+        return "holdout"
+    return "unlisted"
+
+
+def select(corpus: str) -> tuple[str, ...]:
+    """The dataset names of ``corpus`` (``design``, ``holdout`` or ``all``)."""
+    return _SETS[corpus]
+
+
+def ci_datasets(corpus: str) -> list[str]:
+    """``select(corpus)`` without the local-only datasets."""
+    return [name for name in select(corpus) if name not in LOCAL_ONLY]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="List the FS link-cut routing corpus.")
+    ap.add_argument("--list", required=True, choices=sorted(_SETS), help="corpus to list")
+    ap.add_argument("--ci", action="store_true", help="drop local-only datasets")
+    args = ap.parse_args(argv)
+    names = ci_datasets(args.list) if args.ci else list(select(args.list))
+    print(json.dumps(names))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autoconfig_quality/corpus.py
+++ b/scripts/autoconfig_quality/corpus.py
@@ -27,6 +27,16 @@ DESIGN: tuple[str, ...] = (
     "dblp_acm",
     "dblp_scholar",
     "amazon_google",
+    "musicbrainz_20k",
+    "geo_settlements",
+    "affiliations",
+    "synth_biblio_d02",
+    "synth_person_d02",
+    "synth_product_d02",
+    "synth_product_d20",
+    "ncvr_synthetic_s7",
+    "household_hardneg_s7",
+    "cotenant_hardneg_s7",
 )
 
 HOLDOUT: tuple[str, ...] = (

--- a/scripts/autoconfig_quality/datasets.py
+++ b/scripts/autoconfig_quality/datasets.py
@@ -118,6 +118,28 @@ def _ncvr_synthetic() -> tuple[pl.DataFrame, set]:
     return df, _pairs_to_row_index(df, "ncid", ncid_pairs)
 
 
+def _household_hardneg_s7() -> tuple[pl.DataFrame, set]:
+    """DESIGN seed variant for link-cut routing (P3): household_hardneg at seed 7."""
+    from scripts.autoconfig_quality.anchors import gen_household_hardneg
+
+    return gen_household_hardneg(n_households=350, seed=7)
+
+
+def _cotenant_hardneg_s7() -> tuple[pl.DataFrame, set]:
+    """DESIGN seed variant for link-cut routing (P3): cotenant_hardneg at seed 7."""
+    from scripts.autoconfig_quality.anchors import gen_cotenant_hardneg
+
+    return gen_cotenant_hardneg(n_addresses=300, seed=7)
+
+
+def _ncvr_synthetic_s7() -> tuple[pl.DataFrame, set]:
+    """DESIGN seed variant for link-cut routing (P3): ncvr_synthetic at seed 7."""
+    from scripts.dqbench_adapters.ncvr import build_ncvr_synthetic_df_and_gt
+
+    df, ncid_pairs = build_ncvr_synthetic_df_and_gt(seed=7)
+    return df, _pairs_to_row_index(df, "ncid", ncid_pairs)
+
+
 def _ncvr_real() -> tuple[pl.DataFrame, set] | None:
     """Real NCVR sample (gitignored PII, local-only). None when the file is absent."""
     from scripts.dqbench_adapters.ncvr import build_ncvr_df_and_gt

--- a/scripts/autoconfig_quality/rule_sweep.py
+++ b/scripts/autoconfig_quality/rule_sweep.py
@@ -46,6 +46,9 @@ CUT_ENV_VARS = (
     "GOLDENMATCH_FS_CALIBRATED",
     "GOLDENMATCH_FS_EVIDENCE_CUT",
     "GOLDENMATCH_FS_CALIBRATE_THRESHOLD",
+    # Passes a pair_filter to load_or_train_em, which stops model_path from
+    # saving, so arms would retrain their own model instead of sharing one.
+    "GOLDENMATCH_FS_SIGNATURE_PRUNE",
 )
 
 
@@ -86,14 +89,27 @@ def pin_rule(cfg, rule: str | None, model_dir: Path):
     return cfg.model_copy(update={"matchkeys": pinned, "match_settings": None})
 
 
-def arm_record(arm: str, summary: dict, stats: dict | None, partition: tuple[int, str]) -> dict:
+def arm_record(
+    arm: str,
+    summary: dict,
+    stats: dict | None,
+    partition: tuple[int, str],
+    expected_matchkeys: list[str],
+) -> dict:
     """One arm's result from ``evaluate_clusters(...).summary()`` and the run's stats.
 
-    ``applied``: every probabilistic matchkey's cut came from the pinned rule.
+    ``expected_matchkeys``: the probabilistic matchkey names ``pin_rule`` pinned.
+    Every one of them must show up in the ``fs_link_thresholds`` report or the arm
+    is voided -- a matchkey silently missing from the report is not distinguishable
+    from one that never ran.
 
-    ``voided``: the arm measured something other than what it claims, and the sweep
-    fails. That happens when the run reported no FS cutoff at all, or when an
-    earlier precedence step overrode a pin (``cut_reason`` starts ``link_cut_rule=``).
+    ``applied``: every expected matchkey is present and its cut came from the
+    pinned rule.
+
+    ``voided``: the arm measured something other than what it claims, and the
+    sweep fails. That happens when the run reported no FS cutoff at all, an
+    expected matchkey is missing from the report, or when an earlier precedence
+    step overrode a pin (``cut_reason`` starts ``link_cut_rule=``).
 
     A rule this model cannot compute is not applied but not voided: for example
     ``otsu`` on 50 or fewer training pairs, which falls back to the default rule. The
@@ -106,11 +122,18 @@ def arm_record(arm: str, summary: dict, stats: dict | None, partition: tuple[int
         for name, entry in sorted(report.items())
     }
     rule = None if arm in ("default", BASELINE_ARM) else arm
-    voided = not per_mk or any(
-        (entry["cut_reason"] or "").startswith("link_cut_rule=") for entry in per_mk.values()
+    missing_expected = [name for name in expected_matchkeys if name not in per_mk]
+    voided = (
+        not per_mk
+        or bool(missing_expected)
+        or any(
+            (entry["cut_reason"] or "").startswith("link_cut_rule=") for entry in per_mk.values()
+        )
     )
-    applied = bool(per_mk) and (
-        rule is None or all(entry["cut_rule"] == rule for entry in per_mk.values())
+    applied = (
+        bool(per_mk)
+        and not missing_expected
+        and (rule is None or all(per_mk[name]["cut_rule"] == rule for name in expected_matchkeys))
     )
     pairs, digest = partition
     return {
@@ -125,43 +148,80 @@ def arm_record(arm: str, summary: dict, stats: dict | None, partition: tuple[int
     }
 
 
+def _model_hashes(model_dir: Path) -> dict[str, str]:
+    """``{file name: sha256 hex of bytes}`` for every saved model in ``model_dir``."""
+    import hashlib
+
+    return {
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in sorted(model_dir.glob("*.json"))
+    }
+
+
 def sweep_frame(df, gt: set, model_dir: Path) -> dict:
     """Run every arm on one labelled frame. ``model_dir`` must start empty."""
+    import time
+
     import goldenmatch
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
     from goldenmatch.core.evaluate import evaluate_clusters
 
     from scripts.bench_er_headtohead.ab_lever import _partition_fingerprint
 
+    start = time.perf_counter()
     base = auto_configure_probabilistic_df(df)
+    probabilistic_matchkeys = sorted(
+        mk.name for mk in base.get_matchkeys() if mk.type == "probabilistic"
+    )
     arms: dict[str, dict] = {}
     diagnostics: dict[str, dict | None] = {}
     models_saved: list[str] = []
+    hashes_after_default: dict[str, str] = {}
     for arm in ARMS:
         rule = None if arm in ("default", BASELINE_ARM) else arm
         result = goldenmatch.dedupe_df(df, config=pin_rule(base, rule, model_dir))
         summary = evaluate_clusters(result.clusters, gt).summary()
-        arms[arm] = arm_record(arm, summary, result.stats, _partition_fingerprint(result.clusters))
+        arms[arm] = arm_record(
+            arm,
+            summary,
+            result.stats,
+            _partition_fingerprint(result.clusters),
+            probabilistic_matchkeys,
+        )
         if arm == "default":
             models_saved = sorted(p.name for p in model_dir.glob("*.json"))
+            hashes_after_default = _model_hashes(model_dir)
         if arm == BASELINE_ARM:
             report = (result.stats or {}).get("fs_link_thresholds") or {}
             diagnostics = {
                 name: entry.get("cut_diagnostics") for name, entry in sorted(report.items())
             }
+    hashes_after_last = _model_hashes(model_dir)
     baseline = arms[BASELINE_ARM]["f1"]
+    model_complete = bool(models_saved) and sorted(models_saved) == sorted(
+        f"{name}.json" for name in probabilistic_matchkeys
+    )
+    model_stable = (
+        bool(hashes_after_default)
+        and bool(hashes_after_last)
+        and hashes_after_default == hashes_after_last
+    )
     return {
         "rows": df.height,
         "gt_pairs": len(gt),
+        "probabilistic_matchkeys": probabilistic_matchkeys,
         "arms": arms,
         "cut_diagnostics": diagnostics,
         "models_saved": models_saved,
+        "model_complete": model_complete,
+        "model_stable": model_stable,
+        "reload_partition_match": arms["default"]["digest"] == arms[BASELINE_ARM]["digest"],
         "model_reload_delta": float(baseline - arms["default"]["f1"]),
         "below_default": sorted(
             rule
             for rule in CUT_RULES
             if arms[rule]["applied"] and arms[rule]["f1"] < baseline - TOLERANCE
         ),
+        "wall_seconds": round(time.perf_counter() - start, 1),
     }
 
 
@@ -230,53 +290,61 @@ def run(argv: list[str]) -> int:
     card = build_scorecard(results, native_version=native_version, git_sha=git_sha, skipped=skipped)
     card["meta"]["cut_env_overrides"] = overrides
     card["meta"]["tolerance"] = TOLERANCE
+    card["meta"]["goldenmatch_env"] = {
+        k: v for k, v in sorted(os.environ.items()) if k.startswith("GOLDENMATCH_")
+    }
+    card["meta"]["pythonhashseed"] = os.environ.get("PYTHONHASHSEED")
+
+    required = [d.strip() for d in args.require_datasets.split(",") if d.strip()]
+    failures: list[str] = []
+    for name in required:
+        if name not in results:
+            failures.append(f"{name}: required dataset not measured")
+    for name, record in results.items():
+        for arm, rec in record["arms"].items():
+            if rec["voided"]:
+                failures.append(f"{name}:{arm} voided")
+        if not record.get("model_complete"):
+            failures.append(f"{name}: shared EM model not saved for every probabilistic matchkey")
+        if not record.get("model_stable"):
+            failures.append(f"{name}: shared EM model changed between arms")
+    if not results:
+        failures.append("0 datasets measured")
+    failures.sort()
+
+    card["meta"]["failures"] = failures
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(dumps(card) + "\n", encoding="utf-8")
 
-    required = [d.strip() for d in args.require_datasets.split(",") if d.strip()]
-    missing = [d for d in required if d not in results]
-    voided = sorted(
-        f"{name}:{arm}"
-        for name, record in results.items()
-        for arm, rec in record["arms"].items()
-        if rec["voided"]
-    )
     print(
         f"[cut-rules] measured {len(results)}, skipped {len(skipped)} -> {args.out}",
         file=sys.stderr,
     )
-    if not results:
-        print(
-            "FAIL: 0 datasets measured; a sweep that measures nothing cannot pass", file=sys.stderr
-        )
-        return 1
-    if missing:
-        print(f"FAIL: required datasets not measured: {missing}", file=sys.stderr)
-        return 1
-    if voided:
-        print(
-            f"FAIL: voided arms (a pin was overridden or no FS cutoff reported): {voided}",
-            file=sys.stderr,
-        )
-        return 1
-    return 0
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    return 1 if failures else 0
 
 
-def merge_cards(cards: list[dict]) -> dict:
+def merge_cards(cards: list[dict], expected: list[str] | None = None) -> dict:
     """One scorecard from per-dataset sweep scorecards (the CI matrix writes one per job)."""
     from scripts.autoconfig_quality.scorecard import build_scorecard
+
+    if not cards:
+        raise ValueError("no sweep results to merge")
 
     datasets: dict[str, dict] = {}
     skipped: dict[str, str] = {}
     overrides: dict[str, str] = {}
     shas: set[str] = set()
     natives: set[str] = set()
+    failures: list[str] = []
     for card in cards:
         meta = card["meta"]
         shas.add(meta["git_sha"])
         natives.add(meta["native_version"])
         skipped.update(meta.get("datasets_skipped") or {})
         overrides.update(meta.get("cut_env_overrides") or {})
+        failures.extend(meta.get("failures") or [])
         for name, record in card["datasets"].items():
             if name in datasets:
                 raise ValueError(f"dataset {name!r} appears in two sweep results")
@@ -291,12 +359,16 @@ def merge_cards(cards: list[dict]) -> dict:
     )
     merged["meta"]["cut_env_overrides"] = overrides
     merged["meta"]["tolerance"] = TOLERANCE
+    merged["meta"]["failures"] = sorted(failures)
+    merged["meta"]["missing"] = sorted(set(expected) - set(datasets)) if expected else []
     return merged
 
 
 def best_rule(record: dict) -> tuple[str, float]:
     """The highest-F1 applied rule arm; ties go to the earlier ``CUT_RULES`` name.
-    Falls back to the baseline arm when no rule applied."""
+    Falls back to the baseline arm (``BASELINE_ARM``) when no rule applied --
+    callers rendering this for humans should treat that sentinel as "no rule
+    applied", not as a real rule name."""
     best: tuple[str, float] | None = None
     for rule in CUT_RULES:
         arm = record["arms"][rule]
@@ -305,27 +377,85 @@ def best_rule(record: dict) -> tuple[str, float]:
     return best or (BASELINE_ARM, record["arms"][BASELINE_ARM]["f1"])
 
 
-def render_markdown(card: dict) -> str:
-    """One table row per dataset, design set first, for the CI step summary."""
-    order = {"design": 0, "holdout": 1}
-    lines = [
-        "| dataset | corpus | default F1 | best rule | best F1 | Δ best | below default |",
-        "|---|---|---|---|---|---|---|",
-    ]
-    names = sorted(
-        card["datasets"],
-        key=lambda n: (order.get(card["datasets"][n].get("corpus"), 2), n),
+def _not_applied_rules(record: dict) -> list[str]:
+    """Rules whose arm neither applied nor voided (e.g. otsu falling back
+    on too few training pairs)."""
+    return sorted(
+        rule
+        for rule in CUT_RULES
+        if not record["arms"][rule]["applied"] and not record["arms"][rule]["voided"]
     )
-    for name in names:
+
+
+def render_markdown(card: dict, holdout_card: dict | None = None) -> str:
+    """The design table (full detail), and -- when ``holdout_card`` is given -- the
+    held-out gate view (counts only, no rule names or per-rule F1: the held-out set
+    stays out of view of row-writing). Missing datasets (``card["meta"]["missing"]``)
+    render as an all-MISSING row in whichever table matches their corpus."""
+    from scripts.autoconfig_quality.corpus import corpus_of
+
+    missing = sorted(card["meta"].get("missing") or [])
+    design_missing = [n for n in missing if corpus_of(n) != "holdout"]
+    holdout_missing = [n for n in missing if corpus_of(n) == "holdout"]
+
+    lines = [
+        "### Design",
+        "",
+        "| dataset | default F1 | best rule | best F1 | Δ best | below default"
+        " | not applied | reload digest |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for name in sorted(card["datasets"]):
         record = card["datasets"][name]
         baseline = record["arms"][BASELINE_ARM]["f1"]
         rule, f1 = best_rule(record)
+        label = "no rule applied" if rule == BASELINE_ARM else rule
         below = ", ".join(record.get("below_default") or []) or "none"
+        not_applied = ", ".join(_not_applied_rules(record)) or "none"
+        digest = "same" if record.get("reload_partition_match", True) else "DIFFERS"
         lines.append(
-            f"| {name} | {record.get('corpus', '')} | {baseline:.4f} | {rule} | {f1:.4f} "
-            f"| {f1 - baseline:+.4f} | {below} |"
+            f"| {name} | {baseline:.4f} | {label} | {f1:.4f} "
+            f"| {f1 - baseline:+.4f} | {below} | {not_applied} | {digest} |"
         )
-    return "\n".join(lines) + "\n"
+    for name in design_missing:
+        lines.append(
+            f"| {name} | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |"
+        )
+
+    out = "\n".join(lines) + "\n"
+
+    if holdout_card is not None:
+        h_lines = [
+            "",
+            "### Held-out (gate view)",
+            "",
+            "| dataset | default F1 | rules below default | rules not applied |",
+            "|---|---|---|---|",
+        ]
+        for name in sorted(holdout_card["datasets"]):
+            record = holdout_card["datasets"][name]
+            baseline = record["arms"][BASELINE_ARM]["f1"]
+            below_n = len(record.get("below_default") or [])
+            not_applied_n = len(_not_applied_rules(record))
+            h_lines.append(f"| {name} | {baseline:.4f} | {below_n} | {not_applied_n} |")
+        for name in holdout_missing:
+            h_lines.append(f"| {name} | MISSING | MISSING | MISSING |")
+        out += "\n".join(h_lines) + "\n"
+
+    failures = card["meta"].get("failures") or []
+    if failures:
+        out += "\n**Failures**\n\n" + "\n".join(f"- {f}" for f in failures) + "\n"
+
+    return out
+
+
+def _split_by_corpus(card: dict) -> tuple[dict, dict]:
+    """``card``'s datasets split into (design + unlisted, holdout), same meta."""
+    from scripts.autoconfig_quality.corpus import corpus_of
+
+    design = {n: r for n, r in card["datasets"].items() if corpus_of(n) != "holdout"}
+    holdout = {n: r for n, r in card["datasets"].items() if corpus_of(n) == "holdout"}
+    return {"meta": card["meta"], "datasets": design}, {"meta": card["meta"], "datasets": holdout}
 
 
 def merge(argv: list[str]) -> int:
@@ -335,15 +465,41 @@ def merge(argv: list[str]) -> int:
 
     ap = argparse.ArgumentParser(description="Merge per-dataset link-cut sweep scorecards.")
     ap.add_argument("files", nargs="+", type=Path)
-    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path, help="design + unlisted datasets only")
+    ap.add_argument("--holdout-out", type=Path, default=None, help="held-out datasets, gate input")
     ap.add_argument("--summary-md", type=Path, default=None)
+    ap.add_argument("--expect-json", default=None, help="JSON array of expected dataset names")
     args = ap.parse_args(argv)
-    card = merge_cards([json.loads(p.read_text(encoding="utf-8")) for p in args.files])
+
+    expected = json.loads(args.expect_json) if args.expect_json else None
+    card = merge_cards(
+        [json.loads(p.read_text(encoding="utf-8")) for p in args.files], expected=expected
+    )
+    design_card, holdout_card = _split_by_corpus(card)
+
+    if holdout_card["datasets"] and args.holdout_out is None:
+        print(
+            "FAIL: merged results include held-out datasets but --holdout-out was not given",
+            file=sys.stderr,
+        )
+        return 2
+
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(dumps(card) + "\n", encoding="utf-8")
+    args.out.write_text(dumps(design_card) + "\n", encoding="utf-8")
+    if args.holdout_out is not None:
+        args.holdout_out.parent.mkdir(parents=True, exist_ok=True)
+        args.holdout_out.write_text(dumps(holdout_card) + "\n", encoding="utf-8")
     if args.summary_md is not None:
-        args.summary_md.write_text(render_markdown(card), encoding="utf-8")
-    return 0
+        rendered = render_markdown(design_card, holdout_card if holdout_card["datasets"] else None)
+        args.summary_md.write_text(rendered, encoding="utf-8")
+
+    failures = card["meta"].get("failures") or []
+    missing = card["meta"].get("missing") or []
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    for name in missing:
+        print(f"FAIL: missing dataset {name}", file=sys.stderr)
+    return 1 if (failures or missing) else 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/autoconfig_quality/rule_sweep.py
+++ b/scripts/autoconfig_quality/rule_sweep.py
@@ -262,8 +262,95 @@ def run(argv: list[str]) -> int:
     return 0
 
 
+def merge_cards(cards: list[dict]) -> dict:
+    """One scorecard from per-dataset sweep scorecards (the CI matrix writes one per job)."""
+    from scripts.autoconfig_quality.scorecard import build_scorecard
+
+    datasets: dict[str, dict] = {}
+    skipped: dict[str, str] = {}
+    overrides: dict[str, str] = {}
+    shas: set[str] = set()
+    natives: set[str] = set()
+    for card in cards:
+        meta = card["meta"]
+        shas.add(meta["git_sha"])
+        natives.add(meta["native_version"])
+        skipped.update(meta.get("datasets_skipped") or {})
+        overrides.update(meta.get("cut_env_overrides") or {})
+        for name, record in card["datasets"].items():
+            if name in datasets:
+                raise ValueError(f"dataset {name!r} appears in two sweep results")
+            datasets[name] = record
+    if len(shas) > 1:
+        raise ValueError(f"sweep results come from different commits: {sorted(shas)}")
+    merged = build_scorecard(
+        datasets,
+        native_version=",".join(sorted(natives)),
+        git_sha=next(iter(shas), "unknown"),
+        skipped={name: why for name, why in skipped.items() if name not in datasets},
+    )
+    merged["meta"]["cut_env_overrides"] = overrides
+    merged["meta"]["tolerance"] = TOLERANCE
+    return merged
+
+
+def best_rule(record: dict) -> tuple[str, float]:
+    """The highest-F1 applied rule arm; ties go to the earlier ``CUT_RULES`` name.
+    Falls back to the baseline arm when no rule applied."""
+    best: tuple[str, float] | None = None
+    for rule in CUT_RULES:
+        arm = record["arms"][rule]
+        if arm["applied"] and (best is None or arm["f1"] > best[1]):
+            best = (rule, arm["f1"])
+    return best or (BASELINE_ARM, record["arms"][BASELINE_ARM]["f1"])
+
+
+def render_markdown(card: dict) -> str:
+    """One table row per dataset, design set first, for the CI step summary."""
+    order = {"design": 0, "holdout": 1}
+    lines = [
+        "| dataset | corpus | default F1 | best rule | best F1 | Δ best | below default |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    names = sorted(
+        card["datasets"],
+        key=lambda n: (order.get(card["datasets"][n].get("corpus"), 2), n),
+    )
+    for name in names:
+        record = card["datasets"][name]
+        baseline = record["arms"][BASELINE_ARM]["f1"]
+        rule, f1 = best_rule(record)
+        below = ", ".join(record.get("below_default") or []) or "none"
+        lines.append(
+            f"| {name} | {record.get('corpus', '')} | {baseline:.4f} | {rule} | {f1:.4f} "
+            f"| {f1 - baseline:+.4f} | {below} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def merge(argv: list[str]) -> int:
+    import json
+
+    from scripts.autoconfig_quality.scorecard import dumps
+
+    ap = argparse.ArgumentParser(description="Merge per-dataset link-cut sweep scorecards.")
+    ap.add_argument("files", nargs="+", type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--summary-md", type=Path, default=None)
+    args = ap.parse_args(argv)
+    card = merge_cards([json.loads(p.read_text(encoding="utf-8")) for p in args.files])
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(dumps(card) + "\n", encoding="utf-8")
+    if args.summary_md is not None:
+        args.summary_md.write_text(render_markdown(card), encoding="utf-8")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
-    return run(sys.argv[1:] if argv is None else argv)
+    argv = sys.argv[1:] if argv is None else argv
+    if argv and argv[0] == "merge":
+        return merge(argv[1:])
+    return run(argv)
 
 
 if __name__ == "__main__":

--- a/scripts/autoconfig_quality/rule_sweep.py
+++ b/scripts/autoconfig_quality/rule_sweep.py
@@ -1,0 +1,270 @@
+"""Per-rule link-cut matrix (spec 2026-09-11-fs-cut-rule-routing-design, P3).
+
+For one dataset: auto-configure the probabilistic config once, then run the full
+pipeline once per arm. Every probabilistic matchkey is pinned to one
+``link_cut_rule`` and points at one saved EM model (``model_path``), so the arms
+differ only in where the cut lands.
+
+Arms, in run order:
+  default         link_cut_rule unset; trains the EM model and saves it
+  default_loaded  link_cut_rule unset; loads the saved model -- the baseline
+                  every rule arm is compared against, on the same model
+  <rule>          one arm per fs_cut_rules.CUT_RULES name, model loaded
+
+Measurement only: nothing here chooses a rule.
+
+Usage:
+  python -m scripts.autoconfig_quality.rule_sweep --corpus all --ci --out cut-rules.json
+  python -m scripts.autoconfig_quality.rule_sweep --datasets person --out person.json
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_DETERMINISTIC", "1")
+
+import argparse  # noqa: E402
+import sys  # noqa: E402
+import tempfile  # noqa: E402
+from collections.abc import Callable  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from goldenmatch.core.fs_cut_rules import CUT_RULES  # noqa: E402
+
+BASELINE_ARM = "default_loaded"
+ARMS: tuple[str, ...] = ("default", BASELINE_ARM, *CUT_RULES)
+
+#: The spec's gate tolerance: a rule is below the default when F1 < default - 0.01.
+TOLERANCE = 0.01
+
+#: Env vars that move the cut or void a pin process-wide. A sweep run with any of
+#: them set measures something other than the shipped default, so it refuses.
+CUT_ENV_VARS = (
+    "GOLDENMATCH_FS_LINEAR_CUT",
+    "GOLDENMATCH_FS_CALIBRATED",
+    "GOLDENMATCH_FS_EVIDENCE_CUT",
+    "GOLDENMATCH_FS_CALIBRATE_THRESHOLD",
+)
+
+
+def cut_env_overrides(environ: dict[str, str] | None = None) -> dict[str, str]:
+    """The ``CUT_ENV_VARS`` that are set to a non-blank value."""
+    env = os.environ if environ is None else environ
+    return {k: env[k] for k in CUT_ENV_VARS if (env.get(k) or "").strip()}
+
+
+def resolve_loader(name: str) -> Callable:
+    """Loader for a corpus name.
+
+    The ``scripts.autoconfig_quality.datasets._<name>`` loader when one exists (the
+    ``ab_lever`` panel convention), else the head-to-head loader via
+    ``_from_headtohead``. An unknown name raises ``KeyError``, so a typo cannot
+    silently shrink a run."""
+    from scripts.autoconfig_quality import datasets as quality
+    from scripts.bench_er_headtohead import datasets as headtohead
+
+    fn = getattr(quality, f"_{name}", None)
+    if callable(fn):
+        return fn
+    if name in headtohead._LOADERS:
+        return lambda: quality._from_headtohead(name)
+    raise KeyError(f"unknown corpus dataset {name!r}")
+
+
+def pin_rule(cfg, rule: str | None, model_dir: Path):
+    """Copy of ``cfg`` with every probabilistic matchkey pinned to ``rule`` (None
+    leaves it unset) and pointed at one saved model per matchkey in ``model_dir``."""
+    pinned = []
+    for mk in cfg.get_matchkeys():
+        if mk.type == "probabilistic":
+            mk = mk.model_copy(
+                update={"link_cut_rule": rule, "model_path": str(model_dir / f"{mk.name}.json")}
+            )
+        pinned.append(mk)
+    return cfg.model_copy(update={"matchkeys": pinned, "match_settings": None})
+
+
+def arm_record(arm: str, summary: dict, stats: dict | None, partition: tuple[int, str]) -> dict:
+    """One arm's result from ``evaluate_clusters(...).summary()`` and the run's stats.
+
+    ``applied``: every probabilistic matchkey's cut came from the pinned rule.
+
+    ``voided``: the arm measured something other than what it claims, and the sweep
+    fails. That happens when the run reported no FS cutoff at all, or when an
+    earlier precedence step overrode a pin (``cut_reason`` starts ``link_cut_rule=``).
+
+    A rule this model cannot compute is not applied but not voided: for example
+    ``otsu`` on 50 or fewer training pairs, which falls back to the default rule. The
+    fallback is itself the finding."""
+    report = (stats or {}).get("fs_link_thresholds") or {}
+    per_mk = {
+        name: {
+            key: entry.get(key) for key in ("link_threshold", "source", "cut_rule", "cut_reason")
+        }
+        for name, entry in sorted(report.items())
+    }
+    rule = None if arm in ("default", BASELINE_ARM) else arm
+    voided = not per_mk or any(
+        (entry["cut_reason"] or "").startswith("link_cut_rule=") for entry in per_mk.values()
+    )
+    applied = bool(per_mk) and (
+        rule is None or all(entry["cut_rule"] == rule for entry in per_mk.values())
+    )
+    pairs, digest = partition
+    return {
+        "f1": summary["f1"],
+        "precision": summary["precision"],
+        "recall": summary["recall"],
+        "pairs": pairs,
+        "digest": digest,
+        "matchkeys": per_mk,
+        "applied": applied,
+        "voided": voided,
+    }
+
+
+def sweep_frame(df, gt: set, model_dir: Path) -> dict:
+    """Run every arm on one labelled frame. ``model_dir`` must start empty."""
+    import goldenmatch
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    from goldenmatch.core.evaluate import evaluate_clusters
+
+    from scripts.bench_er_headtohead.ab_lever import _partition_fingerprint
+
+    base = auto_configure_probabilistic_df(df)
+    arms: dict[str, dict] = {}
+    diagnostics: dict[str, dict | None] = {}
+    models_saved: list[str] = []
+    for arm in ARMS:
+        rule = None if arm in ("default", BASELINE_ARM) else arm
+        result = goldenmatch.dedupe_df(df, config=pin_rule(base, rule, model_dir))
+        summary = evaluate_clusters(result.clusters, gt).summary()
+        arms[arm] = arm_record(arm, summary, result.stats, _partition_fingerprint(result.clusters))
+        if arm == "default":
+            models_saved = sorted(p.name for p in model_dir.glob("*.json"))
+        if arm == BASELINE_ARM:
+            report = (result.stats or {}).get("fs_link_thresholds") or {}
+            diagnostics = {
+                name: entry.get("cut_diagnostics") for name, entry in sorted(report.items())
+            }
+    baseline = arms[BASELINE_ARM]["f1"]
+    return {
+        "rows": df.height,
+        "gt_pairs": len(gt),
+        "arms": arms,
+        "cut_diagnostics": diagnostics,
+        "models_saved": models_saved,
+        "model_reload_delta": float(baseline - arms["default"]["f1"]),
+        "below_default": sorted(
+            rule
+            for rule in CUT_RULES
+            if arms[rule]["applied"] and arms[rule]["f1"] < baseline - TOLERANCE
+        ),
+    }
+
+
+def sweep_dataset(name: str, work_dir: Path) -> dict | None:
+    """Sweep one corpus dataset, or None when it is unavailable or unlabelled."""
+    from scripts.autoconfig_quality.corpus import corpus_of
+
+    loaded = resolve_loader(name)()
+    if loaded is None:
+        return None
+    df, gt = loaded
+    if not gt:
+        return None
+    model_dir = work_dir / name
+    model_dir.mkdir(parents=True, exist_ok=True)
+    record = sweep_frame(df, gt, model_dir)
+    record["corpus"] = corpus_of(name)
+    return record
+
+
+def run(argv: list[str]) -> int:
+    from scripts.autoconfig_quality.corpus import ci_datasets, select
+    from scripts.autoconfig_quality.scorecard import build_scorecard, dumps, gather_meta
+
+    ap = argparse.ArgumentParser(description="Measure every FS link-cut rule per dataset.")
+    ap.add_argument("--corpus", choices=["design", "holdout", "all"], default="all")
+    ap.add_argument("--datasets", default="", help="comma list; overrides --corpus")
+    ap.add_argument("--ci", action="store_true", help="drop local-only datasets from --corpus")
+    ap.add_argument("--out", required=True, type=Path, help="scorecard JSON to write")
+    ap.add_argument("--require-datasets", default="", help="comma list that MUST be measured")
+    ap.add_argument(
+        "--allow-cut-env",
+        action="store_true",
+        help=f"measure even with any of {', '.join(CUT_ENV_VARS)} set",
+    )
+    args = ap.parse_args(argv)
+
+    overrides = cut_env_overrides()
+    if overrides and not args.allow_cut_env:
+        print(
+            f"refusing to sweep: {sorted(overrides)} set; they move the cut or void a pin "
+            "for every arm (pass --allow-cut-env to measure under them on purpose)",
+            file=sys.stderr,
+        )
+        return 2
+    os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"
+
+    names = [d.strip() for d in args.datasets.split(",") if d.strip()] or (
+        ci_datasets(args.corpus) if args.ci else list(select(args.corpus))
+    )
+    for name in names:
+        resolve_loader(name)  # fail on a typo before any long run starts
+
+    results: dict[str, dict] = {}
+    skipped: dict[str, str] = {}
+    with tempfile.TemporaryDirectory(prefix="gm_cut_rules_") as td:
+        for name in names:
+            print(f"[cut-rules] {name}", file=sys.stderr)
+            record = sweep_dataset(name, Path(td))
+            if record is None:
+                skipped[name] = "unavailable or unlabelled"
+            else:
+                results[name] = record
+
+    native_version, git_sha = gather_meta()
+    card = build_scorecard(results, native_version=native_version, git_sha=git_sha, skipped=skipped)
+    card["meta"]["cut_env_overrides"] = overrides
+    card["meta"]["tolerance"] = TOLERANCE
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(dumps(card) + "\n", encoding="utf-8")
+
+    required = [d.strip() for d in args.require_datasets.split(",") if d.strip()]
+    missing = [d for d in required if d not in results]
+    voided = sorted(
+        f"{name}:{arm}"
+        for name, record in results.items()
+        for arm, rec in record["arms"].items()
+        if rec["voided"]
+    )
+    print(
+        f"[cut-rules] measured {len(results)}, skipped {len(skipped)} -> {args.out}",
+        file=sys.stderr,
+    )
+    if not results:
+        print(
+            "FAIL: 0 datasets measured; a sweep that measures nothing cannot pass", file=sys.stderr
+        )
+        return 1
+    if missing:
+        print(f"FAIL: required datasets not measured: {missing}", file=sys.stderr)
+        return 1
+    if voided:
+        print(
+            f"FAIL: voided arms (a pin was overridden or no FS cutoff reported): {voided}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(sys.argv[1:] if argv is None else argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autoconfig_quality/rule_sweep.py
+++ b/scripts/autoconfig_quality/rule_sweep.py
@@ -163,11 +163,21 @@ def _model_hashes(model_dir: Path) -> dict[str, str]:
 #: the runner itself dies and takes every other arm's measurement with it.
 ARM_MEMORY_CAP_MB = 12000
 ARM_TIMEOUT_S = 3600
+#: The child's RSS misses the parent's memory, spikes between polls and swap, so an
+#: arm is also killed when the whole machine's available memory drops below this.
+MIN_AVAILABLE_MB = 1500
+#: Wall budget for all of one dataset's arms, from the first arm's start; None means
+#: no budget. CI sets it so every arm fits inside the job's own timeout.
+DATASET_BUDGET_S: float | None = None
 ARM_MEMORY_CAP_ENV = "GOLDENMATCH_CUT_RULES_ARM_MEM_MB"
 ARM_TIMEOUT_ENV = "GOLDENMATCH_CUT_RULES_ARM_TIMEOUT_S"
+MIN_AVAILABLE_ENV = "GOLDENMATCH_CUT_RULES_MIN_AVAILABLE_MB"
+DATASET_BUDGET_ENV = "GOLDENMATCH_CUT_RULES_DATASET_BUDGET_S"
+#: How long to wait for a killed process to go away before giving up on reaping it.
+KILL_WAIT_S = 10
 
 
-def _limit(value: float | None, env_var: str, default: float) -> float:
+def _limit(value: float | None, env_var: str, default: float | None) -> float | None:
     """``value`` when given, else the env override, else ``default``."""
     if value is not None:
         return value
@@ -175,11 +185,27 @@ def _limit(value: float | None, env_var: str, default: float) -> float:
     return float(raw) if raw else default
 
 
+# The two timing fields on every arm record:
+#   wall_seconds     pipeline time, measured inside execute_arm by the child; None
+#                    when no pipeline result came back (killed, crashed, not started).
+#   process_seconds  the parent's clock from starting the child to its exit or kill,
+#                    including interpreter start-up and loading; 0.0 if never started.
+
+
 def killed_record(
-    status: str, returncode: int | None, peak_rss_mb: float, wall_seconds: float
+    status: str,
+    returncode: int | None,
+    peak_rss_mb: float,
+    process_seconds: float,
+    kill_reason: str | None = None,
 ) -> dict:
-    """The record of an arm whose child was killed or crashed: no measurement, not
-    voided (nothing claimed a result it did not measure), and the reason."""
+    """The record of an arm whose child was killed, crashed or never started: no
+    measurement, not voided (nothing claimed a result it did not measure), and the
+    reason.
+
+    ``kill_reason`` says which trigger fired: ``rss_cap`` / ``available_floor`` for
+    ``memory_cap``, ``dataset_budget`` for a timeout the budget left no time to start,
+    else None."""
     return {
         "f1": None,
         "precision": None,
@@ -190,9 +216,11 @@ def killed_record(
         "applied": False,
         "voided": False,
         "crashed": status,
+        "kill_reason": kill_reason,
         "returncode": returncode,
         "peak_rss_mb": round(peak_rss_mb, 1),
-        "wall_seconds": round(wall_seconds, 1),
+        "wall_seconds": None,
+        "process_seconds": round(process_seconds, 1),
     }
 
 
@@ -216,20 +244,41 @@ def _tree_rss_mb(proc) -> float:
 
 
 def _kill_tree(pid: int) -> None:
-    """Kill ``pid`` and every descendant; no POSIX-only signals."""
+    """Kill ``pid`` and every descendant; no POSIX-only signals. Never raises: it
+    runs inside error handlers, where a cleanup error must not mask the original.
+
+    Waits only for the descendants. The root is the caller's ``Popen`` child, which
+    the caller reaps (``_reap``): if psutil reaped it first, ``Popen`` would get
+    ECHILD on Linux and report a killed arm as ``returncode`` 0."""
     import psutil
 
     try:
-        parent = psutil.Process(pid)
-        procs = [*parent.children(recursive=True), parent]
-    except psutil.NoSuchProcess:
+        root = psutil.Process(pid)
+    except psutil.Error:
         return
-    for p in procs:
+    try:
+        descendants = root.children(recursive=True)
+    except psutil.Error:
+        descendants = []
+    for p in [*descendants, root]:
         try:
             p.kill()
-        except psutil.NoSuchProcess:
+        except psutil.Error:
             pass
-    psutil.wait_procs(procs, timeout=10)
+    try:
+        psutil.wait_procs(descendants, timeout=KILL_WAIT_S)
+    except psutil.Error:
+        pass
+
+
+def _reap(popen) -> None:
+    """Wait for a killed ``Popen`` child, but never forever."""
+    import subprocess
+
+    try:
+        popen.wait(timeout=KILL_WAIT_S)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def run_arm(
@@ -241,13 +290,16 @@ def run_arm(
     env: dict[str, str] | None = None,
     memory_cap_mb: float | None = None,
     timeout_s: float | None = None,
+    min_available_mb: float | None = None,
     poll_s: float = 0.5,
 ) -> tuple[dict, dict | None]:
     """Run one arm's child (``argv``) under the watchdog. Never raises for the child.
 
     Returns ``(arm record, child payload)``. The payload is None when the child was
     killed (``memory_cap`` / ``timeout``) or ``crashed`` (non-zero exit or no JSON
-    at ``out_path``); the record then says which, instead of the sweep dying."""
+    at ``out_path``); the record then says which, instead of the sweep dying.
+    ``memory_cap`` fires on the child tree's RSS (``rss_cap``) or on the machine's
+    available memory (``available_floor``)."""
     import json
     import subprocess
     import time
@@ -256,22 +308,26 @@ def run_arm(
 
     cap = _limit(memory_cap_mb, ARM_MEMORY_CAP_ENV, ARM_MEMORY_CAP_MB)
     limit = _limit(timeout_s, ARM_TIMEOUT_ENV, ARM_TIMEOUT_S)
+    floor = _limit(min_available_mb, MIN_AVAILABLE_ENV, MIN_AVAILABLE_MB)
     out_path.unlink(missing_ok=True)  # a stale result must not pass for this run's
     start = time.perf_counter()
     popen = subprocess.Popen(argv, env=env)
     peak = 0.0
     status: str | None = None
+    kill_reason: str | None = None
     try:
         proc = psutil.Process(popen.pid)
         while True:
             peak = max(peak, _tree_rss_mb(proc))
             if peak > cap:
-                status = "memory_cap"
+                status, kill_reason = "memory_cap", "rss_cap"
+            elif psutil.virtual_memory().available / 2**20 < floor:
+                status, kill_reason = "memory_cap", "available_floor"
             elif time.perf_counter() - start > limit:
                 status = "timeout"
             if status is not None:
                 _kill_tree(popen.pid)
-                popen.wait()
+                _reap(popen)
                 break
             try:
                 popen.wait(timeout=poll_s)
@@ -279,20 +335,24 @@ def run_arm(
             except subprocess.TimeoutExpired:
                 continue
     except psutil.NoSuchProcess:
-        popen.wait()  # exited before the first sample; classified below
+        _reap(popen)  # exited before the first sample; classified below
     except BaseException:
         _kill_tree(popen.pid)  # a cancelled sweep must not orphan a capped child
+        _reap(popen)
         raise
-    wall = time.perf_counter() - start
+    process_seconds = time.perf_counter() - start
     returncode = popen.returncode
     if status is not None:
-        return killed_record(status, returncode, peak, wall), None
+        # A killed arm never reports a clean exit: 0 here could only be a child that
+        # finished in the instant between the sample and the kill, or a lost reap.
+        killed_rc = None if returncode == 0 else returncode
+        return killed_record(status, killed_rc, peak, process_seconds, kill_reason), None
     try:
         payload = json.loads(out_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         payload = None
     if returncode != 0 or payload is None:
-        return killed_record("crashed", returncode, peak, wall), None
+        return killed_record("crashed", returncode, peak, process_seconds), None
     record = arm_record(
         arm,
         payload["summary"],
@@ -300,7 +360,13 @@ def run_arm(
         tuple(payload["partition"]),
         expected_matchkeys,
     )
-    record.update(crashed=None, peak_rss_mb=round(peak, 1), wall_seconds=payload["wall_seconds"])
+    # wall_seconds from the child's pipeline, process_seconds from the parent's clock.
+    record.update(
+        crashed=None,
+        peak_rss_mb=round(peak, 1),
+        wall_seconds=payload["wall_seconds"],
+        process_seconds=round(process_seconds, 1),
+    )
     return record, payload
 
 
@@ -380,12 +446,22 @@ def arm_main(argv: list[str]) -> int:
     return 0
 
 
-def sweep_dataset(name: str, work_dir: Path, arms: tuple[str, ...] = ARMS) -> dict | None:
+def sweep_dataset(
+    name: str,
+    work_dir: Path,
+    arms: tuple[str, ...] = ARMS,
+    budget_s: float | None = None,
+) -> dict | None:
     """Sweep one corpus dataset, or None when it is unavailable or unlabelled.
 
     Loads and auto-configures once, writes the config every arm reads to
     ``<work_dir>/<name>/config.json``, then runs each arm in its own child process
-    under the watchdog (``run_arm``)."""
+    under the watchdog (``run_arm``).
+
+    ``budget_s`` (else ``GOLDENMATCH_CUT_RULES_DATASET_BUDGET_S``, else no budget)
+    bounds all the arms together, from the first arm's start: each arm's timeout is
+    at most its share of what is left, and once the budget is spent the remaining
+    arms are recorded as ``timeout`` without being started."""
     import time
 
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
@@ -412,18 +488,35 @@ def sweep_dataset(name: str, work_dir: Path, arms: tuple[str, ...] = ARMS) -> di
     del loaded, df, gt  # every child reloads the dataset; the parent holds none of it
 
     env = arm_env()
+    budget = _limit(budget_s, DATASET_BUDGET_ENV, DATASET_BUDGET_S)
+    arm_timeout = _limit(None, ARM_TIMEOUT_ENV, ARM_TIMEOUT_S)
+    # Held-out per-rule F1 stays out of CI logs, like it stays out of the gate view.
+    holdout = corpus_of(name) == "holdout"
     records: dict[str, dict] = {}
     diagnostics: dict[str, dict | None] = {}
     models_saved: list[str] = []
     hashes_after_default: dict[str, str] = {}
-    for arm in arms:
-        out_path = dataset_dir / f"arm_{arm}.json"
-        argv = arm_argv(name, config_path, arm, model_dir, out_path)
-        records[arm], payload = run_arm(argv, out_path, arm, probabilistic_matchkeys, env=env)
+    arms_start = time.perf_counter()
+    for index, arm in enumerate(arms):
+        timeout_s = arm_timeout
+        if budget is not None:
+            remaining = budget - (time.perf_counter() - arms_start)
+            timeout_s = min(arm_timeout, remaining / (len(arms) - index))
+        if budget is not None and timeout_s <= 0:
+            records[arm] = killed_record("timeout", None, 0.0, 0.0, "dataset_budget")
+            payload = None
+        else:
+            out_path = dataset_dir / f"arm_{arm}.json"
+            argv = arm_argv(name, config_path, arm, model_dir, out_path)
+            records[arm], payload = run_arm(
+                argv, out_path, arm, probabilistic_matchkeys, env=env, timeout_s=timeout_s
+            )
         rec = records[arm]
+        f1_part = "" if holdout else f" f1={rec['f1']}"
         print(
-            f"[cut-rules] {name}:{arm} crashed={rec['crashed']} f1={rec['f1']} "
-            f"peak_rss_mb={rec['peak_rss_mb']} wall_seconds={rec['wall_seconds']}",
+            f"[cut-rules] {name}:{arm} crashed={rec['crashed']}{f1_part} "
+            f"peak_rss_mb={rec['peak_rss_mb']} wall_seconds={rec['wall_seconds']} "
+            f"process_seconds={rec['process_seconds']}",
             file=sys.stderr,
         )
         if arm == "default":
@@ -526,7 +619,11 @@ def run(argv: list[str]) -> int:
     card["meta"]["goldenmatch_env"] = {
         k: v for k, v in sorted(os.environ.items()) if k.startswith("GOLDENMATCH_")
     }
-    card["meta"]["pythonhashseed"] = os.environ.get("PYTHONHASHSEED")
+    # The sweep process's own seed, and the one every arm's child runs under.
+    card["meta"]["pythonhashseed"] = {
+        "sweep": os.environ.get("PYTHONHASHSEED"),
+        "arms": arm_env()["PYTHONHASHSEED"],
+    }
 
     required = [d.strip() for d in args.require_datasets.split(",") if d.strip()]
     failures: list[str] = []

--- a/scripts/autoconfig_quality/rule_sweep.py
+++ b/scripts/autoconfig_quality/rule_sweep.py
@@ -1,7 +1,8 @@
 """Per-rule link-cut matrix (spec 2026-09-11-fs-cut-rule-routing-design, P3).
 
 For one dataset: auto-configure the probabilistic config once, then run the full
-pipeline once per arm. Every probabilistic matchkey is pinned to one
+pipeline once per arm, each arm in its own child process under a memory cap and a
+timeout (``run_arm``). Every probabilistic matchkey is pinned to one
 ``link_cut_rule`` and points at one saved EM model (``model_path``), so the arms
 differ only in where the cut lands.
 
@@ -157,76 +158,238 @@ def _model_hashes(model_dir: Path) -> dict[str, str]:
     }
 
 
-def sweep_frame(df, gt: set, model_dir: Path) -> dict:
-    """Run every arm on one labelled frame. ``model_dir`` must start empty."""
+#: Watchdog limits for one arm's child process. The memory cap leaves headroom on
+#: the 16 GB hosted runner, so an over-merging rule is killed and recorded before
+#: the runner itself dies and takes every other arm's measurement with it.
+ARM_MEMORY_CAP_MB = 12000
+ARM_TIMEOUT_S = 3600
+ARM_MEMORY_CAP_ENV = "GOLDENMATCH_CUT_RULES_ARM_MEM_MB"
+ARM_TIMEOUT_ENV = "GOLDENMATCH_CUT_RULES_ARM_TIMEOUT_S"
+
+
+def _limit(value: float | None, env_var: str, default: float) -> float:
+    """``value`` when given, else the env override, else ``default``."""
+    if value is not None:
+        return value
+    raw = (os.environ.get(env_var) or "").strip()
+    return float(raw) if raw else default
+
+
+def killed_record(
+    status: str, returncode: int | None, peak_rss_mb: float, wall_seconds: float
+) -> dict:
+    """The record of an arm whose child was killed or crashed: no measurement, not
+    voided (nothing claimed a result it did not measure), and the reason."""
+    return {
+        "f1": None,
+        "precision": None,
+        "recall": None,
+        "pairs": None,
+        "digest": None,
+        "matchkeys": {},
+        "applied": False,
+        "voided": False,
+        "crashed": status,
+        "returncode": returncode,
+        "peak_rss_mb": round(peak_rss_mb, 1),
+        "wall_seconds": round(wall_seconds, 1),
+    }
+
+
+def _tree_rss_mb(proc) -> float:
+    """RSS of ``proc`` plus all its recursive children, in MB. On Windows a venv
+    ``python.exe`` is a launcher whose real interpreter is a child, so the tree
+    is what holds the memory."""
+    import psutil
+
+    try:
+        procs = [proc, *proc.children(recursive=True)]
+    except psutil.NoSuchProcess:
+        return 0.0
+    total = 0
+    for p in procs:
+        try:
+            total += p.memory_info().rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return total / 2**20
+
+
+def _kill_tree(pid: int) -> None:
+    """Kill ``pid`` and every descendant; no POSIX-only signals."""
+    import psutil
+
+    try:
+        parent = psutil.Process(pid)
+        procs = [*parent.children(recursive=True), parent]
+    except psutil.NoSuchProcess:
+        return
+    for p in procs:
+        try:
+            p.kill()
+        except psutil.NoSuchProcess:
+            pass
+    psutil.wait_procs(procs, timeout=10)
+
+
+def run_arm(
+    argv: list[str],
+    out_path: Path,
+    arm: str,
+    expected_matchkeys: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    memory_cap_mb: float | None = None,
+    timeout_s: float | None = None,
+    poll_s: float = 0.5,
+) -> tuple[dict, dict | None]:
+    """Run one arm's child (``argv``) under the watchdog. Never raises for the child.
+
+    Returns ``(arm record, child payload)``. The payload is None when the child was
+    killed (``memory_cap`` / ``timeout``) or ``crashed`` (non-zero exit or no JSON
+    at ``out_path``); the record then says which, instead of the sweep dying."""
+    import json
+    import subprocess
+    import time
+
+    import psutil
+
+    cap = _limit(memory_cap_mb, ARM_MEMORY_CAP_ENV, ARM_MEMORY_CAP_MB)
+    limit = _limit(timeout_s, ARM_TIMEOUT_ENV, ARM_TIMEOUT_S)
+    out_path.unlink(missing_ok=True)  # a stale result must not pass for this run's
+    start = time.perf_counter()
+    popen = subprocess.Popen(argv, env=env)
+    peak = 0.0
+    status: str | None = None
+    try:
+        proc = psutil.Process(popen.pid)
+        while True:
+            peak = max(peak, _tree_rss_mb(proc))
+            if peak > cap:
+                status = "memory_cap"
+            elif time.perf_counter() - start > limit:
+                status = "timeout"
+            if status is not None:
+                _kill_tree(popen.pid)
+                popen.wait()
+                break
+            try:
+                popen.wait(timeout=poll_s)
+                break
+            except subprocess.TimeoutExpired:
+                continue
+    except psutil.NoSuchProcess:
+        popen.wait()  # exited before the first sample; classified below
+    except BaseException:
+        _kill_tree(popen.pid)  # a cancelled sweep must not orphan a capped child
+        raise
+    wall = time.perf_counter() - start
+    returncode = popen.returncode
+    if status is not None:
+        return killed_record(status, returncode, peak, wall), None
+    try:
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        payload = None
+    if returncode != 0 or payload is None:
+        return killed_record("crashed", returncode, peak, wall), None
+    record = arm_record(
+        arm,
+        payload["summary"],
+        {"fs_link_thresholds": payload["report"]},
+        tuple(payload["partition"]),
+        expected_matchkeys,
+    )
+    record.update(crashed=None, peak_rss_mb=round(peak, 1), wall_seconds=payload["wall_seconds"])
+    return record, payload
+
+
+def execute_arm(df, gt: set, cfg, arm: str, model_dir: Path) -> dict:
+    """Run one arm on one labelled frame and return its JSON-able result.
+
+    The only place an arm's pipeline runs: the ``arm`` child process calls it, and
+    so does any in-process caller."""
     import time
 
     import goldenmatch
-    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
     from goldenmatch.core.evaluate import evaluate_clusters
 
     from scripts.bench_er_headtohead.ab_lever import _partition_fingerprint
 
     start = time.perf_counter()
-    base = auto_configure_probabilistic_df(df)
-    probabilistic_matchkeys = sorted(
-        mk.name for mk in base.get_matchkeys() if mk.type == "probabilistic"
-    )
-    arms: dict[str, dict] = {}
-    diagnostics: dict[str, dict | None] = {}
-    models_saved: list[str] = []
-    hashes_after_default: dict[str, str] = {}
-    for arm in ARMS:
-        rule = None if arm in ("default", BASELINE_ARM) else arm
-        result = goldenmatch.dedupe_df(df, config=pin_rule(base, rule, model_dir))
-        summary = evaluate_clusters(result.clusters, gt).summary()
-        arms[arm] = arm_record(
-            arm,
-            summary,
-            result.stats,
-            _partition_fingerprint(result.clusters),
-            probabilistic_matchkeys,
-        )
-        if arm == "default":
-            models_saved = sorted(p.name for p in model_dir.glob("*.json"))
-            hashes_after_default = _model_hashes(model_dir)
-        if arm == BASELINE_ARM:
-            report = (result.stats or {}).get("fs_link_thresholds") or {}
-            diagnostics = {
-                name: entry.get("cut_diagnostics") for name, entry in sorted(report.items())
-            }
-    hashes_after_last = _model_hashes(model_dir)
-    baseline = arms[BASELINE_ARM]["f1"]
-    model_complete = bool(models_saved) and sorted(models_saved) == sorted(
-        f"{name}.json" for name in probabilistic_matchkeys
-    )
-    model_stable = (
-        bool(hashes_after_default)
-        and bool(hashes_after_last)
-        and hashes_after_default == hashes_after_last
-    )
+    rule = None if arm in ("default", BASELINE_ARM) else arm
+    result = goldenmatch.dedupe_df(df, config=pin_rule(cfg, rule, model_dir))
+    summary = evaluate_clusters(result.clusters, gt).summary()
+    pairs, digest = _partition_fingerprint(result.clusters)
     return {
-        "rows": df.height,
-        "gt_pairs": len(gt),
-        "probabilistic_matchkeys": probabilistic_matchkeys,
-        "arms": arms,
-        "cut_diagnostics": diagnostics,
-        "models_saved": models_saved,
-        "model_complete": model_complete,
-        "model_stable": model_stable,
-        "reload_partition_match": arms["default"]["digest"] == arms[BASELINE_ARM]["digest"],
-        "model_reload_delta": float(baseline - arms["default"]["f1"]),
-        "below_default": sorted(
-            rule
-            for rule in CUT_RULES
-            if arms[rule]["applied"] and arms[rule]["f1"] < baseline - TOLERANCE
-        ),
+        "summary": {key: summary[key] for key in ("f1", "precision", "recall")},
+        "report": (result.stats or {}).get("fs_link_thresholds") or {},
+        "partition": [pairs, digest],
         "wall_seconds": round(time.perf_counter() - start, 1),
     }
 
 
-def sweep_dataset(name: str, work_dir: Path) -> dict | None:
-    """Sweep one corpus dataset, or None when it is unavailable or unlabelled."""
+def arm_env() -> dict[str, str]:
+    """A child's env: the parent's, plus one hash seed shared by every arm and no
+    autoconfig memory."""
+    return {**os.environ, "PYTHONHASHSEED": "0", "GOLDENMATCH_AUTOCONFIG_MEMORY": "0"}
+
+
+def arm_argv(name: str, config_path: Path, arm: str, model_dir: Path, out_path: Path) -> list[str]:
+    """The command that runs one arm in a child process (the ``arm`` subcommand)."""
+    return [
+        sys.executable,
+        "-m",
+        "scripts.autoconfig_quality.rule_sweep",
+        "arm",
+        "--dataset",
+        name,
+        "--config",
+        str(config_path),
+        "--arm",
+        arm,
+        "--model-dir",
+        str(model_dir),
+        "--out",
+        str(out_path),
+    ]
+
+
+def arm_main(argv: list[str]) -> int:
+    """Hidden ``arm`` subcommand: one arm on one dataset, result JSON at ``--out``."""
+    import json
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    ap = argparse.ArgumentParser(description="Run one link-cut sweep arm (the sweep's child).")
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--config", required=True, type=Path)
+    ap.add_argument("--arm", required=True, choices=ARMS)
+    ap.add_argument("--model-dir", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args(argv)
+
+    loaded = resolve_loader(args.dataset)()
+    if loaded is None or not loaded[1]:
+        print(f"arm: dataset {args.dataset!r} unavailable or unlabelled", file=sys.stderr)
+        return 1
+    df, gt = loaded
+    cfg = GoldenMatchConfig.model_validate_json(args.config.read_text(encoding="utf-8"))
+    payload = execute_arm(df, gt, cfg, args.arm, args.model_dir)
+    args.out.write_text(json.dumps(payload), encoding="utf-8")
+    return 0
+
+
+def sweep_dataset(name: str, work_dir: Path, arms: tuple[str, ...] = ARMS) -> dict | None:
+    """Sweep one corpus dataset, or None when it is unavailable or unlabelled.
+
+    Loads and auto-configures once, writes the config every arm reads to
+    ``<work_dir>/<name>/config.json``, then runs each arm in its own child process
+    under the watchdog (``run_arm``)."""
+    import time
+
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
     from scripts.autoconfig_quality.corpus import corpus_of
 
     loaded = resolve_loader(name)()
@@ -235,11 +398,81 @@ def sweep_dataset(name: str, work_dir: Path) -> dict | None:
     df, gt = loaded
     if not gt:
         return None
-    model_dir = work_dir / name
+    start = time.perf_counter()
+    dataset_dir = work_dir / name
+    model_dir = dataset_dir / "models"
     model_dir.mkdir(parents=True, exist_ok=True)
-    record = sweep_frame(df, gt, model_dir)
-    record["corpus"] = corpus_of(name)
-    return record
+    cfg = auto_configure_probabilistic_df(df)
+    config_path = dataset_dir / "config.json"
+    config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+    probabilistic_matchkeys = sorted(
+        mk.name for mk in cfg.get_matchkeys() if mk.type == "probabilistic"
+    )
+    rows, gt_pairs = df.height, len(gt)
+    del loaded, df, gt  # every child reloads the dataset; the parent holds none of it
+
+    env = arm_env()
+    records: dict[str, dict] = {}
+    diagnostics: dict[str, dict | None] = {}
+    models_saved: list[str] = []
+    hashes_after_default: dict[str, str] = {}
+    for arm in arms:
+        out_path = dataset_dir / f"arm_{arm}.json"
+        argv = arm_argv(name, config_path, arm, model_dir, out_path)
+        records[arm], payload = run_arm(argv, out_path, arm, probabilistic_matchkeys, env=env)
+        rec = records[arm]
+        print(
+            f"[cut-rules] {name}:{arm} crashed={rec['crashed']} f1={rec['f1']} "
+            f"peak_rss_mb={rec['peak_rss_mb']} wall_seconds={rec['wall_seconds']}",
+            file=sys.stderr,
+        )
+        if arm == "default":
+            models_saved = sorted(p.name for p in model_dir.glob("*.json"))
+            hashes_after_default = _model_hashes(model_dir)
+        if arm == BASELINE_ARM and payload is not None:
+            diagnostics = {
+                mk: entry.get("cut_diagnostics") for mk, entry in sorted(payload["report"].items())
+            }
+    hashes_after_last = _model_hashes(model_dir)
+    baseline = records[BASELINE_ARM]["f1"]
+    rules = [arm for arm in arms if arm in CUT_RULES]
+    # Without both baselines there is nothing to compare a rule against; run() fails it.
+    baseline_ok = not records["default"]["crashed"] and not records[BASELINE_ARM]["crashed"]
+    model_complete = bool(models_saved) and sorted(models_saved) == sorted(
+        f"{mk}.json" for mk in probabilistic_matchkeys
+    )
+    model_stable = (
+        bool(hashes_after_default)
+        and bool(hashes_after_last)
+        and hashes_after_default == hashes_after_last
+    )
+    return {
+        "corpus": corpus_of(name),
+        "rows": rows,
+        "gt_pairs": gt_pairs,
+        "probabilistic_matchkeys": probabilistic_matchkeys,
+        "arms": records,
+        "cut_diagnostics": diagnostics,
+        "models_saved": models_saved,
+        "model_complete": model_complete,
+        "model_stable": model_stable,
+        "reload_partition_match": (
+            records["default"]["digest"] == records[BASELINE_ARM]["digest"] if baseline_ok else None
+        ),
+        "model_reload_delta": (float(baseline - records["default"]["f1"]) if baseline_ok else None),
+        # A rule arm that was killed or crashed is worse than the baseline.
+        "below_default": sorted(
+            rule
+            for rule in rules
+            if baseline_ok
+            and (
+                records[rule]["crashed"]
+                or (records[rule]["applied"] and records[rule]["f1"] < baseline - TOLERANCE)
+            )
+        ),
+        "crashed": {rule: records[rule]["crashed"] for rule in rules if records[rule]["crashed"]},
+        "wall_seconds": round(time.perf_counter() - start, 1),
+    }
 
 
 def run(argv: list[str]) -> int:
@@ -304,6 +537,10 @@ def run(argv: list[str]) -> int:
         for arm, rec in record["arms"].items():
             if rec["voided"]:
                 failures.append(f"{name}:{arm} voided")
+        for arm in ("default", BASELINE_ARM):
+            status = record["arms"].get(arm, {}).get("crashed")
+            if status:
+                failures.append(f"{name}: baseline arm {arm} {status}")
         if not record.get("model_complete"):
             failures.append(f"{name}: shared EM model not saved for every probabilistic matchkey")
         if not record.get("model_stable"):
@@ -365,26 +602,35 @@ def merge_cards(cards: list[dict], expected: list[str] | None = None) -> dict:
 
 
 def best_rule(record: dict) -> tuple[str, float]:
-    """The highest-F1 applied rule arm; ties go to the earlier ``CUT_RULES`` name.
-    Falls back to the baseline arm (``BASELINE_ARM``) when no rule applied --
-    callers rendering this for humans should treat that sentinel as "no rule
-    applied", not as a real rule name."""
+    """The highest-F1 applied rule arm that did not crash; ties go to the earlier
+    ``CUT_RULES`` name. Falls back to the baseline arm (``BASELINE_ARM``) when no
+    rule applied -- callers rendering this for humans should treat that sentinel as
+    "no rule applied", not as a real rule name."""
     best: tuple[str, float] | None = None
     for rule in CUT_RULES:
         arm = record["arms"][rule]
+        if arm.get("crashed"):
+            continue
         if arm["applied"] and (best is None or arm["f1"] > best[1]):
             best = (rule, arm["f1"])
     return best or (BASELINE_ARM, record["arms"][BASELINE_ARM]["f1"])
 
 
 def _not_applied_rules(record: dict) -> list[str]:
-    """Rules whose arm neither applied nor voided (e.g. otsu falling back
-    on too few training pairs)."""
+    """Rules whose arm ran but neither applied nor voided (e.g. otsu falling back
+    on too few training pairs). A crashed arm is reported as crashed instead."""
     return sorted(
         rule
         for rule in CUT_RULES
-        if not record["arms"][rule]["applied"] and not record["arms"][rule]["voided"]
+        if not record["arms"][rule]["applied"]
+        and not record["arms"][rule]["voided"]
+        and not record["arms"][rule].get("crashed")
     )
+
+
+def _f1_cell(value: float | None) -> str:
+    """An F1 table cell; a crashed baseline has none."""
+    return "crashed" if value is None else f"{value:.4f}"
 
 
 def render_markdown(card: dict, holdout_card: dict | None = None) -> str:
@@ -402,25 +648,29 @@ def render_markdown(card: dict, holdout_card: dict | None = None) -> str:
         "### Design",
         "",
         "| dataset | default F1 | best rule | best F1 | Δ best | below default"
-        " | not applied | reload digest |",
-        "|---|---|---|---|---|---|---|---|",
+        " | not applied | crashed | reload digest |",
+        "|---|---|---|---|---|---|---|---|---|",
     ]
     for name in sorted(card["datasets"]):
         record = card["datasets"][name]
         baseline = record["arms"][BASELINE_ARM]["f1"]
         rule, f1 = best_rule(record)
         label = "no rule applied" if rule == BASELINE_ARM else rule
+        delta = "crashed" if baseline is None or f1 is None else f"{f1 - baseline:+.4f}"
         below = ", ".join(record.get("below_default") or []) or "none"
         not_applied = ", ".join(_not_applied_rules(record)) or "none"
-        digest = "same" if record.get("reload_partition_match", True) else "DIFFERS"
+        crashed = (
+            ", ".join(f"{r}:{s}" for r, s in sorted((record.get("crashed") or {}).items()))
+            or "none"
+        )
+        match = record.get("reload_partition_match", True)
+        digest = "n/a" if match is None else ("same" if match else "DIFFERS")
         lines.append(
-            f"| {name} | {baseline:.4f} | {label} | {f1:.4f} "
-            f"| {f1 - baseline:+.4f} | {below} | {not_applied} | {digest} |"
+            f"| {name} | {_f1_cell(baseline)} | {label} | {_f1_cell(f1)} "
+            f"| {delta} | {below} | {not_applied} | {crashed} | {digest} |"
         )
     for name in design_missing:
-        lines.append(
-            f"| {name} | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |"
-        )
+        lines.append(f"| {name} |" + " MISSING |" * 8)
 
     out = "\n".join(lines) + "\n"
 
@@ -429,17 +679,20 @@ def render_markdown(card: dict, holdout_card: dict | None = None) -> str:
             "",
             "### Held-out (gate view)",
             "",
-            "| dataset | default F1 | rules below default | rules not applied |",
-            "|---|---|---|---|",
+            "| dataset | default F1 | rules below default | rules not applied | rules crashed |",
+            "|---|---|---|---|---|",
         ]
         for name in sorted(holdout_card["datasets"]):
             record = holdout_card["datasets"][name]
             baseline = record["arms"][BASELINE_ARM]["f1"]
             below_n = len(record.get("below_default") or [])
             not_applied_n = len(_not_applied_rules(record))
-            h_lines.append(f"| {name} | {baseline:.4f} | {below_n} | {not_applied_n} |")
+            crashed_n = len(record.get("crashed") or {})
+            h_lines.append(
+                f"| {name} | {_f1_cell(baseline)} | {below_n} | {not_applied_n} | {crashed_n} |"
+            )
         for name in holdout_missing:
-            h_lines.append(f"| {name} | MISSING | MISSING | MISSING |")
+            h_lines.append(f"| {name} |" + " MISSING |" * 4)
         out += "\n".join(h_lines) + "\n"
 
     failures = card["meta"].get("failures") or []
@@ -506,6 +759,8 @@ def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
     if argv and argv[0] == "merge":
         return merge(argv[1:])
+    if argv and argv[0] == "arm":
+        return arm_main(argv[1:])
     return run(argv)
 
 

--- a/scripts/autoconfig_quality/tests/test_corpus.py
+++ b/scripts/autoconfig_quality/tests/test_corpus.py
@@ -1,0 +1,74 @@
+"""The FS link-cut routing corpus is frozen: rows are written from DESIGN and must
+also hold on HOLDOUT, which is why HOLDOUT is pinned verbatim here."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.autoconfig_quality import corpus as C
+
+
+def test_design_set_is_pinned():
+    assert C.DESIGN == (
+        "person",
+        "household_hardneg",
+        "cotenant_hardneg",
+        "febrl3",
+        "febrl4",
+        "ncvr_synthetic",
+        "ncvr_real",
+        "historical_50k",
+        "dblp_acm",
+        "dblp_scholar",
+        "amazon_google",
+    )
+
+
+def test_holdout_set_is_frozen():
+    """Changing this list after any routing row exists means re-running the full
+    gate on both sets (spec: Corpus and harness)."""
+    assert C.HOLDOUT == (
+        "abt_buy",
+        "walmart_amazon",
+        "itunes_amazon",
+        "fodors_zagats",
+        "febrl1",
+        "febrl2",
+        "synth_person_c05_d10",
+        "synth_person_c05_d40",
+        "synth_person_c20_d10",
+        "synth_person_c20_d40",
+        "synth_biblio_c05_d10",
+        "synth_biblio_c05_d40",
+        "synth_biblio_c20_d10",
+        "synth_biblio_c20_d40",
+    )
+
+
+def test_sets_are_disjoint_and_duplicate_free():
+    assert not set(C.DESIGN) & set(C.HOLDOUT)
+    assert len(set(C.DESIGN)) == len(C.DESIGN)
+    assert len(set(C.HOLDOUT)) == len(C.HOLDOUT)
+
+
+def test_corpus_of_and_select():
+    assert C.corpus_of("febrl3") == "design"
+    assert C.corpus_of("abt_buy") == "holdout"
+    assert C.corpus_of("synthetic_person") == "unlisted"
+    assert C.select("all") == C.DESIGN + C.HOLDOUT
+    with pytest.raises(KeyError):
+        C.select("everything")
+
+
+def test_ci_never_provisions_real_voter_pii():
+    assert "ncvr_real" in C.LOCAL_ONLY
+    assert "ncvr_real" not in C.ci_datasets("design")
+    assert C.ci_datasets("holdout") == list(C.HOLDOUT)
+
+
+def test_cli_lists_ci_datasets_as_json(capsys):
+    assert C.main(["--list", "design", "--ci"]) == 0
+    listed = json.loads(capsys.readouterr().out)
+    assert listed == C.ci_datasets("design")

--- a/scripts/autoconfig_quality/tests/test_corpus.py
+++ b/scripts/autoconfig_quality/tests/test_corpus.py
@@ -23,6 +23,16 @@ def test_design_set_is_pinned():
         "dblp_acm",
         "dblp_scholar",
         "amazon_google",
+        "musicbrainz_20k",
+        "geo_settlements",
+        "affiliations",
+        "synth_biblio_d02",
+        "synth_person_d02",
+        "synth_product_d02",
+        "synth_product_d20",
+        "ncvr_synthetic_s7",
+        "household_hardneg_s7",
+        "cotenant_hardneg_s7",
     )
 
 

--- a/scripts/autoconfig_quality/tests/test_datasets.py
+++ b/scripts/autoconfig_quality/tests/test_datasets.py
@@ -113,3 +113,27 @@ def test_historical_50k_registered_full_scan():
 
     h = next(d for d in REGISTRY if d.name == "historical_50k")
     assert h.full_scan is True
+
+
+@pytest.mark.parametrize(
+    ("s7_name", "default_name"),
+    [
+        ("_household_hardneg_s7", "_household_hardneg"),
+        ("_cotenant_hardneg_s7", "_cotenant_hardneg"),
+        ("_ncvr_synthetic_s7", "_ncvr_synthetic"),
+    ],
+)
+def test_s7_seed_variant_loads_and_differs_from_default_seed(s7_name, default_name):
+    """DESIGN seed variants (link-cut routing P3): a non-empty frame, non-empty
+    row-index truth, and a different frame than the default-seed loader."""
+    import scripts.autoconfig_quality.datasets as ds
+
+    s7_fn = getattr(ds, s7_name)
+    default_fn = getattr(ds, default_name)
+
+    s7_df, s7_gt = s7_fn()
+    assert s7_df.height > 0
+    assert s7_gt and all(0 <= a < b < s7_df.height for a, b in s7_gt)
+
+    default_df, _ = default_fn()
+    assert not s7_df.equals(default_df)

--- a/scripts/autoconfig_quality/tests/test_rule_sweep.py
+++ b/scripts/autoconfig_quality/tests/test_rule_sweep.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+
+import pytest
 from goldenmatch.config.schemas import (
     BlockingConfig,
     BlockingKeyConfig,
@@ -68,6 +71,7 @@ def test_arm_record_applied_rule():
         _SUMMARY,
         _stats(fs=_entry("evidence_9", "pinned by link_cut_rule")),
         (4, "abc"),
+        ["fs"],
     )
     assert rec["applied"] is True and rec["voided"] is False
     assert (rec["f1"], rec["pairs"], rec["digest"]) == (0.9, 4, "abc")
@@ -76,7 +80,7 @@ def test_arm_record_applied_rule():
 
 def test_arm_record_uncomputable_rule_is_not_applied_but_not_voided():
     reason = "otsu unavailable: needs a training histogram of more than 50 pairs; default rule"
-    rec = S.arm_record("otsu", _SUMMARY, _stats(fs=_entry("prior_mid", reason)), (0, "x"))
+    rec = S.arm_record("otsu", _SUMMARY, _stats(fs=_entry("prior_mid", reason)), (0, "x"), ["fs"])
     assert rec["applied"] is False and rec["voided"] is False
 
 
@@ -84,18 +88,33 @@ def test_arm_record_overridden_pin_is_voided():
     """KNOWN-POSITIVE for the pinned-arm assertion: an env var that switched on
     posterior scoring voids the arm instead of silently measuring the default."""
     reason = "link_cut_rule=evidence_9 not applied: posterior scoring"
-    rec = S.arm_record("evidence_9", _SUMMARY, _stats(fs=_entry(None, reason)), (0, "x"))
+    rec = S.arm_record("evidence_9", _SUMMARY, _stats(fs=_entry(None, reason)), (0, "x"), ["fs"])
     assert rec["applied"] is False and rec["voided"] is True
 
 
 def test_arm_record_without_a_report_is_voided():
-    assert S.arm_record("default", _SUMMARY, {}, (0, "x"))["voided"] is True
+    assert S.arm_record("default", _SUMMARY, {}, (0, "x"), ["fs"])["voided"] is True
     assert (
-        S.arm_record("default", _SUMMARY, _stats(fs=_entry("prior_mid", "default rule")), (0, "x"))[
-            "voided"
-        ]
+        S.arm_record(
+            "default", _SUMMARY, _stats(fs=_entry("prior_mid", "default rule")), (0, "x"), ["fs"]
+        )["voided"]
         is False
     )
+
+
+def test_arm_record_voided_when_an_expected_matchkey_is_missing_from_the_report():
+    """KNOWN-POSITIVE: two probabilistic matchkeys were pinned, but the report only
+    carries one -- the other's cut can't be attributed to the pin, so this must not
+    read as a clean applied arm."""
+    rec = S.arm_record(
+        "evidence_9",
+        _SUMMARY,
+        _stats(fs_a=_entry("evidence_9", "pinned by link_cut_rule")),
+        (0, "x"),
+        ["fs_a", "fs_b"],
+    )
+    assert rec["voided"] is True
+    assert rec["applied"] is False
 
 
 def test_cut_env_overrides_reports_only_non_empty_values():
@@ -103,9 +122,14 @@ def test_cut_env_overrides_reports_only_non_empty_values():
     assert S.cut_env_overrides(env) == {"GOLDENMATCH_FS_EVIDENCE_CUT": "6"}
 
 
-def test_every_corpus_name_resolves_to_a_loader():
-    import pytest
+def test_cut_env_vars_refuses_the_signature_prune_variable():
+    """KNOWN-POSITIVE: GOLDENMATCH_FS_SIGNATURE_PRUNE passes a pair_filter, which
+    stops model_path from saving, so arms would silently retrain instead of
+    sharing one model."""
+    assert "GOLDENMATCH_FS_SIGNATURE_PRUNE" in S.CUT_ENV_VARS
 
+
+def test_every_corpus_name_resolves_to_a_loader():
     missing = []
     for name in DESIGN + HOLDOUT:
         try:
@@ -141,10 +165,38 @@ def test_sweep_frame_runs_every_arm_on_one_saved_model(tmp_path, monkeypatch):
     assert all(d and "midpoint_bits" in d for d in out["cut_diagnostics"].values())
     assert set(out["below_default"]) <= set(CUT_RULES)
     assert isinstance(out["model_reload_delta"], float)
+    # I1: one shared EM model per dataset, enforced (not just recorded).
+    assert out["probabilistic_matchkeys"], "must record the auto-configured matchkey names"
+    assert sorted(out["models_saved"]) == sorted(
+        f"{n}.json" for n in out["probabilistic_matchkeys"]
+    )
+    assert out["model_complete"] is True
+    assert out["model_stable"] is True
+    assert out["reload_partition_match"] in (True, False)
+    assert isinstance(out["wall_seconds"], float)
+    assert out["wall_seconds"] >= 0.0
 
 
-def _record(corpus: str, f1_by_arm: dict, applied: dict | None = None) -> dict:
+# ─── run() metadata and failure paths (I1 + I2 + I5) ──────────────────────────
+
+
+def _clear_cut_env(monkeypatch):
+    for var in S.CUT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _record(
+    corpus: str,
+    f1_by_arm: dict,
+    applied: dict | None = None,
+    voided: dict | None = None,
+    *,
+    model_complete: bool = True,
+    model_stable: bool = True,
+    reload_partition_match: bool = True,
+) -> dict:
     applied = applied or {}
+    voided = voided or {}
     arms = {
         arm: {
             "f1": f1_by_arm.get(arm, 0.5),
@@ -154,7 +206,7 @@ def _record(corpus: str, f1_by_arm: dict, applied: dict | None = None) -> dict:
             "digest": "d",
             "matchkeys": {},
             "applied": applied.get(arm, True),
-            "voided": False,
+            "voided": voided.get(arm, False),
         }
         for arm in S.ARMS
     }
@@ -162,15 +214,20 @@ def _record(corpus: str, f1_by_arm: dict, applied: dict | None = None) -> dict:
         "corpus": corpus,
         "rows": 10,
         "gt_pairs": 3,
+        "probabilistic_matchkeys": ["fs"],
         "arms": arms,
         "cut_diagnostics": {},
         "models_saved": ["fs.json"],
+        "model_complete": model_complete,
+        "model_stable": model_stable,
+        "reload_partition_match": reload_partition_match,
         "model_reload_delta": 0.0,
         "below_default": ["midpoint"],
+        "wall_seconds": 1.0,
     }
 
 
-def _card(sha: str, **datasets) -> dict:
+def _card(sha: str, *, failures: list[str] | None = None, **datasets) -> dict:
     return {
         "meta": {
             "git_sha": sha,
@@ -179,9 +236,93 @@ def _card(sha: str, **datasets) -> dict:
             "datasets_skipped": {},
             "cut_env_overrides": {},
             "tolerance": 0.01,
+            "failures": failures or [],
         },
         "datasets": datasets,
     }
+
+
+def test_run_records_goldenmatch_env_and_pythonhashseed_in_meta(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    monkeypatch.setenv("PYTHONHASHSEED", "7")
+    monkeypatch.setattr(S, "sweep_dataset", lambda name, work_dir: _record("design", {}))
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 0
+    card = json.loads(out.read_text())
+    assert card["meta"]["goldenmatch_env"].get("GOLDENMATCH_NATIVE") == "0"
+    assert card["meta"]["pythonhashseed"] == "7"
+
+
+def test_run_reports_failure_when_an_arm_is_voided(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+
+    def fake(name, work_dir):
+        rec = _record("design", {})
+        rec["arms"]["prior_mid"]["voided"] = True
+        return rec
+
+    monkeypatch.setattr(S, "sweep_dataset", fake)
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 1
+    card = json.loads(out.read_text())
+    assert "person:prior_mid voided" in card["meta"]["failures"]
+
+
+def test_run_reports_failure_when_a_required_dataset_is_not_measured(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    monkeypatch.setattr(S, "sweep_dataset", lambda name, work_dir: None)
+    out = tmp_path / "card.json"
+    rc = S.run(["--datasets", "person", "--require-datasets", "person", "--out", str(out)])
+    assert rc == 1
+    card = json.loads(out.read_text())
+    assert any("person" in f for f in card["meta"]["failures"])
+
+
+def test_run_reports_failure_when_zero_datasets_are_measured(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    monkeypatch.setattr(S, "sweep_dataset", lambda name, work_dir: None)
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 1
+    card = json.loads(out.read_text())
+    assert "0 datasets measured" in card["meta"]["failures"]
+
+
+def test_run_reports_failure_when_model_not_complete(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    monkeypatch.setattr(
+        S, "sweep_dataset", lambda name, work_dir: _record("design", {}, model_complete=False)
+    )
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 1
+    card = json.loads(out.read_text())
+    assert any(
+        "shared EM model not saved for every probabilistic matchkey" in f
+        for f in card["meta"]["failures"]
+    )
+
+
+def test_run_reports_failure_when_model_not_stable(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    monkeypatch.setattr(
+        S, "sweep_dataset", lambda name, work_dir: _record("design", {}, model_stable=False)
+    )
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 1
+    card = json.loads(out.read_text())
+    assert any("shared EM model changed between arms" in f for f in card["meta"]["failures"])
+
+
+def test_run_returns_zero_with_no_failures_for_a_clean_fake_record(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    monkeypatch.setattr(S, "sweep_dataset", lambda name, work_dir: _record("design", {}))
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 0
+    card = json.loads(out.read_text())
+    assert card["meta"]["failures"] == []
+
+
+# ─── best_rule / merge_cards / render_markdown / merge CLI ────────────────────
 
 
 def test_best_rule_takes_the_highest_applied_rule_with_ties_in_rule_order():
@@ -208,11 +349,10 @@ def test_merge_cards_combines_datasets_from_one_commit():
     assert sorted(merged["datasets"]) == ["abt_buy", "febrl3"]
     assert merged["meta"]["git_sha"] == "abc"
     assert merged["meta"]["tolerance"] == 0.01
+    assert merged["meta"]["missing"] == []
 
 
 def test_merge_cards_refuses_mixed_commits_and_duplicates():
-    import pytest
-
     with pytest.raises(ValueError, match="different commits"):
         S.merge_cards(
             [_card("abc", a=_record("design", {})), _card("def", b=_record("design", {}))]
@@ -223,26 +363,174 @@ def test_merge_cards_refuses_mixed_commits_and_duplicates():
         )
 
 
-def test_render_markdown_has_one_row_per_dataset_design_first():
-    card = S.merge_cards(
+def test_merge_cards_empty_raises():
+    with pytest.raises(ValueError, match="no sweep results to merge"):
+        S.merge_cards([])
+
+
+def test_merge_cards_carries_failures_and_computes_missing():
+    merged = S.merge_cards(
         [
-            _card("abc", abt_buy=_record("holdout", {"default_loaded": 0.8, "evidence_12": 0.85})),
-            _card("abc", febrl3=_record("design", {"default_loaded": 0.9, "prior_mid": 0.95})),
+            _card("abc", febrl3=_record("design", {}), failures=["febrl3:otsu voided"]),
+        ],
+        expected=["febrl3", "dblp_acm", "walmart_amazon"],
+    )
+    assert merged["meta"]["failures"] == ["febrl3:otsu voided"]
+    assert merged["meta"]["missing"] == ["dblp_acm", "walmart_amazon"]
+
+
+def test_render_markdown_design_table_then_holdout_gate_view():
+    full = S.merge_cards(
+        [
+            _card(
+                "abc",
+                febrl3=_record("design", {"default_loaded": 0.9, "prior_mid": 0.95}),
+                abt_buy=_record("holdout", {"default_loaded": 0.8, "evidence_12": 0.85}),
+            )
         ]
     )
-    lines = S.render_markdown(card).strip().splitlines()
-    assert lines[0].startswith("| dataset | corpus | default F1 | best rule |")
-    assert lines[2] == "| febrl3 | design | 0.9000 | prior_mid | 0.9500 | +0.0500 | midpoint |"
-    assert lines[3].startswith("| abt_buy | holdout | 0.8000 | evidence_12 | 0.8500 |")
+    design_card, holdout_card = S._split_by_corpus(full)
+    md = S.render_markdown(design_card, holdout_card)
+    assert "### Design" in md
+    assert "### Held-out (gate view)" in md
+    lines = md.splitlines()
+    assert "| febrl3 | 0.9000 | prior_mid | 0.9500 | +0.0500 | midpoint | none | same |" in lines
+    assert "| abt_buy | 0.8000 | 1 | 0 |" in lines
+    # gate view is counts only: no rule names, no per-rule F1.
+    assert "evidence_12" not in md.split("### Held-out")[1]
 
 
-def test_merge_cli_writes_json_and_markdown(tmp_path):
-    import json
+def test_render_markdown_shows_no_rule_applied_when_nothing_applied():
+    rec = _record("design", {"default_loaded": 0.7}, applied={r: False for r in CUT_RULES})
+    card = S.merge_cards([_card("abc", x=rec)])
+    md = S.render_markdown(card)
+    assert "| x | 0.7000 | no rule applied | 0.7000 | +0.0000 |" in md
 
+
+def test_render_markdown_not_applied_column_excludes_voided_rules():
+    rec = _record(
+        "design",
+        {"default_loaded": 0.7},
+        applied={"otsu": False, "evidence_9": False},
+        voided={"evidence_9": True},
+    )
+    card = S.merge_cards([_card("abc", x=rec)])
+    md = S.render_markdown(card)
+    row = next(line for line in md.splitlines() if line.startswith("| x |"))
+    assert "otsu" in row
+    assert "evidence_9" not in row
+
+
+def test_render_markdown_reload_digest_differs_when_partition_mismatches():
+    rec = _record("design", {"default_loaded": 0.6}, reload_partition_match=False)
+    card = S.merge_cards([_card("abc", y=rec)])
+    md = S.render_markdown(card)
+    row = next(line for line in md.splitlines() if line.startswith("| y |"))
+    assert row.endswith("| DIFFERS |")
+
+
+def test_render_markdown_missing_rows_land_in_the_matching_corpus_table():
+    full = S.merge_cards(
+        [_card("abc", febrl3=_record("design", {}))],
+        expected=["febrl3", "dblp_acm", "walmart_amazon"],
+    )
+    design_card, holdout_card = S._split_by_corpus(full)
+    md = S.render_markdown(design_card, holdout_card)
+    assert (
+        "| dblp_acm | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |" in md
+    )
+    assert "| walmart_amazon | MISSING | MISSING | MISSING |" in md
+
+
+def test_render_markdown_renders_a_failures_section():
+    card = S.merge_cards([_card("abc", x=_record("design", {}), failures=["x:otsu voided"])])
+    md = S.render_markdown(card)
+    assert "**Failures**" in md
+    assert "- x:otsu voided" in md
+
+
+def test_merge_cli_writes_json_and_markdown_split_by_corpus(tmp_path):
     a, b = tmp_path / "a.json", tmp_path / "b.json"
     a.write_text(json.dumps(_card("abc", febrl3=_record("design", {}))))
     b.write_text(json.dumps(_card("abc", abt_buy=_record("holdout", {}))))
-    out, md = tmp_path / "m.json", tmp_path / "m.md"
-    assert S.main(["merge", str(a), str(b), "--out", str(out), "--summary-md", str(md)]) == 0
-    assert sorted(json.loads(out.read_text())["datasets"]) == ["abt_buy", "febrl3"]
+    out, hout, md = tmp_path / "m.json", tmp_path / "mh.json", tmp_path / "m.md"
+    rc = S.main(
+        [
+            "merge",
+            str(a),
+            str(b),
+            "--out",
+            str(out),
+            "--holdout-out",
+            str(hout),
+            "--summary-md",
+            str(md),
+        ]
+    )
+    assert rc == 0
+    design = json.loads(out.read_text())
+    holdout = json.loads(hout.read_text())
+    assert sorted(design["datasets"]) == ["febrl3"]
+    assert sorted(holdout["datasets"]) == ["abt_buy"]
     assert "| febrl3 |" in md.read_text()
+
+
+def test_merge_cli_exits_2_when_holdout_present_without_holdout_out(tmp_path):
+    a = tmp_path / "a.json"
+    a.write_text(json.dumps(_card("abc", abt_buy=_record("holdout", {}))))
+    out = tmp_path / "m.json"
+    rc = S.main(["merge", str(a), "--out", str(out)])
+    assert rc == 2
+    assert not out.exists()
+
+
+def test_merge_cli_returns_1_and_still_writes_outputs_when_a_card_carries_failures(tmp_path):
+    a = tmp_path / "a.json"
+    a.write_text(
+        json.dumps(_card("abc", febrl3=_record("design", {}), failures=["febrl3:otsu voided"]))
+    )
+    out, md = tmp_path / "m.json", tmp_path / "m.md"
+    rc = S.main(["merge", str(a), "--out", str(out), "--summary-md", str(md)])
+    assert rc == 1
+    assert out.exists()
+    assert md.exists()
+    assert "febrl3:otsu voided" in json.loads(out.read_text())["meta"]["failures"]
+
+
+def test_merge_cli_expect_json_reports_missing_and_returns_1(tmp_path):
+    a = tmp_path / "a.json"
+    a.write_text(json.dumps(_card("abc", febrl3=_record("design", {}))))
+    out = tmp_path / "m.json"
+    rc = S.main(["merge", str(a), "--out", str(out), "--expect-json", '["febrl3", "dblp_acm"]'])
+    assert rc == 1
+    assert json.loads(out.read_text())["meta"]["missing"] == ["dblp_acm"]
+
+
+def test_merge_cli_holdout_gate_view_hides_rule_names(tmp_path):
+    a = tmp_path / "a.json"
+    a.write_text(
+        json.dumps(
+            _card(
+                "abc",
+                febrl3=_record("design", {"default_loaded": 0.9, "prior_mid": 0.95}),
+                abt_buy=_record("holdout", {"default_loaded": 0.8, "evidence_12": 0.85}),
+            )
+        )
+    )
+    out, hout, md = tmp_path / "m.json", tmp_path / "mh.json", tmp_path / "m.md"
+    rc = S.main(
+        [
+            "merge",
+            str(a),
+            "--out",
+            str(out),
+            "--holdout-out",
+            str(hout),
+            "--summary-md",
+            str(md),
+        ]
+    )
+    assert rc == 0
+    text = md.read_text()
+    assert "prior_mid" in text
+    assert "evidence_12" not in text.split("### Held-out")[1]

--- a/scripts/autoconfig_quality/tests/test_rule_sweep.py
+++ b/scripts/autoconfig_quality/tests/test_rule_sweep.py
@@ -1,0 +1,143 @@
+"""Per-rule link-cut sweep (FS link-cut routing P3)."""
+
+from __future__ import annotations
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.fs_cut_rules import CUT_RULES
+
+from scripts.autoconfig_quality import rule_sweep as S
+from scripts.autoconfig_quality.corpus import DESIGN, HOLDOUT
+
+
+def _cfg() -> GoldenMatchConfig:
+    field = MatchkeyField(field="name", scorer="jaro_winkler")
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(name="fs_a", type="probabilistic", fields=[field]),
+            MatchkeyConfig(name="fs_b", type="probabilistic", fields=[field]),
+        ],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["name"])]),
+    )
+
+
+def _stats(**per_mk) -> dict:
+    return {"fs_link_thresholds": per_mk}
+
+
+def _entry(cut_rule=None, cut_reason=None) -> dict:
+    return {
+        "link_threshold": 0.6,
+        "source": "evidence_rule",
+        "cut_rule": cut_rule,
+        "cut_reason": cut_reason,
+        "cut_diagnostics": {"midpoint_bits": 2.0},
+    }
+
+
+_SUMMARY = {"f1": 0.9, "precision": 0.95, "recall": 0.85}
+
+
+def test_arms_run_both_baselines_then_every_rule_once():
+    assert S.ARMS == ("default", "default_loaded", *CUT_RULES)
+    assert len(set(S.ARMS)) == len(S.ARMS)
+    assert S.BASELINE_ARM == "default_loaded"
+
+
+def test_pin_rule_pins_every_probabilistic_matchkey_without_mutating_the_input(tmp_path):
+    cfg = _cfg()
+    pinned = S.pin_rule(cfg, "evidence_9", tmp_path)
+    got = {mk.name: (mk.link_cut_rule, mk.model_path) for mk in pinned.get_matchkeys()}
+    assert got == {
+        "fs_a": ("evidence_9", str(tmp_path / "fs_a.json")),
+        "fs_b": ("evidence_9", str(tmp_path / "fs_b.json")),
+    }
+    assert all(mk.link_cut_rule is None and mk.model_path is None for mk in cfg.get_matchkeys())
+    unset = S.pin_rule(cfg, None, tmp_path)
+    assert all(mk.link_cut_rule is None for mk in unset.get_matchkeys())
+
+
+def test_arm_record_applied_rule():
+    rec = S.arm_record(
+        "evidence_9",
+        _SUMMARY,
+        _stats(fs=_entry("evidence_9", "pinned by link_cut_rule")),
+        (4, "abc"),
+    )
+    assert rec["applied"] is True and rec["voided"] is False
+    assert (rec["f1"], rec["pairs"], rec["digest"]) == (0.9, 4, "abc")
+    assert rec["matchkeys"]["fs"]["cut_rule"] == "evidence_9"
+
+
+def test_arm_record_uncomputable_rule_is_not_applied_but_not_voided():
+    reason = "otsu unavailable: needs a training histogram of more than 50 pairs; default rule"
+    rec = S.arm_record("otsu", _SUMMARY, _stats(fs=_entry("prior_mid", reason)), (0, "x"))
+    assert rec["applied"] is False and rec["voided"] is False
+
+
+def test_arm_record_overridden_pin_is_voided():
+    """KNOWN-POSITIVE for the pinned-arm assertion: an env var that switched on
+    posterior scoring voids the arm instead of silently measuring the default."""
+    reason = "link_cut_rule=evidence_9 not applied: posterior scoring"
+    rec = S.arm_record("evidence_9", _SUMMARY, _stats(fs=_entry(None, reason)), (0, "x"))
+    assert rec["applied"] is False and rec["voided"] is True
+
+
+def test_arm_record_without_a_report_is_voided():
+    assert S.arm_record("default", _SUMMARY, {}, (0, "x"))["voided"] is True
+    assert (
+        S.arm_record("default", _SUMMARY, _stats(fs=_entry("prior_mid", "default rule")), (0, "x"))[
+            "voided"
+        ]
+        is False
+    )
+
+
+def test_cut_env_overrides_reports_only_non_empty_values():
+    env = {"GOLDENMATCH_FS_EVIDENCE_CUT": "6", "GOLDENMATCH_FS_CALIBRATED": " ", "PATH": "x"}
+    assert S.cut_env_overrides(env) == {"GOLDENMATCH_FS_EVIDENCE_CUT": "6"}
+
+
+def test_every_corpus_name_resolves_to_a_loader():
+    import pytest
+
+    missing = []
+    for name in DESIGN + HOLDOUT:
+        try:
+            assert callable(S.resolve_loader(name))
+        except KeyError:
+            missing.append(name)
+    assert not missing, missing
+    with pytest.raises(KeyError):
+        S.resolve_loader("not_a_dataset")
+
+
+def test_run_refuses_when_a_cut_env_var_is_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_FS_EVIDENCE_CUT", "6")
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 2
+    assert not out.exists()
+
+
+def test_sweep_frame_runs_every_arm_on_one_saved_model(tmp_path, monkeypatch):
+    for var in S.CUT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    from scripts.autoconfig_quality.anchors import gen_labeled
+
+    df, gt = gen_labeled(n_entities=60, seed=7)
+    out = S.sweep_frame(df, gt, tmp_path)
+
+    assert set(out["arms"]) == set(S.ARMS)
+    assert not [a for a, rec in out["arms"].items() if rec["voided"]]
+    not_applied = [r for r in CUT_RULES if r != "otsu" and not out["arms"][r]["applied"]]
+    assert not not_applied, not_applied
+    assert out["models_saved"], "the default arm must save the EM model the other arms load"
+    assert all(d and "midpoint_bits" in d for d in out["cut_diagnostics"].values())
+    assert set(out["below_default"]) <= set(CUT_RULES)
+    assert isinstance(out["model_reload_delta"], float)

--- a/scripts/autoconfig_quality/tests/test_rule_sweep.py
+++ b/scripts/autoconfig_quality/tests/test_rule_sweep.py
@@ -141,3 +141,108 @@ def test_sweep_frame_runs_every_arm_on_one_saved_model(tmp_path, monkeypatch):
     assert all(d and "midpoint_bits" in d for d in out["cut_diagnostics"].values())
     assert set(out["below_default"]) <= set(CUT_RULES)
     assert isinstance(out["model_reload_delta"], float)
+
+
+def _record(corpus: str, f1_by_arm: dict, applied: dict | None = None) -> dict:
+    applied = applied or {}
+    arms = {
+        arm: {
+            "f1": f1_by_arm.get(arm, 0.5),
+            "precision": 0.0,
+            "recall": 0.0,
+            "pairs": 0,
+            "digest": "d",
+            "matchkeys": {},
+            "applied": applied.get(arm, True),
+            "voided": False,
+        }
+        for arm in S.ARMS
+    }
+    return {
+        "corpus": corpus,
+        "rows": 10,
+        "gt_pairs": 3,
+        "arms": arms,
+        "cut_diagnostics": {},
+        "models_saved": ["fs.json"],
+        "model_reload_delta": 0.0,
+        "below_default": ["midpoint"],
+    }
+
+
+def _card(sha: str, **datasets) -> dict:
+    return {
+        "meta": {
+            "git_sha": sha,
+            "native_version": "0.2.2",
+            "datasets_run": sorted(datasets),
+            "datasets_skipped": {},
+            "cut_env_overrides": {},
+            "tolerance": 0.01,
+        },
+        "datasets": datasets,
+    }
+
+
+def test_best_rule_takes_the_highest_applied_rule_with_ties_in_rule_order():
+    rec = _record(
+        "design",
+        {"default_loaded": 0.8, "prior": 0.9, "evidence_9": 0.9, "otsu": 0.99},
+        applied={"otsu": False},
+    )
+    assert S.best_rule(rec) == ("prior", 0.9)
+
+
+def test_best_rule_falls_back_to_the_baseline_when_nothing_applied():
+    rec = _record("design", {"default_loaded": 0.7}, applied={r: False for r in CUT_RULES})
+    assert S.best_rule(rec) == ("default_loaded", 0.7)
+
+
+def test_merge_cards_combines_datasets_from_one_commit():
+    merged = S.merge_cards(
+        [
+            _card("abc", febrl3=_record("design", {})),
+            _card("abc", abt_buy=_record("holdout", {})),
+        ]
+    )
+    assert sorted(merged["datasets"]) == ["abt_buy", "febrl3"]
+    assert merged["meta"]["git_sha"] == "abc"
+    assert merged["meta"]["tolerance"] == 0.01
+
+
+def test_merge_cards_refuses_mixed_commits_and_duplicates():
+    import pytest
+
+    with pytest.raises(ValueError, match="different commits"):
+        S.merge_cards(
+            [_card("abc", a=_record("design", {})), _card("def", b=_record("design", {}))]
+        )
+    with pytest.raises(ValueError, match="two sweep results"):
+        S.merge_cards(
+            [_card("abc", a=_record("design", {})), _card("abc", a=_record("design", {}))]
+        )
+
+
+def test_render_markdown_has_one_row_per_dataset_design_first():
+    card = S.merge_cards(
+        [
+            _card("abc", abt_buy=_record("holdout", {"default_loaded": 0.8, "evidence_12": 0.85})),
+            _card("abc", febrl3=_record("design", {"default_loaded": 0.9, "prior_mid": 0.95})),
+        ]
+    )
+    lines = S.render_markdown(card).strip().splitlines()
+    assert lines[0].startswith("| dataset | corpus | default F1 | best rule |")
+    assert lines[2] == "| febrl3 | design | 0.9000 | prior_mid | 0.9500 | +0.0500 | midpoint |"
+    assert lines[3].startswith("| abt_buy | holdout | 0.8000 | evidence_12 | 0.8500 |")
+
+
+def test_merge_cli_writes_json_and_markdown(tmp_path):
+    import json
+
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    a.write_text(json.dumps(_card("abc", febrl3=_record("design", {}))))
+    b.write_text(json.dumps(_card("abc", abt_buy=_record("holdout", {}))))
+    out, md = tmp_path / "m.json", tmp_path / "m.md"
+    assert S.main(["merge", str(a), str(b), "--out", str(out), "--summary-md", str(md)]) == 0
+    assert sorted(json.loads(out.read_text())["datasets"]) == ["abt_buy", "febrl3"]
+    assert "| febrl3 |" in md.read_text()

--- a/scripts/autoconfig_quality/tests/test_rule_sweep.py
+++ b/scripts/autoconfig_quality/tests/test_rule_sweep.py
@@ -148,33 +148,135 @@ def test_run_refuses_when_a_cut_env_var_is_set(tmp_path, monkeypatch):
     assert not out.exists()
 
 
-def test_sweep_frame_runs_every_arm_on_one_saved_model(tmp_path, monkeypatch):
+# ─── watchdog: one capped child process per arm ───────────────────────────────
+
+
+def _alive(pid: int) -> bool:
+    import psutil
+
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def test_run_arm_classifies_a_child_that_exits_non_zero_as_crashed(tmp_path):
+    import sys
+
+    argv = [sys.executable, "-c", "import os; os._exit(137)"]
+    rec, payload = S.run_arm(argv, tmp_path / "arm.json", "prior", ["fs"])
+    assert rec["crashed"] == "crashed"
+    assert rec["returncode"] == 137
+    assert rec["f1"] is None
+    assert rec["voided"] is False
+    assert rec["applied"] is False
+    assert payload is None
+
+
+def test_run_arm_kills_a_child_over_the_memory_cap(tmp_path):
+    import sys
+    import time
+
+    pid_file = tmp_path / "pid"
+    code = (
+        "import os, pathlib, time; "
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+        "b = bytearray(400 * 2**20); time.sleep(30)"
+    )
+    start = time.perf_counter()
+    rec, _ = S.run_arm(
+        [sys.executable, "-c", code], tmp_path / "arm.json", "prior", ["fs"], memory_cap_mb=150
+    )
+    assert rec["crashed"] == "memory_cap"
+    assert time.perf_counter() - start < 20, "the watchdog must kill before the child's sleep ends"
+    assert rec["peak_rss_mb"] > 150
+    assert not _alive(int(pid_file.read_text()))
+
+
+def test_run_arm_kills_a_child_past_the_timeout(tmp_path):
+    import sys
+    import time
+
+    start = time.perf_counter()
+    rec, _ = S.run_arm(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        tmp_path / "arm.json",
+        "prior",
+        ["fs"],
+        timeout_s=1,
+    )
+    assert rec["crashed"] == "timeout"
+    assert rec["f1"] is None
+    assert time.perf_counter() - start < 20
+
+
+def test_execute_arm_applies_every_rule_on_one_saved_model(tmp_path, monkeypatch):
+    """Every arm through the one function the child process runs, in-process, on a
+    small frame: no arm voided, every computable rule applied, one saved model."""
     for var in S.CUT_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
     from scripts.autoconfig_quality.anchors import gen_labeled
 
     df, gt = gen_labeled(n_entities=60, seed=7)
-    out = S.sweep_frame(df, gt, tmp_path)
+    cfg = auto_configure_probabilistic_df(df)
+    matchkeys = sorted(mk.name for mk in cfg.get_matchkeys() if mk.type == "probabilistic")
+    assert matchkeys, "must auto-configure at least one probabilistic matchkey"
 
-    assert set(out["arms"]) == set(S.ARMS)
-    assert not [a for a, rec in out["arms"].items() if rec["voided"]]
-    not_applied = [r for r in CUT_RULES if r != "otsu" and not out["arms"][r]["applied"]]
+    records, payloads = {}, {}
+    for arm in S.ARMS:
+        payload = json.loads(json.dumps(S.execute_arm(df, gt, cfg, arm, tmp_path)))
+        payloads[arm] = payload
+        records[arm] = S.arm_record(
+            arm,
+            payload["summary"],
+            {"fs_link_thresholds": payload["report"]},
+            tuple(payload["partition"]),
+            matchkeys,
+        )
+        assert payload["wall_seconds"] >= 0.0
+
+    assert not [a for a, rec in records.items() if rec["voided"]]
+    not_applied = [r for r in CUT_RULES if r != "otsu" and not records[r]["applied"]]
     assert not not_applied, not_applied
-    assert out["models_saved"], "the default arm must save the EM model the other arms load"
-    assert all(d and "midpoint_bits" in d for d in out["cut_diagnostics"].values())
-    assert set(out["below_default"]) <= set(CUT_RULES)
-    assert isinstance(out["model_reload_delta"], float)
+    assert sorted(p.name for p in tmp_path.glob("*.json")) == sorted(f"{n}.json" for n in matchkeys)
+    report = payloads[S.BASELINE_ARM]["report"]
+    assert all(
+        e["cut_diagnostics"] and "midpoint_bits" in e["cut_diagnostics"] for e in report.values()
+    )
+
+
+def test_sweep_dataset_runs_each_arm_in_its_own_child_on_one_saved_model(tmp_path, monkeypatch):
+    """End-to-end isolation: real child processes, one config file, one EM model."""
+    for var in S.CUT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    arms = ("default", "default_loaded", "evidence_9")
+    out = S.sweep_dataset("person", tmp_path, arms=arms)
+
+    assert (tmp_path / "person" / "config.json").is_file()
+    assert set(out["arms"]) == set(arms)
+    assert all(rec["crashed"] is None for rec in out["arms"].values())
+    assert all(rec["peak_rss_mb"] > 0 for rec in out["arms"].values())
+    assert not [a for a, rec in out["arms"].items() if rec["voided"]]
+    assert out["arms"]["evidence_9"]["applied"] is True
+    assert out["crashed"] == {}
+    assert set(out["below_default"]) <= {"evidence_9"}
     # I1: one shared EM model per dataset, enforced (not just recorded).
     assert out["probabilistic_matchkeys"], "must record the auto-configured matchkey names"
+    assert out["models_saved"], "the default arm must save the EM model the other arms load"
     assert sorted(out["models_saved"]) == sorted(
         f"{n}.json" for n in out["probabilistic_matchkeys"]
     )
     assert out["model_complete"] is True
     assert out["model_stable"] is True
+    assert all(d and "midpoint_bits" in d for d in out["cut_diagnostics"].values())
+    assert isinstance(out["model_reload_delta"], float)
     assert out["reload_partition_match"] in (True, False)
     assert isinstance(out["wall_seconds"], float)
-    assert out["wall_seconds"] >= 0.0
+    assert out["corpus"] == "design"
 
 
 # ─── run() metadata and failure paths (I1 + I2 + I5) ──────────────────────────
@@ -207,6 +309,9 @@ def _record(
             "matchkeys": {},
             "applied": applied.get(arm, True),
             "voided": voided.get(arm, False),
+            "crashed": None,
+            "peak_rss_mb": 10.0,
+            "wall_seconds": 0.1,
         }
         for arm in S.ARMS
     }
@@ -223,6 +328,7 @@ def _record(
         "reload_partition_match": reload_partition_match,
         "model_reload_delta": 0.0,
         "below_default": ["midpoint"],
+        "crashed": {},
         "wall_seconds": 1.0,
     }
 
@@ -322,6 +428,83 @@ def test_run_returns_zero_with_no_failures_for_a_clean_fake_record(tmp_path, mon
     assert card["meta"]["failures"] == []
 
 
+# ─── crashed arms: a rule crash is a result, a baseline crash is a failure ────
+
+
+def _small_person(monkeypatch):
+    """``person`` resolves to a 60-entity frame, so the parent's auto-configure is fast."""
+    from scripts.autoconfig_quality.anchors import gen_labeled
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    monkeypatch.setattr(S, "resolve_loader", lambda name: lambda: gen_labeled(60, seed=7))
+
+
+def _fake_run_arm(crash: dict[str, str]):
+    """An arm runner that runs nothing: every arm applies at ``_SUMMARY``'s F1,
+    except the arms in ``crash``, which come back killed with that status."""
+
+    def fake(argv, out_path, arm, expected_matchkeys, **kwargs):
+        if arm in crash:
+            return S.killed_record(crash[arm], 1, 20.0, 0.1), None
+        rule = None if arm in ("default", S.BASELINE_ARM) else arm
+        report = {mk: _entry(rule, "pinned by link_cut_rule") for mk in expected_matchkeys}
+        rec = S.arm_record(arm, _SUMMARY, _stats(**report), (1, "d"), expected_matchkeys)
+        rec.update(crashed=None, peak_rss_mb=20.0, wall_seconds=0.1)
+        payload = {
+            "summary": _SUMMARY,
+            "report": report,
+            "partition": [1, "d"],
+            "wall_seconds": 0.1,
+        }
+        return rec, payload
+
+    return fake
+
+
+def _cells(md: str, name: str) -> list[str]:
+    row = next(line for line in md.splitlines() if line.startswith(f"| {name} |"))
+    return [cell.strip() for cell in row.strip().strip("|").split("|")]
+
+
+def test_a_crashed_rule_arm_counts_below_default_and_is_reported(tmp_path, monkeypatch):
+    _small_person(monkeypatch)
+    monkeypatch.setattr(S, "run_arm", _fake_run_arm({"prior": "memory_cap"}))
+    rec = S.sweep_dataset("person", tmp_path)
+
+    assert rec["arms"]["prior"]["crashed"] == "memory_cap"
+    assert rec["crashed"] == {"prior": "memory_cap"}
+    assert rec["below_default"] == ["prior"]
+    assert isinstance(rec["model_reload_delta"], float)
+    assert S.best_rule(rec)[0] not in ("prior", S.BASELINE_ARM)
+
+    design = S.render_markdown(S.merge_cards([_card("abc", person=rec)]))
+    cells = _cells(design, "person")
+    assert cells[7] == "prior:memory_cap"
+    assert "prior" not in cells[6], "a crashed arm is crashed, not 'not applied'"
+
+    holdout_card = S.merge_cards([_card("abc", abt_buy={**rec, "corpus": "holdout"})])
+    gate = S.render_markdown({"meta": holdout_card["meta"], "datasets": {}}, holdout_card)
+    assert "| abt_buy | 0.9000 | 1 | 0 | 1 |" in gate.splitlines()
+    assert "prior" not in gate.split("### Held-out")[1]
+
+
+def test_a_crashed_baseline_arm_fails_the_dataset(tmp_path, monkeypatch):
+    _clear_cut_env(monkeypatch)
+    _small_person(monkeypatch)
+    monkeypatch.setattr(S, "run_arm", _fake_run_arm({"default_loaded": "crashed"}))
+    out = tmp_path / "card.json"
+    assert S.run(["--datasets", "person", "--out", str(out)]) == 1
+
+    card = json.loads(out.read_text())
+    assert "person: baseline arm default_loaded crashed" in card["meta"]["failures"]
+    rec = card["datasets"]["person"]
+    assert rec["below_default"] == []
+    assert rec["model_reload_delta"] is None
+    assert rec["reload_partition_match"] is None
+    # The matrix still renders a dataset whose baseline has no F1.
+    assert _cells(S.render_markdown(card), "person")[1] == "crashed"
+
+
 # ─── best_rule / merge_cards / render_markdown / merge CLI ────────────────────
 
 
@@ -394,8 +577,11 @@ def test_render_markdown_design_table_then_holdout_gate_view():
     assert "### Design" in md
     assert "### Held-out (gate view)" in md
     lines = md.splitlines()
-    assert "| febrl3 | 0.9000 | prior_mid | 0.9500 | +0.0500 | midpoint | none | same |" in lines
-    assert "| abt_buy | 0.8000 | 1 | 0 |" in lines
+    assert (
+        "| febrl3 | 0.9000 | prior_mid | 0.9500 | +0.0500 | midpoint | none | none | same |"
+        in lines
+    )
+    assert "| abt_buy | 0.8000 | 1 | 0 | 0 |" in lines
     # gate view is counts only: no rule names, no per-rule F1.
     assert "evidence_12" not in md.split("### Held-out")[1]
 
@@ -436,10 +622,8 @@ def test_render_markdown_missing_rows_land_in_the_matching_corpus_table():
     )
     design_card, holdout_card = S._split_by_corpus(full)
     md = S.render_markdown(design_card, holdout_card)
-    assert (
-        "| dblp_acm | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |" in md
-    )
-    assert "| walmart_amazon | MISSING | MISSING | MISSING |" in md
+    assert "| dblp_acm |" + " MISSING |" * 8 in md
+    assert "| walmart_amazon | MISSING | MISSING | MISSING | MISSING |" in md
 
 
 def test_render_markdown_renders_a_failures_section():

--- a/scripts/autoconfig_quality/tests/test_rule_sweep.py
+++ b/scripts/autoconfig_quality/tests/test_rule_sweep.py
@@ -160,17 +160,55 @@ def _alive(pid: int) -> bool:
         return False
 
 
+# Tests that exercise another trigger pin ``min_available_mb=0``: the available-memory
+# floor reads the whole machine, and a busy laptop can sit below the 1500 MB default.
+
+
+def _sleeping_child(tmp_path) -> tuple[list[str], str]:
+    """A child that writes its interpreter's pid to ``tmp_path / "pid"``, then sleeps
+    30 s. Returns ``(argv, marker)``; the marker is in its argv, for cleanup."""
+    import sys
+    import uuid
+
+    marker = f"gm-arm-test-{uuid.uuid4().hex}"
+    code = (
+        f"import os, pathlib, time; marker = {marker!r}; "
+        f"pathlib.Path({str(tmp_path / 'pid')!r}).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+    return [sys.executable, "-c", code], marker
+
+
+def _kill_marked(marker: str) -> None:
+    """Kill every process whose argv carries ``marker`` (cleanup after a kill-path test)."""
+    import psutil
+
+    victims = [
+        p for p in psutil.process_iter(["cmdline"]) if marker in " ".join(p.info["cmdline"] or [])
+    ]
+    for p in victims:
+        try:
+            p.kill()
+        except psutil.Error:
+            pass
+    psutil.wait_procs(victims, timeout=10)
+
+
 def test_run_arm_classifies_a_child_that_exits_non_zero_as_crashed(tmp_path):
     import sys
 
     argv = [sys.executable, "-c", "import os; os._exit(137)"]
-    rec, payload = S.run_arm(argv, tmp_path / "arm.json", "prior", ["fs"])
+    rec, payload = S.run_arm(argv, tmp_path / "arm.json", "prior", ["fs"], min_available_mb=0)
     assert rec["crashed"] == "crashed"
     assert rec["returncode"] == 137
+    assert rec["kill_reason"] is None
     assert rec["f1"] is None
     assert rec["voided"] is False
     assert rec["applied"] is False
     assert payload is None
+    # M4: no pipeline result came back, so no pipeline time; the parent still clocked it.
+    assert rec["wall_seconds"] is None
+    assert rec["process_seconds"] >= 0.0
 
 
 def test_run_arm_kills_a_child_over_the_memory_cap(tmp_path):
@@ -185,9 +223,16 @@ def test_run_arm_kills_a_child_over_the_memory_cap(tmp_path):
     )
     start = time.perf_counter()
     rec, _ = S.run_arm(
-        [sys.executable, "-c", code], tmp_path / "arm.json", "prior", ["fs"], memory_cap_mb=150
+        [sys.executable, "-c", code],
+        tmp_path / "arm.json",
+        "prior",
+        ["fs"],
+        memory_cap_mb=150,
+        min_available_mb=0,
     )
     assert rec["crashed"] == "memory_cap"
+    assert rec["kill_reason"] == "rss_cap"
+    assert rec["returncode"] != 0, "a killed arm never reports a clean exit"
     assert time.perf_counter() - start < 20, "the watchdog must kill before the child's sleep ends"
     assert rec["peak_rss_mb"] > 150
     assert not _alive(int(pid_file.read_text()))
@@ -204,10 +249,103 @@ def test_run_arm_kills_a_child_past_the_timeout(tmp_path):
         "prior",
         ["fs"],
         timeout_s=1,
+        min_available_mb=0,
     )
     assert rec["crashed"] == "timeout"
+    assert rec["kill_reason"] is None
+    assert rec["returncode"] != 0, "a killed arm never reports a clean exit"
     assert rec["f1"] is None
+    assert rec["process_seconds"] >= 1.0
     assert time.perf_counter() - start < 20
+
+
+def test_run_arm_kills_a_child_when_machine_available_memory_drops_below_the_floor(
+    tmp_path, monkeypatch
+):
+    """I2: the child's RSS stays tiny, but the machine runs out -- the floor fires."""
+    import time
+    from types import SimpleNamespace
+
+    import psutil
+
+    pid_file = tmp_path / "pid"
+
+    def low_once_the_child_runs():
+        mb = 100 if pid_file.exists() else 10**6
+        return SimpleNamespace(available=mb * 2**20)
+
+    monkeypatch.setattr(psutil, "virtual_memory", low_once_the_child_runs)
+    argv, marker = _sleeping_child(tmp_path)
+    start = time.perf_counter()
+    try:
+        rec, _ = S.run_arm(
+            argv, tmp_path / "arm.json", "prior", ["fs"], memory_cap_mb=10**6, min_available_mb=1500
+        )
+    finally:
+        _kill_marked(marker)  # no-op when the watchdog did its job
+    assert rec["crashed"] == "memory_cap"
+    assert rec["kill_reason"] == "available_floor"
+    assert time.perf_counter() - start < 20
+    assert not _alive(int(pid_file.read_text()))
+
+
+def test_run_arm_leaves_the_killed_root_to_popen_and_bounds_every_wait(tmp_path, monkeypatch):
+    """M1 + M2: psutil must not reap the direct child (on Linux Popen then reports
+    returncode 0 for a killed arm), and no wait after a kill may block forever."""
+    import subprocess
+
+    import psutil
+
+    waited_by_psutil: list[int] = []
+    popen_pids: set[int] = set()
+    popen_timeouts: list[float | None] = []
+    real_wait_procs = psutil.wait_procs
+    real_popen_wait = subprocess.Popen.wait
+
+    def wait_procs(procs, *args, **kwargs):
+        waited_by_psutil.extend(p.pid for p in procs)
+        return real_wait_procs(procs, *args, **kwargs)
+
+    def popen_wait(self, timeout=None):
+        popen_pids.add(self.pid)
+        popen_timeouts.append(timeout)
+        return real_popen_wait(self, timeout)
+
+    monkeypatch.setattr(psutil, "wait_procs", wait_procs)
+    monkeypatch.setattr(subprocess.Popen, "wait", popen_wait)
+    argv, marker = _sleeping_child(tmp_path)
+    try:
+        rec, _ = S.run_arm(
+            argv, tmp_path / "arm.json", "prior", ["fs"], timeout_s=1, min_available_mb=0
+        )
+    finally:
+        monkeypatch.undo()
+        _kill_marked(marker)
+    assert rec["crashed"] == "timeout"
+    assert rec["returncode"] != 0
+    assert popen_pids and not popen_pids & set(waited_by_psutil)
+    assert popen_timeouts and None not in popen_timeouts
+
+
+def test_run_arm_kill_path_cannot_mask_the_original_error(tmp_path, monkeypatch):
+    """M2: an AccessDenied while cleaning up must not replace the error that caused it."""
+    import psutil
+
+    def boom(proc):
+        raise RuntimeError("original")
+
+    def denied(self, recursive=False):
+        raise psutil.AccessDenied(self.pid)
+
+    monkeypatch.setattr(S, "_tree_rss_mb", boom)
+    monkeypatch.setattr(psutil.Process, "children", denied)
+    argv, marker = _sleeping_child(tmp_path)
+    try:
+        with pytest.raises(RuntimeError, match="original"):
+            S.run_arm(argv, tmp_path / "arm.json", "prior", ["fs"], min_available_mb=0)
+    finally:
+        monkeypatch.undo()
+        _kill_marked(marker)
 
 
 def test_execute_arm_applies_every_rule_on_one_saved_model(tmp_path, monkeypatch):
@@ -253,6 +391,9 @@ def test_sweep_dataset_runs_each_arm_in_its_own_child_on_one_saved_model(tmp_pat
     for var in S.CUT_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    # The floor reads the whole machine; this test is about isolation, not pressure.
+    monkeypatch.setenv("GOLDENMATCH_CUT_RULES_MIN_AVAILABLE_MB", "0")
+    monkeypatch.delenv("GOLDENMATCH_CUT_RULES_DATASET_BUDGET_S", raising=False)
     arms = ("default", "default_loaded", "evidence_9")
     out = S.sweep_dataset("person", tmp_path, arms=arms)
 
@@ -260,6 +401,8 @@ def test_sweep_dataset_runs_each_arm_in_its_own_child_on_one_saved_model(tmp_pat
     assert set(out["arms"]) == set(arms)
     assert all(rec["crashed"] is None for rec in out["arms"].values())
     assert all(rec["peak_rss_mb"] > 0 for rec in out["arms"].values())
+    # M4: the parent's clock spans interpreter start-up, so it covers the pipeline time.
+    assert all(rec["process_seconds"] >= rec["wall_seconds"] for rec in out["arms"].values())
     assert not [a for a, rec in out["arms"].items() if rec["voided"]]
     assert out["arms"]["evidence_9"]["applied"] is True
     assert out["crashed"] == {}
@@ -357,7 +500,8 @@ def test_run_records_goldenmatch_env_and_pythonhashseed_in_meta(tmp_path, monkey
     assert S.run(["--datasets", "person", "--out", str(out)]) == 0
     card = json.loads(out.read_text())
     assert card["meta"]["goldenmatch_env"].get("GOLDENMATCH_NATIVE") == "0"
-    assert card["meta"]["pythonhashseed"] == "7"
+    # I3: the sweep's own seed, and the seed every arm's child actually ran under.
+    assert card["meta"]["pythonhashseed"] == {"sweep": "7", "arms": "0"}
 
 
 def test_run_reports_failure_when_an_arm_is_voided(tmp_path, monkeypatch):
@@ -449,7 +593,7 @@ def _fake_run_arm(crash: dict[str, str]):
         rule = None if arm in ("default", S.BASELINE_ARM) else arm
         report = {mk: _entry(rule, "pinned by link_cut_rule") for mk in expected_matchkeys}
         rec = S.arm_record(arm, _SUMMARY, _stats(**report), (1, "d"), expected_matchkeys)
-        rec.update(crashed=None, peak_rss_mb=20.0, wall_seconds=0.1)
+        rec.update(crashed=None, peak_rss_mb=20.0, wall_seconds=0.1, process_seconds=0.2)
         payload = {
             "summary": _SUMMARY,
             "report": report,
@@ -503,6 +647,58 @@ def test_a_crashed_baseline_arm_fails_the_dataset(tmp_path, monkeypatch):
     assert rec["reload_partition_match"] is None
     # The matrix still renders a dataset whose baseline has no F1.
     assert _cells(S.render_markdown(card), "person")[1] == "crashed"
+
+
+def test_dataset_budget_times_out_the_arms_it_cannot_fit_without_starting_them(
+    tmp_path, monkeypatch
+):
+    """I1: every arm here needs 0.3 s against a 0.5 s dataset budget, so two arms
+    run and the rest are recorded as timed out, never started."""
+    import time
+
+    _small_person(monkeypatch)
+    started: list[str] = []
+    timeouts: list[float] = []
+    instant = _fake_run_arm({})
+
+    def slow(argv, out_path, arm, expected_matchkeys, **kwargs):
+        started.append(arm)
+        timeouts.append(kwargs["timeout_s"])
+        time.sleep(0.3)
+        return instant(argv, out_path, arm, expected_matchkeys, **kwargs)
+
+    monkeypatch.setattr(S, "run_arm", slow)
+    arms = ("default", "default_loaded", "evidence_9", "prior")
+    rec = S.sweep_dataset("person", tmp_path, arms=arms, budget_s=0.5)
+
+    assert started == ["default", "default_loaded"]
+    assert timeouts[0] <= 0.5 / len(arms), "each arm gets at most its share of what is left"
+    shape = set(S.killed_record("timeout", None, 0.0, 0.0))
+    for arm in ("evidence_9", "prior"):
+        assert rec["arms"][arm]["crashed"] == "timeout"
+        assert rec["arms"][arm]["kill_reason"] == "dataset_budget"
+        assert rec["arms"][arm]["returncode"] is None
+        assert set(rec["arms"][arm]) == shape
+    assert rec["below_default"] == ["evidence_9", "prior"]
+
+
+def test_arm_log_line_omits_f1_for_holdout_datasets(tmp_path, monkeypatch, capsys):
+    """M3: per-rule F1 on a held-out dataset must not reach the CI log."""
+    _small_person(monkeypatch)
+    monkeypatch.setattr(S, "run_arm", _fake_run_arm({}))
+    arms = ("default", "default_loaded", "evidence_9")
+
+    S.sweep_dataset("abt_buy", tmp_path, arms=arms)
+    holdout = [
+        ln for ln in capsys.readouterr().err.splitlines() if ln.startswith("[cut-rules] abt_buy:")
+    ]
+    S.sweep_dataset("person", tmp_path, arms=arms)
+    design = [
+        ln for ln in capsys.readouterr().err.splitlines() if ln.startswith("[cut-rules] person:")
+    ]
+
+    assert len(holdout) == len(arms) and not [ln for ln in holdout if "f1" in ln]
+    assert len(design) == len(arms) and all("f1=0.9" in ln for ln in design)
 
 
 # ─── best_rule / merge_cards / render_markdown / merge CLI ────────────────────

--- a/scripts/bench_er_headtohead/datasets.py
+++ b/scripts/bench_er_headtohead/datasets.py
@@ -475,9 +475,11 @@ def _magellan(subdir: str) -> tuple[pa.Table, pa.Table]:
     never committed; Konda et al. 2016, Mudgal et al. 2018).
 
     Records are tableA + tableB with ``a:<id>`` / ``b:<id>`` ids. Truth links the
-    ``label == 1`` pairs of the train/valid/test candidate splits, so a true match
-    DeepMatcher's own blocking never proposed counts as a non-match -- identically
-    for every arm a sweep compares."""
+    ``label == 1`` pairs of the train/valid/test candidate splits: it covers only
+    DeepMatcher's labelled candidate positives. An unlabelled true match that a
+    rule links is scored as a false positive, so lower cuts are penalised; recall
+    a higher cut loses on unlabelled matches is not counted. The bias therefore
+    favours high-cut rules such as ``evidence_12`` and ``posterior_099``."""
     base = DATASETS_DIR / "Magellan" / subdir
     paths = [base / "tableA.csv", base / "tableB.csv", *(base / s for s in _MAGELLAN_SPLITS)]
     missing = [p for p in paths if not p.exists()]
@@ -566,7 +568,7 @@ _HELDOUT_SYNTH_SEED = 1009
 #: name -> (shape, corruption, dupe_rate). c05 = corruption 0.5, c20 = 2.0;
 #: d10 = dupe_rate 0.10, d40 = 0.40.
 _SYNTH_HELDOUT: dict[str, tuple[str, float, float]] = {
-    f"synth_{shape}_c{int(c * 10):02d}_d{int(round(d * 100)):02d}": (shape, c, d)
+    f"synth_{shape}_c{int(round(c * 10)):02d}_d{int(round(d * 100)):02d}": (shape, c, d)
     for shape in ("person", "biblio")
     for c in (0.5, 2.0)
     for d in (0.10, 0.40)
@@ -598,7 +600,8 @@ _LOADERS = {
     # agreeing byte-for-byte while person's diverge, and only a labelled score
     # distribution can say whether an empty band is why.
     "synthetic_biblio": _synthetic_biblio,
-    # Held-out (never in the FS-lever tuning panel) -- generalisation tests.
+    # Not in the FS threshold-refit tuning panel (these are DESIGN datasets for
+    # link-cut routing).
     "febrl4": _febrl4,
     "dblp_scholar": _dblp_scholar,
     "amazon_google": _amazon_google,

--- a/scripts/bench_er_headtohead/datasets.py
+++ b/scripts/bench_er_headtohead/datasets.py
@@ -562,6 +562,152 @@ def _febrl2() -> tuple[pa.Table, pa.Table]:
     return _febrl_raw("dataset2")
 
 
+# ── DESIGN corpus widening (spec 2026-09-11-fs-cut-rule-routing-design, P3) ───
+# Leipzig clustering trio (many-source, not two-source like _two_source_leipzig)
+# plus synthetic design variants. Approved so the candidate rule
+# "lambda < 0.004 with the prior binding -> posterior_099" does not rest on
+# dblp_acm alone. DESIGN, never HOLDOUT: see corpus.py.
+
+
+def _musicbrainz_20k() -> tuple[pa.Table, pa.Table]:
+    """Leipzig MusicBrainz 20K clustering benchmark (CC-BY: credit the Database
+    Group Leipzig and Saeedi, Peukert & Rahm, ADBIS 2017). 5 sources of the same
+    ~10K tracks; ``CID`` is the ground-truth cluster id, never empty."""
+    path = DATASETS_DIR / "Leipzig-Clustering" / "MusicBrainz" / "musicbrainz-20-A01.csv"
+    if not path.exists():
+        raise DatasetUnavailable(f"MusicBrainz 20K not found at {path}")
+    raw = _read_csv_lossy(path)
+    record_ids = pa.array([f"mb:{v}" for v in raw.column("TID").to_pylist()], pa.string())
+    cluster_ids = pa.array([int(v) for v in raw.column("CID").to_pylist()], pa.int64())
+    keep = ["number", "title", "length", "artist", "album", "year", "language"]
+    records = raw.select(keep).append_column("record_id", record_ids)
+    truth = pa.table({"record_id": record_ids, "cluster_id": cluster_ids})
+    return records, truth
+
+
+def _geo_settlements() -> tuple[pa.Table, pa.Table]:
+    """Leipzig geographic settlements clustering benchmark (CC-BY: credit the
+    Database Group Leipzig and Saeedi, Peukert & Rahm, ADBIS 2017). Settlement
+    labels from 5 sources; ``combinedSettlements(PerfectMatch).json``'s
+    ``clusteredVertices`` give the ground-truth clusters (one record can appear
+    in two clusters, which then merge under union)."""
+    import json
+
+    base = DATASETS_DIR / "Leipzig-Clustering" / "GeoSettlements"
+    records_path = base / "settlements.json"
+    clusters_path = base / "combinedSettlements(PerfectMatch).json"
+    missing = [p for p in (records_path, clusters_path) if not p.exists()]
+    if missing:
+        raise DatasetUnavailable(
+            f"GeoSettlements source JSON not found (vendor under {base}); "
+            f"missing: {[p.name for p in missing]}"
+        )
+
+    record_ids: list[str] = []
+    labels: list[str | None] = []
+    lats: list[str | None] = []
+    lons: list[str | None] = []
+    types: list[str | None] = []
+    for line in records_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        data = obj.get("data", {})
+        record_ids.append(f"geo:{obj['id']}")
+        labels.append(data.get("label"))
+        lat = data.get("lat")
+        lon = data.get("lon")
+        lats.append(str(lat) if lat is not None else None)
+        lons.append(str(lon) if lon is not None else None)
+        t = data.get("type")
+        if isinstance(t, list):
+            t = "|".join(t)
+        types.append(t)
+    records = pa.table(
+        {
+            "record_id": pa.array(record_ids, pa.string()),
+            "label": pa.array(labels, pa.string()),
+            "lat": pa.array(lats, pa.string()),
+            "lon": pa.array(lons, pa.string()),
+            "type": pa.array(types, pa.string()),
+        }
+    )
+
+    pairs: list[tuple[Hashable, Hashable]] = []
+    for line in clusters_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        vertices = obj.get("data", {}).get("clusteredVertices") or []
+        ids = [f"geo:{v}" for v in vertices]
+        pairs.extend(zip(ids, ids[1:]))
+
+    all_ids = records.column("record_id").to_pylist()
+    cmap = _cluster_ids_from_pairs(all_ids, pairs)
+    truth = pa.table({"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]})
+    return records, truth
+
+
+def _affiliations() -> tuple[pa.Table, pa.Table]:
+    """Leipzig affiliation-strings clustering benchmark (CC-BY: credit the
+    Database Group Leipzig and Saeedi, Peukert & Rahm, ADBIS 2017). Free-text
+    affiliation strings; the headerless mapping CSV's id pairs give the
+    ground-truth clusters."""
+    import csv as _csv
+
+    base = DATASETS_DIR / "Leipzig-Clustering" / "Affiliations"
+    ids_path = base / "affiliationstrings_ids.csv"
+    mapping_path = base / "affiliationstrings_mapping.csv"
+    missing = [p for p in (ids_path, mapping_path) if not p.exists()]
+    if missing:
+        raise DatasetUnavailable(
+            f"Affiliations source CSVs not found (vendor under {base}); "
+            f"missing: {[p.name for p in missing]}"
+        )
+
+    ids_table = _read_csv_lossy(ids_path)
+    record_ids = pa.array([f"aff:{v}" for v in ids_table.column("id1").to_pylist()], pa.string())
+    records = pa.table({"record_id": record_ids, "affiliation": ids_table.column("affil1")})
+
+    text = mapping_path.read_bytes().decode("utf-8-sig", errors="replace")
+    pairs: list[tuple[Hashable, Hashable]] = [
+        (f"aff:{row[0]}", f"aff:{row[1]}") for row in _csv.reader(io.StringIO(text)) if row
+    ]
+
+    all_ids = records.column("record_id").to_pylist()
+    cmap = _cluster_ids_from_pairs(all_ids, pairs)
+    truth = pa.table({"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]})
+    return records, truth
+
+
+#: Seed for the design-set synthetic variants: distinct from the held-out 1009 and
+#: the design panel's 42.
+_DESIGN_SYNTH_SEED = 7
+
+#: name -> (shape, corruption, dupe_rate). d02 = dupe_rate 0.02 (tiny lambda), d20 = 0.20.
+_SYNTH_DESIGN: dict[str, tuple[str, float, float]] = {
+    "synth_biblio_d02": ("biblio", 1.0, 0.02),
+    "synth_person_d02": ("person", 1.0, 0.02),
+    "synth_product_d02": ("product", 1.0, 0.02),
+    "synth_product_d20": ("product", 1.0, 0.20),
+}
+
+
+def _synthetic_design(shape: str, corruption: float, dupe_rate: float) -> tuple[pa.Table, pa.Table]:
+    """A design synthetic variant: the design panel's dedicated seed (distinct
+    from both the held-out seed and the head-to-head panel's default 42), at
+    ``dupe_rate`` and ``corruption``."""
+    return _synthetic(
+        shape,
+        _synthetic_rows(),
+        dupe_rate=dupe_rate,
+        seed=_DESIGN_SYNTH_SEED,
+        corruption=corruption,
+    )
+
+
 #: Seed for the held-out synthetic variants; the design panel's synthetic sets use 42.
 _HELDOUT_SYNTH_SEED = 1009
 
@@ -615,6 +761,11 @@ _LOADERS = {
     **{
         name: (lambda spec=spec: _synthetic_heldout(*spec)) for name, spec in _SYNTH_HELDOUT.items()
     },
+    # DESIGN corpus widening (P3): Leipzig clustering trio + synthetic variants.
+    "musicbrainz_20k": _musicbrainz_20k,
+    "geo_settlements": _geo_settlements,
+    "affiliations": _affiliations,
+    **{name: (lambda spec=spec: _synthetic_design(*spec)) for name, spec in _SYNTH_DESIGN.items()},
 }
 
 

--- a/scripts/bench_er_headtohead/datasets.py
+++ b/scripts/bench_er_headtohead/datasets.py
@@ -10,6 +10,7 @@ people, with a ground-truth cluster label). Loaded via splink_datasets when
 splink is installed, else from a vendored parquet under the gitignored
 tests/benchmarks/datasets/.
 """
+
 from __future__ import annotations
 
 import csv
@@ -30,9 +31,7 @@ logger = logging.getLogger(__name__)
 
 def _rename_columns(table: pa.Table, mapping: dict[str, str]) -> pa.Table:
     """Rename columns via a {old: new} mapping (pyarrow renames by full list)."""
-    return table.rename_columns(
-        [mapping.get(name, name) for name in table.column_names]
-    )
+    return table.rename_columns([mapping.get(name, name) for name in table.column_names])
 
 
 def _cast_column_to_string(table: pa.Table, name: str) -> pa.Table:
@@ -61,14 +60,13 @@ def _read_csv_lossy(path: Path) -> pa.Table:
     )
 
 
-def _with_source_ids(
-    table: pa.Table, src: str, rename: dict[str, str] | None = None
-) -> pa.Table:
+def _with_source_ids(table: pa.Table, src: str, rename: dict[str, str] | None = None) -> pa.Table:
     """Rename columns, then replace ``id`` with a trailing ``record_id`` of ``<src>:<id>``."""
     if rename:
         table = _rename_columns(table, rename)
     ids = pa.array([f"{src}:{v}" for v in table.column("id").to_pylist()], pa.string())
     return table.append_column("record_id", ids).drop_columns(["id"])
+
 
 REPO = Path(__file__).resolve().parents[2]
 DATASETS_DIR = REPO / "packages" / "python" / "goldenmatch" / "tests" / "benchmarks" / "datasets"
@@ -127,19 +125,17 @@ def _historical_50k() -> tuple[pa.Table, pa.Table]:
     if splink_datasets is not None:
         try:
             df = pa.Table.from_pandas(
-                splink_datasets.historical_50k, preserve_index=False  # type: ignore
+                splink_datasets.historical_50k,
+                preserve_index=False,  # type: ignore
             )
         except Exception as e:  # splink present but dataset unusable -> try vendored
-            logger.warning(
-                "splink_datasets.historical_50k failed (%s); trying vendored parquet", e
-            )
+            logger.warning("splink_datasets.historical_50k failed (%s); trying vendored parquet", e)
             df = None
     if df is None:
         vendored = DATASETS_DIR / "historical_50k.parquet"
         if not vendored.exists():
             raise DatasetUnavailable(
-                "install `goldenmatch[bench]` (for splink_datasets) or vendor "
-                f"{vendored}"
+                f"install `goldenmatch[bench]` (for splink_datasets) or vendor {vendored}"
             )
         df = pq.read_table(vendored)
 
@@ -219,9 +215,7 @@ def _febrl3() -> tuple[pa.Table, pa.Table]:
     records = _cast_column_to_string(records, "record_id")
 
     all_ids = records.column("record_id").to_pylist()
-    pairs: list[tuple[Hashable, Hashable]] = [
-        (str(a), str(b)) for a, b in links
-    ]
+    pairs: list[tuple[Hashable, Hashable]] = [(str(a), str(b)) for a, b in links]
     cmap = _cluster_ids_from_pairs(all_ids, pairs)
     truth = pa.table(
         {
@@ -255,7 +249,14 @@ def _ncvr() -> tuple[pa.Table, pa.Table]:
     )
 
 
-def _synthetic(shape: str, rows: int) -> tuple[pa.Table, pa.Table]:
+def _synthetic(
+    shape: str,
+    rows: int,
+    *,
+    dupe_rate: float = 0.20,
+    seed: int = 42,
+    corruption: float = 1.0,
+) -> tuple[pa.Table, pa.Table]:
     """Synthetic rows of one head-to-head SHAPE, as a (records, truth) dataset.
 
     Reuses ``generate_fixture.generate`` (writes records + truth parquet to a
@@ -295,12 +296,13 @@ def _synthetic(shape: str, rows: int) -> tuple[pa.Table, pa.Table]:
         truth_path = Path(td) / "truth.parquet"
         generate(
             rows=rows,
-            dupe_rate=0.20,
+            dupe_rate=dupe_rate,
             out=out,
             truth=truth_path,
-            seed=42,
+            seed=seed,
             batch=1_000_000,
             shape=shape,
+            corruption=corruption,
         )
         records = pq.read_table(out)
         truth = pq.read_table(truth_path)
@@ -376,9 +378,7 @@ def _two_source_leipzig(
     ]
     all_ids = records.column("record_id").to_pylist()
     cmap = _cluster_ids_from_pairs(all_ids, pairs)
-    truth = pa.table(
-        {"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]}
-    )
+    truth = pa.table({"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]})
     return records, truth
 
 
@@ -388,9 +388,13 @@ def _dblp_scholar() -> tuple[pa.Table, pa.Table]:
     linkage — Scholar side is web-scraped) — so it tests whether an FS lever
     tuned on dblp_acm generalises to unseen bibliographic data."""
     return _two_source_leipzig(
-        "DBLP-Scholar", "DBLP1.csv", "Scholar.csv",
-        "DBLP-Scholar_perfectMapping.csv", ("idDBLP", "idScholar"),
-        "dblp", "scholar",
+        "DBLP-Scholar",
+        "DBLP1.csv",
+        "Scholar.csv",
+        "DBLP-Scholar_perfectMapping.csv",
+        ("idDBLP", "idScholar"),
+        "dblp",
+        "scholar",
     )
 
 
@@ -400,9 +404,14 @@ def _amazon_google() -> tuple[pa.Table, pa.Table]:
     threshold lever tuned on PII + bibliographic panels. Google's ``name`` is
     renamed to ``title`` so the two sources share a comparable field."""
     return _two_source_leipzig(
-        "Amazon-Google", "Amazon.csv", "GoogleProducts.csv",
-        "Amzon_GoogleProducts_perfectMapping.csv", ("idAmazon", "idGoogleBase"),
-        "amazon", "google", rename={"name": "title"},
+        "Amazon-Google",
+        "Amazon.csv",
+        "GoogleProducts.csv",
+        "Amzon_GoogleProducts_perfectMapping.csv",
+        ("idAmazon", "idGoogleBase"),
+        "amazon",
+        "google",
+        rename={"name": "title"},
     )
 
 
@@ -420,6 +429,7 @@ def _febrl4() -> tuple[pa.Table, pa.Table]:
         ) from e
 
     dfa, dfb, links = load_febrl4(return_links=True)
+
     # Indices are globally unique across the two frames ('rec-N-org' vs
     # 'rec-N-dup-0'), so a plain concat keeps record ids distinct. recordlinkage
     # hands back its own frames: convert each once here and stay in arrow after.
@@ -433,10 +443,148 @@ def _febrl4() -> tuple[pa.Table, pa.Table]:
     all_ids = records.column("record_id").to_pylist()
     pairs: list[tuple[Hashable, Hashable]] = [(str(a), str(b)) for a, b in links]
     cmap = _cluster_ids_from_pairs(all_ids, pairs)
-    truth = pa.table(
-        {"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]}
-    )
+    truth = pa.table({"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]})
     return records, truth
+
+
+# ── Held-out corpus for FS link-cut routing (spec 2026-09-11, P3) ─────────────
+# Never used to write or tune a routing row. Data is fetched at run time (see
+# .github/workflows/fs-cut-rule-matrix.yml) and never committed.
+
+
+def _abt_buy() -> tuple[pa.Table, pa.Table]:
+    """Leipzig Abt-Buy product ER (CC-BY: credit the Database Group Leipzig and
+    Köpcke, Thor & Rahm, VLDB 2010). Buy's extra ``manufacturer`` column is kept,
+    null on Abt rows."""
+    return _two_source_leipzig(
+        "Abt-Buy",
+        "Abt.csv",
+        "Buy.csv",
+        "abt_buy_perfectMapping.csv",
+        ("idAbt", "idBuy"),
+        "abt",
+        "buy",
+    )
+
+
+_MAGELLAN_SPLITS = ("train.csv", "valid.csv", "test.csv")
+
+
+def _magellan(subdir: str) -> tuple[pa.Table, pa.Table]:
+    """A DeepMatcher/Magellan structured benchmark (cite-only: fetched at run time,
+    never committed; Konda et al. 2016, Mudgal et al. 2018).
+
+    Records are tableA + tableB with ``a:<id>`` / ``b:<id>`` ids. Truth links the
+    ``label == 1`` pairs of the train/valid/test candidate splits, so a true match
+    DeepMatcher's own blocking never proposed counts as a non-match -- identically
+    for every arm a sweep compares."""
+    base = DATASETS_DIR / "Magellan" / subdir
+    paths = [base / "tableA.csv", base / "tableB.csv", *(base / s for s in _MAGELLAN_SPLITS)]
+    missing = [p for p in paths if not p.exists()]
+    if missing:
+        raise DatasetUnavailable(
+            f"{subdir} Magellan CSVs not found under {base}; missing: {[p.name for p in missing]}"
+        )
+    records = pa.concat_tables(
+        [
+            _with_source_ids(_read_csv_lossy(paths[0]), "a"),
+            _with_source_ids(_read_csv_lossy(paths[1]), "b"),
+        ],
+        promote_options="default",
+    )
+    pairs: list[tuple[Hashable, Hashable]] = []
+    for split in paths[2:]:
+        table = _read_csv_lossy(split)
+        for left, right, label in zip(
+            table.column("ltable_id").to_pylist(),
+            table.column("rtable_id").to_pylist(),
+            table.column("label").to_pylist(),
+        ):
+            if label.strip() == "1":
+                pairs.append((f"a:{left}", f"b:{right}"))
+    all_ids = records.column("record_id").to_pylist()
+    cmap = _cluster_ids_from_pairs(all_ids, pairs)
+    truth = pa.table({"record_id": all_ids, "cluster_id": [cmap[r] for r in all_ids]})
+    return records, truth
+
+
+def _walmart_amazon() -> tuple[pa.Table, pa.Table]:
+    """Magellan Walmart-Amazon: electronics products, ~24.6k records."""
+    return _magellan("Walmart-Amazon")
+
+
+def _itunes_amazon() -> tuple[pa.Table, pa.Table]:
+    """Magellan iTunes-Amazon: music tracks, ~62.8k records, not saturated."""
+    return _magellan("iTunes-Amazon")
+
+
+def _fodors_zagats() -> tuple[pa.Table, pa.Table]:
+    """Magellan Fodors-Zagats: restaurants, 946 records, near-saturated (F1 ~1.0)."""
+    return _magellan("Fodors-Zagats")
+
+
+def _febrl_raw(name: str) -> tuple[pa.Table, pa.Table]:
+    """FEBRL ``dataset1`` / ``dataset2`` from the raw CSVs recordlinkage ships (ANU
+    open-source licence, MPL-1.1 derived; Christen 2008), read without pandas.
+
+    Headers and values carry a space after each comma, so both are trimmed.
+    ``rec-<N>-org`` and ``rec-<N>-dup-<k>`` are the same entity ``N``."""
+    path = DATASETS_DIR / "FEBRL" / f"{name}.csv"
+    if not path.exists():
+        raise DatasetUnavailable(f"FEBRL {name} not found at {path}")
+    raw = _read_csv_lossy(path)
+    records = _rename_columns(
+        pa.table(
+            {col.strip(): pc.utf8_trim_whitespace(raw.column(col)) for col in raw.column_names}
+        ),
+        {"rec_id": "record_id"},
+    )
+    ids = records.column("record_id").to_pylist()
+    entity: list[int] = []
+    for rid in ids:
+        parts = rid.split("-")
+        if len(parts) < 3 or parts[0] != "rec" or not parts[1].isdigit():
+            raise ValueError(f"FEBRL {name}: unexpected rec_id {rid!r}")
+        entity.append(int(parts[1]))
+    truth = pa.table({"record_id": ids, "cluster_id": entity})
+    return records, truth
+
+
+def _febrl1() -> tuple[pa.Table, pa.Table]:
+    """FEBRL dataset1: 1,000 records, 500 originals with one duplicate each."""
+    return _febrl_raw("dataset1")
+
+
+def _febrl2() -> tuple[pa.Table, pa.Table]:
+    """FEBRL dataset2: 5,000 records, 4,000 originals and 1,000 duplicates."""
+    return _febrl_raw("dataset2")
+
+
+#: Seed for the held-out synthetic variants; the design panel's synthetic sets use 42.
+_HELDOUT_SYNTH_SEED = 1009
+
+#: name -> (shape, corruption, dupe_rate). c05 = corruption 0.5, c20 = 2.0;
+#: d10 = dupe_rate 0.10, d40 = 0.40.
+_SYNTH_HELDOUT: dict[str, tuple[str, float, float]] = {
+    f"synth_{shape}_c{int(c * 10):02d}_d{int(round(d * 100)):02d}": (shape, c, d)
+    for shape in ("person", "biblio")
+    for c in (0.5, 2.0)
+    for d in (0.10, 0.40)
+}
+
+
+def _synthetic_heldout(
+    shape: str, corruption: float, dupe_rate: float
+) -> tuple[pa.Table, pa.Table]:
+    """A held-out synthetic variant: a seed the design panel never used, duplicate
+    noise scaled by ``corruption``, and ``dupe_rate`` duplicates."""
+    return _synthetic(
+        shape,
+        _synthetic_rows(),
+        dupe_rate=dupe_rate,
+        seed=_HELDOUT_SYNTH_SEED,
+        corruption=corruption,
+    )
 
 
 _LOADERS = {
@@ -454,6 +602,16 @@ _LOADERS = {
     "febrl4": _febrl4,
     "dblp_scholar": _dblp_scholar,
     "amazon_google": _amazon_google,
+    # Held-out corpus for FS link-cut routing (P3): never used to write a row.
+    "abt_buy": _abt_buy,
+    "walmart_amazon": _walmart_amazon,
+    "itunes_amazon": _itunes_amazon,
+    "fodors_zagats": _fodors_zagats,
+    "febrl1": _febrl1,
+    "febrl2": _febrl2,
+    **{
+        name: (lambda spec=spec: _synthetic_heldout(*spec)) for name, spec in _SYNTH_HELDOUT.items()
+    },
 }
 
 

--- a/scripts/bench_er_headtohead/generate_fixture.py
+++ b/scripts/bench_er_headtohead/generate_fixture.py
@@ -26,6 +26,7 @@ Usage:
         --out fixtures/bench_1000000.parquet \
         --ground-truth fixtures/bench_1000000.truth.parquet
 """
+
 from __future__ import annotations
 
 import argparse
@@ -181,7 +182,10 @@ def _build_pools(seed: int):
     base = np.datetime64("1940-01-01")
     dobs = (base + np.arange(DOB_DAYS).astype("timedelta64[D]")).astype("datetime64[D]")
     dob_pool = np.datetime_as_string(dobs)
-    postcodes = [f"{int(rng.integers(10,99))}{rng.choice(_ALPHA).upper()}{rng.choice(_ALPHA).upper()} {int(rng.integers(0,9))}{rng.choice(_ALPHA).upper()}{rng.choice(_ALPHA).upper()}" for _ in range(N_POSTCODE)]
+    postcodes = [
+        f"{int(rng.integers(10, 99))}{rng.choice(_ALPHA).upper()}{rng.choice(_ALPHA).upper()} {int(rng.integers(0, 9))}{rng.choice(_ALPHA).upper()}{rng.choice(_ALPHA).upper()}"
+        for _ in range(N_POSTCODE)
+    ]
     return {
         # Combined [base | typo] arrays so a single fancy-index picks exact-or-typo.
         "first": np.array(first_base + first_typo, dtype=object),
@@ -273,9 +277,18 @@ def generate(
     seed: int,
     batch: int,
     shape: str = "person",
+    corruption: float = 1.0,
 ) -> dict:
     if shape not in ("person", "biblio", "product"):
         raise ValueError(f"unknown shape: {shape!r}")
+    if corruption < 0:
+        raise ValueError(f"corruption must be >= 0, got {corruption!r}")
+
+    def noise(base: float) -> float:
+        # Scale one duplicate-noise probability. corruption=1.0 leaves every
+        # threshold, the RNG draw sequence, and so every written byte unchanged.
+        return min(1.0, base * corruption)
+
     schema = {"person": SCHEMA, "biblio": BIBLIO_SCHEMA, "product": PRODUCT_SCHEMA}[shape]
     if shape == "person":
         pools = _build_pools(seed)
@@ -344,9 +357,9 @@ def generate(
                 # Duplicate variation (vectorised masks). Typo => offset into
                 # [base|typo] half.
                 r = rng.random(total)
-                fi_pick = fi + np.where(is_dup & (r < 0.40), n_first, 0)
+                fi_pick = fi + np.where(is_dup & (r < noise(0.40)), n_first, 0)
                 r = rng.random(total)
-                si_pick = si + np.where(is_dup & (r < 0.50), n_surname, 0)
+                si_pick = si + np.where(is_dup & (r < noise(0.50)), n_surname, 0)
 
                 first = pools["first"][fi_pick]
                 surname = pools["surname"][si_pick]
@@ -355,10 +368,10 @@ def generate(
                 city = pools["city"][ci].copy()
 
                 # Occasional nulls on weaker / strong fields for duplicate rows.
-                city = np.where(is_dup & (rng.random(total) < 0.20), None, city)
-                dnull = is_dup & (rng.random(total) < 0.05)
+                city = np.where(is_dup & (rng.random(total) < noise(0.20)), None, city)
+                dnull = is_dup & (rng.random(total) < noise(0.05))
                 dob = np.where(dnull, None, dob)
-                pnull = is_dup & (rng.random(total) < 0.05)
+                pnull = is_dup & (rng.random(total) < noise(0.05))
                 postcode = np.where(pnull, None, postcode)
 
                 columns = {
@@ -385,17 +398,23 @@ def generate(
                         wi_pick = wi
                     else:
                         r = rng.random(total)
-                        wi_pick = wi + np.where(is_dup & (r < 0.30), n_title_words, 0)
+                        wi_pick = wi + np.where(is_dup & (r < noise(0.30)), n_title_words, 0)
                     word = pools["title_words"][wi_pick]
                     title = word if title is None else (title + " " + word)
 
                 # Authors: 1-3 surnames per identity, broadcast. Duplicate variation
                 # = author-order permutation (swap first two) on ~half of duplicates.
-                a0 = pools["author_surnames"][np.repeat(rng.integers(0, n_author, len(sizes)), sizes)]
-                a1 = pools["author_surnames"][np.repeat(rng.integers(0, n_author, len(sizes)), sizes)]
-                a2 = pools["author_surnames"][np.repeat(rng.integers(0, n_author, len(sizes)), sizes)]
+                a0 = pools["author_surnames"][
+                    np.repeat(rng.integers(0, n_author, len(sizes)), sizes)
+                ]
+                a1 = pools["author_surnames"][
+                    np.repeat(rng.integers(0, n_author, len(sizes)), sizes)
+                ]
+                a2 = pools["author_surnames"][
+                    np.repeat(rng.integers(0, n_author, len(sizes)), sizes)
+                ]
                 n_auth = np.repeat(rng.integers(1, 4, len(sizes)), sizes)
-                reorder = is_dup & (rng.random(total) < 0.50)
+                reorder = is_dup & (rng.random(total) < noise(0.50))
                 b0 = np.where(reorder & (n_auth >= 2), a1, a0)
                 b1 = np.where(reorder & (n_auth >= 2), a0, a1)
                 authors = b0
@@ -407,7 +426,7 @@ def generate(
                 # Occasional null year on duplicates (mirrors person null postcode);
                 # a null-year duplicate simply doesn't block, and year is unique per
                 # cluster where non-null.
-                year = np.where(is_dup & (rng.random(total) < 0.05), None, year)
+                year = np.where(is_dup & (rng.random(total) < noise(0.05)), None, year)
 
                 columns = {
                     "record_id": pa.array(rids, pa.int64()),
@@ -434,7 +453,7 @@ def generate(
                         wi_pick = wi
                     else:
                         r = rng.random(total)
-                        wi_pick = wi + np.where(is_dup & (r < 0.30), n_title_words, 0)
+                        wi_pick = wi + np.where(is_dup & (r < noise(0.30)), n_title_words, 0)
                     word = pools["title_words"][wi_pick]
                     title = word if title is None else (title + " " + word)
 
@@ -446,14 +465,14 @@ def generate(
                     rng.uniform(PRODUCT_PRICE_MIN, PRODUCT_PRICE_MAX, len(sizes)), 2
                 )
                 price_val = np.repeat(base_price, sizes)
-                pert = is_dup & (rng.random(total) < 0.40)
+                pert = is_dup & (rng.random(total) < noise(0.40))
                 factors = np.where(pert, 1.0 + rng.uniform(-0.05, 0.05, total), 1.0)
                 price_val = np.round(price_val * factors, 2)
                 price = np.char.mod("%.2f", price_val).astype(object)
                 # Occasional null price on duplicates (mirrors person null postcode /
                 # biblio null year); a null-price duplicate still blocks + scores on
                 # title, so the weighted matchkey degrades rather than drops it.
-                price = np.where(is_dup & (rng.random(total) < 0.05), None, price)
+                price = np.where(is_dup & (rng.random(total) < noise(0.05)), None, price)
 
                 brand = pools["brands"][bi]  # stable, never corrupted/nulled
                 category = pools["categories"][cati]  # stable, never corrupted/nulled
@@ -469,7 +488,10 @@ def generate(
             writer.write_table(pa.table(columns, schema=schema))
             twriter.write_table(
                 pa.table(
-                    {"record_id": pa.array(rids, pa.int64()), "cluster_id": pa.array(row_cid, pa.int64())},
+                    {
+                        "record_id": pa.array(rids, pa.int64()),
+                        "cluster_id": pa.array(row_cid, pa.int64()),
+                    },
                     schema=TRUTH_SCHEMA,
                 )
             )
@@ -517,6 +539,13 @@ def main() -> None:
     ap.add_argument("--batch", type=int, default=1_000_000)
     ap.add_argument("--shape", choices=["person", "biblio", "product"], default="person")
     ap.add_argument(
+        "--corruption",
+        type=float,
+        default=1.0,
+        help="multiplier on every duplicate-noise probability (typos, reorders, nulls); "
+        "1.0 is the historical fixture, 0 gives noise-free duplicates",
+    )
+    ap.add_argument(
         "--check-block-size",
         type=int,
         default=None,
@@ -542,7 +571,14 @@ def main() -> None:
         ap.error("--rows, --out, and --ground-truth are required to generate a fixture")
 
     meta = generate(
-        args.rows, args.dupe_rate, args.out, args.ground_truth, args.seed, args.batch, args.shape
+        args.rows,
+        args.dupe_rate,
+        args.out,
+        args.ground_truth,
+        args.seed,
+        args.batch,
+        args.shape,
+        corruption=args.corruption,
     )
     print(
         f"[generate] {meta['rows']:,} rows / {meta['clusters']:,} clusters / "

--- a/scripts/bench_er_headtohead/test_design_loaders.py
+++ b/scripts/bench_er_headtohead/test_design_loaders.py
@@ -1,0 +1,184 @@
+"""DESIGN-corpus loaders for FS link-cut routing P3 (widened set, 2026-09-11).
+
+Real Leipzig clustering loaders (musicbrainz_20k, geo_settlements, affiliations)
+plus the design synthetic variants. Same fake-file pattern as
+``test_heldout_loaders.py``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.bench_er_headtohead import datasets as D
+
+DESIGN_REAL_NAMES = ("musicbrainz_20k", "geo_settlements", "affiliations")
+
+DESIGN_SYNTH_NAMES = (
+    "synth_biblio_d02",
+    "synth_person_d02",
+    "synth_product_d02",
+    "synth_product_d20",
+)
+
+
+def _write(path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_jsonl(path, objs: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(o) for o in objs) + "\n", encoding="utf-8")
+
+
+def _cluster_of(truth) -> dict:
+    return dict(zip(truth.column("record_id").to_pylist(), truth.column("cluster_id").to_pylist()))
+
+
+def test_every_design_real_name_is_registered():
+    missing = [n for n in DESIGN_REAL_NAMES if n not in D._LOADERS]
+    assert not missing, missing
+
+
+def test_every_design_synth_name_is_registered():
+    missing = [n for n in DESIGN_SYNTH_NAMES if n not in D._LOADERS]
+    assert not missing, missing
+
+
+# ── musicbrainz_20k ─────────────────────────────────────────────────────────
+
+
+def test_musicbrainz_drops_leakage_columns_and_links_by_cid(tmp_path, monkeypatch):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    _write(
+        tmp_path / "Leipzig-Clustering" / "MusicBrainz" / "musicbrainz-20-A01.csv",
+        "TID,CID,CTID,SourceID,id,number,title,length,artist,album,year,language\n"
+        "1,10,1,2,MBox1,9,Song One,219,Artist A,Album A,1999,English\n"
+        "2,10,1,4,MBox2,7,Song One (dup),null,Artist A,Album A,1999,English\n"
+        "3,20,1,5,MBox3,10,Song Two,unk.,Artist B,Album B,2005,English\n",
+    )
+    records, truth = D.load_dataset("musicbrainz_20k")
+    assert records.column("record_id").to_pylist() == ["mb:1", "mb:2", "mb:3"]
+    for leaked in ("CID", "CTID", "SourceID", "id", "TID"):
+        assert leaked not in records.column_names
+    assert set(records.column_names) == {
+        "record_id",
+        "number",
+        "title",
+        "length",
+        "artist",
+        "album",
+        "year",
+        "language",
+    }
+    cid = _cluster_of(truth)
+    assert cid["mb:1"] == cid["mb:2"]
+    assert cid["mb:1"] != cid["mb:3"]
+
+
+# ── geo_settlements ──────────────────────────────────────────────────────────
+
+
+def test_geo_settlements_nulls_missing_latlon_joins_list_type_and_unions_clusters(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    base = tmp_path / "Leipzig-Clustering" / "GeoSettlements"
+    _write_jsonl(
+        base / "settlements.json",
+        [
+            {"data": {"label": "Petra (Jordan)", "lat": 30.3167, "lon": 35.4833}, "id": 0},
+            # No lat/lon -> null.
+            {"data": {"label": "Petra"}, "id": 1},
+            # type as a list -> joined with "|".
+            {
+                "data": {
+                    "label": "Split",
+                    "lat": 43.5089,
+                    "lon": 16.4392,
+                    "type": ["city", "village"],
+                },
+                "id": 2,
+            },
+            {"data": {"label": "Dresden", "lat": 51.05, "lon": 13.74}, "id": 3},
+        ],
+    )
+    _write_jsonl(
+        base / "combinedSettlements(PerfectMatch).json",
+        [
+            # Cluster A: 0, 1.
+            {"id": 0, "data": {"label": "petra", "clusteredVertices": [0, 1]}},
+            # Cluster B shares vertex 1 with cluster A -> the two clusters merge.
+            {"id": 2, "data": {"label": "split", "clusteredVertices": [1, 2]}},
+        ],
+    )
+    records, truth = D.load_dataset("geo_settlements")
+    by_id = dict(zip(records.column("record_id").to_pylist(), range(records.num_rows)))
+    lat = records.column("lat").to_pylist()
+    lon = records.column("lon").to_pylist()
+    assert lat[by_id["geo:1"]] is None
+    assert lon[by_id["geo:1"]] is None
+    type_col = records.column("type").to_pylist()
+    assert type_col[by_id["geo:2"]] == "city|village"
+    assert "ontology" not in records.column_names
+
+    cid = _cluster_of(truth)
+    assert cid["geo:0"] == cid["geo:1"] == cid["geo:2"]
+    assert cid["geo:3"] != cid["geo:0"]
+
+
+# ── affiliations ─────────────────────────────────────────────────────────────
+
+
+def test_affiliations_headerless_mapping_joins_transitively(tmp_path, monkeypatch):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    base = tmp_path / "Leipzig-Clustering" / "Affiliations"
+    _write(
+        base / "affiliationstrings_ids.csv",
+        '"id1","affil1"\n"1","IBM Almaden"\n"2","IBM Almaden Research Center"\n'
+        '"3","IBM Research"\n',
+    )
+    _write(base / "affiliationstrings_mapping.csv", '"1","2"\n"2","3"\n')
+    records, truth = D.load_dataset("affiliations")
+    assert records.column("record_id").to_pylist() == ["aff:1", "aff:2", "aff:3"]
+    assert records.column_names == ["record_id", "affiliation"]
+    cid = _cluster_of(truth)
+    assert cid["aff:1"] == cid["aff:2"] == cid["aff:3"]
+
+
+# ── missing files ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", DESIGN_REAL_NAMES)
+def test_design_real_loader_raises_dataset_unavailable_when_absent(tmp_path, monkeypatch, name):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    with pytest.raises(D.DatasetUnavailable):
+        D.load_dataset(name)
+
+
+# ── synthetic design variants ─────────────────────────────────────────────────
+
+
+def test_synth_product_d02_loads_with_matched_row_counts(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_BENCH_SYNTHETIC_ROWS", "300")
+    records, truth = D.load_dataset("synth_product_d02")
+    assert records.num_rows == truth.num_rows
+    assert records.num_rows in (300, 301)
+
+
+def test_synth_design_spec_table_has_the_expected_entries():
+    assert D._SYNTH_DESIGN["synth_product_d20"] == ("product", 1.0, 0.20)
+    assert D._SYNTH_DESIGN["synth_product_d02"] == ("product", 1.0, 0.02)
+    assert D._SYNTH_DESIGN["synth_biblio_d02"] == ("biblio", 1.0, 0.02)
+    assert D._SYNTH_DESIGN["synth_person_d02"] == ("person", 1.0, 0.02)
+
+
+def test_design_synth_seed_differs_from_heldout_and_default():
+    assert D._DESIGN_SYNTH_SEED != D._HELDOUT_SYNTH_SEED
+    assert D._DESIGN_SYNTH_SEED != 42
+
+
+def test_synth_heldout_names_are_untouched():
+    for name in D._SYNTH_HELDOUT:
+        assert name in D._LOADERS

--- a/scripts/bench_er_headtohead/test_generate_fixture_corruption.py
+++ b/scripts/bench_er_headtohead/test_generate_fixture_corruption.py
@@ -1,0 +1,159 @@
+"""generate_fixture's `corruption` knob: default output unchanged, noise scales with it."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+HERE = Path(__file__).resolve().parent
+
+#: sha256 of generate(rows=600, dupe_rate=0.3, seed=42) per shape, captured from the
+#: generator BEFORE the corruption knob existed (see `--print-digests` below).
+EXPECTED_DIGESTS: dict[str, str] = {
+    "person": "595fb203a687445017d9aa2255dc0b6f99e7f13e68fc7f2f932343af98303c03",
+    "biblio": "6d871307b8e8af2d82941dfdf6459cd8460700e1f6e8c7980a8c6a92cc58ab48",
+    "product": "97df953dd01d185b8be2f0f492db3f7a1689d5b6bf1fafd155030394fe60d3dc",
+}
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, HERE / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def fixture_digest(gen, shape: str, tmp: Path, **kwargs) -> str:
+    tmp.mkdir(parents=True, exist_ok=True)
+    out, truth = tmp / f"{shape}.parquet", tmp / f"{shape}.truth.parquet"
+    gen.generate(
+        rows=600,
+        dupe_rate=0.3,
+        out=out,
+        truth=truth,
+        seed=42,
+        batch=1_000_000,
+        shape=shape,
+        **kwargs,
+    )
+    h = hashlib.sha256()
+    for path in (out, truth):
+        h.update(json.dumps(pq.read_table(path).to_pydict(), sort_keys=True, default=str).encode())
+    return h.hexdigest()
+
+
+def _duplicate_name_noise(gen, tmp: Path, corruption: float) -> float:
+    """Share of duplicate person rows whose (first_name, surname) differs from their
+    cluster's canonical row (the first row written for that cluster)."""
+    tmp.mkdir(parents=True, exist_ok=True)
+    out, truth = tmp / "p.parquet", tmp / "p.truth.parquet"
+    gen.generate(
+        rows=4000,
+        dupe_rate=0.4,
+        out=out,
+        truth=truth,
+        seed=7,
+        batch=1_000_000,
+        shape="person",
+        corruption=corruption,
+    )
+    rec = pq.read_table(out).to_pydict()
+    clusters = pq.read_table(truth).column("cluster_id").to_pylist()
+    canonical: dict[int, tuple[str, str]] = {}
+    dups = differ = 0
+    for cid, first, sur in zip(clusters, rec["first_name"], rec["surname"]):
+        if cid not in canonical:
+            canonical[cid] = (first, sur)
+            continue
+        dups += 1
+        differ += (first, sur) != canonical[cid]
+    assert dups > 0
+    return differ / dups
+
+
+def test_default_corruption_is_byte_identical_to_the_pre_knob_generator(tmp_path):
+    gen = _load("generate_fixture")
+    for shape, expected in EXPECTED_DIGESTS.items():
+        assert fixture_digest(gen, shape, tmp_path / shape) == expected
+        assert (
+            fixture_digest(gen, shape, tmp_path / f"{shape}-explicit", corruption=1.0) == expected
+        )
+
+
+def test_corruption_scales_duplicate_name_noise(tmp_path):
+    """KNOWN-POSITIVE: zero corruption leaves duplicate names untouched; more corruption
+    changes more of them."""
+    gen = _load("generate_fixture")
+    none = _duplicate_name_noise(gen, tmp_path / "none", 0.0)
+    low = _duplicate_name_noise(gen, tmp_path / "low", 0.5)
+    high = _duplicate_name_noise(gen, tmp_path / "high", 2.0)
+    assert none == 0.0
+    assert 0.0 < low < high
+
+
+def test_negative_corruption_is_rejected(tmp_path):
+    import pytest
+
+    gen = _load("generate_fixture")
+    with pytest.raises(ValueError, match="corruption"):
+        gen.generate(
+            rows=10,
+            dupe_rate=0.2,
+            out=tmp_path / "o.parquet",
+            truth=tmp_path / "t.parquet",
+            seed=1,
+            batch=1_000_000,
+            corruption=-0.1,
+        )
+
+
+def test_cli_accepts_corruption(tmp_path, monkeypatch):
+    gen = _load("generate_fixture")
+    # Row count is deliberately not asserted here: a pre-existing clip off-by-one
+    # in generate()'s batch loop (unrelated to corruption) is tracked separately.
+    cli_out, cli_truth = tmp_path / "cli.parquet", tmp_path / "cli.truth.parquet"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_fixture.py",
+            "--rows",
+            "50",
+            "--seed",
+            "42",
+            "--out",
+            str(cli_out),
+            "--ground-truth",
+            str(cli_truth),
+            "--corruption",
+            "0",
+        ],
+    )
+    gen.main()
+    direct_out, direct_truth = tmp_path / "direct.parquet", tmp_path / "direct.truth.parquet"
+    gen.generate(
+        rows=50,
+        dupe_rate=0.20,
+        out=direct_out,
+        truth=direct_truth,
+        seed=42,
+        batch=1_000_000,
+        corruption=0.0,
+    )
+    assert pq.read_table(cli_out).equals(pq.read_table(direct_out))
+    assert pq.read_table(cli_truth).equals(pq.read_table(direct_truth))
+
+
+if __name__ == "__main__" and "--print-digests" in sys.argv:
+    import tempfile
+
+    _gen = _load("generate_fixture")
+    with tempfile.TemporaryDirectory() as _td:
+        for _shape in ("person", "biblio", "product"):
+            print(f'    "{_shape}": "{fixture_digest(_gen, _shape, Path(_td) / _shape)}",')

--- a/scripts/bench_er_headtohead/test_heldout_loaders.py
+++ b/scripts/bench_er_headtohead/test_heldout_loaders.py
@@ -1,0 +1,119 @@
+"""Held-out loaders for FS link-cut routing P3 (pyarrow only, fetched data)."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from scripts.bench_er_headtohead import datasets as D
+
+HELDOUT_NAMES = (
+    "abt_buy",
+    "walmart_amazon",
+    "itunes_amazon",
+    "fodors_zagats",
+    "febrl1",
+    "febrl2",
+    "synth_person_c05_d10",
+    "synth_person_c05_d40",
+    "synth_person_c20_d10",
+    "synth_person_c20_d40",
+    "synth_biblio_c05_d10",
+    "synth_biblio_c05_d40",
+    "synth_biblio_c20_d10",
+    "synth_biblio_c20_d40",
+)
+
+
+def _write(path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _cluster_of(truth) -> dict:
+    return dict(zip(truth.column("record_id").to_pylist(), truth.column("cluster_id").to_pylist()))
+
+
+def test_every_heldout_name_is_registered():
+    missing = [n for n in HELDOUT_NAMES if n not in D._LOADERS]
+    assert not missing, missing
+
+
+def test_abt_buy_unions_both_sources_and_links_the_mapping(tmp_path, monkeypatch):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    _write(
+        tmp_path / "Abt-Buy" / "Abt.csv",
+        "id,name,description,price\n1,sony tv,big tv,$10\n2,lg radio,small,$5\n",
+    )
+    _write(
+        tmp_path / "Abt-Buy" / "Buy.csv",
+        "id,name,description,manufacturer,price\n7,Sony TV 40,tv,Sony,10\n8,Bose,spk,Bose,99\n",
+    )
+    _write(tmp_path / "Abt-Buy" / "abt_buy_perfectMapping.csv", "idAbt,idBuy\n1,7\n")
+    records, truth = D.load_dataset("abt_buy")
+    assert records.column("record_id").to_pylist() == ["abt:1", "abt:2", "buy:7", "buy:8"]
+    cid = _cluster_of(truth)
+    assert cid["abt:1"] == cid["buy:7"]
+    assert len({cid["abt:1"], cid["abt:2"], cid["buy:8"]}) == 3
+
+
+def test_magellan_links_only_label_one_pairs_across_all_splits(tmp_path, monkeypatch):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    base = tmp_path / "Magellan" / "Walmart-Amazon"
+    _write(base / "tableA.csv", "id,title\n0,apple ipod\n1,bose speaker\n")
+    _write(base / "tableB.csv", "id,title\n0,ipod apple 8gb\n1,sony tv\n")
+    _write(base / "train.csv", "ltable_id,rtable_id,label\n1,1,0\n")
+    _write(base / "valid.csv", "ltable_id,rtable_id,label\n")
+    _write(base / "test.csv", "ltable_id,rtable_id,label\n0,0,1\n")
+    records, truth = D.load_dataset("walmart_amazon")
+    assert records.column("record_id").to_pylist() == ["a:0", "a:1", "b:0", "b:1"]
+    cid = _cluster_of(truth)
+    assert cid["a:0"] == cid["b:0"]
+    assert cid["a:1"] != cid["b:1"]
+
+
+def test_febrl_raw_trims_the_space_after_commas_and_groups_by_entity(tmp_path, monkeypatch):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    _write(
+        tmp_path / "FEBRL" / "dataset1.csv",
+        "rec_id, given_name, surname\nrec-1-org, ann, lee\nrec-1-dup-0, anne, lee\nrec-2-org, bob, ray\n",
+    )
+    records, truth = D.load_dataset("febrl1")
+    assert records.column_names == ["record_id", "given_name", "surname"]
+    assert records.column("given_name").to_pylist() == ["ann", "anne", "bob"]
+    cid = _cluster_of(truth)
+    assert cid["rec-1-org"] == cid["rec-1-dup-0"] != cid["rec-2-org"]
+
+
+def test_febrl_raw_rejects_an_unexpected_record_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    _write(tmp_path / "FEBRL" / "dataset2.csv", "rec_id, surname\nperson-9, lee\n")
+    with pytest.raises(ValueError, match="rec_id"):
+        D.load_dataset("febrl2")
+
+
+@pytest.mark.parametrize("name", ["abt_buy", "itunes_amazon", "fodors_zagats", "febrl1"])
+def test_absent_data_is_unavailable_not_a_crash(tmp_path, monkeypatch, name):
+    monkeypatch.setattr(D, "DATASETS_DIR", tmp_path)
+    with pytest.raises(D.DatasetUnavailable):
+        D.load_dataset(name)
+
+
+def test_synthetic_heldout_variant_uses_its_own_seed_and_knobs(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_BENCH_SYNTHETIC_ROWS", "300")
+    assert D._SYNTH_HELDOUT["synth_biblio_c20_d40"] == ("biblio", 2.0, 0.40)
+    records, truth = D.load_dataset("synth_person_c20_d40")
+    # The generator has a pre-existing final-batch clip off-by-one (rows+1 for some
+    # (rows, seed)); fixing it would move committed fixtures, so it is tracked separately.
+    assert records.num_rows == truth.num_rows
+    assert records.num_rows in (300, 301)
+    assert len(set(truth.column("cluster_id").to_pylist())) < records.num_rows
+
+
+def test_design_synthetic_defaults_are_unchanged():
+    params = inspect.signature(D._synthetic).parameters
+    assert params["dupe_rate"].default == 0.20
+    assert params["seed"].default == 42
+    assert params["corruption"].default == 1.0
+    assert D._HELDOUT_SYNTH_SEED != params["seed"].default


### PR DESCRIPTION
Stacked on #2942 (P1–P2, rebased onto `main` after #2939 merged). This PR is **P3** of the FS link-cut routing design (`docs/superpowers/specs/2026-09-11-fs-cut-rule-routing-design.md`): a frozen held-out corpus and a per-rule measurement matrix.

It only measures. It does not choose a rule and adds no routing row; that is P4.

## What changes

- **Generator `corruption` knob.**
  - `generate_fixture.generate(..., corruption=1.0)` scales every duplicate-noise probability: typos, reorders and nulls.
  - The default output is byte-identical, pinned by a digest test captured from the unmodified generator.
  - There is also a `--corruption` CLI flag.
- **Held-out loaders** in `scripts/bench_er_headtohead/datasets.py`. They are pyarrow-only and read data fetched at run time, never committed:
  - `abt_buy`
  - `walmart_amazon`, `itunes_amazon`, `fodors_zagats`
  - `febrl1`, `febrl2`
  - eight synthetic variants, `synth_{person,biblio}_c{05,20}_d{10,40}`, with seed 1009
- **Frozen corpus** in `scripts/autoconfig_quality/corpus.py`:
  - `DESIGN`, 20 datasets:
    - the labelled registry and the `ab_lever` panel;
    - Leipzig clustering sets `musicbrainz_20k`, `geo_settlements` and `affiliations`;
    - seed-7 synthetic variants `synth_{biblio,person,product}_d02` and `synth_product_d20`;
    - seed variants `ncvr_synthetic_s7`, `household_hardneg_s7` and `cotenant_hardneg_s7`.

    It was widened before writing any routing row, so that no row rests on a single dataset.
  - `HOLDOUT`: the 14 held-out datasets, pinned verbatim.
  - `ncvr_real` is local-only.
- **Per-rule sweep** in `scripts/autoconfig_quality/rule_sweep.py`. Each dataset is auto-configured once, then runs the full pipeline once per arm:
  - `default` trains and saves the EM model;
  - `default_loaded` reloads it and is the baseline;
  - nine `link_cut_rule` arms reuse the same model.
- **The sweep fails loudly, never quietly.** The run fails, and the failures are stamped into the scorecard, when:
  - an arm's pin was overridden, or a pinned matchkey is missing from the report (**voided**);
  - the shared model was not saved for every probabilistic matchkey, or changed between arms;
  - a required dataset was not measured;
  - nothing was measured at all.

  It also refuses to start while a cut-moving or model-voiding env var is set. `GOLDENMATCH_*` env and both hash seeds (sweep and arms) are recorded.
- **Each arm runs in its own child process.**
  - All arms read one shared `config.json` and the saved model.
  - A psutil watchdog kills an arm on any of:
    - the RSS cap;
    - machine available memory below a floor;
    - the per-arm timeout;
    - the per-dataset time budget.
  - A killed or crashed rule arm is recorded as a result and counts as below default. A crashed baseline arm fails the dataset.
  - Why: in the first CI run the `prior` arm over-merged `historical_50k` (λ 0.66, cut at W ≥ 0), exhausted the 16 GB runner, and lost the whole dataset.
- **Merge.**
  - Design results and held-out results go to **separate artifacts**.
  - The summary shows the full design table, plus a held-out *gate view* with counts only: no best rule, no per-rule F1. This keeps held-out winners out of view while rows are written.
  - Missing datasets render as `MISSING`, and failures are listed.
- **CI.**
  - `fs-cut-rule-matrix.yml` runs plan → one sweep job per dataset → merge. Triggers: pull requests touching the sweep or corpus files, a weekly schedule, and manual dispatch.
  - `fs-cut-rule-matrix-unit.yml` runs the unit tests whenever the matrix code's dependencies change.
  - Neither is in `ci-required`.

## Deliberate deviation from the spec wording, now amended in the spec

The per-rule results are a separate scorecard file and artifact rather than a block in the committed baseline `scorecard.json`. The baseline is diffed by the required 20-minute `quality_gate`, and 11 full runs per dataset do not fit. The spec also now says that P4 row authors read the design matrix only.

## Data and licences

| Dataset | Source | Licence / credit | Handling |
|---|---|---|---|
| abt_buy | Leipzig | CC-BY; Database Group Leipzig; Köpcke, Thor & Rahm, VLDB 2010 | fetched at run time |
| walmart_amazon, itunes_amazon, fodors_zagats | Magellan / DeepMatcher | cite-only; Konda et al. 2016; Mudgal et al. 2018 | fetched for evaluation only, never committed |
| febrl1, febrl2 | FEBRL raw CSVs via recordlinkage | ANU open-source licence (MPL-1.1 derived); Christen 2008 | fetched at run time |
| musicbrainz_20k, geo_settlements, affiliations (design) | Leipzig clustering benchmarks | Creative Commons; Database Group Leipzig; Saeedi, Peukert & Rahm, ADBIS 2017 | fetched at run time |

## Caveats for P4

- **Magellan truth is biased toward high cuts.** It covers only DeepMatcher's labelled candidate positives. An unlabelled true match that a rule links counts as a false positive, and recall lost by high cuts on those pairs is not counted. Before a Magellan dataset gates a row, P4 needs a metric restricted to labelled pairs.
- **Held-out independence is thinner than 14 names suggest.**
  - `febrl1`/`febrl2` share the FEBRL generator with design `febrl3`/`febrl4`.
  - The eight synthetic variants share one generator.
  - `fodors_zagats` is near-saturated.
  - That leaves three independent real held-out sets: `abt_buy`, `walmart_amazon`, `itunes_amazon`.

## Known pre-existing issues surfaced, not fixed here

- **Row-count off-by-one.** `generate_fixture.generate`'s final-batch clip writes `rows + 1` for some `(rows, seed)`, for example 300 rows at seed 1009. Fixing it would move committed fixtures, so the tests tolerate it.
- **Failing scale-envelope test.** `scripts/bench_er_headtohead/test_scale_envelope.py::test_lane_registry_and_cmd` fails identically without this branch.
- **Failing signals test.** `scripts/autoconfig_quality/tests/test_signals.py::test_extract_signals_sparse_zip` fails locally on `main` too: 415,097 candidate pairs against its bound of 50,000. No CI job runs that folder.

## Tests

- `test_generate_fixture_corruption.py`: default digests, known-positive noise scaling, negative rejection, CLI pass-through.
- `test_heldout_loaders.py`: each loader family on fake files, missing data, synthetic knobs.
- `test_corpus.py`: frozen sets, disjointness, CI excludes PII, CLI.
- `test_rule_sweep.py`:
  - arm bookkeeping and void/applied logic against the P1–P2 reason strings;
  - the env guard and every exit-1 path;
  - an 11-arm end-to-end sweep on one saved model;
  - merge completeness and failures;
  - holdout routing and the gate view.

## First matrix (design set)

From [run 34638483397](https://github.com/benseverndev-oss/goldenmatch/actions/runs/34638483397) on the widened 20-dataset design corpus. All 34 dataset jobs and the merge passed, with `meta.failures` and `meta.missing` both empty.

"Default" means `link_cut_rule` unset on the reloaded model, which is `prior_mid`. "Below default" means F1 more than 0.01 under it. Held-out results live only in the `cut-rule-matrix-holdout` artifact and are not reproduced here.

| dataset | default F1 | best rule | best F1 | Δ best | below default | not applied | crashed | reload digest |
|---|---|---|---|---|---|---|---|---|
| affiliations | 0.3234 | midpoint | 0.3234 | +0.0000 | none | none | none | same |
| amazon_google | 0.0475 | posterior_099 | 0.0624 | +0.0149 | midpoint, otsu | none | none | same |
| cotenant_hardneg | 0.9959 | midpoint | 0.9959 | +0.0000 | evidence_12, posterior_099 | none | none | same |
| cotenant_hardneg_s7 | 0.9926 | midpoint | 0.9926 | +0.0000 | evidence_12, posterior_099 | none | none | same |
| dblp_acm | 0.8159 | posterior_099 | 0.9077 | +0.0918 | evidence_3, evidence_5, midpoint, otsu | none | none | same |
| dblp_scholar | 0.5050 | midpoint | 0.5050 | +0.0000 | evidence_12, evidence_3, evidence_5, evidence_9, posterior_099, prior | none | none | same |
| febrl3 | 0.9952 | prior | 0.9992 | +0.0040 | none | none | none | same |
| febrl4 | 0.9977 | evidence_9 | 0.9986 | +0.0009 | none | none | none | same |
| geo_settlements | 0.5406 | prior | 0.5406 | +0.0000 | midpoint, otsu | none | none | same |
| historical_50k | 0.8339 | midpoint | 0.8339 | +0.0000 | evidence_12, evidence_3, evidence_5, evidence_9, otsu, posterior_099, prior | none | prior:memory_cap | same |
| household_hardneg | 1.0000 | midpoint | 1.0000 | +0.0000 | evidence_12, posterior_099 | none | none | same |
| household_hardneg_s7 | 1.0000 | midpoint | 1.0000 | +0.0000 | evidence_12, posterior_099 | none | none | same |
| musicbrainz_20k | 0.3327 | evidence_5 | 0.6000 | +0.2673 | none | none | none | same |
| ncvr_synthetic | 0.9990 | prior | 0.9990 | +0.0000 | midpoint, otsu | none | none | same |
| ncvr_synthetic_s7 | 0.9996 | prior | 0.9996 | +0.0000 | evidence_3, evidence_5, midpoint, otsu | none | none | same |
| person | 1.0000 | midpoint | 1.0000 | +0.0000 | none | none | none | same |
| synth_biblio_d02 | 0.9827 | midpoint | 0.9827 | +0.0000 | none | none | none | same |
| synth_person_d02 | 0.8779 | midpoint | 0.9966 | +0.1187 | posterior_099 | none | none | same |
| synth_product_d02 | 0.9966 | midpoint | 0.9966 | +0.0000 | none | none | none | same |
| synth_product_d20 | 0.9960 | midpoint | 0.9960 | +0.0000 | none | none | none | same |

Ties go to the earliest rule in `CUT_RULES` order, so `midpoint` is listed as "best" wherever every rule equals the default.

### What the widened design set changed

- **The first candidate row is falsified.** The row "λ < 0.004 and prior bound binds → `posterior_099`" wins on `dblp_acm` (+0.092). It also fires on `synth_person_d02`, where it drops F1 from 0.878 to 0.545; lower cuts win there (`midpoint` 0.997).
- **A new, large effect appears.** On `musicbrainz_20k` the midpoint bound binds at 17.3 bits, and `evidence_5` / `prior` reach F1 0.60 against the default's 0.33. `febrl3` and `febrl4` lean the same way. `dblp_scholar` goes the opposite way under the same bound.
- **`historical_50k` `prior` again hits the 12 GB cap** and is recorded as crashed. The runner survives.

No routing row is written in this PR; that is P4.
