### PR TITLE
fix(autoconfig): keep key-less blocking out of the >=50K learned upgrade

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -17,6 +17,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   the same ordering for weighted matchkeys; the FS route kept it. The strategy
   check now runs first, and such plans score on the memory-bounded external-blocks
   scorer. On MusicBrainz-20K zero-config `dedupe_df` went from F1 0.034 to 0.176.
+- **Zero-config no longer returns zero matches on large free-text data.** At 50,000
+  rows or more, auto-config replaced the blocking plan with learned blocking. For
+  free text that plan is key-less (token, LSH or SimHash), and learned blocking
+  samples on blocking keys, so it built no blocks, fell back to static blocking on
+  the same empty keys, and the run returned no matches and raised nothing. Key-less
+  plans now keep their strategy. On DBLP-Scholar (66,879 rows) zero-config
+  `dedupe_df` went from 0 clusters to 43,957 scored pairs (F1 0.0 to 0.189).
 
 ## [3.17.1] - 2026-08-31
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -5804,12 +5804,27 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
         # block-bounding value is redundant. `build_blocking` already gated the
         # union on OR-coverage before emitting it, so KEEP any strong-id union it
         # returned rather than overwriting it. Learned blocking stays the default
-        # for every non-union large shape.
+        # for every other large shape that has blocking keys.
         if _is_strong_identifier_union(blocking, profiles):
             logger.info(
                 "Keeping the strong-identifier blocking UNION at %d rows; learned "
                 "blocking under-blocks this null-sparse multi-source shape (see "
                 "#1316).",
+                total_rows,
+            )
+        elif not blocking.keys:
+            # Learned blocking needs keys. Its first pass is static blocking on
+            # `blocking.keys` over a sample, run to find training pairs. A key-less
+            # plan -- the token / lsh / simhash plans `_text_corpus_blocking` returns
+            # for free text -- builds no sample blocks, finds no training pairs, and
+            # "falls back to static blocking" on the same empty keys: zero blocks,
+            # zero candidate pairs, zero matches, and nothing raised. Measured on
+            # DBLP-Scholar (66,879 rows): zero-config returned 0 clusters; keeping
+            # the token plan scores 43,957 pairs.
+            logger.info(
+                "Keeping key-less %s blocking at %d rows; learned blocking needs "
+                "blocking keys to sample on.",
+                blocking.strategy,
                 total_rows,
             )
         else:

