### PR TITLE
fix(autoconfig_verify): postflight no longer re-cuts a probabilistic matchkey's pairs

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -48,6 +48,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   the same empty keys, and the run returned no matches and raised nothing. Key-less
   plans now keep their strategy. On DBLP-Scholar (66,879 rows) zero-config
   `dedupe_df` went from 0 clusters to 43,957 scored pairs (F1 0.0 to 0.189).
+- **Postflight no longer re-cuts a Fellegi-Sunter matchkey's pairs.** On
+  auto-configured runs, postflight reads the score histogram against the first
+  weighted matchkey's threshold, or 0.7 when there is none. An FS-only config was
+  therefore judged against 0.7, a weighted default unrelated to the link cut the FS
+  model resolved. When the histogram was bimodal, every FS pair below its valley was
+  dropped before clustering, bypassing the FS refit and its over-merge and
+  expelled-share checks. Postflight now emits a threshold adjustment only when there
+  is a weighted threshold (or a caller-supplied one) to move, and says why when it
+  declines. Weighted matchkeys are unchanged. On MusicBrainz-20K zero-config
+  `dedupe_df` (with the bucket-route fix applied) went from F1 0.176 to 0.475.
 
 ## [3.17.1] - 2026-08-31
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -1338,8 +1338,26 @@ def postflight(
                 f"not a boundary between populations, so no threshold "
                 f"adjustment was emitted."
             )
+    # A threshold adjustment moves a WEIGHTED matchkey's cut: `_resolve_current_threshold`
+    # reads the first weighted matchkey's threshold and otherwise falls back to 0.7. An
+    # FS-only config has no weighted threshold, so its pairs were read against that 0.7
+    # fallback -- unrelated to the link cut the FS model resolved -- and a valley far from
+    # 0.7 re-cut every FS pair below it in `_apply_postflight`. That re-cut bypasses the FS
+    # refit, which only moves the cut when re-clustering passes its over-merge and
+    # expelled-share checks. Measured on MusicBrainz-20K zero-config: F1 0.176 with the
+    # re-cut, 0.475 without it. A caller-supplied threshold still counts as a cut to move.
+    _has_weighted_cut = current_threshold is not None or any(
+        mk.type == "weighted" and mk.threshold is not None
+        for mk in config.get_matchkeys()
+    )
     if is_bimodal and valley is not None and not _tail_artifact:
-        if abs(valley - threshold) > 0.05 and not strict:
+        if abs(valley - threshold) > 0.05 and not strict and not _has_weighted_cut:
+            report.advisories.append(
+                f"score distribution is bimodal (valley at {valley:.3f}), but the config "
+                f"has no weighted matchkey threshold to move: a probabilistic matchkey's "
+                f"link cut is resolved by its model, so postflight does not re-cut it."
+            )
+        elif abs(valley - threshold) > 0.05 and not strict:
             report.adjustments.append(
                 PostflightAdjustment(
                     field="threshold",

--- a/packages/python/goldenmatch/tests/test_postflight_fs_no_recut.py
+++ b/packages/python/goldenmatch/tests/test_postflight_fs_no_recut.py
@@ -1,0 +1,94 @@
+"""Postflight must not re-cut a Fellegi-Sunter (probabilistic) matchkey's pairs.
+
+`postflight()` reads the score histogram against `_resolve_current_threshold`: the first
+WEIGHTED matchkey's threshold, else 0.7. An FS-only config has no weighted threshold, so
+its pairs were measured against 0.7 -- a weighted scorer's default with no relation to the
+link cut the FS model resolved (link-cut rules, then the refit guard). A bimodal histogram
+whose valley sat more than 0.05 from 0.7 produced a threshold adjustment, and
+`_apply_postflight` then dropped every FS pair below that valley before clustering. That is
+a second, unguarded re-cut of the FS link: the refit that already moves the FS cut only
+commits when re-clustering passes its over-merge and expelled-share checks.
+
+Measured on MusicBrainz-20K zero-config (with the planner's bucket backend already removed):
+F1 0.176 with the postflight re-cut, 0.475 without it.
+
+Weighted matchkeys keep the adjustment; configs mixing a weighted matchkey with a
+probabilistic one are unchanged here.
+"""
+from __future__ import annotations
+
+import random
+
+import polars as pl
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_verify import PreflightReport, postflight
+
+
+def _df() -> pl.DataFrame:
+    return pl.DataFrame({"name": [f"x{i}" for i in range(100)]})
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["name"])])
+
+
+def _fs_config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        blocking=_blocking(),
+        matchkeys=[MatchkeyConfig(
+            name="probabilistic_auto", type="probabilistic",
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler")],
+        )],
+    )
+
+
+def _weighted_config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        blocking=_blocking(),
+        matchkeys=[MatchkeyConfig(
+            name="mk", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field="name", scorer="token_sort", weight=1.0)],
+        )],
+    )
+
+
+def _bimodal_pairs() -> list[tuple[int, int, float]]:
+    """Two modes at 0.2 and 0.9, the valley far from 0.7 -- the shape that re-cut."""
+    rng = random.Random(42)
+    low = [(i, i + 1000, max(0.0, min(1.0, rng.gauss(0.2, 0.08)))) for i in range(500)]
+    high = [(i + 2000, i + 3000, max(0.0, min(1.0, rng.gauss(0.9, 0.05)))) for i in range(500)]
+    return low + high
+
+
+def test_postflight_emits_no_threshold_adjustment_for_an_fs_only_config() -> None:
+    """THE REGRESSION. Before the fix this emitted a threshold adjustment to the valley."""
+    report = postflight(_df(), _fs_config(), pair_scores=_bimodal_pairs())
+    assert not any(adj.field == "threshold" for adj in report.adjustments)
+    assert any("probabilistic" in a for a in report.advisories), (
+        "declining silently looks exactly like a guard that never ran -- say why"
+    )
+
+
+def test_postflight_still_adjusts_a_weighted_config_on_the_same_scores() -> None:
+    """The control: the signal is unchanged where there is a weighted threshold to move."""
+    report = postflight(_df(), _weighted_config(), pair_scores=_bimodal_pairs())
+    assert any(adj.field == "threshold" for adj in report.adjustments)
+
+
+def test_apply_postflight_keeps_every_fs_pair() -> None:
+    """End of the chain: an auto-configured FS config (it carries a preflight report)
+    reaches clustering with its pairs intact."""
+    from goldenmatch.core.pipeline import _apply_postflight
+
+    cfg = _fs_config()
+    cfg._preflight_report = PreflightReport()
+    pairs = _bimodal_pairs()
+    kept, report = _apply_postflight(_df(), cfg, pairs)
+    assert report is not None, "postflight must still run and report its signals"
+    assert kept == pairs


