### PR TITLE
Normalize line endings for Windows and Linux checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,15 @@
+# Line endings: identical bytes on the Linux homelab and the Windows laptop, whatever each machine's
+# core.autocrlf says. Text is stored and checked out with LF, Windows scripts with CRLF, and data
+# fixtures byte for byte. More specific lines below override these.
+* text=auto eol=lf
+*.sh   text eol=lf
+*.bash text eol=lf
+*.cmd  text eol=crlf
+*.bat  text eol=crlf
+*.ps1  text eol=crlf
+*.csv  -text
+*.tsv  -text
+
 /tests/fixtures/synthetic_1m.csv filter=lfs diff=lfs merge=lfs -text
 /packages/python/goldenmatch/tests/fixtures/synthetic_1m.csv filter=lfs diff=lfs merge=lfs -text
 


### PR DESCRIPTION
Adds line-ending attributes at the top of `.gitattributes`, so a checkout has the same bytes on Linux (the homelab desktop, where agents write and run tests) and on Windows (the laptop, where Git for Windows defaults to `core.autocrlf=true`).

- Text files are stored and checked out with LF (`* text=auto eol=lf`).
- Shell scripts use LF; `.cmd`, `.bat` and `.ps1` use CRLF.
- `.csv` and `.tsv` are kept byte for byte (`-text`), so fixture tests compare the same bytes on both machines.
- Existing attributes are unchanged and still take precedence, because they come later in the file.

Checked with `git add --renormalize .`: nothing other than `.gitattributes` changes, so this carries no content churn.
