### PR TITLE
fix(pipeline): check the blocking strategy before honoring backend=bucket on the FS route

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+
+- **A planner-chosen `backend="bucket"` no longer sends a Fellegi-Sunter matchkey
+  onto a blocking plan the bucket scorer cannot express.** The execution planner
+  writes `backend="bucket"` onto zero-config configs, and `_fs_use_bucket_route`
+  honored it before checking the blocking strategy. The bucket scorer builds field
+  block keys from `blocking.keys` / `passes`, so on a token or LSH plan it scored
+  whatever keys the config carried instead of the plan's candidates. #2488 fixed
+  the same ordering for weighted matchkeys; the FS route kept it. The strategy
+  check now runs first, and such plans score on the memory-bounded external-blocks
+  scorer. On MusicBrainz-20K zero-config `dedupe_df` went from F1 0.034 to 0.176.
+
 ## [3.17.1] - 2026-08-31
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -541,9 +541,22 @@ def _fs_use_bucket_route(config: GoldenMatchConfig, mk: Any) -> bool:
         lsh / ann / learned / canopy / sorted_neighborhood candidates are not
         field-hash reproducible).
     """
+    # Correctness gate FIRST -- the FS twin of #2488. The execution planner writes
+    # backend="bucket" onto the committed config, so a blocking strategy bucket
+    # cannot express must be refused before the explicit-bucket short-circuit, not
+    # after it. Bucket derives field block keys from `blocking.keys` / `passes`; on
+    # a token / lsh / ... plan it scores whatever keys the config happens to carry
+    # instead of the plan's candidates. Measured on MusicBrainz-20K zero-config
+    # (token plan on `title` with a stray `language` key): F1 0.034 on bucket,
+    # 0.176 off it.
+    _blk = getattr(config, "blocking", None)
+    if _blk is not None and getattr(_blk, "strategy", None) not in (
+        None, "static", "multi_pass",
+    ):
+        return False
     backend = getattr(config, "backend", None)
     if backend == "bucket":
-        return True  # explicit choice -- honored at any size
+        return True  # explicit choice on an expressible plan -- honored at any size
     # `duckdb` is a single-node pair-STORAGE backend with NO distinct FS scoring
     # route -- an FS matchkey under it simply falls to the legacy batched scorer
     # (this function's own "#1798 OOM path"), which is measurably quality-DIVERGENT
@@ -590,11 +603,9 @@ def _fs_use_bucket_route(config: GoldenMatchConfig, mk: Any) -> bool:
     # requires a single weighted matchkey), so a probabilistic matchkey never
     # enters it -- excluding FS here only demoted FS to the batched path for
     # users who happened to have the columnar opt-in set.
-    _blk = getattr(config, "blocking", None)
-    if _blk is not None and getattr(_blk, "strategy", None) not in (
-        None, "static", "multi_pass",
-    ):
-        return False
+    # (The blocking-strategy exclusion that used to sit here now runs at the top of
+    # this function -- below the explicit-bucket short-circuit it was unreachable
+    # for exactly the planner-written configs it existed to protect.)
     from goldenmatch.core.profile_emitter import has_active_emitter
 
     return not has_active_emitter()
@@ -617,7 +628,11 @@ def _fs_external_blocks_route(config: GoldenMatchConfig) -> bool:
     active-emitter probe runs are calibrated against the legacy path (the
     #1829 lesson), and explicit scale backends keep their own routing.
     """