### PR DESCRIPTION
## What and why

On auto-configured runs, postflight reads the pair-score histogram against `_resolve_current_threshold`. That is the first weighted matchkey's threshold, or 0.7 when there is none. An FS-only config has no weighted threshold, so its pairs were judged against 0.7, a weighted-scorer default unrelated to the link cut the FS model resolved.

When the histogram was bimodal with its valley more than 0.05 from 0.7, postflight emitted a threshold adjustment. `_apply_postflight` then dropped every FS pair below the valley before clustering. That is a second, unguarded re-cut of the FS link. The FS refit that already moves the cut commits only when re-clustering passes its over-merge and expelled-share checks; this one had no such check.

Postflight now emits a threshold adjustment only when there is a weighted threshold, or a caller-supplied one, to move. Otherwise it records an advisory saying why it declined. Weighted matchkeys are unchanged.

## Measured

Zero-config `dedupe_df` F1 on the 20-dataset FS link-cut routing design corpus, run on the homelab for three code states:
- `origin/main`;
- `main` with #2949 and #2950 (the key-less learned-blocking and FS bucket-route fixes);
- the same with this change.

All three used one environment, with `PYTHONPATH` pointed at each state's worktree.

| dataset | main | +#2949 +#2950 | + this PR |
|---|---|---|---|
| household_hardneg | 0.9774 | 0.9774 | **1.0** |
| household_hardneg_s7 | 0.9768 | 0.9768 | **1.0** |
| musicbrainz_20k | 0.0339 | 0.1763 | **0.4753** |
| dblp_scholar | 0.0 | 0.1894 | 0.1894 |
| historical_50k | 0.8339 | 0.8339 | 0.8339 |
| 15 others | unchanged | unchanged | unchanged |

No dataset drops. This change on its own moves three datasets, all upward: MusicBrainz-20K and both household hard-negative variants.

On MusicBrainz-20K, a blocking x matchkey ablation with the planner's bucket backend already removed isolated the postflight report as the cause. Zero-config F1 was 0.176 with it and 0.475 without it.

## Changes

- `core/autoconfig_verify.py`: `postflight` skips the threshold adjustment when the config has no weighted matchkey threshold and no caller-supplied threshold, and appends an advisory naming the reason.
- `tests/test_postflight_fs_no_recut.py`:
  - an FS-only config with a bimodal histogram gets no threshold adjustment, and an advisory explains why;
  - a weighted config with the same scores still gets one;
  - `_apply_postflight` keeps every FS pair on an auto-configured FS config.
- `CHANGELOG.md`: Fixed entry.

Scope: a config mixing a weighted matchkey with a probabilistic one is unchanged. Its weighted threshold still drives the adjustment, and the filter still applies to all pairs.

## Testing

- `pytest tests/test_postflight_fs_no_recut.py tests/test_autoconfig_verify.py tests/test_threshold_suggestion_survives_postflight.py`: 48 passed, 1 skipped (the skip is pre-existing).
- The two FS cases failed on `main` before the change.
- `scripts/regen_docs.py --check`: current.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (not applicable)