--- a/packages/python/goldenmatch/tests/test_learned_blocking_keyless.py
+++ b/packages/python/goldenmatch/tests/test_learned_blocking_keyless.py
@@ -1,0 +1,91 @@
+"""The >=50K learned-blocking upgrade must not overwrite a key-less blocking plan.
+
+`_legacy_auto_configure_v0` (the heuristic the zero-config controller calls) sets
+`blocking.strategy = "learned"` at `total_rows >= 50_000`. Learned blocking's first pass
+is static blocking on `blocking.keys`, run on a sample to find training pairs. A key-less
+plan -- the token / lsh / simhash plans `_text_corpus_blocking` returns for free text --
+has no keys, so that pass builds no blocks and finds no training pairs, and the "falling
+back to static blocking" that follows uses the same empty keys. The run ends with zero
+blocks, zero candidate pairs and zero matches, and raises nothing.
+
+Measured on DBLP-Scholar (66,879 rows): zero-config `dedupe_df` returned 0 clusters.
+Keeping the token plan returns 43,957 scored pairs (F1 0.0 -> 0.189).
+
+These tests use a small frame with an `n_rows_full` override so the >=50K branch fires
+without materializing 50K rows, the same way tests/test_blocking_union_learned_1316.py does.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import BlockingConfig, LSHKeyConfig, TokenBlockingConfig
+from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+from goldenmatch.core.blocker import build_blocks
+
+_LARGE = 60_000  # >= the 50K learned-blocking gate
+
+_BASES = (
+    "entity resolution at scale with learned blocking",
+    "probabilistic record linkage for bibliographic data",
+    "fast approximate string matching over large corpora",
+    "a survey of duplicate detection in databases",
+    "scalable clustering of noisy author names",
+)
+
+
+def _titles_df(n: int = 1000) -> pl.DataFrame:
+    return pl.DataFrame({
+        "title": [f"{_BASES[i % len(_BASES)]} part {i % 300}" for i in range(n)],
+        "venue": [f"venue {i % 40}" for i in range(n)],
+        "year": [str(1990 + i % 30) for i in range(n)],
+    })
+
+
+def _token_plan() -> BlockingConfig:
+    return BlockingConfig(
+        strategy="token",
+        token=TokenBlockingConfig(column="title", min_token_length=3, max_df_ratio=0.02),
+    )
+
+
+def _lsh_plan() -> BlockingConfig:
+    return BlockingConfig(
+        strategy="lsh",
+        lsh=LSHKeyConfig(column="title", mode="word", k=2, num_perms=128, threshold=0.5, seed=0),
+    )
+
+
+_KEYLESS_PLANS = {"token": _token_plan, "lsh": _lsh_plan}
+
+
+def _block_count(df: pl.DataFrame, blocking: BlockingConfig) -> int:
+    return len(build_blocks(df.with_row_index("__row_id__"), blocking))
+
+
+@pytest.mark.parametrize("strategy", sorted(_KEYLESS_PLANS))
+def test_learned_blocking_on_a_keyless_plan_builds_no_blocks(strategy: str) -> None:
+    """Why the upgrade has to skip these plans: the same plan re-labelled `learned`
+    builds nothing, while the plan as chosen builds blocks."""
+    df = _titles_df()
+    plan = _KEYLESS_PLANS[strategy]()
+    assert plan.keys == []
+    assert _block_count(df, plan) > 0
+    relabelled = plan.model_copy(update={"strategy": "learned"})
+    assert _block_count(df, relabelled) == 0
+
+
+@pytest.mark.parametrize("strategy", sorted(_KEYLESS_PLANS))
+def test_keyless_plan_survives_the_learned_upgrade(monkeypatch, strategy: str) -> None:
+    """THE REGRESSION. Before the fix the >=50K gate turned these plans into learned
+    blocking with no keys, and zero-config dedupe found nothing."""
+    df = _titles_df()
+    monkeypatch.setattr(
+        "goldenmatch.core.autoconfig.build_blocking",
+        lambda *a, **k: _KEYLESS_PLANS[strategy](),
+    )
+    cfg = _legacy_auto_configure_v0(df, n_rows_full=_LARGE)
+    assert cfg.blocking is not None
+    assert cfg.blocking.strategy == strategy, (
+        f"the >=50K gate replaced a key-less {strategy} plan with {cfg.blocking.strategy!r}"
+    )
+    assert _block_count(df, cfg.blocking) > 0


### PR DESCRIPTION
## What and why

At 50,000 rows or more, auto-config replaced the blocking plan with learned blocking, unless the plan was the #1316 strong-identifier union. For free text that plan is key-less: the token, LSH and SimHash plans `_text_corpus_blocking` returns carry no `blocking.keys`. Learned blocking's first pass is static blocking on `blocking.keys` over a sample, used to find training pairs. With no keys it built no sample blocks and found no training pairs. It then logged "No scored pairs from sample run. Falling back to static blocking." and ran static blocking on the same empty keys.

The result was zero blocks, zero candidate pairs and zero matches, and nothing was raised.

Measured on DBLP-Scholar (66,879 rows): zero-config `dedupe_df` returned 0 clusters in 3.3 s. With the plan kept as token blocking it scores 43,957 pairs, and cluster F1 goes from 0.0 to 0.189. Forced Fellegi-Sunter gets 0.505 on the same data. The rest of that gap is the title-only weighted matchkey zero-config picks, which is a separate issue.

## Changes

- `core/autoconfig.py`: the >=50K learned upgrade now skips a blocking plan with no keys, logging that it kept the key-less strategy. Keyed plans still upgrade.
- `tests/test_learned_blocking_keyless.py`:
  - pins the mechanism: a key-less token or LSH plan builds blocks, and the same plan relabelled `learned` builds none;
  - adds the regression: those plans keep their strategy through `_legacy_auto_configure_v0` at `n_rows_full=60_000` and still build blocks.
- `CHANGELOG.md`: Fixed entry.

## Testing

- `pytest tests/test_learned_blocking_keyless.py tests/test_blocking_union_learned_1316.py` plus the four learned-blocking gate tests in `tests/test_autoconfig_regressions.py`: 13 passed.
- The two regression tests failed on `main` before the change. `_legacy_auto_configure_v0` turned both plans into `learned`.
- The existing 50K boundary fixture blocks on `soundex(name)` keys, so the boundary tests still engage learned blocking and are unchanged.
- `scripts/regen_docs.py --check`: current.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (not applicable)