-    if getattr(config, "backend", None) not in (None, "polars-direct"):
+    # "bucket" is accepted because the execution planner writes it onto zero-config
+    # configs whatever the blocking strategy; `_fs_use_bucket_route` refuses such a
+    # plan, and its candidates belong on this memory-bounded scorer, not the batched
+    # one. The distributed backends (ray / datafusion / chunked-to-ray) stay out.
+    if getattr(config, "backend", None) not in (None, "polars-direct", "bucket"):
         return False
     if (
         os.environ.get("GOLDENMATCH_FS_DEFAULT_BUCKET", "1").strip().lower()

--- a/packages/python/goldenmatch/tests/test_fs_bucket_route_strategy_guard.py
+++ b/packages/python/goldenmatch/tests/test_fs_bucket_route_strategy_guard.py
@@ -1,0 +1,112 @@
+"""The FS twin of #2488: `backend="bucket"` must not send a blocking strategy the bucket
+scorer cannot express onto the bucket route.
+
+The bucket scorer derives FIELD-based block keys from `blocking.keys` / `blocking.passes`.
+Token / lsh / ann / learned / canopy / sorted_neighborhood candidates are not field-hash
+reproducible, and `_fs_use_bucket_route` has an exclusion for exactly those strategies --
+but it sat BELOW an unconditional `if backend == "bucket": return True`.
+`ExecutionPlan.apply_to` writes `backend="bucket"` onto the committed zero-config config,
+so an FS matchkey on a token plan scored through bucket, which blocked on whatever keys the
+config happened to carry instead of the plan's tokens. #2488 moved the same check above the
+same short-circuit in `_use_bucket_scorer` (the weighted route); the FS route kept the old
+order.
+
+Measured on MusicBrainz-20K zero-config (probabilistic matchkey, token plan on `title` with
+a stray `language` key): F1 0.034 with the planner's `backend="bucket"`, 0.176 without it.
+
+`_fs_external_blocks_route` is where such a plan should land instead: the memory-bounded
+external-blocks scorer, not the legacy batched scorer (the #1826 OOM shape). It only
+accepted `backend in (None, "polars-direct")`, so a planner-written "bucket" also has to
+count there.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    LSHKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    TokenBlockingConfig,
+)
+from goldenmatch.core.execution_plan import ExecutionPlan
+from goldenmatch.core.pipeline import _fs_external_blocks_route, _fs_use_bucket_route
+
+
+def _token_plan() -> BlockingConfig:
+    return BlockingConfig(strategy="token", token=TokenBlockingConfig(column="title"))
+
+
+def _lsh_plan() -> BlockingConfig:
+    return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(column="title", threshold=0.5))
+
+
+_UNEXPRESSIBLE = {"token": _token_plan, "lsh": _lsh_plan}
+
+
+def _config(blocking: BlockingConfig, backend: str | None = None) -> GoldenMatchConfig:
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="probabilistic_auto", type="probabilistic",
+            fields=[MatchkeyField(field="title", scorer="jaro_winkler"),
+                    MatchkeyField(field="artist", scorer="jaro_winkler")],
+        )],
+        blocking=blocking,
+    )
+    if backend is not None:
+        cfg.backend = backend
+    return cfg
+
+
+def _mk(cfg: GoldenMatchConfig):
+    return cfg.get_matchkeys()[0]
+
+
+@pytest.mark.parametrize("backend", [None, "bucket"])
+@pytest.mark.parametrize("strategy", sorted(_UNEXPRESSIBLE))
+def test_unexpressible_plan_never_takes_the_fs_bucket_route(strategy: str, backend: str | None) -> None:
+    """THE REGRESSION. Before the fix this returned True for backend='bucket'."""
+    cfg = _config(_UNEXPRESSIBLE[strategy](), backend)
+    assert _fs_use_bucket_route(cfg, _mk(cfg)) is False
+
+
+@pytest.mark.parametrize("backend", [None, "bucket"])
+@pytest.mark.parametrize("strategy", sorted(_UNEXPRESSIBLE))
+def test_unexpressible_plan_takes_the_external_blocks_route(strategy: str, backend: str | None) -> None:
+    """Off the bucket route, the plan's own blocks go to the memory-bounded external-blocks
+    scorer whichever of these two wrote the backend."""
+    cfg = _config(_UNEXPRESSIBLE[strategy](), backend)
+    assert _fs_external_blocks_route(cfg) is True
+
+
+def test_planner_written_backend_cannot_bypass_the_fs_gate() -> None:
+    """`ExecutionPlan.apply_to` is how `backend` became "bucket" in the wild."""
+    cfg = _config(_token_plan())
+    ExecutionPlan(backend="bucket").apply_to(cfg)
+    assert cfg.backend == "bucket"
+    assert _fs_use_bucket_route(cfg, _mk(cfg)) is False
+    assert _fs_external_blocks_route(cfg) is True
+
+
+def test_explicit_bucket_still_honored_for_a_field_keyed_plan() -> None:
+    """The guard must not break what it protects: a keyed plan under an explicit
+    backend='bucket' stays on bucket, and does not take the external-blocks route."""
+    cfg = _config(
+        BlockingConfig(strategy="multi_pass",
+                       keys=[BlockingKeyConfig(fields=["title"], transforms=["lowercase"])],
+                       passes=[BlockingKeyConfig(fields=["title"], transforms=["lowercase"])]),
+        "bucket",
+    )
+    assert _fs_use_bucket_route(cfg, _mk(cfg)) is True
+    assert _fs_external_blocks_route(cfg) is False
+
+
+@pytest.mark.parametrize("backend", ["ray", "datafusion"])
+def test_distributed_backends_keep_their_own_routing(backend: str) -> None:
+    """Accepting a planner-written 'bucket' must not pull a distributed backend onto the
+    single-node external-blocks scorer."""
+    cfg = _config(_token_plan(), backend)
+    assert _fs_use_bucket_route(cfg, _mk(cfg)) is False
+    assert _fs_external_blocks_route(cfg) is False


### PR DESCRIPTION
## What and why

`_fs_use_bucket_route` returned True for `backend == "bucket"` before its own blocking-strategy exclusion. That made the exclusion unreachable for exactly the configs it exists for. `ExecutionPlan.apply_to` writes `backend="bucket"` onto zero-config configs whatever their blocking strategy.

The bucket scorer derives field block keys from `blocking.keys` / `passes`. On a token or LSH plan it therefore scored whatever keys the config happened to carry, not the plan's own candidates. #2488 fixed this ordering in `_use_bucket_scorer`, the weighted route. The Fellegi-Sunter route kept the old order.

Measured on MusicBrainz-20K, zero-config `dedupe_df` with a probabilistic matchkey, a token plan on `title`, and a stray `language` prefix key:

| Backend | F1 | Linked pairs |
|---|---|---|
| Planner's `backend="bucket"` | 0.034 | 331 |
| Same config, backend removed | 0.176 | 1,581 |

The rest of that dataset's gap is a separate postflight re-cut, handled in its own PR.

## Changes

- `core/pipeline.py`:
  - `_fs_use_bucket_route`: the strategy check (anything other than `static` / `multi_pass`) now runs before the explicit-bucket short-circuit. The old, unreachable copy below is removed.
  - `_fs_external_blocks_route`: now accepts `backend="bucket"`. A refused plan then scores on the memory-bounded external-blocks scorer instead of the legacy batched scorer (the #1826 OOM shape). `ray` and `datafusion` still keep their own routing.
- `tests/test_fs_bucket_route_strategy_guard.py`, modelled on `test_bucket_routing_guard_2488.py`, covers:
  - token and LSH plans under `backend=None` and `"bucket"`;
  - a backend written by the planner;
  - an explicit bucket on a keyed plan, which stays on bucket;
  - distributed backends, which stay out of both routes.
- `CHANGELOG.md`: Fixed entry.

## Testing

- `pytest tests/test_fs_bucket_route_strategy_guard.py tests/test_fs_route_chunked_keeps_bucket.py tests/test_bucket_routing_guard_2488.py tests/test_fs_bucket_native.py`: 56 passed.
- Five of the new cases failed on `main` before the change: every `backend="bucket"` case, plus the planner-written case.
- `scripts/regen_docs.py --check`: current.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (not applicable)
